### PR TITLE
after install package, add $GOPATH/bin to env PATH

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -10,6 +10,9 @@ cd "${REPO_ROOT}"
 
 echo "Generating with deepcopy-gen"
 GO111MODULE=on go install k8s.io/code-generator/cmd/deepcopy-gen
+GOPATH=$(go env GOPATH | awk -F ':' '{print $1}')
+export PATH=$PATH:$GOPATH/bin
+
 deepcopy-gen \
   --go-header-file hack/boilerplate/boilerplate.go.txt \
   --input-dirs=github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1 \

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -29,6 +29,8 @@ function util::install_tools() {
 	temp_path=$(mktemp -d)
 	pushd "${temp_path}" >/dev/null
 	GO111MODULE=on go get "${package}"@"${version}"
+	GOPATH=$(go env GOPATH | awk -F ':' '{print $1}')
+	export PATH=$PATH:$GOPATH/bin
 	popd >/dev/null
 	rm -rf "${temp_path}"
 }


### PR DESCRIPTION
Signed-off-by: gy95 <guoyao17@huawei.com>

**What type of PR is this?**
/king bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
run `make verify`, error output is 
```
hack/verify-all.sh
Generating with deepcopy-gen
hack/../hack/../hack/update-codegen.sh: line 14: deepcopy-gen: command not found
make: *** [Makefile:82: verify] Error 127
```
cmd `make verfify` will install some tools or packages in `$GOPATH/bin` and then run some installed package related commands, so if we don't add `$GOPATH/bin` to `env PATH` before, `linux os` cannot find binary, and so error is `command not found`
to solve this problem, we can export  `$GOPATH/bin` to `env PATH` in scripts

And the GOPATH is a path list, we just need the first path.
According to go help gopath:
```
The GOPATH environment variable lists places to look for Go code.
On Unix, the value is a colon-separated string.
On Windows, the value is a semicolon-separated string.
On Plan 9, the value is a list.
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

