### PR TITLE
use RB lister generated from the SingleClusterInformerManager

### DIFF
--- a/pkg/util/helper/unstructured.go
+++ b/pkg/util/helper/unstructured.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 )
 
 // ConvertToPropagationPolicy converts a PropagationPolicy object from unstructured to typed.
@@ -20,6 +21,16 @@ func ConvertToPropagationPolicy(obj *unstructured.Unstructured) (*policyv1alpha1
 // ConvertToClusterPropagationPolicy converts a ClusterPropagationPolicy object from unstructured to typed.
 func ConvertToClusterPropagationPolicy(obj *unstructured.Unstructured) (*policyv1alpha1.ClusterPropagationPolicy, error) {
 	typedObj := &policyv1alpha1.ClusterPropagationPolicy{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
+		return nil, err
+	}
+
+	return typedObj, nil
+}
+
+// ConvertToResourceBinding converts a ResourceBinding object from unstructured to typed.
+func ConvertToResourceBinding(obj *unstructured.Unstructured) (*workv1alpha1.ResourceBinding, error) {
+	typedObj := &workv1alpha1.ResourceBinding{}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Part of #545 ,  use resourceBinding lister which generated from the SingleClusterInformerManager to get ResourceBinding, rather than get it from controller-runtime Client, prevent target object not found due to delay.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

