### PR TITLE
update SpreadConstraint fields, use maxGroups and minGroups instead of maximum and minimum.

### DIFF
--- a/artifacts/deploy/policy.karmada.io_propagationpolicies.yaml
+++ b/artifacts/deploy/policy.karmada.io_propagationpolicies.yaml
@@ -209,24 +209,34 @@ spec:
                       description: SpreadConstraint represents the spread constraints
                         on resources.
                       properties:
-                        maximum:
-                          description: Maximum restricts the maximum number of cluster
-                            units to be selected.
+                        maxGroups:
+                          description: MaxGroups restricts the maximum number of cluster
+                            groups to be selected.
                           type: integer
-                        minimum:
-                          description: Minimum restricts the minimum number of cluster
-                            units to be selected.
+                        minGroups:
+                          description: MinGroups restricts the minimum number of cluster
+                            groups to be selected. Defaults to 1.
                           type: integer
                         spreadByField:
-                          description: 'SpreadByField represents the field used for
-                            grouping member clusters into units. Resources will be
-                            spread among different cluster units. Available field
-                            for spreading are: region, zone, cluster and provider.'
+                          description: 'SpreadByField represents the fields on Karmada
+                            cluster API used for dynamically grouping member clusters
+                            into different groups. Resources will be spread among
+                            different cluster groups. Available fields for spreading
+                            are: cluster, region, zone, and provider. SpreadByField
+                            should not co-exist with SpreadByLabel. If both SpreadByField
+                            and SpreadByLabel are empty, SpreadByField will be set
+                            to "cluster" by system.'
+                          enum:
+                          - cluster
+                          - region
+                          - zone
+                          - provider
                           type: string
                         spreadByLabel:
                           description: SpreadByLabel represents the label key used
-                            for grouping member clusters into units. Resources will
-                            be spread among different cluster units.
+                            for grouping member clusters into different groups. Resources
+                            will be spread among different cluster groups. SpreadByLabel
+                            should not co-exist with SpreadByField.
                           type: string
                       type: object
                     type: array

--- a/pkg/apis/policy/v1alpha1/propagation_types.go
+++ b/pkg/apis/policy/v1alpha1/propagation_types.go
@@ -95,26 +95,44 @@ type Placement struct {
 	SpreadConstraints []SpreadConstraint `json:"spreadConstraints,omitempty"`
 }
 
+// SpreadFieldValue is the type to define valid values for SpreadConstraint.SpreadByField
+type SpreadFieldValue string
+
+// Available fields for spreading are: cluster, region, zone, and provider.
+const (
+	SpreadByCluster  SpreadFieldValue = "cluster"
+	SpreadByRegion   SpreadFieldValue = "region"
+	SpreadByZone     SpreadFieldValue = "zone"
+	SpreadByProvider SpreadFieldValue = "provider"
+)
+
 // SpreadConstraint represents the spread constraints on resources.
 type SpreadConstraint struct {
-	// SpreadByField represents the field used for grouping member clusters into units.
-	// Resources will be spread among different cluster units.
-	// Available field for spreading are: region, zone, cluster and provider.
+	// SpreadByField represents the fields on Karmada cluster API used for
+	// dynamically grouping member clusters into different groups.
+	// Resources will be spread among different cluster groups.
+	// Available fields for spreading are: cluster, region, zone, and provider.
+	// SpreadByField should not co-exist with SpreadByLabel.
+	// If both SpreadByField and SpreadByLabel are empty, SpreadByField will be set to "cluster" by system.
+	// +kubebuilder:validation:Enum=cluster;region;zone;provider
 	// +optional
-	SpreadByField string `json:"spreadByField,omitempty"`
+	SpreadByField SpreadFieldValue `json:"spreadByField,omitempty"`
 
-	// SpreadByLabel represents the label key used for grouping member clusters into units.
-	// Resources will be spread among different cluster units.
+	// SpreadByLabel represents the label key used for
+	// grouping member clusters into different groups.
+	// Resources will be spread among different cluster groups.
+	// SpreadByLabel should not co-exist with SpreadByField.
 	// +optional
 	SpreadByLabel string `json:"spreadByLabel,omitempty"`
 
-	// Maximum restricts the maximum number of cluster units to be selected.
+	// MaxGroups restricts the maximum number of cluster groups to be selected.
 	// +optional
-	Maximum int `json:"maximum,omitempty"`
+	MaxGroups int `json:"maxGroups,omitempty"`
 
-	// Minimum restricts the minimum number of cluster units to be selected.
+	// MinGroups restricts the minimum number of cluster groups to be selected.
+	// Defaults to 1.
 	// +optional
-	Minimum int `json:"minimum,omitempty"`
+	MinGroups int `json:"minGroups,omitempty"`
 }
 
 // ClusterAffinity represents the filter to select clusters.


### PR DESCRIPTION
Signed-off-by: Kevin Wang <kevinwzf0126@gmail.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:


/kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Improve API readability, use maxGroups and minGroups instead of maximum and minimum in spreadConstraint

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Improve API readability, use maxGroups and minGroups instead of maximum and minimum in spreadConstraint
```

