### PR TITLE
Refelect resource running status to PropagationWork

### DIFF
--- a/pkg/util/label.go
+++ b/pkg/util/label.go
@@ -1,0 +1,10 @@
+package util
+
+// GetLabelValue retrieves the value via 'labelKey' if exist, otherwise returns an empty string.
+func GetLabelValue(labels map[string]string, labelKey string) string {
+	if labels == nil {
+		return ""
+	}
+
+	return labels[labelKey]
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Reflect resource running status to PropagationWork.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
``` yaml
status:
  conditions:
  - lastTransitionTime: "2021-01-05T06:47:53Z"
    message: Success sync resource in member cluster
    reason: AppliedSuccess
    status: "True"
    type: Applied
  manifestStatuses:
  - Status:
      availableReplicas: 1
      conditions:
      - lastTransitionTime: "2021-01-05T06:47:56Z"
        lastUpdateTime: "2021-01-05T06:47:56Z"
        message: Deployment has minimum availability.
        reason: MinimumReplicasAvailable
        status: "True"
        type: Available
      - lastTransitionTime: "2021-01-05T06:47:53Z"
        lastUpdateTime: "2021-01-05T06:47:56Z"
        message: ReplicaSet "nginx-6799fc88d8" has successfully progressed.
        reason: NewReplicaSetAvailable
        status: "True"
        type: Progressing
      observedGeneration: 1
      readyReplicas: 1
      replicas: 1
      updatedReplicas: 1
    identifier:
      group: apps
      kind: Deployment
      name: nginx
      namespace: default
      ordinal: 0
      resource: ""
      version: v1
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
resource running status is now shown in the relevant PropagationWork object.
```

