### PR TITLE
prevent empty key from queue

### DIFF
--- a/pkg/controllers/status/workstatus_controller.go
+++ b/pkg/controllers/status/workstatus_controller.go
@@ -116,11 +116,11 @@ func generateKey(obj interface{}) (util.QueueKey, error) {
 	resource := obj.(*unstructured.Unstructured)
 	cluster, err := getClusterNameFromLabel(resource)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	// it happens when the obj not managed by Karmada.
+	// return a nil key when the obj not managed by Karmada, which will be discarded before putting to queue.
 	if cluster == "" {
-		return "", nil
+		return nil, nil
 	}
 
 	return keys.FederatedKeyFunc(cluster, obj)


### PR DESCRIPTION
Signed-off-by: lihanbo <lihanbo2@huawei.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
I found the following message in log:
```
E1101 07:50:08.574255       1 workstatus_controller.go:149] Failed to sync status as invalid key:
```
I run the following code in my IDE:
```
func generateKey(obj interface{}) interface{} {
	return ""
}

func main() {
	test := generateKey("")
	if test == nil {
		fmt.Println("is nil")
	}else {
		fmt.Println("not nil")
	}
}
```
The result show that `""` is not equal to `nil`.

if return "", the empty key will add to queue:
```
func (w *asyncWorker) EnqueueRateLimited(obj runtime.Object) {
	key, err := w.keyFunc(obj)
	if err != nil {
		klog.Warningf("Failed to generate key for obj: %s", obj.GetObjectKind().GroupVersionKind())
		return
	}

	if key == nil {
		return
	}

	w.AddRateLimited(key)
}
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
"NONE"

