### PR TITLE
prevent nil key from queue

### DIFF
--- a/pkg/util/worker.go
+++ b/pkg/util/worker.go
@@ -107,6 +107,10 @@ func (w *asyncWorker) EnqueueRateLimited(obj runtime.Object) {
 		return
 	}
 
+	if key == nil {
+		return
+	}
+
 	w.AddRateLimited(key)
 }
 


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

In karmada-controller-manager  log file, there are much error info:

```
worker.go:115] Ignore nil item from queue
```

This is useless and disturbing.

The reason for this is the changes of resources which not managed by Karmada  in member cluster will be wathched.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

