### PR TITLE
suppress some useless logs

### DIFF
--- a/pkg/util/helper/workstatus.go
+++ b/pkg/util/helper/workstatus.go
@@ -28,7 +28,7 @@ func AggregateResourceBindingWorkStatus(c client.Client, binding *workv1alpha1.R
 	}
 
 	if reflect.DeepEqual(binding.Status.AggregatedStatus, aggregatedStatuses) {
-		klog.Infof("New aggregatedStatuses are equal with old resourceBinding(%s/%s) AggregatedStatus, no update required.",
+		klog.V(4).Infof("New aggregatedStatuses are equal with old resourceBinding(%s/%s) AggregatedStatus, no update required.",
 			binding.Namespace, binding.Name)
 		return nil
 	}

--- a/pkg/util/objectwatcher/objectwatcher.go
+++ b/pkg/util/objectwatcher/objectwatcher.go
@@ -52,7 +52,6 @@ func NewObjectWatcher(client client.Client, kubeClientSet kubernetes.Interface, 
 }
 
 func (o *objectWatcherImpl) Create(clusterName string, desireObj *unstructured.Unstructured) error {
-	klog.Infof("Start to create resource %v/%v", desireObj.GetNamespace(), desireObj.GetName())
 	dynamicClusterClient, err := util.BuildDynamicClusterClient(o.Client, o.KubeClientSet, clusterName)
 	if err != nil {
 		klog.Errorf("Failed to build dynamic cluster client for cluster %s.", clusterName)
@@ -73,6 +72,7 @@ func (o *objectWatcherImpl) Create(clusterName string, desireObj *unstructured.U
 		klog.Errorf("Failed to create resource %v, err is %v ", desireObj.GetName(), err)
 		return err
 	}
+	klog.Infof("Created resource(kind=%s, %s/%s) on cluster: %s", desireObj.GetKind(), desireObj.GetNamespace(), desireObj.GetName(), clusterName)
 
 	// record version
 	o.recordVersion(clusterObj, dynamicClusterClient.ClusterName)
@@ -80,7 +80,6 @@ func (o *objectWatcherImpl) Create(clusterName string, desireObj *unstructured.U
 }
 
 func (o *objectWatcherImpl) Update(clusterName string, desireObj, clusterObj *unstructured.Unstructured) error {
-	klog.Infof("Start to update resource %v/%v", desireObj.GetNamespace(), desireObj.GetName())
 	dynamicClusterClient, err := util.BuildDynamicClusterClient(o.Client, o.KubeClientSet, clusterName)
 	if err != nil {
 		klog.Errorf("Failed to build dynamic cluster client for cluster %s.", clusterName)
@@ -105,13 +104,14 @@ func (o *objectWatcherImpl) Update(clusterName string, desireObj, clusterObj *un
 		return err
 	}
 
+	klog.Infof("Updated resource(kind=%s, %s/%s) on cluster: %s", desireObj.GetKind(), desireObj.GetNamespace(), desireObj.GetName(), clusterName)
+
 	// record version
 	o.recordVersion(resource, clusterName)
 	return nil
 }
 
 func (o *objectWatcherImpl) Delete(clusterName string, desireObj *unstructured.Unstructured) error {
-	klog.Infof("Start to delete resource %v/%v", desireObj.GetNamespace(), desireObj.GetName())
 	dynamicClusterClient, err := util.BuildDynamicClusterClient(o.Client, o.KubeClientSet, clusterName)
 	if err != nil {
 		klog.Errorf("Failed to build dynamic cluster client for cluster %s.", clusterName)
@@ -132,6 +132,7 @@ func (o *objectWatcherImpl) Delete(clusterName string, desireObj *unstructured.U
 		klog.Errorf("Failed to delete resource %v, err is %v ", desireObj.GetName(), err)
 		return err
 	}
+	klog.Infof("Deleted resource(kind=%s, %s/%s) on cluster: %s", desireObj.GetKind(), desireObj.GetNamespace(), desireObj.GetName(), clusterName)
 
 	objectKey := o.genObjectKey(desireObj)
 	o.deleteVersionRecord(dynamicClusterClient.ClusterName, objectKey)

--- a/pkg/util/worker.go
+++ b/pkg/util/worker.go
@@ -111,7 +111,8 @@ func GenerateKey(obj interface{}) (QueueKey, error) {
 func getClusterNameFromLabel(resource *unstructured.Unstructured) (string, error) {
 	workNamespace := GetLabelValue(resource.GetLabels(), WorkNamespaceLabel)
 	if len(workNamespace) == 0 {
-		klog.Infof("Resource(%s/%s/%s) not created by karmada", resource.GetKind(), resource.GetNamespace(), resource.GetName())
+		klog.V(4).Infof("Ignore resource(%s/%s/%s) which not managed by karmada", resource.GetKind(), resource.GetNamespace(), resource.GetName())
+		return "", nil
 	}
 
 	cluster, err := names.GetClusterName(workNamespace)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Minor change: suppress some useless logs:
```
I0318 09:45:08.661776       1 worker.go:114] Resource(Deployment/kube-system/coredns) not created by karmada
E0318 09:45:08.661792       1 worker.go:119] Failed to get cluster name from work namespace: , error: the execution space name is in wrong format.
W0318 09:45:08.661800       1 worker.go:150] Failed to generate key for obj: apps/v1, Kind=Deployment
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

