### PR TITLE
Fix the bug that join with dry-run may create resources

### DIFF
--- a/pkg/karmadactl/join.go
+++ b/pkg/karmadactl/join.go
@@ -233,6 +233,10 @@ func JoinCluster(controlPlaneRestConfig, clusterConfig *rest.Config, clusterName
 }
 
 func generateSecretInMemberCluster(clusterKubeClient kubeclient.Interface, clusterNamespace, clusterName string, dryRun bool) (*corev1.Secret, error) {
+	if dryRun {
+		return nil, nil
+	}
+
 	var err error
 
 	// ensure namespace where the karmada control plane credential be stored exists in cluster.
@@ -263,10 +267,6 @@ func generateSecretInMemberCluster(clusterKubeClient kubeclient.Interface, clust
 	clusterRoleBinding.RoleRef = buildClusterRoleReference(clusterRole.Name)
 	if _, err = ensureClusterRoleBindingExist(clusterKubeClient, clusterRoleBinding, dryRun); err != nil {
 		return nil, err
-	}
-
-	if dryRun {
-		return nil, nil
 	}
 
 	var clusterSecret *corev1.Secret


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Dry-run should not create real K8s resources

https://github.com/karmada-io/karmada/blob/master/pkg/karmadactl/join.go#L238-L266

The code before judging dry-run may create resources

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

