### PR TITLE
Adapt for macOS in local(kind) environment

### DIFF
--- a/artifacts/kindClusterConfig/karmada-host.yaml
+++ b/artifacts/kindClusterConfig/karmada-host.yaml
@@ -1,0 +1,11 @@
+kind: Cluster
+apiVersion: "kind.x-k8s.io/v1alpha4"
+networking:
+  apiServerAddress: "{{host_ipaddress}}"
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 5443
+        hostPort: 5443
+        protocol: TCP
+        listenAddress: "{{host_ipaddress}}"

--- a/hack/create-cluster.sh
+++ b/hack/create-cluster.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# This script only fits for Linux, macOS adaptation will come soon
 
 set -o errexit
 set -o nounset

--- a/hack/deploy-karmada-agent.sh
+++ b/hack/deploy-karmada-agent.sh
@@ -85,9 +85,9 @@ kubectl create secret generic karmada-kubeconfig --from-file=karmada-kubeconfig=
 # deploy karmada agent
 TEMP_PATH=$(mktemp -d)
 cp "${REPO_ROOT}"/artifacts/agent/karmada-agent.yaml "${TEMP_PATH}"/karmada-agent.yaml
-sed -i "s/{{karmada_context}}/${KARMADA_APISERVER_CONTEXT_NAME}/g" "${TEMP_PATH}"/karmada-agent.yaml
-sed -i "s/{{member_cluster_name}}/${MEMBER_CLUSTER_NAME}/g" "${TEMP_PATH}"/karmada-agent.yaml
-sed -i "s/{{image_pull_policy}}/${AGENT_IMAGE_PULL_POLICY}/g" "${TEMP_PATH}"/karmada-agent.yaml
+sed -i'' -e "s/{{karmada_context}}/${KARMADA_APISERVER_CONTEXT_NAME}/g" "${TEMP_PATH}"/karmada-agent.yaml
+sed -i'' -e "s/{{member_cluster_name}}/${MEMBER_CLUSTER_NAME}/g" "${TEMP_PATH}"/karmada-agent.yaml
+sed -i'' -e "s/{{image_pull_policy}}/${AGENT_IMAGE_PULL_POLICY}/g" "${TEMP_PATH}"/karmada-agent.yaml
 echo -e "Apply dynamic rendered deployment in ${TEMP_PATH}/karmada-agent.yaml.\n"
 kubectl apply -f "${TEMP_PATH}"/karmada-agent.yaml
 

--- a/hack/deploy-karmada.sh
+++ b/hack/deploy-karmada.sh
@@ -176,18 +176,22 @@ if [ "${HOST_CLUSTER_TYPE}" = "remote" ]; then
     ;;
     LoadBalancer)
       if util::wait_service_external_ip "karmada-apiserver" "${KARMADA_SYSTEM_NAMESPACE}"; then
-      KARMADA_APISERVER_IP=$(util::get_load_balancer_ip)
+        echo "Get service external IP: ${SERVICE_EXTERNAL_IP}, wait to check network connectivity"
+        KARMADA_APISERVER_IP=$(util::get_load_balancer_ip) || KARMADA_APISERVER_IP=''
+      else
+        echo "ERROR: wait service external IP timeout, please check the load balancer IP of service: karmada-apiserver"
+        exit 1
       fi
     ;;
   esac
 fi
 
-if [[ -z "${KARMADA_APISERVER_IP}" ]]; then
-  echo -e "ERROR: failed to get Karmada API server IP after creating service 'karmada-apiserver' (host cluster type: ${HOST_CLUSTER_TYPE}), please verify.\n"
+if [[ -n "${KARMADA_APISERVER_IP}" ]]; then
+  echo -e "\nKarmada API Server's IP is: ${KARMADA_APISERVER_IP}, host cluster type is: ${HOST_CLUSTER_TYPE}"
+else
+  echo -e "\nERROR: failed to get Karmada API server IP after creating service 'karmada-apiserver' (host cluster type: ${HOST_CLUSTER_TYPE}), please verify."
   recover_kubeconfig
   exit 1
