### PR TITLE
remove work ownerReferences field

### DIFF
--- a/pkg/webhook/work/mutating.go
+++ b/pkg/webhook/work/mutating.go
@@ -109,6 +109,8 @@ func removeIrrelevantField(workload *unstructured.Unstructured) error {
 	// populated by the kubernetes.
 	unstructured.RemoveNestedField(workload.Object, "metadata", "uid")
 
+	unstructured.RemoveNestedField(workload.Object, "metadata", "ownerReferences")
+
 	unstructured.RemoveNestedField(workload.Object, "status")
 
 	if workload.GetKind() == util.ServiceKind {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**What this PR does / why we need it**:

member cluster's object should not have the same ownerReferences(especially the uid of ownerReference)  with fed cluster's object.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

