### PR TITLE
fix controller-manager crash when consuming informer before initialized

### DIFF
--- a/pkg/controllers/mcs/service_export_controller.go
+++ b/pkg/controllers/mcs/service_export_controller.go
@@ -285,11 +285,6 @@ func (c *ServiceExportController) handleEndpointSliceEvent(endpointSliceKey keys
 		return err
 	}
 
-	if endpointSliceObj == nil {
-		klog.V(2).Infof("Ignore the event key %s which not listened by karmada.", endpointSliceKey)
-		return nil
-	}
-
 	if err = c.reportEndpointSliceWithEndpointSliceCreateOrUpdate(endpointSliceKey.Cluster, endpointSliceObj); err != nil {
 		klog.Errorf("Failed to handle endpointSlice(%s) event, Error: %v",
 			endpointSliceKey.NamespaceKey(), err)

--- a/pkg/controllers/status/workstatus_controller.go
+++ b/pkg/controllers/status/workstatus_controller.go
@@ -159,12 +159,6 @@ func (c *WorkStatusController) syncWorkStatus(key util.QueueKey) error {
 		return err
 	}
 
-	if obj == nil {
-		// Ignore the object which not managed by current karmada.
-		klog.V(2).Infof("Ignore the event key %s which not managed by karmada.", key)
-		return nil
-	}
-
 	workNamespace := util.GetLabelValue(obj.GetLabels(), workv1alpha1.WorkNamespaceLabel)
 	workName := util.GetLabelValue(obj.GetLabels(), workv1alpha1.WorkNameLabel)
 	if len(workNamespace) == 0 || len(workName) == 0 {


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When I create a deployment and propagate it to the member clusters, and then delete pod `karmada-controller-manager-xxx` in `karmada-host` cluster, the new created `karmada-controller-manager` pod will be panic:

```log
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x19e7e98]

goroutine 1367 [running]:
k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.(*Unstructured).GetResourceVersion(...)
	/root/cz/karmada/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go:282
github.com/karmada-io/karmada/pkg/util/objectwatcher.RetainClusterFields(0xc000528b30, 0x0, 0xc001045888, 0x4)
	/root/cz/karmada/pkg/util/objectwatcher/retain.go:29 +0xd8
github.com/karmada-io/karmada/pkg/util/objectwatcher.(*objectWatcherImpl).Update(0xc00064a0a0, 0xc0006e6e00, 0xc000528b30, 0x0, 0xc000e0c290, 0x7)
	/root/cz/karmada/pkg/util/objectwatcher/objectwatcher.go:114 +0x605
github.com/karmada-io/karmada/pkg/controllers/execution.(*Controller).tryUpdateWorkload(0xc0007a6d20, 0xc0006e6e00, 0xc000528b30, 0x1eb9906, 0x7)
	/root/cz/karmada/pkg/controllers/execution/execution_controller.go:220 +0x649
github.com/karmada-io/karmada/pkg/controllers/execution.(*Controller).syncToClusters(0xc0007a6d20, 0xc0006e6e00, 0xc00117d760, 0x1eb75a6, 0x5)
	/root/cz/karmada/pkg/controllers/execution/execution_controller.go:167 +0xb26
github.com/karmada-io/karmada/pkg/controllers/execution.(*Controller).syncWork(0xc0007a6d20, 0xc0006e6e00, 0xc00117d760, 0x7, 0xc0006e6e00, 0x0, 0x0)
	/root/cz/karmada/pkg/controllers/execution/execution_controller.go:102 +0xbf
github.com/karmada-io/karmada/pkg/controllers/execution.(*Controller).Reconcile(0xc0007a6d20, 0x2147eb8, 0xc000572f30, 0xc000c67338, 0x12, 0xc000d4ebc0, 0x10, 0xc000572f30, 0xc00003a000, 0x1d10940, ...)
	/root/cz/karmada/pkg/controllers/execution/execution_controller.go:84 +0x54b
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0007b83c0, 0x2147e10, 0xc0002bc900, 0x1cb2aa0, 0xc00005a5c0)
	/root/cz/karmada/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:298 +0x30d
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0007b83c0, 0x2147e10, 0xc0002bc900, 0xc0005ab700)
	/root/cz/karmada/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:253 +0x205
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2(0xc00078a100, 0xc0007b83c0, 0x2147e10, 0xc0002bc900)
	/root/cz/karmada/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:214 +0x6b
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
	/root/cz/karmada/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:210 +0x425
```

It's because the informer of cluster has not been initialized.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

