### PR TITLE
Delete the extra getClusterHealthStatus logic and use the wait.Poll framework directly

### DIFF
--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -131,26 +131,22 @@ func (c *ClusterStatusController) syncClusterStatus(cluster *v1alpha1.Cluster) (
 
 	var currentClusterStatus = v1alpha1.ClusterStatus{}
 
-	// get the health status of member cluster
-	online, healthy := getClusterHealthStatus(clusterClient)
-
+	var online, healthy bool
 	// in case of cluster offline, retry a few times to avoid network unstable problems.
 	// Note: retry timeout should not be too long, otherwise will block other cluster reconcile.
-	if !online {
-		err := wait.Poll(clusterStatusRetryInterval, clusterStatusRetryTimeout, func() (done bool, err error) {
-			online, healthy = getClusterHealthStatus(clusterClient)
-			if !online {
-				return false, nil
-			}
-			klog.V(2).Infof("Cluster(%s) back to online after retry.", cluster.Name)
-			return true, nil
-		})
-		// error indicates that retry timeout, update cluster status immediately and return.
-		if err != nil {
-			currentClusterStatus.Conditions = generateReadyCondition(false, false)
-			setTransitionTime(&cluster.Status, &currentClusterStatus)
-			return c.updateStatusIfNeeded(cluster, currentClusterStatus)
+	err = wait.PollImmediate(clusterStatusRetryInterval, clusterStatusRetryTimeout, func() (done bool, err error) {
+		online, healthy = getClusterHealthStatus(clusterClient)
+		if !online {
+			return false, nil
 		}
+		klog.V(2).Infof("Cluster(%s) back to online after retry.", cluster.Name)
+		return true, nil
+	})
+	// error indicates that retry timeout, update cluster status immediately and return.
+	if err != nil {
+		currentClusterStatus.Conditions = generateReadyCondition(false, false)
+		setTransitionTime(&cluster.Status, &currentClusterStatus)
+		return c.updateStatusIfNeeded(cluster, currentClusterStatus)
 	}
 
 	clusterVersion, err := getKubernetesVersion(clusterClient)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

It is not necessary to call `getClusterHealthStatus` once in addition to `wait.Poll`, `wait.Poll ` will automatically retry

`wait.PollImmediate` is more appropriate than `wait.PollImmediate`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