-else
-  echo -e "\nKarmada API Server's IP is: ${KARMADA_APISERVER_IP}, host cluster type is: ${HOST_CLUSTER_TYPE}"
 fi
 
 # write karmada api server config to kubeconfig file

--- a/hack/deploy-karmada.sh
+++ b/hack/deploy-karmada.sh
@@ -9,7 +9,7 @@ set -o nounset
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 CERT_DIR=${CERT_DIR:-"${HOME}/.karmada"}
 mkdir -p "${CERT_DIR}" &>/dev/null || sudo mkdir -p "${CERT_DIR}"
-rm -f "${CERT_DIR:-${HOME}/.karmada}/*"
+rm -f "${CERT_DIR}/*" &>/dev/null || sudo rm -f "${CERT_DIR}/*"
 KARMADA_APISERVER_SECURE_PORT=${KARMADA_APISERVER_SECURE_PORT:-5443}
 
 # The host cluster name which used to install karmada control plane components.
@@ -21,10 +21,24 @@ CLUSTER_IP_ONLY=${CLUSTER_IP_ONLY:-false} # whether create a 'ClusterIP' type se
 source "${REPO_ROOT}"/hack/util.sh
 
 function usage() {
-  echo "This script will deploy karmada control plane to a given cluster."
-  echo "Usage: hack/deploy-karmada.sh <KUBECONFIG> <CONTEXT_NAME> [KARMADA_API_SERVER_IP]"
-  echo "Example: hack/deploy-karmada.sh ~/.kube/config karmada-host"
-  unset KUBECONFIG
+  echo "This script deploys karmada control plane components to a given cluster."
+  echo "Note: This script is an internal script and is not intended used by end-users."
+  echo "Usage: hack/deploy-karmada.sh <KUBECONFIG> <CONTEXT_NAME> [HOST_CLUSTER_TYPE]"
+  echo "Example: hack/deploy-karmada.sh ~/.kube/config karmada-host local"
+  echo -e "Parameters:\n\tKUBECONFIG\t\tYour cluster's kubeconfig that you want to install to"
+  echo -e "\tCONTEXT_NAME\t\tThe name of context in 'kubeconfig'"
+  echo -e "\tHOST_CLUSTER_TYPE\tThe type of your cluster that will install Karmada. Optional values are 'local' and 'remote',"
+  echo -e "\t\t\t\t'local' is default, as that is for the local environment, i.e. for the cluster created by kind."
+  echo -e "\t\t\t\tAnd if you want to install karmada to a standalone cluster, set it as 'remote'"
+}
+
+# recover the former value of KUBECONFIG
+function recover_kubeconfig {
+  if [ -n "${CURR_KUBECONFIG+x}" ];then
+    export KUBECONFIG="${CURR_KUBECONFIG}"
+  else
+    unset KUBECONFIG
+  fi
 }
 
 if [[ $# -lt 2 ]]; then
@@ -40,17 +54,22 @@ if [[ ! -f "${HOST_CLUSTER_KUBECONFIG}" ]]; then
   exit 1
 fi
 
-# check context existence
+# check context existence and switch
+# backup current kubeconfig before changing KUBECONFIG
+if [ -n "${KUBECONFIG+x}" ];then
+  CURR_KUBECONFIG=$KUBECONFIG
+fi
 export KUBECONFIG="${HOST_CLUSTER_KUBECONFIG}"
 HOST_CLUSTER_NAME=$2
-if ! kubectl config get-contexts "${HOST_CLUSTER_NAME}" > /dev/null 2>&1;
+if ! kubectl config use-context "${HOST_CLUSTER_NAME}" > /dev/null 2>&1;
 then
-  echo -e "ERROR: failed to get context: '${HOST_CLUSTER_NAME}' not in ${HOST_CLUSTER_KUBECONFIG}. \n"
+  echo -e "ERROR: failed to use context: '${HOST_CLUSTER_NAME}' not in ${HOST_CLUSTER_KUBECONFIG}. \n"
   usage
+  recover_kubeconfig
   exit 1
 fi
 
-KARMADA_APISERVER_IP=${3:-}
+HOST_CLUSTER_TYPE=${3:-"local"} # the default of host cluster type is local, i.e. cluster created by kind.
 
 # generate a secret to store the certificates
 function generate_cert_secret {
@@ -64,16 +83,16 @@ function generate_cert_secret {
     cp -rf "${REPO_ROOT}"/artifacts/deploy/secret.yaml "${TEMP_PATH}"/secret-tmp.yaml
     cp -rf "${REPO_ROOT}"/artifacts/deploy/karmada-webhook-cert-secret.yaml "${TEMP_PATH}"/karmada-webhook-cert-secret-tmp.yaml
 
-    sed -i "s/{{ca_crt}}/${karmada_ca}/g" "${TEMP_PATH}"/karmada-cert-secret-tmp.yaml
-    sed -i "s/{{client_cer}}/${KARMADA_CRT}/g" "${TEMP_PATH}"/karmada-cert-secret-tmp.yaml
-    sed -i "s/{{client_key}}/${KARMADA_KEY}/g" "${TEMP_PATH}"/karmada-cert-secret-tmp.yaml
+    sed -i'' -e "s/{{ca_crt}}/${karmada_ca}/g" "${TEMP_PATH}"/karmada-cert-secret-tmp.yaml
+    sed -i'' -e "s/{{client_cer}}/${KARMADA_CRT}/g" "${TEMP_PATH}"/karmada-cert-secret-tmp.yaml
+    sed -i'' -e "s/{{client_key}}/${KARMADA_KEY}/g" "${TEMP_PATH}"/karmada-cert-secret-tmp.yaml
 
-    sed -i "s/{{ca_crt}}/${karmada_ca}/g" "${TEMP_PATH}"/secret-tmp.yaml
-    sed -i "s/{{client_cer}}/${KARMADA_CRT}/g" "${TEMP_PATH}"/secret-tmp.yaml
-    sed -i "s/{{client_key}}/${KARMADA_KEY}/g" "${TEMP_PATH}"/secret-tmp.yaml
+    sed -i'' -e "s/{{ca_crt}}/${karmada_ca}/g" "${TEMP_PATH}"/secret-tmp.yaml
+    sed -i'' -e "s/{{client_cer}}/${KARMADA_CRT}/g" "${TEMP_PATH}"/secret-tmp.yaml
+    sed -i'' -e "s/{{client_key}}/${KARMADA_KEY}/g" "${TEMP_PATH}"/secret-tmp.yaml
 
-    sed -i "s/{{server_key}}/${KARMADA_KEY}/g" "${TEMP_PATH}"/karmada-webhook-cert-secret-tmp.yaml
-    sed -i "s/{{server_certificate}}/${KARMADA_CRT}/g" "${TEMP_PATH}"/karmada-webhook-cert-secret-tmp.yaml
+    sed -i'' -e "s/{{server_key}}/${KARMADA_KEY}/g" "${TEMP_PATH}"/karmada-webhook-cert-secret-tmp.yaml
+    sed -i'' -e "s/{{server_certificate}}/${KARMADA_CRT}/g" "${TEMP_PATH}"/karmada-webhook-cert-secret-tmp.yaml
 
     kubectl apply -f "${TEMP_PATH}"/karmada-cert-secret-tmp.yaml
     kubectl apply -f "${TEMP_PATH}"/secret-tmp.yaml
@@ -81,8 +100,8 @@ function generate_cert_secret {
     rm -rf "${TEMP_PATH}"
 }
 
+# install Karmada's APIs
 function installCRDs() {
-    # install APIs
     kubectl apply -f "${REPO_ROOT}/artifacts/deploy/namespace.yaml"
     kubectl apply -f "${REPO_ROOT}/artifacts/deploy/cluster.karmada.io_clusters.yaml"
     kubectl apply -f "${REPO_ROOT}/artifacts/deploy/policy.karmada.io_propagationpolicies.yaml"
@@ -97,7 +116,7 @@ function installCRDs() {
     kubectl apply -f "${REPO_ROOT}/artifacts/deploy/multicluster.x-k8s.io_serviceimports.yaml"
 }
 
-#generate cert
+# generate cert
 util::cmd_must_exist "openssl"
 util::cmd_must_exist_cfssl ${CFSSL_VERSION}
 # create CA signers
@@ -113,8 +132,8 @@ kubectl apply -f "${REPO_ROOT}/artifacts/deploy/serviceaccount.yaml"
 kubectl apply -f "${REPO_ROOT}/artifacts/deploy/clusterrole.yaml"
 kubectl apply -f "${REPO_ROOT}/artifacts/deploy/clusterrolebinding.yaml"
 
-KARMADA_CRT=$(sudo base64 "${CERT_DIR}/karmada.crt" | tr -d '\r\n')
-KARMADA_KEY=$(sudo base64 "${CERT_DIR}/karmada.key" | tr -d '\r\n')
+KARMADA_CRT=$(base64 "${CERT_DIR}/karmada.crt" | tr -d '\r\n')
+KARMADA_KEY=$(base64 "${CERT_DIR}/karmada.key" | tr -d '\r\n')
 generate_cert_secret
 
 # deploy karmada etcd
@@ -123,29 +142,40 @@ kubectl apply -f "${REPO_ROOT}/artifacts/deploy/karmada-etcd.yaml"
 # Wait for karmada-etcd to come up before launching the rest of the components.
 util::wait_pod_ready "${ETCD_POD_LABEL}" "${KARMADA_SYSTEM_NAMESPACE}"
 
-# If it provided a karmada API Server IP we can access karmada API Server (cluster by kind), we will create a ClusterIP type Service
-# Or we need to create a LoadBalancer service($CLUSTER_IP_ONLY=false) so that we can access karmada API Server outside the karmada-host cluster
+#KARMADA_APISERVER_SERVICE_TYPE is the service type of karmada API Server, For connectivity, it will be different when
+# HOST_CLUSTER_TYPE is different. When HOST_CLUSTER_TYPE=local, we will create a ClusterIP type Service. And when
+# HOST_CLUSTER_TYPE=remote, we need to create a LoadBalancer service to access Karmada API Server outside the
+# karmada-host cluster. Of course, you can still use a ClusterIP type Service by setting $CLUSTER_IP_ONLY=true
 KARMADA_APISERVER_SERVICE_TYPE="ClusterIP"
-if [[ -z "${KARMADA_APISERVER_IP}" ]] && [ "${CLUSTER_IP_ONLY}" = false ]; then
-  KARMADA_APISERVER_SERVICE_TYPE="LoadBalancer"
+
+if [ "${HOST_CLUSTER_TYPE}" = "local" ]; then # local mode
+  KARMADA_APISERVER_IP=$(util::get_apiserver_ip_from_kubeconfig "${HOST_CLUSTER_NAME}")
+else # remote mode
+# KARMADA_APISERVER_IP will be got when Karmada API Server is ready
+  if [ "${CLUSTER_IP_ONLY}" = false ]; then
+    KARMADA_APISERVER_SERVICE_TYPE="LoadBalancer"
+  fi
+  HOST_CLUSTER_TYPE="remote" # make sure HOST_CLUSTER_TYPE is in local and remote
 fi
 
 # deploy karmada apiserver
 TEMP_PATH_APISERVER=$(mktemp -d)
 cp "${REPO_ROOT}"/artifacts/deploy/karmada-apiserver.yaml "${TEMP_PATH_APISERVER}"/karmada-apiserver.yaml
-sed -i "s/{{service_type}}/${KARMADA_APISERVER_SERVICE_TYPE}/g" "${TEMP_PATH_APISERVER}"/karmada-apiserver.yaml
+sed -i'' -e "s/{{service_type}}/${KARMADA_APISERVER_SERVICE_TYPE}/g" "${TEMP_PATH_APISERVER}"/karmada-apiserver.yaml
 echo -e "\nApply dynamic rendered apiserver service in ${TEMP_PATH_APISERVER}/karmada-apiserver.yaml."
 kubectl apply -f "${TEMP_PATH_APISERVER}"/karmada-apiserver.yaml
 
 # Wait for karmada-apiserver to come up before launching the rest of the components.
 util::wait_pod_ready "${APISERVER_POD_LABEL}" "${KARMADA_SYSTEM_NAMESPACE}"
 
-# get Karmada apiserver IP
-if [[ -z "${KARMADA_APISERVER_IP}" ]]; then
+# get Karmada apiserver IP at remote mode
+if [ "${HOST_CLUSTER_TYPE}" = "remote" ]; then
   case $KARMADA_APISERVER_SERVICE_TYPE in
-    ClusterIP)  KARMADA_APISERVER_IP=$(kubectl get service karmada-apiserver -n "${KARMADA_SYSTEM_NAMESPACE}" -o=jsonpath='{.spec.clusterIP}')
+    ClusterIP)
+      KARMADA_APISERVER_IP=$(kubectl get service karmada-apiserver -n "${KARMADA_SYSTEM_NAMESPACE}" -o=jsonpath='{.spec.clusterIP}')
     ;;
-    LoadBalancer)  if util::wait_service_external_ip "karmada-apiserver" "${KARMADA_SYSTEM_NAMESPACE}"; then
+    LoadBalancer)
+      if util::wait_service_external_ip "karmada-apiserver" "${KARMADA_SYSTEM_NAMESPACE}"; then
       KARMADA_APISERVER_IP=$(util::get_load_balancer_ip)
       fi
     ;;
@@ -153,8 +183,11 @@ if [[ -z "${KARMADA_APISERVER_IP}" ]]; then
 fi
 
 if [[ -z "${KARMADA_APISERVER_IP}" ]]; then
-  echo -e "ERROR: failed to get Karmada API server IP after creating service 'karmada-apiserver', please verify.\n"
+  echo -e "ERROR: failed to get Karmada API server IP after creating service 'karmada-apiserver' (host cluster type: ${HOST_CLUSTER_TYPE}), please verify.\n"
+  recover_kubeconfig
   exit 1
+else
+  echo -e "\nKarmada API Server's IP is: ${KARMADA_APISERVER_IP}, host cluster type is: ${HOST_CLUSTER_TYPE}"
 fi
 
 # write karmada api server config to kubeconfig file
@@ -164,12 +197,12 @@ util::append_client_kubeconfig "${HOST_CLUSTER_KUBECONFIG}" "${CERT_DIR}/karmada
 kubectl apply -f "${REPO_ROOT}/artifacts/deploy/kube-controller-manager.yaml"
 
 # install CRD APIs on karmada apiserver.
-if ! kubectl config get-contexts karmada-apiserver > /dev/null 2>&1;
+if ! kubectl config use-context karmada-apiserver > /dev/null 2>&1;
 then
-  echo -e "ERROR: failed to get context: karmada-apiserver not in ${HOST_CLUSTER_KUBECONFIG}."
+  echo -e "ERROR: failed to use context: karmada-apiserver not in ${HOST_CLUSTER_KUBECONFIG}."
+  recover_kubeconfig
   exit 1
 fi
-kubectl config use-context karmada-apiserver
 installCRDs
 
 # deploy webhook configurations on karmada apiserver

--- a/hack/karmada-bootstrap.sh
+++ b/hack/karmada-bootstrap.sh
@@ -40,7 +40,7 @@ util::create_cluster "${PULL_MODE_CLUSTER_NAME}" "${MEMBER_CLUSTER_KUBECONFIG}" 
 #step2. make images and get karmadactl
 export VERSION="latest"
 export REGISTRY="swr.ap-southeast-1.myhuaweicloud.com/karmada"
-make images --directory="${REPO_ROOT}"
+make images GOOS="linux" --directory="${REPO_ROOT}"
 
 GO111MODULE=on go install "github.com/karmada-io/karmada/cmd/karmadactl"
 GOPATH=$(go env GOPATH | awk -F ':' '{print $1}')
@@ -58,8 +58,7 @@ kind load docker-image "${REGISTRY}/karmada-scheduler:${VERSION}" --name="${HOST
 kind load docker-image "${REGISTRY}/karmada-webhook:${VERSION}" --name="${HOST_CLUSTER_NAME}"
 
 #step5. install karmada control plane components
-KARMADA_APISERVER_IP=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${HOST_CLUSTER_NAME}-control-plane")
-"${REPO_ROOT}"/hack/deploy-karmada.sh "${MAIN_KUBECONFIG}" "${HOST_CLUSTER_NAME}" "${KARMADA_APISERVER_IP}"
+"${REPO_ROOT}"/hack/deploy-karmada.sh "${MAIN_KUBECONFIG}" "${HOST_CLUSTER_NAME}"
 
 #step6. wait until the member cluster ready and join member clusters
 util::check_clusters_ready "${MEMBER_CLUSTER_KUBECONFIG}" "${MEMBER_CLUSTER_1_NAME}"
@@ -85,12 +84,9 @@ kind load docker-image "${REGISTRY}/karmada-agent:${VERSION}" --name="${PULL_MOD
 "${REPO_ROOT}"/hack/deploy-karmada-agent.sh "${MAIN_KUBECONFIG}" "${KARMADA_APISERVER_CLUSTER_NAME}" "${MEMBER_CLUSTER_KUBECONFIG}" "${PULL_MODE_CLUSTER_NAME}"
 
 function print_success() {
-  echo
-  echo "Local Karmada is running."
+  echo -e "\nLocal Karmada is running."
   echo "To start using your karmada, run:"
-cat <<EOF
-  export KUBECONFIG=${MAIN_KUBECONFIG}
-EOF
+  echo -e "  export KUBECONFIG=${MAIN_KUBECONFIG}"
 }
 
 print_success

--- a/hack/local-up-karmada.sh
+++ b/hack/local-up-karmada.sh
@@ -16,23 +16,68 @@ HOST_CLUSTER_NAME=${HOST_CLUSTER_NAME:-"karmada-host"}
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 # The KUBECONFIG path for the 'host cluster'.
 HOST_CLUSTER_KUBECONFIG="${KUBECONFIG_PATH}/karmada.config"
+CLUSTER_VERSION=${CLUSTER_VERSION:-"kindest/node:v1.19.1"}
+KIND_LOG_FILE=${KIND_LOG_FILE:-"/tmp/karmada"}
 
 # Make sure go exists
 source "${SCRIPT_ROOT}"/hack/util.sh
 util::cmd_must_exist "go"
+
+# Check kind exists or install
+if [[ ! -x $(command -v kind) ]]; then
+  util::install_kind "v0.11.1"
+fi
 
 # Make sure KUBECONFIG path exists.
 if [ ! -d "$KUBECONFIG_PATH" ]; then
   mkdir -p "$KUBECONFIG_PATH"
 fi
 
+# Adapt for macOS
+if [[ $(go env GOOS) = "darwin" ]]; then
+  tmp_ip=$(ipconfig getifaddr en0 || true)
+  echo ""
+  echo " Detected that you are installing Karmada on macOS "
+  echo ""
+  echo "It needs a Macintosh IP address to bind Karmada API Server(port 5443),"
+  echo "so that member clusters can access it from docker containers, please"
+  echo -n "input an available IP, "
+  if [[ -z ${tmp_ip} ]]; then
+    echo "you can use the command 'ifconfig' to look for one"
+    tips_msg="[Enter IP address]:"
+  else
+    echo "default IP will be en0 inet addr if exists"
+    tips_msg="[Enter for default ${tmp_ip}]:"
+  fi
+  read -r -p "${tips_msg}" MAC_NIC_IPADDRESS
+  MAC_NIC_IPADDRESS=${MAC_NIC_IPADDRESS:-$tmp_ip}
+  if [[ "${MAC_NIC_IPADDRESS}" =~ ^(([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))\.){3}([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))$ ]]; then
+    echo "Using IP address: ${MAC_NIC_IPADDRESS}"
+  else
+    echo -e "\nError: you input an invalid IP address"
+    exit 1
+  fi
+else # non-macOS
+  MAC_NIC_IPADDRESS=${MAC_NIC_IPADDRESS:-}
+fi
+
 # create a cluster to deploy karmada control plane components.
-"${SCRIPT_ROOT}"/hack/create-cluster.sh "${HOST_CLUSTER_NAME}" "${HOST_CLUSTER_KUBECONFIG}"
+if [[ -n "${MAC_NIC_IPADDRESS}" ]]; then # install on macOS
+  TEMP_PATH=$(mktemp -d)
+  cp -rf "${SCRIPT_ROOT}"/artifacts/kindClusterConfig/karmada-host.yaml "${TEMP_PATH}"/karmada-host.yaml
+  sed -i'' -e "s/{{host_ipaddress}}/${MAC_NIC_IPADDRESS}/g" "${TEMP_PATH}"/karmada-host.yaml
+  util::create_cluster "${HOST_CLUSTER_NAME}" "${HOST_CLUSTER_KUBECONFIG}" "${CLUSTER_VERSION}" "${KIND_LOG_FILE}" "${TEMP_PATH}/karmada-host.yaml"
+else
+  util::create_cluster "${HOST_CLUSTER_NAME}" "${HOST_CLUSTER_KUBECONFIG}" "${CLUSTER_VERSION}" "${KIND_LOG_FILE}"
+fi
 
 # make controller-manager image
 export VERSION="latest"
 export REGISTRY="swr.ap-southeast-1.myhuaweicloud.com/karmada"
-make images --directory="${SCRIPT_ROOT}"
+make images GOOS="linux" --directory="${SCRIPT_ROOT}"
+
+echo "Waiting for the host clusters to be ready... it may take a long time for pulling the kind image"
+util::check_clusters_ready "${HOST_CLUSTER_KUBECONFIG}" "${HOST_CLUSTER_NAME}"
 
 # load controller-manager image
 kind load docker-image "${REGISTRY}/karmada-controller-manager:${VERSION}" --name="${HOST_CLUSTER_NAME}"
@@ -44,8 +89,7 @@ kind load docker-image "${REGISTRY}/karmada-scheduler:${VERSION}" --name="${HOST
 kind load docker-image "${REGISTRY}/karmada-webhook:${VERSION}" --name="${HOST_CLUSTER_NAME}"
 
 # deploy karmada control plane
-KARMADA_APISERVER_IP=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${HOST_CLUSTER_NAME}-control-plane")
-"${SCRIPT_ROOT}"/hack/deploy-karmada.sh "${HOST_CLUSTER_KUBECONFIG}" "${HOST_CLUSTER_NAME}" "${KARMADA_APISERVER_IP}"
+"${SCRIPT_ROOT}"/hack/deploy-karmada.sh "${HOST_CLUSTER_KUBECONFIG}" "${HOST_CLUSTER_NAME}"
 kubectl config use-context karmada-apiserver --kubeconfig="${HOST_CLUSTER_KUBECONFIG}"
 
 function print_success() {

--- a/hack/remote-up-karmada.sh
+++ b/hack/remote-up-karmada.sh
@@ -45,7 +45,7 @@ fi
 
 # deploy karmada control plane
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-"${SCRIPT_ROOT}"/hack/deploy-karmada.sh "${HOST_CLUSTER_KUBECONFIG}" "${HOST_CLUSTER_NAME}"
+"${SCRIPT_ROOT}"/hack/deploy-karmada.sh "${HOST_CLUSTER_KUBECONFIG}" "${HOST_CLUSTER_NAME}" "remote"
 kubectl config use-context karmada-apiserver --kubeconfig="${HOST_CLUSTER_KUBECONFIG}"
 
 function print_success() {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

The local installation script `hack/local-up-karmada.sh` supports macOS

**Which issue(s) this PR fixes**:
Fixes #486

**Special notes for your reviewer**:

- fix sed command on macOS (macOS>10.9)
- clear 'REMOTE_MODE' and 'KARMADA_API_SERVER_IP' in hack/deploy-karmada.sh, there are no longer related:  'REMOTE_MODE' decides how to install karmada, kind-cluster(local) or standalone cluster(remote). 'KARMADA_API_SERVER_IP' will auto find by installation mode.
- add  GOOS="linux" for the command `make images` for compiling 'linux version' binary for docker image on macOS
- macOS network: add a mac IP for the karmada-host cluster and karmada-apiserver cluster because member clusters need to access the karmada-apiserver from their container, 127.0.0.1 will not work. No other new technologies have been introduced for the time being for the network requires.
- TODO next : `hack/create-cluster.sh`, `hack/karmada-bootstrap.sh` and `hack/remote-up-karmada.sh` adapt for macOS after this PR merged

**Does this PR introduce a user-facing change?**:
NONE

