### PR TITLE
Fix Resource's annotation have not been updated after the overridepolicy updated

### DIFF
--- a/pkg/util/annotation.go
+++ b/pkg/util/annotation.go
@@ -11,3 +11,10 @@ func MergeAnnotation(obj *unstructured.Unstructured, annotationKey string, annot
 	objectAnnotation[annotationKey] = annotationValue
 	obj.SetAnnotations(objectAnnotation)
 }
+
+// MergeAnnotations merges the annotations from 'src' to 'dst'.
+func MergeAnnotations(dst *unstructured.Unstructured, src *unstructured.Unstructured) {
+	for key, value := range src.GetAnnotations() {
+		MergeAnnotation(dst, key, value)
+	}
+}

--- a/pkg/util/detector/detector.go
+++ b/pkg/util/detector/detector.go
@@ -670,6 +670,7 @@ func (d *ResourceDetector) OnPropagationPolicyAdd(obj interface{}) {
 		return
 	}
 
+	klog.V(2).Infof("Create PropagationPolicy(%s)", key)
 	d.policyReconcileWorker.AddRateLimited(key)
 }
 
@@ -680,7 +681,13 @@ func (d *ResourceDetector) OnPropagationPolicyUpdate(oldObj, newObj interface{})
 
 // OnPropagationPolicyDelete handles object delete event and push the object to queue.
 func (d *ResourceDetector) OnPropagationPolicyDelete(obj interface{}) {
-	d.OnPropagationPolicyAdd(obj)
+	key, err := ClusterWideKeyFunc(obj)
+	if err != nil {
+		return
+	}
+
+	klog.V(2).Infof("Delete PropagationPolicy(%s)", key)
+	d.policyReconcileWorker.AddRateLimited(key)
 }
 
 // ReconcilePropagationPolicy handles PropagationPolicy resource changes.
@@ -717,6 +724,7 @@ func (d *ResourceDetector) OnClusterPropagationPolicyAdd(obj interface{}) {
 		return
 	}
 
+	klog.V(2).Infof("Create ClusterPropagationPolicy(%s)", key)
 	d.clusterPolicyReconcileWorker.AddRateLimited(key)
 }
 
@@ -727,7 +735,13 @@ func (d *ResourceDetector) OnClusterPropagationPolicyUpdate(oldObj, newObj inter
 
 // OnClusterPropagationPolicyDelete handles object delete event and push the object to queue.
 func (d *ResourceDetector) OnClusterPropagationPolicyDelete(obj interface{}) {
-	d.OnClusterPropagationPolicyAdd(obj)
+	key, err := ClusterWideKeyFunc(obj)
+	if err != nil {
+		return
+	}
+
+	klog.V(2).Infof("Delete ClusterPropagationPolicy(%s)", key)
+	d.clusterPolicyReconcileWorker.AddRateLimited(key)
 }
 
 // ReconcileClusterPropagationPolicy handles ClusterPropagationPolicy resource changes.
@@ -748,6 +762,8 @@ func (d *ResourceDetector) ReconcileClusterPropagationPolicy(key util.QueueKey) 
 			klog.Infof("Policy(%s) has been removed", ckey.NamespaceKey())
 			return d.HandleClusterPropagationPolicyDeletion(ckey.Name)
 		}
+
+		klog.Errorf("Failed to get Policy(%s): %v", ckey.NamespaceKey(), err)
 		return err
 	}
 

--- a/pkg/util/objectwatcher/retain.go
+++ b/pkg/util/objectwatcher/retain.go
@@ -26,11 +26,13 @@ func RetainClusterFields(desiredObj, clusterObj *unstructured.Unstructured) erro
 	// Pass the same ResourceVersion as in the cluster object for update operation, otherwise operation will fail.
 	desiredObj.SetResourceVersion(clusterObj.GetResourceVersion())
 
-	// Retain finalizers and annotations since they will typically be set by
+	// Retain finalizers since they will typically be set by
 	// controllers in a member cluster.  It is still possible to set the fields
 	// via overrides.
 	desiredObj.SetFinalizers(clusterObj.GetFinalizers())
-	desiredObj.SetAnnotations(clusterObj.GetAnnotations())
+	// Merge annotations since they will typically be set by controllers in a member cluster
+	// and be set by user in karmada-controller-plane.
+	util.MergeAnnotations(desiredObj, clusterObj)
 
 	if targetKind == util.PodKind {
 		return retainPodFields(desiredObj, clusterObj)

--- a/test/e2e/scheduling_test.go
+++ b/test/e2e/scheduling_test.go
@@ -67,7 +67,7 @@ var _ = ginkgo.Describe("propagation with label and group constraints testing", 
 			ginkgo.By(fmt.Sprintf("creating policy(%s/%s)", policyNamespace, policyName), func() {
 				_, err := karmadaClient.PolicyV1alpha1().PropagationPolicies(policyNamespace).Create(context.TODO(), policy, metav1.CreateOptions{})
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-				klog.Infof("created policy(%s)", policyNamespace, policyName)
+				klog.Infof("created policy(%s/%s)", policyNamespace, policyName)
 			})
 		})
 


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When overridepolicy's overriders modified, the resource's annotations have not been updated in member clusters.

**Which issue(s) this PR fixes**:
Fixes #507 

**Special notes for your reviewer**:
I will merge the annotations from `desire object` and `member cluster object`, this resulting in old annotations which added by overridepolicy can not be removed from newest object. Because we don't know which annotations are added by user before, and which annotations are setted by controllers in a member cluster.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

