### PR TITLE
update workload's labels when it's policy has been deleted

### DIFF
--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -107,6 +107,7 @@ func setupControllers(mgr controllerruntime.Manager, stopChan <-chan struct{}) {
 		Client:             mgr.GetClient(),
 		InformerManager:    informermanager.NewSingleClusterInformerManager(dynamicClientSet, 0),
 		RESTMapper:         mgr.GetRESTMapper(),
+		DynamicClient:      dynamicClientSet,
 	}
 	resourceDetector.EventHandler = informermanager.NewFilteringHandlerOnAllEvents(resourceDetector.EventFilter, resourceDetector.OnAdd, resourceDetector.OnUpdate, resourceDetector.OnDelete)
 	resourceDetector.Processor = util.NewAsyncWorker("resource detector", time.Microsecond, detector.ClusterWideKeyFunc, resourceDetector.Reconcile)


### PR DESCRIPTION
**What type of PR is this?**
Cleanup status from resource template after policy removed

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #243 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

