### PR TITLE
Add simple local-up-karmada.sh

### DIFF
--- a/hack/local-up-karmada.sh
+++ b/hack/local-up-karmada.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBECONFIG_PATH=${KUBECONFIG_PATH:-"${HOME}/.kube"}
+
+# This script starts a local karmada control plane.
+# Usage: hack/local-up-karmada.sh
+# Example: hack/local-up-karmada.sh (start local karmada)
+
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+
+# Make sure KUBECONFIG path exists.
+if [ ! -d "$KUBECONFIG_PATH" ]; then
+  mkdir -p "$KUBECONFIG_PATH"
+fi
+
+KARMADA_KUBECONFIG="${KUBECONFIG_PATH}/karmada.config"
+
+# create a cluster to deploy karmada control plane components.
+"${SCRIPT_ROOT}"/hack/create-cluster.sh karmada "${KARMADA_KUBECONFIG}"
+export KUBECONFIG="${KARMADA_KUBECONFIG}"
+
+# deploy karmada control plane
+"${SCRIPT_ROOT}"/hack/deploy-karmada.sh
+
+function print_success() {
+  echo
+  echo "Local Karmada is running."
+  echo "To start using your karmada, run:"
+cat <<EOF
+  export KUBECONFIG=${KARMADA_KUBECONFIG}
+EOF
+}
+
+print_success


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Added a script for start karmada automatically.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

```shell
# hack/local-up-karmada.sh 
Creating cluster "host" ...
 ✓ Ensuring node image (kindest/node:v1.19.1) 🖼
 ✓ Preparing nodes 📦  
 ✓ Writing configuration 📜 
 ✓ Starting control-plane 🕹️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
 ✓ Waiting ≤ 2m0s for control-plane = Ready ⏳ 
 • Ready after 32s 💚
Set kubectl context to "kind-host"
You can now use your cluster with:

kubectl cluster-info --context kind-host --kubeconfig /root/.kube/host.config

Have a nice day! 👋
Context "kind-host" renamed to "host".
Cluster "kind-host" set.
namespace/karmada-system created
serviceaccount/karmada-controller-manager created
clusterrole.rbac.authorization.k8s.io/karmada-controller-manager created
clusterrolebinding.rbac.authorization.k8s.io/karmada-controller-manager created
customresourcedefinition.apiextensions.k8s.io/memberclusters.membercluster.karmada.io created
customresourcedefinition.apiextensions.k8s.io/propagationpolicies.propagationstrategy.karmada.io created
customresourcedefinition.apiextensions.k8s.io/propagationbindings.propagationstrategy.karmada.io created
customresourcedefinition.apiextensions.k8s.io/propagationworks.propagationstrategy.karmada.io created
deployment.apps/karmada-controller-manager created
Creating cluster "member1" ...
 ✓ Ensuring node image (kindest/node:v1.19.1) 🖼
 ✓ Preparing nodes 📦  
 ✓ Writing configuration 📜 
 ✓ Starting control-plane 🕹️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
 ✓ Waiting ≤ 2m0s for control-plane = Ready ⏳ 
 • Ready after 32s 💚
Set kubectl context to "kind-member1"
You can now use your cluster with:

kubectl cluster-info --context kind-member1 --kubeconfig /root/.kube/member1.config

Thanks for using kind! 😊
Context "kind-member1" renamed to "member1".
Cluster "kind-member1" set.
Creating cluster "member2" ...
 ✓ Ensuring node image (kindest/node:v1.19.1) 🖼
 ✓ Preparing nodes 📦  
 ✓ Writing configuration 📜 
 ✓ Starting control-plane 🕹️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
 ✓ Waiting ≤ 2m0s for control-plane = Ready ⏳ 
 • Ready after 33s 💚
Set kubectl context to "kind-member2"
You can now use your cluster with:

kubectl cluster-info --context kind-member2 --kubeconfig /root/.kube/member2.config

Thanks for using kind! 😊
Context "kind-member2" renamed to "member2".
Cluster "kind-member2" set.

Local Karmada is running.
To start using your karmada, run:
  export KUBECONFIG=/root/.kube/host.config
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

