### PR TITLE
fix panic: when the summary weight is zero

### DIFF
--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -278,6 +278,10 @@ func calculateReplicas(c client.Client, policy *v1alpha1.ReplicaSchedulingPolicy
 		}
 	}
 
+	if weightSum == 0 {
+		return desireReplicaInfos, nil
+	}
+
 	allocatedReplicas := int32(0)
 	for clusterName, weight := range matchClusters {
 		desireReplicaInfos[clusterName] = weight * int64(policy.Spec.TotalReplicas) / weightSum


### PR DESCRIPTION
…0, calculateReplicas func divide by 0

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
when staticWeightList weight sum is 0, calculateReplicas will panic. 
```
      staticWeightList:
      - targetCluster:
          clusterNames:
          - qcbj1
        weight: 0
```

```
E0818 06:55:02.820591       1 runtime.go:78] Observed a panic: "integer divide by zero" (runtime error: integer divide by zero)
goroutine 962 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x19e0d20, 0x2a43220)
	/Users/xiaorui.zoux/work/karmada/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x95
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/Users/xiaorui.zoux/work/karmada/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x86
panic(0x19e0d20, 0x2a43220)
	/usr/local/Cellar/go/1.16.2/libexec/src/runtime/panic.go:965 +0x1b9
github.com/karmada-io/karmada/pkg/util/helper.calculateReplicas(0x1e983e8, 0xc0005b4870, 0xc002567a20, 0xc004802cc0, 0x1, 0x1, 0x9df8a7, 0xc00408bcb0, 0xc000ed94e0)
	/Users/xiaorui.zoux/work/karmada/pkg/util/helper/binding.go:392 +0x865
github.com/karmada-io/karmada/pkg/util/helper.calculateReplicasIfNeeded(0x1e983e8, 0xc0005b4870, 0xc000caa2b0, 0xc004802cc0, 0x1, 0x1, 0xc004498cf0, 0x4, 0xc004498cf5, 0x2)
	/Users/xiaorui.zoux/work/karmada/pkg/util/helper/binding.go:320 +0x1ad
github.com/karmada-io/karmada/pkg/util/helper.EnsureWork(0x1e983e8, 0xc0005b4870, 0xc000caa2b0, 0xc004802cc0, 0x1, 0x1, 0xc001306450, 0x1, 0x1, 0x1e45d20, ...)
	/Users/xiaorui.zoux/work/karmada/pkg/util/helper/binding.go:176 +0x23f7
github.com/karmada-io/karmada/pkg/controllers/binding.(*ResourceBindingController).syncBinding(0xc000a345a0, 0xc00011f180, 0xc000046050, 0xc000a7f8e0, 0x4, 0xc00094d1a0)
	/Users/xiaorui.zoux/work/karmada/pkg/controllers/binding/binding_controller.go:95 +0x91a
github.com/karmada-io/karmada/pkg/controllers/binding.(*ResourceBindingController).Reconcile(0xc000a345a0, 0x1e81d98, 0xc004809620, 0xc000a7f8e0, 0x4, 0xc00094d1a0, 0x13, 0xc004809620, 0xc000010000, 0x1a9e540, ...)
	/Users/xiaorui.zoux/work/karmada/pkg/controllers/binding/binding_controller.go:68 +0x3fb
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0002c99a0, 0x1e81cf0, 0xc0004b1c80, 0x1a50a40, 0xc000b41a20)
	/Users/xiaorui.zoux/work/karmada/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:298 +0x30d
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0002c99a0, 0x1e81cf0, 0xc0004b1c80, 0x0)
	/Users/xiaorui.zoux/work/karmada/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:253 +0x205
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.2(0x1e81cf0, 0xc0004b1c80)
	/Users/xiaorui.zoux/work/karmada/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:216 +0x4a
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1()
	/Users/xiaorui.zoux/work/karmada/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:185 +0x37
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc0012edf50)
	/Users/xiaorui.zoux/work/karmada/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x5f
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc000ed9f50, 0x1e46880, 0xc000b2a030, 0xc0004b1c01, 0xc000c58000)
	/Users/xiaorui.zoux/work/karmada/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0x9b
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0012edf50, 0x3b9aca00, 0x0, 0x19f7601, 0xc000c58000)
	/Users/xiaorui.zoux/work/karmada/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x98
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext(0x1e81cf0, 0xc0004b1c80, 0xc000ab1d80, 0x3b9aca00, 0x0, 0xc000e36701)
	/Users/xiaorui.zoux/work/karmada/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:185 +0xa6
k8s.io/apimachinery/pkg/util/wait.UntilWithContext(0x1e81cf0, 0xc0004b1c80, 0xc000ab1d80, 0x3b9aca00)
	/Users/xiaorui.zoux/work/karmada/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:99 +0x57
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
	/Users/xiaorui.zoux/work/karmada/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:213 +0x40d
panic: runtime error: integer divide by zero [recovered]
	panic: runtime error: integer divide by zero

goroutine 962 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/Users/xiaorui.zoux/work/karmada/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:55 +0x109
panic(0x19e0d20, 0x2a43220)
	/usr/local/Cellar/go/1.16.2/libexec/src/runtime/panic.go:965 +0x1b9
github.com/karmada-io/karmada/pkg/util/helper.calculateReplicas(0x1e983e8, 0xc0005b4870, 0xc002567a20, 0xc004802cc0, 0x1, 0x1, 0x9df8a7, 0xc00408bcb0, 0xc000ed94e0)
	/Users/xiaorui.zoux/work/karmada/pkg/util/helper/binding.go:392 +0x865
github.com/karmada-io/karmada/pkg/util/helper.calculateReplicasIfNeeded(0x1e983e8, 0xc0005b4870, 0xc000caa2b0, 0xc004802cc0, 0x1, 0x1, 0xc004498cf0, 0x4, 0xc004498cf5, 0x2)
	/Users/xiaorui.zoux/work/karmada/pkg/util/helper/binding.go:320 +0x1ad
github.com/karmada-io/karmada/pkg/util/helper.EnsureWork(0x1e983e8, 0xc0005b4870, 0xc000caa2b0, 0xc004802cc0, 0x1, 0x1, 0xc001306450, 0x1, 0x1, 0x1e45d20, ...)
	/Users/xiaorui.zoux/work/karmada/pkg/util/helper/binding.go:176 +0x23f7
github.com/karmada-io/karmada/pkg/controllers/binding.(*ResourceBindingController).syncBinding(0xc000a345a0, 0xc00011f180, 0xc000046050, 0xc000a7f8e0, 0x4, 0xc00094d1a0)
	/Users/xiaorui.zoux/work/karmada/pkg/controllers/binding/binding_controller.go:95 +0x91a
github.com/karmada-io/karmada/pkg/controllers/binding.(*ResourceBindingController).Reconcile(0xc000a345a0, 0x1e81d98, 0xc004809620, 0xc000a7f8e0, 0x4, 0xc00094d1a0, 0x13, 0xc004809620, 0xc000010000, 0x1a9e540, ...)
	/Users/xiaorui.zoux/work/karmada/pkg/controllers/binding/binding_controller.go:68 +0x3fb
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0002c99a0, 0x1e81cf0, 0xc0004b1c80, 0x1a50a40, 0xc000b41a20)
	/Users/xiaorui.zoux/work/karmada/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:298 +0x30d
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0002c99a0, 0x1e81cf0, 0xc0004b1c80, 0x0)
	/Users/xiaorui.zoux/work/karmada/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:253 +0x205
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.2(0x1e81cf0, 0xc0004b1c80)
	/Users/xiaorui.zoux/work/karmada/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:216 +0x4a
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1()
	/Users/xiaorui.zoux/work/karmada/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:185 +0x37
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc0012edf50)
	/Users/xiaorui.zoux/work/karmada/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x5f
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc000ed9f50, 0x1e46880, 0xc000b2a030, 0xc0004b1c01, 0xc000c58000)
	/Users/xiaorui.zoux/work/karmada/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0x9b
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0012edf50, 0x3b9aca00, 0x0, 0x19f7601, 0xc000c58000)
	/Users/xiaorui.zoux/work/karmada/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x98
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext(0x1e81cf0, 0xc0004b1c80, 0xc000ab1d80, 0x3b9aca00, 0x0, 0xc000e36701)
	/Users/xiaorui.zoux/work/karmada/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:185 +0xa6
k8s.io/apimachinery/pkg/util/wait.UntilWithContext(0x1e81cf0, 0xc0004b1c80, 0xc000ab1d80, 0x3b9aca00)
	/Users/xiaorui.zoux/work/karmada/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:99 +0x57
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
	/Users/xiaorui.zoux/work/karmada/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:213 +0x40d‘

```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

