### PR TITLE
use const string instead of string literal

### DIFF
--- a/pkg/util/detector/detector.go
+++ b/pkg/util/detector/detector.go
@@ -802,7 +802,7 @@ func (d *ResourceDetector) ReconcileResourceBinding(key util.QueueKey) error {
 
 	klog.Infof("Reconciling resource binding(%s/%s)", binding.Namespace, binding.Name)
 	switch binding.Spec.Resource.Kind {
-	case "Deployment":
+	case helper.DeploymentKind:
 		return d.AggregateDeploymentStatus(binding.Spec.Resource, binding.Status.AggregatedStatus)
 	default:
 		// Unsupported resource type.
@@ -867,7 +867,7 @@ func (d *ResourceDetector) ReconcileClusterResourceBinding(key util.QueueKey) er
 
 	klog.Infof("Reconciling cluster resource binding(%s)", binding.Name)
 	switch binding.Spec.Resource.Kind {
-	case "Deployment":
+	case helper.DeploymentKind:
 		return d.AggregateDeploymentStatus(binding.Spec.Resource, binding.Status.AggregatedStatus)
 	default:
 		// Unsupported resource type.
@@ -934,7 +934,7 @@ func (d *ResourceDetector) AggregateDeploymentStatus(objRef workv1alpha1.ObjectR
 // Note: Only limited resource type supported.
 func (d *ResourceDetector) CleanupResourceTemplateStatus(objRef workv1alpha1.ObjectReference) error {
 	switch objRef.Kind {
-	case "Deployment":
+	case helper.DeploymentKind:
 		return d.CleanupDeploymentStatus(objRef)
 	}
 


### PR DESCRIPTION
Signed-off-by: gy95 <guoyao17@huawei.com>

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
`helper` package has defined a const string to represent resource kind: deployment , so don't need to use string `"Deployment"` literal
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

