### PR TITLE
enable log collection for e2e testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
     name: e2e test
     needs: build
     runs-on: ubuntu-18.04
+    env:
+      ARTIFACTS_PATH: ${{ github.workspace }}/karmada-e2e-logs/
     steps:
       - name: checkout code
         uses: actions/checkout@v2
@@ -76,3 +78,9 @@ jobs:
         run: hack/karmada-bootstrap.sh
       - name: run e2e
         run: hack/run-e2e.sh
+      - name: upload logs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: karmada_e2e_log
+          path: ${{ github.workspace }}/karmada-e2e-logs/


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
There were lots of falling tests recently, unfortunately, no logs for investigating.

This PR enables collecting E2E logs by GitHub Action.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Just collected the logs from `karmada-host` cluster.
For the member cluster will be done by following PR.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

