### PR TITLE
Scheduler support ClusterResourceBinding

### DIFF
--- a/pkg/util/detector/detector.go
+++ b/pkg/util/detector/detector.go
@@ -442,7 +442,7 @@ func (d *ResourceDetector) BuildResourceBinding(object *unstructured.Unstructure
 
 // BuildClusterResourceBinding builds a desired ClusterResourceBinding for object.
 func (d *ResourceDetector) BuildClusterResourceBinding(object *unstructured.Unstructured, objectKey ClusterWideKey, policy *policyv1alpha1.ClusterPropagationPolicy) *workv1alpha1.ClusterResourceBinding {
-	bindingName := names.GenerateBindingName(object.GetNamespace(), object.GetKind(), object.GetName())
+	bindingName := names.GenerateClusterResourceBindingName(object.GetKind(), object.GetName())
 	binding := &workv1alpha1.ClusterResourceBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: bindingName,


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind feature

**What this PR does / why we need it**:
When developing the failover feature, we refactored the logic about the scheduler and forgot to schedule `ClusterResourceBinding`.
That's a mistake for the v0.4 release.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
For `Binding` names changes, let's do it by separated PR.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
cc @GitHubxsy @tinyma123 @XiShanYongYe-Chang 
