### PR TITLE
adapt to the deployment of Submariner

### DIFF
--- a/artifacts/kindClusterConfig/general-config.yaml
+++ b/artifacts/kindClusterConfig/general-config.yaml
@@ -1,0 +1,11 @@
+kind: Cluster
+apiVersion: "kind.x-k8s.io/v1alpha4"
+networking:
+  disableDefaultCNI: {{disable_cni}}
+  podSubnet: {{pod_cidr}}
+  serviceSubnet: {{service_cidr}}
+featureGates:
+  EndpointSliceProxying: true
+nodes:
+  - role: control-plane
+  - role: worker

--- a/hack/create-cluster.sh
+++ b/hack/create-cluster.sh
@@ -21,6 +21,7 @@ if [[ -z "${CLUSTER_NAME}" ]]; then
   usage
   exit 1
 fi
+
 if [[ -z "${2-}" ]]; then
   KUBECONFIG=$KUBECONFIG
 else
@@ -47,7 +48,45 @@ if [ -f "${KUBECONFIG}" ];then
   fi
 fi
 
-kind create cluster --name "${CLUSTER_NAME}" --kubeconfig="${KUBECONFIG}" --wait=120s
+function rand() {
+    min=$1
+    max=$(($2-$min+1))
+    num=$(date +%s%N)
+    echo $(($num%$max+$min))
+}
+
+function generate_cidr() {
+    local val=$(rand 1 254)
+    echo "$1.${val}.0.0/16"
+}
+
+POD_CIDR=${POD_CIDR:-""}
+if [[ -z "${POD_CIDR}" ]]; then
+    POD_CIDR=$(generate_cidr 10)
+fi
+
+SERVICE_CIDR=${SERVICE_CIDR:-""}
+if [[ -z "${SERVICE_CIDR}" ]]; then
+    SERVICE_CIDR=$(generate_cidr 100)
+fi
+
+function deploy_weave_cni() {
+  echo "Applying weave network..."
+  kubectl --kubeconfig=$1 apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl --kubeconfig=$1 version | base64 | tr -d '\n')&env.IPALLOC_RANGE=$2"
+  echo "Waiting for weave-net pods to be ready..."
+  kubectl --kubeconfig=$1 wait --for=condition=Ready pods -l name=weave-net -n kube-system --timeout=10m
+  echo "Waiting for core-dns deployment to be ready..."
+  kubectl --kubeconfig=$1 -n kube-system rollout status deploy/coredns --timeout=5m
+}
+
+#generate for kindClusterConfig
+TEMP_PATH=$(mktemp -d)
+cp -rf "${REPO_ROOT}"/artifacts/kindClusterConfig/general-config.yaml "${TEMP_PATH}"/"${CLUSTER_NAME}"-config.yaml
+sed -i'' -e "s#{{disable_cni}}#true#g" "${TEMP_PATH}"/"${CLUSTER_NAME}"-config.yaml
+sed -i'' -e "s#{{pod_cidr}}#${POD_CIDR}#g" "${TEMP_PATH}"/"${CLUSTER_NAME}"-config.yaml
+sed -i'' -e "s#{{service_cidr}}#${SERVICE_CIDR}#g" "${TEMP_PATH}"/"${CLUSTER_NAME}"-config.yaml
+
+kind create cluster --name "${CLUSTER_NAME}" --kubeconfig="${KUBECONFIG}" --config="${TEMP_PATH}"/"${CLUSTER_NAME}"-config.yaml
 
 # Kind cluster's context name contains a "kind-" prefix by default.
 # Change context name to cluster name.
@@ -56,4 +95,8 @@ kubectl config rename-context "kind-${CLUSTER_NAME}" "${CLUSTER_NAME}" --kubecon
 # Kind cluster uses `127.0.0.1` as kube-apiserver endpoint by default, thus kind clusters can't reach each other.
 # So we need to update endpoint with container IP.
 container_ip=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${CLUSTER_NAME}-control-plane")
-kubectl config set-cluster "kind-${CLUSTER_NAME}" --server="https://${container_ip}:6443" --kubeconfig="${KUBECONFIG}"
+kubectl config set-cluster "kind-\"${CLUSTER_NAME}\"" --server="https://${container_ip}:6443" --kubeconfig="${KUBECONFIG}"
+
+deploy_weave_cni "${KUBECONFIG}" "${POD_CIDR}"
+
+echo "cluster \"${CLUSTER_NAME}\" is created successfully!"


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adapt to the deployment of [Submariner](https://github.com/submariner-io/submariner).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Use the `hack/create-cluster.sh` script to create a kind cluster in the following three modifications:
- `POD CIDR` and `SERVICE CIDR` needs to be specified.
- The created kind cluster uses the `weave` CNI instead of the default `kindnet` CNI.
- The created kind cluster has a worker node.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`POD CIDR` and `SERVICE CIDR` needs to be specified.
```

