### PR TITLE
disable StorageObjectInUseProtection admission plugin

### DIFF
--- a/artifacts/deploy/karmada-apiserver.yaml
+++ b/artifacts/deploy/karmada-apiserver.yaml
@@ -47,6 +47,7 @@ spec:
             - --kubelet-client-certificate=/etc/kubernetes/pki/karmada.crt
             - --kubelet-client-key=/etc/kubernetes/pki/karmada.key
             - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+            - --disable-admission-plugins=StorageObjectInUseProtection
             - --runtime-config=
             - --secure-port=5443
             - --service-cluster-ip-range=10.96.0.0/12


### PR DESCRIPTION
Signed-off-by: lihanbo <lihanbo2@huawei.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
StorageObjectInUseProtection admission plugin will add "kubernetes.io/pvc-protection" finalizers to pvc we create in karmada apiserver.  It results in that we can't delete the pv/pvc in karmada apiserver because we disable pvc-protection controller in karmada kube controller manager.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
"NONE"

