### PR TITLE
Use cluster lister instead of map to implement scheduler cache

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -1,9 +1,11 @@
 package cache
 
 import (
-	"sync"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	clusterlister "github.com/karmada-io/karmada/pkg/generated/listers/cluster/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework"
 )
 
@@ -17,43 +19,38 @@ type Cache interface {
 }
 
 type schedulerCache struct {
-	mutex    sync.RWMutex
-	clusters map[string]*clusterv1alpha1.Cluster
+	clusterLister clusterlister.ClusterLister
 }
 
 // NewCache instantiates a cache used only by scheduler.
-func NewCache() Cache {
+func NewCache(clusterLister clusterlister.ClusterLister) Cache {
 	return &schedulerCache{
-		clusters: make(map[string]*clusterv1alpha1.Cluster),
+		clusterLister: clusterLister,
 	}
 }
 
+// AddCluster does nothing since clusterLister would synchronize automatically
 func (c *schedulerCache) AddCluster(cluster *clusterv1alpha1.Cluster) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-	c.clusters[cluster.Name] = cluster
 }
 
+// UpdateCluster does nothing since clusterLister would synchronize automatically
 func (c *schedulerCache) UpdateCluster(cluster *clusterv1alpha1.Cluster) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-	c.clusters[cluster.Name] = cluster
 }
 
+// DeleteCluster does nothing since clusterLister would synchronize automatically
 func (c *schedulerCache) DeleteCluster(cluster *clusterv1alpha1.Cluster) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-	delete(c.clusters, cluster.Name)
 }
 
 // TODO: need optimization, only clone when necessary
 func (c *schedulerCache) Snapshot() *Snapshot {
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
-
+	clusters, err := c.clusterLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("Failed to list clusters: %v", err)
+		return nil
+	}
 	out := NewEmptySnapshot()
-	out.clusterInfoList = make([]*framework.ClusterInfo, 0, len(c.clusters))
-	for _, cluster := range c.clusters {
+	out.clusterInfoList = make([]*framework.ClusterInfo, 0, len(clusters))
+	for _, cluster := range clusters {
 		cloned := cluster.DeepCopy()
 		out.clusterInfoList = append(out.clusterInfoList, framework.NewClusterInfo(cloned))
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
There is no need to use an extra map for caching because the cluster lister (indexer of `memclusterInformer`) has already preserved all member clusters.

Use cluster lister instead of map to implement scheduler cache.

**Which issue(s) this PR fixes**:
Fixes #727

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

