### PR TITLE
add version command to components

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -26,6 +26,8 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/informermanager"
 	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/pkg/util/objectwatcher"
+	"github.com/karmada-io/karmada/pkg/version"
+	"github.com/karmada-io/karmada/pkg/version/sharedcommand"
 )
 
 // NewAgentCommand creates a *cobra.Command object with default parameters
@@ -45,11 +47,13 @@ func NewAgentCommand(ctx context.Context) *cobra.Command {
 	}
 
 	opts.AddFlags(cmd.Flags())
+	cmd.AddCommand(sharedcommand.NewCmdVersion(os.Stdout, "karmada-agent"))
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 	return cmd
 }
 
 func run(ctx context.Context, karmadaConfig karmadactl.KarmadaConfig, opts *options.Options) error {
+	klog.Infof("karmada-agent version: %s", version.Get())
 	controlPlaneRestConfig, err := karmadaConfig.GetRestConfig(opts.KarmadaContext, opts.KarmadaKubeConfig)
 	if err != nil {
 		return fmt.Errorf("error building kubeconfig of karmada control plane: %s", err.Error())

--- a/cmd/scheduler-estimator/app/scheduler-estimator.go
+++ b/cmd/scheduler-estimator/app/scheduler-estimator.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/karmada-io/karmada/cmd/scheduler-estimator/app/options"
 	"github.com/karmada-io/karmada/pkg/estimator/server"
+	"github.com/karmada-io/karmada/pkg/version"
+	"github.com/karmada-io/karmada/pkg/version/sharedcommand"
 )
 
 // NewSchedulerEstimatorCommand creates a *cobra.Command object with default parameters
@@ -21,8 +23,8 @@ func NewSchedulerEstimatorCommand(ctx context.Context) *cobra.Command {
 	opts := options.NewOptions()
 
 	cmd := &cobra.Command{
-		Use:  "scheduler-estimator",
-		Long: `The scheduler estimator runs an accurate scheduler estimator of a cluster`,
+		Use:  "karmada-scheduler-estimator",
+		Long: `The karmada scheduler estimator runs an accurate scheduler estimator of a cluster`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := run(ctx, opts); err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
@@ -32,11 +34,13 @@ func NewSchedulerEstimatorCommand(ctx context.Context) *cobra.Command {
 	}
 
 	opts.AddFlags(cmd.Flags())
+	cmd.AddCommand(sharedcommand.NewCmdVersion(os.Stdout, "karmada-scheduler-estimator"))
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 	return cmd
 }
 
 func run(ctx context.Context, opts *options.Options) error {
+	klog.Infof("karmada-scheduler-estimator version: %s", version.Get())
 	go serveHealthz(fmt.Sprintf("%s:%d", opts.BindAddress, opts.SecurePort))
 
 	restConfig, err := clientcmd.BuildConfigFromFlags(opts.Master, opts.KubeConfig)

--- a/cmd/scheduler/app/scheduler.go
+++ b/cmd/scheduler/app/scheduler.go
@@ -20,6 +20,8 @@ import (
 	"github.com/karmada-io/karmada/cmd/scheduler/app/options"
 	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
 	"github.com/karmada-io/karmada/pkg/scheduler"
+	"github.com/karmada-io/karmada/pkg/version"
+	"github.com/karmada-io/karmada/pkg/version/sharedcommand"
 )
 
 // NewSchedulerCommand creates a *cobra.Command object with default parameters
@@ -27,7 +29,7 @@ func NewSchedulerCommand(stopChan <-chan struct{}) *cobra.Command {
 	opts := options.NewOptions()
 
 	cmd := &cobra.Command{
-		Use:  "scheduler",
+		Use:  "karmada-scheduler",
 		Long: `The karmada scheduler binds resources to the clusters it manages.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := run(opts, stopChan); err != nil {
@@ -38,11 +40,13 @@ func NewSchedulerCommand(stopChan <-chan struct{}) *cobra.Command {
 	}
 
 	opts.AddFlags(cmd.Flags())
+	cmd.AddCommand(sharedcommand.NewCmdVersion(os.Stdout, "karmada-scheduler"))
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 	return cmd
 }
 
 func run(opts *options.Options, stopChan <-chan struct{}) error {
+	klog.Infof("karmada-scheduler version: %s", version.Get())
 	go serveHealthz(fmt.Sprintf("%s:%d", opts.BindAddress, opts.SecurePort))
 
 	restConfig, err := clientcmd.BuildConfigFromFlags(opts.Master, opts.KubeConfig)

--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/karmada-io/karmada/cmd/webhook/app/options"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
+	"github.com/karmada-io/karmada/pkg/version"
+	"github.com/karmada-io/karmada/pkg/version/sharedcommand"
 	"github.com/karmada-io/karmada/pkg/webhook/cluster"
 	"github.com/karmada-io/karmada/pkg/webhook/clusterpropagationpolicy"
 	"github.com/karmada-io/karmada/pkg/webhook/overridepolicy"
@@ -27,8 +29,8 @@ func NewWebhookCommand(ctx context.Context) *cobra.Command {
 	opts := options.NewOptions()
 
 	cmd := &cobra.Command{
-		Use:  "webhook",
-		Long: `Start a webhook server`,
+		Use:  "karmada-webhook",
+		Long: `Start a karmada webhook server`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := Run(ctx, opts); err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
@@ -38,6 +40,7 @@ func NewWebhookCommand(ctx context.Context) *cobra.Command {
 	}
 
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
+	cmd.AddCommand(sharedcommand.NewCmdVersion(os.Stdout, "karmada-webhook"))
 	opts.AddFlags(cmd.Flags())
 
 	return cmd
@@ -45,6 +48,7 @@ func NewWebhookCommand(ctx context.Context) *cobra.Command {
 
 // Run runs the webhook server with options. This should never exit.
 func Run(ctx context.Context, opts *options.Options) error {
+	klog.Infof("karmada-webhook version: %s", version.Get())
 	config, err := controllerruntime.GetConfig()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
```
$ ./karmada-scheduler version
karmada-scheduler version: version.Info{GitVersion:"v0.8.0-106-gb2b36a2-dirty", GitCommit:"b2b36a2aaf9038684e96a6c56c1589dbb43bef37", GitTreeState:"dirty", BuildDate:"2021-09-13T03:13:33Z", GoVersion:"go1.16.7", Compiler:"gc", Platform:"linux/amd64"}
```
```
$ ./karmada-webhook version
karmada-webhook version: version.Info{GitVersion:"v0.8.0-106-gb2b36a2-dirty", GitCommit:"b2b36a2aaf9038684e96a6c56c1589dbb43bef37", GitTreeState:"dirty", BuildDate:"2021-09-13T03:13:33Z", GoVersion:"go1.16.7", Compiler:"gc", Platform:"linux/amd64"}
```
```
$ ./karmada-agent version
karmada-agent version: version.Info{GitVersion:"v0.8.0-106-gb2b36a2-dirty", GitCommit:"b2b36a2aaf9038684e96a6c56c1589dbb43bef37", GitTreeState:"dirty", BuildDate:"2021-09-13T03:13:33Z", GoVersion:"go1.16.7", Compiler:"gc", Platform:"linux/amd64"}
```
```
$ ./karmada-scheduler-estimator version
karmada-scheduler-estimator version: version.Info{GitVersion:"v0.8.0-106-gb2b36a2-dirty", GitCommit:"b2b36a2aaf9038684e96a6c56c1589dbb43bef37", GitTreeState:"dirty", BuildDate:"2021-09-13T03:13:33Z", GoVersion:"go1.16.7", Compiler:"gc", Platform:"linux/amd64"}
```

**Which issue(s) this PR fixes**:
Fixes #716 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-scheduler` introduced a `version` command to represent version information.
`karmada-webhook` introduced a `version` command to represent version information.
`karmada-agent` introduced a `version` command to represent version information.
`karmada-scheduler-estimator` introduced a `version` command to represent version information.
```

