### PR TITLE
Fix failover test

### DIFF
--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -79,6 +79,7 @@ var (
 	clusterProvider       *cluster.Provider
 	pullModeClusters      map[string]string
 	clusterLabels         = map[string]string{"location": "CHN"}
+	pushModeClusterLabels = map[string]string{"sync-mode": "Push"}
 )
 
 func TestE2E(t *testing.T) {
@@ -329,6 +330,9 @@ func SetClusterLabel(c client.Client, clusterName string) error {
 			clusterObj.Labels = make(map[string]string)
 		}
 		clusterObj.Labels["location"] = "CHN"
+		if clusterObj.Spec.SyncMode == clusterv1alpha1.Push {
+			clusterObj.Labels["sync-mode"] = "Push"
+		}
 		if err := c.Update(context.TODO(), clusterObj); err != nil {
 			if apierrors.IsConflict(err) {
 				return false, nil


### PR DESCRIPTION
Signed-off-by: dddddai <dddwq@foxmail.com>

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
The code that waits for cluster status changing to false doesn't make sense, it should be `meta.IsStatusConditionPresentAndEqual` without **`!`**
https://github.com/karmada-io/karmada/blob/a0c7ef95fdd6e8bd3f52da4de58cda5630dbfa4f/test/e2e/failover_test.go#L102-L110
Maybe associated with [this failed check](https://github.com/karmada-io/karmada/runs/3857090520?check_suite_focus=true)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

