### PR TITLE
karmada-scheduler: integrate karmada-scheduler-estimator

### DIFF
--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	defaultBindAddress = "0.0.0.0"
-	defaultPort        = 10351
+	defaultBindAddress   = "0.0.0.0"
+	defaultPort          = 10351
+	defaultEstimatorPort = 10352
 )
 
 var (
@@ -39,6 +40,13 @@ type Options struct {
 	KubeAPIQPS float32
 	// KubeAPIBurst is the burst to allow while talking with karmada-apiserver.
 	KubeAPIBurst int
+
+	// EnableSchedulerEstimator represents whether the accurate scheduler estimator should be enabled.
+	EnableSchedulerEstimator bool
+	// SchedulerEstimatorTimeout specifies the timeout period of calling the accurate scheduler estimator service.
+	SchedulerEstimatorTimeout metav1.Duration
+	// SchedulerEstimatorPort is the port that the accurate scheduler estimator server serves at.
+	SchedulerEstimatorPort int
 }
 
 // NewOptions builds an default scheduler options.
@@ -71,4 +79,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.Failover, "failover", false, "Reschedule on cluster failure.")
 	fs.Float32Var(&o.KubeAPIQPS, "kube-api-qps", 40.0, "QPS to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")
 	fs.IntVar(&o.KubeAPIBurst, "kube-api-burst", 60, "Burst to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")
+	fs.BoolVar(&o.EnableSchedulerEstimator, "enable-scheduler-estimator", false, "Enable calling cluster scheduler estimator for adjusting replicas.")
+	fs.DurationVar(&o.SchedulerEstimatorTimeout.Duration, "scheduler-estimator-timeout", 3*time.Second, "Specifies the timeout period of calling the scheduler estimator service.")
+	fs.IntVar(&o.SchedulerEstimatorPort, "scheduler-estimator-port", defaultEstimatorPort, "The secure port on which to connect the accurate scheduler estimator.")
 }

--- a/cmd/scheduler/app/scheduler.go
+++ b/cmd/scheduler/app/scheduler.go
@@ -66,7 +66,7 @@ func run(opts *options.Options, stopChan <-chan struct{}) error {
 	}()
 
 	scheduler.Failover = opts.Failover
