### PR TITLE
fix undeploy script

### DIFF
--- a/hack/undeploy-karmada.sh
+++ b/hack/undeploy-karmada.sh
@@ -13,7 +13,7 @@ function usage() {
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 KUBECONFIG_PATH=${KUBECONFIG_PATH:-"${HOME}/.kube"}
-HOST_CLUSTER_KUBECONFIG="${KUBECONFIG_PATH}/karmada.config"
+HOST_CLUSTER_KUBECONFIG="${KUBECONFIG_PATH}/karmada-host.config"
 
 export KUBECONFIG=${HOST_CLUSTER_KUBECONFIG}
 kubectl delete ns karmada-system


### PR DESCRIPTION
Signed-off-by: Kevin Wang <kevinwzf0126@gmail.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
the undeploy script is using wrong kubeconfig, this PR is to fix it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

