### PR TITLE
E2E: Stop prepare namespace for member clusters

### DIFF
--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -216,13 +216,6 @@ func setupTestNamespace(namespace string, kubeClient kubernetes.Interface, clust
 		return err
 	}
 
-	for _, clusterClient := range clusterClients {
-		_, err = util.CreateNamespace(clusterClient.KubeClient, namespaceObj)
-		if err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -231,13 +224,6 @@ func cleanupTestNamespace(namespace string, kubeClient kubernetes.Interface, clu
 	err := util.DeleteNamespace(kubeClient, namespace)
 	if err != nil {
 		return err
-	}
-
-	for _, clusterClient := range clusterClients {
-		err = util.DeleteNamespace(clusterClient.KubeClient, namespace)
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

We support auto create namespace with [namespace_sync_controller](https://github.com/karmada-io/karmada/blob/master/pkg/controllers/namespace/namespace_sync_controller.go), so we needn't to create namespace for each member cluster explicitly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

