### PR TITLE
Enable goimports local prefix check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,7 @@ linters:
   enable:
   # linters maintained by golang.org
   - gofmt
+  - goimports
   - golint
   - govet
   # linters default enabled by golangci-lint .
@@ -40,7 +41,9 @@ linters:
   - typecheck
   - unused
   - varcheck
-
+linters-settings:
+  goimports:
+    local-prefixes: github.com/karmada-io/karmada
 issues:
   # The list of ids of default excludes to include or disable. By default it's empty.
   include:

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime"
+	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"

--- a/pkg/controllers/propagationpolicy/propagationpolicy_controller.go
+++ b/pkg/controllers/propagationpolicy/propagationpolicy_controller.go
@@ -6,7 +6,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime"
+	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"

--- a/pkg/util/overridemanager/overridemanager.go
+++ b/pkg/util/overridemanager/overridemanager.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/evanphx/json-patch/v5"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

As described in this issue: https://github.com/karmada-io/karmada/issues/308#issue-883181898
We usually group import paths in the order of std packages --> third-party packages-->karmada packages
If we enable this check on golangci-lint, we don't need to care about this on code review.

when this is check failed, golangci-lint will report :
```
File is not `goimports`-ed with -local github.com/karmada-io/karmada (goimports)
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

