### PR TITLE
add judgment with work label when joining binding queue

### DIFF
--- a/pkg/controllers/binding/binding_controller.go
+++ b/pkg/controllers/binding/binding_controller.go
@@ -113,6 +113,11 @@ func (c *ResourceBindingController) SetupWithManager(mgr controllerruntime.Manag
 			var requests []reconcile.Request
 
 			labels := a.Meta.GetLabels()
+			_, namespaceExist := labels[util.ResourceBindingNamespaceLabel]
+			_, nameExist := labels[util.ResourceBindingNameLabel]
+			if !namespaceExist || !nameExist {
+				return nil
+			}
 			namespacesName := types.NamespacedName{
 				Namespace: labels[util.ResourceBindingNamespaceLabel],
 				Name:      labels[util.ResourceBindingNameLabel],

--- a/pkg/controllers/binding/cluster_resource_binding_controller.go
+++ b/pkg/controllers/binding/cluster_resource_binding_controller.go
@@ -108,6 +108,10 @@ func (c *ClusterResourceBindingController) SetupWithManager(mgr controllerruntim
 			var requests []reconcile.Request
 
 			labels := a.Meta.GetLabels()
+			_, nameExist := labels[util.ClusterResourceBindingLabel]
+			if !nameExist {
+				return nil
+			}
 			namespacesName := types.NamespacedName{
 				Name: labels[util.ClusterResourceBindingLabel],
 			}


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

> /kind cleanup

**What this PR does / why we need it**:

When the status of  work changes, add judgment with work label to distinguish whether the work is produced by resourcebinding or clusterresourcebinding, and eventually add them to their respective queues.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```