### PR TITLE
introduce kubectl plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 /karmada-scheduler
 /karmada-webhook
 /karmadactl
+/kubectl-karmada

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ ifeq ($(VERSION), "")
     endif
 endif
 
-all: karmada-controller-manager karmada-scheduler karmadactl karmada-webhook karmada-agent
+all: karmada-controller-manager karmada-scheduler karmadactl kubectl-karmada karmada-webhook karmada-agent
 
 karmada-controller-manager: $(SOURCES)
 	CGO_ENABLED=0 GOOS=$(GOOS) go build \
@@ -58,6 +58,12 @@ karmadactl: $(SOURCES)
 		-o karmadactl \
 		cmd/karmadactl/karmadactl.go
 
+kubectl-karmada: $(SOURCES)
+	CGO_ENABLED=0 GOOS=$(GOOS) go build \
+		-ldflags $(LDFLAGS) \
+		-o kubectl-karmada \
+		cmd/kubectl-karmada/kubectl-karmada.go
+
 karmada-webhook: $(SOURCES)
 	CGO_ENABLED=0 GOOS=$(GOOS) go build \
 		-ldflags $(LDFLAGS) \
@@ -71,7 +77,7 @@ karmada-agent: $(SOURCES)
 		cmd/agent/main.go
 
 clean:
-	rm -rf karmada-controller-manager karmada-scheduler karmadactl karmada-webhook karmada-agent
+	rm -rf karmada-controller-manager karmada-scheduler karmadactl kubectl-karmada karmada-webhook karmada-agent
 
 .PHONY: update
 update:

--- a/cmd/kubectl-karmada/kubectl-karmada.go
+++ b/cmd/kubectl-karmada/kubectl-karmada.go
@@ -13,7 +13,7 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	if err := karmadactl.NewKarmadaCtlCommand(os.Stdout, "karmadactl", "karmadactl").Execute(); err != nil {
+	if err := karmadactl.NewKarmadaCtlCommand(os.Stdout, "karmada", "kubectl karmada").Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}

--- a/pkg/karmadactl/cordon.go
+++ b/pkg/karmadactl/cordon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/spf13/cobra"
@@ -20,18 +21,18 @@ import (
 )
 
 var (
-	cordonLong = `Mark cluster as unschedulable.`
-
+	cordonShort   = `Mark cluster as unschedulable`
+	cordonLong    = `Mark cluster as unschedulable.`
 	cordonExample = `
 # Mark cluster "foo" as unschedulable.
-karmadactl cordon foo
+%s cordon foo
 `
 
-	uncordonLong = `Mark cluster as schedulable.`
-
+	uncordonShort   = `Mark cluster as schedulable`
+	uncordonLong    = `Mark cluster as schedulable.`
 	uncordonExample = `
 # Mark cluster "foo" as schedulable.
-karmadactl uncordon foo
+%s uncordon foo
 `
 )
 
@@ -41,13 +42,13 @@ const (
 )
 
 // NewCmdCordon defines the `cordon` command that mark cluster as unschedulable.
