### PR TITLE
fix failed deletion of object in member cluster when object in host is deleted

### DIFF
--- a/pkg/controllers/execution/execution_controller.go
+++ b/pkg/controllers/execution/execution_controller.go
@@ -77,8 +77,8 @@ func (c *Controller) Reconcile(ctx context.Context, req controllerruntime.Reques
 				klog.Errorf("Failed to delete work %v, namespace is %v, err is %v", work.Name, work.Namespace, err)
 				return controllerruntime.Result{Requeue: true}, err
 			}
+			return c.removeFinalizer(work)
 		}
-		return c.removeFinalizer(work)
 	}
 
 	return c.syncWork(cluster, work)

--- a/pkg/util/objectwatcher/retain.go
+++ b/pkg/util/objectwatcher/retain.go
@@ -27,11 +27,12 @@ func RetainClusterFields(desiredObj, clusterObj *unstructured.Unstructured) erro
 	targetKind := desiredObj.GetKind()
 	// Pass the same ResourceVersion as in the cluster object for update operation, otherwise operation will fail.
 	desiredObj.SetResourceVersion(clusterObj.GetResourceVersion())
-
 	// Retain finalizers since they will typically be set by
 	// controllers in a member cluster.  It is still possible to set the fields
 	// via overrides.
 	desiredObj.SetFinalizers(clusterObj.GetFinalizers())
+	// Retain deletionGracePeriodSeconds because field `metadata.deletionGracePeriodSeconds` is immutable, otherwise operation will fail.
+	desiredObj.SetDeletionGracePeriodSeconds(clusterObj.GetDeletionGracePeriodSeconds())
 	// Merge annotations since they will typically be set by controllers in a member cluster
 	// and be set by user in karmada-controller-plane.
 	util.MergeAnnotations(desiredObj, clusterObj)


### PR DESCRIPTION
cluster is deleted

Signed-off-by: jingxueli <jingxueli@trip.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When object in host cluster is deleted,  deletion of object in member cluster may fail.

**Which issue(s) this PR fixes**:

```
Failed to update resource ...... metadata.deletionGracePeriodSeconds: Invalid value: 0: field is immutable
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