-	sched := scheduler.NewScheduler(dynamicClientSet, karmadaClient, kubeClientSet)
+	sched := scheduler.NewScheduler(dynamicClientSet, karmadaClient, kubeClientSet, opts)
 	if !opts.LeaderElection.LeaderElect {
 		sched.Run(ctx)
 		return fmt.Errorf("scheduler exited")

--- a/pkg/estimator/client/accurate.go
+++ b/pkg/estimator/client/accurate.go
@@ -1,0 +1,90 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/estimator/pb"
+	"github.com/karmada-io/karmada/pkg/util"
+)
+
+// RegisterSchedulerEstimator will register a SchedulerEstimator.
+func RegisterSchedulerEstimator(se *SchedulerEstimator) {
+	replicaEstimators["scheduler-estimator"] = se
+}
+
+type getClusterReplicasFunc func(ctx context.Context, cluster string) (int32, error)
+
+// SchedulerEstimator is an estimator that calls karmada-scheduler-estimator for estimation.
+type SchedulerEstimator struct {
+	cache   *SchedulerEstimatorCache
+	timeout time.Duration
+}
+
+// NewSchedulerEstimator builds a new SchedulerEstimator.
+func NewSchedulerEstimator(cache *SchedulerEstimatorCache, timeout time.Duration) *SchedulerEstimator {
+	return &SchedulerEstimator{
+		cache:   cache,
+		timeout: timeout,
+	}
+}
+
+// MaxAvailableReplicas estimates the maximum replicas that can be applied to the target cluster by calling karmada-scheduler-estimator.
+func (se *SchedulerEstimator) MaxAvailableReplicas(clusters []*clusterv1alpha1.Cluster, replicaRequirements *workv1alpha1.ReplicaRequirements) ([]workv1alpha1.TargetCluster, error) {
+	return getClusterReplicasConcurrently(clusters, se.timeout, func(ctx context.Context, cluster string) (int32, error) {
+		return se.maxAvailableReplicas(ctx, cluster, replicaRequirements.DeepCopy())
+	})
+}
+
+func (se *SchedulerEstimator) maxAvailableReplicas(ctx context.Context, cluster string, replicaRequirements *workv1alpha1.ReplicaRequirements) (int32, error) {
+	client, err := se.cache.GetClient(cluster)
+	if err != nil {
+		return 0, err
+	}
+
+	req := &pb.MaxAvailableReplicasRequest{
+		Cluster: cluster,
+		ReplicaRequirements: pb.ReplicaRequirements{
+			ResourceRequest: replicaRequirements.ResourceRequest,
+		},
+	}
+	if replicaRequirements.NodeClaim != nil {
+		req.ReplicaRequirements.NodeClaim = &pb.NodeClaim{
+			NodeAffinity: replicaRequirements.NodeClaim.HardNodeAffinity,
+			NodeSelector: replicaRequirements.NodeClaim.NodeSelector,
+			Tolerations:  replicaRequirements.NodeClaim.Tolerations,
+		}
+	}
+	res, err := client.MaxAvailableReplicas(ctx, req)
+	if err != nil {
+		return 0, fmt.Errorf("gRPC request cluster(%s) estimator error: %v", cluster, err)
+	}
+	return res.MaxReplicas, nil
+}
+
+func getClusterReplicasConcurrently(clusters []*clusterv1alpha1.Cluster, timeout time.Duration, getClusterReplicas getClusterReplicasFunc) ([]workv1alpha1.TargetCluster, error) {
+	availableTargetClusters := make([]workv1alpha1.TargetCluster, len(clusters))
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	errChan := make(chan error, len(clusters))
+	for i := range clusters {
+		wg.Add(1)
+		go func(idx int, cluster string) {
+			defer wg.Done()
+			replicas, err := getClusterReplicas(ctx, cluster)
+			if err != nil {
+				errChan <- err
+			}
+			availableTargetClusters[idx] = workv1alpha1.TargetCluster{Name: cluster, Replicas: replicas}
+		}(i, clusters[i].Name)
+	}
+	wg.Wait()
+
+	return availableTargetClusters, util.AggregateErrors(errChan)
+}

--- a/pkg/estimator/client/cache.go
+++ b/pkg/estimator/client/cache.go
@@ -1,0 +1,97 @@
+package client
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc"
+	"k8s.io/klog/v2"
+
+	"github.com/karmada-io/karmada/pkg/estimator/pb"
+	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/names"
+)
+
+// SchedulerEstimatorCache is a cache that stores gRPC clients of all the cluster accurate scheduler estimator.
+type SchedulerEstimatorCache struct {
+	lock      sync.RWMutex
+	estimator map[string]*clientWrapper
+}
+
+// NewSchedulerEstimatorCache returns an accurate scheduler estimator cache.
+func NewSchedulerEstimatorCache() *SchedulerEstimatorCache {
+	return &SchedulerEstimatorCache{
+		estimator: make(map[string]*clientWrapper),
+	}
+}
+
+type clientWrapper struct {
+	connection *grpc.ClientConn
+	client     pb.EstimatorClient
+}
+
+// IsEstimatorExist checks whether the cluster estimator exists in the cache.
+func (c *SchedulerEstimatorCache) IsEstimatorExist(name string) bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	_, exist := c.estimator[name]
+	return exist
+}
+
+// AddCluster adds a grpc connection and associated client into the cache.
+func (c *SchedulerEstimatorCache) AddCluster(name string, connection *grpc.ClientConn, client pb.EstimatorClient) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	// If more than one worker have established connections at the same time,
+	// only the first one will be used. The ladder ones would be abandoned.
+	if _, exist := c.estimator[name]; exist {
+		_ = connection.Close()
+		return
+	}
+	c.estimator[name] = &clientWrapper{
+		connection: connection,
+		client:     client,
+	}
+}
+
+// DeleteCluster closes the connection and deletes it from the cache.
+func (c *SchedulerEstimatorCache) DeleteCluster(name string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	es, exist := c.estimator[name]
+	if !exist {
+		return
+	}
+	_ = es.connection.Close()
+	delete(c.estimator, name)
+}
+
+// GetClient returns the gRPC client of a cluster accurate replica estimator.
+func (c *SchedulerEstimatorCache) GetClient(name string) (pb.EstimatorClient, error) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	es, exist := c.estimator[name]
+	if !exist {
+		return nil, fmt.Errorf("cluster %s does not exist in estimator cache", name)
+	}
+	return es.client, nil
+}
+
+// EstablishConnection establishes a new gRPC connection with the specified cluster scheduler estimator.
+func EstablishConnection(name string, estimatorCache *SchedulerEstimatorCache, port int) error {
+	if estimatorCache.IsEstimatorExist(name) {
+		return nil
+	}
+	serverAddr := fmt.Sprintf("%s:%d", names.GenerateEstimatorServiceName(name), port)
+	klog.Infof("Start dialing estimator server(%s) of cluster(%s).", serverAddr, name)
+	cc, err := util.Dial(serverAddr, 5*time.Second)
+	if err != nil {
+		klog.Errorf("Failed to dial cluster(%s): %v.", name, err)
+		return err
+	}
+	c := pb.NewEstimatorClient(cc)
+	estimatorCache.AddCluster(name, cc, c)
+	klog.Infof("Connection with estimator server(%s) of cluster(%s) has been established.", serverAddr, name)
+	return nil
+}

