### PR TITLE
Suppress reported work from propagating

### DIFF
--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -210,7 +210,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 		EventRecorder:        mgr.GetEventRecorderFor(execution.ControllerName),
 		RESTMapper:           mgr.GetRESTMapper(),
 		ObjectWatcher:        objectWatcher,
-		PredicateFunc:        helper.NewWorkPredicate(mgr),
+		PredicateFunc:        helper.NewExecutionPredicate(mgr),
 		ClusterClientSetFunc: util.NewClusterDynamicClientSet,
 	}
 	if err := executionController.SetupWithManager(mgr); err != nil {
@@ -225,7 +225,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 		StopChan:             stopChan,
 		WorkerNumber:         1,
 		ObjectWatcher:        objectWatcher,
-		PredicateFunc:        helper.NewWorkPredicate(mgr),
+		PredicateFunc:        helper.NewExecutionPredicate(mgr),
 		ClusterClientSetFunc: util.NewClusterDynamicClientSet,
 	}
 	workStatusController.RunWorkQueue()

--- a/pkg/controllers/mcs/service_export_controller.go
+++ b/pkg/controllers/mcs/service_export_controller.go
@@ -374,7 +374,8 @@ func reportEndpointSlice(c client.Client, endpointSlice *unstructured.Unstructur
 		Labels: map[string]string{
 			util.ServiceNamespaceLabel: endpointSlice.GetNamespace(),
 			util.ServiceNameLabel:      endpointSlice.GetLabels()[discoveryv1beta1.LabelServiceName],
-			// todo: add label to indicate work do not need execute
+			// indicate the Work should be not propagated since it's collected resource.
+			util.PropagationInstruction: util.PropagationInstructionSuppressed,
 		},
 	}
 

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -30,6 +30,14 @@ const (
 
 	// ServiceNameLabel is added to work object, which is report by member cluster, to specify service name associated with EndpointSlice.
 	ServiceNameLabel = "endpointslice.karmada.io/name"
+
+	// PropagationInstruction is used to mark a resource(like Work) propagation instruction.
+	// Valid values includes:
+	// - suppressed: indicates that the resource should not be propagated.
+	//
+	// Note: This instruction is intended to set on Work objects to indicate the Work should be ignored by
+	// execution controller. The instruction maybe deprecated once we extend the Work API and no other scenario want this.
+	PropagationInstruction = "propagation.karmada.io/instruction"
 )
 
 // Define annotations used by karmada system.
@@ -98,4 +106,9 @@ const (
 	ReplicasField = "replicas"
 	// TemplateField indicates the 'template' field of a resource
 	TemplateField = "template"
+)
+
+const (
+	// PropagationInstructionSuppressed indicates that the resource should not be propagated.
+	PropagationInstructionSuppressed = "suppressed"
 )


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
For now, all `Work` resources under the execution namespace(prefixed by `execution-es-`) will be propagated to member clusters.

But for some scenarios, we want to collect or report some resources from member clusters, the resources still need to report to the execution namespace.

This PR provides a way to indicate a Work should be prevented from propagating.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

