### PR TITLE
Add FullyApplied to binding

### DIFF
--- a/pkg/apis/work/v1alpha2/binding_types.go
+++ b/pkg/apis/work/v1alpha2/binding_types.go
@@ -139,6 +139,10 @@ type AggregatedStatusItem struct {
 const (
 	// Scheduled represents the condition that the ResourceBinding or ClusterResourceBinding has been scheduled.
 	Scheduled string = "Scheduled"
+
+	// FullyApplied represents the condition that the resource referencing by ResourceBinding or ClusterResourceBinding
+	// has been applied to all scheduled clusters.
+	FullyApplied string = "FullyApplied"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -24,6 +24,12 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/overridemanager"
 )
 
+const (
+	FullyAppliedSuccessReason = "FullyAppliedSuccess"
+
+	FullyAppliedSuccessMessage = "All works have been successfully applied"
+)
+
 var workPredicateFn = builder.WithPredicates(predicate.Funcs{
 	CreateFunc: func(e event.CreateEvent) bool {
 		return false
@@ -322,4 +328,14 @@ func calculateReplicas(c client.Client, policy *policyv1alpha1.ReplicaScheduling
 	}
 
 	return desireReplicaInfos, nil
+}
+
+// areWorksFullyApplied checks if all works are applied for a Binding
+func areWorksFullyApplied(aggregatedStatuses []workv1alpha2.AggregatedStatusItem) bool {
+	for _, aggregatedSatusItem := range aggregatedStatuses {
+		if !aggregatedSatusItem.Applied {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
FullyApplied represents if the resource is applied to all of the scheduled clusters.

**Which issue(s) this PR fixes**:
Fixes #820 

**Special notes for your reviewer**:
The process also can be moved to `workstatus.go`, but that is not a accurate place for resourcebinding. so I put them to ResourceBindingController.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

