### PR TITLE
Remove Accepted field from Cluster API

### DIFF
--- a/artifacts/deploy/cluster.karmada.io_clusters.yaml
+++ b/artifacts/deploy/cluster.karmada.io_clusters.yaml
@@ -47,13 +47,6 @@ spec:
             description: Spec represents the specification of the desired behavior
               of member cluster.
             properties:
-              accepted:
-                description: Accepted represents if the member cluster has been accepted
-                  by control plane. Default value is false. If member cluster working
-                  in 'Delegation' mode, this always be true. If member cluster working
-                  in 'SelfManagement' mode, this will turn to true only after administrator
-                  accepted the request from member cluster.
-                type: boolean
               apiEndpoint:
                 description: The API endpoint of the member cluster. This can be a
                   hostname, hostname:port, IP or IP:port.

--- a/pkg/apis/cluster/v1alpha1/types.go
+++ b/pkg/apis/cluster/v1alpha1/types.go
@@ -34,14 +34,6 @@ type ClusterSpec struct {
 	// +optional
 	ManageMode ClusterManageMode `json:"manageMode,omitempty"`
 
-	// Accepted represents if the member cluster has been accepted by control plane.
-	// Default value is false.
-	// If member cluster working in 'Delegation' mode, this always be true.
-	// If member cluster working in 'SelfManagement' mode, this will turn to true only after administrator
-	// accepted the request from member cluster.
-	// +optional
-	Accepted bool `json:"accepted,omitempty"`
-
 	// The API endpoint of the member cluster. This can be a hostname,
 	// hostname:port, IP or IP:port.
 	// +optional


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
Remove `Accepted` field from Cluster API, the registration process should be re-designed in the future.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @Dingshujie 