### PR TITLE
fix:network config problem during deployment

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -492,7 +492,7 @@ function util::get_load_balancer_ip() {
 #  - $3: the context in kubeconfig of the cluster wanted to be connected
 function util::add_routes() {
   unset IFS
-  routes=$(kubectl --kubeconfig ${2} --context ${3} get nodes -o jsonpath='{range .items[*]}ip route add {.spec.podCIDR} via {.status.addresses[?(.type=="InternalIP")].address}{"\n"}')
+  routes=$(kubectl --kubeconfig ${2} --context ${3} get nodes -o jsonpath='{range .items[*]}ip route add {.spec.podCIDR} via {.status.addresses[?(.type=="InternalIP")].address}{"\n"}{end}')
   echo "Connecting cluster ${1} to ${2}"
 
   IFS=$'\n'


### PR DESCRIPTION
Signed-off-by: Pilipalaca <85749695@qq.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug

-->

What this PR does / why we need it:
When I deployed using local_up_karmda. sh, an error was reported during network configuration, because the deployment was interrupted due to an invalid command generated in util::add_routes.

Verify the validity of the route rule command to resolve this problem.

Error message:
![image](https://user-images.githubusercontent.com/31329928/137940760-0fe4a7cc-fad3-4b94-897a-10e453e6d905.png)


Verification result after modification:
![image](https://user-images.githubusercontent.com/31329928/137940801-9134b552-7d94-42d2-a527-3a946adff468.png)
