### PR TITLE
fix bugs of agent deployment

### DIFF
--- a/hack/deploy-karmada-agent.sh
+++ b/hack/deploy-karmada-agent.sh
@@ -53,7 +53,9 @@ MEMBER_CLUSTER_NAME=$4
 source "${REPO_ROOT}"/hack/util.sh
 
 # install agent to member cluster
-CURR_KUBECONFIG=$KUBECONFIG # backup current kubeconfig
+if [ -n "${KUBECONFIG+x}" ];then
+  CURR_KUBECONFIG=$KUBECONFIG # backup current kubeconfig
+fi
 export KUBECONFIG="${MEMBER_CLUSTER_KUBECONFIG}" # switch to member cluster
 kubectl config use-context "${MEMBER_CLUSTER_NAME}"
 
@@ -92,5 +94,9 @@ kubectl apply -f "${TEMP_PATH}"/karmada-agent.yaml
 # Wait for karmada-etcd to come up before launching the rest of the components.
 util::wait_pod_ready "${AGENT_POD_LABEL}" "${KARMADA_SYSTEM_NAMESPACE}"
 
-# recover the kubeconfig before installing agent
-export KUBECONFIG="${CURR_KUBECONFIG}"
+# recover the kubeconfig before installing agent if necessary
+if [ -n "${CURR_KUBECONFIG+x}" ];then
+  export KUBECONFIG="${CURR_KUBECONFIG}"
+else
+  unset KUBECONFIG
+fi

--- a/pkg/util/cluster.go
+++ b/pkg/util/cluster.go
@@ -3,6 +3,7 @@ package util
 import (
 	"context"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,4 +28,18 @@ func GetCluster(hostClient client.Client, clusterName string) (*v1alpha1.Cluster
 		return nil, err
 	}
 	return cluster, nil
+}
+
+// CreateClusterIfNotExist try to create the cluster if it does not exist.
+func CreateClusterIfNotExist(client client.Client, clusterObj *v1alpha1.Cluster) error {
+	cluster := &v1alpha1.Cluster{}
+	if err := client.Get(context.TODO(), types.NamespacedName{Name: clusterObj.Name}, cluster); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		if err := client.Create(context.TODO(), clusterObj); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/util/namespace.go
+++ b/pkg/util/namespace.go
@@ -6,7 +6,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	kubeclient "k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // IsNamespaceExist tells if specific already exists.
@@ -42,6 +44,20 @@ func DeleteNamespace(client kubeclient.Interface, namespace string) error {
 	err := client.CoreV1().Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
+	}
+	return nil
+}
+
+// CreateNamespaceIfNotExist try to create the namespace if it does not exist.
+func CreateNamespaceIfNotExist(client client.Client, namespaceObj *corev1.Namespace) error {
+	namespace := &corev1.Namespace{}
+	if err := client.Get(context.TODO(), types.NamespacedName{Name: namespaceObj.Name}, namespace); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		if err := client.Create(context.TODO(), namespaceObj); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Garrybest <garrybest@foxmail.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Fix 2 bugs.
1. When environment `KUBECONFIG` is nil, use `${HOME}/.kube` instead to record current kubeconfig.
2. Create namespace `karmada-cluster` where cluster lease is created.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

