### PR TITLE
remove health data explicitly when a cluster is being deleted

### DIFF
--- a/pkg/controllers/cluster/cluster_controller.go
+++ b/pkg/controllers/cluster/cluster_controller.go
@@ -139,6 +139,9 @@ func (c *Controller) removeCluster(cluster *v1alpha1.Cluster) (controllerruntime
 		return controllerruntime.Result{Requeue: true}, fmt.Errorf("requeuing operation until the execution space %v deleted, ", cluster.Name)
 	}
 
+	// delete the health data from the map explicitly after we removing the cluster.
+	c.clusterHealthMap.Delete(cluster.Name)
+
 	return c.removeFinalizer(cluster)
 }
 


### PR DESCRIPTION

**What type of PR is this?**
/kind flake
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
I issue this PR in order to remove health data explicitly when a cluster is being deleted, though the health data are deleted in the monitor loop. https://github.com/karmada-io/karmada/blob/c37bedc1cfe5a98b47703464fed837380c90902f/pkg/controllers/cluster/cluster_controller.go#L263-L269

**Special notes for your reviewer**:
I'm new to karmada and have not tested with this, but consider the situation here:
Say a cluster CR have been deleted during the duration of `ClusterMonitorPeriod` https://github.com/karmada-io/karmada/blob/c37bedc1cfe5a98b47703464fed837380c90902f/pkg/controllers/cluster/cluster_controller.go#L94-L98 then in the monitor loops later on, client.List() will not be able to get the deleted cluster, will the cluster health data stored before being staled and leaked? https://github.com/karmada-io/karmada/blob/c37bedc1cfe5a98b47703464fed837380c90902f/pkg/controllers/cluster/cluster_controller.go#L250-L258


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

