### PR TITLE
stop the lease controller when cluster does not exist

### DIFF
--- a/pkg/util/informermanager/single-cluster-manager.go
+++ b/pkg/util/informermanager/single-cluster-manager.go
@@ -45,6 +45,9 @@ type SingleClusterInformerManager interface {
 
 	// WaitForCacheSync waits for all caches to populate.
 	WaitForCacheSync() map[schema.GroupVersionResource]bool
+
+	// Context returns the single cluster context.
+	Context() context.Context
 }
 
 // NewSingleClusterInformerManager constructs a new instance of singleClusterInformerManagerImpl.
@@ -142,4 +145,8 @@ func (s *singleClusterInformerManagerImpl) WaitForCacheSync() map[schema.GroupVe
 		}
 	}
 	return res
+}
+
+func (s *singleClusterInformerManagerImpl) Context() context.Context {
+	return s.ctx
 }


### PR DESCRIPTION
Signed-off-by: Garrybest <garrybest@foxmail.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Delete cluster lease controller after cluster is deleted according to #590.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

