### PR TITLE
change kubectl config delete-user command to kubectl config unset

### DIFF
--- a/hack/undeploy-karmada.sh
+++ b/hack/undeploy-karmada.sh
@@ -38,5 +38,5 @@ kubectl delete ns karmada-system --kubeconfig="${HOST_CLUSTER_KUBECONFIG}"
 
 # clear configs about karmada-apiserver in kubeconfig
 kubectl config delete-cluster karmada-apiserver --kubeconfig="${HOST_CLUSTER_KUBECONFIG}"
-kubectl config delete-user karmada-apiserver --kubeconfig="${HOST_CLUSTER_KUBECONFIG}"
+kubectl config unset users.karmada-apiserver --kubeconfig="${HOST_CLUSTER_KUBECONFIG}"
 kubectl config delete-context karmada-apiserver --kubeconfig="${HOST_CLUSTER_KUBECONFIG}"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
kubectl config doesn`t have delete-user command.
```
[root@master67 karmada]# hack/undeploy-karmada.sh ~/.kube/config karmada-host
Switched to context "karmada-host".
namespace "karmada-system" deleted
deleted cluster karmada-apiserver from /root/.kube/config
error: unknown command "delete-user karmada-apiserver"
See 'kubectl config -h' for help and examples
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

