### PR TITLE
Cleanup: update misleading log

### DIFF
--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -137,13 +137,14 @@ func (c *ClusterStatusController) syncClusterStatus(cluster *v1alpha1.Cluster) (
 	err = wait.PollImmediate(clusterStatusRetryInterval, clusterStatusRetryTimeout, func() (done bool, err error) {
 		online, healthy = getClusterHealthStatus(clusterClient)
 		if !online {
+			klog.V(2).Infof("Cluster(%s) is offline.", cluster.Name)
 			return false, nil
 		}
-		klog.V(2).Infof("Cluster(%s) back to online after retry.", cluster.Name)
 		return true, nil
 	})
 	// error indicates that retry timeout, update cluster status immediately and return.
 	if err != nil {
+		klog.V(2).Infof("Cluster(%s) still offline after retry, ensuring offline is set.", cluster.Name)
 		currentClusterStatus.Conditions = generateReadyCondition(false, false)
 		setTransitionTime(&cluster.Status, &currentClusterStatus)
 		return c.updateStatusIfNeeded(cluster, currentClusterStatus)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
After PR #597, I can see a misleading log from `karmada-controller-manager`:
```
I0816 03:49:03.714941       1 cluster_status_controller.go:142] Cluster(member2) back to online after retry.
```

This log represents a cluster `back to` online state, and should not be printed in normal situations.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
/cc @Garrybest 