-func NewCmdCordon(cmdOut io.Writer, karmadaConfig KarmadaConfig) *cobra.Command {
+func NewCmdCordon(cmdOut io.Writer, karmadaConfig KarmadaConfig, cmdStr string) *cobra.Command {
 	opts := CommandCordonOption{}
 	cmd := &cobra.Command{
 		Use:     "cordon CLUSTER",
-		Short:   "Mark cluster as unschedulable",
+		Short:   cordonShort,
 		Long:    cordonLong,
-		Example: cordonExample,
+		Example: fmt.Sprintf(cordonExample, cmdStr),
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(args)
 			if err != nil {
@@ -72,13 +73,13 @@ func NewCmdCordon(cmdOut io.Writer, karmadaConfig KarmadaConfig) *cobra.Command 
 }
 
 // NewCmdUncordon defines the `cordon` command that mark cluster as schedulable.
-func NewCmdUncordon(cmdOut io.Writer, karmadaConfig KarmadaConfig) *cobra.Command {
+func NewCmdUncordon(cmdOut io.Writer, karmadaConfig KarmadaConfig, cmdStr string) *cobra.Command {
 	opts := CommandCordonOption{}
 	cmd := &cobra.Command{
 		Use:     "uncordon CLUSTER",
-		Short:   "Mark cluster as schedulable",
+		Short:   uncordonShort,
 		Long:    uncordonLong,
-		Example: uncordonExample,
+		Example: fmt.Sprintf(uncordonExample, cmdStr),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Set default values
 			err := opts.Complete(args)

--- a/pkg/karmadactl/join.go
+++ b/pkg/karmadactl/join.go
@@ -30,10 +30,10 @@ import (
 )
 
 var (
-	joinLong = `Join registers a cluster to control plane.`
-
+	joinShort   = `Register a cluster to control plane`
+	joinLong    = `Join registers a cluster to control plane.`
 	joinExample = `
-karmadactl join CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG>
+%s join CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG>
 `
 )
 
@@ -65,14 +65,14 @@ const (
 )
 
 // NewCmdJoin defines the `join` command that registers a cluster.
-func NewCmdJoin(cmdOut io.Writer, karmadaConfig KarmadaConfig) *cobra.Command {
+func NewCmdJoin(cmdOut io.Writer, karmadaConfig KarmadaConfig, cmdStr string) *cobra.Command {
 	opts := CommandJoinOption{}
 
 	cmd := &cobra.Command{
 		Use:     "join CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG>",
-		Short:   "Register a cluster to control plane",
+		Short:   joinShort,
 		Long:    joinLong,
-		Example: joinExample,
+		Example: fmt.Sprintf(joinExample, cmdStr),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Set default values
 			err := opts.Complete(args)

--- a/pkg/karmadactl/karmadactl.go
+++ b/pkg/karmadactl/karmadactl.go
@@ -2,6 +2,7 @@ package karmadactl
 
 import (
 	"flag"
+	"fmt"
 	"io"
 
 	"github.com/spf13/cobra"
@@ -10,13 +11,18 @@ import (
 	apiserverflag "k8s.io/component-base/cli/flag"
 )
 
+var (
+	rootCmdShort = "%s controls a Kubernetes Cluster Federation."
+	rootCmdLong  = "%s controls a Kubernetes Cluster Federation."
+)
+
 // NewKarmadaCtlCommand creates the `karmadactl` command.
-func NewKarmadaCtlCommand(out io.Writer) *cobra.Command {
+func NewKarmadaCtlCommand(out io.Writer, cmdUse, cmdStr string) *cobra.Command {
 	// Parent command to which all sub-commands are added.
 	rootCmd := &cobra.Command{
-		Use:   "karmadactl",
-		Short: "karmadactl controls a Kubernetes Cluster Federation.",
-		Long:  "karmadactl controls a Kubernetes Cluster Federation.",
+		Use:   cmdUse,
+		Short: fmt.Sprintf(rootCmdShort, cmdStr),
+		Long:  fmt.Sprintf(rootCmdLong, cmdStr),
 
 		RunE: runHelp,
 	}
@@ -34,11 +40,11 @@ func NewKarmadaCtlCommand(out io.Writer) *cobra.Command {
 	_ = flag.CommandLine.Parse(nil)
 
 	karmadaConfig := NewKarmadaConfig(clientcmd.NewDefaultPathOptions())
-	rootCmd.AddCommand(NewCmdJoin(out, karmadaConfig))
-	rootCmd.AddCommand(NewCmdUnjoin(out, karmadaConfig))
-	rootCmd.AddCommand(NewCmdVersion(out))
-	rootCmd.AddCommand(NewCmdCordon(out, karmadaConfig))
-	rootCmd.AddCommand(NewCmdUncordon(out, karmadaConfig))
+	rootCmd.AddCommand(NewCmdJoin(out, karmadaConfig, cmdStr))
+	rootCmd.AddCommand(NewCmdUnjoin(out, karmadaConfig, cmdStr))
+	rootCmd.AddCommand(NewCmdVersion(out, cmdStr))
+	rootCmd.AddCommand(NewCmdCordon(out, karmadaConfig, cmdStr))
+	rootCmd.AddCommand(NewCmdUncordon(out, karmadaConfig, cmdStr))
 
 	return rootCmd
 }

--- a/pkg/karmadactl/unjoin.go
+++ b/pkg/karmadactl/unjoin.go
@@ -3,6 +3,7 @@ package karmadactl
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"time"
 
@@ -22,22 +23,22 @@ import (
 )
 
 var (
-	unjoinLong = `Unjoin removes the registration of a cluster from control plane.`
-
+	unjoinShort   = `Remove the registration of a cluster from control plane`
+	unjoinLong    = `Unjoin removes the registration of a cluster from control plane.`
 	unjoinExample = `
-karmadactl unjoin CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG>
+%s unjoin CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG>
 `
 )
 
 // NewCmdUnjoin defines the `unjoin` command that removes registration of a cluster from control plane.
-func NewCmdUnjoin(cmdOut io.Writer, karmadaConfig KarmadaConfig) *cobra.Command {
+func NewCmdUnjoin(cmdOut io.Writer, karmadaConfig KarmadaConfig, cmdStr string) *cobra.Command {
 	opts := CommandUnjoinOption{}
 
 	cmd := &cobra.Command{
 		Use:     "unjoin CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG>",
-		Short:   "Remove the registration of a cluster from control plane",
+		Short:   unjoinShort,
 		Long:    unjoinLong,
-		Example: unjoinExample,
+		Example: fmt.Sprintf(unjoinExample, cmdStr),
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(args)
 			if err != nil {

--- a/pkg/karmadactl/version.go
+++ b/pkg/karmadactl/version.go
@@ -10,21 +10,21 @@ import (
 )
 
 var (
-	versionLong = `Version prints the version info of this command.`
-
-	versionExample = `  # Print karmadactl command version
-  karmadactl version`
+	versionShort   = `Print the version info`
+	versionLong    = `Version prints the version info of this command.`
+	versionExample = `  # Print %s command version
+  %s version`
 )
 
 // NewCmdVersion prints out the release version info for this command binary.
-func NewCmdVersion(out io.Writer) *cobra.Command {
+func NewCmdVersion(out io.Writer, cmdStr string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "version",
-		Short:   "Print the version info",
+		Short:   versionShort,
 		Long:    versionLong,
-		Example: versionExample,
+		Example: fmt.Sprintf(versionExample, cmdStr, cmdStr),
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Fprintf(out, "karmadactl version: %s\n", fmt.Sprintf("%#v", version.Get()))
+			fmt.Fprintf(out, "%s version: %s\n", cmdStr, fmt.Sprintf("%#v", version.Get()))
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Support kubectl karmada plugin.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

```
# kubectl karmada -h
kubectl karmada controls a Kubernetes Cluster Federation.

Usage:
  karmada [flags]
  karmada [command]

Available Commands:
  cordon      Mark cluster as unschedulable
  help        Help about any command
  join        Register a cluster to control plane
  uncordon    Mark cluster as schedulable
  unjoin      Remove the registration of a cluster from control plane
  version     Print the version info

Flags:
      --add-dir-header                   If true, adds the file directory to the header of the log messages
      --alsologtostderr                  log to standard error as well as files
  -h, --help                             help for karmada
      --kubeconfig string                Paths to a kubeconfig. Only required if out-of-cluster.
      --log-backtrace-at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log-dir string                   If non-empty, write log files in this directory
      --log-file string                  If non-empty, use this log file
      --log-file-max-size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
      --log-flush-frequency duration     Maximum number of seconds between log flushes (default 5s)
      --logtostderr                      log to standard error instead of files (default true)
      --one-output                       If true, only write logs to their native severity level (vs also writing to each lower severity level)
      --skip-headers                     If true, avoid header prefixes in the log messages
      --skip-log-headers                 If true, avoid headers when opening log files
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
  -v, --v Level                          number for the log level verbosity
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

Use "karmada [command] --help" for more information about a command.
```

```
# kubectl karmada version
kubectl karmada version: version.Info{GitVersion:"v0.8.0-60-g5250689", GitCommit:"5250689ebc9e8e7b67e5055f6f38c28a3c6d8a45", GitTreeState:"clean", BuildDate:"2021-09-01T10:02:37Z", GoVersion:"go1.16", Compiler:"gc", Platform:"linux/amd64"}
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
User can use `kubectl karmada` command, this command is the same as that of karmadactl.
```

