### PR TITLE
add e2e of imageoverride

### DIFF
--- a/test/e2e/overridepolicy_test.go
+++ b/test/e2e/overridepolicy_test.go
@@ -1,0 +1,259 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+
+	"github.com/karmada-io/karmada/test/helper"
+)
+
+var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
+	ginkgo.Context("Deployment override all images in container list", func() {
+		deploymentNamespace := testNamespace
+		deploymentName := deploymentNamePrefix + rand.String(RandomStrLength)
+		propagationPolicyNamespace := testNamespace
+		propagationPolicyName := deploymentName
+		overridePolicyNamespace := testNamespace
+		overridePolicyName := deploymentName
+
+		deployment := helper.NewDeployment(deploymentNamespace, deploymentName)
+		propagationPolicy := helper.NewPolicyWithSingleDeployment(propagationPolicyNamespace, propagationPolicyName, deployment, clusterNames)
+		overridePolicy := helper.NewOverridePolicyWithDeployment(overridePolicyNamespace, overridePolicyName, deployment, clusterNames, helper.NewImageOverriderWithEmptyPredicate())
+
+		ginkgo.BeforeEach(func() {
+			ginkgo.By(fmt.Sprintf("creating propagationPolicy(%s/%s)", propagationPolicyNamespace, propagationPolicyName), func() {
+				_, err := karmadaClient.PolicyV1alpha1().PropagationPolicies(propagationPolicyNamespace).Create(context.TODO(), propagationPolicy, metav1.CreateOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+
+		ginkgo.BeforeEach(func() {
+			ginkgo.By(fmt.Sprintf("creating overridePolicy(%s/%s)", overridePolicyNamespace, overridePolicyName), func() {
+				_, err := karmadaClient.PolicyV1alpha1().OverridePolicies(overridePolicyNamespace).Create(context.TODO(), overridePolicy, metav1.CreateOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+
+		ginkgo.AfterEach(func() {
+			ginkgo.By(fmt.Sprintf("removing overridePolicy(%s/%s)", overridePolicyNamespace, overridePolicyName), func() {
+				err := karmadaClient.PolicyV1alpha1().OverridePolicies(overridePolicyNamespace).Delete(context.TODO(), overridePolicyName, metav1.DeleteOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+
+		ginkgo.AfterEach(func() {
+			ginkgo.By(fmt.Sprintf("removing propagationPolicy(%s/%s)", propagationPolicyNamespace, propagationPolicyName), func() {
+				err := karmadaClient.PolicyV1alpha1().PropagationPolicies(propagationPolicyNamespace).Delete(context.TODO(), propagationPolicyName, metav1.DeleteOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+
+		ginkgo.It("deployment imageOverride testing", func() {
+			ginkgo.By(fmt.Sprintf("creating deployment(%s/%s)", deploymentNamespace, deploymentName), func() {
+				_, err := kubeClient.AppsV1().Deployments(testNamespace).Create(context.TODO(), deployment, metav1.CreateOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+
+			ginkgo.By("check if deployment present on member clusters have correct image value", func() {
+				for _, cluster := range clusters {
+					clusterClient := getClusterClient(cluster.Name)
+					gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+
+					var deploymentInCluster *appsv1.Deployment
+
+					klog.Infof("Waiting for deployment(%s/%s) present on cluster(%s)", deploymentNamespace, deploymentName, cluster.Name)
+					err := wait.Poll(pollInterval, pollTimeout, func() (done bool, err error) {
+						deploymentInCluster, err = clusterClient.AppsV1().Deployments(deploymentNamespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+						if err != nil {
+							if errors.IsNotFound(err) {
+								return false, nil
+							}
+							return false, err
+						}
+						return true, nil
+					})
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+					for _, container := range deploymentInCluster.Spec.Template.Spec.Containers {
+						gomega.Expect(container.Image).Should(gomega.Equal("fictional.registry.us/busybox:1.0"))
+					}
+				}
+			})
+
+			ginkgo.By(fmt.Sprintf("removing deployment(%s/%s)", deploymentNamespace, deploymentName), func() {
+				err := kubeClient.AppsV1().Deployments(testNamespace).Delete(context.TODO(), deploymentName, metav1.DeleteOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+
+	})
+
+	ginkgo.Context("Pod override all images in container list", func() {
+		podNamespace := testNamespace
+		podName := podNamePrefix + rand.String(RandomStrLength)
+		propagationPolicyNamespace := testNamespace
+		propagationPolicyName := podName
+		overridePolicyNamespace := testNamespace
+		overridePolicyName := podName
+
+		pod := helper.NewPod(podNamespace, podName)
+		propagationPolicy := helper.NewPolicyWithSinglePod(propagationPolicyNamespace, propagationPolicyName, pod, clusterNames)
+		overridePolicy := helper.NewOverridePolicyWithPod(overridePolicyNamespace, overridePolicyName, pod, clusterNames, helper.NewImageOverriderWithEmptyPredicate())
+
+		ginkgo.BeforeEach(func() {
+			ginkgo.By(fmt.Sprintf("creating propagationPolicy(%s/%s)", propagationPolicyNamespace, propagationPolicyName), func() {
+				_, err := karmadaClient.PolicyV1alpha1().PropagationPolicies(propagationPolicyNamespace).Create(context.TODO(), propagationPolicy, metav1.CreateOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+
+		ginkgo.BeforeEach(func() {
+			ginkgo.By(fmt.Sprintf("creating overridePolicy(%s/%s)", overridePolicyNamespace, overridePolicyName), func() {
+				_, err := karmadaClient.PolicyV1alpha1().OverridePolicies(overridePolicyNamespace).Create(context.TODO(), overridePolicy, metav1.CreateOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+
+		ginkgo.AfterEach(func() {
+			ginkgo.By(fmt.Sprintf("removing overridePolicy(%s/%s)", overridePolicyNamespace, overridePolicyName), func() {
+				err := karmadaClient.PolicyV1alpha1().OverridePolicies(overridePolicyNamespace).Delete(context.TODO(), overridePolicyName, metav1.DeleteOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+
+		ginkgo.AfterEach(func() {
+			ginkgo.By(fmt.Sprintf("removing propagationPolicy(%s/%s)", propagationPolicyNamespace, propagationPolicyName), func() {
+				err := karmadaClient.PolicyV1alpha1().PropagationPolicies(propagationPolicyNamespace).Delete(context.TODO(), propagationPolicyName, metav1.DeleteOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+
+		ginkgo.It("pod imageOverride testing", func() {
+			ginkgo.By(fmt.Sprintf("creating pod(%s/%s)", podNamespace, podName), func() {
+				_, err := kubeClient.CoreV1().Pods(testNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+
+			ginkgo.By("check if pod present on member clusters have correct image value", func() {
+				for _, cluster := range clusters {
+					clusterClient := getClusterClient(cluster.Name)
+					gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+
+					var podInClusters *corev1.Pod
+
+					klog.Infof("Waiting for pod(%s/%s) present on cluster(%s)", podNamespace, podName, cluster.Name)
+					err := wait.Poll(pollInterval, pollTimeout, func() (done bool, err error) {
+						podInClusters, err = clusterClient.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+
+						if err != nil {
+							if errors.IsNotFound(err) {
+								return false, nil
+							}
+							return false, err
+						}
+						return true, nil
+					})
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+					for _, container := range podInClusters.Spec.Containers {
+						gomega.Expect(container.Image).Should(gomega.Equal("fictional.registry.us/busybox:1.0"))
+					}
+				}
+			})
+
+			ginkgo.By(fmt.Sprintf("removing pod(%s/%s)", podNamespace, podName), func() {
+				err := kubeClient.CoreV1().Pods(testNamespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+
+	})
+
+	ginkgo.Context("Deployment override specific images in container list", func() {
+		deploymentNamespace := testNamespace
+		deploymentName := deploymentNamePrefix + rand.String(RandomStrLength)
+		propagationPolicyNamespace := testNamespace
+		propagationPolicyName := deploymentName
+		overridePolicyNamespace := testNamespace
+		overridePolicyName := deploymentName
+
+		deployment := helper.NewDeployment(deploymentNamespace, deploymentName)
+		propagationPolicy := helper.NewPolicyWithSingleDeployment(propagationPolicyNamespace, propagationPolicyName, deployment, clusterNames)
+		overridePolicy := helper.NewOverridePolicyWithDeployment(overridePolicyNamespace, overridePolicyName, deployment, clusterNames, helper.NewImageOverriderWithPredicate())
+
+		ginkgo.BeforeEach(func() {
+			ginkgo.By(fmt.Sprintf("creating propagationPolicy(%s/%s)", propagationPolicyNamespace, propagationPolicyName), func() {
+				_, err := karmadaClient.PolicyV1alpha1().PropagationPolicies(propagationPolicyNamespace).Create(context.TODO(), propagationPolicy, metav1.CreateOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+
+		ginkgo.BeforeEach(func() {
+			ginkgo.By(fmt.Sprintf("creating overridePolicy(%s/%s)", overridePolicyNamespace, overridePolicyName), func() {
+				_, err := karmadaClient.PolicyV1alpha1().OverridePolicies(overridePolicyNamespace).Create(context.TODO(), overridePolicy, metav1.CreateOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+
+		ginkgo.AfterEach(func() {
+			ginkgo.By(fmt.Sprintf("removing overridePolicy(%s/%s)", overridePolicyNamespace, overridePolicyName), func() {
+				err := karmadaClient.PolicyV1alpha1().OverridePolicies(overridePolicyNamespace).Delete(context.TODO(), overridePolicyName, metav1.DeleteOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+
+		ginkgo.AfterEach(func() {
+			ginkgo.By(fmt.Sprintf("removing propagationPolicy(%s/%s)", propagationPolicyNamespace, propagationPolicyName), func() {
+				err := karmadaClient.PolicyV1alpha1().PropagationPolicies(propagationPolicyNamespace).Delete(context.TODO(), propagationPolicyName, metav1.DeleteOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+
+		ginkgo.It("deployment imageOverride testing", func() {
+			ginkgo.By(fmt.Sprintf("creating deployment(%s/%s)", deploymentNamespace, deploymentName), func() {
+				_, err := kubeClient.AppsV1().Deployments(testNamespace).Create(context.TODO(), deployment, metav1.CreateOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+
+			ginkgo.By("check if deployment present on member clusters have correct image value", func() {
+				for _, cluster := range clusters {
+					clusterClient := getClusterClient(cluster.Name)
+					gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+
+					var deploymentInCluster *appsv1.Deployment
+
+					klog.Infof("Waiting for deployment(%s/%s) present on cluster(%s)", deploymentNamespace, deploymentName, cluster.Name)
+					err := wait.Poll(pollInterval, pollTimeout, func() (done bool, err error) {
+						deploymentInCluster, err = clusterClient.AppsV1().Deployments(deploymentNamespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+						if err != nil {
+							if errors.IsNotFound(err) {
+								return false, nil
+							}
+							return false, err
+						}
+						return true, nil
+					})
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+					gomega.Expect(deploymentInCluster.Spec.Template.Spec.Containers[0].Image).Should(gomega.Equal("fictional.registry.us/nginx:1.19.0"))
+				}
+			})
+
+			ginkgo.By(fmt.Sprintf("removing deployment(%s/%s)", deploymentNamespace, deploymentName), func() {
+				err := kubeClient.AppsV1().Deployments(testNamespace).Delete(context.TODO(), deploymentName, metav1.DeleteOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+
+	})
+})

--- a/test/helper/overridepolicy.go
+++ b/test/helper/overridepolicy.go
@@ -1,0 +1,84 @@
+package helper
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+)
+
+// NewOverridePolicyWithDeployment will build a OverridePolicy object that select with Deployment resource.
+func NewOverridePolicyWithDeployment(namespace, name string, deployment *appsv1.Deployment, clusters []string, overriders policyv1alpha1.Overriders) *policyv1alpha1.OverridePolicy {
+	return newOverridePolicy(namespace, name, deployment.APIVersion, deployment.Kind, deployment.Name, clusters, overriders)
+}
+
+// NewOverridePolicyWithPod will build a OverridePolicy object that select with Pod resource.
+func NewOverridePolicyWithPod(namespace, name string, pod *corev1.Pod, clusters []string, overriders policyv1alpha1.Overriders) *policyv1alpha1.OverridePolicy {
+	return newOverridePolicy(namespace, name, pod.APIVersion, pod.Kind, pod.Name, clusters, overriders)
+}
+
+func newOverridePolicy(namespace, policyName, apiVersion, kind, resourceName string, clusters []string, overriders policyv1alpha1.Overriders) *policyv1alpha1.OverridePolicy {
+	return &policyv1alpha1.OverridePolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "policy.karmada.io/v1alpha1",
+			Kind:       "OverridePolicy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      policyName,
+		},
+		Spec: policyv1alpha1.OverrideSpec{
+			ResourceSelectors: []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: apiVersion,
+					Kind:       kind,
+					Name:       resourceName,
+				},
+			},
+			TargetCluster: &policyv1alpha1.ClusterAffinity{
+				ClusterNames: clusters,
+			},
+			Overriders: overriders,
+		},
+	}
+}
+
+// NewImageOverriderWithEmptyPredicate will build a Overriders object with empty predicate.
+func NewImageOverriderWithEmptyPredicate() policyv1alpha1.Overriders {
+	return policyv1alpha1.Overriders{
+		ImageOverrider: []policyv1alpha1.ImageOverrider{
+			{
+				Component: "Registry",
+				Operator:  "replace",
+				Value:     "fictional.registry.us",
+			},
+			{
+				Component: "Repository",
+				Operator:  "replace",
+				Value:     "busybox",
+			},
+			{
+				Component: "Tag",
+				Operator:  "replace",
+				Value:     "1.0",
+			},
+		},
+	}
+}
+
+// NewImageOverriderWithPredicate will build a Overriders object with predicate.
+func NewImageOverriderWithPredicate() policyv1alpha1.Overriders {
+	return policyv1alpha1.Overriders{
+		ImageOverrider: []policyv1alpha1.ImageOverrider{
+			{
+				Predicate: &policyv1alpha1.ImagePredicate{
+					Path: "/spec/template/spec/containers/0/image",
+				},
+				Component: "Registry",
+				Operator:  "replace",
+				Value:     "fictional.registry.us",
+			},
+		},
+	}
+}

--- a/test/helper/resource.go
+++ b/test/helper/resource.go
@@ -94,6 +94,17 @@ func NewPod(namespace string, name string) *corev1.Pod {
 						},
 					},
 				},
+				{
+					Name:  "busybox",
+					Image: "busybox-old:1.19.0",
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "web",
+							ContainerPort: 81,
+							Protocol:      corev1.ProtocolTCP,
+						},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

add e2e of imageoverride with https://github.com/karmada-io/karmada/pull/370


```
SSS
------------------------------
[OverridePolicy] apply overriders testing Deployment imageOverride with empty predicate test 
  deployment imageOverride testing
  /root/karmada/test/e2e/overridepolicy_test.go:61
STEP: creating propagationPolicy(karmadatest-nm6/deploy-xr4)
STEP: creating overridePolicy(karmadatest-nm6/deploy-xr4)
STEP: creating deployment(karmadatest-nm6/deploy-xr4)
STEP: check if deployment present on member clusters have correct image value
I0527 12:18:46.108427   22970 overridepolicy_test.go:74] Waiting for deployment(karmadatest-nm6/deploy-xr4) present on cluster(member1)
I0527 12:18:51.112567   22970 overridepolicy_test.go:74] Waiting for deployment(karmadatest-nm6/deploy-xr4) present on cluster(member2)
STEP: removing deployment(karmadatest-nm6/deploy-xr4)
STEP: removing overridePolicy(karmadatest-nm6/deploy-xr4)
STEP: removing propagationPolicy(karmadatest-nm6/deploy-xr4)

• [SLOW TEST:10.067 seconds]
[OverridePolicy] apply overriders testing
/root/karmada/test/e2e/overridepolicy_test.go:20
  Deployment imageOverride with empty predicate test
  /root/karmada/test/e2e/overridepolicy_test.go:21
    deployment imageOverride testing
    /root/karmada/test/e2e/overridepolicy_test.go:61
------------------------------
[OverridePolicy] apply overriders testing Pod imageOverride test 
  pod imageOverride testing
  /root/karmada/test/e2e/overridepolicy_test.go:145
STEP: creating propagationPolicy(karmadatest-nm6/pod-bsf)
STEP: creating overridePolicy(karmadatest-nm6/pod-bsf)
STEP: creating pod(karmadatest-nm6/pod-bsf)
STEP: check if pod present on member clusters have correct image value
I0527 12:18:56.163858   22970 overridepolicy_test.go:158] Waiting for pod(karmadatest-nm6/pod-bsf) present on cluster(member1)
I0527 12:19:01.167646   22970 overridepolicy_test.go:158] Waiting for pod(karmadatest-nm6/pod-bsf) present on cluster(member2)
STEP: removing pod(karmadatest-nm6/pod-bsf)
STEP: removing overridePolicy(karmadatest-nm6/pod-bsf)
STEP: removing propagationPolicy(karmadatest-nm6/pod-bsf)

• [SLOW TEST:10.055 seconds]
[OverridePolicy] apply overriders testing
/root/karmada/test/e2e/overridepolicy_test.go:20
  Pod imageOverride test
  /root/karmada/test/e2e/overridepolicy_test.go:105
    pod imageOverride testing
    /root/karmada/test/e2e/overridepolicy_test.go:145
------------------------------
[OverridePolicy] apply overriders testing Deployment imageOverride with predicate test 
  deployment imageOverride testing
  /root/karmada/test/e2e/overridepolicy_test.go:230
STEP: creating propagationPolicy(karmadatest-nm6/deploy-rpv)
STEP: creating overridePolicy(karmadatest-nm6/deploy-rpv)
STEP: creating deployment(karmadatest-nm6/deploy-rpv)
STEP: check if deployment present on member clusters have correct image value
I0527 12:19:06.198839   22970 overridepolicy_test.go:243] Waiting for deployment(karmadatest-nm6/deploy-rpv) present on cluster(member1)
I0527 12:19:11.202521   22970 overridepolicy_test.go:243] Waiting for deployment(karmadatest-nm6/deploy-rpv) present on cluster(member2)
STEP: removing deployment(karmadatest-nm6/deploy-rpv)
STEP: removing overridePolicy(karmadatest-nm6/deploy-rpv)
STEP: removing propagationPolicy(karmadatest-nm6/deploy-rpv)

• [SLOW TEST:10.035 seconds]
[OverridePolicy] apply overriders testing
/root/karmada/test/e2e/overridepolicy_test.go:20
  Deployment imageOverride with predicate test
  /root/karmada/test/e2e/overridepolicy_test.go:190
    deployment imageOverride testing
    /root/karmada/test/e2e/overridepolicy_test.go:230
------------------------------
SSSSSSSSSSSSS
Ran 3 of 19 Specs in 38.398 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 16 Skipped
PASS
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

