### PR TITLE
Retain pvc volumeName when updating

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -94,6 +94,8 @@ const (
 	StatefulSetKind = "StatefulSet"
 	// EndpointSliceKind indicates the target resource is a endpointslice
 	EndpointSliceKind = "EndpointSlice"
+	// PersistentVolumeClaimKind indicated the target resource is a persistentvolumeclaim
+	PersistentVolumeClaimKind = "PersistentVolumeClaim"
 
 	// ServiceExportKind indicates the target resource is a serviceexport crd
 	ServiceExportKind = "ServiceExport"


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When user create a pvc in karmada and propagate it to member clusters, there will be an error when update pvc in member cluster:

```
E0727 20:23:58.228500      13 objectwatcher.go:121] Failed to update resource(kind=PersistentVolumeClaim, xxx/xxx), err is PersistentVolumeClaim "xxx" is invalid: spec: Forbidden: spec is immutable after creation except resources.requests for bound claims
  core.PersistentVolumeClaimSpec{
        AccessModes:      []core.PersistentVolumeAccessMode{"ReadWriteOnce"},
        Selector:         nil,
        Resources:        core.ResourceRequirements{Requests: core.ResourceList{s"storage": {i: resource.int64Amount{value: 1}, s: "1", Format: "DecimalSI"}}},
-       VolumeName:       "",
+       VolumeName:       "xxx",
        StorageClassName: &"csi-disk",
        VolumeMode:       &"Filesystem",
        DataSource:       nil,
  }
```

As a result, karmada fails to collect the pvc status to Work object.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

