### PR TITLE
Introduce --wait flag for karmada unjoin command

### DIFF
--- a/pkg/clusterdiscovery/clusterapi/clusterapi.go
+++ b/pkg/clusterdiscovery/clusterapi/clusterapi.go
@@ -198,6 +198,7 @@ func (d *ClusterDetector) unJoinClusterAPICluster(clusterName string) error {
 			DryRun:           false,
 		},
 		ClusterName: clusterName,
+		Wait:        options.DefaultKarmadactlCommandDuration,
 	}
 	err := karmadactl.UnJoinCluster(d.ControllerPlaneConfig, nil, opts)
 	if err != nil {

--- a/pkg/karmadactl/options/global.go
+++ b/pkg/karmadactl/options/global.go
@@ -1,10 +1,17 @@
 package options
 
-import "github.com/spf13/pflag"
+import (
+	"time"
+
+	"github.com/spf13/pflag"
+)
 
 // DefaultKarmadaClusterNamespace defines the default namespace where the member cluster objects are stored.
 // The secret owns by cluster objects will be stored in the namespace too.
 const DefaultKarmadaClusterNamespace = "karmada-cluster"
+
+// DefaultKarmadactlCommandDuration defines the default timeout for karmadactl execute
+const DefaultKarmadactlCommandDuration = 60 * time.Second
 
 // GlobalCommandOptions holds the configuration shared by the all sub-commands of `karmadactl`.
 type GlobalCommandOptions struct {

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -168,6 +168,7 @@ var _ = ginkgo.Describe("[namespace auto-provision] namespace auto-provision tes
 					ClusterName:       clusterName,
 					ClusterContext:    clusterContext,
 					ClusterKubeConfig: kubeConfigPath,
+					Wait:              options.DefaultKarmadactlCommandDuration,
 				}
 				err := karmadactl.RunUnjoin(os.Stdout, karmadaConfig, opts)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())


### PR DESCRIPTION
Signed-off-by: wawa0210 <xiaozhang0210@hotmail.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Introduce --wait flag for karmada join and unjoin command
We can control the timeout of join and unjoin by passing the wait parameter, such as 

Two minutes timeout during unjoin
```
karmadactl unjoin CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG> --wait 2m
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

