### PR TITLE
enable karmada-scheduler health check endpoint /healthz

### DIFF
--- a/artifacts/deploy/karmada-scheduler.yaml
+++ b/artifacts/deploy/karmada-scheduler.yaml
@@ -26,6 +26,8 @@ spec:
           command:
             - /bin/karmada-scheduler
             - --kubeconfig=/etc/kubeconfig
+            - --bind-address=0.0.0.0
+            - --secure-port=10351
           volumeMounts:
             - name: kubeconfig
               subPath: kubeconfig

--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -9,6 +9,11 @@ import (
 	componentbaseconfig "k8s.io/component-base/config"
 )
 
+const (
+	defaultBindAddress = "0.0.0.0"
+	defaultPort        = 10351
+)
+
 var (
 	defaultElectionLeaseDuration = metav1.Duration{Duration: 15 * time.Second}
 	defaultElectionRenewDeadline = metav1.Duration{Duration: 10 * time.Second}
@@ -20,6 +25,10 @@ type Options struct {
 	LeaderElection componentbaseconfig.LeaderElectionConfiguration
 	KubeConfig     string
 	Master         string
+	// BindAddress is the IP address on which to listen for the --secure-port port.
+	BindAddress string
+	// SecurePort is the port that the server serves at.
+	SecurePort int
 }
 
 // NewOptions builds an default scheduler options.
@@ -45,4 +54,6 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.LeaderElection.ResourceNamespace, "lock-namespace", "", "Define the namespace of the lock object.")
 	fs.StringVar(&o.KubeConfig, "kubeconfig", o.KubeConfig, "Path to a KubeConfig. Only required if out-of-cluster.")
 	fs.StringVar(&o.Master, "master", o.Master, "The address of the Kubernetes API server. Overrides any value in KubeConfig. Only required if out-of-cluster.")
+	fs.StringVar(&o.BindAddress, "bind-address", defaultBindAddress, "The IP address on which to listen for the --secure-port port.")
+	fs.IntVar(&o.SecurePort, "secure-port", defaultPort, "The secure port on which to serve HTTPS.")
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

enable `karmada-scheduler` health check endpoint /healthz.

```
# curl http://10.244.0.8:10358/healthz
OK
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

