### PR TITLE
Namespace Sameness Feature implementation

### DIFF
--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/controllers/cluster"
 	"github.com/karmada-io/karmada/pkg/controllers/execution"
 	"github.com/karmada-io/karmada/pkg/controllers/hpa"
+	"github.com/karmada-io/karmada/pkg/controllers/namespace"
 	"github.com/karmada-io/karmada/pkg/controllers/propagationpolicy"
 	"github.com/karmada-io/karmada/pkg/controllers/status"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
@@ -167,5 +168,13 @@ func setupControllers(mgr controllerruntime.Manager, stopChan <-chan struct{}) {
 	workStatusController.RunWorkQueue()
 	if err := workStatusController.SetupWithManager(mgr); err != nil {
 		klog.Fatalf("Failed to setup work status controller: %v", err)
+	}
+
+	namespaceSyncController := &namespace.Controller{
+		Client:        mgr.GetClient(),
+		EventRecorder: mgr.GetEventRecorderFor(namespace.ControllerName),
+	}
+	if err := namespaceSyncController.SetupWithManager(mgr); err != nil {
+		klog.Fatalf("Failed to setup namespace sync controller: %v", err)
 	}
 }

--- a/pkg/controllers/namespace/namespace_sync_controller.go
+++ b/pkg/controllers/namespace/namespace_sync_controller.go
@@ -1,0 +1,176 @@
+package namespace
+
+import (
+	"context"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/names"
+)
+
+const (
+	// ControllerName is the controller name that will be used when reporting events.
+	ControllerName              = "namespace-sync-controller"
+	namespaceKarmadaSystem      = "karmada-system"
+	namespaceKarmadaCluster     = "karmada-cluster"
+	namespaceDefault            = "default"
+	karmadaExecutionSpacePrefix = "karmada-es-"
+	kubeSystemNamespacePrefix   = "kube-"
+)
+
+// Controller is to sync Work.
+type Controller struct {
+	client.Client // used to operate Work resources.
+	EventRecorder record.EventRecorder
+}
+
+// Reconcile performs a full reconciliation for the object referred to by the Request.
+// The Controller will requeue the Request to be processed again if an error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (c *Controller) Reconcile(req controllerruntime.Request) (controllerruntime.Result, error) {
+	klog.V(4).Infof("Namespaces sync controller reconciling %s", req.NamespacedName.String())
+	if !c.namespaceShouldBeSynced(req.Name) {
+		return controllerruntime.Result{}, nil
+	}
+
+	namespace := &v1.Namespace{}
+	if err := c.Client.Get(context.TODO(), req.NamespacedName, namespace); err != nil {
+		// The resource may no longer exist, in which case we stop processing.
+		if errors.IsNotFound(err) {
+			return controllerruntime.Result{}, nil
+		}
+
+		return controllerruntime.Result{Requeue: true}, err
+	}
+
+	if !namespace.DeletionTimestamp.IsZero() {
+		// Do nothing, just return as we have added owner reference to Work.
+		// Work will be removed automatically by garbage collector.
+		return controllerruntime.Result{}, nil
+	}
+
+	clusterList := &v1alpha1.ClusterList{}
+	if err := c.Client.List(context.TODO(), clusterList); err != nil {
+		klog.Errorf("Failed to list clusters, error: %v", err)
+		return controllerruntime.Result{Requeue: true}, err
+	}
+
+	err := c.buildWorks(namespace, clusterList.Items)
+	if err != nil {
+		klog.Errorf("Failed to build work for namespace %s. Error: %v.", namespace.GetName(), err)
+		return controllerruntime.Result{Requeue: true}, err
+	}
+
+	return controllerruntime.Result{}, nil
+}
+
+func (c *Controller) namespaceShouldBeSynced(namespace string) bool {
+	if namespace == namespaceKarmadaCluster || namespace == namespaceKarmadaSystem || namespace == namespaceDefault ||
+		strings.HasPrefix(namespace, karmadaExecutionSpacePrefix) || strings.HasPrefix(namespace, kubeSystemNamespacePrefix) {
+		return false
+	}
+	return true
+}
+
+func (c *Controller) buildWorks(namespace *v1.Namespace, clusters []v1alpha1.Cluster) error {
+	uncastObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(namespace)
+	if err != nil {
+		klog.Errorf("Failed to transform namespace %s. Error: %v", namespace.GetName(), err)
+		return nil
+	}
+	namespaceObj := &unstructured.Unstructured{Object: uncastObj}
+	util.RemoveIrrelevantField(namespaceObj)
+
+	for _, cluster := range clusters {
+		namespaceJSON, err := namespaceObj.MarshalJSON()
+		if err != nil {
+			klog.Errorf("Failed to marshal namespace %s. Error: %v", namespaceObj.GetName(), err)
+			return err
+		}
+
+		executionSpace, err := names.GenerateExecutionSpaceName(cluster.Name)
+		if err != nil {
+			klog.Errorf("Failed to generate execution space name for member cluster %s, err is %v", cluster.Name, err)
+			return err
+		}
+
+		workName := names.GenerateClusterResourceBindingName(namespaceObj.GetKind(), namespaceObj.GetName())
+		objectMeta := metav1.ObjectMeta{
+			Name:       workName,
+			Namespace:  executionSpace,
+			Finalizers: []string{util.ExecutionControllerFinalizer},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(namespace, namespace.GroupVersionKind()),
+			},
+			Labels: map[string]string{util.OwnerLabel: names.GenerateOwnerLabelValueForClusterResourceBinding(ControllerName + "." + namespace.GetName())},
+		}
+
+		err = util.CreateOrUpdateWork(c.Client, objectMeta, namespaceJSON)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SetupWithManager creates a controller and register to controller manager.
+func (c *Controller) SetupWithManager(mgr controllerruntime.Manager) error {
+	namespaceFn := handler.ToRequestsFunc(
+		func(a handler.MapObject) []reconcile.Request {
+			var requests []reconcile.Request
+			namespaceList := &v1.NamespaceList{}
+			if err := c.Client.List(context.TODO(), namespaceList); err != nil {
+				klog.Errorf("Failed to list namespace, error: %v", err)
+				return nil
+			}
+
+			for _, namespace := range namespaceList.Items {
+				requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+					Name: namespace.Name,
+				}})
+			}
+			return requests
+		})
+
+	predicate := builder.WithPredicates(predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			if e.Meta == nil {
+				klog.Errorf("CreateEvent received with no metadata, event: %v", e)
+				return false
+			}
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	})
+
+	return controllerruntime.NewControllerManagedBy(mgr).
+		For(&v1.Namespace{}).Watches(&source.Kind{Type: &v1alpha1.Cluster{}}, &handler.EnqueueRequestsFromMapFunc{
+		ToRequests: namespaceFn},
+		predicate).Complete(c)
+}

