### PR TITLE
sort OverridePolicy/ClusterOverridePolicy by name when more than one policy matched

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -478,7 +478,7 @@ func (s *Scheduler) scheduleClusterResourceBinding(clusterResourceBinding *workv
 }
 
 func (s *Scheduler) handleErr(err error, key interface{}) {
-	if err == nil || errors.HasStatusCause(err, v1.NamespaceTerminatingCause) {
+	if err == nil || errors.HasStatusCause(err, corev1.NamespaceTerminatingCause) {
 		s.queue.Forget(key)
 		return
 	}
@@ -655,7 +655,7 @@ func (s *Scheduler) rescheduleClusterResourceBinding(clusterResourceBinding *wor
 			policyName := util.GetLabelValue(clusterResourceBinding.Labels, util.ClusterPropagationPolicyLabel)
 			policy, _ := s.clusterPolicyLister.Get(policyName)
 
-			if !util.ClusterMatches(curCluster, *policy.Spec.Placement.ClusterAffinity) {
+			if policy.Spec.Placement.ClusterAffinity != nil && !util.ClusterMatches(curCluster, *policy.Spec.Placement.ClusterAffinity) {
 				continue
 			}
 
@@ -703,7 +703,7 @@ func (s *Scheduler) rescheduleResourceBinding(resourceBinding *workv1alpha1.Reso
 			policyName := util.GetLabelValue(resourceBinding.Labels, util.PropagationPolicyNameLabel)
 			policy, _ := s.policyLister.PropagationPolicies(policyNamespace).Get(policyName)
 
-			if !util.ClusterMatches(curCluster, *policy.Spec.Placement.ClusterAffinity) {
+			if policy.Spec.Placement.ClusterAffinity != nil && !util.ClusterMatches(curCluster, *policy.Spec.Placement.ClusterAffinity) {
 				continue
 			}
 			klog.Infof("Rescheduling %s/ %s to member cluster %s", resourceBinding.Namespace, resourceBinding.Name, clusterName)

--- a/pkg/util/overridemanager/overridemanager.go
+++ b/pkg/util/overridemanager/overridemanager.go
@@ -3,6 +3,7 @@ package overridemanager
 import (
 	"context"
 	"encoding/json"
+	"sort"
 
 	"github.com/evanphx/json-patch/v5"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -87,14 +88,14 @@ func (o *overrideManagerImpl) applyClusterOverrides(rawObj *unstructured.Unstruc
 		return nil, nil
 	}
 
-	matchedPolicies := o.getMatchedClusterOverridePolicy(policyList.Items, rawObj, cluster)
-	if len(matchedPolicies) == 0 {
+	matchingPolicies := o.getMatchingClusterOverridePolicies(policyList.Items, rawObj, cluster)
+	if len(matchingPolicies) == 0 {
 		klog.V(2).Infof("No cluster override policy for resource: %s/%s", rawObj.GetNamespace(), rawObj.GetName())
 		return nil, nil
 	}
 
 	appliedList := &AppliedOverrides{}
-	for _, p := range matchedPolicies {
+	for _, p := range matchingPolicies {
 		if err := applyJSONPatch(rawObj, parseJSONPatch(p.Spec.Overriders.Plaintext)); err != nil {
 			return nil, err
 		}
@@ -118,14 +119,14 @@ func (o *overrideManagerImpl) applyNamespacedOverrides(rawObj *unstructured.Unst
 		return nil, nil
 	}
 
-	matchedPolicies := o.getMatchedOverridePolicy(policyList.Items, rawObj, cluster)
-	if len(matchedPolicies) == 0 {
+	matchingPolicies := o.getMatchingOverridePolicies(policyList.Items, rawObj, cluster)
+	if len(matchingPolicies) == 0 {
 		klog.V(2).Infof("No override policy for resource: %s/%s", rawObj.GetNamespace(), rawObj.GetName())
 		return nil, nil
 	}
 
 	appliedList := &AppliedOverrides{}
-	for _, p := range matchedPolicies {
+	for _, p := range matchingPolicies {
 		if err := applyJSONPatch(rawObj, parseJSONPatch(p.Spec.Overriders.Plaintext)); err != nil {
 			return nil, err
 		}
@@ -136,64 +137,74 @@ func (o *overrideManagerImpl) applyNamespacedOverrides(rawObj *unstructured.Unst
 	return appliedList, nil
 }
 
-func (o *overrideManagerImpl) getMatchedClusterOverridePolicy(policies []policyv1alpha1.ClusterOverridePolicy, resource *unstructured.Unstructured, cluster *clusterv1alpha1.Cluster) []policyv1alpha1.ClusterOverridePolicy {
-	// select policy in which at least one resource selector matches target resource.
-	resourceMatches := make([]policyv1alpha1.ClusterOverridePolicy, 0)
+func (o *overrideManagerImpl) getMatchingClusterOverridePolicies(policies []policyv1alpha1.ClusterOverridePolicy, resource *unstructured.Unstructured, cluster *clusterv1alpha1.Cluster) []policyv1alpha1.ClusterOverridePolicy {
+	resourceMatchingPolicies := make([]policyv1alpha1.ClusterOverridePolicy, 0)
 	for _, policy := range policies {
-		if OverridePolicyMatches(resource, policy.Spec.ResourceSelectors) {
-			resourceMatches = append(resourceMatches, policy)
+		if policy.Spec.ResourceSelectors == nil {
+			resourceMatchingPolicies = append(resourceMatchingPolicies, policy)
+			continue
+		}
+
+		if util.ResourceMatchSelectors(resource, policy.Spec.ResourceSelectors...) {
+			resourceMatchingPolicies = append(resourceMatchingPolicies, policy)
 		}
 	}
 
-	// select policy which cluster selector matches target resource.
-	clusterMatches := make([]policyv1alpha1.ClusterOverridePolicy, 0)
-	for _, policy := range resourceMatches {
+	clusterMatchingPolicies := make([]policyv1alpha1.ClusterOverridePolicy, 0)
+	for _, policy := range resourceMatchingPolicies {
 		if policy.Spec.TargetCluster == nil {
-			clusterMatches = append(clusterMatches, policy)
+			clusterMatchingPolicies = append(clusterMatchingPolicies, policy)
 			continue
 		}
 
 		if util.ClusterMatches(cluster, *policy.Spec.TargetCluster) {
-			clusterMatches = append(clusterMatches, policy)
+			clusterMatchingPolicies = append(clusterMatchingPolicies, policy)
 		}
 	}
 
 	// select policy in which at least one PlaintextOverrider matches target resource.
 	// TODO(RainbowMango): check if the overrider instructions can be applied to target resource.
 
-	// TODO(RainbowMango): Sort by policy names.
+	sort.Slice(clusterMatchingPolicies, func(i, j int) bool {
+		return clusterMatchingPolicies[i].Name < clusterMatchingPolicies[j].Name
+	})
 
-	return clusterMatches
+	return clusterMatchingPolicies
 }
 
-func (o *overrideManagerImpl) getMatchedOverridePolicy(policies []policyv1alpha1.OverridePolicy, resource *unstructured.Unstructured, cluster *clusterv1alpha1.Cluster) []policyv1alpha1.OverridePolicy {
-	// select policy in which at least one resource selector matches target resource.
-	resourceMatches := make([]policyv1alpha1.OverridePolicy, 0)
+func (o *overrideManagerImpl) getMatchingOverridePolicies(policies []policyv1alpha1.OverridePolicy, resource *unstructured.Unstructured, cluster *clusterv1alpha1.Cluster) []policyv1alpha1.OverridePolicy {
+	resourceMatchingPolicies := make([]policyv1alpha1.OverridePolicy, 0)
 	for _, policy := range policies {
-		if OverridePolicyMatches(resource, policy.Spec.ResourceSelectors) {
-			resourceMatches = append(resourceMatches, policy)
+		if policy.Spec.ResourceSelectors == nil {
+			resourceMatchingPolicies = append(resourceMatchingPolicies, policy)
+			continue
+		}
+
+		if util.ResourceMatchSelectors(resource, policy.Spec.ResourceSelectors...) {
+			resourceMatchingPolicies = append(resourceMatchingPolicies, policy)
 		}
 	}
 
-	// select policy which cluster selector matches target resource.
-	clusterMatches := make([]policyv1alpha1.OverridePolicy, 0)
-	for _, policy := range resourceMatches {
+	clusterMatchingPolicies := make([]policyv1alpha1.OverridePolicy, 0)
+	for _, policy := range resourceMatchingPolicies {
 		if policy.Spec.TargetCluster == nil {
-			clusterMatches = append(clusterMatches, policy)
+			clusterMatchingPolicies = append(clusterMatchingPolicies, policy)
 			continue
 		}
 
 		if util.ClusterMatches(cluster, *policy.Spec.TargetCluster) {
-			clusterMatches = append(clusterMatches, policy)
+			clusterMatchingPolicies = append(clusterMatchingPolicies, policy)
 		}
 	}
 
 	// select policy in which at least one PlaintextOverrider matches target resource.
 	// TODO(RainbowMango): check if the overrider instructions can be applied to target resource.
 
-	// TODO(RainbowMango): Sort by policy names.
+	sort.Slice(clusterMatchingPolicies, func(i, j int) bool {
+		return clusterMatchingPolicies[i].Name < clusterMatchingPolicies[j].Name
+	})
 
-	return clusterMatches
+	return clusterMatchingPolicies
 }
 
 func parseJSONPatch(overriders []policyv1alpha1.PlaintextOverrider) []overrideOption {
@@ -232,15 +243,4 @@ func applyJSONPatch(obj *unstructured.Unstructured, overrides []overrideOption) 
 
 	err = obj.UnmarshalJSON(patchedObjectJSONBytes)
 	return err
-}
-
-// OverridePolicyMatches tells if the override policy should be applied to the resource.
-func OverridePolicyMatches(resource *unstructured.Unstructured, resourceSelector []policyv1alpha1.ResourceSelector) bool {
-	for _, rs := range resourceSelector {
-		if util.ResourceMatches(resource, rs) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/pkg/util/overridemanager/shadow.go
+++ b/pkg/util/overridemanager/shadow.go
@@ -9,7 +9,7 @@ import (
 
 // OverridePolicyShadow is the condensed version of a OverridePolicy or ClusterOverridePolicy.
 type OverridePolicyShadow struct {
-	// OverridePolicy is the name of the referencing policy.
+	// PolicyName is the name of the referencing policy.
 	PolicyName string `json:"policyName"`
 
 	// Overriders is the overrider list of the referencing policy.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

When more than one OverridePolicy/ClusterOverridePolicy matched with resource and cluster name, sort ploicies by name and apply to resource object one by one.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

