### PR TITLE
Optimize install

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,52 +117,92 @@ There are several demonstrations of common cases.
 ```
 
 #### 3. Deploy and run karmada control plane:
+
+Choose a way:
+
+##### 3.1. I have not any cluster
+
+run the following script: (It will create a host cluster by kind)
+
 ```
 # hack/local-up-karmada.sh
 ```
+
 The script `hack/local-up-karmada.sh` will do following tasks for you:
 - Start a Kubernetes cluster to run the karmada control plane, aka. the `host cluster`.
-- Build karmada control plane components based on current codebase.
+- Build karmada control plane components based on a current codebase.
 - Deploy karmada control plane components on `host cluster`.
 
 If everything goes well, at the end of the script output, you will see similar messages as follows:
 ```
 Local Karmada is running.
-To start using your karmada, run:
-  export KUBECONFIG=/var/run/karmada/karmada-apiserver.config
-To start checking karmada components running status on the host cluster, please run:
-  export KUBECONFIG="/root/.kube/karmada-host.config"
+
+Kubeconfig for karmada in file: /root/.kube/karmada.config, so you can run:
+  export KUBECONFIG="/root/.kube/karmada.config"
+Or use kubectl with --kubeconfig=/root/.kube/karmada.config
+Please use 'kubectl config use-context <Context_Name>' to switch cluster to operate, 
+the following is context intro:
+  ------------------------------------------------------
+  |    Context Name   |          Purpose               |
+  |----------------------------------------------------|
+  | karmada-host      | the cluster karmada install in |
+  |----------------------------------------------------|
+  | karmada-apiserver | karmada control plane          |
+  ------------------------------------------------------
 ```
 
-The two `KUBECONFIG` files after the script run are:
-- karmada-apiserver.config
-- karmada-host.config
+There are two contexts you can switch after the script run are:
+- karmada-apiserver `kubectl config use-context karmada-apiserver`
+- karmada-host `kubectl config use-context karmada-host`
 
-The `karmada-apiserver.config` is the **main kubeconfig** to be used when interacting with karamda control plane, while `karmada-host.config` is only used for debuging karmada installation with host cluster.
+The `karmada-apiserver` is the **main kubeconfig** to be used when interacting with karamda control plane, while `karmada-host` is only used for debugging karmada installation with host cluster, you can check all clusters at any time by run: `kubectl config view` and switch by `kubectl config use-context [CONTEXT_NAME]`
+
+##### 3.2. I have present cluster for installing
+Before run the following script, please make sure you are in the node or master of the cluster to install:
+```
+# hack/remote-up-karmada.sh <kubeconfig> <context_name>
+```
+`kubeconfig` is your cluster's kubeconfig that you want to install to
+
+`context_name` is the name of context in 'kubeconfig'
+
+If everything goes well, at the end of the script output, you will see similar messages as follows:
+```
+Karmada is installed.
+
+Kubeconfig for karmada in file: /root/.kube/karmada.config, so you can run:
+  export KUBECONFIG="/root/.kube/karmada.config"
+Or use kubectl with --kubeconfig=/root/.kube/karmada.config
+Please use 'kubectl config use-context karmada-apiserver' to switch the cluster of karmada control plane
+And use 'kubectl config use-context your-host' for debugging karmada installation
+```
+#### Tips
+- Please make sure you can access google cloud registry: k8s.gcr.io
+- Install script will download golang package, if your server is in the mainland, you need set go proxy like this `export GOPROXY=https://goproxy.cn`
 
 ### Join member cluster
-In the following steps, we are going to create a member cluster and then join the cluster to
+In the following steps, we are going to create a member cluster and then join the cluster to 
 karmada control plane.
 
 #### 1. Create member cluster
-We are going to create a cluster named `member1` and we want the `KUBECONFIG` file
-in `$HOME/.kube/member1.config`. Run following command:
+We are going to create a cluster named `member1` and we want the `KUBECONFIG` file 
+in `/root/.kube/karmada.config`. Run following command:
 ```
-# hack/create-cluster.sh member1 $HOME/.kube/member1.config
+# hack/create-cluster.sh member1 /root/.kube/karmada.config
 ```
-The script `hack/create-cluster.sh` will create a standalone cluster.
+The script `hack/create-cluster.sh` will create a standalone cluster by kind.
 
 #### 2. Join member cluster to karmada control plane
