### PR TITLE
enable show cluster version and conditions

### DIFF
--- a/artifacts/deploy/membercluster.karmada.io_memberclusters.yaml
+++ b/artifacts/deploy/membercluster.karmada.io_memberclusters.yaml
@@ -16,7 +16,14 @@ spec:
     singular: membercluster
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.kubernetesVersion
+      name: KubernetesVersion
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: MemberCluster represents the desire state and status of a member

--- a/pkg/apis/membercluster/v1alpha1/types.go
+++ b/pkg/apis/membercluster/v1alpha1/types.go
@@ -10,6 +10,8 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:scope="Cluster"
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:JSONPath=`.status.kubernetesVersion`,name="KubernetesVersion",type=string
+// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Ready")].status`,name="Ready",type=string
 
 // MemberCluster represents the desire state and status of a member cluster.
 type MemberCluster struct {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
enable show cluster version and conditions:

```
# kubectl get memberclusters.membercluster.karmada.io
NAME      KUBERNETESVERSION   READY
member1   v1.19.1             True
member2   v1.19.1             True

```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

