### PR TITLE
Karmada-agent install script support the standalone cluster and some misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ There are two contexts you can switch after the script run are:
 The `karmada-apiserver` is the **main kubeconfig** to be used when interacting with karamda control plane, while `karmada-host` is only used for debugging karmada installation with host cluster, you can check all clusters at any time by run: `kubectl config view` and switch by `kubectl config use-context [CONTEXT_NAME]`
 
 ##### 3.2. I have present cluster for installing
-Before run the following script, please make sure you are in the node or master of the cluster to install:
+Before running the following script, please make sure your cluster could provide `LoadBalancer` type service.
 ```
 # hack/remote-up-karmada.sh <kubeconfig> <context_name>
 ```
@@ -192,9 +192,15 @@ in `$HOME/.kube/karmada.config`. Run following command:
 ```
 # hack/create-cluster.sh member1 $HOME/.kube/karmada.config
 ```
-The script `hack/create-cluster.sh` will create a standalone cluster by kind.
+The script `hack/create-cluster.sh` will create a cluster by kind.
 
 #### 2. Join member cluster to karmada control plane
+
+You can choose one of mode: [push](#21-push-mode-karmada-controls-the-member-cluster-initiative-by-using-karmadactl) or
+[pull](#22-pull-mode-installing-karmada-agent-in-the-member-cluster), either will help you join a member cluster.
+
+##### 2.1. Push Mode: Karmada controls the member cluster initiative by using `karmadactl`
+
 The command `karmadactl` will help to join the member cluster to karmada control plane,
 before that, we should switch to karmada apiserver:
 ```
@@ -208,7 +214,14 @@ Then, install `karmadactl` command and join the member cluster:
 ```
 The `karmadactl join` command will create a `Cluster` object to reflect the member cluster.
 
-### 3. Check member cluster status
+##### 2.2. Pull Mode: Installing karmada-agent in the member cluster
+
+The following script will install the `karamda-agent` to your member cluster, you need to specify the kubeconfig and the cluster context of the karmada control plane and member cluster.
+```
+# hack/deploy-karmada-agent.sh <karmada_apiserver_kubeconfig> <karmada_apiserver_context_name> <member_cluster_kubeconfig> <member_cluster_context_name>
+```
+
+#### 3. Check member cluster status
 Now, check the member clusters from karmada control plane by following command:
 ```
 # kubectl get clusters

--- a/artifacts/agent/karmada-agent.yaml
+++ b/artifacts/agent/karmada-agent.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
         - name: karmada-agent
           image: swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-agent:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{image_pull_policy}}
           command:
             - /bin/karmada-agent
             - --karmada-kubeconfig=/etc/kubeconfig/karmada-kubeconfig

--- a/artifacts/deploy/karmada-apiserver.yaml
+++ b/artifacts/deploy/karmada-apiserver.yaml
@@ -126,3 +126,4 @@ spec:
       targetPort: 5443
   selector:
     app: karmada-apiserver
+  type: {{service_type}}

--- a/hack/remote-up-karmada.sh
+++ b/hack/remote-up-karmada.sh
@@ -6,11 +6,16 @@ set -o pipefail
 
 function usage() {
   echo "This script will deploy karmada control plane to a given cluster."
-  echo "Usage: hack/remote-up-karmada.sh <KUBECONFIG> <CONTEXT_NAME>"
+  echo "Usage: hack/remote-up-karmada.sh <KUBECONFIG> <CONTEXT_NAME> [CLUSTER_IP_ONLY]"
   echo "Example: hack/remote-up-karmada.sh ~/.kube/config karmada-host"
+  echo -e "Parameters:\n\tKUBECONFIG\tYour cluster's kubeconfig that you want to install to"
+  echo -e "\tCONTEXT_NAME\tThe name of context in 'kubeconfig'"
+  echo -e "\tCLUSTER_IP_ONLY\tThis option default is 'false', and there will create a 'LoadBalancer' type service
+  \t\t\tfor karmada apiserver so that it can easy communicate outside the karmada-host cluster,
+  \t\t\tif you want only a 'ClusterIP' type service for karmada apiserver, set as 'true'."
 }
 
-if [[ $# -ne 2 ]]; then
+if [[ $# -lt 2 ]]; then
   usage
   exit 1
 fi
@@ -31,6 +36,11 @@ then
   echo -e "ERROR: failed to get context: '${HOST_CLUSTER_NAME}' not in ${HOST_CLUSTER_KUBECONFIG}. \n"
   usage
   exit 1
+fi
+
+if [ "${3:-false}" = true ]; then
+  CLUSTER_IP_ONLY=true
+  export CLUSTER_IP_ONLY
 fi
 
 # deploy karmada control plane

--- a/hack/undeploy-karmada.sh
+++ b/hack/undeploy-karmada.sh
@@ -6,14 +6,37 @@ set -o pipefail
 
 function usage() {
   echo "This script will remove karmada control plane from a cluster."
-  echo "Usage: hack/undeploy-karmada.sh"
-  echo "Example: hack/undeploy-karmada.sh"
+  echo "Usage: hack/undeploy-karmada.sh [KUBECONFIG] [CONTEXT_NAME]"
+  echo "Example: hack/undeploy-karmada.sh ~/.kube/karmada.config karmada-host"
 }
 
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-
+# delete all keys and certificates
+rm -fr "${HOME}/.karmada"
+# set default host cluster's kubeconfig file (created by kind)
 KUBECONFIG_PATH=${KUBECONFIG_PATH:-"${HOME}/.kube"}
-HOST_CLUSTER_KUBECONFIG="${KUBECONFIG_PATH}/karmada-host.config"
+HOST_CLUSTER_KUBECONFIG="${KUBECONFIG_PATH}/karmada.config"
+HOST_CLUSTER_NAME=${HOST_CLUSTER_NAME:-"karmada-host"}
 
-export KUBECONFIG=${HOST_CLUSTER_KUBECONFIG}
-kubectl delete ns karmada-system
+# if provider the custom kubeconfig and context name
+if [[ -f "${1:-}" ]]; then
+  if ! kubectl config get-contexts "${2:-}" --kubeconfig="${1}" > /dev/null 2>&1;
+  then
+    echo -e "ERROR: failed to get context: '${2:-}' not in ${1}. \n"
+    usage
+    exit 1
+  else
+    HOST_CLUSTER_KUBECONFIG=${1:-}
+    HOST_CLUSTER_NAME=${2:-}
+  fi
+fi
+
+kubectl config use-context "${HOST_CLUSTER_NAME}" --kubeconfig="${HOST_CLUSTER_KUBECONFIG}"
+
+# clear all in namespace karmada-system
+kubectl delete ns karmada-system --kubeconfig="${HOST_CLUSTER_KUBECONFIG}"
+
+# clear configs about karmada-apiserver in kubeconfig
+kubectl config delete-cluster karmada-apiserver --kubeconfig="${HOST_CLUSTER_KUBECONFIG}"
+kubectl config delete-user karmada-apiserver --kubeconfig="${HOST_CLUSTER_KUBECONFIG}"
+kubectl config delete-context karmada-apiserver --kubeconfig="${HOST_CLUSTER_KUBECONFIG}"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Further optimizing get started experiences

**Which issue(s) this PR fixes**:
Fixes #434

**Special notes for your reviewer**:

Some facets:

- document: add `karmada-agent` install script usage in `README.md`
- keep the latest version for `karmada-agent` when installing, remove `imagePullPolicy: IfNotPresent` from `artifacts/agent/karmada-agent.yaml` when deploys to standalone cluster, and add rebuilding image when deploys to the local cluster.
- [UNIGNORABLE] change the service type of karmada-apiserver to `LoadBalancer` when remote install. because 1. it's no longer to find a work node or a master node to install karmada, 2. karmada-agent could access the `LoadBalancer` IP rather than a `Cluster` IP across the diff clusters
- improving `hack/undeploy-karmada.sh`

**Does this PR introduce a user-facing change?**:
NONE


