### PR TITLE
adapt the Scheduled condition for binding

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -36,6 +36,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins/tainttoleration"
 	"github.com/karmada-io/karmada/pkg/scheduler/metrics"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/helper"
 )
 
 // ScheduleType defines the schedule type of a binding object should be performed.
@@ -811,7 +812,7 @@ func (s *Scheduler) getTypeFromResourceBindings(ns, name string) ScheduleType {
 		return Unknown
 	}
 
-	if len(resourceBinding.Spec.Clusters) == 0 {
+	if !helper.IsBindingReady(&resourceBinding.Status) {
 		return FirstSchedule
 	}
 
@@ -842,7 +843,7 @@ func (s *Scheduler) getTypeFromClusterResourceBindings(name string) ScheduleType
 		return Unknown
 	}
 
-	if len(binding.Spec.Clusters) == 0 {
+	if !helper.IsBindingReady(&binding.Status) {
 		return FirstSchedule
 	}
 

--- a/test/e2e/failover_test.go
+++ b/test/e2e/failover_test.go
@@ -20,8 +20,9 @@ import (
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/helper"
 	"github.com/karmada-io/karmada/pkg/util/names"
-	"github.com/karmada-io/karmada/test/helper"
+	testhelper "github.com/karmada-io/karmada/test/helper"
 )
 
 // failover testing is used to test the rescheduling situation when some initially scheduled clusters fail
@@ -32,7 +33,7 @@ var _ = ginkgo.Describe("failover testing", func() {
 		policyName := deploymentNamePrefix + rand.String(RandomStrLength)
 		deploymentNamespace := testNamespace
 		deploymentName := policyName
-		deployment := helper.NewDeployment(deploymentNamespace, deploymentName)
+		deployment := testhelper.NewDeployment(deploymentNamespace, deploymentName)
 		maxGroups := 1
 		minGroups := 1
 		numOfFailedClusters := 1
@@ -41,7 +42,7 @@ var _ = ginkgo.Describe("failover testing", func() {
 		var targetClusterNames []string
 
 		// set MaxGroups=MinGroups=1, label is location=CHN.
-		policy := helper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
+		policy := testhelper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
 			{
 				APIVersion: deployment.APIVersion,
 				Kind:       deployment.Kind,
@@ -250,7 +251,7 @@ func getTargetClusterNames(deployment *appsv1.Deployment) (targetClusterNames []
 			return false, err
 		}
 
-		if len(binding.Spec.Clusters) == 0 {
+		if !helper.IsBindingReady(&binding.Status) {
 			klog.Infof("The ResourceBinding(%s/%s) hasn't been scheduled.", binding.Namespace, binding.Name)
 			return false, nil
 		}

--- a/test/e2e/fieldselector_test.go
+++ b/test/e2e/fieldselector_test.go
@@ -75,7 +75,7 @@ var _ = ginkgo.Describe("propagation with fieldSelector testing", func() {
 					if index > 2 {
 						break
 					}
-					fmt.Printf("setting provider and region for cluster %v", cluster)
+					fmt.Printf("setting provider and region for cluster %v\n", cluster)
 					gomega.Eventually(func() error {
 						clusterObj := &clusterv1alpha1.Cluster{}
 						err := controlPlaneClient.Get(context.TODO(), client.ObjectKey{Name: cluster}, clusterObj)


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

After merge PR #823, there still are some logic use `len(binding.Spec.Clusters) == 0` to judge weather binding has been ready to sync. So this pr modify this.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