-The command `karmadactl` will help to join the member cluster to karmada control plane,
-before that, we should set `KUBECONFIG` to karmada apiserver:
+The command `karmadactl` will help to join the member cluster to karmada control plane, 
+before that, we should switch to karmada apiserver:
 ```
-# export KUBECONFIG=/var/run/karmada/karmada-apiserver.config
+# kubectl config use-context karmada-apiserver
 ```
 
 Then, install `karmadactl` command and join the member cluster:
 ```
 # go get github.com/karmada-io/karmada/cmd/karmadactl
-# karmadactl join member1 --cluster-kubeconfig=$HOME/.kube/member1.config
+# karmadactl join member1 --cluster-kubeconfig=/root/.kube/karmada.config
 ```
 The `karmadactl join` command will create a `Cluster` object to reflect the member cluster.
 
@@ -187,7 +227,7 @@ First, create a [deployment](samples/nginx/deployment.yaml) named `nginx`:
 Then, we need create a policy to drive the deployment to our member cluster.
 ```
 # kubectl create -f samples/nginx/propagationpolicy.yaml
-```
+``` 
 
 #### 3. Check the deployment status from karmada
 You can check deployment status from karmada, don't need to access member cluster:
@@ -196,23 +236,6 @@ You can check deployment status from karmada, don't need to access member cluste
 NAME    READY   UP-TO-DATE   AVAILABLE   AGE
 nginx   1/1     1            1           43s
 ```
