### PR TITLE
refactor: add framework for e2e

### DIFF
--- a/test/e2e/clusterpropagationpolicy_test.go
+++ b/test/e2e/clusterpropagationpolicy_test.go
@@ -1,23 +1,14 @@
 package e2e
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog/v2"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
-	"github.com/karmada-io/karmada/pkg/util/helper"
+	"github.com/karmada-io/karmada/test/e2e/framework"
 	testhelper "github.com/karmada-io/karmada/test/helper"
 )
 
@@ -40,83 +31,20 @@ var _ = ginkgo.Describe("[BasicClusterPropagation] basic cluster propagation tes
 			},
 		}, policyv1alpha1.Placement{
 			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: clusterNames,
+				ClusterNames: framework.ClusterNames(),
 			},
-		})
-		crdGVR := schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}
-
-		ginkgo.BeforeEach(func() {
-			ginkgo.By(fmt.Sprintf("creating crdPolicy(%s)", crdPolicy.Name), func() {
-				_, err := karmadaClient.PolicyV1alpha1().ClusterPropagationPolicies().Create(context.TODO(), crdPolicy, metav1.CreateOptions{})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
-		})
-
-		ginkgo.AfterEach(func() {
-			ginkgo.By(fmt.Sprintf("removing crdPolicy(%s)", crdPolicy.Name), func() {
-				err := karmadaClient.PolicyV1alpha1().ClusterPropagationPolicies().Delete(context.TODO(), crdPolicy.Name, metav1.DeleteOptions{})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
 		})
 
 		ginkgo.It("crd propagation testing", func() {
-			ginkgo.By(fmt.Sprintf("creating crd(%s)", crd.Name), func() {
-				unstructObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(crd)
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			framework.CreateClusterPropagationPolicy(karmadaClient, crdPolicy)
+			framework.CreateCRD(dynamicClient, crd)
+			framework.GetCRD(dynamicClient, crd.Name)
+			framework.WaitCRDPresentOnClusters(karmadaClient, framework.ClusterNames(),
+				fmt.Sprintf("%s/%s", crd.Spec.Group, "v1alpha1"), crd.Spec.Names.Kind)
 
-				_, err = dynamicClient.Resource(crdGVR).Namespace(crd.Namespace).Create(context.TODO(), &unstructured.Unstructured{Object: unstructObj}, metav1.CreateOptions{})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
-
-			ginkgo.By(fmt.Sprintf("get crd(%s)", crd.Name), func() {
-				_, err := dynamicClient.Resource(crdGVR).Namespace(crd.Namespace).Get(context.TODO(), crd.Name, metav1.GetOptions{})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
-
-			// Check CRD enablement from cluster objects instead of member clusters.
-			// After CRD installed on member cluster, the cluster status controller takes at most cluster-status-update-frequency
-			// time to collect the API list, before that the scheduler will filter out the cluster from scheduling.
-			ginkgo.By("check if crd present on member clusters", func() {
-				crAPIVersion := fmt.Sprintf("%s/%s", crd.Spec.Group, "v1alpha1")
-				err := wait.PollImmediate(pollInterval, pollTimeout, func() (done bool, err error) {
-					clusters, err := fetchClusters(karmadaClient)
-					if err != nil {
-						return false, err
-					}
-					for _, cluster := range clusters {
-						if !helper.IsAPIEnabled(cluster.Status.APIEnablements, crAPIVersion, crdSpecNames.Kind) {
-							return false, nil
-						}
-					}
-					return true, nil
-				})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
-
-			ginkgo.By(fmt.Sprintf("removing crd(%s)", crd.Name), func() {
-				err := dynamicClient.Resource(crdGVR).Namespace(crd.Namespace).Delete(context.TODO(), crd.Name, metav1.DeleteOptions{})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
-
-			ginkgo.By("check if crd disappeared from member clusters", func() {
-				for _, cluster := range clusters {
-					clusterDynamicClient := getClusterDynamicClient(cluster.Name)
-					gomega.Expect(clusterDynamicClient).ShouldNot(gomega.BeNil())
-
-					klog.Infof("Waiting for crd(%s) disappeared on cluster(%s)", crd.Name, cluster.Name)
-					err := wait.PollImmediate(pollInterval, pollTimeout, func() (done bool, err error) {
-						_, err = clusterDynamicClient.Resource(crdGVR).Namespace(crd.Namespace).Get(context.TODO(), crd.Name, metav1.GetOptions{})
-						if err != nil {
-							if apierrors.IsNotFound(err) {
-								return true, nil
-							}
-							return false, err
-						}
-						return false, nil
-					})
-					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-				}
-			})
+			framework.RemoveCRD(dynamicClient, crd.Name)
+			framework.WaitCRDDisappearedOnClusters(framework.ClusterNames(), crd.Name)
+			framework.RemoveClusterPropagationPolicy(karmadaClient, crdPolicy.Name)
 		})
 	})
 })

--- a/test/e2e/framework/cluster.go
+++ b/test/e2e/framework/cluster.go
@@ -1,0 +1,228 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	karmada "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
+	"github.com/karmada-io/karmada/pkg/util"
+)
+
+const (
+	// MinimumCluster represents the minimum number of member clusters to run E2E test.
+	MinimumCluster = 2
+)
+
+var (
+	clusters              []*clusterv1alpha1.Cluster
+	clusterNames          []string
+	clusterClients        []*util.ClusterClient
+	clusterDynamicClients []*util.DynamicClusterClient
+	pullModeClusters      map[string]string
+)
+
+// Clusters will return all member clusters we have.
+func Clusters() []*clusterv1alpha1.Cluster {
+	return clusters
+}
+
+// ClusterNames will return all member clusters' names we have.
+func ClusterNames() []string {
+	return clusterNames
+}
+
+// InitClusterInformation init the E2E test's cluster information.
+func InitClusterInformation(karmadaClient karmada.Interface, controlPlaneClient client.Client) {
+	var err error
+
+	pullModeClusters, err = fetchPullBasedClusters()
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	clusters, err = fetchClusters(karmadaClient)
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	var meetRequirement bool
+	meetRequirement, err = isClusterMeetRequirements(clusters)
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	gomega.Expect(meetRequirement).Should(gomega.BeTrue())
+
+	for _, cluster := range clusters {
+		clusterClient, clusterDynamicClient, err := newClusterClientSet(controlPlaneClient, cluster)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		clusterNames = append(clusterNames, cluster.Name)
+		clusterClients = append(clusterClients, clusterClient)
+		clusterDynamicClients = append(clusterDynamicClients, clusterDynamicClient)
+
+		err = setClusterLabel(controlPlaneClient, cluster.Name)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	}
+	gomega.Expect(clusterNames).Should(gomega.HaveLen(len(clusters)))
+}
+
+// GetClusterClient get cluster client
+func GetClusterClient(clusterName string) kubernetes.Interface {
+	for _, clusterClient := range clusterClients {
+		if clusterClient.ClusterName == clusterName {
+			return clusterClient.KubeClient
+		}
+	}
+
+	return nil
+}
+
+// GetClusterDynamicClient get cluster dynamicClient
+func GetClusterDynamicClient(clusterName string) dynamic.Interface {
+	for _, clusterClient := range clusterDynamicClients {
+		if clusterClient.ClusterName == clusterName {
+			return clusterClient.DynamicClientSet
+		}
+	}
+
+	return nil
+}
+
+func fetchPullBasedClusters() (map[string]string, error) {
+	pullBasedClusters := os.Getenv("PULL_BASED_CLUSTERS")
+	if pullBasedClusters == "" {
+		return nil, nil
+	}
+
+	pullBasedClustersMap := make(map[string]string)
+	pullBasedClusters = strings.TrimSuffix(pullBasedClusters, ";")
+	clusterInfo := strings.Split(pullBasedClusters, ";")
+	for _, cluster := range clusterInfo {
+		clusterNameAndConfigPath := strings.Split(cluster, ":")
+		if len(clusterNameAndConfigPath) != 2 {
+			return nil, fmt.Errorf("failed to parse config path for cluster: %s", cluster)
+		}
+		pullBasedClustersMap[clusterNameAndConfigPath[0]] = clusterNameAndConfigPath[1]
+	}
+	return pullBasedClustersMap, nil
+}
+
+// fetchClusters will fetch all member clusters we have.
+func fetchClusters(client karmada.Interface) ([]*clusterv1alpha1.Cluster, error) {
+	clusterList, err := client.ClusterV1alpha1().Clusters().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	clusters := make([]*clusterv1alpha1.Cluster, 0, len(clusterList.Items))
+	for _, cluster := range clusterList.Items {
+		pinedCluster := cluster
+		if pinedCluster.Spec.SyncMode == clusterv1alpha1.Pull {
+			if _, exist := pullModeClusters[cluster.Name]; !exist {
+				continue
+			}
+		}
+		clusters = append(clusters, &pinedCluster)
+	}
+
+	return clusters, nil
+}
+
+// fetchCluster will fetch member cluster by name.
+func fetchCluster(client karmada.Interface, clusterName string) (*clusterv1alpha1.Cluster, error) {
+	cluster, err := client.ClusterV1alpha1().Clusters().Get(context.TODO(), clusterName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return cluster, nil
+}
+
+// isClusterMeetRequirements checks if current environment meet the requirements of E2E.
+func isClusterMeetRequirements(clusters []*clusterv1alpha1.Cluster) (bool, error) {
+	// check if member cluster number meets requirements
+	if len(clusters) < MinimumCluster {
+		return false, fmt.Errorf("needs at lease %d member cluster to run, but got: %d", MinimumCluster, len(clusters))
+	}
+
+	// check if all member cluster status is ready
+	for _, cluster := range clusters {
+		if !util.IsClusterReady(&cluster.Status) {
+			return false, fmt.Errorf("cluster %s not ready", cluster.GetName())
+		}
+	}
+
+	klog.Infof("Got %d member cluster and all in ready state.", len(clusters))
+	return true, nil
+}
+
+func newClusterClientSet(controlPlaneClient client.Client, c *clusterv1alpha1.Cluster) (*util.ClusterClient, *util.DynamicClusterClient, error) {
+	if c.Spec.SyncMode == clusterv1alpha1.Push {
+		clusterClient, err := util.NewClusterClientSet(c, controlPlaneClient, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		clusterDynamicClient, err := util.NewClusterDynamicClientSet(c, controlPlaneClient)
+		if err != nil {
+			return nil, nil, err
+		}
+		return clusterClient, clusterDynamicClient, nil
+	}
+
+	clusterConfigPath := pullModeClusters[c.Name]
+	clusterConfig, err := clientcmd.BuildConfigFromFlags("", clusterConfigPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	clusterClientSet := util.ClusterClient{ClusterName: c.Name}
+	clusterDynamicClientSet := util.DynamicClusterClient{ClusterName: c.Name}
+	clusterClientSet.KubeClient = kubernetes.NewForConfigOrDie(clusterConfig)
+	clusterDynamicClientSet.DynamicClientSet = dynamic.NewForConfigOrDie(clusterConfig)
+
+	return &clusterClientSet, &clusterDynamicClientSet, nil
+}
+
+// setClusterLabel set cluster label of E2E
+func setClusterLabel(c client.Client, clusterName string) error {
+	err := wait.PollImmediate(2*time.Second, 10*time.Second, func() (done bool, err error) {
+		clusterObj := &clusterv1alpha1.Cluster{}
+		if err := c.Get(context.TODO(), client.ObjectKey{Name: clusterName}, clusterObj); err != nil {
+			if apierrors.IsConflict(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		if clusterObj.Labels == nil {
+			clusterObj.Labels = make(map[string]string)
+		}
+		clusterObj.Labels["location"] = "CHN"
+		if clusterObj.Spec.SyncMode == clusterv1alpha1.Push {
+			clusterObj.Labels["sync-mode"] = "Push"
+		}
+		if err := c.Update(context.TODO(), clusterObj); err != nil {
+			if apierrors.IsConflict(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+	return err
+}
+
+// GetClusterNamesFromClusters will get Clusters' names form Clusters Object.
+func GetClusterNamesFromClusters(clusters []*clusterv1alpha1.Cluster) []string {
+	clusterNames := make([]string, 0, len(clusters))
+	for _, cluster := range clusters {
+		clusterNames = append(clusterNames, cluster.Name)
+	}
+	return clusterNames
+}

--- a/test/e2e/framework/clusterpropagationpolicy.go
+++ b/test/e2e/framework/clusterpropagationpolicy.go
@@ -1,0 +1,29 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	karmada "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
+)
+
+// CreateClusterPropagationPolicy create ClusterPropagationPolicy with karmada client.
+func CreateClusterPropagationPolicy(client karmada.Interface, policy *policyv1alpha1.ClusterPropagationPolicy) {
+	ginkgo.By(fmt.Sprintf("Creating ClusterPropagationPolicy(%s)", policy.Name), func() {
+		_, err := client.PolicyV1alpha1().ClusterPropagationPolicies().Create(context.TODO(), policy, metav1.CreateOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+}
+
+// RemoveClusterPropagationPolicy delete ClusterPropagationPolicy with karmada client.
+func RemoveClusterPropagationPolicy(client karmada.Interface, name string) {
+	ginkgo.By(fmt.Sprintf("Removing ClusterPropagationPolicy(%s)", name), func() {
+		err := client.PolicyV1alpha1().ClusterPropagationPolicies().Delete(context.TODO(), name, metav1.DeleteOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+}

--- a/test/e2e/framework/constant.go
+++ b/test/e2e/framework/constant.go
@@ -1,0 +1,10 @@
+package framework
+
+import "time"
+
+const (
+	// pollInterval defines the interval time for a poll operation.
+	pollInterval = 5 * time.Second
+	// pollTimeout defines the time after which the poll operation times out.
+	pollTimeout = 300 * time.Second
+)

--- a/test/e2e/framework/customresourcedefine.go
+++ b/test/e2e/framework/customresourcedefine.go
@@ -1,0 +1,83 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
+
+	karmada "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
+	"github.com/karmada-io/karmada/pkg/util/helper"
+)
+
+var crdGVR = schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}
+
+// CreateCRD create CustomResourceDefinition with dynamic client.
+func CreateCRD(client dynamic.Interface, crd *apiextensionsv1.CustomResourceDefinition) {
+	ginkgo.By(fmt.Sprintf("Creating crd(%s)", crd.Name), func() {
+		unstructObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(crd)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+		_, err = client.Resource(crdGVR).Create(context.TODO(), &unstructured.Unstructured{Object: unstructObj}, metav1.CreateOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+}
+
+// GetCRD get CustomResourceDefinition with dynamic client.
+func GetCRD(client dynamic.Interface, name string) {
+	ginkgo.By(fmt.Sprintf("Get crd(%s)", name), func() {
+		_, err := client.Resource(crdGVR).Get(context.TODO(), name, metav1.GetOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+}
+
+// RemoveCRD delete CustomResourceDefinition with dynamic client.
+func RemoveCRD(client dynamic.Interface, name string) {
+	ginkgo.By(fmt.Sprintf("Removing crd(%s)", name), func() {
+		err := client.Resource(crdGVR).Delete(context.TODO(), name, metav1.DeleteOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+}
+
+// WaitCRDPresentOnClusters wait CustomResourceDefinition present on clusters until timeout.
+func WaitCRDPresentOnClusters(client karmada.Interface, clusters []string, crdAPIVersion, crdKind string) {
+	// Check CRD enablement from cluster objects instead of member clusters.
+	// After CRD installed on member cluster, the cluster status controller takes at most cluster-status-update-frequency
+	// time to collect the API list, before that the scheduler will filter out the cluster from scheduling.
+	ginkgo.By(fmt.Sprintf("Check if crd(%s/%s) present on member clusters", crdAPIVersion, crdKind), func() {
+		for _, clusterName := range clusters {
+			klog.Infof("Waiting for crd present on cluster(%s)", clusterName)
+			gomega.Eventually(func() bool {
+				cluster, err := fetchCluster(client, clusterName)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+				return helper.IsAPIEnabled(cluster.Status.APIEnablements, crdAPIVersion, crdKind)
+			}, pollTimeout, pollInterval).Should(gomega.Equal(true))
+		}
+	})
+}
+
+// WaitCRDDisappearedOnClusters wait CustomResourceDefinition disappear on clusters until timeout.
+func WaitCRDDisappearedOnClusters(clusters []string, crdName string) {
+	ginkgo.By("Check if crd disappeared on member clusters", func() {
+		for _, clusterName := range clusters {
+			clusterDynamicClient := GetClusterDynamicClient(clusterName)
+			gomega.Expect(clusterDynamicClient).ShouldNot(gomega.BeNil())
+
+			klog.Infof("Waiting for crd(%s) disappeared on cluster(%s)", crdName, clusterName)
+			gomega.Eventually(func() bool {
+				_, err := clusterDynamicClient.Resource(crdGVR).Get(context.TODO(), crdName, metav1.GetOptions{})
+				return apierrors.IsNotFound(err)
+			}, pollTimeout, pollInterval).Should(gomega.Equal(true))
+		}
+	})
+}

--- a/test/e2e/framework/deployment.go
+++ b/test/e2e/framework/deployment.go
@@ -1,0 +1,86 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+// CreateDeployment create Deployment.
+func CreateDeployment(client kubernetes.Interface, deployment *appsv1.Deployment) {
+	ginkgo.By(fmt.Sprintf("Creating Deployment(%s/%s)", deployment.Namespace, deployment.Name), func() {
+		_, err := client.AppsV1().Deployments(deployment.Namespace).Create(context.TODO(), deployment, metav1.CreateOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+}
+
+// RemoveDeployment delete Deployment.
+func RemoveDeployment(client kubernetes.Interface, namespace, name string) {
+	ginkgo.By(fmt.Sprintf("Removing Deployment(%s/%s)", namespace, name), func() {
+		err := client.AppsV1().Deployments(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+}
+
+// WaitDeploymentPresentOnClusters wait deployment present on member clusters until timeout.
+func WaitDeploymentPresentOnClusters(clusters []string, namespace, name string) {
+	ginkgo.By(fmt.Sprintf("Check if deployment(%s/%s) present on member clusters", namespace, name), func() {
+		for _, clusterName := range clusters {
+			clusterClient := GetClusterClient(clusterName)
+			gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+
+			klog.Infof("Waiting for deployment present on cluster(%s)", clusterName)
+			gomega.Eventually(func() bool {
+				_, err := clusterClient.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+				return true
+			}, pollTimeout, pollInterval).Should(gomega.Equal(true))
+		}
+	})
+}
+
+// WaitDeploymentDisappearOnClusters wait deployment disappear on member clusters until timeout.
+func WaitDeploymentDisappearOnClusters(clusters []string, namespace, name string) {
+	ginkgo.By(fmt.Sprintf("Check if deployment(%s/%s) diappeare on member clusters", namespace, name), func() {
+		for _, clusterName := range clusters {
+			clusterClient := GetClusterClient(clusterName)
+			gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+
+			klog.Infof("Waiting for deployment disappear on cluster(%s)", clusterName)
+			gomega.Eventually(func() bool {
+				_, err := clusterClient.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+				return apierrors.IsNotFound(err)
+			}, pollTimeout, pollInterval).Should(gomega.Equal(true))
+		}
+	})
+}
+
+// UpdateDeploymentReplicas update deployment's replicas.
+func UpdateDeploymentReplicas(client kubernetes.Interface, deployment *appsv1.Deployment, replicas int32) {
+	ginkgo.By(fmt.Sprintf("Updating Deployment(%s/%s)'s replicas to %d", deployment.Namespace, deployment.Name, replicas), func() {
+		deployment.Spec.Replicas = &replicas
+		gomega.Eventually(func() error {
+			_, err := client.AppsV1().Deployments(deployment.Namespace).Update(context.TODO(), deployment, metav1.UpdateOptions{})
+			return err
+		}, pollTimeout, pollInterval).ShouldNot(gomega.HaveOccurred())
+	})
+}
+
+// WaitDeploymentPresentOnClusterFitWith wait deployment present on member clusters fit with fit func.
+func WaitDeploymentPresentOnClusterFitWith(client kubernetes.Interface, namespace, name string, fit func(deployment *appsv1.Deployment) bool) {
+	gomega.Eventually(func() bool {
+		dep, err := client.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return fit(dep)
+	}, pollTimeout, pollInterval).Should(gomega.Equal(true))
+}

--- a/test/e2e/framework/propagationpolicy.go
+++ b/test/e2e/framework/propagationpolicy.go
@@ -1,0 +1,29 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	karmada "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
+)
+
+// CreatePropagationPolicy create PropagationPolicy with karmada client.
+func CreatePropagationPolicy(client karmada.Interface, policy *policyv1alpha1.PropagationPolicy) {
+	ginkgo.By(fmt.Sprintf("Creating PropataionPolicy(%s/%s)", policy.Namespace, policy.Name), func() {
+		_, err := client.PolicyV1alpha1().PropagationPolicies(policy.Namespace).Create(context.TODO(), policy, metav1.CreateOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+}
+
+// RemovePropagationPolicy delete PropagationPolicy with karmada client.
+func RemovePropagationPolicy(client karmada.Interface, namespace, name string) {
+	ginkgo.By(fmt.Sprintf("Removing PropataionPolicy(%s/%s)", namespace, name), func() {
+		err := client.PolicyV1alpha1().PropagationPolicies(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+}

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/karmadactl"
 	"github.com/karmada-io/karmada/pkg/karmadactl/options"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/test/e2e/framework"
 	"github.com/karmada-io/karmada/test/helper"
 )
 
@@ -39,8 +40,8 @@ var _ = ginkgo.Describe("[namespace auto-provision] namespace auto-provision tes
 
 		ginkgo.It("namespace should be propagated to member clusters", func() {
 			ginkgo.By("check if namespace appear in member clusters", func() {
-				for _, cluster := range clusters {
-					clusterClient := getClusterClient(cluster.Name)
+				for _, cluster := range framework.Clusters() {
+					clusterClient := framework.GetClusterClient(cluster.Name)
 					gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
 
 					err := wait.PollImmediate(pollInterval, pollTimeout, func() (done bool, err error) {
@@ -70,8 +71,8 @@ var _ = ginkgo.Describe("[namespace auto-provision] namespace auto-provision tes
 			})
 
 			ginkgo.By("check if namespace appear in member clusters", func() {
-				for _, cluster := range clusters {
-					clusterClient := getClusterClient(cluster.Name)
+				for _, cluster := range framework.Clusters() {
+					clusterClient := framework.GetClusterClient(cluster.Name)
 					gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
 
 					err := wait.PollImmediate(pollInterval, pollTimeout, func() (done bool, err error) {
@@ -97,8 +98,8 @@ var _ = ginkgo.Describe("[namespace auto-provision] namespace auto-provision tes
 			})
 
 			ginkgo.By(fmt.Sprintf("namespace(%s) shoud be disappeared", namespaceName), func() {
-				for _, cluster := range clusters {
-					clusterClient := getClusterClient(cluster.Name)
+				for _, cluster := range framework.Clusters() {
+					clusterClient := framework.GetClusterClient(cluster.Name)
 					gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
 
 					err := wait.PollImmediate(pollInterval, pollTimeout, func() (done bool, err error) {

--- a/test/e2e/overridepolicy_test.go
+++ b/test/e2e/overridepolicy_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/klog/v2"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	"github.com/karmada-io/karmada/test/e2e/framework"
 	"github.com/karmada-io/karmada/test/helper"
 )
 
@@ -36,7 +37,7 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 			},
 		}, policyv1alpha1.Placement{
 			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: clusterNames,
+				ClusterNames: framework.ClusterNames(),
 			},
 		})
 		overridePolicy := helper.NewOverridePolicy(overridePolicyNamespace, overridePolicyName, []policyv1alpha1.ResourceSelector{
@@ -46,7 +47,7 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 				Name:       deployment.Name,
 			},
 		}, policyv1alpha1.ClusterAffinity{
-			ClusterNames: clusterNames,
+			ClusterNames: framework.ClusterNames(),
 		}, policyv1alpha1.Overriders{
 			ImageOverrider: []policyv1alpha1.ImageOverrider{
 				{
@@ -68,10 +69,7 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 		})
 
 		ginkgo.BeforeEach(func() {
-			ginkgo.By(fmt.Sprintf("creating propagationPolicy(%s/%s)", propagationPolicyNamespace, propagationPolicyName), func() {
-				_, err := karmadaClient.PolicyV1alpha1().PropagationPolicies(propagationPolicyNamespace).Create(context.TODO(), propagationPolicy, metav1.CreateOptions{})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
+			framework.CreatePropagationPolicy(karmadaClient, propagationPolicy)
 		})
 
 		ginkgo.BeforeEach(func() {
@@ -89,21 +87,15 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 		})
 
 		ginkgo.AfterEach(func() {
-			ginkgo.By(fmt.Sprintf("removing propagationPolicy(%s/%s)", propagationPolicyNamespace, propagationPolicyName), func() {
-				err := karmadaClient.PolicyV1alpha1().PropagationPolicies(propagationPolicyNamespace).Delete(context.TODO(), propagationPolicyName, metav1.DeleteOptions{})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
+			framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
 		})
 
 		ginkgo.It("deployment imageOverride testing", func() {
-			ginkgo.By(fmt.Sprintf("creating deployment(%s/%s)", deploymentNamespace, deploymentName), func() {
-				_, err := kubeClient.AppsV1().Deployments(testNamespace).Create(context.TODO(), deployment, metav1.CreateOptions{})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
+			framework.CreateDeployment(kubeClient, deployment)
 
 			ginkgo.By("check if deployment present on member clusters have correct image value", func() {
-				for _, cluster := range clusters {
-					clusterClient := getClusterClient(cluster.Name)
+				for _, cluster := range framework.Clusters() {
+					clusterClient := framework.GetClusterClient(cluster.Name)
 					gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
 
 					var deploymentInCluster *appsv1.Deployment
@@ -127,10 +119,7 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 				}
 			})
 
-			ginkgo.By(fmt.Sprintf("removing deployment(%s/%s)", deploymentNamespace, deploymentName), func() {
-				err := kubeClient.AppsV1().Deployments(testNamespace).Delete(context.TODO(), deploymentName, metav1.DeleteOptions{})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
+			framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
 		})
 
 	})
@@ -152,7 +141,7 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 			},
 		}, policyv1alpha1.Placement{
 			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: clusterNames,
+				ClusterNames: framework.ClusterNames(),
 			},
 		})
 		overridePolicy := helper.NewOverridePolicy(overridePolicyNamespace, overridePolicyName, []policyv1alpha1.ResourceSelector{
@@ -162,7 +151,7 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 				Name:       pod.Name,
 			},
 		}, policyv1alpha1.ClusterAffinity{
-			ClusterNames: clusterNames,
+			ClusterNames: framework.ClusterNames(),
 		}, policyv1alpha1.Overriders{
 			ImageOverrider: []policyv1alpha1.ImageOverrider{
 				{
@@ -184,10 +173,7 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 		})
 
 		ginkgo.BeforeEach(func() {
-			ginkgo.By(fmt.Sprintf("creating propagationPolicy(%s/%s)", propagationPolicyNamespace, propagationPolicyName), func() {
-				_, err := karmadaClient.PolicyV1alpha1().PropagationPolicies(propagationPolicyNamespace).Create(context.TODO(), propagationPolicy, metav1.CreateOptions{})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
+			framework.CreatePropagationPolicy(karmadaClient, propagationPolicy)
 		})
 
 		ginkgo.BeforeEach(func() {
@@ -205,10 +191,7 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 		})
 
 		ginkgo.AfterEach(func() {
-			ginkgo.By(fmt.Sprintf("removing propagationPolicy(%s/%s)", propagationPolicyNamespace, propagationPolicyName), func() {
-				err := karmadaClient.PolicyV1alpha1().PropagationPolicies(propagationPolicyNamespace).Delete(context.TODO(), propagationPolicyName, metav1.DeleteOptions{})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
+			framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
 		})
 
 		ginkgo.It("pod imageOverride testing", func() {
@@ -218,8 +201,8 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 			})
 
 			ginkgo.By("check if pod present on member clusters have correct image value", func() {
-				for _, cluster := range clusters {
-					clusterClient := getClusterClient(cluster.Name)
+				for _, cluster := range framework.Clusters() {
+					clusterClient := framework.GetClusterClient(cluster.Name)
 					gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
 
 					var podInClusters *corev1.Pod
@@ -269,7 +252,7 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 			},
 		}, policyv1alpha1.Placement{
 			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: clusterNames,
+				ClusterNames: framework.ClusterNames(),
 			},
 		})
 		overridePolicy := helper.NewOverridePolicy(overridePolicyNamespace, overridePolicyName, []policyv1alpha1.ResourceSelector{
@@ -279,7 +262,7 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 				Name:       deployment.Name,
 			},
 		}, policyv1alpha1.ClusterAffinity{
-			ClusterNames: clusterNames,
+			ClusterNames: framework.ClusterNames(),
 		}, policyv1alpha1.Overriders{
 			ImageOverrider: []policyv1alpha1.ImageOverrider{
 				{
@@ -294,10 +277,7 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 		})
 
 		ginkgo.BeforeEach(func() {
-			ginkgo.By(fmt.Sprintf("creating propagationPolicy(%s/%s)", propagationPolicyNamespace, propagationPolicyName), func() {
-				_, err := karmadaClient.PolicyV1alpha1().PropagationPolicies(propagationPolicyNamespace).Create(context.TODO(), propagationPolicy, metav1.CreateOptions{})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
+			framework.CreatePropagationPolicy(karmadaClient, propagationPolicy)
 		})
 
 		ginkgo.BeforeEach(func() {
@@ -315,21 +295,15 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 		})
 
 		ginkgo.AfterEach(func() {
-			ginkgo.By(fmt.Sprintf("removing propagationPolicy(%s/%s)", propagationPolicyNamespace, propagationPolicyName), func() {
-				err := karmadaClient.PolicyV1alpha1().PropagationPolicies(propagationPolicyNamespace).Delete(context.TODO(), propagationPolicyName, metav1.DeleteOptions{})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
+			framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
 		})
 
 		ginkgo.It("deployment imageOverride testing", func() {
-			ginkgo.By(fmt.Sprintf("creating deployment(%s/%s)", deploymentNamespace, deploymentName), func() {
-				_, err := kubeClient.AppsV1().Deployments(testNamespace).Create(context.TODO(), deployment, metav1.CreateOptions{})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
+			framework.CreateDeployment(kubeClient, deployment)
 
 			ginkgo.By("check if deployment present on member clusters have correct image value", func() {
-				for _, cluster := range clusters {
-					clusterClient := getClusterClient(cluster.Name)
+				for _, cluster := range framework.Clusters() {
+					clusterClient := framework.GetClusterClient(cluster.Name)
 					gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
 
 					var deploymentInCluster *appsv1.Deployment
@@ -351,10 +325,7 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 				}
 			})
 
-			ginkgo.By(fmt.Sprintf("removing deployment(%s/%s)", deploymentNamespace, deploymentName), func() {
-				err := kubeClient.AppsV1().Deployments(testNamespace).Delete(context.TODO(), deploymentName, metav1.DeleteOptions{})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
+			framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
 		})
 
 	})
@@ -378,11 +349,11 @@ var _ = ginkgo.Describe("OverridePolicy with nil resourceSelectors", func() {
 			},
 		}, policyv1alpha1.Placement{
 			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: clusterNames,
+				ClusterNames: framework.ClusterNames(),
 			},
 		})
 		overridePolicy := helper.NewOverridePolicy(overridePolicyNamespace, overridePolicyName, nil, policyv1alpha1.ClusterAffinity{
-			ClusterNames: clusterNames,
+			ClusterNames: framework.ClusterNames(),
 		}, policyv1alpha1.Overriders{
 			ImageOverrider: []policyv1alpha1.ImageOverrider{
 				{
@@ -397,10 +368,7 @@ var _ = ginkgo.Describe("OverridePolicy with nil resourceSelectors", func() {
 		})
 
 		ginkgo.BeforeEach(func() {
-			ginkgo.By(fmt.Sprintf("creating propagationPolicy(%s/%s)", propagationPolicyNamespace, propagationPolicyName), func() {
-				_, err := karmadaClient.PolicyV1alpha1().PropagationPolicies(propagationPolicyNamespace).Create(context.TODO(), propagationPolicy, metav1.CreateOptions{})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
+			framework.CreatePropagationPolicy(karmadaClient, propagationPolicy)
 		})
 
 		ginkgo.BeforeEach(func() {
@@ -418,21 +386,15 @@ var _ = ginkgo.Describe("OverridePolicy with nil resourceSelectors", func() {
 		})
 
 		ginkgo.AfterEach(func() {
-			ginkgo.By(fmt.Sprintf("removing propagationPolicy(%s/%s)", propagationPolicyNamespace, propagationPolicyName), func() {
-				err := karmadaClient.PolicyV1alpha1().PropagationPolicies(propagationPolicyNamespace).Delete(context.TODO(), propagationPolicyName, metav1.DeleteOptions{})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
+			framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
 		})
 
 		ginkgo.It("deployment imageOverride testing", func() {
-			ginkgo.By(fmt.Sprintf("creating deployment(%s/%s)", deploymentNamespace, deploymentName), func() {
-				_, err := kubeClient.AppsV1().Deployments(testNamespace).Create(context.TODO(), deployment, metav1.CreateOptions{})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
+			framework.CreateDeployment(kubeClient, deployment)
 
 			ginkgo.By("check if deployment present on member clusters have correct image value", func() {
-				for _, cluster := range clusters {
-					clusterClient := getClusterClient(cluster.Name)
+				for _, cluster := range framework.Clusters() {
+					clusterClient := framework.GetClusterClient(cluster.Name)
 					gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
 
 					var deploymentInCluster *appsv1.Deployment
@@ -454,10 +416,7 @@ var _ = ginkgo.Describe("OverridePolicy with nil resourceSelectors", func() {
 				}
 			})
 
-			ginkgo.By(fmt.Sprintf("removing deployment(%s/%s)", deploymentNamespace, deploymentName), func() {
-				err := kubeClient.AppsV1().Deployments(testNamespace).Delete(context.TODO(), deploymentName, metav1.DeleteOptions{})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
+			framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
 		})
 
 	})

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -13,14 +12,12 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/kind/pkg/cluster"
 	"sigs.k8s.io/kind/pkg/exec"
@@ -29,6 +26,7 @@ import (
 	karmada "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
+	"github.com/karmada-io/karmada/test/e2e/framework"
 	"github.com/karmada-io/karmada/test/helper"
 )
 
@@ -42,9 +40,6 @@ const (
 	pollInterval = 5 * time.Second
 	// pollTimeout defines the time after which the poll operation times out.
 	pollTimeout = 300 * time.Second
-
-	// MinimumCluster represents the minimum number of member clusters to run E2E test.
-	MinimumCluster = 2
 
 	// RandomStrLength represents the random string length to combine names.
 	RandomStrLength = 3
@@ -71,13 +66,8 @@ var (
 	karmadaClient         karmada.Interface
 	dynamicClient         dynamic.Interface
 	controlPlaneClient    client.Client
-	clusters              []*clusterv1alpha1.Cluster
-	clusterNames          []string
-	clusterClients        []*util.ClusterClient
-	clusterDynamicClients []*util.DynamicClusterClient
 	testNamespace         = fmt.Sprintf("karmadatest-%s", rand.String(RandomStrLength))
 	clusterProvider       *cluster.Provider
-	pullModeClusters      map[string]string
 	clusterLabels         = map[string]string{"location": "CHN"}
 	pushModeClusterLabels = map[string]string{"sync-mode": "Push"}
 )
@@ -107,112 +97,28 @@ var _ = ginkgo.BeforeSuite(func() {
 
 	controlPlaneClient = gclient.NewForConfigOrDie(restConfig)
 
-	pullModeClusters, err = fetchPullBasedClusters()
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	framework.InitClusterInformation(karmadaClient, controlPlaneClient)
 
-	clusters, err = fetchClusters(karmadaClient)
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-
-	var meetRequirement bool
-	meetRequirement, err = isClusterMeetRequirements(clusters)
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-	gomega.Expect(meetRequirement).Should(gomega.BeTrue())
-
-	for _, cluster := range clusters {
-		clusterClient, clusterDynamicClient, err := newClusterClientSet(cluster)
-		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-		clusterNames = append(clusterNames, cluster.Name)
-		clusterClients = append(clusterClients, clusterClient)
-		clusterDynamicClients = append(clusterDynamicClients, clusterDynamicClient)
-
-		err = SetClusterLabel(controlPlaneClient, cluster.Name)
-		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-	}
-	gomega.Expect(clusterNames).Should(gomega.HaveLen(len(clusters)))
-
-	clusters, err = fetchClusters(karmadaClient)
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-
-	fmt.Printf("There are %d clusters\n", len(clusters))
-
-	err = setupTestNamespace(testNamespace, kubeClient, clusterClients)
+	err = setupTestNamespace(testNamespace, kubeClient)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 }, TestSuiteSetupTimeOut.Seconds())
 
 var _ = ginkgo.AfterSuite(func() {
 	// cleanup clusterLabels set by the E2E test
-	for _, cluster := range clusters {
-		err := DeleteClusterLabel(controlPlaneClient, cluster.Name)
+	for _, cluster := range framework.Clusters() {
+		err := deleteClusterLabel(controlPlaneClient, cluster.Name)
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	}
 
 	// cleanup all namespaces we created both in control plane and member clusters.
 	// It will not return error even if there is no such namespace in there that may happen in case setup failed.
-	err := cleanupTestNamespace(testNamespace, kubeClient, clusterClients)
+	err := cleanupTestNamespace(testNamespace, kubeClient)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 }, TestSuiteTeardownTimeOut.Seconds())
 
-func fetchPullBasedClusters() (map[string]string, error) {
-	pullBasedClusters := os.Getenv("PULL_BASED_CLUSTERS")
-	if pullBasedClusters == "" {
-		return nil, nil
-	}
-
-	pullBasedClustersMap := make(map[string]string)
-	pullBasedClusters = strings.TrimSuffix(pullBasedClusters, ";")
-	clusterInfo := strings.Split(pullBasedClusters, ";")
-	for _, cluster := range clusterInfo {
-		clusterNameAndConfigPath := strings.Split(cluster, ":")
-		if len(clusterNameAndConfigPath) != 2 {
-			return nil, fmt.Errorf("failed to parse config path for cluster: %s", cluster)
-		}
-		pullBasedClustersMap[clusterNameAndConfigPath[0]] = clusterNameAndConfigPath[1]
-	}
-	return pullBasedClustersMap, nil
-}
-
-// fetchClusters will fetch all member clusters we have.
-func fetchClusters(client karmada.Interface) ([]*clusterv1alpha1.Cluster, error) {
-	clusterList, err := client.ClusterV1alpha1().Clusters().List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	clusters := make([]*clusterv1alpha1.Cluster, 0, len(clusterList.Items))
-	for _, cluster := range clusterList.Items {
-		pinedCluster := cluster
-		if pinedCluster.Spec.SyncMode == clusterv1alpha1.Pull {
-			if _, exist := pullModeClusters[cluster.Name]; !exist {
-				continue
-			}
-		}
-		clusters = append(clusters, &pinedCluster)
-	}
-
-	return clusters, nil
-}
-
-// isClusterMeetRequirements checks if current environment meet the requirements of E2E.
-func isClusterMeetRequirements(clusters []*clusterv1alpha1.Cluster) (bool, error) {
-	// check if member cluster number meets requirements
-	if len(clusters) < MinimumCluster {
-		return false, fmt.Errorf("needs at lease %d member cluster to run, but got: %d", MinimumCluster, len(clusters))
-	}
-
-	// check if all member cluster status is ready
-	for _, cluster := range clusters {
-		if !util.IsClusterReady(&cluster.Status) {
-			return false, fmt.Errorf("cluster %s not ready", cluster.GetName())
-		}
-	}
-
-	klog.Infof("Got %d member cluster and all in ready state.", len(clusters))
-	return true, nil
-}
-
 // setupTestNamespace will create a namespace in control plane and all member clusters, most of cases will run against it.
 // The reason why we need a separated namespace is it will make it easier to cleanup resources deployed by the testing.
-func setupTestNamespace(namespace string, kubeClient kubernetes.Interface, clusterClients []*util.ClusterClient) error {
+func setupTestNamespace(namespace string, kubeClient kubernetes.Interface) error {
 	namespaceObj := helper.NewNamespace(namespace)
 	_, err := util.CreateNamespace(kubeClient, namespaceObj)
 	if err != nil {
@@ -223,30 +129,10 @@ func setupTestNamespace(namespace string, kubeClient kubernetes.Interface, clust
 }
 
 // cleanupTestNamespace will remove the namespace we setup before for the whole testing.
-func cleanupTestNamespace(namespace string, kubeClient kubernetes.Interface, clusterClients []*util.ClusterClient) error {
+func cleanupTestNamespace(namespace string, kubeClient kubernetes.Interface) error {
 	err := util.DeleteNamespace(kubeClient, namespace)
 	if err != nil {
 		return err
-	}
-
-	return nil
-}
-
-func getClusterClient(clusterName string) kubernetes.Interface {
-	for _, client := range clusterClients {
-		if client.ClusterName == clusterName {
-			return client.KubeClient
-		}
-	}
-
-	return nil
-}
-
-func getClusterDynamicClient(clusterName string) dynamic.Interface {
-	for _, client := range clusterDynamicClients {
-		if client.ClusterName == clusterName {
-			return client.DynamicClientSet
-		}
 	}
 
 	return nil
@@ -289,63 +175,8 @@ func deleteCluster(clusterName, kubeConfigPath string) error {
 	return clusterProvider.Delete(clusterName, kubeConfigPath)
 }
 
-func newClusterClientSet(c *clusterv1alpha1.Cluster) (*util.ClusterClient, *util.DynamicClusterClient, error) {
-	if c.Spec.SyncMode == clusterv1alpha1.Push {
-		clusterClient, err := util.NewClusterClientSet(c, controlPlaneClient, nil)
-		if err != nil {
-			return nil, nil, err
-		}
-		clusterDynamicClient, err := util.NewClusterDynamicClientSet(c, controlPlaneClient)
-		if err != nil {
-			return nil, nil, err
-		}
-		return clusterClient, clusterDynamicClient, nil
-	}
-
-	clusterConfigPath := pullModeClusters[c.Name]
-	clusterConfig, err := clientcmd.BuildConfigFromFlags("", clusterConfigPath)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	clusterClientSet := util.ClusterClient{ClusterName: c.Name}
-	clusterDynamicClientSet := util.DynamicClusterClient{ClusterName: c.Name}
-	clusterClientSet.KubeClient = kubernetes.NewForConfigOrDie(clusterConfig)
-	clusterDynamicClientSet.DynamicClientSet = dynamic.NewForConfigOrDie(clusterConfig)
-
-	return &clusterClientSet, &clusterDynamicClientSet, nil
-}
-
-// set cluster label of E2E
-func SetClusterLabel(c client.Client, clusterName string) error {
-	err := wait.PollImmediate(2*time.Second, 10*time.Second, func() (done bool, err error) {
-		clusterObj := &clusterv1alpha1.Cluster{}
-		if err := c.Get(context.TODO(), client.ObjectKey{Name: clusterName}, clusterObj); err != nil {
-			if apierrors.IsConflict(err) {
-				return false, nil
-			}
-			return false, err
-		}
-		if clusterObj.Labels == nil {
-			clusterObj.Labels = make(map[string]string)
-		}
-		clusterObj.Labels["location"] = "CHN"
-		if clusterObj.Spec.SyncMode == clusterv1alpha1.Push {
-			clusterObj.Labels["sync-mode"] = "Push"
-		}
-		if err := c.Update(context.TODO(), clusterObj); err != nil {
-			if apierrors.IsConflict(err) {
-				return false, nil
-			}
-			return false, err
-		}
-		return true, nil
-	})
-	return err
-}
-
-// delete cluster label of E2E
-func DeleteClusterLabel(c client.Client, clusterName string) error {
+// deleteClusterLabel delete cluster label of E2E
+func deleteClusterLabel(c client.Client, clusterName string) error {
 	err := wait.PollImmediate(2*time.Second, 10*time.Second, func() (done bool, err error) {
 		clusterObj := &clusterv1alpha1.Cluster{}
 		if err := c.Get(context.TODO(), client.ObjectKey{Name: clusterName}, clusterObj); err != nil {


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

When resources (such as `Deployment`, `PropogationPolicy`,etc.) are created in E2E test, a large amount of duplicate code is generated, which makes the code bloated. Therefore, I refactor the related code, put some common methods into the framework package.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Only partially refactored and will continue to be modified if the method is reasonable.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

