### PR TITLE
Introduced version command to karmada-controller-manager

### DIFF
--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -36,6 +36,8 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/informermanager"
 	"github.com/karmada-io/karmada/pkg/util/objectwatcher"
 	"github.com/karmada-io/karmada/pkg/util/overridemanager"
+	"github.com/karmada-io/karmada/pkg/version"
+	"github.com/karmada-io/karmada/pkg/version/sharedcommand"
 )
 
 // NewControllerManagerCommand creates a *cobra.Command object with default parameters
@@ -43,8 +45,8 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 	opts := options.NewOptions()
 
 	cmd := &cobra.Command{
-		Use:  "controller-manager",
-		Long: `The controller manager runs a bunch of controllers`,
+		Use:  "karmada-controller-manager",
+		Long: `The karmada controller manager runs a bunch of controllers`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := Run(ctx, opts); err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
@@ -54,12 +56,14 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 	}
 
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
+	cmd.AddCommand(sharedcommand.NewCmdVersion(os.Stdout, "karmada-controller-manager"))
 	opts.AddFlags(cmd.Flags())
 	return cmd
 }
 
 // Run runs the controller-manager with options. This should never exit.
 func Run(ctx context.Context, opts *options.Options) error {
+	klog.Infof("karmada-controller-manager version: %s", version.Get())
 	config, err := controllerruntime.GetConfig()
 	if err != nil {
 		panic(err)

--- a/pkg/version/sharedcommand/sharedcommand.go
+++ b/pkg/version/sharedcommand/sharedcommand.go
@@ -1,0 +1,33 @@
+package sharedcommand
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/karmada-io/karmada/pkg/version"
+)
+
+var (
+	versionShort   = `Print the version information.`
+	versionLong    = `Print the version information.`
+	versionExample = `  # Print %s command version
+  %s version`
+)
+
+// NewCmdVersion prints out the release version info for this command binary.
+// It is used as a subcommand of a parent command.
+func NewCmdVersion(out io.Writer, parentCommand string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "version",
+		Short:   versionShort,
+		Long:    versionLong,
+		Example: fmt.Sprintf(versionExample, parentCommand, parentCommand),
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Fprintf(out, "%s version: %s\n", parentCommand, version.Get())
+		},
+	}
+
+	return cmd
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,6 +16,11 @@ type Info struct {
 	Platform     string `json:"platform"`
 }
 
+// String returns a Go-syntax representation of the Info.
+func (info Info) String() string {
+	return fmt.Sprintf("%#v", info)
+}
+
 // Get returns the overall codebase version. It's for detecting
 // what code a binary was built from.
 func Get() Info {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
```bash
$ ./karmada-controller-manager version
karmada-controller-manager version: version.Info{GitVersion:"v0.8.0-105-g0f2345d", GitCommit:"0f2345d7f17d8aec16d53feaa53636b76684f3c4", GitTreeState:"clean", BuildDate:"2021-09-11T07:18:24Z", GoVersion:"go1.16.7", Compiler:"gc", Platform:"linux/amd64"}
```

**Which issue(s) this PR fixes**:
Part of #716

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager` introduced a `version` command to represent version information.
```

