### PR TITLE
Fix an issue when misdeleting namespace in member cluster

### DIFF
--- a/pkg/util/worker.go
+++ b/pkg/util/worker.go
@@ -3,8 +3,6 @@ package util
 import (
 	"time"
 
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -124,7 +122,7 @@ func (w *asyncWorker) AddRateLimited(item interface{}) {
 }
 
 func (w *asyncWorker) handleError(err error, key interface{}) {
-	if err == nil || errors.HasStatusCause(err, v1.NamespaceTerminatingCause) {
+	if err == nil {
 		w.queue.Forget(key)
 		return
 	}


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When user misdeleting someone namespace in member cluster, namespace will be recreated in member cluster, but resources which under namespace will not be recreated. Resources template in karmada controller-plane still exist.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

