### PR TITLE
Replicas changes with aggregated ReplicaDivisionPreference

### DIFF
--- a/pkg/util/binding.go
+++ b/pkg/util/binding.go
@@ -36,3 +36,12 @@ func IsBindingReplicasChanged(bindingSpec *workv1alpha1.ResourceBindingSpec, str
 	}
 	return false
 }
+
+// GetSumOfReplicas will get the sum of replicas in target clusters
+func GetSumOfReplicas(clusters []workv1alpha1.TargetCluster) int32 {
+	replicasSum := int32(0)
+	for i := range clusters {
+		replicasSum += clusters[i].Replicas
+	}
+	return replicasSum
+}


### PR DESCRIPTION
Signed-off-by: junqian <junqian@tencent.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of #344

How to work with it:

Create deployment like this

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  labels:
    app: nginx
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
      ···
```
and policy like this

```
apiVersion: policy.karmada.io/v1alpha1
kind: PropagationPolicy
metadata:
  name: example-policy
spec:
  resourceSelectors:
    - apiVersion: apps/v1
      kind: Deployment
      name: nginx
  placement:
    clusterAffinity:
      clusterNames:
        - member1
        - member2
    replicaScheduling:
      replicaSchedulingType: Divided
      replicaDivisionPreference: Aggregated
```
and we will get a binding with the following clusters, result may be different according to the real resource of clusters

```
spec:
  clusters:
    - name: member1
       replicas : 3
    - name: member2
```
Then we update the replicas of deployment to 6. and the binding will change
```
spec:
  clusters:
    - name: member1
       replicas : 6
    - name: member2
```
