### PR TITLE
retain necessary fields in Pod object

### DIFF
--- a/pkg/util/helper/unstructured.go
+++ b/pkg/util/helper/unstructured.go
@@ -1,6 +1,9 @@
 package helper
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -31,6 +34,66 @@ func ConvertToClusterPropagationPolicy(obj *unstructured.Unstructured) (*policyv
 // ConvertToResourceBinding converts a ResourceBinding object from unstructured to typed.
 func ConvertToResourceBinding(obj *unstructured.Unstructured) (*workv1alpha1.ResourceBinding, error) {
 	typedObj := &workv1alpha1.ResourceBinding{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
+		return nil, err
+	}
+
+	return typedObj, nil
+}
+
+// ConvertToPod converts a Pod object from unstructured to typed.
+func ConvertToPod(obj *unstructured.Unstructured) (*corev1.Pod, error) {
+	typedObj := &corev1.Pod{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
+		return nil, err
+	}
+
+	return typedObj, nil
+}
+
+// ConvertToReplicaSet converts a ReplicaSet object from unstructured to typed.
+func ConvertToReplicaSet(obj *unstructured.Unstructured) (*appsv1.ReplicaSet, error) {
+	typedObj := &appsv1.ReplicaSet{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
+		return nil, err
+	}
+
+	return typedObj, nil
+}
+
+// ConvertToDeployment converts a Deployment object from unstructured to typed.
+func ConvertToDeployment(obj *unstructured.Unstructured) (*appsv1.Deployment, error) {
+	typedObj := &appsv1.Deployment{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
+		return nil, err
+	}
+
+	return typedObj, nil
+}
+
+// ConvertToDaemonSet converts a DaemonSet object from unstructured to typed.
+func ConvertToDaemonSet(obj *unstructured.Unstructured) (*appsv1.DaemonSet, error) {
+	typedObj := &appsv1.DaemonSet{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
+		return nil, err
+	}
+
+	return typedObj, nil
+}
+
+// ConvertToStatefulSet converts a StatefulSet object from unstructured to typed.
+func ConvertToStatefulSet(obj *unstructured.Unstructured) (*appsv1.StatefulSet, error) {
+	typedObj := &appsv1.StatefulSet{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
+		return nil, err
+	}
+
+	return typedObj, nil
+}
+
+// ConvertToJob converts a Job object from unstructured to typed.
+func ConvertToJob(obj *unstructured.Unstructured) (*batchv1.Job, error) {
+	typedObj := &batchv1.Job{}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Retain necessary fields in Pod object when update pod in `karmada controller-plane`, as noted in https://github.com/karmada-io/karmada/pull/641#issuecomment-903524449 .

**Which issue(s) this PR fixes**:
Related to #641 

**Special notes for your reviewer**:
Before retaining fileds is performed, i convert unstructed object to `Pod`, and finally convert `Pod` to unstructed object.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

