### PR TITLE
Increase E2E poll timeout setting

### DIFF
--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -39,7 +39,7 @@ const (
 	// pollInterval defines the interval time for a poll operation.
 	pollInterval = 5 * time.Second
 	// pollTimeout defines the time after which the poll operation times out.
-	pollTimeout = 60 * time.Second
+	pollTimeout = 300 * time.Second
 
 	// MinimumCluster represents the minimum number of member clusters to run E2E test.
 	MinimumCluster = 2


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Given the E2E testing fails from time to time, but the testing can be barely reproducible from the local side. 
So, the gap might be caused by the virtual environment's performance. 

This PR intends to increase the timeout and getting a report after multiple testing.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Timeout = 120s:
- Succeed:
- Failed:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/hold