### PR TITLE
disable serviceaccount-token controller

### DIFF
--- a/artifacts/deploy/kube-controller-manager.yaml
+++ b/artifacts/deploy/kube-controller-manager.yaml
@@ -42,7 +42,7 @@ spec:
             - --cluster-name=karmada
             - --cluster-signing-cert-file=/etc/karmada/pki/server-ca.crt
             - --cluster-signing-key-file=/etc/karmada/pki/server-ca.key
-            - --controllers=namespace,garbagecollector,serviceaccount-token,serviceaccount
+            - --controllers=namespace,garbagecollector,serviceaccount
             - --kubeconfig=/etc/kubeconfig
             - --leader-elect=true
             - --node-cidr-mask-size=24
@@ -50,7 +50,6 @@ spec:
             - --root-ca-file=/etc/karmada/pki/server-ca.crt
             - --service-account-private-key-file=/etc/karmada/pki/karmada.key
             - --service-cluster-ip-range=10.96.0.0/12
-            - --use-service-account-credentials=true
             - --v=4
           image: k8s.gcr.io/kube-controller-manager:v1.19.1
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Signed-off-by: lihanbo <lihanbo2@huawei.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
kube controller manager will use individual service account credentials for each controller if --use-service-account-credentials flag is true. So we set  --use-service-account-credentials flag to be false and disable serviceaccount-token controller

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
"NONE"

