### PR TITLE
deploy karmada-agent and karmada-scheduler-estimator

### DIFF
--- a/artifacts/deploy/karmada-scheduler.yaml
+++ b/artifacts/deploy/karmada-scheduler.yaml
@@ -29,6 +29,7 @@ spec:
             - --bind-address=0.0.0.0
             - --secure-port=10351
             - --failover=true
+            - --enable-scheduler-estimator=true
             - --v=4
           volumeMounts:
             - name: kubeconfig

--- a/hack/deploy-agent-and-estimator.sh
+++ b/hack/deploy-agent-and-estimator.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+function usage() {
+  echo "This script will deploy karmada-agent and karmada-scheduler-estimator of a cluster in karmada-host."
+  echo "Usage: hack/deploy-agent-and-estimator.sh <HOST_CLUSTER_KUBECONFIG> <HOST_CLUSTER_NAME> <KARMADA_APISERVER_KUBECONFIG> <KARMADA_APISERVER_CONTEXT_NAME> <MEMBER_CLUSTER_KUBECONFIG> <MEMBER_CLUSTER_NAME>"
+  echo "Example: hack/deploy-agent-and-estimator.sh ~/.kube/karmada.config karmada-host ~/.kube/karmada.config karmada-apiserver ~/.kube/members.config member1"
+}
+
+if [[ $# -ne 6 ]]; then
+  usage
+  exit 1
+fi
+
+# check kube config file existence
+if [[ ! -f "${1}" ]]; then
+  echo -e "ERROR: failed to get host kubernetes config file: '${1}', not existed.\n"
+  usage
+  exit 1
+fi
+HOST_CLUSTER_KUBECONFIG=$1
+
+# check context existence
+if ! kubectl config get-contexts "${2}" --kubeconfig="${HOST_CLUSTER_KUBECONFIG}" > /dev/null 2>&1;
+then
+  echo -e "ERROR: failed to get context: '${2}' not in ${HOST_CLUSTER_KUBECONFIG}. \n"
+  usage
+  exit 1
+fi
+HOST_CLUSTER_NAME=$2
+
+
+# check kube config file existence
+if [[ ! -f "${3}" ]]; then
+  echo -e "ERROR: failed to get kubernetes config file: '${3}', not existed.\n"
+  usage
+  exit 1
+fi
+KARMADA_APISERVER_KUBECONFIG=$3
+
+# check context existence
+if ! kubectl config use-context "${4}" --kubeconfig="${KARMADA_APISERVER_KUBECONFIG}" > /dev/null 2>&1;
+then
+  echo -e "ERROR: failed to use context: '${4}' not in ${KARMADA_APISERVER_KUBECONFIG}. \n"
+  usage
+  exit 1
+fi
+KARMADA_APISERVER_CONTEXT_NAME=$4
+
+# check kube config file existence
+if [[ ! -f "${5}" ]]; then
+  echo -e "ERROR: failed to get kubernetes config file: '${5}', not existed.\n"
+  usage
+  exit 1
+fi
+MEMBER_CLUSTER_KUBECONFIG=$5
+
+# check context existence
+if ! kubectl config use-context "${6}" --kubeconfig="${MEMBER_CLUSTER_KUBECONFIG}" > /dev/null 2>&1;
+then
+  echo -e "ERROR: failed to get context: '${6}' not in ${MEMBER_CLUSTER_KUBECONFIG}. \n"
+  usage
+  exit 1
+fi
+MEMBER_CLUSTER_NAME=$6
+
+
+"${REPO_ROOT}"/hack/deploy-scheduler-estimator.sh ${HOST_CLUSTER_KUBECONFIG} ${HOST_CLUSTER_NAME} ${MEMBER_CLUSTER_KUBECONFIG} ${MEMBER_CLUSTER_NAME}
+"${REPO_ROOT}"/hack/deploy-karmada-agent.sh ${KARMADA_APISERVER_KUBECONFIG} ${KARMADA_APISERVER_CONTEXT_NAME} ${MEMBER_CLUSTER_KUBECONFIG} ${MEMBER_CLUSTER_NAME}

--- a/hack/deploy-scheduler-estimator.sh
+++ b/hack/deploy-scheduler-estimator.sh
@@ -6,8 +6,8 @@ set -o nounset
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 function usage() {
   echo "This script will deploy karmada-scheduler-estimator of a cluster."
-  echo "Usage: hack/deploy-scheduler-estimator <HOST_CLUSTER_KUBECONFIG> <HOST_CLUSTER_NAME> <MEMBER_CLUSTER_KUBECONFIG> <MEMBER_CLUSTER_NAME>"
-  echo "Example: hack/deploy-scheduler-estimator ~/.kube/karmada.config karmada-host ~/.kube/members.config member1"
+  echo "Usage: hack/deploy-scheduler-estimator.sh <HOST_CLUSTER_KUBECONFIG> <HOST_CLUSTER_NAME> <MEMBER_CLUSTER_KUBECONFIG> <MEMBER_CLUSTER_NAME>"
+  echo "Example: hack/deploy-scheduler-estimator.sh ~/.kube/karmada.config karmada-host ~/.kube/members.config member1"
 }
 
 if [[ $# -ne 4 ]]; then
@@ -52,7 +52,7 @@ MEMBER_CLUSTER_NAME=$4
 kubectl --kubeconfig="${MEMBER_CLUSTER_KUBECONFIG}" config use-context "${MEMBER_CLUSTER_NAME}"
 
 # check whether the kubeconfig secret has been created before
-if ! kubectl --kubeconfig="${HOST_CLUSTER_KUBECONFIG}" get secrets -n karmada-system | grep "${MEMBER_CLUSTER_NAME}-kubeconfig"; then
+if ! kubectl --kubeconfig="${HOST_CLUSTER_KUBECONFIG}" --context="${HOST_CLUSTER_NAME}" get secrets -n karmada-system | grep "${MEMBER_CLUSTER_NAME}-kubeconfig"; then
   # create secret
   kubectl --kubeconfig="${HOST_CLUSTER_KUBECONFIG}" --context="${HOST_CLUSTER_NAME}" create secret generic ${MEMBER_CLUSTER_NAME}-kubeconfig --from-file=${MEMBER_CLUSTER_NAME}-kubeconfig="${MEMBER_CLUSTER_KUBECONFIG}" -n "karmada-system"
 fi

--- a/hack/local-up-karmada.sh
+++ b/hack/local-up-karmada.sh
@@ -112,14 +112,16 @@ echo "cluster networks connected"
 export KUBECONFIG="${MAIN_KUBECONFIG}"
 kubectl config use-context "${KARMADA_APISERVER_CLUSTER_NAME}"
 ${KARMADACTL_BIN} join member1 --cluster-kubeconfig="${MEMBER_CLUSTER_KUBECONFIG}"
+"${REPO_ROOT}"/hack/deploy-scheduler-estimator.sh "${MAIN_KUBECONFIG}" "${HOST_CLUSTER_NAME}" "${MEMBER_CLUSTER_KUBECONFIG}" "${MEMBER_CLUSTER_1_NAME}"
 ${KARMADACTL_BIN} join member2 --cluster-kubeconfig="${MEMBER_CLUSTER_KUBECONFIG}"
+"${REPO_ROOT}"/hack/deploy-scheduler-estimator.sh "${MAIN_KUBECONFIG}" "${HOST_CLUSTER_NAME}" "${MEMBER_CLUSTER_KUBECONFIG}" "${MEMBER_CLUSTER_2_NAME}"
 
 # wait until the pull mode cluster ready
 util::check_clusters_ready "${MEMBER_CLUSTER_KUBECONFIG}" "${PULL_MODE_CLUSTER_NAME}"
 kind load docker-image "${REGISTRY}/karmada-agent:${VERSION}" --name="${PULL_MODE_CLUSTER_NAME}"
 
 #step7. deploy karmada agent in pull mode member clusters
-"${REPO_ROOT}"/hack/deploy-karmada-agent.sh "${MAIN_KUBECONFIG}" "${KARMADA_APISERVER_CLUSTER_NAME}" "${MEMBER_CLUSTER_KUBECONFIG}" "${PULL_MODE_CLUSTER_NAME}"
+"${REPO_ROOT}"/hack/deploy-agent-and-estimator.sh "${MAIN_KUBECONFIG}" "${HOST_CLUSTER_NAME}" "${MAIN_KUBECONFIG}" "${KARMADA_APISERVER_CLUSTER_NAME}" "${MEMBER_CLUSTER_KUBECONFIG}" "${PULL_MODE_CLUSTER_NAME}"
 
 function print_success() {
   echo -e "---\n"


### PR DESCRIPTION
Signed-off-by: Garrybest <garrybest@foxmail.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
1. Now karmada-agent will be deployed into member clusters. Actually, it can be deployed in any real clusters as long as we have both karmada-kubeconfig and member-kubeconfig. So I modify the agent deployment script to make it more compatible by using karmada-kubeconfig and member-kubeconfig.
2. It is noticed that karmada-scheduler-estimator of all clusters must be deployed into karmada-host due to scheduler connnection. From the user's point of view, they may deploy agent and estimator together when a new cluster needs to be joined into karmada. So `deploy-agent-and-estimator.sh` script will use `deploy-karmada-agent.sh` and `deploy-scheduler-estimator.sh`to deploy agent and estimator together into karmada-host. If using karmadactl to join clusters, the former script `deploy-scheduler-estimator.sh` still works.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

