### PR TITLE
cleanup status after work object gone

### DIFF
--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -47,7 +47,7 @@ var workPredicateFn = builder.WithPredicates(predicate.Funcs{
 		return !reflect.DeepEqual(statusesOld, statusesNew)
 	},
 	DeleteFunc: func(event.DeleteEvent) bool {
-		return false
+		return true
 	},
 	GenericFunc: func(event.GenericEvent) bool {
 		return false


### PR DESCRIPTION
Signed-off-by: lihanbo <lihanbo2@huawei.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
the scenario in #706 happened because the work object won't be deleted immediately when deleting due to the existing finalizer.  

**Which issue(s) this PR fixes**:
Fixes #706 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
"NONE"