--- a/pkg/estimator/client/general.go
+++ b/pkg/estimator/client/general.go
@@ -1,0 +1,81 @@
+package client
+
+import (
+	"math"
+
+	corev1 "k8s.io/api/core/v1"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
+)
+
+// GeneralEstimator is the default replica estimator.
+func init() {
+	replicaEstimators["general-estimator"] = NewGeneralEstimator()
+}
+
+// GeneralEstimator is a normal estimator in terms of cluster ResourceSummary.
+type GeneralEstimator struct{}
+
+// NewGeneralEstimator builds a new GeneralEstimator.
+func NewGeneralEstimator() *GeneralEstimator {
+	return &GeneralEstimator{}
+}
+
+// MaxAvailableReplicas estimates the maximum replicas that can be applied to the target cluster by cluster ResourceSummary.
+func (ge *GeneralEstimator) MaxAvailableReplicas(clusters []*clusterv1alpha1.Cluster, replicaRequirements *workv1alpha1.ReplicaRequirements) ([]workv1alpha1.TargetCluster, error) {
+	availableTargetClusters := make([]workv1alpha1.TargetCluster, len(clusters))
+	for i, cluster := range clusters {
+		maxReplicas := ge.maxAvailableReplicas(cluster, replicaRequirements)
+		availableTargetClusters[i] = workv1alpha1.TargetCluster{Name: cluster.Name, Replicas: maxReplicas}
+	}
+	return availableTargetClusters, nil
+}
+
+func (ge *GeneralEstimator) maxAvailableReplicas(cluster *clusterv1alpha1.Cluster, replicaRequirements *workv1alpha1.ReplicaRequirements) int32 {
+	var maximumReplicas int64 = math.MaxInt32
+	resourceSummary := cluster.Status.ResourceSummary
+
+	if resourceSummary == nil {
+		return 0
+	}
+
+	for key, value := range replicaRequirements.ResourceRequest {
+		requestedQuantity := value.Value()
+		if requestedQuantity <= 0 {
+			continue
+		}
+
+		// calculates available resource quantity
+		// available = allocatable - allocated - allocating
+		allocatable, ok := resourceSummary.Allocatable[key]
+		if !ok {
+			return 0
+		}
+		allocated, ok := resourceSummary.Allocated[key]
+		if ok {
+			allocatable.Sub(allocated)
+		}
+		allocating, ok := resourceSummary.Allocating[key]
+		if ok {
+			allocatable.Sub(allocating)
+		}
+		availableQuantity := allocatable.Value()
+		// short path: no more resource left.
+		if availableQuantity <= 0 {
+			return 0
+		}
+
+		if key == corev1.ResourceCPU {
+			requestedQuantity = value.MilliValue()
+			availableQuantity = allocatable.MilliValue()
+		}
+
+		maximumReplicasForResource := availableQuantity / requestedQuantity
+		if maximumReplicasForResource < maximumReplicas {
+			maximumReplicas = maximumReplicasForResource
+		}
+	}
+
+	return int32(maximumReplicas)
+}

