### PR TITLE
replace deprecated package io/ioutil with packages io and os

### DIFF
--- a/pkg/clusterdiscovery/clusterapi/clusterapi.go
+++ b/pkg/clusterdiscovery/clusterapi/clusterapi.go
@@ -3,7 +3,7 @@ package clusterapi
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -200,7 +200,7 @@ func (d *ClusterDetector) unJoinClusterAPICluster(clusterName string) error {
 
 func generateKubeconfigFile(clusterName string, kubeconfigData []byte) (string, error) {
 	kubeconfigPath := fmt.Sprintf("/etc/%s.kubeconfig", clusterName)
-	err := ioutil.WriteFile(kubeconfigPath, kubeconfigData, 0600)
+	err := os.WriteFile(kubeconfigPath, kubeconfigData, 0600)
 	if err != nil {
 		klog.Errorf("Failed to write File %s: %v", kubeconfigPath, err)
 		return "", err

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -3,7 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -373,7 +373,7 @@ func podLogs(ctx context.Context, k8s kubernetes.Interface, namespace, name stri
 		return "", err
 	}
 	defer logs.Close()
-	data, err := ioutil.ReadAll(logs)
+	data, err := io.ReadAll(logs)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Signed-off-by: guoyao <1015105054@qq.com>

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind cleanup
/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
package `io/ioutil` is deprecated in Go1.16, and according to the official doc(https://golang.org/doc/go1.16#ioutil), we could use definitions in `io` and `os`.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

