### PR TITLE
modify crd names with random string in e2e test

### DIFF
--- a/test/helper/resource.go
+++ b/test/helper/resource.go
@@ -1,6 +1,8 @@
 package helper
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -98,23 +100,18 @@ func NewPod(namespace string, name string) *corev1.Pod {
 }
 
 // NewCustomResourceDefinition will build a CRD object.
-func NewCustomResourceDefinition(scope apiextensionsv1.ResourceScope) *apiextensionsv1.CustomResourceDefinition {
+func NewCustomResourceDefinition(group string, specNames apiextensionsv1.CustomResourceDefinitionNames, scope apiextensionsv1.ResourceScope) *apiextensionsv1.CustomResourceDefinition {
 	return &apiextensionsv1.CustomResourceDefinition{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apiextensions.k8s.io/v1",
 			Kind:       "CustomResourceDefinition",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "foos.example.karmada.io",
+			Name: fmt.Sprintf("%s.%s", specNames.Plural, group),
 		},
 		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
-			Group: "example.karmada.io",
-			Names: apiextensionsv1.CustomResourceDefinitionNames{
-				Kind:     "Foo",
-				ListKind: "FooList",
-				Plural:   "foos",
-				Singular: "foo",
-			},
+			Group: group,
+			Names: specNames,
 			Scope: scope,
 			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 				{
@@ -179,11 +176,11 @@ func NewCustomResourceDefinition(scope apiextensionsv1.ResourceScope) *apiextens
 }
 
 // NewCustomResource will build a CR object with CRD Foo.
-func NewCustomResource(namespace, name string) *unstructured.Unstructured {
+func NewCustomResource(apiVersion, kind, namespace, name string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "example.karmada.io/v1alpha1",
-			"kind":       "Foo",
+			"apiVersion": apiVersion,
+			"kind":       kind,
 			"metadata": map[string]string{
 				"namespace": namespace,
 				"name":      name,


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

> /kind cleanup

**What this PR does / why we need it**:

Current name of the crd resource used by e2e test are same, as a result, conflicts occur during running. Modify crd names with random string to prevent conflicts.

```
[BasicClusterPropagation] basic cluster propagation testing CustomResourceDefinition propagation testing 
  crd propagation testing
  /root/karmada/test/e2e/clusterpropagationpolicy_test.go:50
STEP: creating crdPolicy(foobhls.example-vtd.karmada.io)
STEP: creating crd(foobhls.example-vtd.karmada.io)
STEP: get crd(foobhls.example-vtd.karmada.io)
STEP: check if crd present on member clusters
I0324 09:36:42.112407 2839661 clusterpropagationpolicy_test.go:69] Waiting for crd(foobhls.example-vtd.karmada.io) present on cluster(member1)
I0324 09:36:47.117472 2839661 clusterpropagationpolicy_test.go:69] Waiting for crd(foobhls.example-vtd.karmada.io) present on cluster(member2)
STEP: removing crd(foobhls.example-vtd.karmada.io)
STEP: check if crd disappeared from member clusters
I0324 09:36:52.130346 2839661 clusterpropagationpolicy_test.go:94] Waiting for crd(foobhls.example-vtd.karmada.io) disappeared on cluster(member1)
I0324 09:36:57.134495 2839661 clusterpropagationpolicy_test.go:94] Waiting for crd(foobhls.example-vtd.karmada.io) disappeared on cluster(member2)
STEP: removing crdPolicy(foobhls.example-vtd.karmada.io)

Ran 1 of 10 Specs in 20.248 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 9 Skipped
PASS
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
None
```

