### PR TITLE
Deprecated PolicyClaimLabel and replace with new labels

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,9 +1,15 @@
 package util
 
 const (
-	// PolicyClaimLabel will set in kubernetes resource, indicates that
-	// the resource is occupied by propagationPolicy
-	PolicyClaimLabel = "karmada.io/driven-by"
+	// PropagationPolicyNamespaceLabel is added to objects to specify associated PropagationPolicy namespace.
+	PropagationPolicyNamespaceLabel = "propagationpolicy.karmada.io/namespace"
+
+	// PropagationPolicyNameLabel is added to objects to specify associated PropagationPolicy's name.
+	PropagationPolicyNameLabel = "propagationpolicy.karmada.io/name"
+
+	// ClusterPropagationPolicyLabel is added to objects to specify associated ClusterPropagationPolicy.
+	ClusterPropagationPolicyLabel = "clusterpropagationpolicy.karmada.io/name"
+
 	// OwnerLabel will set in karmada CRDs, indicates that who created it.
 	// We can use labelSelector to find who created it quickly.
 	// example1: set it in propagationBinding, the label value is propagationPolicy.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Current `PolicyClaimLabel = "karmada.io/driven-by"` can't clearly describe which policy an object associated with, especially.

Replaced with following labels:
- PropagationPolicyNamespaceLabel = "propagationpolicy.karmada.io/namespace"
- PropagationPolicyNameLabel = "propagationpolicy.karmada.io/name"
- ClusterPropagationPolicyLabel = "clusterpropagationpolicy.karmada.io/name"

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

