### PR TITLE
collect status even if cluster's deletionTimestamp is not zero

### DIFF
--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -95,10 +95,6 @@ func (c *ClusterStatusController) Reconcile(ctx context.Context, req controllerr
 		return controllerruntime.Result{Requeue: true}, err
 	}
 
-	if !cluster.DeletionTimestamp.IsZero() {
-		return controllerruntime.Result{}, nil
-	}
-
 	// start syncing status only when the finalizer is present on the given Cluster to
 	// avoid conflict with cluster controller.
 	if !controllerutil.ContainsFinalizer(cluster, util.ClusterControllerFinalizer) {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
I have met a scenario that the member cluster happens to unreachable while unjoin. Under this scenario, cluster status controller won't collect status for this cluster due to the DeletionTimestamp is not zero. This means the cluster will retain `Ready` status while it is actually unavailable.  The unjoin will failed because we can't clean up resource in the given member cluster. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
"NONE"

