### PR TITLE
validate cluster name by webhook

### DIFF
--- a/artifacts/deploy/webhook-configuration.yaml
+++ b/artifacts/deploy/webhook-configuration.yaml
@@ -19,3 +19,25 @@ webhooks:
     sideEffects: None
     admissionReviewVersions: ["v1beta1"]
     timeoutSeconds: 3
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-config
+  labels:
+    app: validating-config
+webhooks:
+  - name: cluster.karmada.io
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["cluster.karmada.io"]
+        apiVersions: ["*"]
+        resources: ["clusters"]
+        scope: "Cluster"
+    clientConfig:
+      url: https://karmada-webhook.karmada-system.svc:443/validate-cluster
+      caBundle: {{caBundle}}
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
+    timeoutSeconds: 3

--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/karmada-io/karmada/cmd/webhook/app/options"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
+	"github.com/karmada-io/karmada/pkg/webhook/cluster"
 	"github.com/karmada-io/karmada/pkg/webhook/overridepolicy"
 )
 
@@ -64,6 +65,7 @@ func Run(opts *options.Options, stopChan <-chan struct{}) error {
 
 	klog.Info("registering webhooks to the webhook server")
 	hookServer := hookManager.GetWebhookServer()
+	hookServer.Register("/validate-cluster", &webhook.Admission{Handler: &cluster.ValidatingAdmission{}})
 	hookServer.Register("/mutate-overridepolicy", &webhook.Admission{Handler: &overridepolicy.MutatingAdmission{}})
 	hookServer.WebhookMux.Handle("/readyz/", http.StripPrefix("/readyz/", &healthz.Handler{}))
 

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -1,0 +1,25 @@
+package validation
+
+import (
+	"fmt"
+
+	kubevalidation "k8s.io/apimachinery/pkg/util/validation"
+)
+
+const clusterNameMaxLength int = 48
+
+// ValidateClusterName tests whether the cluster name passed is valid.
+// If the cluster name is not valid, a list of error strings is returned. Otherwise an empty list (or nil) is returned.
+// Rules of a valid cluster name:
+// - Must be a valid label value as per RFC1123.
+//   * An alphanumeric (a-z, and 0-9) string, with a maximum length of 63 characters,
+//     with the '-' character allowed anywhere except the first or last character.
+// - Length must be less than 48 characters.
+//   * Since cluster name used to generate execution namespace by adding a prefix, so reserve 15 characters for the prefix.
+func ValidateClusterName(name string) []string {
+	if len(name) > clusterNameMaxLength {
+		return []string{fmt.Sprintf("must be no more than %d characters", clusterNameMaxLength)}
+	}
+
+	return kubevalidation.IsDNS1123Label(name)
+}

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -1,0 +1,46 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateClusterName(t *testing.T) {
+	var tests = []struct {
+		name        string
+		cluster     string
+		expectError bool
+	}{
+		{
+			name:        "valid cluster",
+			cluster:     "valid-cluster",
+			expectError: false,
+		},
+		{
+			name:        "contains invalid character is not allowed",
+			cluster:     "invalid.cluster",
+			expectError: true,
+		},
+		{
+			name:        "empty name is not allowed",
+			cluster:     "",
+			expectError: true,
+		},
+		{
+			name:        "too long name is not allowed",
+			cluster:     "abcdefghijklmnopqrstuvwxyz01234567890123456789012", // 49 characters
+			expectError: true,
+		},
+	}
+
+	for _, test := range tests {
+		tc := test
+		errs := ValidateClusterName(tc.cluster)
+		if len(errs) > 0 && tc.expectError != true {
+			t.Fatalf("expect no error but got: %s", strings.Join(errs, ";"))
+		}
+		if len(errs) == 0 && tc.expectError == true {
+			t.Fatalf("expect an error but got none")
+		}
+	}
+}

--- a/pkg/webhook/cluster/validating.go
+++ b/pkg/webhook/cluster/validating.go
@@ -1,0 +1,50 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/util/validation"
+)
+
+// ValidatingAdmission validates cluster object when creating/updating/deleting.
+type ValidatingAdmission struct {
+	decoder *admission.Decoder
+}
+
+// Check if our ValidatingAdmission implements necessary interface
+var _ admission.Handler = &ValidatingAdmission{}
+var _ admission.DecoderInjector = &ValidatingAdmission{}
+
+// Handle implements admission.Handler interface.
+// It yields a response to an AdmissionRequest.
+func (v *ValidatingAdmission) Handle(ctx context.Context, req admission.Request) admission.Response {
+	cluster := &clusterv1alpha1.Cluster{}
+
+	err := v.decoder.Decode(req, cluster)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	klog.V(2).Infof("Validating cluster(%s) for request: %s", cluster.Name, req.Operation)
+
+	if errs := validation.ValidateClusterName(cluster.Name); len(errs) != 0 {
+		errMsg := fmt.Sprintf("invalid cluster name(%s): %s", cluster.Name, strings.Join(errs, ";"))
+		klog.Info(errMsg)
+		return admission.Denied(errMsg)
+	}
+
+	return admission.Allowed("")
+}
+
+// InjectDecoder implements admission.DecoderInjector interface.
+// A decoder will be automatically injected.
+func (v *ValidatingAdmission) InjectDecoder(d *admission.Decoder) error {
+	v.decoder = d
+	return nil
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Restrict cluster names by webhook.

**Which issue(s) this PR fixes**:
Part of #100

**Special notes for your reviewer**:
Trying to create a cluster with name `member3.invalid` will be denied:
```
-bash-4.2# kubectl create -f invalid.yaml 
Error from server (invalid cluster name(member3.invalid): a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')): error when creating "invalid.yaml": admission webhook "cluster.karmada.io" denied the request: invalid cluster name(member3.invalid): a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
```


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

