### PR TITLE
feature: support version command for karmadactl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,20 @@
 GOOS ?= $(shell go env GOOS)
 SOURCES := $(shell find . -type f  -name '*.go')
-LDFLAGS := ""
+
+# Git information
+GIT_VERSION ?= $(shell git describe --always --dirty)
+GIT_COMMIT_HASH ?= $(shell git rev-parse HEAD)
+GIT_TREESTATE = "clean"
+GIT_DIFF = $(shell git diff --quiet >/dev/null 2>&1; if [ $$? -eq 1 ]; then echo "1"; fi)
+ifeq ($(GIT_DIFF), 1)
+    GIT_TREESTATE = "dirty"
+endif
+BUILDDATE = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+LDFLAGS := "-X github.com/karmada-io/karmada/pkg/version.gitVersion=$(GIT_VERSION) \
+                      -X github.com/karmada-io/karmada/pkg/version.gitCommit=$(GIT_COMMIT_HASH) \
+                      -X github.com/karmada-io/karmada/pkg/version.gitTreeState=$(GIT_TREESTATE) \
+                      -X github.com/karmada-io/karmada/pkg/version.buildDate=$(BUILDDATE)"
 
 # Images management
 REGISTRY_REGION?="ap-southeast-1"

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GOOS ?= $(shell go env GOOS)
 SOURCES := $(shell find . -type f  -name '*.go')
 
 # Git information
-GIT_VERSION ?= $(shell git describe --always --dirty)
+GIT_VERSION ?= $(shell git describe --tags --dirty)
 GIT_COMMIT_HASH ?= $(shell git rev-parse HEAD)
 GIT_TREESTATE = "clean"
 GIT_DIFF = $(shell git diff --quiet >/dev/null 2>&1; if [ $$? -eq 1 ]; then echo "1"; fi)

--- a/pkg/karmadactl/karmadactl.go
+++ b/pkg/karmadactl/karmadactl.go
@@ -36,6 +36,7 @@ func NewKarmadaCtlCommand(out io.Writer) *cobra.Command {
 	karmadaConfig := NewKarmadaConfig(clientcmd.NewDefaultPathOptions())
 	rootCmd.AddCommand(NewCmdJoin(out, karmadaConfig))
 	rootCmd.AddCommand(NewCmdUnjoin(out, karmadaConfig))
+	rootCmd.AddCommand(NewCmdVersion(out))
 
 	return rootCmd
 }

--- a/pkg/karmadactl/version.go
+++ b/pkg/karmadactl/version.go
@@ -12,9 +12,8 @@ import (
 var (
 	versionLong = `Version prints the version info of this command.`
 
-	versionExample = `
-		# Print karmadactl command version
-		karmadactl version`
+	versionExample = `  # Print karmadactl command version
+  karmadactl version`
 )
 
 // NewCmdVersion prints out the release version info for this command binary.

--- a/pkg/karmadactl/version.go
+++ b/pkg/karmadactl/version.go
@@ -1,0 +1,33 @@
+package karmadactl
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/karmada-io/karmada/pkg/version"
+)
+
+var (
+	versionLong = `Version prints the version info of this command.`
+
+	versionExample = `
+		# Print karmadactl command version
+		karmadactl version`
+)
+
+// NewCmdVersion prints out the release version info for this command binary.
+func NewCmdVersion(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "version",
+		Short:   "Print the version info",
+		Long:    versionLong,
+		Example: versionExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Fprintf(out, "karmadactl version: %s\n", fmt.Sprintf("%#v", version.Get()))
+		},
+	}
+
+	return cmd
+}

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -1,0 +1,15 @@
+package version
+
+// Base version information.
+//
+// This is the fallback data used when version information from git is not
+// provided via go ldflags. It provides an approximation of the Karmada
+// version for ad-hoc builds (e.g. `go build`) that cannot get the version
+// information from git.
+var (
+	gitVersion   = "v0.0.0-master"
+	gitCommit    = "unknown" // sha1 from git, output of $(git rev-parse HEAD)
+	gitTreeState = "unknown" // state of git tree, either "clean" or "dirty"
+
+	buildDate = "unknown" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,31 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// Info contains versioning information.
+type Info struct {
+	GitVersion   string `json:"gitVersion"`
+	GitCommit    string `json:"gitCommit"`
+	GitTreeState string `json:"gitTreeState"`
+	BuildDate    string `json:"buildDate"`
+	GoVersion    string `json:"goVersion"`
+	Compiler     string `json:"compiler"`
+	Platform     string `json:"platform"`
+}
+
+// Get returns the overall codebase version. It's for detecting
+// what code a binary was built from.
+func Get() Info {
+	return Info{
+		GitVersion:   gitVersion,
+		GitCommit:    gitCommit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
Support `karmadactl` version command that's can print some version information for debug like `kubectl version`.


**Which issue(s) this PR fixes**:
Fixes #264 
