### PR TITLE
support configuring an explict proxy URL for member cluster

### DIFF
--- a/artifacts/deploy/cluster.karmada.io_clusters.yaml
+++ b/artifacts/deploy/cluster.karmada.io_clusters.yaml
@@ -65,6 +65,11 @@ spec:
                 description: Provider represents the cloud provider name of the member
                   cluster.
                 type: string
+              proxyURL:
+                description: 'ProxyURL is the proxy URL for the cluster. If not empty,
+                  the karmada control plane will use this proxy to talk to the cluster.
+                  More details please refer to: https://github.com/kubernetes/client-go/issues/351'
+                type: string
               region:
                 description: Region represents the region of the member cluster locate
                   in.

--- a/pkg/apis/cluster/v1alpha1/types.go
+++ b/pkg/apis/cluster/v1alpha1/types.go
@@ -54,6 +54,12 @@ type ClusterSpec struct {
 	// +optional
 	InsecureSkipTLSVerification bool `json:"insecureSkipTLSVerification,omitempty"`
 
+	// ProxyURL is the proxy URL for the cluster.
+	// If not empty, the karmada control plane will use this proxy to talk to the cluster.
+	// More details please refer to: https://github.com/kubernetes/client-go/issues/351
+	// +optional
+	ProxyURL string `json:"proxyURL,omitempty"`
+
 	// Provider represents the cloud provider name of the member cluster.
 	// +optional
 	Provider string `json:"provider,omitempty"`

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"fmt"
+	"net/url"
 
 	kubevalidation "k8s.io/apimachinery/pkg/util/validation"
 )
@@ -25,4 +26,21 @@ func ValidateClusterName(name string) []string {
 	}
 
 	return kubevalidation.IsDNS1123Label(name)
+}
+
+// ValidateClusterProxyURL tests whether the proxyURL is valid.
+// If not valid, a list of error string is returned. Otherwise an empty list (or nil) is returned.
+func ValidateClusterProxyURL(proxyURL string) []string {
+	u, err := url.Parse(proxyURL)
+	if err != nil {
+		return []string{fmt.Sprintf("cloud not parse: %s, %v", proxyURL, err)}
+	}
+
+	switch u.Scheme {
+	case "http", "https", "socks5":
+	default:
+		return []string{fmt.Sprintf("unsupported scheme %q, must be http, https, or socks5", u.Scheme)}
+	}
+
+	return nil
 }

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -44,3 +44,52 @@ func TestValidateClusterName(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateClusterProxyURL(t *testing.T) {
+	var tests = []struct {
+		name         string
+		proxy        string
+		expectError  bool
+		expectErrMsg string
+	}{
+		{
+			name:        "valid http",
+			proxy:       "http://example.com",
+			expectError: false,
+		},
+		{
+			name:        "valid https",
+			proxy:       "https://example.com",
+			expectError: false,
+		},
+		{
+			name:        "valid socks5",
+			proxy:       "socks5://example.com",
+			expectError: false,
+		},
+		{
+			name:         "no schema is not allowed",
+			proxy:        "example",
+			expectError:  true,
+			expectErrMsg: `unsupported scheme "", must be http, https, or socks5`,
+		},
+		{
+			name:         "schema out of range is not allowed",
+			proxy:        "socks4://example.com",
+			expectError:  true,
+			expectErrMsg: `unsupported scheme "socks4", must be http, https, or socks5`,
+		},
+	}
+
+	for _, test := range tests {
+		tc := test
+		t.Run(tc.name, func(t *testing.T) {
+			errs := ValidateClusterProxyURL(tc.proxy)
+			if !tc.expectError && len(errs) != 0 {
+				t.Errorf("not expect errors but got: %v", errs)
+			} else if tc.expectError && tc.expectErrMsg != strings.Join(errs, ",") {
+				t.Errorf("expected error: %v, but got: %v", tc.expectErrMsg, strings.Join(errs, ","))
+			}
+		})
+	}
+}

--- a/pkg/webhook/cluster/validating.go
+++ b/pkg/webhook/cluster/validating.go
@@ -39,6 +39,14 @@ func (v *ValidatingAdmission) Handle(ctx context.Context, req admission.Request)
 		return admission.Denied(errMsg)
 	}
 
+	if len(cluster.Spec.ProxyURL) > 0 {
+		if errs := validation.ValidateClusterProxyURL(cluster.Spec.ProxyURL); len(errs) != 0 {
+			errMsg := fmt.Sprintf("invalid proxy URL(%s): %s", cluster.Spec.ProxyURL, strings.Join(errs, ";"))
+			klog.Info(errMsg)
+			return admission.Denied(errMsg)
+		}
+	}
+
 	return admission.Allowed("")
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
As described in #257, some member clusters are behind a proxy, for those clusters need to specify a proxy URL.

**Which issue(s) this PR fixes**:
Part of #257

**Special notes for your reviewer**:
The `ProxyURL` provided by kubernetes v1.19+.
https://github.com/kubernetes/client-go/issues/351
https://github.com/kubernetes/kubernetes/pull/81443
