### PR TITLE
Change APIEnablement.Resources to an optional field

### DIFF
--- a/artifacts/deploy/cluster.karmada.io_clusters.yaml
+++ b/artifacts/deploy/cluster.karmada.io_clusters.yaml
@@ -155,7 +155,6 @@ spec:
                       type: array
                   required:
                   - groupVersion
-                  - resources
                   type: object
                 type: array
               conditions:

--- a/pkg/apis/cluster/v1alpha1/types.go
+++ b/pkg/apis/cluster/v1alpha1/types.go
@@ -139,7 +139,8 @@ type APIEnablement struct {
 	// GroupVersion is the group and version this APIEnablement is for.
 	GroupVersion string `json:"groupVersion"`
 	// Resources contains the name of the resources.
-	Resources []string `json:"resources"`
+	// +optional
+	Resources []string `json:"resources,omitempty"`
 }
 
 // NodeSummary represents the summary of nodes status in a specific cluster.


### PR DESCRIPTION
Signed-off-by: lfbear <lfbear@gmail.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When your member cluster has a kind of resource that is empty APIResources in APIResourceList, such as the following, you will not get the current cluster status after joined the member cluster. Finally, Karmada can not send workload to the cluster.
```
v1.APIResourceList{
  TypeMeta: v1.TypeMeta{
    Kind:       "APIResourceList",
    APIVersion: "v1",
  },
  GroupVersion: "external.metrics.k8s.io/v1beta1",
  APIResources: []v1.APIResource{},
}
```
**Which issue(s) this PR fixes**:
Fixes #450

**Special notes for your reviewer**:
I chose the plan that set the `Resources` to an optional field. 
https://github.com/karmada-io/karmada/blob/3f99da3024cd63cd5cec3c43cd782b37d30a96fa/pkg/apis/cluster/v1alpha1/types.go#L142 
**Does this PR introduce a user-facing change?**:
NONE

