### PR TITLE
back off to general estimator when scheduler estimator is unavailable

### DIFF
--- a/pkg/estimator/client/accurate.go
+++ b/pkg/estimator/client/accurate.go
@@ -43,7 +43,7 @@ func (se *SchedulerEstimator) MaxAvailableReplicas(clusters []*clusterv1alpha1.C
 func (se *SchedulerEstimator) maxAvailableReplicas(ctx context.Context, cluster string, replicaRequirements *workv1alpha1.ReplicaRequirements) (int32, error) {
 	client, err := se.cache.GetClient(cluster)
 	if err != nil {
-		return 0, err
+		return UnauthenticReplica, err
 	}
 
 	req := &pb.MaxAvailableReplicasRequest{
@@ -61,7 +61,7 @@ func (se *SchedulerEstimator) maxAvailableReplicas(ctx context.Context, cluster 
 	}
 	res, err := client.MaxAvailableReplicas(ctx, req)
 	if err != nil {
-		return 0, fmt.Errorf("gRPC request cluster(%s) estimator error: %v", cluster, err)
+		return UnauthenticReplica, fmt.Errorf("gRPC request cluster(%s) estimator error: %v", cluster, err)
 	}
 	return res.MaxReplicas, nil
 }

--- a/pkg/estimator/client/interface.go
+++ b/pkg/estimator/client/interface.go
@@ -5,6 +5,11 @@ import (
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 )
 
+// UnauthenticReplica is special replica number returned by estimator in case of estimator can't calculate the available
+// replicas.
+// The scheduler should discard the estimator's result and back-off to rely on other estimator's result.
+const UnauthenticReplica = -1
+
 var (
 	replicaEstimators = map[string]ReplicaEstimator{}
 )

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -344,6 +344,9 @@ func (g *genericScheduler) calAvailableReplicas(clusters []*clusterv1alpha1.Clus
 			continue
 		}
 		for i := range res {
+			if res[i].Replicas == estimatorclient.UnauthenticReplica {
+				continue
+			}
 			if availableTargetClusters[i].Name == res[i].Name && availableTargetClusters[i].Replicas > res[i].Replicas {
 				availableTargetClusters[i].Replicas = res[i].Replicas
 			}


### PR DESCRIPTION
Signed-off-by: Garrybest <garrybest@foxmail.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
According to https://github.com/karmada-io/karmada/pull/742#issuecomment-926301019

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

