### PR TITLE
replace err report with RunE

### DIFF
--- a/cmd/karmadactl/karmadactl.go
+++ b/cmd/karmadactl/karmadactl.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"k8s.io/component-base/logs"
@@ -14,7 +13,6 @@ func main() {
 	defer logs.FlushLogs()
 
 	if err := karmadactl.NewKarmadaCtlCommand(os.Stdout, "karmadactl", "karmadactl").Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
 }

--- a/pkg/karmadactl/get.go
+++ b/pkg/karmadactl/get.go
@@ -61,9 +61,15 @@ func NewCmdGet(out io.Writer, karmadaConfig KarmadaConfig) *cobra.Command {
 		Use:                   "get [NAME | -l label | -n namespace]  [flags]",
 		DisableFlagsInUseLine: true,
 		Short:                 getShort,
-		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(o.Complete(cmd, args))
-			cmdutil.CheckErr(o.Run(karmadaConfig, cmd, args))
+		SilenceUsage:          true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(cmd, args); err != nil {
+				return err
+			}
+			if err := o.Run(karmadaConfig, cmd, args); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", "default", "-n=namespace or -n namespace")


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When I execute command incorrectly,  reporting an error is very unfriendly! 
```
[root@master67 karmada]# karmadactl join
F1029 11:19:57.904391    5914 join.go:73] Error: cluster name is required
goroutine 1 [running]:
k8s.io/klog/v2.stacks(0xc000182001, 0xc0005300a0, 0x4a, 0x9f)
	/root/lonelyCZ/karmada-lonelyCZ/karmada/vendor/k8s.io/klog/v2/klog.go:1026 +0xb9
k8s.io/klog/v2.(*loggingT).output(0x2ceda00, 0xc000000003, 0x0, 0x0, 0xc0004565b0, 0x0, 0x2439540, 0x7, 0x49, 0x0)
	/root/lonelyCZ/karmada-lonelyCZ/karmada/vendor/k8s.io/klog/v2/klog.go:975 +0x1e5
k8s.io/klog/v2.(*loggingT).printf(0x2ceda00, 0xc000000003, 0x0, 0x0, 0x0, 0x0, 0x1dad45f, 0x9, 0xc000070a00, 0x1, ...)
	/root/lonelyCZ/karmada-lonelyCZ/karmada/vendor/k8s.io/klog/v2/klog.go:753 +0x19a
k8s.io/klog/v2.Fatalf(...)
	/root/lonelyCZ/karmada-lonelyCZ/karmada/vendor/k8s.io/klog/v2/klog.go:1514
github.com/karmada-io/karmada/pkg/karmadactl.NewCmdJoin.func1(0xc0002b4f00, 0x2d1d250, 0x0, 0x0)
	/root/lonelyCZ/karmada-lonelyCZ/karmada/pkg/karmadactl/join.go:73 +0x190
......
```

Use cmdutil to fix this problem.
```
[root@master67 karmada]# karmadactl join
error: USAGE: join CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG> [flags]
See 'karmadactl join -h' for help and examples
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

