### PR TITLE
fatal when errors heppen in karmadactl

### DIFF
--- a/pkg/karmadactl/cordon.go
+++ b/pkg/karmadactl/cordon.go
@@ -52,18 +52,16 @@ func NewCmdCordon(cmdOut io.Writer, karmadaConfig KarmadaConfig, cmdStr string) 
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(args)
 			if err != nil {
-				klog.Errorf("Error: %v", err)
-				return
+				klog.Fatalf("Error: %v", err)
 			}
 
 			if errs := opts.Validate(); len(errs) != 0 {
-				klog.Error(utilerrors.NewAggregate(errs).Error())
-				return
+				klog.Fatalf("Error: %v", utilerrors.NewAggregate(errs).Error())
 			}
 
 			err = RunCordonOrUncordon(cmdOut, desiredCordon, karmadaConfig, opts)
 			if err != nil {
-				klog.Errorf("Error: %v", err)
+				klog.Fatalf("Error: %v", err)
 				return
 			}
 		},

--- a/pkg/karmadactl/join.go
+++ b/pkg/karmadactl/join.go
@@ -70,19 +70,16 @@ func NewCmdJoin(cmdOut io.Writer, karmadaConfig KarmadaConfig, cmdStr string) *c
 			// Set default values
 			err := opts.Complete(args)
 			if err != nil {
-				klog.Errorf("Error: %v", err)
-				return
+				klog.Fatalf("Error: %v", err)
 			}
 
 			if errs := opts.Validate(); len(errs) != 0 {
-				klog.Error(utilerrors.NewAggregate(errs).Error())
-				return
+				klog.Fatalf("Error: %v", utilerrors.NewAggregate(errs).Error())
 			}
 
 			err = RunJoin(cmdOut, karmadaConfig, opts)
 			if err != nil {
-				klog.Errorf("Error: %v", err)
-				return
+				klog.Fatalf("Error: %v", err)
 			}
 		},
 	}

--- a/pkg/karmadactl/unjoin.go
+++ b/pkg/karmadactl/unjoin.go
@@ -42,14 +42,12 @@ func NewCmdUnjoin(cmdOut io.Writer, karmadaConfig KarmadaConfig, cmdStr string) 
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(args)
 			if err != nil {
-				klog.Errorf("Error: %v", err)
-				return
+				klog.Fatalf("Error: %v", err)
 			}
 
 			err = RunUnjoin(cmdOut, karmadaConfig, opts)
 			if err != nil {
-				klog.Errorf("Error: %v", err)
-				return
+				klog.Fatalf("Error: %v", err)
 			}
 		},
 	}


### PR DESCRIPTION
Signed-off-by: lihanbo <lihanbo2@huawei.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Some users will check exection status of karmadactl commands according to the exit status. Thus, I suggest to use `klog.Fatalf` instead of return which will call os.Exit(255).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
"NONE"

