### PR TITLE
add deploymentStatus collection testing

### DIFF
--- a/test/e2e/propagationpolicy_test.go
+++ b/test/e2e/propagationpolicy_test.go
@@ -22,18 +22,6 @@ import (
 	"github.com/karmada-io/karmada/test/helper"
 )
 
-const (
-	deploymentNamePrefix = "deploy-"
-	serviceNamePrefix    = "service-"
-	podNamePrefix        = "pod-"
-	crdNamePrefix        = "cr-"
-
-	updateDeploymentReplicas = 6
-	updateServicePort        = 81
-	updatePodImage           = "nginx:latest"
-	updateCRnamespace        = "e2e-test"
-)
-
 // BasicPropagation focus on basic propagation functionality testing.
 var _ = ginkgo.Describe("[BasicPropagation] basic propagation testing", func() {
 	ginkgo.Context("Deployment propagation testing", func() {

--- a/test/e2e/resource_test.go
+++ b/test/e2e/resource_test.go
@@ -1,0 +1,110 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
+
+	"github.com/karmada-io/karmada/test/helper"
+)
+
+var _ = ginkgo.Describe("[resource-status collection] resource status collection testing", func() {
+
+	ginkgo.Context("DeploymentStatus collection testing", func() {
+		policyNamespace := testNamespace
+		policyName := deploymentNamePrefix + rand.String(RandomStrLength)
+		deploymentNamespace := testNamespace
+		deploymentName := policyName
+
+		deployment := helper.NewDeployment(deploymentNamespace, deploymentName)
+		policy := helper.NewPolicyWithSingleDeployment(policyNamespace, policyName, deployment, clusterNames)
+
+		ginkgo.BeforeEach(func() {
+			ginkgo.By(fmt.Sprintf("creating policy(%s/%s)", policyNamespace, policyName), func() {
+				_, err := karmadaClient.PolicyV1alpha1().PropagationPolicies(policyNamespace).Create(context.TODO(), policy, metav1.CreateOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+
+		ginkgo.AfterEach(func() {
+			ginkgo.By(fmt.Sprintf("removing policy(%s/%s)", policyNamespace, policyName), func() {
+				err := karmadaClient.PolicyV1alpha1().PropagationPolicies(policyNamespace).Delete(context.TODO(), policyName, metav1.DeleteOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+
+		ginkgo.It("deployment status collection testing", func() {
+			ginkgo.By(fmt.Sprintf("creating deployment(%s/%s)", deploymentNamespace, deploymentName), func() {
+				_, err := kubeClient.AppsV1().Deployments(testNamespace).Create(context.TODO(), deployment, metav1.CreateOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+
+			ginkgo.By("check whether the deployment status can be correctly collected", func() {
+				wantedReplicas := *deployment.Spec.Replicas * int32(len(clusters))
+
+				klog.Infof("Waiting for deployment(%s/%s) collecting correctly status", deploymentNamespace, deploymentName)
+				err := wait.Poll(pollInterval, pollTimeout, func() (done bool, err error) {
+					currentDeployment, err := kubeClient.AppsV1().Deployments(testNamespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+					if currentDeployment.Status.ReadyReplicas == wantedReplicas &&
+						currentDeployment.Status.AvailableReplicas == wantedReplicas &&
+						currentDeployment.Status.UpdatedReplicas == wantedReplicas &&
+						currentDeployment.Status.Replicas == wantedReplicas {
+						return true, nil
+					}
+
+					return false, nil
+				})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+
+			ginkgo.By("updating deployment replicas", func() {
+				patch := map[string]interface{}{
+					"spec": map[string]interface{}{
+						"replicas": pointer.Int32Ptr(updateDeploymentReplicas),
+					},
+				}
+				bytes, err := json.Marshal(patch)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+				_, err = kubeClient.AppsV1().Deployments(deploymentNamespace).Patch(context.TODO(), deploymentName, types.StrategicMergePatchType, bytes, metav1.PatchOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+
+			ginkgo.By("check if deployment status has been update whit new collection", func() {
+				wantedReplicas := updateDeploymentReplicas * int32(len(clusters))
+
+				klog.Infof("Waiting for deployment(%s/%s) collecting correctly status", deploymentNamespace, deploymentName)
+				err := wait.Poll(pollInterval, pollTimeout, func() (done bool, err error) {
+					currentDeployment, err := kubeClient.AppsV1().Deployments(testNamespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+					if currentDeployment.Status.ReadyReplicas == wantedReplicas &&
+						currentDeployment.Status.AvailableReplicas == wantedReplicas &&
+						currentDeployment.Status.UpdatedReplicas == wantedReplicas &&
+						currentDeployment.Status.Replicas == wantedReplicas {
+						return true, nil
+					}
+
+					return false, nil
+				})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+
+			ginkgo.By(fmt.Sprintf("removing deployment(%s/%s)", deploymentNamespace, deploymentName), func() {
+				err := kubeClient.AppsV1().Deployments(testNamespace).Delete(context.TODO(), deploymentName, metav1.DeleteOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+	})
+})

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -45,6 +45,18 @@ const (
 	RandomStrLength = 3
 )
 
+const (
+	deploymentNamePrefix = "deploy-"
+	serviceNamePrefix    = "service-"
+	podNamePrefix        = "pod-"
+	crdNamePrefix        = "cr-"
+
+	updateDeploymentReplicas = 6
+	updateServicePort        = 81
+	updatePodImage           = "nginx:latest"
+	updateCRnamespace        = "e2e-test"
+)
+
 var (
 	kubeconfig            string
 	restConfig            *rest.Config


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

> /kind cleanup

**What this PR does / why we need it**:

add deploymentStatus collection testing:

[resource-status collection] resource status collection testing DeploymentStatus collection testing 
  deployment status collection testing
  /root/karmada/test/e2e/resource_test.go:45
STEP: creating policy(karmadatest-m25/deploy-z4b)
STEP: creating deployment(karmadatest-m25/deploy-z4b)
STEP: check whether the deployment status can be correctly collected
I0402 12:10:15.027099 1350995 resource_test.go:54] Waiting for deployment(karmadatest-m25/deploy-z4b) collecting correctly status
STEP: updating deployment replicas
STEP: check if deployment status has been update whit new collection
I0402 12:10:20.036777 1350995 resource_test.go:87] Waiting for deployment(karmadatest-m25/deploy-z4b) collecting correctly status
STEP: removing deployment(karmadatest-m25/deploy-z4b)
STEP: removing policy(karmadatest-m25/deploy-z4b)

Ran 1 of 11 Specs in 10.263 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 10 Skipped
PASS


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

