### PR TITLE
docs: move installation docs out of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,27 +108,20 @@ There are several demonstrations of common cases.
 
 #### 1. Clone this repo to your machine:
 ```
-# git clone https://github.com/karmada-io/karmada
+git clone https://github.com/karmada-io/karmada
 ```
 
 #### 2. Change to karmada directory:
 ```
-# cd karmada
+cd karmada
 ```
 
 #### 3. Deploy and run karmada control plane:
 
-Choose a way:
-- [I have not any cluster](#31-i-have-not-any-cluster)
-- [I have present cluster for installing](#32-i-have-present-cluster-for-installing)
-
-
-##### 3.1. I have not any cluster
-
 run the following script: (It will create a host cluster by kind)
 
 ```
-# hack/local-up-karmada.sh
+hack/local-up-karmada.sh
 ```
 The script `hack/local-up-karmada.sh` will do following tasks for you:
 - Start a Kubernetes cluster to run the karmada control plane, aka. the `host cluster`.
@@ -159,25 +152,6 @@ There are two contexts:
 
 The `karmada-apiserver` is the **main kubeconfig** to be used when interacting with karamda control plane, while `karmada-host` is only used for debugging karmada installation with the host cluster. You can check all clusters at any time by running: `kubectl config view`. To switch cluster contexts, run `kubectl config use-context [CONTEXT_NAME]`
 
-##### 3.2. I have present cluster for installing
-Before running the following script, please make sure your cluster could provide the `LoadBalancer` type service. Otherwise, type `export CLUSTER_IP_ONLY=true` with the `ClusterIP` type service before the following script.
-```
-# hack/remote-up-karmada.sh <kubeconfig> <context_name>
-```
-`kubeconfig` is your cluster's kubeconfig that you want to install to
-
-`context_name` is the name of context in 'kubeconfig'
-
-If everything goes well, at the end of the script output, you will see similar messages as follows:
-```
-Karmada is installed.
-
-Kubeconfig for karmada in file: /root/.kube/karmada.config, so you can run:
-  export KUBECONFIG="/root/.kube/karmada.config"
-Or use kubectl with --kubeconfig=/root/.kube/karmada.config
-Please use 'kubectl config use-context karmada-apiserver' to switch the cluster of karmada control plane
-And use 'kubectl config use-context your-host' for debugging karmada installation
-```
 #### Tips
 - Please make sure you can access google cloud registry: k8s.gcr.io
 - Install script will download golang package, if your server is in the mainland China, you may set go proxy like this `export GOPROXY=https://goproxy.cn`
@@ -190,7 +164,7 @@ karmada control plane.
 We are going to create a cluster named `member1` and we want the `KUBECONFIG` file
 in `$HOME/.kube/karmada.config`. Run following command:
 ```
-# hack/create-cluster.sh member1 $HOME/.kube/karmada.config
+hack/create-cluster.sh member1 $HOME/.kube/karmada.config
 ```
 The script `hack/create-cluster.sh` will create a cluster by kind.
 
@@ -204,13 +178,13 @@ You can choose one of mode: [push](#21-push-mode-karmada-controls-the-member-clu
 The command `karmadactl` will help to join the member cluster to karmada control plane,
 before that, we should switch to karmada apiserver:
 ```
-# kubectl config use-context karmada-apiserver
+kubectl config use-context karmada-apiserver
 ```
 
 Then, install `karmadactl` command and join the member cluster:
 ```
-# go get github.com/karmada-io/karmada/cmd/karmadactl
-# karmadactl join member1 --cluster-kubeconfig=$HOME/.kube/karmada.config
+go get github.com/karmada-io/karmada/cmd/karmadactl
+karmadactl join member1 --cluster-kubeconfig=$HOME/.kube/karmada.config
 ```
 The `karmadactl join` command will create a `Cluster` object to reflect the member cluster.
 
@@ -218,13 +192,13 @@ The `karmadactl join` command will create a `Cluster` object to reflect the memb
 
 The following script will install the `karamda-agent` to your member cluster, you need to specify the kubeconfig and the cluster context of the karmada control plane and member cluster.
 ```
-# hack/deploy-karmada-agent.sh <karmada_apiserver_kubeconfig> <karmada_apiserver_context_name> <member_cluster_kubeconfig> <member_cluster_context_name>
+hack/deploy-karmada-agent.sh <karmada_apiserver_kubeconfig> <karmada_apiserver_context_name> <member_cluster_kubeconfig> <member_cluster_context_name>
 ```
 
 #### 3. Check member cluster status
 Now, check the member clusters from karmada control plane by following command:
 ```
-# kubectl get clusters
+$ kubectl get clusters
 NAME      VERSION   MODE   READY   AGE
 member1   v1.20.2   Push   True    66s
 ```
@@ -235,19 +209,19 @@ In the following steps, we are going to propagate a deployment by karmada.
 #### 1. Create nginx deployment in karmada.
 First, create a [deployment](samples/nginx/deployment.yaml) named `nginx`:
 ```
-# kubectl create -f samples/nginx/deployment.yaml
+kubectl create -f samples/nginx/deployment.yaml
 ```
 
 #### 2. Create PropagationPolicy that will propagate nginx to member cluster
 Then, we need create a policy to drive the deployment to our member cluster.
 ```
-# kubectl create -f samples/nginx/propagationpolicy.yaml
+kubectl create -f samples/nginx/propagationpolicy.yaml
 ```
 
 #### 3. Check the deployment status from karmada
 You can check deployment status from karmada, don't need to access member cluster:
 ```
-# kubectl get deployment
+$ kubectl get deployment
 NAME    READY   UP-TO-DATE   AVAILABLE   AGE
 nginx   1/1     1            1           43s
 ```

--- a/docs/installation/fromsource.md
+++ b/docs/installation/fromsource.md
@@ -1,0 +1,62 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Installing Karmada on Cluster from Source](#installing-karmada-on-cluster-from-source)
+  - [Select a way to expose karmada-apiserver](#select-a-way-to-expose-karmada-apiserver)
+    - [1. expose by service with `LoadBalancer` type](#1-expose-by-service-with-loadbalancer-type)
+    - [2. expose by service with `ClusterIP` type](#2-expose-by-service-with-clusterip-type)
+  - [Install](#install)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Installing Karmada on Cluster from Source
+
+This document describes how you can use the `hack/remote-up-karmada.sh` script to install Karmada on 
+your clusters based on the codebase.
+
+## Select a way to expose karmada-apiserver
+
+The `hack/remote-up-karmada.sh` will install `karmada-apiserver` and provide two ways to expose the server:
+
+### 1. expose by service with `LoadBalancer` type
+
+By default, the `hack/remote-up-karmada.sh` will expose `karmada-apiserver` by a service with `LoadBalancer`
+type, and continue the installation progress after the `Load Balancer` allocates an external IP for the
+`karmada-apiserver`.
+
+No extra operations needed with this type, but that *requires your cluster have deployed the `Load Balancer`*.
+
+### 2. expose by service with `ClusterIP` type
+If you don't want to use the `Load Balancer`, you can ask `hack/remote-up-karmada.sh` to expose `karmada-apiserver`
+by a service with `ClusterIP` type. All you need to do is set an environment:
+```bash
+export CLUSTER_IP_ONLY=true
+```
+
+> Note: You should run `hack/remote-up-karmada.sh` on one of the nodes of the cluster, otherwise the `hack/remote-up-karmada.sh`
+> can't access the `karmada-apiserver` exposed by a `cluster IP`.
+
+## Install
+From the `root` directory the `karmada` repo, install Karmada by command:
+```bash
+hack/remote-up-karmada.sh <kubeconfig> <context_name>
+```
+- `kubeconfig` is your cluster's kubeconfig that you want to install to
+- `context_name` is the name of context in 'kubeconfig'
+
+For example:
+```bash
+hack/remote-up-karmada.sh $HOME/.kube/config mycluster
+```
+
+If everything goes well, at the end of the script output, you will see similar messages as follows:
+```
+Karmada is installed.
+
+Kubeconfig for karmada in file: /root/.kube/karmada.config, so you can run:
+  export KUBECONFIG="/root/.kube/karmada.config"
+Or use kubectl with --kubeconfig=/root/.kube/karmada.config
+Please use 'kubectl config use-context karmada-apiserver' to switch the cluster of karmada control plane
+And use 'kubectl config use-context your-host' for debugging karmada installation
+```


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
As discussed at the last community meeting, we are gonna clean up `README`.

This PR moves `I have present cluster for installing` part to a separated file.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

