### PR TITLE
Replicas changes with Duplicated ReplicaSchedulingStrategy or Weighte…

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -56,6 +56,9 @@ const (
 	// ReconcileSchedule means the binding object associated policy has been changed.
 	ReconcileSchedule ScheduleType = "ReconcileSchedule"
 
+	// ScaleSchedule means the replicas of binding object has been changed.
+	ScaleSchedule ScheduleType = "ScaleSchedule"
+
 	// FailoverSchedule means one of the cluster a binding object associated with becomes failure.
 	FailoverSchedule ScheduleType = "FailoverSchedule"
 
@@ -340,7 +343,7 @@ func (s *Scheduler) getScheduleType(key string) ScheduleType {
 			return FirstSchedule
 		}
 
-		_, policyPlacementStr, err := s.getPlacement(resourceBinding)
+		policyPlacement, policyPlacementStr, err := s.getPlacement(resourceBinding)
 		if err != nil {
 			return Unknown
 		}
@@ -349,6 +352,10 @@ func (s *Scheduler) getScheduleType(key string) ScheduleType {
 
 		if policyPlacementStr != appliedPlacement {
 			return ReconcileSchedule
+		}
+
+		if policyPlacement.ReplicaScheduling != nil && util.IsBindingReplicasChanged(&resourceBinding.Spec, policyPlacement.ReplicaScheduling) {
+			return ScaleSchedule
 		}
 
 		clusters := s.schedulerCache.Snapshot().GetClusters()
@@ -391,6 +398,10 @@ func (s *Scheduler) getScheduleType(key string) ScheduleType {
 			return ReconcileSchedule
 		}
 
+		if policy.Spec.Placement.ReplicaScheduling != nil && util.IsBindingReplicasChanged(&binding.Spec, policy.Spec.Placement.ReplicaScheduling) {
+			return ScaleSchedule
+		}
+
 		clusters := s.schedulerCache.Snapshot().GetClusters()
 		for _, tc := range binding.Spec.Clusters {
 			boundCluster := tc.Name
@@ -423,6 +434,9 @@ func (s *Scheduler) scheduleNext() bool {
 	case ReconcileSchedule: // share same logic with first schedule
 		err = s.scheduleOne(key.(string))
 		klog.Infof("Reschedule binding(%s) as placement changed", key.(string))
+	case ScaleSchedule:
+		err = s.scaleScheduleOne(key.(string))
+		klog.Infof("Reschedule binding(%s) as replicas scaled down or scaled up", key.(string))
 	case FailoverSchedule:
 		if Failover {
 			err = s.rescheduleOne(key.(string))
@@ -774,6 +788,99 @@ func (s *Scheduler) rescheduleResourceBinding(resourceBinding *workv1alpha1.Reso
 	klog.Infof("The final binding.Spec.Cluster values are: %v\n", resourceBinding.Spec.Clusters)
 
 	_, err = s.KarmadaClient.WorkV1alpha1().ResourceBindings(ns).Update(context.TODO(), resourceBinding, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Scheduler) scaleScheduleOne(key string) (err error) {
+	klog.V(4).Infof("begin scale scheduling ResourceBinding %s", key)
+	defer klog.V(4).Infof("end scale scheduling ResourceBinding %s: %v", key, err)
+
+	ns, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+
+	if ns == "" {
+		clusterResourceBinding, err := s.clusterBindingLister.Get(name)
+		if errors.IsNotFound(err) {
+			return nil
+		}
+
+		clusterPolicyName := util.GetLabelValue(clusterResourceBinding.Labels, util.ClusterPropagationPolicyLabel)
+
+		clusterPolicy, err := s.clusterPolicyLister.Get(clusterPolicyName)
+		if err != nil {
+			return err
+		}
+
+		return s.scaleScheduleClusterResourceBinding(clusterResourceBinding, clusterPolicy)
+	}
+
+	resourceBinding, err := s.bindingLister.ResourceBindings(ns).Get(name)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+
+	return s.scaleScheduleResourceBinding(resourceBinding)
+}
+
+func (s *Scheduler) scaleScheduleResourceBinding(resourceBinding *workv1alpha1.ResourceBinding) (err error) {
+	placement, placementStr, err := s.getPlacement(resourceBinding)
+	if err != nil {
+		return err
+	}
+
+	scheduleResult, err := s.Algorithm.ScaleSchedule(context.TODO(), &placement, &resourceBinding.Spec)
+	if err != nil {
+		klog.V(2).Infof("failed rescheduling ResourceBinding %s/%s after replicas changes: %v", resourceBinding.Namespace, resourceBinding.Name, err)
+		return err
+	}
+
+	klog.V(4).Infof("ResourceBinding %s/%s scheduled to clusters %v", resourceBinding.Namespace, resourceBinding.Name, scheduleResult.SuggestedClusters)
+
+	binding := resourceBinding.DeepCopy()
+	binding.Spec.Clusters = scheduleResult.SuggestedClusters
+
+	if binding.Annotations == nil {
+		binding.Annotations = make(map[string]string)
+	}
+	binding.Annotations[util.PolicyPlacementAnnotation] = placementStr
+
+	_, err = s.KarmadaClient.WorkV1alpha1().ResourceBindings(binding.Namespace).Update(context.TODO(), binding, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Scheduler) scaleScheduleClusterResourceBinding(clusterResourceBinding *workv1alpha1.ClusterResourceBinding,
+	policy *policyv1alpha1.ClusterPropagationPolicy) (err error) {
+	scheduleResult, err := s.Algorithm.ScaleSchedule(context.TODO(), &policy.Spec.Placement, &clusterResourceBinding.Spec)
+	if err != nil {
+		klog.V(2).Infof("failed rescheduling ClusterResourceBinding %s after replicas scaled down: %v", clusterResourceBinding.Name, err)
+		return err
+	}
+
+	klog.V(4).Infof("ClusterResourceBinding %s scheduled to clusters %v", clusterResourceBinding.Name, scheduleResult.SuggestedClusters)
+
+	binding := clusterResourceBinding.DeepCopy()
+	binding.Spec.Clusters = scheduleResult.SuggestedClusters
+
+	placement, err := json.Marshal(policy.Spec.Placement)
+	if err != nil {
+		klog.Errorf("Failed to marshal placement of propagationPolicy %s/%s, error: %v", policy.Namespace, policy.Name, err)
+		return err
+	}
+
+	if binding.Annotations == nil {
+		binding.Annotations = make(map[string]string)
+	}
+	binding.Annotations[util.PolicyPlacementAnnotation] = string(placement)
+
+	_, err = s.KarmadaClient.WorkV1alpha1().ClusterResourceBindings().Update(context.TODO(), binding, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/util/binding.go
+++ b/pkg/util/binding.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 )
 
@@ -11,4 +12,27 @@ func GetBindingClusterNames(binding *workv1alpha1.ResourceBinding) []string {
 		clusterNames = append(clusterNames, targetCluster.Name)
 	}
 	return clusterNames
+}
+
+// IsBindingReplicasChanged will check if the sum of replicas is different from the replicas of object
+func IsBindingReplicasChanged(bindingSpec *workv1alpha1.ResourceBindingSpec, strategy *policyv1alpha1.ReplicaSchedulingStrategy) bool {
+	if strategy == nil {
+		return false
+	}
+	if strategy.ReplicaSchedulingType == policyv1alpha1.ReplicaSchedulingTypeDuplicated {
+		for _, targetCluster := range bindingSpec.Clusters {
+			if targetCluster.Replicas != bindingSpec.Resource.Replicas {
+				return true
+			}
+		}
+		return false
+	}
+	if strategy.ReplicaSchedulingType == policyv1alpha1.ReplicaSchedulingTypeDivided {
+		replicasSum := int32(0)
+		for _, targetCluster := range bindingSpec.Clusters {
+			replicasSum += targetCluster.Replicas
+		}
+		return replicasSum != bindingSpec.Resource.Replicas
+	}
+	return false
 }


### PR DESCRIPTION
…d ReplicaDivisionPreference

Signed-off-by: junqian <junqian@tencent.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of #344
**How to work with it**:

Create deployment like this
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  labels:
    app: nginx
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
      ···
```
and policy like this
```
apiVersion: policy.karmada.io/v1alpha1
kind: PropagationPolicy
metadata:
  name: example-policy
spec:
  resourceSelectors:
    - apiVersion: apps/v1
      kind: Deployment
      name: nginx
  placement:
    clusterAffinity:
      clusterNames:
        - member1
        - member2
    replicaScheduling:
      replicaSchedulingType: Divided
      replicaDivisionPreference: Weighted
      weightPreference: 
        staticWeightList:
        - targetCluster:
             clusterNames: [member1]
          weight: 1
        - targetCluster:
            clusterNames: [member2]
          weight: 2
```
and  we will get a binding with the following clusters
```
spec:
  clusters:
    - name: member1
       replicas : 1
    - name: member2
       replicas : 2
```

Then we update the replicas of deployment to 6. and the binding will change 
```
spec:
  clusters:
    - name: member1
       replicas : 2
    - name: member2
       replicas : 4
```
