### PR TITLE
added validation rules to replicaSchedulingStrategy

### DIFF
--- a/artifacts/deploy/policy.karmada.io_clusterpropagationpolicies.yaml
+++ b/artifacts/deploy/policy.karmada.io_clusterpropagationpolicies.yaml
@@ -222,6 +222,9 @@ spec:
                           respecting clusters' resource availabilities during the
                           division. "Weighted" divides replicas by weight according
                           to WeightPreference.
+                        enum:
+                        - Aggregated
+                        - Weighted
                         type: string
                       replicaSchedulingType:
                         description: ReplicaSchedulingType determines how the replicas
@@ -231,6 +234,9 @@ spec:
                           resource. "Divided" divides replicas into parts according
                           to number of valid candidate member clusters, and exact
                           replicas for each cluster are determined by ReplicaDivisionPreference.
+                        enum:
+                        - Duplicated
+                        - Divided
                         type: string
                       weightPreference:
                         description: WeightPreference describes weight for each cluster

--- a/artifacts/deploy/policy.karmada.io_propagationpolicies.yaml
+++ b/artifacts/deploy/policy.karmada.io_propagationpolicies.yaml
@@ -218,6 +218,9 @@ spec:
                           respecting clusters' resource availabilities during the
                           division. "Weighted" divides replicas by weight according
                           to WeightPreference.
+                        enum:
+                        - Aggregated
+                        - Weighted
                         type: string
                       replicaSchedulingType:
                         description: ReplicaSchedulingType determines how the replicas
@@ -227,6 +230,9 @@ spec:
                           resource. "Divided" divides replicas into parts according
                           to number of valid candidate member clusters, and exact
                           replicas for each cluster are determined by ReplicaDivisionPreference.
+                        enum:
+                        - Duplicated
+                        - Divided
                         type: string
                       weightPreference:
                         description: WeightPreference describes weight for each cluster

--- a/pkg/apis/policy/v1alpha1/propagation_types.go
+++ b/pkg/apis/policy/v1alpha1/propagation_types.go
@@ -198,6 +198,7 @@ type ReplicaSchedulingStrategy struct {
 	// "Duplicated" duplicates the same replicas to each candidate member cluster from resource.
 	// "Divided" divides replicas into parts according to number of valid candidate member
 	// clusters, and exact replicas for each cluster are determined by ReplicaDivisionPreference.
+	// +kubebuilder:validation:Enum=Duplicated;Divided
 	// +optional
 	ReplicaSchedulingType ReplicaSchedulingType `json:"replicaSchedulingType,omitempty"`
 
@@ -206,6 +207,7 @@ type ReplicaSchedulingStrategy struct {
 	// "Aggregated" divides replicas into clusters as few as possible,
 	// while respecting clusters' resource availabilities during the division.
 	// "Weighted" divides replicas by weight according to WeightPreference.
+	// +kubebuilder:validation:Enum=Aggregated;Weighted
 	// +optional
 	ReplicaDivisionPreference ReplicaDivisionPreference `json:"replicaDivisionPreference,omitempty"`
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Restrict `replicaSchedulingStrategy` values by `kubebuilder validation`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @qianjun1993 @Garrybest 