### PR TITLE
Move wellknown labels to apis package

### DIFF
--- a/pkg/apis/policy/v1alpha1/well_known_labels.go
+++ b/pkg/apis/policy/v1alpha1/well_known_labels.go
@@ -1,0 +1,12 @@
+package v1alpha1
+
+const (
+	// PropagationPolicyNamespaceLabel is added to objects to specify associated PropagationPolicy namespace.
+	PropagationPolicyNamespaceLabel = "propagationpolicy.karmada.io/namespace"
+
+	// PropagationPolicyNameLabel is added to objects to specify associated PropagationPolicy's name.
+	PropagationPolicyNameLabel = "propagationpolicy.karmada.io/name"
+
+	// ClusterPropagationPolicyLabel is added to objects to specify associated ClusterPropagationPolicy.
+	ClusterPropagationPolicyLabel = "clusterpropagationpolicy.karmada.io/name"
+)

--- a/pkg/apis/work/v1alpha1/well_known_labels.go
+++ b/pkg/apis/work/v1alpha1/well_known_labels.go
@@ -1,0 +1,18 @@
+package v1alpha1
+
+const (
+	// ResourceBindingNamespaceLabel is added to objects to specify associated ResourceBinding's namespace.
+	ResourceBindingNamespaceLabel = "resourcebinding.karmada.io/namespace"
+
+	// ResourceBindingNameLabel is added to objects to specify associated ResourceBinding's name.
+	ResourceBindingNameLabel = "resourcebinding.karmada.io/name"
+
+	// ClusterResourceBindingLabel is added to objects to specify associated ClusterResourceBinding.
+	ClusterResourceBindingLabel = "clusterresourcebinding.karmada.io/name"
+
+	// WorkNamespaceLabel is added to objects to specify associated Work's namespace.
+	WorkNamespaceLabel = "work.karmada.io/namespace"
+
+	// WorkNameLabel is added to objects to specify associated Work's name.
+	WorkNameLabel = "work.karmada.io/name"
+)

