### PR TITLE
Add workv1alpha2 to SkippedResourceConfig

### DIFF
--- a/pkg/util/apigroup.go
+++ b/pkg/util/apigroup.go
@@ -9,6 +9,7 @@ import (
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 )
 
 // SkippedResourceConfig represents the configuration that identifies the API resources should be skipped from propagating.
@@ -32,6 +33,7 @@ func NewSkippedResourceConfig() *SkippedResourceConfig {
 	r.DisableGroup(clusterv1alpha1.GroupVersion.Group)
 	r.DisableGroup(policyv1alpha1.GroupVersion.Group)
 	r.DisableGroup(workv1alpha1.GroupVersion.Group)
+	r.DisableGroup(workv1alpha2.GroupVersion.Group)
 	return r
 }
 


### PR DESCRIPTION
Signed-off-by: dddddai <dddwq@foxmail.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
#722 updated binding to `workv1alpha2`, but it didn't update `SkippedResourceConfig`, which means resource detector would reconcile `(Cluster)ResourceBingding` as normal resources and there would be pointless bingding objects consuming memory in the `waitingObjects`
https://github.com/karmada-io/karmada/blob/ede9fad83cebbb3dd4f0b4cfca7d05c9c109880f/pkg/util/detector/detector.go#L244-L245
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

