### PR TITLE
Fix an bug when add secret ownerreference with cluster

### DIFF
--- a/pkg/karmadactl/config.go
+++ b/pkg/karmadactl/config.go
@@ -40,7 +40,7 @@ func (a *karmadaConfig) GetRestConfig(context, kubeconfigPath string) (*rest.Con
 	return restConfig, nil
 }
 
-// getClientConfig is a helper method to create a client config from the
+// GetClientConfig is a helper method to create a client config from the
 // context and kubeconfig passed as arguments.
 func (a *karmadaConfig) GetClientConfig(context, kubeconfigPath string) clientcmd.ClientConfig {
 	loadingRules := *a.pathOptions.LoadingRules

--- a/pkg/karmadactl/join.go
+++ b/pkg/karmadactl/join.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/klog/v2"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
-	"github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
 	"github.com/karmada-io/karmada/pkg/karmadactl/options"
 	"github.com/karmada-io/karmada/pkg/util"
@@ -55,7 +54,7 @@ var (
 	}
 )
 
-var resourceKind = v1alpha1.SchemeGroupVersion.WithKind("Cluster")
+var clusterResourceKind = clusterv1alpha1.SchemeGroupVersion.WithKind("Cluster")
 
 const (
 	// TODO(RainbowMango) token and caData key both used by command and controller.
@@ -157,7 +156,7 @@ func RunJoin(cmdOut io.Writer, karmadaConfig KarmadaConfig, opts CommandJoinOpti
 	klog.V(1).Infof("joining cluster. cluster name: %s", opts.ClusterName)
 	klog.V(1).Infof("joining cluster. cluster namespace: %s", opts.ClusterNamespace)
 
-	// Get control plane kube-apiserver client
+	// Get control plane karmada-apiserver client
 	controlPlaneRestConfig, err := karmadaConfig.GetRestConfig(opts.KarmadaContext, opts.KubeConfig)
 	if err != nil {
 		klog.Errorf("failed to get control plane rest config. context: %s, kube-config: %s, error: %v",
@@ -286,7 +285,7 @@ func RunJoin(cmdOut io.Writer, karmadaConfig KarmadaConfig, opts CommandJoinOpti
 	patchSecretBody := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(cluster, resourceKind),
+				*metav1.NewControllerRef(cluster, clusterResourceKind),
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind bug
/kind cleanup

**What this PR does / why we need it**:

When user join cluster to karmada, karmada-controller-plane will create a secret to record cluster certification, and add ownerreference with cluster so that when cluster was deleted, the secret will also be deleted. In our code, we add incorrect cluster apiVersion with correct:

```yaml
ownerReferences:
  - apiVersion: policy.karmada.io/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: Cluster
    name: member1
    uid: 81995a12-069d-4d40-b108-5ef892fb67fb
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

