### PR TITLE
Cleanup for `hack/local-up-karmada.sh`

### DIFF
--- a/hack/local-up-karmada.sh
+++ b/hack/local-up-karmada.sh
@@ -43,10 +43,11 @@ util::verify_go_version
 
 # install kind and kubectl
 kind_version=v0.11.1
+echo -n "Preparing: 'kind' existence check - "
 if util::cmd_exist kind; then
-  echo "kind exists"
+  echo "passed"
 else
-  echo "kind not exists, will install kind $kind_version"
+  echo "not pass"
   util::install_kind $kind_version
 fi
 # get arch name and os name in bootstrap
@@ -54,11 +55,13 @@ BS_ARCH=$(go env GOARCH)
 BS_OS=$(go env GOOS)
 # check arch and os name before installing
 util::install_environment_check "${BS_ARCH}" "${BS_OS}"
-# we choose v1.18.0, because in kubectl after versions 1.18 exist a bug which will give wrong output when using jsonpath.
-# bug details: https://github.com/kubernetes/kubernetes/pull/98057
-kubectl_version=v1.18.0
-util::install_kubectl $kubectl_version "${BS_ARCH}" "${BS_OS}"
-
+echo -n "Preparing: 'kubectl' existence check - "
+if util::cmd_exist kubectl; then
+  echo "passed"
+else
+  echo "not pass"
+  util::install_kubectl "" "${BS_ARCH}" "${BS_OS}"
+fi
 #step1. create host cluster and member clusters in parallel
 # host IP address: script parameter ahead of macOS IP
 if [[ -z "${HOST_IPADDRESS}" ]]; then

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -107,11 +107,13 @@ function util::install_kubectl {
     local KUBECTL_VERSION=${1}
     local ARCH=${2}
     local OS=${3:-linux}
+    if [ -z "$KUBECTL_VERSION" ]; then
+      KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+    fi
     echo "Installing 'kubectl ${KUBECTL_VERSION}' for you"
     curl --retry 5 -sSLo ./kubectl -w "%{http_code}" https://dl.k8s.io/release/"$KUBECTL_VERSION"/bin/"$OS"/"$ARCH"/kubectl | grep '200' > /dev/null
     ret=$?
     if [ ${ret} -eq 0 ]; then
-        rm -rf "$(which kubectl 2> /dev/null)"
         chmod +x ./kubectl
         mkdir -p ~/.local/bin/
         mv ./kubectl ~/.local/bin/kubectl
@@ -134,11 +136,8 @@ function util::install_kind {
   curl --retry 5 -sSLo ./kind -w "%{http_code}" "https://kind.sigs.k8s.io/dl/${kind_version}/kind-${os_name:-linux}-${arch_name:-amd64}" | grep '200' > /dev/null
   ret=$?
   if [ ${ret} -eq 0 ]; then
-      rm -rf "$(which kind> /dev/null)"
       chmod +x ./kind
       mkdir -p ~/.local/bin/
-
-      rm -rf "$(which kind 2> /dev/null)"
       mv ./kind ~/.local/bin/kind
 
       export PATH=$PATH:~/.local/bin


### PR DESCRIPTION
Cleanup for `hack/local-up-karmada.sh`

Signed-off-by: lfbear <lfbear@gmail.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
- remove the `kubectl` version check because there is a solution that no longer needs to enforce `kubectl v1.18`
-  do not delete the local binary when installing `kind` and `kubeclt`

**Which issue(s) this PR fixes**:
Fixes #832

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

