### PR TITLE
Introduce the --plugins flag to control scheduler plugins

### DIFF
--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -8,6 +8,9 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	componentbaseconfig "k8s.io/component-base/config"
 
+	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins/apiinstalled"
+	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins/clusteraffinity"
+	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins/tainttoleration"
 	"github.com/karmada-io/karmada/pkg/util"
 )
 
@@ -21,6 +24,7 @@ var (
 	defaultElectionLeaseDuration = metav1.Duration{Duration: 15 * time.Second}
 	defaultElectionRenewDeadline = metav1.Duration{Duration: 10 * time.Second}
 	defaultElectionRetryPeriod   = metav1.Duration{Duration: 2 * time.Second}
+	defaultSchedulerPlugins      = []string{clusteraffinity.Name, tainttoleration.Name, apiinstalled.Name}
 )
 
 // Options contains everything necessary to create and run controller-manager.
@@ -47,6 +51,8 @@ type Options struct {
 	SchedulerEstimatorTimeout metav1.Duration
 	// SchedulerEstimatorPort is the port that the accurate scheduler estimator server serves at.
 	SchedulerEstimatorPort int
+	// SchedulerPlugins is the name of plugins that needs to be enabled.
+	SchedulerPlugins []string
 }
 
 // NewOptions builds an default scheduler options.
@@ -82,4 +88,5 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.EnableSchedulerEstimator, "enable-scheduler-estimator", false, "Enable calling cluster scheduler estimator for adjusting replicas.")
 	fs.DurationVar(&o.SchedulerEstimatorTimeout.Duration, "scheduler-estimator-timeout", 3*time.Second, "Specifies the timeout period of calling the scheduler estimator service.")
 	fs.IntVar(&o.SchedulerEstimatorPort, "scheduler-estimator-port", defaultEstimatorPort, "The secure port on which to connect the accurate scheduler estimator.")
+	fs.StringSliceVar(&o.SchedulerPlugins, "plugins", defaultSchedulerPlugins, "The name of plugins that needs to be enabled.")
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -31,9 +31,6 @@ import (
 	worklister "github.com/karmada-io/karmada/pkg/generated/listers/work/v1alpha2"
 	schedulercache "github.com/karmada-io/karmada/pkg/scheduler/cache"
 	"github.com/karmada-io/karmada/pkg/scheduler/core"
-	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins/apiinstalled"
-	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins/clusteraffinity"
-	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins/tainttoleration"
 	"github.com/karmada-io/karmada/pkg/scheduler/metrics"
 	"github.com/karmada-io/karmada/pkg/util"
 )
@@ -107,8 +104,7 @@ func NewScheduler(dynamicClient dynamic.Interface, karmadaClient karmadaclientse
 	clusterLister := factory.Cluster().V1alpha1().Clusters().Lister()
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 	schedulerCache := schedulercache.NewCache(clusterLister)
-	// TODO: make plugins as a flag
-	algorithm := core.NewGenericScheduler(schedulerCache, policyLister, []string{clusteraffinity.Name, tainttoleration.Name, apiinstalled.Name})
+	algorithm := core.NewGenericScheduler(schedulerCache, policyLister, opts.SchedulerPlugins)
 	sched := &Scheduler{
 		DynamicClient:            dynamicClient,
 		KarmadaClient:            karmadaClient,


### PR DESCRIPTION
Signed-off-by: iawia002 <z2d@jifangcheng.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Introduce a new flag to control which scheduler plugins to enable, with all enabled by default.

```
--plugins strings  The name of plugins that needs to be enabled. (default [ClusterAffinity,TaintToleration,APIInstalled])
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Introduce the `--plugins` flag to control which scheduler plugins to enable.
```

/cc @RainbowMango 