### PR TITLE
fix the problem that the replicas count of deployment may be inaccurate

### DIFF
--- a/pkg/util/helper/workstatus.go
+++ b/pkg/util/helper/workstatus.go
@@ -79,6 +79,9 @@ func assembleWorkStatus(c client.Client, selector labels.Selector, workload *uns
 
 	statuses := make([]workv1alpha1.AggregatedStatusItem, 0)
 	for _, work := range workList.Items {
+		if work.ObjectMeta.DeletionTimestamp != nil {
+			continue
+		}
 		identifierIndex, err := GetManifestIndex(work.Spec.Workload.Manifests, workload)
 		if err != nil {
 			klog.Errorf("Failed to get manifestIndex of workload in work.Spec.Workload.Manifests. Error: %v.", err)


### PR DESCRIPTION
Signed-off-by: hansedong <admin@yinxiaoluo.com>

Fixed the problem that when the works CRD is being deleted (when it is still available from K8s), the Aggregate Staus of the binding CRD includes the deleted works resource, resulting in an inaccurate deployment status count.

What type of PR is this?
/kind bug

What this PR does / why we need it:

First, the number of instances of deployment deployed in karmada comes from all the associated works CRDs in the resourcebindings CRD.

karmada aggregates all the replicas of the works CRD, and calculates the replicas of the deployment. The whole process is in the pkg/util/helper/workstatus.go#AggregateResourceBindingWorkStatus function.

However, when the clusters configured by clusterAffinity in the propagationpolicies strategy are reduced from two to one, in a very short period of time, a problem will arise: karmada has obtained two works, one of which is Valid, but the other one is in the state of being deleted, and the DeletionTimestamp of this CRD resource is not nil. At this time, if two resources are counted, there will be an inaccurate count problem.

Therefore, we should ignore the works CRD resources that are being deleted.

Which issue(s) this PR fixes:
Fixes #

Special notes for your reviewer:

NONE

Does this PR introduce a user-facing change?:

NONE