### PR TITLE
Change the receiver of Stringer interface implementation

### DIFF
--- a/pkg/util/imageparser/parser.go
+++ b/pkg/util/imageparser/parser.go
@@ -68,7 +68,7 @@ func (c *Components) FullRepository() string {
 }
 
 // String returns the full name of the image, including repository and tag(or digest).
-func (c *Components) String() string {
+func (c Components) String() string {
 	if c.tag != "" {
 		return c.FullRepository() + ":" + c.tag
 	} else if c.digest != "" {

--- a/pkg/util/imageparser/parser_test.go
+++ b/pkg/util/imageparser/parser_test.go
@@ -189,3 +189,25 @@ func ExampleComponents_SetTagOrDigest() {
 	// gcr.io/kube-apiserver@sha256:50d858e0985ecc7f60418aaf0cc5ab587f42c2570a884095a9e8ccacd0f6545c
 	// gcr.io/kube-apiserver
 }
+
+func ExampleComponents_String() {
+	key := Components{
+		hostname:   "fictional.registry.example",
+		repository: "karmada-scheduler",
+		tag:        "v1.0.0",
+	}
+	pKey := &key
+	fmt.Printf("%s\n", key)
+	fmt.Printf("%v\n", key)
+	fmt.Printf("%s\n", key.String())
+	fmt.Printf("%s\n", pKey)
+	fmt.Printf("%v\n", pKey)
+	fmt.Printf("%s\n", pKey.String())
+	// Output:
+	// fictional.registry.example/karmada-scheduler:v1.0.0
+	// fictional.registry.example/karmada-scheduler:v1.0.0
+	// fictional.registry.example/karmada-scheduler:v1.0.0
+	// fictional.registry.example/karmada-scheduler:v1.0.0
+	// fictional.registry.example/karmada-scheduler:v1.0.0
+	// fictional.registry.example/karmada-scheduler:v1.0.0
+}

--- a/pkg/util/informermanager/keys/keys.go
+++ b/pkg/util/informermanager/keys/keys.go
@@ -29,7 +29,7 @@ type ClusterWideKey struct {
 
 // String returns the key's printable info with format:
 // "<GroupVersion>, kind=<Kind>, <NamespaceKey>"
-func (k *ClusterWideKey) String() string {
+func (k ClusterWideKey) String() string {
 	return fmt.Sprintf("%s, kind=%s, %s", k.GroupVersion().String(), k.Kind, k.NamespaceKey())
 }
 
@@ -93,7 +93,7 @@ type FederatedKey struct {
 
 // String returns the key's printable info with format:
 // "cluster=<Cluster>, <GroupVersion>, kind=<Kind>, <NamespaceKey>"
-func (f *FederatedKey) String() string {
+func (f FederatedKey) String() string {
 	return fmt.Sprintf("cluster=%s, %s, kind=%s, %s", f.Cluster, f.GroupVersion().String(), f.Kind, f.NamespaceKey())
 }
 

--- a/pkg/util/informermanager/keys/keys_test.go
+++ b/pkg/util/informermanager/keys/keys_test.go
@@ -1,6 +1,7 @@
 package keys
 
 import (
+	"fmt"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -185,4 +186,54 @@ func TestFederatedKeyFunc(t *testing.T) {
 			}
 		})
 	}
+}
+
+func ExampleClusterWideKey_String() {
+	key := ClusterWideKey{
+		Group:     "apps",
+		Version:   "v1",
+		Kind:      "Namespace",
+		Namespace: "default",
+		Name:      "foo",
+	}
+	pKey := &key
+	fmt.Printf("%s\n", key)
+	fmt.Printf("%v\n", key)
+	fmt.Printf("%s\n", key.String())
+	fmt.Printf("%s\n", pKey)
+	fmt.Printf("%v\n", pKey)
+	fmt.Printf("%s\n", pKey.String())
+	// Output:
+	// apps/v1, kind=Namespace, default/foo
+	// apps/v1, kind=Namespace, default/foo
+	// apps/v1, kind=Namespace, default/foo
+	// apps/v1, kind=Namespace, default/foo
+	// apps/v1, kind=Namespace, default/foo
+	// apps/v1, kind=Namespace, default/foo
+}
+
+func ExampleFederatedKey_String() {
+	key := FederatedKey{
+		Cluster: "karamda",
+		ClusterWideKey: ClusterWideKey{
+			Group:     "apps",
+			Version:   "v1",
+			Kind:      "Namespace",
+			Namespace: "default",
+			Name:      "foo"},
+	}
+	pKey := &key
+	fmt.Printf("%s\n", key)
+	fmt.Printf("%v\n", key)
+	fmt.Printf("%s\n", key.String())
+	fmt.Printf("%s\n", pKey)
+	fmt.Printf("%v\n", pKey)
+	fmt.Printf("%s\n", pKey.String())
+	// Output:
+	// cluster=karamda, apps/v1, kind=Namespace, default/foo
+	// cluster=karamda, apps/v1, kind=Namespace, default/foo
+	// cluster=karamda, apps/v1, kind=Namespace, default/foo
+	// cluster=karamda, apps/v1, kind=Namespace, default/foo
+	// cluster=karamda, apps/v1, kind=Namespace, default/foo
+	// cluster=karamda, apps/v1, kind=Namespace, default/foo
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
When implementing the `type Stringer interface` with a pointer receiver, then the `String()` method will only be called for a pointer of that type. 

The significant change is reflected in the log:
```
// without the patch
I0602 04:30:41.048943       1 detector.go:149] Reconciling object: { v1 Secret default default-token-kdmsv}
// with the patch, the output will using the customized info instead of the raw structure.
I0602 07:57:38.249626       1 detector.go:149] Reconciling object: v1, kind=Namespace, karmada-es-member2
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
More details please refer to [here](https://stackoverflow.com/questions/52240972/implement-stringer-interface-using-value-or-pointer-receiver).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

