### PR TITLE
fix make verify cmd generated codes output package is ./

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -10,7 +10,7 @@ cd "${REPO_ROOT}"
 
 echo "Generating with deepcopy-gen"
 GO111MODULE=on go install k8s.io/code-generator/cmd/deepcopy-gen
-GOPATH=$(go env GOPATH | awk -F ':' '{print $1}')
+export GOPATH=$(go env GOPATH | awk -F ':' '{print $1}')
 export PATH=$PATH:$GOPATH/bin
 
 deepcopy-gen \


### PR DESCRIPTION
Signed-off-by: gy95 <guoyao17@huawei.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
fix `make verify` generated codes output package is `./` but not `$GOPATH/src/`

**Which issue(s) this PR fixes**:
Fixes #412

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

