### PR TITLE
Fix misleading logs

### DIFF
--- a/pkg/util/detector/detector.go
+++ b/pkg/util/detector/detector.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	errors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
@@ -1035,6 +1035,6 @@ func (d *ResourceDetector) CleanupLabels(objRef workv1alpha1.ObjectReference, la
 		klog.Errorf("Failed to update resource %v/%v, err is %v ", workload.GetNamespace(), workload.GetName(), err)
 		return err
 	}
-	klog.V(2).Infof("Updated resource(kind=%s, %s/%s) on cluster: %s", newWorkload.GetKind(), newWorkload.GetNamespace(), newWorkload.GetName(), newWorkload.GetClusterName())
+	klog.V(2).Infof("Updated resource template(kind=%s, %s/%s) successfully", newWorkload.GetKind(), newWorkload.GetNamespace(), newWorkload.GetName())
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

The log is misleading when we successfully cleaned up labels from a resource template as the `on cluster: %s` is always empty, since newWorkload.GetClusterName() always be empty.


**Which issue(s) this PR fixes**:
Fixes # https://github.com/karmada-io/karmada/issues/414

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

