### PR TITLE
Revert "remove Makefile SOURCES variable (#334)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 GOOS ?= $(shell go env GOOS)
+SOURCES := $(shell find . -type f  -name '*.go')
 
 # Git information
 GIT_VERSION ?= $(shell git describe --tags --dirty)
@@ -39,31 +40,31 @@ endif
 
 all: karmada-controller-manager karmada-scheduler karmadactl karmada-webhook karmada-agent
 
-karmada-controller-manager:
+karmada-controller-manager: $(SOURCES)
 	CGO_ENABLED=0 GOOS=$(GOOS) go build \
 		-ldflags $(LDFLAGS) \
 		-o karmada-controller-manager \
 		cmd/controller-manager/controller-manager.go
 
-karmada-scheduler:
+karmada-scheduler: $(SOURCES)
 	CGO_ENABLED=0 GOOS=$(GOOS) go build \
 		-ldflags $(LDFLAGS) \
 		-o karmada-scheduler \
 		cmd/scheduler/main.go
 
-karmadactl:
+karmadactl: $(SOURCES)
 	CGO_ENABLED=0 GOOS=$(GOOS) go build \
 		-ldflags $(LDFLAGS) \
 		-o karmadactl \
 		cmd/karmadactl/karmadactl.go
 
-karmada-webhook:
+karmada-webhook: $(SOURCES)
 	CGO_ENABLED=0 GOOS=$(GOOS) go build \
 		-ldflags $(LDFLAGS) \
 		-o karmada-webhook \
 		cmd/webhook/main.go
 
-karmada-agent:
+karmada-agent: $(SOURCES)
 	CGO_ENABLED=0 GOOS=$(GOOS) go build \
 		-ldflags $(LDFLAGS) \
 		-o karmada-agent \


### PR DESCRIPTION
**What type of PR is this?**
Reverts karmada-io/karmada#334

**What this PR does / why we need it**:
The `dependency` of a `target` in the makefile is used to make sure the `target` up to date.

Revert #334 will make all binaries and images re-build when a change happens on the `*.go` file. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
It's my bad that didn't catch it in the previous review. Thanks @mrlihanbo point it out.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
cc @daixiang0 @gy95 
/priority important-soon