### PR TITLE
Disable excluding of issues about comments from golint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,3 +41,7 @@ linters:
   - unused
   - varcheck
 
+issues:
+  # The list of ids of default excludes to include or disable. By default it's empty.
+  include:
+    - EXC0002 # disable excluding of issues about comments from golint

--- a/cmd/controller-manager/app/leaderelection/leaderelection.go
+++ b/cmd/controller-manager/app/leaderelection/leaderelection.go
@@ -18,6 +18,7 @@ import (
 	"github.com/huawei-cloudnative/karmada/cmd/controller-manager/app/options"
 )
 
+// NewLeaderElector builds a leader elector.
 func NewLeaderElector(opts *options.Options, fnStartControllers func(*options.Options, <-chan struct{})) (*leaderelection.LeaderElector, error) {
 	const component = "controller-manager"
 	rest.AddUserAgent(opts.KubeConfig, "leader-election")

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -23,6 +23,7 @@ type Options struct {
 	LeaderElection componentbaseconfig.LeaderElectionConfiguration
 }
 
+// NewOptions builds an empty options.
 func NewOptions() *Options {
 	return &Options{}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
- Fixed `golangci-lint` can not report comments issue; 
- Fixed `golint` issues.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
```
[root@ecs-d8b6 karmada]# hack/verify-staticcheck.sh 
cmd/controller-manager/app/options/options.go:26:1: exported function `NewOptions` should have comment or be unexported (golint)
func NewOptions() *Options {
^
cmd/controller-manager/app/leaderelection/leaderelection.go:21:1: exported function `NewLeaderElector` should have comment or be unexported (golint)
func NewLeaderElector(opts *options.Options, fnStartControllers func(*options.Options, <-chan struct{})) (*leaderelection.LeaderElector, error) {
^

Please review the above warnings.
If the above warnings do not make sense, feel free to file an issue.
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

