### PR TITLE
replace github.com/pkg/errors with Go native error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/kr/pretty v0.3.0
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.14.0
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.11.0
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/tools v0.1.2

--- a/pkg/karmadactl/get.go
+++ b/pkg/karmadactl/get.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -213,7 +212,7 @@ func (g *CommandGetOptions) Run(karmadaConfig KarmadaConfig, cmd *cobra.Command,
 		}
 
 		if err := g.getSecretTokenInKarmada(karmadaclient, g.Clusters[idx], clusterInfos); err != nil {
-			return errors.Wrap(err, "Method getSecretTokenInKarmada get Secret info in karmada failed, err is")
+			return fmt.Errorf("Method getSecretTokenInKarmada get Secret info in karmada failed, err is: %w", err)
 		}
 		f := getFactory(g.Clusters[idx], clusterInfos)
 		go g.getObjInfo(&wg, &mux, f, g.Clusters[idx], &objs, &allErrs, args)
@@ -396,11 +395,11 @@ type ClusterInfo struct {
 func clusterInfoInit(g *CommandGetOptions, karmadaConfig KarmadaConfig, clusterInfos map[string]*ClusterInfo) (*rest.Config, error) {
 	karmadaclient, err := karmadaConfig.GetRestConfig(g.KarmadaContext, g.KubeConfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "Func GetRestConfig get karmada client failed, err is")
+		return nil, fmt.Errorf("Func GetRestConfig get karmada client failed, err is: %w", err)
 	}
 
 	if err := getClusterInKarmada(karmadaclient, clusterInfos); err != nil {
-		return nil, errors.Wrap(err, "Method getClusterInKarmada get cluster info in karmada failed, err is")
+		return nil, fmt.Errorf("Method getClusterInKarmada get cluster info in karmada failed, err is: %w", err)
 	}
 
 	if err := getRBInKarmada(g.Namespace, karmadaclient); err != nil {


### PR DESCRIPTION
Signed-off-by: guoyao <1015105054@qq.com>

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
stop using `github.com/pkg/errors`, replaced by Go native error. just as https://github.com/kubernetes/kubernetes/issues/103043
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

