### PR TITLE
restrict override operation

### DIFF
--- a/artifacts/deploy/propagationstrategy.karmada.io_overridepolicies.yaml
+++ b/artifacts/deploy/propagationstrategy.karmada.io_overridepolicies.yaml
@@ -50,7 +50,11 @@ spec:
                       properties:
                         operator:
                           description: 'Operator indicates the operation on target
-                            field. Available operators are: Add, Update and Remove.'
+                            field. Available operators are: add, update and remove.'
+                          enum:
+                          - add
+                          - remove
+                          - replace
                           type: string
                         path:
                           description: Path indicates the path of target field

--- a/artifacts/example/example-override.yaml
+++ b/artifacts/example/example-override.yaml
@@ -8,7 +8,7 @@ spec:
   resourceSelectors:
     - apiVersion: apps/v1
       kind: Deployment
-      name:                   # user can either select resource by name or by labelselector
+      name: nginx             # user can either select resource by name or by labelselector
       labelSelector:
         matchLabels:
           image: nginx
@@ -24,11 +24,11 @@ spec:
   overriders:
     plaintext:
     - path: "/spec/template/spec/containers/0/image"
-      operator: Replace
+      operator: replace
       value: "dc-1.registry.io/nginx:1.17.0-alpine"
     - path: "/metadata/annotations"
-      operator: Add
+      operator: add
       value:
         foo: bar
     - path: "/metadata/annotations/foo"
-      operator: Remove
+      operator: remove

--- a/pkg/apis/propagationstrategy/v1alpha1/override_types.go
+++ b/pkg/apis/propagationstrategy/v1alpha1/override_types.go
@@ -42,7 +42,8 @@ type PlaintextOverrider struct {
 	// Path indicates the path of target field
 	Path string `json:"path"`
 	// Operator indicates the operation on target field.
-	// Available operators are: Add, Update and Remove.
+	// Available operators are: add, update and remove.
+	// +kubebuilder:validation:Enum=add;remove;replace
 	Operator OverriderOperator `json:"operator"`
 	// Value to be applied to target field.
 	// Must be empty when operator is Remove.
@@ -55,9 +56,9 @@ type OverriderOperator string
 
 // These are valid overrider operators.
 const (
-	OverriderOpAdd     OverriderOperator = "Add"
-	OverriderOpRemove  OverriderOperator = "Remove"
-	OverriderOpReplace OverriderOperator = "Replace"
+	OverriderOpAdd     OverriderOperator = "add"
+	OverriderOpRemove  OverriderOperator = "remove"
+	OverriderOpReplace OverriderOperator = "replace"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
1. Update operator constant value to lowercase, in order to facilitate operation with JSON patch.
Usually, constant values for a field will be `CamelCase`, here matches the exception addressed by [API convention](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#constants):
```
When a proper name or the name of a command-line executable is used as a constant the proper name should be represented in consistent casing
```

2. Restrict enum values by CRD validation
When set with an invalid value, such as `Replace`, the operation will be denied:
```
# kubectl create -f override.yaml 
The OverridePolicy "example-override" is invalid: spec.overriders.plaintext.operator: Unsupported value: "Replace": supported values: "add", "remove", "replace"
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

