### PR TITLE
add resource pod in cluster.status.resourceSummary

### DIFF
--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -507,23 +507,27 @@ func getClusterAllocatable(nodeList []*corev1.Node) (allocatable corev1.Resource
 
 func getAllocatingResource(podList []*corev1.Pod) corev1.ResourceList {
 	allocating := util.EmptyResource()
+	podNum := int64(0)
 	for _, pod := range podList {
 		if len(pod.Spec.NodeName) == 0 {
 			allocating.AddPodRequest(&pod.Spec)
+			podNum++
 		}
 	}
-
+	allocating.AddResourcePods(podNum)
 	return allocating.ResourceList()
 }
 
 func getAllocatedResource(podList []*corev1.Pod) corev1.ResourceList {
 	allocated := util.EmptyResource()
+	podNum := int64(0)
 	for _, pod := range podList {
 		// When the phase of a pod is Succeeded or Failed, kube-scheduler would not consider its resource occupation.
 		if len(pod.Spec.NodeName) != 0 && pod.Status.Phase != corev1.PodSucceeded && pod.Status.Phase != corev1.PodFailed {
 			allocated.AddPodRequest(&pod.Spec)
+			podNum++
 		}
 	}
-
+	allocated.AddResourcePods(podNum)
 	return allocated.ResourceList()
 }


### PR DESCRIPTION
Signed-off-by: Garrybest <garrybest@foxmail.com>

**What type of PR is this?**
/kind feature
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Now the `pods` resource has been aggregated in `cluster.status.resourceSummary.allocatable` since the kubernetes node has a `pods` resource in `node.Status.Allocatable`. However, a pod resource request will not explicitly specify the `pods` resource. So it must be aggregated independently.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

