### PR TITLE
Enable print MemberCluster age and change simplify version.

### DIFF
--- a/artifacts/deploy/membercluster.karmada.io_memberclusters.yaml
+++ b/artifacts/deploy/membercluster.karmada.io_memberclusters.yaml
@@ -18,11 +18,14 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.kubernetesVersion
-      name: KubernetesVersion
+      name: Version
       type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/pkg/apis/membercluster/v1alpha1/types.go
+++ b/pkg/apis/membercluster/v1alpha1/types.go
@@ -10,8 +10,9 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:scope="Cluster"
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:JSONPath=`.status.kubernetesVersion`,name="KubernetesVersion",type=string
+// +kubebuilder:printcolumn:JSONPath=`.status.kubernetesVersion`,name="Version",type=string
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Ready")].status`,name="Ready",type=string
+// +kubebuilder:printcolumn:JSONPath=`.metadata.creationTimestamp`,name="Age",type=date
 
 // MemberCluster represents the desire state and status of a member cluster.
 type MemberCluster struct {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Enable `age` column and rename `KUBERNETESVERSION` to `VERSION`.

With this PR, it looks as follows:
```
# kubectl get membercluster
NAME      VERSION   READY   AGE
member1   v1.19.1   True    30m
member2   v1.19.1   True    29m
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

