### PR TITLE
Embed certs to kubeconfig

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -112,7 +112,7 @@ function util::append_client_kubeconfig {
     local client_id=$6
     local token=${7:-}
     kubectl config set-cluster "${client_id}" --server=https://"${api_host}:${api_port}" --insecure-skip-tls-verify=true --kubeconfig="${kubeconfig_path}"
-    kubectl config set-credentials "${client_id}" --token="${token}" --client-certificate="${client_certificate_file}" --client-key="${client_key_file}" --kubeconfig="${kubeconfig_path}"
+    kubectl config set-credentials "${client_id}" --token="${token}" --client-certificate="${client_certificate_file}" --client-key="${client_key_file}" --embed-certs=true --kubeconfig="${kubeconfig_path}"
     kubectl config set-context "${client_id}" --cluster="${client_id}" --user="${client_id}" --kubeconfig="${kubeconfig_path}"
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Save the contents of the client certificate and client key to kubeconfig instead of their file path.
Though it works well now, it will occur a mistake when deploying the karmada agent, because it can not find the certificate files path in the agent container.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

NONE

