### PR TITLE
Deprecate ReplicaSchedulingPolicy API

### DIFF
--- a/charts/_crds/bases/cluster.karmada.io_clusters.yaml
+++ b/charts/_crds/bases/cluster.karmada.io_clusters.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: clusters.cluster.karmada.io
 spec:

--- a/charts/_crds/bases/policy.karmada.io_clusteroverridepolicies.yaml
+++ b/charts/_crds/bases/policy.karmada.io_clusteroverridepolicies.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: clusteroverridepolicies.policy.karmada.io
 spec:

--- a/charts/_crds/bases/policy.karmada.io_clusterpropagationpolicies.yaml
+++ b/charts/_crds/bases/policy.karmada.io_clusterpropagationpolicies.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: clusterpropagationpolicies.policy.karmada.io
 spec:

--- a/charts/_crds/bases/policy.karmada.io_overridepolicies.yaml
+++ b/charts/_crds/bases/policy.karmada.io_overridepolicies.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: overridepolicies.policy.karmada.io
 spec:

--- a/charts/_crds/bases/policy.karmada.io_propagationpolicies.yaml
+++ b/charts/_crds/bases/policy.karmada.io_propagationpolicies.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: propagationpolicies.policy.karmada.io
 spec:

--- a/charts/_crds/bases/policy.karmada.io_replicaschedulingpolicies.yaml
+++ b/charts/_crds/bases/policy.karmada.io_replicaschedulingpolicies.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: replicaschedulingpolicies.policy.karmada.io
 spec:
@@ -18,7 +18,8 @@ spec:
     singular: replicaschedulingpolicy
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - deprecated: true
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ReplicaSchedulingPolicy represents the policy that propagates

--- a/charts/_crds/bases/work.karmada.io_clusterresourcebindings.yaml
+++ b/charts/_crds/bases/work.karmada.io_clusterresourcebindings.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: clusterresourcebindings.work.karmada.io
 spec:

--- a/charts/_crds/bases/work.karmada.io_resourcebindings.yaml
+++ b/charts/_crds/bases/work.karmada.io_resourcebindings.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: resourcebindings.work.karmada.io
 spec:

--- a/charts/_crds/bases/work.karmada.io_works.yaml
+++ b/charts/_crds/bases/work.karmada.io_works.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: works.work.karmada.io
 spec:

--- a/hack/update-crdgen.sh
+++ b/hack/update-crdgen.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 CONTROLLER_GEN_PKG="sigs.k8s.io/controller-tools/cmd/controller-gen"
-CONTROLLER_GEN_VER="v0.4.1"
+CONTROLLER_GEN_VER="v0.6.2"
 
 source hack/util.sh
 

--- a/pkg/apis/policy/v1alpha1/replicascheduling_types.go
+++ b/pkg/apis/policy/v1alpha1/replicascheduling_types.go
@@ -5,6 +5,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=rsp
+// +kubebuilder:deprecatedversion
 
 // ReplicaSchedulingPolicy represents the policy that propagates total number of replicas for deployment.
 type ReplicaSchedulingPolicy struct {

--- a/pkg/controllers/hpa/hpa_controller.go
+++ b/pkg/controllers/hpa/hpa_controller.go
@@ -17,6 +17,7 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/helper"
@@ -98,8 +99,8 @@ func (c *HorizontalPodAutoscalerController) buildWorks(hpa *autoscalingv1.Horizo
 			Finalizers: []string{util.ExecutionControllerFinalizer},
 		}
 
-		util.MergeLabel(hpaObj, workv1alpha2.WorkNamespaceLabel, workNamespace)
-		util.MergeLabel(hpaObj, workv1alpha2.WorkNameLabel, workName)
+		util.MergeLabel(hpaObj, workv1alpha1.WorkNamespaceLabel, workNamespace)
+		util.MergeLabel(hpaObj, workv1alpha1.WorkNameLabel, workName)
 
 		if err = helper.CreateOrUpdateWork(c.Client, objectMeta, hpaObj); err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: RainbowMango <qdurenhongcai@gmail.com>

**What type of PR is this?**
/kind api-change
/kind documentation
/kind cleanup

**What this PR does / why we need it**:
This PR deprecated RSP. A warning will be raised when people try to create the objects.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
The API `ReplicaSchedulingPolicy` has been deprecated and will be removed from the following release. The feature now has been integrated into `ReplicaScheduling`.
```

