### PR TITLE
karmadactl: fix join in dry-run mode

### DIFF
--- a/pkg/karmadactl/join.go
+++ b/pkg/karmadactl/join.go
@@ -210,6 +210,10 @@ func RunJoin(cmdOut io.Writer, karmadaConfig KarmadaConfig, opts CommandJoinOpti
 		return err
 	}
 
+	if opts.DryRun {
+		return nil
+	}
+
 	var clusterSecret *corev1.Secret
 	// It will take a short time to create service account secret for cluster.
 	err = wait.Poll(1*time.Second, 30*time.Second, func() (done bool, err error) {
@@ -247,10 +251,6 @@ func RunJoin(cmdOut io.Writer, karmadaConfig KarmadaConfig, opts CommandJoinOpti
 	if err != nil {
 		klog.Errorf("Failed to create secret in control plane. error: %v", err)
 		return err
-	}
-
-	if opts.DryRun {
-		return nil
 	}
 
 	clusterObj := &clusterv1alpha1.Cluster{}


### PR DESCRIPTION
Signed-off-by: Iceber Gu <wei.cai-nat@daocloud.io>

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind bug

**What this PR does / why we need it**:
It doesn't actually create an `sa` in dry-run mode, so we can't get the `sa`
```sh
╰─➤  ./karmadactl join caiwei --dry-run
E0518 13:49:02.092163   40844 join.go:218] Failed to retrieve service account(/) from cluster. err: serviceaccounts "karmada-caiwei" not found
E0518 13:49:02.092318   40844 join.go:229] Failed to get service account secret from  cluster. error: serviceaccounts "karmada-caiwei" not found
E0518 13:49:02.092328   40844 join.go:91] Error: serviceaccounts "karmada-caiwei" not found
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

