### PR TITLE
nil resourceSelectors of newCreating policy match all resource

### DIFF
--- a/pkg/util/detector/detector.go
+++ b/pkg/util/detector/detector.go
@@ -574,6 +574,11 @@ func (d *ResourceDetector) GetMatching(resourceSelectors []policyv1alpha1.Resour
 	var matchedResult []keys.ClusterWideKey
 
 	for waitKey := range d.waitingObjects {
+		if resourceSelectors == nil {
+			matchedResult = append(matchedResult, waitKey)
+			continue
+		}
+
 		waitObj, err := d.GetUnstructuredObject(waitKey)
 		if err != nil {
 			// all object in waiting list should exist. Just print a log to trace.

--- a/pkg/util/detector/detector_test.go
+++ b/pkg/util/detector/detector_test.go
@@ -1,0 +1,46 @@
+package detector
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/util/informermanager/keys"
+)
+
+func TestResourceDetector_GetMatching(t *testing.T) {
+	tests := []struct {
+		name              string
+		waitingObjects    map[keys.ClusterWideKey]struct{}
+		resourceSelectors []policyv1alpha1.ResourceSelector
+		want              []keys.ClusterWideKey
+	}{
+		{
+			name: "nil resourceSelectors",
+			waitingObjects: map[keys.ClusterWideKey]struct{}{
+				{Version: "v1", Kind: "Pod", Namespace: "default", Name: "pod-a"}:                       {},
+				{Group: "apps", Version: "v1", Kind: "Deployment", Namespace: "ns-a", Name: "deploy-b"}: {},
+			},
+			resourceSelectors: nil,
+			want: []keys.ClusterWideKey{
+				{Version: "v1", Kind: "Pod", Namespace: "default", Name: "pod-a"},
+				{Group: "apps", Version: "v1", Kind: "Deployment", Namespace: "ns-a", Name: "deploy-b"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &ResourceDetector{
+				waitingObjects: tt.waitingObjects,
+			}
+
+			got := d.GetMatching(tt.resourceSelectors)
+			sort.Slice(tt.want, func(i, j int) bool { return tt.want[i].Name < tt.want[j].Name })
+			sort.Slice(got, func(i, j int) bool { return got[i].Name < got[j].Name })
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetMatching() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

When a new PropagationPolicy/ClusterPropagationPolicy with nil resourceSelectors is creating, it will match all resource in waitingObjects of ResourceDetector, and add them to reconcile queue.

**Special notes for your reviewer**:

Create resources first, and then create propagation policy.

