### PR TITLE
add Timeout in WaitForCacheSync

### DIFF
--- a/pkg/controllers/mcs/service_export_controller.go
+++ b/pkg/controllers/mcs/service_export_controller.go
@@ -95,6 +95,11 @@ func (c *ServiceExportController) Reconcile(ctx context.Context, req controllerr
 		return controllerruntime.Result{Requeue: true}, err
 	}
 
+	if !util.IsClusterReady(&cluster.Status) {
+		klog.Errorf("Stop sync work(%s/%s) for cluster(%s) as cluster not ready.", work.Namespace, work.Name, cluster.Name)
+		return controllerruntime.Result{Requeue: true}, fmt.Errorf("cluster(%s) not ready", cluster.Name)
+	}
+
 	return c.buildResourceInformers(cluster)
 }
 
@@ -175,16 +180,22 @@ func (c *ServiceExportController) registerInformersAndStart(cluster *clusterv1al
 	}
 
 	c.InformerManager.Start(cluster.Name)
-	synced := c.InformerManager.WaitForCacheSync(cluster.Name)
-	if synced == nil {
-		klog.Errorf("No informerFactory for cluster %s exist.", cluster.Name)
-		return fmt.Errorf("no informerFactory for cluster %s exist", cluster.Name)
-	}
-	for _, gvr := range gvrTargets {
-		if !synced[gvr] {
-			klog.Errorf("Informer for %s hasn't synced.", gvr)
-			return fmt.Errorf("informer for %s hasn't synced", gvr)
+
+	if err := func() error {
+		synced := c.InformerManager.WaitForCacheSyncWithTimeout(cluster.Name, util.CacheSyncTimeout)
+		if synced == nil {
+			return fmt.Errorf("no informerFactory for cluster %s exist", cluster.Name)
 		}
+		for _, gvr := range gvrTargets {
+			if !synced[gvr] {
+				return fmt.Errorf("informer for %s hasn't synced", gvr)
+			}
+		}
+		return nil
+	}(); err != nil {
+		klog.Errorf("Failed to sync cache for cluster: %s, error: %v", cluster.Name, err)
+		c.InformerManager.Stop(cluster.Name)
+		return err
 	}
 
 	return nil

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,5 +1,7 @@
 package util
 
+import "time"
+
 const (
 	// ServiceNamespaceLabel is added to work object, which is report by member cluster, to specify service namespace associated with EndpointSlice.
 	ServiceNamespaceLabel = "endpointslice.karmada.io/namespace"
@@ -124,4 +126,9 @@ type ContextKey string
 const (
 	// ContextKeyObject is the context value key of a resource.
 	ContextKeyObject ContextKey = "object"
+)
+
+const (
+	// CacheSyncTimeout refers to the time limit set on waiting for cache to sync
+	CacheSyncTimeout = 30 * time.Second
 )

--- a/pkg/util/informermanager/multi-cluster-manager.go
+++ b/pkg/util/informermanager/multi-cluster-manager.go
@@ -57,6 +57,10 @@ type MultiClusterInformerManager interface {
 	// WaitForCacheSync waits for all caches to populate.
 	// Should call after 'ForCluster', otherwise no-ops.
 	WaitForCacheSync(cluster string) map[schema.GroupVersionResource]bool
+
+	// WaitForCacheSyncWithTimeout waits for all caches to populate with a definitive timeout.
+	// Should call after 'ForCluster', otherwise no-ops.
+	WaitForCacheSyncWithTimeout(cluster string, cacheSyncTimeout time.Duration) map[schema.GroupVersionResource]bool
 }
 
 // NewMultiClusterInformerManager constructs a new instance of multiClusterInformerManagerImpl.
@@ -131,4 +135,12 @@ func (m *multiClusterInformerManagerImpl) WaitForCacheSync(cluster string) map[s
 		return nil
 	}
 	return manager.WaitForCacheSync()
+}
+
+func (m *multiClusterInformerManagerImpl) WaitForCacheSyncWithTimeout(cluster string, cacheSyncTimeout time.Duration) map[schema.GroupVersionResource]bool {
+	manager, exist := m.getManager(cluster)
+	if !exist {
+		return nil
+	}
+	return manager.WaitForCacheSyncWithTimeout(cacheSyncTimeout)
 }


### PR DESCRIPTION
Signed-off-by: lihanbo <lihanbo2@huawei.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
There exists a scenario that some of joined cluster are unhealth in karmada. At the moment, if karmada controller manager restart, it will be blocked in `WaitForCacheSync` process until the unhealth cluster recovers. 


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
"NONE"

