### PR TITLE
improve spreadByField consts naming

### DIFF
--- a/pkg/apis/policy/v1alpha1/propagation_types.go
+++ b/pkg/apis/policy/v1alpha1/propagation_types.go
@@ -100,10 +100,10 @@ type SpreadFieldValue string
 
 // Available fields for spreading are: cluster, region, zone, and provider.
 const (
-	SpreadByCluster  SpreadFieldValue = "cluster"
-	SpreadByRegion   SpreadFieldValue = "region"
-	SpreadByZone     SpreadFieldValue = "zone"
-	SpreadByProvider SpreadFieldValue = "provider"
+	SpreadByFieldCluster  SpreadFieldValue = "cluster"
+	SpreadByFieldRegion   SpreadFieldValue = "region"
+	SpreadByFieldZone     SpreadFieldValue = "zone"
+	SpreadByFieldProvider SpreadFieldValue = "provider"
 )
 
 // SpreadConstraint represents the spread constraints on resources.

--- a/pkg/webhook/propagationpolicy/mutating.go
+++ b/pkg/webhook/propagationpolicy/mutating.go
@@ -41,8 +41,8 @@ func (a *MutatingAdmission) Handle(ctx context.Context, req admission.Request) a
 	spreadConstraints := policy.Spec.Placement.SpreadConstraints
 	for i := range spreadConstraints {
 		if len(spreadConstraints[i].SpreadByLabel) == 0 && len(spreadConstraints[i].SpreadByField) == 0 {
-			klog.Infof("Setting default SpreadByField with %s", policyv1alpha1.SpreadByCluster)
-			spreadConstraints[i].SpreadByField = policyv1alpha1.SpreadByCluster
+			klog.Infof("Setting default SpreadByField with %s", policyv1alpha1.SpreadByFieldCluster)
+			spreadConstraints[i].SpreadByField = policyv1alpha1.SpreadByFieldCluster
 		}
 
 		if spreadConstraints[i].MinGroups == 0 {


### PR DESCRIPTION
Signed-off-by: Kevin Wang <kevinwzf0126@gmail.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

/kind api-change
> /kind bug

/kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Improve the naming:

	SpreadByCluster    =>    SpreadByFieldCluster 
	SpreadByRegion     =>    SpreadByFieldRegion  
	SpreadByZone       =>    SpreadByFieldZone    
	SpreadByProvider   =>    SpreadByFieldProvider

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

