### PR TITLE
fix informer cache delay issue

### DIFF
--- a/pkg/util/helper/unstructured.go
+++ b/pkg/util/helper/unstructured.go
@@ -1,0 +1,28 @@
+package helper
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+)
+
+// ConvertToPropagationPolicy converts a PropagationPolicy object from unstructured to typed.
+func ConvertToPropagationPolicy(obj *unstructured.Unstructured) (*policyv1alpha1.PropagationPolicy, error) {
+	typedObj := &policyv1alpha1.PropagationPolicy{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
+		return nil, err
+	}
+
+	return typedObj, nil
+}
+
+// ConvertToClusterPropagationPolicy converts a ClusterPropagationPolicy object from unstructured to typed.
+func ConvertToClusterPropagationPolicy(obj *unstructured.Unstructured) (*policyv1alpha1.ClusterPropagationPolicy, error) {
+	typedObj := &policyv1alpha1.ClusterPropagationPolicy{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
+		return nil, err
+	}
+
+	return typedObj, nil
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently, we are using [SingleClusterInformerManager][1] to watch PropagationPolicy and ClusterPropagationPolicy changes, but in the reconcile loop, we are using the controller manager's client to retrieve the resources, like:
https://github.com/karmada-io/karmada/blob/aa5abf29e271ef7c0b76dad4f95d02b41d36a64d/pkg/util/detector/detector.go#L706

The `Client` is generated from the controller manager and it will retrieve objects from it's not from the [SingleClusterInformerManager][1]'s cache.  So, sometimes there will be a delay that after [SingleClusterInformerManager][1] received an event but can't get it from the controller manager's cache. A similar issue can be found at [here](https://github.com/kubernetes-sigs/controller-runtime/issues/343).

We have found this issue many times from CI:
```
2021-07-19T01:27:39.231240855Z stderr F I0719 01:27:39.231110       1 detector.go:727] Create ClusterPropagationPolicy(policy.karmada.io/v1alpha1, kind=ClusterPropagationPolicy, serviceexports-k48-policy)
2021-07-19T01:27:39.231254055Z stderr F I0719 01:27:39.231175       1 detector.go:727] Create ClusterPropagationPolicy(policy.karmada.io/v1alpha1, kind=ClusterPropagationPolicy, serviceimports-rxb-policy)
2021-07-19T01:27:39.239677402Z stderr F I0719 01:27:39.239567       1 detector.go:762] Policy(serviceexports-k48-policy) has been removed
2021-07-19T01:27:39.239690202Z stderr F I0719 01:27:39.239628       1 detector.go:762] Policy(serviceimports-rxb-policy) has been removed
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR introduced PP/CPP lister which was generated from the [SingleClusterInformerManager][1].

The `Client` in the `detector` should be deprecated by following PRs.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

[1]: https://github.com/karmada-io/karmada/blob/aa5abf29e271ef7c0b76dad4f95d02b41d36a64d/pkg/util/informermanager/single-cluster-manager.go#L15