### PR TITLE
remove orphan work objects as much as possible

### DIFF
--- a/pkg/util/helper/binding.go
+++ b/pkg/util/helper/binding.go
@@ -141,12 +141,17 @@ func FindOrphanWorks(c client.Client, bindingNamespace, bindingName string, clus
 
 // RemoveOrphanWorks will remove orphan works.
 func RemoveOrphanWorks(c client.Client, works []workv1alpha1.Work) error {
+	var errs []error
 	for workIndex, work := range works {
 		err := c.Delete(context.TODO(), &works[workIndex])
 		if err != nil {
-			return err
+			klog.Errorf("Failed to delete orphan work %s/%s, err is %v", work.GetNamespace(), work.GetName(), err)
+			errs = append(errs, err)
 		}
 		klog.Infof("Delete orphan work %s/%s successfully.", work.GetNamespace(), work.GetName())
+	}
+	if len(errs) > 0 {
+		return errors.NewAggregate(errs)
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: wawa0210 <xiaozhang0210@hotmail.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Previously, deleting any item in the ophranworks array would interrupt the entire process, which is not very scientific. The reasonable logic should be to try to delete all the sub-items of the array, summarize the last abnormal items, and return

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

