### PR TITLE
Cleanup status from resource template after binding object removed

### DIFF
--- a/pkg/util/informermanager/handlers.go
+++ b/pkg/util/informermanager/handlers.go
@@ -5,7 +5,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
 )
 
 // NewHandlerOnAllEvents builds a ResourceEventHandler that the function 'fn' will be called on all events(add/update/delete).
@@ -13,13 +12,11 @@ func NewHandlerOnAllEvents(fn func(runtime.Object)) cache.ResourceEventHandler {
 	return &cache.ResourceEventHandlerFuncs{
 		AddFunc: func(cur interface{}) {
 			curObj := cur.(runtime.Object)
-			klog.V(2).Infof("Receive add event, obj is: %+v", curObj)
 			fn(curObj)
 		},
 		UpdateFunc: func(old, cur interface{}) {
 			curObj := cur.(runtime.Object)
 			if !reflect.DeepEqual(old, cur) {
-				klog.V(2).Infof("Receive update event, obj is: %+v", curObj)
 				fn(curObj)
 			}
 		},
@@ -32,7 +29,6 @@ func NewHandlerOnAllEvents(fn func(runtime.Object)) cache.ResourceEventHandler {
 				}
 			}
 			oldObj := old.(runtime.Object)
-			klog.V(2).Infof("Receive delete event, obj is: %+v", oldObj)
 			fn(oldObj)
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

```bash
-bash-4.2# kubectl get deployments.apps 
NAME    READY   UP-TO-DATE   AVAILABLE   AGE
nginx   0/1     0            0           17m
-bash-4.2# kubectl create -f samples/nginx/propagationpolicy.yaml 
propagationpolicy.policy.karmada.io/nginx-propagation created
-bash-4.2# kubectl get deployments.apps 
NAME    READY   UP-TO-DATE   AVAILABLE   AGE
nginx   1/1     1            1           18m
-bash-4.2# kubectl delete -f samples/nginx/propagationpolicy.yaml 
propagationpolicy.policy.karmada.io "nginx-propagation" deleted
-bash-4.2# kubectl get deployments.apps 
NAME    READY   UP-TO-DATE   AVAILABLE   AGE
nginx   0/1     0            0           18m

```

**Which issue(s) this PR fixes**:
Fixes #244

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

