### PR TITLE
Update binding object with replicas and replicaRequirements

### DIFF
--- a/pkg/util/detector/detector.go
+++ b/pkg/util/detector/detector.go
@@ -440,6 +440,8 @@ func (d *ResourceDetector) ApplyPolicy(object *unstructured.Unstructured, object
 		bindingCopy.Labels = binding.Labels
 		bindingCopy.OwnerReferences = binding.OwnerReferences
 		bindingCopy.Spec.Resource = binding.Spec.Resource
+		bindingCopy.Spec.ReplicaRequirements = binding.Spec.ReplicaRequirements
+		bindingCopy.Spec.Replicas = binding.Spec.Replicas
 		return nil
 	})
 	if err != nil {
@@ -486,6 +488,8 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 			bindingCopy.Labels = binding.Labels
 			bindingCopy.OwnerReferences = binding.OwnerReferences
 			bindingCopy.Spec.Resource = binding.Spec.Resource
+			bindingCopy.Spec.ReplicaRequirements = binding.Spec.ReplicaRequirements
+			bindingCopy.Spec.Replicas = binding.Spec.Replicas
 			return nil
 		})
 
@@ -513,6 +517,8 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 			bindingCopy.Labels = binding.Labels
 			bindingCopy.OwnerReferences = binding.OwnerReferences
 			bindingCopy.Spec.Resource = binding.Spec.Resource
+			bindingCopy.Spec.ReplicaRequirements = binding.Spec.ReplicaRequirements
+			bindingCopy.Spec.Replicas = binding.Spec.Replicas
 			return nil
 		})
 

--- a/test/e2e/scheduling_test.go
+++ b/test/e2e/scheduling_test.go
@@ -451,11 +451,26 @@ var _ = ginkgo.Describe("[ReplicaScheduling] ReplicaSchedulingStrategy testing",
 		})
 
 		ginkgo.It("replicas duplicated testing when rescheduling", func() {
-			ginkgo.By(fmt.Sprintf("Update deployment(%s/%s)'s replicas to 2", policyNamespace, policyName), func() {
+			ginkgo.By("make sure deployment has been propagated to member clusters", func() {
+				for _, cluster := range clusters {
+					clusterClient := getClusterClient(cluster.Name)
+					gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+
+					gomega.Eventually(func() bool {
+						_, err := clusterClient.AppsV1().Deployments(deploymentNamespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+						gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+						return true
+					}, pollTimeout, pollInterval).Should(gomega.Equal(true))
+				}
+			})
+
+			ginkgo.By(fmt.Sprintf("Update deployment(%s/%s)'s replicas", deploymentNamespace, deploymentName), func() {
 				updateReplicas := int32(2)
 				deployment.Spec.Replicas = &updateReplicas
 				_, err := kubeClient.AppsV1().Deployments(deploymentNamespace).Update(context.TODO(), deployment, metav1.UpdateOptions{})
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				klog.Infof("Update deployment(%s/%s)'s replicas to %d", deploymentNamespace, deploymentName, *deployment.Spec.Replicas)
 			})
 
 			ginkgo.By("check if deployment's replicas have been updated on member clusters", func() {
@@ -598,6 +613,20 @@ var _ = ginkgo.Describe("[ReplicaScheduling] ReplicaSchedulingStrategy testing",
 		})
 
 		ginkgo.It("replicas divided and weighted testing when rescheduling", func() {
+			ginkgo.By("make sure deployment has been propagated to member clusters", func() {
+				for _, cluster := range clusters {
+					clusterClient := getClusterClient(cluster.Name)
+					gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+
+					gomega.Eventually(func() bool {
+						_, err := clusterClient.AppsV1().Deployments(deploymentNamespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+						gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+						return true
+					}, pollTimeout, pollInterval).Should(gomega.Equal(true))
+				}
+			})
+
 			expectedReplicas := int32(3)
 			ginkgo.By(fmt.Sprintf("Update deployment(%s/%s)'s replicas to 3*len(clusters)", policyNamespace, policyName), func() {
 				updateReplicas := expectedReplicas * int32(len(clusters))
@@ -780,6 +809,20 @@ var _ = ginkgo.Describe("[ReplicaScheduling] ReplicaSchedulingStrategy testing",
 		})
 
 		ginkgo.It("replicas divided and weighted testing when rescheduling", func() {
+			ginkgo.By("make sure deployment has been propagated to member clusters", func() {
+				for _, cluster := range clusters {
+					clusterClient := getClusterClient(cluster.Name)
+					gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+
+					gomega.Eventually(func() bool {
+						_, err := clusterClient.AppsV1().Deployments(deploymentNamespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+						gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+						return true
+					}, pollTimeout, pollInterval).Should(gomega.Equal(true))
+				}
+			})
+
 			ginkgo.By(fmt.Sprintf("Update deployment(%s/%s)'s replicas to 2*sumWeight", policyNamespace, policyName), func() {
 				sumWeight := 0
 				for index := range clusterNames {


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

After **move ReplicaResourceRequirements and Replicas into ResourceBindingSpec**(refer to #637), when update binding object, it will not update the fields: `.spec.replicas` and `.spec.replicaRequirements`, as a result, the deployment does not reschedule when the number of replicas changes. 

During the E2E test #696, the deployment replicas are directly updated without checking：

https://github.com/karmada-io/karmada/blob/f717c3ab0cf38436d7972b890e8cf20e2977741f/test/e2e/scheduling_test.go#L453-L459

This time is too short, equivalent to no update.

The above two points cause occasional E2E failures like this:
https://github.com/karmada-io/karmada/runs/3543010048?check_suite_focus=true
https://github.com/karmada-io/karmada/runs/3541520540?check_suite_focus=true

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

