### PR TITLE
Add finalizer in (Cluster)ResourceBinding to delete works

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -43,6 +43,14 @@ const (
 	// ExecutionControllerFinalizer is added to Work to ensure manifests propagated to member cluster
 	// is deleted before Work itself is deleted.
 	ExecutionControllerFinalizer = "karmada.io/execution-controller"
+
+	// BindingControllerFinalizer is added to ResourceBinding to ensure related Works are deleted
+	// before ResourceBinding itself is deleted.
+	BindingControllerFinalizer = "karmada.io/binding-controller"
+
+	// ClusterResourceBindingControllerFinalizer is added to ClusterResourceBinding to ensure related Works are deleted
+	// before ClusterResourceBinding itself is deleted.
+	ClusterResourceBindingControllerFinalizer = "karmada.io/cluster-resource-binding-controller"
 )
 
 const (

--- a/pkg/util/detector/detector.go
+++ b/pkg/util/detector/detector.go
@@ -438,6 +438,7 @@ func (d *ResourceDetector) ApplyPolicy(object *unstructured.Unstructured, object
 		// Just update necessary fields, especially avoid modifying Spec.Clusters which is scheduling result, if already exists.
 		bindingCopy.Labels = binding.Labels
 		bindingCopy.OwnerReferences = binding.OwnerReferences
+		bindingCopy.Finalizers = binding.Finalizers
 		bindingCopy.Spec.Resource = binding.Spec.Resource
 		bindingCopy.Spec.ReplicaRequirements = binding.Spec.ReplicaRequirements
 		bindingCopy.Spec.Replicas = binding.Spec.Replicas
@@ -486,6 +487,7 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 			// Just update necessary fields, especially avoid modifying Spec.Clusters which is scheduling result, if already exists.
 			bindingCopy.Labels = binding.Labels
 			bindingCopy.OwnerReferences = binding.OwnerReferences
+			bindingCopy.Finalizers = binding.Finalizers
 			bindingCopy.Spec.Resource = binding.Spec.Resource
 			bindingCopy.Spec.ReplicaRequirements = binding.Spec.ReplicaRequirements
 			bindingCopy.Spec.Replicas = binding.Spec.Replicas
@@ -515,6 +517,7 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 			// Just update necessary fields, especially avoid modifying Spec.Clusters which is scheduling result, if already exists.
 			bindingCopy.Labels = binding.Labels
 			bindingCopy.OwnerReferences = binding.OwnerReferences
+			bindingCopy.Finalizers = binding.Finalizers
 			bindingCopy.Spec.Resource = binding.Spec.Resource
 			bindingCopy.Spec.ReplicaRequirements = binding.Spec.ReplicaRequirements
 			bindingCopy.Spec.Replicas = binding.Spec.Replicas
@@ -625,7 +628,8 @@ func (d *ResourceDetector) BuildResourceBinding(object *unstructured.Unstructure
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(object, objectKey.GroupVersionKind()),
 			},
-			Labels: labels,
+			Labels:     labels,
+			Finalizers: []string{util.BindingControllerFinalizer},
 		},
 		Spec: workv1alpha2.ResourceBindingSpec{
 			Resource: workv1alpha2.ObjectReference{
@@ -656,7 +660,8 @@ func (d *ResourceDetector) BuildClusterResourceBinding(object *unstructured.Unst
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(object, objectKey.GroupVersionKind()),
 			},
-			Labels: labels,
+			Labels:     labels,
+			Finalizers: []string{util.ClusterResourceBindingControllerFinalizer},
 		},
 		Spec: workv1alpha2.ResourceBindingSpec{
 			Resource: workv1alpha2.ObjectReference{

--- a/pkg/util/helper/binding.go
+++ b/pkg/util/helper/binding.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
-	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
@@ -175,11 +174,11 @@ func GetWorks(c client.Client, ls labels.Set) (*workv1alpha1.WorkList, error) {
 }
 
 // DeleteWorks will delete all Work objects by labels.
-func DeleteWorks(c client.Client, selector labels.Set) (controllerruntime.Result, error) {
+func DeleteWorks(c client.Client, selector labels.Set) error {
 	workList, err := GetWorks(c, selector)
 	if err != nil {
 		klog.Errorf("Failed to get works by label %v: %v", selector, err)
-		return controllerruntime.Result{Requeue: true}, err
+		return err
 	}
 
 	var errs []error
@@ -191,10 +190,10 @@ func DeleteWorks(c client.Client, selector labels.Set) (controllerruntime.Result
 	}
 
 	if len(errs) > 0 {
-		return controllerruntime.Result{Requeue: true}, errors.NewAggregate(errs)
+		return errors.NewAggregate(errs)
 	}
 
-	return controllerruntime.Result{}, nil
+	return nil
 }
 
 // GenerateNodeClaimByPodSpec will return a NodeClaim from PodSpec.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Add finalizer in ResourceBinding and ClusterResourceBinding to delete works.

If we delete workload while karmada-controller-manager crashes, this will make sure **(Cluster)ResourceBinding remains until controller-manager is ready, then it handles the delete event to delete related works**.

**Which issue(s) this PR fixes**:
Fixes #708

**Special notes for your reviewer**:
I followed [this](https://github.com/karmada-io/karmada/issues/708#issue-990675467) and verified it works in my local environment.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```