### PR TITLE
Bump golangci-lint version to v1.42.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,7 +29,6 @@ linters:
   # linters maintained by golang.org
   - gofmt
   - goimports
-  - golint
   - govet
   # linters default enabled by golangci-lint .
   - deadcode
@@ -45,6 +44,7 @@ linters:
   - gocyclo
   - gosec
   - whitespace
+  - revive
 
 linters-settings:
   goimports:

--- a/hack/verify-staticcheck.sh
+++ b/hack/verify-staticcheck.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 GOLANGCI_LINT_PKG="github.com/golangci/golangci-lint/cmd/golangci-lint"
-GOLANGCI_LINT_VER="v1.32.2"
+GOLANGCI_LINT_VER="v1.42.1"
 
 cd "${REPO_ROOT}"
 source "hack/util.sh"


### PR DESCRIPTION
Signed-off-by: iawia002 <z2d@jifangcheng.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The `golint` linter has been deprecated, I replaced it with the [revive](https://github.com/mgechev/revive) linter.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

/cc @RainbowMango 