--- a/pkg/util/names/names.go
+++ b/pkg/util/names/names.go
@@ -40,9 +40,19 @@ func GenerateBindingName(namespace, kind, name string) string {
 	return strings.ToLower(namespace + "-" + kind + "-" + name)
 }
 
+// GenerateClusterResourceBindingName will generate ClusterResourceBinding name by kind and name
+func GenerateClusterResourceBindingName(kind, name string) string {
+	return strings.ToLower(kind + "-" + name)
+}
+
 // GenerateOwnerLabelValue will get owner label value.
 func GenerateOwnerLabelValue(namespace, name string) string {
 	return namespace + "." + name
+}
+
+// GenerateOwnerLabelValueForClusterResourceBinding will get owner label value for ClusterResourceBinding.
+func GenerateOwnerLabelValueForClusterResourceBinding(name string) string {
+	return name
 }
 
 // GenerateServiceAccountName generates the name of a ServiceAccount.


### PR DESCRIPTION
Signed-off-by: lihanbo <lihanbo2@huawei.com>

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
add namespace sync controller

Please refer to [namespace-sameness-position-statement](https://github.com/kubernetes/community/blob/master/sig-multicluster/namespace-sameness-position-statement.md)

**Which issue(s) this PR fixes**:
Ref #175 

**Special notes for your reviewer**:
![image](https://user-images.githubusercontent.com/74236054/109126446-326a0a80-7788-11eb-8863-b931635c7d4c.png)


**Does this PR introduce a user-facing change?**:
```
Namespace Sameness Feature is introduced which syncing namespaces from `Karmada` API server to all of the member clusters automatically.
```

