### PR TITLE
Adapt karmada-bootstrap.sh for macOS

### DIFF
--- a/hack/karmada-bootstrap.sh
+++ b/hack/karmada-bootstrap.sh
@@ -3,7 +3,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# This script starts a local karmada control plane based on current codebase and with a certain number of clusters joined.	REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+# This script starts a local karmada control plane based on current codebase and with a certain number of clusters joined.
+# Parameters: [HOST_IPADDRESS](optional) if you want to export clusters' API server port to specific IP address
 # This script depends on utils in: ${REPO_ROOT}/hack/util.sh
 # 1. used by developer to setup develop environment quickly.
 # 2. used by e2e testing to setup test environment automatically.
@@ -20,21 +21,45 @@ MEMBER_CLUSTER_KUBECONFIG=${MEMBER_CLUSTER_KUBECONFIG:-"${KUBECONFIG_PATH}/membe
 MEMBER_CLUSTER_1_NAME=${MEMBER_CLUSTER_1_NAME:-"member1"}
 MEMBER_CLUSTER_2_NAME=${MEMBER_CLUSTER_2_NAME:-"member2"}
 PULL_MODE_CLUSTER_NAME=${PULL_MODE_CLUSTER_NAME:-"member3"}
-CLUSTER_VERSION=${CLUSTER_VERSION:-"kindest/node:v1.19.1"}
+HOST_IPADDRESS=${1:-}
 
+CLUSTER_VERSION=${CLUSTER_VERSION:-"kindest/node:v1.19.1"}
 KIND_LOG_FILE=${KIND_LOG_FILE:-"/tmp/karmada"}
 
 #step0: prepare
+# Make sure go exists
+util::cmd_must_exist "go"
 # install kind and kubectl
 util::install_tools sigs.k8s.io/kind v0.10.0
+# get arch name and os name in bootstrap
+BS_ARCH=$(go env GOARCH)
+BS_OS=$(go env GOOS)
 # we choose v1.18.0, because in kubectl after versions 1.18 exist a bug which will give wrong output when using jsonpath.
 # bug details: https://github.com/kubernetes/kubernetes/pull/98057
-util::install_kubectl "v1.18.0" "amd64"
+util::install_kubectl "v1.18.0" "${BS_ARCH}" "${BS_OS}"
 
 #step1. create host cluster and member clusters in parallel
-util::create_cluster "${HOST_CLUSTER_NAME}" "${MAIN_KUBECONFIG}" "${CLUSTER_VERSION}" "${KIND_LOG_FILE}"
-util::create_cluster "${MEMBER_CLUSTER_1_NAME}" "${MEMBER_CLUSTER_KUBECONFIG}" "${CLUSTER_VERSION}" "${KIND_LOG_FILE}" "${REPO_ROOT}/artifacts/kindClusterConfig/member1.yaml"
-util::create_cluster "${MEMBER_CLUSTER_2_NAME}" "${MEMBER_CLUSTER_KUBECONFIG}" "${CLUSTER_VERSION}" "${KIND_LOG_FILE}" "${REPO_ROOT}/artifacts/kindClusterConfig/member2.yaml"
+# host IP address: script parameter ahead of macOS IP
+if [[ -z "${HOST_IPADDRESS}" ]]; then
+  util::get_macos_ipaddress # Adapt for macOS
+  HOST_IPADDRESS=${MAC_NIC_IPADDRESS:-}
+fi
+#prepare for kindClusterConfig
+TEMP_PATH=$(mktemp -d)
+echo -e "Preparing kindClusterConfig in path: ${TEMP_PATH}"
+cp -rf "${REPO_ROOT}"/artifacts/kindClusterConfig/member1.yaml "${TEMP_PATH}"/member1.yaml
+cp -rf "${REPO_ROOT}"/artifacts/kindClusterConfig/member2.yaml "${TEMP_PATH}"/member2.yaml
+if [[ -n "${HOST_IPADDRESS}" ]]; then # If bind the port of clusters(karmada-host, member1 and member2) to the host IP
+  cp -rf "${REPO_ROOT}"/artifacts/kindClusterConfig/karmada-host.yaml "${TEMP_PATH}"/karmada-host.yaml
+  sed -i'' -e "s/{{host_ipaddress}}/${HOST_IPADDRESS}/g" "${TEMP_PATH}"/karmada-host.yaml
+  sed -i'' -e '/networking:/a\'$'\n''  apiServerAddress: '"${HOST_IPADDRESS}"''$'\n' "${TEMP_PATH}"/member1.yaml
+  sed -i'' -e '/networking:/a\'$'\n''  apiServerAddress: '"${HOST_IPADDRESS}"''$'\n' "${TEMP_PATH}"/member2.yaml
+  util::create_cluster "${HOST_CLUSTER_NAME}" "${MAIN_KUBECONFIG}" "${CLUSTER_VERSION}" "${KIND_LOG_FILE}" "${TEMP_PATH}"/karmada-host.yaml
+else
+  util::create_cluster "${HOST_CLUSTER_NAME}" "${MAIN_KUBECONFIG}" "${CLUSTER_VERSION}" "${KIND_LOG_FILE}"
+fi
+util::create_cluster "${MEMBER_CLUSTER_1_NAME}" "${MEMBER_CLUSTER_KUBECONFIG}" "${CLUSTER_VERSION}" "${KIND_LOG_FILE}" "${TEMP_PATH}"/member1.yaml
+util::create_cluster "${MEMBER_CLUSTER_2_NAME}" "${MEMBER_CLUSTER_KUBECONFIG}" "${CLUSTER_VERSION}" "${KIND_LOG_FILE}" "${TEMP_PATH}"/member2.yaml
 util::create_cluster "${PULL_MODE_CLUSTER_NAME}" "${MEMBER_CLUSTER_KUBECONFIG}" "${CLUSTER_VERSION}" "${KIND_LOG_FILE}"
 
 #step2. make images and get karmadactl

--- a/hack/karmada-bootstrap.sh
+++ b/hack/karmada-bootstrap.sh
@@ -34,6 +34,8 @@ util::install_tools sigs.k8s.io/kind v0.10.0
 # get arch name and os name in bootstrap
 BS_ARCH=$(go env GOARCH)
 BS_OS=$(go env GOOS)
+# check arch and os name before installing
+util::install_environment_check "${BS_ARCH}" "${BS_OS}"
 # we choose v1.18.0, because in kubectl after versions 1.18 exist a bug which will give wrong output when using jsonpath.
 # bug details: https://github.com/kubernetes/kubernetes/pull/98057
 util::install_kubectl "v1.18.0" "${BS_ARCH}" "${BS_OS}"

--- a/hack/local-up-karmada.sh
+++ b/hack/local-up-karmada.sh
@@ -33,33 +33,7 @@ if [ ! -d "$KUBECONFIG_PATH" ]; then
   mkdir -p "$KUBECONFIG_PATH"
 fi
 
-# Adapt for macOS
-if [[ $(go env GOOS) = "darwin" ]]; then
-  tmp_ip=$(ipconfig getifaddr en0 || true)
-  echo ""
-  echo " Detected that you are installing Karmada on macOS "
-  echo ""
-  echo "It needs a Macintosh IP address to bind Karmada API Server(port 5443),"
-  echo "so that member clusters can access it from docker containers, please"
-  echo -n "input an available IP, "
-  if [[ -z ${tmp_ip} ]]; then
-    echo "you can use the command 'ifconfig' to look for one"
-    tips_msg="[Enter IP address]:"
-  else
-    echo "default IP will be en0 inet addr if exists"
-    tips_msg="[Enter for default ${tmp_ip}]:"
-  fi
-  read -r -p "${tips_msg}" MAC_NIC_IPADDRESS
-  MAC_NIC_IPADDRESS=${MAC_NIC_IPADDRESS:-$tmp_ip}
-  if [[ "${MAC_NIC_IPADDRESS}" =~ ^(([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))\.){3}([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))$ ]]; then
-    echo "Using IP address: ${MAC_NIC_IPADDRESS}"
-  else
-    echo -e "\nError: you input an invalid IP address"
-    exit 1
-  fi
-else # non-macOS
-  MAC_NIC_IPADDRESS=${MAC_NIC_IPADDRESS:-}
-fi
+util::get_macos_ipaddress # Adapt for macOS
 
 # create a cluster to deploy karmada control plane components.
 if [[ -n "${MAC_NIC_IPADDRESS}" ]]; then # install on macOS


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Users can bootstrap Karmada control plane and members clusters on macOS, and solved the communication between Karmada cluster and member clusters by using MacOS host IP

This is also a todo after https://github.com/karmada-io/karmada/pull/538

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Change details:
- function util::install_kubectl adapts for other OS except for Linux
- add an optional parameter(Host IP) in `hack/karmada-bootstrap.sh` to allow users to expose the API server of clusters
- extract the codes that get macOS'IP interactively out of `hack/local-up-karmada.sh` to add a function `util::get_macos_ipaddress` in `hack/util.sh` 
- add rendering files in `artifacts/kindClusterConfig` when expose the API server of clusters by using host IP
- bug fixed in functions `util::install_kubectl` and `util::install_kind` when the $PATH does not include `/usr/local/bin`
 
**Does this PR introduce a user-facing change?**:
NONE
