### PR TITLE
Adjust the codegen script to automatically list all API groups and then generate code

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -8,6 +8,29 @@ set -o pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}"
 
+# All API group names in the pkg/apis directory that need code generation
+PKGS=(cluster/v1alpha1 policy/v1alpha1 work/v1alpha1 work/v1alpha2)
+
+CLIENT_PATH=github.com/karmada-io/karmada/pkg
+CLIENT_APIS=${CLIENT_PATH}/apis
+
+ALL_PKGS=""
+for path in "${PKGS[@]}"
+do
+  ALL_PKGS=$ALL_PKGS" $CLIENT_APIS/$path"
+done
+
+function join {
+  local IFS="$1"
+  shift
+  result="$*"
+}
+
+join "," $ALL_PKGS
+FULL_PKGS=$result
+
+echo "Generating for API group:" "${PKGS[@]}"
+
 echo "Generating with deepcopy-gen"
 GO111MODULE=on go install k8s.io/code-generator/cmd/deepcopy-gen
 export GOPATH=$(go env GOPATH | awk -F ':' '{print $1}')
@@ -15,46 +38,14 @@ export PATH=$PATH:$GOPATH/bin
 
 deepcopy-gen \
   --go-header-file hack/boilerplate/boilerplate.go.txt \
-  --input-dirs=github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1 \
-  --output-package=github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1 \
-  --output-file-base=zz_generated.deepcopy
-deepcopy-gen \
-  --go-header-file hack/boilerplate/boilerplate.go.txt \
-  --input-dirs=github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1 \
-  --output-package=github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1 \
-  --output-file-base=zz_generated.deepcopy
-deepcopy-gen \
-  --go-header-file hack/boilerplate/boilerplate.go.txt \
-  --input-dirs=github.com/karmada-io/karmada/pkg/apis/work/v1alpha1 \
-  --output-package=github.com/karmada-io/karmada/pkg/apis/work/v1alpha1 \
-  --output-file-base=zz_generated.deepcopy
-deepcopy-gen \
-  --go-header-file hack/boilerplate/boilerplate.go.txt \
-  --input-dirs=github.com/karmada-io/karmada/pkg/apis/work/v1alpha2 \
-  --output-package=github.com/karmada-io/karmada/pkg/apis/work/v1alpha2 \
+  --input-dirs="${FULL_PKGS}" \
   --output-file-base=zz_generated.deepcopy
 
 echo "Generating with register-gen"
 GO111MODULE=on go install k8s.io/code-generator/cmd/register-gen
 register-gen \
   --go-header-file hack/boilerplate/boilerplate.go.txt \
-  --input-dirs=github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1 \
-  --output-package=github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1 \
-  --output-file-base=zz_generated.register
-register-gen \
-  --go-header-file hack/boilerplate/boilerplate.go.txt \
-  --input-dirs=github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1 \
-  --output-package=github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1 \
-  --output-file-base=zz_generated.register
-register-gen \
-  --go-header-file hack/boilerplate/boilerplate.go.txt \
-  --input-dirs=github.com/karmada-io/karmada/pkg/apis/work/v1alpha1 \
-  --output-package=github.com/karmada-io/karmada/pkg/apis/work/v1alpha1 \
-  --output-file-base=zz_generated.register
-register-gen \
-  --go-header-file hack/boilerplate/boilerplate.go.txt \
-  --input-dirs=github.com/karmada-io/karmada/pkg/apis/work/v1alpha2 \
-  --output-package=github.com/karmada-io/karmada/pkg/apis/work/v1alpha2 \
+  --input-dirs="${FULL_PKGS}" \
   --output-file-base=zz_generated.register
 
 echo "Generating with client-gen"
@@ -62,22 +53,22 @@ GO111MODULE=on go install k8s.io/code-generator/cmd/client-gen
 client-gen \
   --go-header-file hack/boilerplate/boilerplate.go.txt \
   --input-base="" \
-  --input=github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1,github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1,github.com/karmada-io/karmada/pkg/apis/work/v1alpha1,github.com/karmada-io/karmada/pkg/apis/work/v1alpha2 \
-  --output-package=github.com/karmada-io/karmada/pkg/generated/clientset \
+  --input="${FULL_PKGS}" \
+  --output-package="${CLIENT_PATH}/generated/clientset" \
   --clientset-name=versioned
 
 echo "Generating with lister-gen"
 GO111MODULE=on go install k8s.io/code-generator/cmd/lister-gen
 lister-gen \
   --go-header-file hack/boilerplate/boilerplate.go.txt \
-  --input-dirs=github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1,github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1,github.com/karmada-io/karmada/pkg/apis/work/v1alpha1,github.com/karmada-io/karmada/pkg/apis/work/v1alpha2 \
-  --output-package=github.com/karmada-io/karmada/pkg/generated/listers
+  --input-dirs="${FULL_PKGS}" \
+  --output-package="${CLIENT_PATH}/generated/listers"
 
 echo "Generating with informer-gen"
 GO111MODULE=on go install k8s.io/code-generator/cmd/informer-gen
 informer-gen \
   --go-header-file hack/boilerplate/boilerplate.go.txt \
-  --input-dirs=github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1,github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1,github.com/karmada-io/karmada/pkg/apis/work/v1alpha1,github.com/karmada-io/karmada/pkg/apis/work/v1alpha2 \
-  --versioned-clientset-package=github.com/karmada-io/karmada/pkg/generated/clientset/versioned \
-  --listers-package=github.com/karmada-io/karmada/pkg/generated/listers \
-  --output-package=github.com/karmada-io/karmada/pkg/generated/informers
+  --input-dirs="${FULL_PKGS}" \
+  --versioned-clientset-package="${CLIENT_PATH}/generated/clientset/versioned" \
+  --listers-package="${CLIENT_PATH}/generated/listers" \
+  --output-package="${CLIENT_PATH}/generated/informers"

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -48,6 +48,13 @@ register-gen \
   --input-dirs="${FULL_PKGS}" \
   --output-file-base=zz_generated.register
 
+echo "Generating with conversion-gen"
+GO111MODULE=on go install k8s.io/code-generator/cmd/conversion-gen
+conversion-gen \
+  --go-header-file hack/boilerplate/boilerplate.go.txt \
+  --input-dirs="${FULL_PKGS}" \
+  --output-file-base=zz_generated.conversion
+
 echo "Generating with client-gen"
 GO111MODULE=on go install k8s.io/code-generator/cmd/client-gen
 client-gen \


### PR DESCRIPTION
Signed-off-by: iawia002 <z2d@jifangcheng.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

It is convenient to not update this file when there is a new API group in the future, I've tested it locally and it generates the same results as before:

```console
$ bash hack/update-codegen.sh

Generating for API group: cluster/v1alpha1,policy/v1alpha1,work/v1alpha1
Generating with deepcopy-gen
Generating with register-gen
Generating with client-gen
Generating with lister-gen
Generating with informer-gen
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

