### PR TITLE
Move the token and caData definitions to the API definition file

### DIFF
--- a/pkg/apis/cluster/v1alpha1/types.go
+++ b/pkg/apis/cluster/v1alpha1/types.go
@@ -79,6 +79,13 @@ type ClusterSpec struct {
 	Taints []corev1.Taint `json:"taints,omitempty"`
 }
 
+const (
+	// SecretTokenKey is the name of secret token key.
+	SecretTokenKey = "token"
+	// SecretCADataKey is the name of secret caBundle key.
+	SecretCADataKey = "caBundle"
+)
+
 // ClusterSyncMode describes the mode of synchronization between member cluster and karmada control plane.
 type ClusterSyncMode string
 

--- a/pkg/karmadactl/join.go
+++ b/pkg/karmadactl/join.go
@@ -57,13 +57,6 @@ var (
 
 var clusterResourceKind = clusterv1alpha1.SchemeGroupVersion.WithKind("Cluster")
 
-const (
-	// TODO(RainbowMango) token and caData key both used by command and controller.
-	// It's better to put them to a common place, such as API definition.
-	tokenKey  = "token"
-	caDataKey = "caBundle"
-)
-
 // NewCmdJoin defines the `join` command that registers a cluster.
 func NewCmdJoin(cmdOut io.Writer, karmadaConfig KarmadaConfig, cmdStr string) *cobra.Command {
 	opts := CommandJoinOption{}
@@ -201,8 +194,8 @@ func JoinCluster(controlPlaneRestConfig, clusterConfig *rest.Config, clusterName
 			Name:      clusterName,
 		},
 		Data: map[string][]byte{
-			caDataKey: clusterSecret.Data["ca.crt"], // TODO(RainbowMango): change ca bundle key to 'ca.crt'.
-			tokenKey:  clusterSecret.Data[tokenKey],
+			clusterv1alpha1.SecretCADataKey: clusterSecret.Data["ca.crt"],
+			clusterv1alpha1.SecretTokenKey:  clusterSecret.Data[clusterv1alpha1.SecretTokenKey],
 		},
 	}
 	secret, err = util.CreateSecret(controlPlaneKubeClient, secret)

--- a/pkg/util/membercluster_client.go
+++ b/pkg/util/membercluster_client.go
@@ -19,11 +19,6 @@ import (
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 )
 
-const (
-	tokenKey  = "token"
-	cADataKey = "caBundle"
-)
-
 // ClusterClient stands for a cluster Clientset for the given member cluster
 type ClusterClient struct {
 	KubeClient  *kubeclientset.Clientset
@@ -134,9 +129,9 @@ func buildClusterConfig(cluster *clusterv1alpha1.Cluster, client client.Client) 
 		return nil, err
 	}
 
-	token, tokenFound := secret.Data[tokenKey]
+	token, tokenFound := secret.Data[clusterv1alpha1.SecretTokenKey]
 	if !tokenFound || len(token) == 0 {
-		return nil, fmt.Errorf("the secret for cluster %s is missing a non-empty value for %q", clusterName, tokenKey)
+		return nil, fmt.Errorf("the secret for cluster %s is missing a non-empty value for %q", clusterName, clusterv1alpha1.SecretTokenKey)
 	}
 
 	clusterConfig, err := clientcmd.BuildConfigFromFlags(apiEndpoint, "")
@@ -149,7 +144,7 @@ func buildClusterConfig(cluster *clusterv1alpha1.Cluster, client client.Client) 
 	if cluster.Spec.InsecureSkipTLSVerification {
 		clusterConfig.TLSClientConfig.Insecure = true
 	} else {
-		clusterConfig.CAData = secret.Data[cADataKey]
+		clusterConfig.CAData = secret.Data[clusterv1alpha1.SecretCADataKey]
 	}
 
 	if cluster.Spec.ProxyURL != "" {


### PR DESCRIPTION
Signed-off-by: iawia002 <z2d@jifangcheng.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Move the `token` and `caData` definitions to the API definition file.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

I see another TODO in this file:

```go
// TODO(RainbowMango): change ca bundle key to 'ca.crt'.
```

Are we sure about this? k/k uses the `caBundle` name in several places, If we are sure about this, I can submit another PR to change it. cc @RainbowMango 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

/assign @RainbowMango 