### PR TITLE
enable gosec and fix warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,7 @@ linters:
   - unused
   - varcheck
   # other linters supported by golangci-lint.
+  - gosec
   - whitespace
 
 linters-settings:

--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -331,11 +331,11 @@ func getClusterAllocatable(nodeList *corev1.NodeList) (allocatable corev1.Resour
 
 func getUsedResource(podList *corev1.PodList) corev1.ResourceList {
 	var requestCPU, requestMem int64
-	for _, pod := range podList.Items {
+	for podIndex, pod := range podList.Items {
 		if pod.Status.Phase == "Running" {
 			for _, c := range pod.Status.Conditions {
 				if c.Type == "Ready" && c.Status == "True" {
-					podRes := addPodRequestResource(&pod)
+					podRes := addPodRequestResource(&podList.Items[podIndex])
 					requestCPU += podRes.MilliCPU
 					requestMem += podRes.Memory
 				}

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -62,7 +62,7 @@ func (frw *frameworkImpl) RunFilterPlugins(ctx context.Context, placement *v1alp
 	return result
 }
 
-// RunFilterPlugins runs the set of configured Filter plugins for resources on the cluster.
+// RunScorePlugins runs the set of configured Filter plugins for resources on the cluster.
 // If any of the result is not success, the cluster is not suited for the resource.
 func (frw *frameworkImpl) RunScorePlugins(ctx context.Context, placement *v1alpha1.Placement, clusters []*cluster.Cluster) (framework.PluginToClusterScores, error) {
 	result := make(framework.PluginToClusterScores, len(frw.filterPlugins))

--- a/pkg/util/detector/detector.go
+++ b/pkg/util/detector/detector.go
@@ -705,7 +705,7 @@ func (d *ResourceDetector) HandlePropagationPolicyDeletion(policyNS string, poli
 		return err
 	}
 
-	for _, binding := range rbs.Items {
+	for itemIndex, binding := range rbs.Items {
 		// Cleanup the labels from the object referencing by binding.
 		// In addition, this will give the object a chance to match another policy.
 		if err := d.CleanupLabels(binding.Spec.Resource, util.PropagationPolicyNameLabel, util.PropagationPolicyNameLabel); err != nil {
@@ -715,7 +715,7 @@ func (d *ResourceDetector) HandlePropagationPolicyDeletion(policyNS string, poli
 		}
 
 		klog.V(2).Infof("Removing binding(%s/%s)", binding.Namespace, binding.Name)
-		if err := d.Client.Delete(context.TODO(), &binding); err != nil {
+		if err := d.Client.Delete(context.TODO(), &rbs.Items[itemIndex]); err != nil {
 			klog.Errorf("Failed to delete binding(%s/%s), error: %v", binding.Namespace, binding.Name, err)
 			return err
 		}
@@ -739,7 +739,7 @@ func (d *ResourceDetector) HandleClusterPropagationPolicyDeletion(policyName str
 		klog.Errorf("Failed to load cluster resource binding by policy(%s), error: %v", policyName, err)
 		errs = append(errs, err)
 	} else if len(crbs.Items) > 0 {
-		for _, binding := range crbs.Items {
+		for itemIndex, binding := range crbs.Items {
 			// Cleanup the labels from the object referencing by binding.
 			// In addition, this will give the object a chance to match another policy.
 			if err := d.CleanupLabels(binding.Spec.Resource, util.ClusterPropagationPolicyLabel); err != nil {
@@ -749,7 +749,7 @@ func (d *ResourceDetector) HandleClusterPropagationPolicyDeletion(policyName str
 			}
 
 			klog.V(2).Infof("Removing cluster resource binding(%s)", binding.Name)
-			if err := d.Client.Delete(context.TODO(), &binding); err != nil {
+			if err := d.Client.Delete(context.TODO(), &crbs.Items[itemIndex]); err != nil {
 				klog.Errorf("Failed to delete cluster resource binding(%s), error: %v", binding.Name, err)
 				errs = append(errs, err)
 			}
@@ -762,7 +762,7 @@ func (d *ResourceDetector) HandleClusterPropagationPolicyDeletion(policyName str
 		klog.Errorf("Failed to load resource binding by policy(%s), error: %v", policyName, err)
 		errs = append(errs, err)
 	} else if len(rbs.Items) > 0 {
-		for _, binding := range rbs.Items {
+		for itemIndex, binding := range rbs.Items {
 			// Cleanup the labels from the object referencing by binding.
 			// In addition, this will give the object a chance to match another policy.
 			if err := d.CleanupLabels(binding.Spec.Resource, util.ClusterPropagationPolicyLabel); err != nil {
@@ -771,7 +771,7 @@ func (d *ResourceDetector) HandleClusterPropagationPolicyDeletion(policyName str
 			}
 
 			klog.V(2).Infof("Removing resource binding(%s)", binding.Name)
-			if err := d.Client.Delete(context.TODO(), &binding); err != nil {
+			if err := d.Client.Delete(context.TODO(), &rbs.Items[itemIndex]); err != nil {
 				klog.Errorf("Failed to delete resource binding(%s/%s), error: %v", binding.Namespace, binding.Name, err)
 				errs = append(errs, err)
 			}

--- a/pkg/util/helper/binding.go
+++ b/pkg/util/helper/binding.go
@@ -120,8 +120,8 @@ func FindOrphanWorks(c client.Client, bindingNamespace, bindingName string, clus
 
 // RemoveOrphanWorks will remove orphan works.
 func RemoveOrphanWorks(c client.Client, works []workv1alpha1.Work) error {
-	for _, work := range works {
-		err := c.Delete(context.TODO(), &work)
+	for workIndex, work := range works {
+		err := c.Delete(context.TODO(), &works[workIndex])
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Error found during golint scan: `G601: Implicit memory aliasing in for loop. (gosec)`. It may lead to unintended behavior. See [Using reference to loop iterator variable](https://github.com/golang/go/wiki/CommonMistakes#using-reference-to-loop-iterator-variable).