--- a/pkg/controllers/binding/binding_controller.go
+++ b/pkg/controllers/binding/binding_controller.go
@@ -47,8 +47,8 @@ func (c *ResourceBindingController) Reconcile(ctx context.Context, req controlle
 		// The resource no longer exist, clean up derived Work objects.
 		if errors.IsNotFound(err) {
 			return helper.DeleteWorks(c.Client, labels.Set{
-				util.ResourceBindingNamespaceLabel: req.Namespace,
-				util.ResourceBindingNameLabel:      req.Name,
+				workv1alpha1.ResourceBindingNamespaceLabel: req.Namespace,
+				workv1alpha1.ResourceBindingNameLabel:      req.Name,
 			})
 		}
 
@@ -116,8 +116,8 @@ func (c *ResourceBindingController) SetupWithManager(mgr controllerruntime.Manag
 			var requests []reconcile.Request
 
 			labels := a.GetLabels()
-			resourcebindingNamespace, namespaceExist := labels[util.ResourceBindingNamespaceLabel]
-			resourcebindingName, nameExist := labels[util.ResourceBindingNameLabel]
+			resourcebindingNamespace, namespaceExist := labels[workv1alpha1.ResourceBindingNamespaceLabel]
+			resourcebindingName, nameExist := labels[workv1alpha1.ResourceBindingNameLabel]
 			if !namespaceExist || !nameExist {
 				return nil
 			}

--- a/pkg/controllers/binding/cluster_resource_binding_controller.go
+++ b/pkg/controllers/binding/cluster_resource_binding_controller.go
@@ -47,7 +47,7 @@ func (c *ClusterResourceBindingController) Reconcile(ctx context.Context, req co
 		// The resource no longer exist, clean up derived Work objects.
 		if errors.IsNotFound(err) {
 			return helper.DeleteWorks(c.Client, labels.Set{
-				util.ClusterResourceBindingLabel: req.Name,
+				workv1alpha1.ClusterResourceBindingLabel: req.Name,
 			})
 		}
 
@@ -110,7 +110,7 @@ func (c *ClusterResourceBindingController) SetupWithManager(mgr controllerruntim
 			var requests []reconcile.Request
 
 			labels := a.GetLabels()
-			clusterResourcebindingName, nameExist := labels[util.ClusterResourceBindingLabel]
+			clusterResourcebindingName, nameExist := labels[workv1alpha1.ClusterResourceBindingLabel]
 			if !nameExist {
 				return nil
 			}

--- a/pkg/controllers/hpa/hpa_controller.go
+++ b/pkg/controllers/hpa/hpa_controller.go
@@ -98,8 +98,8 @@ func (c *HorizontalPodAutoscalerController) buildWorks(hpa *autoscalingv1.Horizo
 			},
 		}
 
-		util.MergeLabel(hpaObj, util.WorkNamespaceLabel, workNamespace)
-		util.MergeLabel(hpaObj, util.WorkNameLabel, workName)
+		util.MergeLabel(hpaObj, workv1alpha1.WorkNamespaceLabel, workNamespace)
+		util.MergeLabel(hpaObj, workv1alpha1.WorkNameLabel, workName)
 
 		if err = helper.CreateOrUpdateWork(c.Client, objectMeta, hpaObj); err != nil {
 			return err

--- a/pkg/controllers/mcs/endpointslice_controller.go
+++ b/pkg/controllers/mcs/endpointslice_controller.go
@@ -40,8 +40,8 @@ func (c *EndpointSliceController) Reconcile(ctx context.Context, req controllerr
 		if errors.IsNotFound(err) {
 			// Cleanup derived EndpointSlices after work has been removed.
 			return helper.DeleteEndpointSlice(c.Client, labels.Set{
-				util.WorkNamespaceLabel: req.Namespace,
-				util.WorkNameLabel:      req.Name,
+				workv1alpha1.WorkNamespaceLabel: req.Namespace,
+				workv1alpha1.WorkNameLabel:      req.Name,
 			})
 		}
 
@@ -96,8 +96,8 @@ func (c *EndpointSliceController) collectEndpointSliceFromWork(work *workv1alpha
 
 		desiredEndpointSlice := deriveEndpointSlice(endpointSlice, clusterName)
 		desiredEndpointSlice.Labels = map[string]string{
-			util.WorkNamespaceLabel:           work.Namespace,
-			util.WorkNameLabel:                work.Name,
+			workv1alpha1.WorkNamespaceLabel:   work.Namespace,
+			workv1alpha1.WorkNameLabel:        work.Name,
 			discoveryv1beta1.LabelServiceName: names.GenerateDerivedServiceName(work.Labels[util.ServiceNameLabel]),
 		}
 

--- a/pkg/controllers/namespace/namespace_sync_controller.go
+++ b/pkg/controllers/namespace/namespace_sync_controller.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/helper"
 	"github.com/karmada-io/karmada/pkg/util/names"
@@ -121,8 +122,8 @@ func (c *Controller) buildWorks(namespace *v1.Namespace, clusters []v1alpha1.Clu
 			},
 		}
 
-		util.MergeLabel(namespaceObj, util.WorkNamespaceLabel, workNamespace)
-		util.MergeLabel(namespaceObj, util.WorkNameLabel, workName)
+		util.MergeLabel(namespaceObj, workv1alpha1.WorkNamespaceLabel, workNamespace)
+		util.MergeLabel(namespaceObj, workv1alpha1.WorkNameLabel, workName)
 
 		if err = helper.CreateOrUpdateWork(c.Client, objectMeta, namespaceObj); err != nil {
 			return err

--- a/pkg/controllers/status/workstatus_controller.go
+++ b/pkg/controllers/status/workstatus_controller.go
@@ -134,8 +134,8 @@ func (c *WorkStatusController) syncWorkStatus(key util.QueueKey) error {
 		return nil
 	}
 
-	workNamespace := util.GetLabelValue(obj.GetLabels(), util.WorkNamespaceLabel)
-	workName := util.GetLabelValue(obj.GetLabels(), util.WorkNameLabel)
+	workNamespace := util.GetLabelValue(obj.GetLabels(), workv1alpha1.WorkNamespaceLabel)
+	workName := util.GetLabelValue(obj.GetLabels(), workv1alpha1.WorkNameLabel)
 	if len(workNamespace) == 0 || len(workName) == 0 {
 		klog.Infof("Ignore object(%s) which not managed by karmada.", fedKey.String())
 		return nil

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -190,8 +190,8 @@ func (s *Scheduler) onPropagationPolicyUpdate(old, cur interface{}) {
 	}
 
 	selector := labels.SelectorFromSet(labels.Set{
-		util.PropagationPolicyNamespaceLabel: oldPropagationPolicy.Namespace,
-		util.PropagationPolicyNameLabel:      oldPropagationPolicy.Name,
+		policyv1alpha1.PropagationPolicyNamespaceLabel: oldPropagationPolicy.Namespace,
+		policyv1alpha1.PropagationPolicyNameLabel:      oldPropagationPolicy.Name,
 	})
 
 	err := s.requeueResourceBindings(selector)
@@ -210,7 +210,7 @@ func (s *Scheduler) onClusterPropagationPolicyUpdate(old, cur interface{}) {
 	}
 
 	selector := labels.SelectorFromSet(labels.Set{
-		util.ClusterPropagationPolicyLabel: oldClusterPropagationPolicy.Name,
+		policyv1alpha1.ClusterPropagationPolicyLabel: oldClusterPropagationPolicy.Name,
 	})
 
 	err := s.requeueClusterResourceBindings(selector)
@@ -275,7 +275,7 @@ func (s *Scheduler) getPlacement(resourceBinding *workv1alpha1.ResourceBinding) 
 	var policyName string
 	var policyNamespace string
 	var err error
-	if clusterPolicyName = util.GetLabelValue(resourceBinding.Labels, util.ClusterPropagationPolicyLabel); clusterPolicyName != "" {
+	if clusterPolicyName = util.GetLabelValue(resourceBinding.Labels, policyv1alpha1.ClusterPropagationPolicyLabel); clusterPolicyName != "" {
 		var clusterPolicy *policyv1alpha1.ClusterPropagationPolicy
 		clusterPolicy, err = s.clusterPolicyLister.Get(clusterPolicyName)
 		if err != nil {
@@ -285,8 +285,8 @@ func (s *Scheduler) getPlacement(resourceBinding *workv1alpha1.ResourceBinding) 
 		placement = clusterPolicy.Spec.Placement
 	}
 
-	if policyName = util.GetLabelValue(resourceBinding.Labels, util.PropagationPolicyNameLabel); policyName != "" {
-		policyNamespace = util.GetLabelValue(resourceBinding.Labels, util.PropagationPolicyNamespaceLabel)
+	if policyName = util.GetLabelValue(resourceBinding.Labels, policyv1alpha1.PropagationPolicyNameLabel); policyName != "" {
+		policyNamespace = util.GetLabelValue(resourceBinding.Labels, policyv1alpha1.PropagationPolicyNamespaceLabel)
 		var policy *policyv1alpha1.PropagationPolicy
 		policy, err = s.policyLister.PropagationPolicies(policyNamespace).Get(policyName)
 		if err != nil {
@@ -370,7 +370,7 @@ func (s *Scheduler) getScheduleType(key string) ScheduleType {
 			return FirstSchedule
 		}
 
-		policyName := util.GetLabelValue(binding.Labels, util.ClusterPropagationPolicyLabel)
+		policyName := util.GetLabelValue(binding.Labels, policyv1alpha1.ClusterPropagationPolicyLabel)
 
 		policy, err := s.clusterPolicyLister.Get(policyName)
 		if err != nil {
@@ -459,7 +459,7 @@ func (s *Scheduler) scheduleOne(key string) (err error) {
 			return nil
 		}
 
-		clusterPolicyName := util.GetLabelValue(clusterResourceBinding.Labels, util.ClusterPropagationPolicyLabel)
+		clusterPolicyName := util.GetLabelValue(clusterResourceBinding.Labels, policyv1alpha1.ClusterPropagationPolicyLabel)
 
 		clusterPolicy, err := s.clusterPolicyLister.Get(clusterPolicyName)
 		if err != nil {
@@ -670,7 +670,7 @@ func (s *Scheduler) rescheduleOne(key string) (err error) {
 }
 
 func (s *Scheduler) rescheduleClusterResourceBinding(clusterResourceBinding *workv1alpha1.ClusterResourceBinding) error {
-	policyName := util.GetLabelValue(clusterResourceBinding.Labels, util.ClusterPropagationPolicyLabel)
+	policyName := util.GetLabelValue(clusterResourceBinding.Labels, policyv1alpha1.ClusterPropagationPolicyLabel)
 	policy, err := s.clusterPolicyLister.Get(policyName)
 	if err != nil {
 		klog.Errorf("Failed to get policy by policyName(%s): Error: %v", policyName, err)
@@ -805,7 +805,7 @@ func (s *Scheduler) scaleScheduleOne(key string) (err error) {
 			return nil
 		}
 
-		clusterPolicyName := util.GetLabelValue(clusterResourceBinding.Labels, util.ClusterPropagationPolicyLabel)
+		clusterPolicyName := util.GetLabelValue(clusterResourceBinding.Labels, policyv1alpha1.ClusterPropagationPolicyLabel)
 
 		clusterPolicy, err := s.clusterPolicyLister.Get(clusterPolicyName)
 		if err != nil {

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,30 +1,6 @@
 package util
 
 const (
-	// PropagationPolicyNamespaceLabel is added to objects to specify associated PropagationPolicy namespace.
-	PropagationPolicyNamespaceLabel = "propagationpolicy.karmada.io/namespace"
-
-	// PropagationPolicyNameLabel is added to objects to specify associated PropagationPolicy's name.
-	PropagationPolicyNameLabel = "propagationpolicy.karmada.io/name"
-
-	// ClusterPropagationPolicyLabel is added to objects to specify associated ClusterPropagationPolicy.
-	ClusterPropagationPolicyLabel = "clusterpropagationpolicy.karmada.io/name"
-
-	// ResourceBindingNamespaceLabel is added to objects to specify associated ResourceBinding's namespace.
-	ResourceBindingNamespaceLabel = "resourcebinding.karmada.io/namespace"
-
-	// ResourceBindingNameLabel is added to objects to specify associated ResourceBinding's name.
-	ResourceBindingNameLabel = "resourcebinding.karmada.io/name"
-
-	// ClusterResourceBindingLabel is added to objects to specify associated ClusterResourceBinding.
-	ClusterResourceBindingLabel = "clusterresourcebinding.karmada.io/name"
-
-	// WorkNamespaceLabel is added to objects to specify associated Work's namespace.
-	WorkNamespaceLabel = "work.karmada.io/namespace"
-
-	// WorkNameLabel is added to objects to specify associated Work's name.
-	WorkNameLabel = "work.karmada.io/name"
-
 	// ServiceNamespaceLabel is added to work object, which is report by member cluster, to specify service namespace associated with EndpointSlice.
 	ServiceNamespaceLabel = "endpointslice.karmada.io/namespace"
 

--- a/pkg/util/helper/binding.go
+++ b/pkg/util/helper/binding.go
@@ -93,8 +93,8 @@ func FindOrphanWorks(c client.Client, bindingNamespace, bindingName string, clus
 	workList := &workv1alpha1.WorkList{}
 	if scope == apiextensionsv1.NamespaceScoped {
 		selector := labels.SelectorFromSet(labels.Set{
-			util.ResourceBindingNamespaceLabel: bindingNamespace,
-			util.ResourceBindingNameLabel:      bindingName,
+			workv1alpha1.ResourceBindingNamespaceLabel: bindingNamespace,
+			workv1alpha1.ResourceBindingNameLabel:      bindingName,
 		})
 
 		if err := c.List(context.TODO(), workList, &client.ListOptions{LabelSelector: selector}); err != nil {
@@ -102,7 +102,7 @@ func FindOrphanWorks(c client.Client, bindingNamespace, bindingName string, clus
 		}
 	} else {
 		selector := labels.SelectorFromSet(labels.Set{
-			util.ClusterResourceBindingLabel: bindingName,
+			workv1alpha1.ClusterResourceBindingLabel: bindingName,
 		})
 
 		if err := c.List(context.TODO(), workList, &client.ListOptions{LabelSelector: selector}); err != nil {
@@ -238,17 +238,17 @@ func getRSPAndReplicaInfos(c client.Client, workload *unstructured.Unstructured,
 
 func mergeLabel(workload *unstructured.Unstructured, workNamespace string, binding metav1.Object, scope apiextensionsv1.ResourceScope) map[string]string {
 	var workLabel = make(map[string]string)
-	util.MergeLabel(workload, util.WorkNamespaceLabel, workNamespace)
-	util.MergeLabel(workload, util.WorkNameLabel, names.GenerateWorkName(workload.GetKind(), workload.GetName(), workload.GetNamespace()))
+	util.MergeLabel(workload, workv1alpha1.WorkNamespaceLabel, workNamespace)
+	util.MergeLabel(workload, workv1alpha1.WorkNameLabel, names.GenerateWorkName(workload.GetKind(), workload.GetName(), workload.GetNamespace()))
 
 	if scope == apiextensionsv1.NamespaceScoped {
-		util.MergeLabel(workload, util.ResourceBindingNamespaceLabel, binding.GetNamespace())
-		util.MergeLabel(workload, util.ResourceBindingNameLabel, binding.GetName())
-		workLabel[util.ResourceBindingNamespaceLabel] = binding.GetNamespace()
-		workLabel[util.ResourceBindingNameLabel] = binding.GetName()
+		util.MergeLabel(workload, workv1alpha1.ResourceBindingNamespaceLabel, binding.GetNamespace())
+		util.MergeLabel(workload, workv1alpha1.ResourceBindingNameLabel, binding.GetName())
+		workLabel[workv1alpha1.ResourceBindingNamespaceLabel] = binding.GetNamespace()
+		workLabel[workv1alpha1.ResourceBindingNameLabel] = binding.GetName()
 	} else {
-		util.MergeLabel(workload, util.ClusterResourceBindingLabel, binding.GetName())
-		workLabel[util.ClusterResourceBindingLabel] = binding.GetName()
+		util.MergeLabel(workload, workv1alpha1.ClusterResourceBindingLabel, binding.GetName())
+		workLabel[workv1alpha1.ClusterResourceBindingLabel] = binding.GetName()
 	}
 
 	return workLabel

--- a/pkg/util/helper/workstatus.go
+++ b/pkg/util/helper/workstatus.go
@@ -13,7 +13,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
-	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
@@ -21,8 +20,8 @@ import (
 // then aggregate status info to current ResourceBinding status.
 func AggregateResourceBindingWorkStatus(c client.Client, binding *workv1alpha1.ResourceBinding, workload *unstructured.Unstructured) error {
 	aggregatedStatuses, err := assembleWorkStatus(c, labels.SelectorFromSet(labels.Set{
-		util.ResourceBindingNamespaceLabel: binding.Namespace,
-		util.ResourceBindingNameLabel:      binding.Name,
+		workv1alpha1.ResourceBindingNamespaceLabel: binding.Namespace,
+		workv1alpha1.ResourceBindingNameLabel:      binding.Name,
 	}), workload)
 	if err != nil {
 		return err
@@ -49,7 +48,7 @@ func AggregateResourceBindingWorkStatus(c client.Client, binding *workv1alpha1.R
 // then aggregate status info to current ClusterResourceBinding status.
 func AggregateClusterResourceBindingWorkStatus(c client.Client, binding *workv1alpha1.ClusterResourceBinding, workload *unstructured.Unstructured) error {
 	aggregatedStatuses, err := assembleWorkStatus(c, labels.SelectorFromSet(labels.Set{
-		util.ClusterResourceBindingLabel: binding.Name,
+		workv1alpha1.ClusterResourceBindingLabel: binding.Name,
 	}), workload)
 	if err != nil {
 		return err

--- a/pkg/util/objectwatcher/objectwatcher.go
+++ b/pkg/util/objectwatcher/objectwatcher.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/restmapper"
 )
@@ -81,7 +82,7 @@ func (o *objectWatcherImpl) Create(cluster *v1alpha1.Cluster, desireObj *unstruc
 			}
 
 			// Avoid updating resources that not managed by karmada.
-			if util.GetLabelValue(desireObj.GetLabels(), util.WorkNameLabel) != util.GetLabelValue(existObj.GetLabels(), util.WorkNameLabel) {
+			if util.GetLabelValue(desireObj.GetLabels(), workv1alpha1.WorkNameLabel) != util.GetLabelValue(existObj.GetLabels(), workv1alpha1.WorkNameLabel) {
 				return fmt.Errorf("resource(kind=%s, %s/%s) already exist in cluster %v but not managed by karamda", desireObj.GetKind(), desireObj.GetNamespace(), desireObj.GetName(), cluster.Name)
 			}
 

--- a/pkg/util/worker.go
+++ b/pkg/util/worker.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
+	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/util/informermanager/keys"
 	"github.com/karmada-io/karmada/pkg/util/names"
 )
@@ -84,7 +85,7 @@ func GenerateKey(obj interface{}) (QueueKey, error) {
 
 // getClusterNameFromLabel gets cluster name from ownerLabel, if label not exist, means resource is not created by karmada.
 func getClusterNameFromLabel(resource *unstructured.Unstructured) (string, error) {
-	workNamespace := GetLabelValue(resource.GetLabels(), WorkNamespaceLabel)
+	workNamespace := GetLabelValue(resource.GetLabels(), workv1alpha1.WorkNamespaceLabel)
 	if len(workNamespace) == 0 {
 		klog.V(4).Infof("Ignore resource(%s/%s/%s) which not managed by karmada", resource.GetKind(), resource.GetNamespace(), resource.GetName())
 		return "", nil


### PR DESCRIPTION
Signed-off-by: pigletfly <wangbing.adam@gmail.com>

**What type of PR is this?**
/kind cleanup

Move labels to apis, so third-party operators can use these labels without  import the whole karmada project,.

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

