### PR TITLE
Enable golangci-lint static check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,43 @@
+# This files contains all configuration options for analysis running.
+# More details please refer to: https://golangci-lint.run/usage/configuration/
+
+run:
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 5m
+
+  # which dirs to skip: issues from them won't be reported;
+  # can use regexp here: generated.*, regexp is applied on full path;
+  # default value is empty list, but default dirs are skipped independently
+  # from this option's value (see skip-dirs-use-default).
+  # "/" will be replaced by current OS file path separator to properly work
+  # on Windows.
+  skip-dirs:
+
+  # default is true. Enables skipping of directories:
+  #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
+  skip-dirs-use-default: true
+
+  # One of 'readonly' and 'vendor'.
+  #  - readonly: the go command is disallowed from the implicit automatic updating of go.mod described above.
+  #              Instead, it fails when any changes to go.mod are needed. This setting is most useful to check
+  #              that go.mod does not need updates, such as in a continuous integration and testing system.
+  #  - vendor: the go command assumes that the vendor directory holds the correct copies of dependencies and ignores
+  #            the dependency descriptions in go.mod.
+  modules-download-mode: readonly
+linters:
+  enable:
+  # linters maintained by golang.org
+  - gofmt
+  - golint
+  - govet
+  # linters default enabled by golangci-lint .
+  - deadcode
+  - errcheck
+  - gosimple
+  - ineffassign
+  - staticcheck
+  - structcheck
+  - typecheck
+  - unused
+  - varcheck
+

--- a/hack/verify-staticcheck.sh
+++ b/hack/verify-staticcheck.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+
+# TODO(RainbowMango): Pin golangci-lint verison to @v1.32.2
+# go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.32.2
+
+cd ${REPO_ROOT}
+
+if golangci-lint run; then
+  echo 'Congratulations!  All Go source files have passed staticcheck.'
+else
+  echo # print one empty line, separate from warning messages.
+  echo 'Please review the above warnings.'
+  echo 'If the above warnings do not make sense, feel free to file an issue.'
+  exit 1
+fi


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Enable static check in favor of [golangci-lint](https://github.com/golangci/golangci-lint).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Run script with errors:
```
[root@ecs-d8b6 karmada]# hack/verify-staticcheck.sh 
cmd/controller-manager/app/controllermanager.go:19: File is not `gofmt`-ed with `-s` (gofmt)
	"github.com/huawei-cloudnative/karmada/pkg/controllers/membercluster"

Please review the above warnings.
If the above warnings do not make sense, feel free to file an issue.
[root@ecs-d8b6 karmada]# echo $?
1
```

Run script without warnings:
```
[root@ecs-d8b6 karmada]# hack/verify-staticcheck.sh 
Congratulations!  All Go source files have passed staticcheck.
[root@ecs-d8b6 karmada]# echo $?
0
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

