### PR TITLE
add work queue metrics for agent and controller-manager

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	_ "sigs.k8s.io/controller-runtime/pkg/metrics"
+
 	apiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"

--- a/cmd/scheduler-estimator/main.go
+++ b/cmd/scheduler-estimator/main.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	_ "sigs.k8s.io/controller-runtime/pkg/metrics"
+
 	apiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/component-base/logs"
 


### PR DESCRIPTION
Signed-off-by: Garrybest <garrybest@foxmail.com>

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
The async worker queue metrics will be registered [here](https://github.com/karmada-io/karmada/blob/master/vendor/sigs.k8s.io/controller-runtime/pkg/metrics/workqueue.go#L90-L101). So we should init the package first.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Instrumentation: Introduced several metrics(`workqueue_adds_total`, `workqueue_depth`, `workqueue_longest_running_processor_seconds`, `workqueue_queue_duration_seconds_bucket`) for `karmada-agent` and `karmada-controller-manager`.
```

