### PR TITLE
Add export command to karmadactl

### DIFF
--- a/pkg/clusterdiscovery/clusterapi/clusterapi.go
+++ b/pkg/clusterdiscovery/clusterapi/clusterapi.go
@@ -20,7 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/karmada-io/karmada/pkg/karmadactl"
-	"github.com/karmada-io/karmada/pkg/karmadactl/options"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/informermanager"
 	"github.com/karmada-io/karmada/pkg/util/informermanager/keys"
@@ -176,7 +175,7 @@ func (d *ClusterDetector) joinClusterAPICluster(clusterName string) error {
 		klog.Fatalf("Failed to get cluster-api management cluster rest config. kubeconfig: %s, err: %v", kubeconfigPath, err)
 	}
 
-	err = karmadactl.JoinCluster(d.ControllerPlaneConfig, clusterRestConfig, options.DefaultKarmadaClusterNamespace, clusterName, false)
+	err = karmadactl.JoinCluster(d.ControllerPlaneConfig, clusterRestConfig, karmadactl.DefaultKarmadaClusterNamespace, clusterName, false)
 	if err != nil {
 		klog.Errorf("Failed to join cluster-api's cluster(%s): %v", clusterName, err)
 		return err
@@ -188,7 +187,7 @@ func (d *ClusterDetector) joinClusterAPICluster(clusterName string) error {
 
 func (d *ClusterDetector) unJoinClusterAPICluster(clusterName string) error {
 	klog.Infof("Begin to unJoin cluster-api's Cluster(%s) to karmada", clusterName)
-	err := karmadactl.UnJoinCluster(d.ControllerPlaneConfig, nil, options.DefaultKarmadaClusterNamespace, clusterName, false, false)
+	err := karmadactl.UnJoinCluster(d.ControllerPlaneConfig, nil, karmadactl.DefaultKarmadaClusterNamespace, clusterName, false, false)
 	if err != nil {
 		klog.Errorf("Failed to unJoin cluster-api's cluster(%s): %v", clusterName, err)
 		return err

--- a/pkg/karmadactl/cordon.go
+++ b/pkg/karmadactl/cordon.go
@@ -18,6 +18,7 @@ import (
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
+	"github.com/karmada-io/karmada/pkg/karmadactl/options"
 )
 
 var (
@@ -106,15 +107,7 @@ func NewCmdUncordon(cmdOut io.Writer, karmadaConfig KarmadaConfig, cmdStr string
 
 // CommandCordonOption holds all command options for cordon and uncordon
 type CommandCordonOption struct {
-	// KubeConfig holds the control plane KUBECONFIG file path.
-	KubeConfig string
-
-	// ClusterContext is the name of the cluster context in control plane KUBECONFIG file.
-	// Default value is the current-context.
-	KarmadaContext string
-
-	// DryRun tells if run the command in dry-run mode, without making any server requests.
-	DryRun bool
+	options.GlobalCommandOptions
 
 	// ClusterName is the cluster's name that we are going to join with.
 	ClusterName string
@@ -138,9 +131,7 @@ func (o *CommandCordonOption) Validate() []error {
 
 // AddFlags adds flags to the specified FlagSet.
 func (o *CommandCordonOption) AddFlags(flags *pflag.FlagSet) {
-	flags.StringVar(&o.KubeConfig, "kubeconfig", "", "Path to the control plane kubeconfig file.")
-	flags.StringVar(&o.KarmadaContext, "karmada-context", "", "Name of the cluster context in control plane kubeconfig file.")
-	flags.BoolVar(&o.DryRun, "dry-run", false, "Run the command in dry-run mode, without making any server requests.")
+	o.GlobalCommandOptions.AddFlags(flags)
 }
 
 // CordonHelper wraps functionality to cordon/uncordon cluster

--- a/pkg/karmadactl/export.go
+++ b/pkg/karmadactl/export.go
@@ -1,0 +1,209 @@
+package karmadactl
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	mcsv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/karmadactl/options"
+	"github.com/karmada-io/karmada/pkg/util/gclient"
+	"github.com/karmada-io/karmada/pkg/util/helper"
+)
+
+// DefaultServiceNamespace defines the namespace specify by default when users export/import service.
+const DefaultServiceNamespace = "default"
+
+var (
+	exportShort   = `Export a service from a group member clusters`
+	exportLong    = `Export a service from a group member clusters`
+	exportExample = `
+%s export SERVICE_NAME --namespace=default --clusters="m1,m2"
+`
+)
+
+// CommandExportOption holds all command options
+type CommandExportOption struct {
+	options.GlobalCommandOptions
+
+	// ServiceName is the service's name that we are going to export.
+	ServiceName string
+
+	// ServiceNamespace is the service's namespace that we are going to export.
+	// Default value is "default".
+	ServiceNamespace string
+
+	// Clusters are a group member clusters that used for service export.
+	Clusters []string
+}
+
+// Complete ensures that options are valid and marshals them if necessary.
+func (o *CommandExportOption) Complete(args []string) error {
+	if len(args) == 0 {
+		return errors.New("service name is required")
+	}
+	o.ServiceName = args[0]
+	return nil
+}
+
+// Validate checks option and return a slice of found errs.
+func (o *CommandExportOption) Validate() []error {
+	return nil
+}
+
+// AddFlags adds flags to the specified FlagSet.
+func (o *CommandExportOption) AddFlags(flags *pflag.FlagSet) {
+	o.GlobalCommandOptions.AddFlags(flags)
+
+	flags.StringVarP(&o.ServiceNamespace, "namespace", "n", DefaultServiceNamespace, "Namespace of service that are going to export")
+	flags.StringSliceVar(&o.Clusters, "clusters", []string{}, "clusters are a group member clusters that used for service export")
+}
+
+// NewCmdExport defines the `export` command that export a service.
+func NewCmdExport(cmdOut io.Writer, karmadaConfig KarmadaConfig, cmdStr string) *cobra.Command {
+	opts := CommandExportOption{}
+
+	cmd := &cobra.Command{
+		Use:     "export SERVICE_NAME --namespace=<NAMESPACE> --clusters=<CLUSTERS>",
+		Short:   exportShort,
+		Long:    exportLong,
+		Example: fmt.Sprintf(exportExample, cmdStr),
+		Run: func(cmd *cobra.Command, args []string) {
+			err := opts.Complete(args)
+			if err != nil {
+				klog.Errorf("Error: %v", err)
+				return
+			}
+
+			errs := opts.Validate()
+			if len(errs) != 0 {
+				klog.Error(utilerrors.NewAggregate(errs).Error())
+				return
+			}
+
+			err = RunExport(cmdOut, karmadaConfig, opts)
+			if err != nil {
+				klog.Errorf("Error: %v", err)
+				return
+			}
+		},
+	}
+
+	flags := cmd.Flags()
+	opts.AddFlags(flags)
+
+	return cmd
+}
+
+// RunExport is the implementation of the 'export' command.
+func RunExport(cmdOut io.Writer, karmadaConfig KarmadaConfig, opts CommandExportOption) error {
+	if len(opts.Clusters) == 0 {
+		klog.Infof("There are no clusters to export service.")
+		return nil
+	}
+
+	// Get control plane karmada-apiserver client
+	controlPlaneRestConfig, err := karmadaConfig.GetRestConfig(opts.KarmadaContext, opts.KubeConfig)
+	if err != nil {
+		klog.Errorf("Failed to get control plane rest config. context: %s, kube-config: %s, error: %v",
+			opts.KarmadaContext, opts.KubeConfig, err)
+		return err
+	}
+	karmadaClient := gclient.NewForConfigOrDie(controlPlaneRestConfig)
+
+	svcNamespacedName := types.NamespacedName{Namespace: opts.ServiceNamespace, Name: opts.ServiceName}
+	svcExport := helper.NewServiceExport(opts.ServiceNamespace, opts.ServiceName)
+	err = createServiceExportIfNotFound(karmadaClient, svcNamespacedName, svcExport)
+	if err != nil {
+		klog.Errorf("Failed to create ServiceExport if not found: %v", err)
+		return err
+	}
+
+	policyNamespacedName := svcNamespacedName
+	policyExport := helper.NewPropagationPolicy(opts.ServiceNamespace, opts.ServiceName, []policyv1alpha1.ResourceSelector{
+		{
+			APIVersion: svcExport.APIVersion,
+			Kind:       svcExport.Kind,
+			Name:       svcExport.Name,
+			Namespace:  svcExport.Namespace,
+		},
+	}, policyv1alpha1.Placement{
+		ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+			ClusterNames: opts.Clusters,
+		},
+	})
+	err = createOrUpdateExportPolicy(karmadaClient, policyNamespacedName, policyExport)
+	if err != nil {
+		klog.Errorf("Failed to create or update export policy: %v", err)
+	}
+
+	return nil
+}
+
+func createServiceExportIfNotFound(karmadaClient client.Client, svcKey types.NamespacedName, svcExport *mcsv1alpha1.ServiceExport) error {
+	oldSvcExport := &mcsv1alpha1.ServiceExport{}
+	err := karmadaClient.Get(context.TODO(), svcKey, oldSvcExport)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return karmadaClient.Create(context.TODO(), svcExport)
+		}
+
+		klog.Errorf("Failed to get Service(%s): %v", svcKey.String(), err)
+		return err
+	}
+
+	// ServiceExport already exist, just update PropagationPolicy
+	return nil
+}
+
+func createOrUpdateExportPolicy(karmadaClient client.Client, policyKey types.NamespacedName, policyExport *policyv1alpha1.PropagationPolicy) error {
+	oldPolicy := &policyv1alpha1.PropagationPolicy{}
+	err := karmadaClient.Get(context.TODO(), policyKey, oldPolicy)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return karmadaClient.Create(context.TODO(), policyExport)
+		}
+
+		klog.Errorf("Failed to get PropagationPolicy(%s): %v", policyKey.String(), err)
+		return err
+	}
+
+	mergeClusterNames := mergeClusterAffinityClusterNames(oldPolicy.Spec.Placement.ClusterAffinity.ClusterNames, policyExport.Spec.Placement.ClusterAffinity.ClusterNames)
+	if len(oldPolicy.Spec.Placement.ClusterAffinity.ClusterNames) == len(mergeClusterNames) {
+		klog.V(4).Infof("There are no new clusterName added.")
+		return nil
+	}
+
+	oldPolicy.Spec.Placement.ClusterAffinity.ClusterNames = mergeClusterNames
+	return karmadaClient.Update(context.TODO(), oldPolicy)
+}
+
+func mergeClusterAffinityClusterNames(oldClusterNames, newClusterNames []string) []string {
+	clusterNames := make([]string, len(oldClusterNames))
+	copy(clusterNames, oldClusterNames)
+
+	for _, newCluster := range newClusterNames {
+		exist := false
+		for _, oldCluster := range oldClusterNames {
+			if newCluster == oldCluster {
+				exist = true
+				break
+			}
+		}
+		if !exist {
+			clusterNames = append(clusterNames, newCluster)
+		}
+	}
+
+	return clusterNames
+}

--- a/pkg/karmadactl/join.go
+++ b/pkg/karmadactl/join.go
@@ -29,6 +29,10 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/validation"
 )
 
+// DefaultKarmadaClusterNamespace defines the default namespace where the member cluster objects are stored.
+// The secret owns by cluster objects will be stored in the namespace too.
+const DefaultKarmadaClusterNamespace = "karmada-cluster"
+
 var (
 	joinShort   = `Register a cluster to control plane`
 	joinLong    = `Join registers a cluster to control plane.`
@@ -104,6 +108,9 @@ func NewCmdJoin(cmdOut io.Writer, karmadaConfig KarmadaConfig, cmdStr string) *c
 type CommandJoinOption struct {
 	options.GlobalCommandOptions
 
+	// ClusterNamespace holds the namespace name where the member cluster objects are stored.
+	ClusterNamespace string
+
 	// ClusterName is the cluster's name that we are going to join with.
 	ClusterName string
 
@@ -144,6 +151,8 @@ func (j *CommandJoinOption) Validate() []error {
 func (j *CommandJoinOption) AddFlags(flags *pflag.FlagSet) {
 	j.GlobalCommandOptions.AddFlags(flags)
 
+	flags.StringVar(&j.ClusterNamespace, "cluster-namespace", DefaultKarmadaClusterNamespace,
+		"Namespace in the control plane where member cluster are stored.")
 	flags.StringVar(&j.ClusterContext, "cluster-context", "",
 		"Context name of cluster in kubeconfig. Only works when there are multiple contexts in the kubeconfig.")
 	flags.StringVar(&j.ClusterKubeConfig, "cluster-kubeconfig", "",

--- a/pkg/karmadactl/karmadactl.go
+++ b/pkg/karmadactl/karmadactl.go
@@ -47,6 +47,7 @@ func NewKarmadaCtlCommand(out io.Writer, cmdUse, cmdStr string) *cobra.Command {
 	rootCmd.AddCommand(sharedcommand.NewCmdVersion(out, cmdStr))
 	rootCmd.AddCommand(NewCmdCordon(out, karmadaConfig, cmdStr))
 	rootCmd.AddCommand(NewCmdUncordon(out, karmadaConfig, cmdStr))
+	rootCmd.AddCommand(NewCmdExport(out, karmadaConfig, cmdStr))
 
 	return rootCmd
 }

--- a/pkg/karmadactl/options/global.go
+++ b/pkg/karmadactl/options/global.go
@@ -2,21 +2,16 @@ package options
 
 import "github.com/spf13/pflag"
 
-// DefaultKarmadaClusterNamespace defines the default namespace where the member cluster objects are stored.
-// The secret owns by cluster objects will be stored in the namespace too.
-const DefaultKarmadaClusterNamespace = "karmada-cluster"
+
 
 // GlobalCommandOptions holds the configuration shared by the all sub-commands of `karmadactl`.
 type GlobalCommandOptions struct {
 	// KubeConfig holds the control plane KUBECONFIG file path.
 	KubeConfig string
 
-	// ClusterContext is the name of the cluster context in control plane KUBECONFIG file.
+	// KarmadaContext is the name of the cluster context in control plane KUBECONFIG file.
 	// Default value is the current-context.
 	KarmadaContext string
-
-	// ClusterNamespace holds the namespace name where the member cluster objects are stored.
-	ClusterNamespace string
 
 	// DryRun tells if run the command in dry-run mode, without making any server requests.
 	DryRun bool
@@ -26,6 +21,5 @@ type GlobalCommandOptions struct {
 func (o *GlobalCommandOptions) AddFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&o.KubeConfig, "kubeconfig", "", "Path to the control plane kubeconfig file.")
 	flags.StringVar(&o.KarmadaContext, "karmada-context", "", "Name of the cluster context in control plane kubeconfig file.")
-	flags.StringVar(&o.ClusterNamespace, "cluster-namespace", DefaultKarmadaClusterNamespace, "Namespace in the control plane where member cluster are stored.")
 	flags.BoolVar(&o.DryRun, "dry-run", false, "Run the command in dry-run mode, without making any server requests.")
 }

--- a/pkg/karmadactl/options/global.go
+++ b/pkg/karmadactl/options/global.go
@@ -2,8 +2,6 @@ package options
 
 import "github.com/spf13/pflag"
 
-
-
 // GlobalCommandOptions holds the configuration shared by the all sub-commands of `karmadactl`.
 type GlobalCommandOptions struct {
 	// KubeConfig holds the control plane KUBECONFIG file path.

--- a/pkg/karmadactl/unjoin.go
+++ b/pkg/karmadactl/unjoin.go
@@ -64,6 +64,9 @@ func NewCmdUnjoin(cmdOut io.Writer, karmadaConfig KarmadaConfig, cmdStr string) 
 type CommandUnjoinOption struct {
 	options.GlobalCommandOptions
 
+	// ClusterNamespace holds the namespace name where the member cluster objects are stored.
+	ClusterNamespace string
+
 	// ClusterName is the cluster's name that we are going to join with.
 	ClusterName string
 
@@ -96,6 +99,8 @@ func (j *CommandUnjoinOption) Complete(args []string) error {
 func (j *CommandUnjoinOption) AddFlags(flags *pflag.FlagSet) {
 	j.GlobalCommandOptions.AddFlags(flags)
 
+	flags.StringVar(&j.ClusterNamespace, "cluster-namespace", DefaultKarmadaClusterNamespace,
+		"Namespace in the control plane where member cluster are stored.")
 	flags.StringVar(&j.ClusterContext, "cluster-context", "",
 		"Context name of cluster in kubeconfig. Only works when there are multiple contexts in the kubeconfig.")
 	flags.StringVar(&j.ClusterKubeConfig, "cluster-kubeconfig", "",

--- a/pkg/util/helper/policy.go
+++ b/pkg/util/helper/policy.go
@@ -7,6 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	mcsv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/util"
@@ -117,6 +118,34 @@ func GenerateResourceSelectorForServiceImport(svcImport policyv1alpha1.ResourceS
 					discoveryv1beta1.LabelServiceName: derivedServiceName,
 				},
 			},
+		},
+	}
+}
+
+// NewServiceExport will build a ServiceExport object
+func NewServiceExport(namespace, name string) *mcsv1alpha1.ServiceExport {
+	return &mcsv1alpha1.ServiceExport{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "multicluster.x-k8s.io/v1alpha1",
+			Kind:       util.ServiceExportKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}
+
+// NewPropagationPolicy will build a PropagationPolicy object.
+func NewPropagationPolicy(namespace, name string, rsSelectors []policyv1alpha1.ResourceSelector, placement policyv1alpha1.Placement) *policyv1alpha1.PropagationPolicy {
+	return &policyv1alpha1.PropagationPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: policyv1alpha1.PropagationSpec{
+			ResourceSelectors: rsSelectors,
+			Placement:         placement,
 		},
 	}
 }

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -144,9 +144,9 @@ var _ = ginkgo.Describe("[namespace auto-provision] namespace auto-provision tes
 				karmadaConfig := karmadactl.NewKarmadaConfig(clientcmd.NewDefaultPathOptions())
 				opts := karmadactl.CommandJoinOption{
 					GlobalCommandOptions: options.GlobalCommandOptions{
-						ClusterNamespace: "karmada-cluster",
-						DryRun:           false,
+						DryRun: false,
 					},
+					ClusterNamespace:  "karmada-cluster",
 					ClusterName:       clusterName,
 					ClusterContext:    clusterContext,
 					ClusterKubeConfig: kubeConfigPath,
@@ -161,9 +161,9 @@ var _ = ginkgo.Describe("[namespace auto-provision] namespace auto-provision tes
 				karmadaConfig := karmadactl.NewKarmadaConfig(clientcmd.NewDefaultPathOptions())
 				opts := karmadactl.CommandUnjoinOption{
 					GlobalCommandOptions: options.GlobalCommandOptions{
-						ClusterNamespace: "karmada-cluster",
-						DryRun:           false,
+						DryRun: false,
 					},
+					ClusterNamespace:  "karmada-cluster",
 					ClusterName:       clusterName,
 					ClusterContext:    clusterContext,
 					ClusterKubeConfig: kubeConfigPath,


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add export command to karmadactl.

```
Flags:
      --clusters strings         clusters are a group member clusters that used for service export
      --dry-run                  Run the command in dry-run mode, without making any server requests.
  -h, --help                     help for export
      --karmada-context string   Name of the cluster context in control plane kubeconfig file.
  -n, --namespace string         Namespace of service that are going to export (default "default")
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

`karmadactl export` will merge user's export clusters:

```
// first
karmadactl export serve -n demo --clusters="member1,member2"

// second
karmadactl export serve -n demo --clusters="member3"
```

you will get:
```yaml
spec:
  placement:
    clusterAffinity:
      clusterNames:
      - member1
      - member2
      - member3
```


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
User can use `karmadactl export` to export service.
```

