### PR TITLE
add object reference information when calling gRPC

### DIFF
--- a/pkg/estimator/client/general.go
+++ b/pkg/estimator/client/general.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"context"
+
 	corev1 "k8s.io/api/core/v1"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
@@ -21,7 +23,7 @@ func NewGeneralEstimator() *GeneralEstimator {
 }
 
 // MaxAvailableReplicas estimates the maximum replicas that can be applied to the target cluster by cluster ResourceSummary.
-func (ge *GeneralEstimator) MaxAvailableReplicas(clusters []*clusterv1alpha1.Cluster, replicaRequirements *workv1alpha2.ReplicaRequirements) ([]workv1alpha2.TargetCluster, error) {
+func (ge *GeneralEstimator) MaxAvailableReplicas(ctx context.Context, clusters []*clusterv1alpha1.Cluster, replicaRequirements *workv1alpha2.ReplicaRequirements) ([]workv1alpha2.TargetCluster, error) {
 	availableTargetClusters := make([]workv1alpha2.TargetCluster, len(clusters))
 	for i, cluster := range clusters {
 		maxReplicas := ge.maxAvailableReplicas(cluster, replicaRequirements)

--- a/pkg/estimator/client/interface.go
+++ b/pkg/estimator/client/interface.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"context"
+
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 )
@@ -16,7 +18,7 @@ var (
 
 // ReplicaEstimator is an estimator which estimates the maximum replicas that can be applied to the target cluster.
 type ReplicaEstimator interface {
-	MaxAvailableReplicas(clusters []*clusterv1alpha1.Cluster, replicaRequirements *workv1alpha2.ReplicaRequirements) ([]workv1alpha2.TargetCluster, error)
+	MaxAvailableReplicas(ctx context.Context, clusters []*clusterv1alpha1.Cluster, replicaRequirements *workv1alpha2.ReplicaRequirements) ([]workv1alpha2.TargetCluster, error)
 }
 
 // GetReplicaEstimators returns all replica estimators.

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -346,8 +346,10 @@ func (g *genericScheduler) calAvailableReplicas(clusters []*clusterv1alpha1.Clus
 
 	// Get the minimum value of MaxAvailableReplicas in terms of all estimators.
 	estimators := estimatorclient.GetReplicaEstimators()
+	ctx := context.WithValue(context.TODO(), util.ContextKeyObject,
+		fmt.Sprintf("kind=%s, name=%s/%s", spec.Resource.Kind, spec.Resource.Namespace, spec.Resource.Name))
 	for _, estimator := range estimators {
-		res, err := estimator.MaxAvailableReplicas(clusters, spec.ReplicaRequirements)
+		res, err := estimator.MaxAvailableReplicas(ctx, clusters, spec.ReplicaRequirements)
 		if err != nil {
 			klog.Errorf("Max cluster available replicas error: %v", err)
 			continue

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -117,3 +117,11 @@ const (
 	// NamespaceKarmadaSystem is the karmada system namespace.
 	NamespaceKarmadaSystem = "karmada-system"
 )
+
+// ContextKey is the key of context.
+type ContextKey string
+
+const (
+	// ContextKeyObject is the context value key of a resource.
+	ContextKeyObject ContextKey = "object"
+)


### PR DESCRIPTION
Signed-off-by: Garrybest <garrybest@foxmail.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Now estimator only logs the max replicas and time elapse when calculating max available replicas. See [here](https://github.com/karmada-io/karmada/blob/f00208d6f85b5d45f58ba07887ade59dc000f3f9/pkg/estimator/server/server.go#L191-L201) .

I add the resource object reference into gRPC context of metadata. It is significant for tracing replica estimation of scheduler.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