-
-## Meeting
-
-Regular Community Meeting:
-* Tuesday at 14:30 CST(China Standard Time)(biweekly). [Convert to your timezone.](https://www.thetimezoneconverter.com/?t=14%3A30&tz=GMT%2B8&)
-
-Resources:
-- [Meeting notes and agenda](https://docs.google.com/document/d/1y6YLVC-v7cmVAdbjedoyR5WL0-q45DBRXTvz5_I7bkA/edit)
-- [Meeting Calendar](https://calendar.google.com/calendar/embed?src=karmadaoss%40gmail.com&ctz=Asia%2FShanghai) | [Subscribe](https://calendar.google.com/calendar/u/1?cid=a2FybWFkYW9zc0BnbWFpbC5jb20)
-
-## Contact
-
-If you have questions, feel free to reach out to us in the following ways:
-
-- [mailing list](https://groups.google.com/forum/#!forum/karmada)
-- [slack](https://join.slack.com/t/karmada-io/shared_invite/zt-omhy1wfa-LmAkCLfpDMnBjVXp3_U~0w)
-- [twitter](https://twitter.com/karmada_io)
 
 ## Contributing
 

--- a/artifacts/deploy/karmada-apiserver.yaml
+++ b/artifacts/deploy/karmada-apiserver.yaml
@@ -42,6 +42,7 @@ spec:
             - --etcd-certfile=/etc/kubernetes/pki/karmada.crt
             - --etcd-keyfile=/etc/kubernetes/pki/karmada.key
             - --etcd-servers=https://etcd-client.karmada-system.svc.cluster.local:2379
+            - --bind-address=0.0.0.0
             - --insecure-port=8080
             - --kubelet-client-certificate=/etc/kubernetes/pki/karmada.crt
             - --kubelet-client-key=/etc/kubernetes/pki/karmada.key
@@ -64,7 +65,6 @@ spec:
           livenessProbe:
             failureThreshold: 8
             httpGet:
-              host: {{api_addr}}
               path: /livez
               port: 5443
               scheme: HTTPS
@@ -75,7 +75,6 @@ spec:
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              host: {{api_addr}}
               path: /readyz
               port: 5443
               scheme: HTTPS

--- a/hack/delete-cluster.sh
+++ b/hack/delete-cluster.sh
@@ -7,7 +7,7 @@ set -o pipefail
 function usage() {
   echo "This script delete a kube cluster by kind."
   echo "Usage: hack/delete-cluster.sh <CLUSTER_NAME> <KUBECONFIG>"
-  echo "Example: hack/delete-cluster.sh host /root/.kube/host.config"
+  echo "Example: hack/delete-cluster.sh host /root/.kube/karmada.config"
 }
 
 if [[ $# -ne 2 ]]; then

--- a/hack/deploy-karmada.sh
+++ b/hack/deploy-karmada.sh
@@ -3,59 +3,85 @@
 set -o errexit
 set -o nounset
 
+# This script deploy karmada control plane to any cluster you want.	REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+# This script intended used in following scenarios:	source ${REPO_ROOT}/hack/util.sh
+
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-CERT_DIR=${CERT_DIR:-"/var/run/karmada"}
+CERT_DIR=${CERT_DIR:-"${HOME}/.karmada"}
 mkdir -p "${CERT_DIR}" &>/dev/null || sudo mkdir -p "${CERT_DIR}"
 KARMADA_APISERVER_CONFIG="${CERT_DIR}/karmada-apiserver.config"
 KARMADA_APISERVER_SECURE_PORT=${KARMADA_APISERVER_SECURE_PORT:-5443}
 
 # The host cluster name which used to install karmada control plane components.
 HOST_CLUSTER_NAME=${HOST_CLUSTER_NAME:-"karmada-host"}
-HOST_CLUSTER_KUBECONFIG=${HOST_CLUSTER_KUBECONFIG:-"${HOME}/.kube/karmada-host.config"}
+HOST_CLUSTER_KUBECONFIG=${1:-"${HOME}/.kube/karmada-host.config"}
 ROOT_CA_FILE=${CERT_DIR}/server-ca.crt
 CFSSL_VERSION="v1.5.0"
 CONTROLPLANE_SUDO=$(test -w "${CERT_DIR}" || echo "sudo -E")
 
-source ${REPO_ROOT}/hack/util.sh
+# shellcheck source=util.sh
+source "${REPO_ROOT}"/hack/util.sh
 
 function usage() {
-  echo "This script will deploy karmada control plane to a cluster."
-  echo "Usage: hack/deploy-karmada.sh"
-  echo "Example: hack/deploy-karmada.sh"
+  echo "This script will deploy karmada control plane to a given cluster."
+  echo "Usage: hack/deploy-karmada.sh <KUBECONFIG> <CONTEXT_NAME> [KARMADA_API_SERVER_IP]"
+  echo "Example: hack/deploy-karmada.sh ~/.kube/config karmada-host"
+  unset KUBECONFIG
 }
+
+if [[ $# -lt 2 ]]; then
+  usage
+  exit 1
+fi
+
+# check config file existence
+HOST_CLUSTER_KUBECONFIG=$1
+if [[ ! -f "${HOST_CLUSTER_KUBECONFIG}" ]]; then
+  echo -e "ERROR: failed to get kubernetes config file: '${HOST_CLUSTER_KUBECONFIG}', not existed.\n"
+  usage
+  exit 1
+fi
+
+# check context existence
+export KUBECONFIG="${HOST_CLUSTER_KUBECONFIG}"
+HOST_CLUSTER_NAME=$2
+if ! kubectl config get-contexts "${HOST_CLUSTER_NAME}" > /dev/null 2>&1;
+then
+  echo -e "ERROR: failed to get context: '${HOST_CLUSTER_NAME}' not in ${HOST_CLUSTER_KUBECONFIG}. \n"
+  usage
+  exit 1
+fi
 
 # generate a secret to store the certificates
 function generate_cert_secret {
-    local karmada_ca=$(base64 "${ROOT_CA_FILE}" | tr -d '\r\n')
+    local karmada_ca
+    karmada_ca=$(base64 "${ROOT_CA_FILE}" | tr -d '\r\n')
 
-    local TEMP_PATH=$(mktemp -d)
-    cp -rf ${REPO_ROOT}/artifacts/deploy/karmada-cert-secret.yaml ${TEMP_PATH}/karmada-cert-secret-tmp.yaml
-    cp -rf ${REPO_ROOT}/artifacts/deploy/secret.yaml ${TEMP_PATH}/secret-tmp.yaml
-    cp -rf ${REPO_ROOT}/artifacts/deploy/karmada-webhook-cert-secret.yaml ${TEMP_PATH}/karmada-webhook-cert-secret-tmp.yaml
+    local TEMP_PATH
+    TEMP_PATH=$(mktemp -d)
 
-    sed -i "s/{{ca_crt}}/${karmada_ca}/g" ${TEMP_PATH}/karmada-cert-secret-tmp.yaml
-    sed -i "s/{{client_cer}}/${KARMADA_CRT}/g" ${TEMP_PATH}/karmada-cert-secret-tmp.yaml
-    sed -i "s/{{client_key}}/${KARMADA_KEY}/g" ${TEMP_PATH}/karmada-cert-secret-tmp.yaml
+    cp -rf "${REPO_ROOT}"/artifacts/deploy/karmada-cert-secret.yaml "${TEMP_PATH}"/karmada-cert-secret-tmp.yaml
+    cp -rf "${REPO_ROOT}"/artifacts/deploy/secret.yaml "${TEMP_PATH}"/secret-tmp.yaml
+    cp -rf "${REPO_ROOT}"/artifacts/deploy/karmada-webhook-cert-secret.yaml "${TEMP_PATH}"/karmada-webhook-cert-secret-tmp.yaml
 
-    sed -i "s/{{ca_crt}}/${karmada_ca}/g" ${TEMP_PATH}/secret-tmp.yaml
-    sed -i "s/{{client_cer}}/${KARMADA_CRT}/g" ${TEMP_PATH}/secret-tmp.yaml
-    sed -i "s/{{client_key}}/${KARMADA_KEY}/g" ${TEMP_PATH}/secret-tmp.yaml
+    sed -i "s/{{ca_crt}}/${karmada_ca}/g" "${TEMP_PATH}"/karmada-cert-secret-tmp.yaml
+    sed -i "s/{{client_cer}}/${KARMADA_CRT}/g" "${TEMP_PATH}"/karmada-cert-secret-tmp.yaml
+    sed -i "s/{{client_key}}/${KARMADA_KEY}/g" "${TEMP_PATH}"/karmada-cert-secret-tmp.yaml
 
-    sed -i "s/{{server_key}}/${KARMADA_KEY}/g" ${TEMP_PATH}/karmada-webhook-cert-secret-tmp.yaml
-    sed -i "s/{{server_certificate}}/${KARMADA_CRT}/g" ${TEMP_PATH}/karmada-webhook-cert-secret-tmp.yaml
+    sed -i "s/{{ca_crt}}/${karmada_ca}/g" "${TEMP_PATH}"/secret-tmp.yaml
+    sed -i "s/{{client_cer}}/${KARMADA_CRT}/g" "${TEMP_PATH}"/secret-tmp.yaml
+    sed -i "s/{{client_key}}/${KARMADA_KEY}/g" "${TEMP_PATH}"/secret-tmp.yaml
 
-    kubectl apply -f ${TEMP_PATH}/karmada-cert-secret-tmp.yaml
-    kubectl apply -f ${TEMP_PATH}/secret-tmp.yaml
-    kubectl apply -f ${TEMP_PATH}/karmada-webhook-cert-secret-tmp.yaml
+    sed -i "s/{{server_key}}/${KARMADA_KEY}/g" "${TEMP_PATH}"/karmada-webhook-cert-secret-tmp.yaml
+    sed -i "s/{{server_certificate}}/${KARMADA_CRT}/g" "${TEMP_PATH}"/karmada-webhook-cert-secret-tmp.yaml
+
+    kubectl apply -f "${TEMP_PATH}"/karmada-cert-secret-tmp.yaml
+    kubectl apply -f "${TEMP_PATH}"/secret-tmp.yaml
+    kubectl apply -f "${TEMP_PATH}"/karmada-webhook-cert-secret-tmp.yaml
     rm -rf "${TEMP_PATH}"
 }
 
 function installCRDs() {
-    if [ ! -f ${KARMADA_APISERVER_CONFIG} ]; then
-        echo "Please provide kubeconfig to connect karmada apiserver"
-        return 1
-    fi
-
     # install APIs
     kubectl apply -f "${REPO_ROOT}/artifacts/deploy/namespace.yaml"
     kubectl apply -f "${REPO_ROOT}/artifacts/deploy/cluster.karmada.io_clusters.yaml"
@@ -77,13 +103,6 @@ util::create_signing_certkey "${CONTROLPLANE_SUDO}" "${CERT_DIR}" server '"clien
 # signs a certificate
 util::create_certkey "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "server-ca" karmada system:admin kubernetes.default.svc "*.etcd.karmada-system.svc.cluster.local" "*.karmada-system.svc.cluster.local" "*.karmada-system.svc" "localhost" "127.0.0.1"
 
-KARMADA_APISERVER_IP=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${HOST_CLUSTER_NAME}-control-plane")
-KARMADA_CRT=$(sudo base64 "${CERT_DIR}/karmada.crt" | tr -d '\r\n')
-KARMADA_KEY=$(sudo base64 "${CERT_DIR}/karmada.key" | tr -d '\r\n')
-util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${KARMADA_CRT}" "${KARMADA_KEY}" "${KARMADA_APISERVER_IP}" "${KARMADA_APISERVER_SECURE_PORT}" karmada-apiserver
-
-export KUBECONFIG="${HOST_CLUSTER_KUBECONFIG}"
-
 # create namespace for control plane components
 kubectl apply -f "${REPO_ROOT}/artifacts/deploy/namespace.yaml"
 
@@ -92,35 +111,53 @@ kubectl apply -f "${REPO_ROOT}/artifacts/deploy/serviceaccount.yaml"
 kubectl apply -f "${REPO_ROOT}/artifacts/deploy/clusterrole.yaml"
 kubectl apply -f "${REPO_ROOT}/artifacts/deploy/clusterrolebinding.yaml"
 
+KARMADA_CRT=$(sudo base64 "${CERT_DIR}/karmada.crt" | tr -d '\r\n')
+KARMADA_KEY=$(sudo base64 "${CERT_DIR}/karmada.key" | tr -d '\r\n')
 generate_cert_secret
 
 # deploy karmada etcd
 kubectl apply -f "${REPO_ROOT}/artifacts/deploy/karmada-etcd.yaml"
 
 # Wait for karmada-etcd to come up before launching the rest of the components.
-util::wait_pod_ready ${ETCD_POD_LABEL} "karmada-system"
+util::wait_pod_ready "${ETCD_POD_LABEL}" "karmada-system"
 
 # deploy karmada apiserver
-TEMP_PATH=$(mktemp -d)
-cp -rf ${REPO_ROOT}/artifacts/deploy/karmada-apiserver.yaml ${TEMP_PATH}/karmada-apiserver-tmp.yaml
-sed -i "s/{{api_addr}}/${KARMADA_APISERVER_IP}/g" ${TEMP_PATH}/karmada-apiserver-tmp.yaml
-kubectl apply -f "${TEMP_PATH}/karmada-apiserver-tmp.yaml"
-rm -rf "${TEMP_PATH}"
+kubectl apply -f "${REPO_ROOT}/artifacts/deploy/karmada-apiserver.yaml"
 
 # Wait for karmada-apiserver to come up before launching the rest of the components.
-util::wait_pod_ready ${APISERVER_POD_LABEL} "karmada-system"
+util::wait_pod_ready "${APISERVER_POD_LABEL}" "karmada-system"
+
+if [[ -z "${3-}" ]]; then
+  KARMADA_APISERVER_IP=$(kubectl get service karmada-apiserver -n karmada-system -o jsonpath='{.spec.clusterIP}')
+else
+  KARMADA_APISERVER_IP=$3
+fi
+
+if [[ -z "${KARMADA_APISERVER_IP}" ]]; then
+  echo -e "ERROR: failed to create service 'karmada-apiserver', please verify.\n"
+  exit 1
+fi
+
+# write karmada api server config to kubeconfig file
+util::append_client_kubeconfig "${HOST_CLUSTER_KUBECONFIG}" "${CERT_DIR}/karmada.crt" "${CERT_DIR}/karmada.key" "${KARMADA_APISERVER_IP}" "${KARMADA_APISERVER_SECURE_PORT}" karmada-apiserver
 
 # deploy kube controller manager
 kubectl apply -f "${REPO_ROOT}/artifacts/deploy/kube-controller-manager.yaml"
 
 # install CRD APIs on karmada apiserver.
-export KUBECONFIG=${KARMADA_APISERVER_CONFIG}
+if ! kubectl config get-contexts karmada-apiserver > /dev/null 2>&1;
+then
+  echo -e "ERROR: failed to get context: karmada-apiserver not in ${HOST_CLUSTER_KUBECONFIG}."
+  exit 1
+fi
+kubectl config use-context karmada-apiserver
 installCRDs
 
 # deploy webhook configurations on karmada apiserver
-util::deploy_webhook_configuration ${ROOT_CA_FILE} "${REPO_ROOT}/artifacts/deploy/webhook-configuration.yaml"
+util::deploy_webhook_configuration "${ROOT_CA_FILE}" "${REPO_ROOT}/artifacts/deploy/webhook-configuration.yaml"
 
-export KUBECONFIG=${HOST_CLUSTER_KUBECONFIG}
+kubectl config use-context "${HOST_CLUSTER_NAME}"
+
 # deploy controller-manager on host cluster
 kubectl apply -f "${REPO_ROOT}/artifacts/deploy/controller-manager.yaml"
 # deploy scheduler on host cluster
@@ -129,7 +166,7 @@ kubectl apply -f "${REPO_ROOT}/artifacts/deploy/karmada-scheduler.yaml"
 kubectl apply -f "${REPO_ROOT}/artifacts/deploy/karmada-webhook.yaml"
 
 # make sure all karmada control plane components are ready
-util::wait_pod_ready ${KARMADA_CONTROLLER_LABEL} "karmada-system"
-util::wait_pod_ready ${KARMADA_SCHEDULER_LABEL} "karmada-system"
-util::wait_pod_ready ${KUBE_CONTROLLER_POD_LABEL} "karmada-system"
-util::wait_pod_ready ${KARMADA_WEBHOOK_LABEL} "karmada-system"
+util::wait_pod_ready "${KARMADA_CONTROLLER_LABEL}" "karmada-system"
+util::wait_pod_ready "${KARMADA_SCHEDULER_LABEL}" "karmada-system"
+util::wait_pod_ready "${KUBE_CONTROLLER_POD_LABEL}" "karmada-system"
+util::wait_pod_ready "${KARMADA_WEBHOOK_LABEL}" "karmada-system"

--- a/hack/local-up-karmada.sh
+++ b/hack/local-up-karmada.sh
@@ -15,7 +15,7 @@ HOST_CLUSTER_NAME=${HOST_CLUSTER_NAME:-"karmada-host"}
 
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 # The KUBECONFIG path for the 'host cluster'.
-HOST_CLUSTER_KUBECONFIG="${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config"
+HOST_CLUSTER_KUBECONFIG="${KUBECONFIG_PATH}/karmada.config"
 
 # Make sure KUBECONFIG path exists.
 if [ ! -d "$KUBECONFIG_PATH" ]; then
@@ -40,18 +40,28 @@ kind load docker-image "${REGISTRY}/karmada-scheduler:${VERSION}" --name="${HOST
 kind load docker-image "${REGISTRY}/karmada-webhook:${VERSION}" --name="${HOST_CLUSTER_NAME}"
 
 # deploy karmada control plane
-"${SCRIPT_ROOT}"/hack/deploy-karmada.sh
+KARMADA_APISERVER_IP=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${HOST_CLUSTER_NAME}-control-plane")
+"${SCRIPT_ROOT}"/hack/deploy-karmada.sh "${HOST_CLUSTER_KUBECONFIG}" "${HOST_CLUSTER_NAME}" "${KARMADA_APISERVER_IP}"
+kubectl config use-context karmada-apiserver
 
 function print_success() {
   echo
   echo "Local Karmada is running."
-  echo "To start using your karmada, run:"
-cat <<EOF
-  export KUBECONFIG=/var/run/karmada/karmada-apiserver.config
-EOF
-  echo "To start checking karmada components running status on the host cluster, please run:"
+  echo
+  echo "Kubeconfig for karmada in file: ${HOST_CLUSTER_KUBECONFIG}, so you can run:"
 cat <<EOF
   export KUBECONFIG="${HOST_CLUSTER_KUBECONFIG}"
+EOF
+  echo "Or use kubectl with --kubeconfig=${HOST_CLUSTER_KUBECONFIG}"
+  echo "Please use 'kubectl config use-context <Context_Name>' to switch cluster to operate, the following is context intro:"
+cat <<EOF
+  ------------------------------------------------------
+  |    Context Name   |          Purpose               |
+  |----------------------------------------------------|
+  | karmada-host      | the cluster karmada install in |
+  |----------------------------------------------------|
+  | karmada-apiserver | karmada control plane          |
+  ------------------------------------------------------
 EOF
 }
 

--- a/hack/remote-up-karmada.sh
+++ b/hack/remote-up-karmada.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+function usage() {
+  echo "This script will deploy karmada control plane to a given cluster."
+  echo "Usage: hack/deploy-karmada.sh <KUBECONFIG> <CONTEXT_NAME>"
+  echo "Example: hack/deploy-karmada.sh ~/.kube/config karmada-host"
+}
+
+if [[ $# -ne 2 ]]; then
+  usage
+  exit 1
+fi
+
+# check config file existence
+HOST_CLUSTER_KUBECONFIG=$1
+if [[ ! -f "${HOST_CLUSTER_KUBECONFIG}" ]]; then
+  echo -e "ERROR: failed to get kubernetes config file: '${HOST_CLUSTER_KUBECONFIG}', not existed.\n"
+  usage
+  exit 1
+fi
+
+# check context existence
+export KUBECONFIG="${HOST_CLUSTER_KUBECONFIG}"
+HOST_CLUSTER_NAME=$2
+if ! kubectl config get-contexts "${HOST_CLUSTER_NAME}" > /dev/null 2>&1;
+then
+  echo -e "ERROR: failed to get context: '${HOST_CLUSTER_NAME}' not in ${HOST_CLUSTER_KUBECONFIG}. \n"
+  usage
+  exit 1
+fi
+
+# deploy karmada control plane
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+"${SCRIPT_ROOT}"/hack/deploy-karmada.sh "${HOST_CLUSTER_KUBECONFIG}" "${HOST_CLUSTER_NAME}"
+
+function print_success() {
+  echo
+  echo "Karmada is installed."
+  echo
+  echo "Kubeconfig for karmada in file: ${HOST_CLUSTER_KUBECONFIG}, so you can run:"
+  echo "  export KUBECONFIG=\"${HOST_CLUSTER_KUBECONFIG}\""
+  echo "Or use kubectl with --kubeconfig=${HOST_CLUSTER_KUBECONFIG}"
+  echo "Please use 'kubectl config use-context karmada-apiserver' to switch the cluster of karmada control plane"
+  echo "And use 'kubectl config use-context ${HOST_CLUSTER_NAME}' for debugging karmada installation"
+}
+
+print_success
+

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -102,6 +102,19 @@ function util::create_certkey {
 EOF
 }
 
+function util::append_client_kubeconfig {
+    local kubeconfig_path=$1
+    local client_certificate_file=$2
+    local client_key_file=$3
+    local api_host=$4
+    local api_port=$5
+    local client_id=$6
+    local token=${7:-}
+    kubectl config set-cluster "${client_id}" --server=https://"${api_host}:${api_port}" --insecure-skip-tls-verify=true --kubeconfig="${kubeconfig_path}"
+    kubectl config set-credentials "${client_id}" --token="${token}" --client-certificate="${client_certificate_file}" --client-key="${client_key_file}" --kubeconfig="${kubeconfig_path}"
+    kubectl config set-context "${client_id}" --cluster="${client_id}" --user="${client_id}" --kubeconfig="${kubeconfig_path}"
+}
+
 # util::write_client_kubeconfig creates a self-contained kubeconfig: args are sudo, dest-dir, client certificate data, client key data, host, port, client id, token(optional)
 function util::write_client_kubeconfig {
     local sudo=$1


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind feature

-->

**What this PR does / why we need it**:

1. Two kinds of karmada deployment:
    + deploy to local cluster by kind `local-up-karmada.sh`
    + deploy to remote(stand-alone) cluster `remote-up-karmada.sh`
2. Multi-clusters kebuconfig Integrate in one config file, default in:  /root/.kube/karmda.config. use `kubectl config use-context` to switch.
3. Add some tips in installation step

**Which issue(s) this PR fixes**:

Fixes #310

**Special notes for your reviewer**:

### Some tech details:
- Add '--bind-address' and remove 'host' in probe: keep it can pass when deploying to remote(stand-alone) cluster
- The 2nd argument in 'hack/create-cluster.sh' change to optional, default is current KUBECONFIG
- There is no longer to delete the existed kubeconfig file when run 'hack/create-cluster.sh'
- Save all certificate files to /root/.karmada/ for avoiding loss after reboot
- Add function 'util::append_client_kubeconfig' to append kubeconfig to a existed file
- TODO: modifies sync to karmada-bootstrap.sh & deploy-karmada-agent.sh if it needs

**Does this PR introduce a user-facing change?**:
NONE

