### PR TITLE
use gomega.Eventually to wait for scheduling in taint toleration test

### DIFF
--- a/test/e2e/tainttoleration_test.go
+++ b/test/e2e/tainttoleration_test.go
@@ -101,10 +101,12 @@ var _ = ginkgo.Describe("propagation with taint and toleration testing", func() 
 			framework.CreateDeployment(kubeClient, deployment)
 
 			ginkgo.By(fmt.Sprintf("check if deployment(%s/%s) only scheduled to tolerated cluster(%s)", deploymentNamespace, deploymentName, tolerationValue), func() {
-				targetClusterNames, err := getTargetClusterNames(deployment)
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-				gomega.Expect(len(targetClusterNames) == 1).Should(gomega.BeTrue())
-				gomega.Expect(targetClusterNames[0] == tolerationValue).Should(gomega.BeTrue())
+				gomega.Eventually(func(g gomega.Gomega) {
+					targetClusterNames, err := getTargetClusterNames(deployment)
+					g.Expect(err).ShouldNot(gomega.HaveOccurred())
+					g.Expect(len(targetClusterNames) == 1).Should(gomega.BeTrue())
+					g.Expect(targetClusterNames[0] == tolerationValue).Should(gomega.BeTrue())
+				}, pollTimeout, pollInterval).Should(gomega.Succeed())
 			})
 
 			framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)


### PR DESCRIPTION
Signed-off-by: dddddai <dddwq@foxmail.com>

**What type of PR is this?**
/kind failing-test


**What this PR does / why we need it**:
Use gomega.Eventually to wait for scheduling instead of check immediately

maybe associated with [this failed test](https://github.com/karmada-io/karmada/runs/4021388332?check_suite_focus=true)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