--- a/pkg/estimator/client/interface.go
+++ b/pkg/estimator/client/interface.go
@@ -1,0 +1,20 @@
+package client
+
+import (
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
+)
+
+var (
+	replicaEstimators = map[string]ReplicaEstimator{}
+)
+
+// ReplicaEstimator is an estimator which estimates the maximum replicas that can be applied to the target cluster.
+type ReplicaEstimator interface {
+	MaxAvailableReplicas(clusters []*clusterv1alpha1.Cluster, replicaRequirements *workv1alpha1.ReplicaRequirements) ([]workv1alpha1.TargetCluster, error)
+}
+
+// GetReplicaEstimators returns all replica estimators.
+func GetReplicaEstimators() map[string]ReplicaEstimator {
+	return replicaEstimators
+}

--- a/pkg/util/dial.go
+++ b/pkg/util/dial.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+// Dial establishes the gRPC communication.
+func Dial(path string, timeout time.Duration) (*grpc.ClientConn, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	opts := []grpc.DialOption{
+		grpc.WithBlock(),
+		grpc.WithInsecure(),
+	}
+	cc, err := grpc.DialContext(ctx, path, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("dial %s error: %v", path, err)
+	}
+
+	return cc, nil
+}

--- a/pkg/util/error.go
+++ b/pkg/util/error.go
@@ -1,0 +1,22 @@
+package util
+
+import utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+// AggregateErrors will receive all errors from the channel and stuff all non-nil errors
+// into the returned Aggregate.
+func AggregateErrors(ch <-chan error) error {
+	var errs []error
+	for {
+		drained := false
+		select {
+		case err := <-ch:
+			errs = append(errs, err)
+		default:
+			drained = true
+		}
+		if drained {
+			break
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}

--- a/pkg/util/names/names.go
+++ b/pkg/util/names/names.go
@@ -33,6 +33,9 @@ const endpointSlicePrefix = "imported"
 // endpointSlicePrefix is the prefix of service derived from ServiceImport.
 const derivedServicePrefix = "derived"
 
+// estimatorServicePrefix is the prefix of scheduler estimator service name.
+const estimatorServicePrefix = "karmada-scheduler-estimator"
+
 // GenerateExecutionSpaceName generates execution space name for the given member cluster
 func GenerateExecutionSpaceName(clusterName string) (string, error) {
 	if clusterName == "" {
@@ -86,6 +89,11 @@ func GenerateEndpointSliceName(endpointSliceName string, cluster string) string 
 // GenerateDerivedServiceName generates the service name derived from ServiceImport.
 func GenerateDerivedServiceName(serviceName string) string {
 	return fmt.Sprintf("%s-%s", derivedServicePrefix, serviceName)
+}
+
+// GenerateEstimatorServiceName generates the gRPC scheduler estimator service name which belongs to a cluster.
+func GenerateEstimatorServiceName(clusterName string) string {
+	return fmt.Sprintf("%s-%s", estimatorServicePrefix, clusterName)
 }
 
 // GenerateClusterAPISecretName generates the secret name of cluster authentication in cluster-api.


### PR DESCRIPTION
Signed-off-by: Garrybest <garrybest@foxmail.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Modify scheduler to support calling scheduler-estimator for estimating max available replicas. 

**Which issue(s) this PR fixes**:
Fixes Step 6 of #617.

**Special notes for your reviewer**:
Now the scheduler does not call scheduler-estimator defaultly. We could open this switch in the future.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

