### PR TITLE
Mutate policy's ResourceSelectors in webhook

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -84,10 +84,13 @@ const (
 	ReplicaSetKind = "ReplicaSet"
 	// StatefulSetKind indicates the target resource is a statefulset
 	StatefulSetKind = "StatefulSet"
-	// ServiceExportKind indicates the target resource is a serviceexport
-	ServiceExportKind = "ServiceExport"
 	// EndpointSliceKind indicates the target resource is a endpointslice
 	EndpointSliceKind = "EndpointSlice"
+
+	// ServiceExportKind indicates the target resource is a serviceexport crd
+	ServiceExportKind = "ServiceExport"
+	// ServiceImportKind indicates the target resource is a serviceimport crd
+	ServiceImportKind = "ServiceImport"
 )
 
 // Define resource filed

--- a/pkg/util/helper/policy.go
+++ b/pkg/util/helper/policy.go
@@ -3,10 +3,14 @@ package helper
 import (
 	"fmt"
 
+	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 // DenyReasonResourceSelectorsModify constructs a reason indicating that modify ResourceSelectors is not allowed.
@@ -72,4 +76,47 @@ func IsDependentClusterOverridesPresent(c client.Client, policy *policyv1alpha1.
 	}
 
 	return true, nil
+}
+
+// GetFollowedResourceSelectorsWhenMatchServiceImport get followed derived-service and endpointSlices resource selectors
+// when policy's ResourceSelectors contains ResourceSelector, whose kind is ServiceImport.
+func GetFollowedResourceSelectorsWhenMatchServiceImport(resourceSelectors []policyv1alpha1.ResourceSelector) []policyv1alpha1.ResourceSelector {
+	var addedResourceSelectors []policyv1alpha1.ResourceSelector
+
+	for _, resourceSelector := range resourceSelectors {
+		if resourceSelector.Kind != util.ServiceImportKind {
+			continue
+		}
+
+		if resourceSelector.Namespace == "" || resourceSelector.Name == "" {
+			continue
+		}
+
+		addedResourceSelectors = append(addedResourceSelectors, GenerateResourceSelectorForServiceImport(resourceSelector)...)
+	}
+
+	return addedResourceSelectors
+}
+
+// GenerateResourceSelectorForServiceImport generates resource selectors for ServiceImport.
+func GenerateResourceSelectorForServiceImport(svcImport policyv1alpha1.ResourceSelector) []policyv1alpha1.ResourceSelector {
+	derivedServiceName := names.GenerateDerivedServiceName(svcImport.Name)
+	return []policyv1alpha1.ResourceSelector{
+		{
+			APIVersion: "v1",
+			Kind:       util.ServiceKind,
+			Namespace:  svcImport.Namespace,
+			Name:       derivedServiceName,
+		},
+		{
+			APIVersion: "discovery.k8s.io/v1beta1",
+			Kind:       util.EndpointSliceKind,
+			Namespace:  svcImport.Namespace,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					discoveryv1beta1.LabelServiceName: derivedServiceName,
+				},
+			},
+		},
+	}
 }

--- a/pkg/webhook/clusterpropagationpolicy/mutating.go
+++ b/pkg/webhook/clusterpropagationpolicy/mutating.go
@@ -38,6 +38,11 @@ func (a *MutatingAdmission) Handle(ctx context.Context, req admission.Request) a
 		return admission.Errored(http.StatusBadRequest, fmt.Errorf("ClusterPropagationPolicy's name should be no more than %d characters", validation.LabelValueMaxLength))
 	}
 
+	addedResourceSelectors := helper.GetFollowedResourceSelectorsWhenMatchServiceImport(policy.Spec.ResourceSelectors)
+	if addedResourceSelectors != nil {
+		policy.Spec.ResourceSelectors = append(policy.Spec.ResourceSelectors, addedResourceSelectors...)
+	}
+
 	marshaledBytes, err := json.Marshal(policy)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)

--- a/pkg/webhook/propagationpolicy/mutating.go
+++ b/pkg/webhook/propagationpolicy/mutating.go
@@ -41,10 +41,15 @@ func (a *MutatingAdmission) Handle(ctx context.Context, req admission.Request) a
 	}
 
 	if len(policy.Name) > validation.LabelValueMaxLength {
-		return admission.Errored(http.StatusBadRequest, fmt.Errorf("PropagationPolicy's name and should be no more than %d characters", validation.LabelValueMaxLength))
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("PropagationPolicy's name should be no more than %d characters", validation.LabelValueMaxLength))
 	}
 	// Set default spread constraints if both 'SpreadByField' and 'SpreadByLabel' not set.
 	helper.SetDefaultSpreadConstraints(policy.Spec.Placement.SpreadConstraints)
+
+	addedResourceSelectors := helper.GetFollowedResourceSelectorsWhenMatchServiceImport(policy.Spec.ResourceSelectors)
+	if addedResourceSelectors != nil {
+		policy.Spec.ResourceSelectors = append(policy.Spec.ResourceSelectors, addedResourceSelectors...)
+	}
 
 	marshaledBytes, err := json.Marshal(policy)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add feature: Multi-Cluster Services. Follow #484, #494, #504

When user create a PropagationPlicy/ClusterPropagationPolicy to propagate serviceImport, karmada will add ResourceSelectors to propagation derived-service and endpointslices related to the serviceImport.

