### PR TITLE
add karmada-scheduler flags verification logic

### DIFF
--- a/cmd/scheduler/app/options/validation.go
+++ b/cmd/scheduler/app/options/validation.go
@@ -1,0 +1,31 @@
+package options
+
+import (
+	"net"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// Validate checks Options and return a slice of found errs.
+func (o *Options) Validate() field.ErrorList {
+	errs := field.ErrorList{}
+
+	newPath := field.NewPath("Options")
+	if net.ParseIP(o.BindAddress) == nil {
+		errs = append(errs, field.Invalid(newPath.Child("BindAddress"), o.BindAddress, "not a valid textual representation of an IP address"))
+	}
+
+	if o.SecurePort < 0 || o.SecurePort > 65535 {
+		errs = append(errs, field.Invalid(newPath.Child("SecurePort"), o.SecurePort, "must be a valid port between 0 and 65535 inclusive"))
+	}
+
+	if o.SchedulerEstimatorPort < 0 || o.SchedulerEstimatorPort > 65535 {
+		errs = append(errs, field.Invalid(newPath.Child("SchedulerEstimatorPort"), o.SchedulerEstimatorPort, "must be a valid port between 0 and 65535 inclusive"))
+	}
+
+	if o.SchedulerEstimatorTimeout.Duration < 0 {
+		errs = append(errs, field.Invalid(newPath.Child("SchedulerEstimatorTimeout"), o.SchedulerEstimatorTimeout, "must be greater than or equal to 0"))
+	}
+
+	return errs
+}

--- a/cmd/scheduler/app/options/validation_test.go
+++ b/cmd/scheduler/app/options/validation_test.go
@@ -1,0 +1,131 @@
+package options
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	componentbaseconfig "k8s.io/component-base/config"
+)
+
+func TestValidateKarmadaSchedulerConfiguration(t *testing.T) {
+	successCases := []Options{
+		{
+			LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
+				LeaderElect: false,
+			},
+			BindAddress:               "127.0.0.1",
+			SecurePort:                9000,
+			KubeAPIQPS:                40,
+			KubeAPIBurst:              30,
+			EnableSchedulerEstimator:  false,
+			SchedulerEstimatorTimeout: metav1.Duration{Duration: 1 * time.Second},
+			SchedulerEstimatorPort:    9001,
+		},
+		{
+			LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
+				LeaderElect: true,
+			},
+			BindAddress:               "127.0.0.1",
+			SecurePort:                9000,
+			KubeAPIQPS:                40,
+			KubeAPIBurst:              30,
+			EnableSchedulerEstimator:  false,
+			SchedulerEstimatorTimeout: metav1.Duration{Duration: 1 * time.Second},
+			SchedulerEstimatorPort:    9001,
+		}, {
+			LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
+				LeaderElect: false,
+			},
+			BindAddress:  "127.0.0.1",
+			SecurePort:   9000,
+			KubeAPIQPS:   40,
+			KubeAPIBurst: 30,
+		}}
+
+	for _, successCase := range successCases {
+		if errs := successCase.Validate(); len(errs) != 0 {
+			t.Errorf("expected success: %v", errs)
+		}
+	}
+
+	newPath := field.NewPath("Options")
+	testCases := map[string]struct {
+		opt          Options
+		expectedErrs field.ErrorList
+	}{
+		"invalid BindAddress": {
+			opt: Options{
+				LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
+					LeaderElect: false,
+				},
+				BindAddress:               "127.0.0.1:8080",
+				SecurePort:                9000,
+				KubeAPIQPS:                40,
+				KubeAPIBurst:              30,
+				EnableSchedulerEstimator:  false,
+				SchedulerEstimatorTimeout: metav1.Duration{Duration: 1 * time.Second},
+				SchedulerEstimatorPort:    9001,
+			},
+			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("BindAddress"), "127.0.0.1:8080", "not a valid textual representation of an IP address")},
+		},
+		"invalid SecurePort": {
+			opt: Options{
+				LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
+					LeaderElect: false,
+				},
+				BindAddress:               "127.0.0.1",
+				SecurePort:                90000,
+				KubeAPIQPS:                40,
+				KubeAPIBurst:              30,
+				EnableSchedulerEstimator:  false,
+				SchedulerEstimatorTimeout: metav1.Duration{Duration: 1 * time.Second},
+				SchedulerEstimatorPort:    9001,
+			},
+			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("SecurePort"), 90000, "must be a valid port between 0 and 65535 inclusive")},
+		},
+		"invalid SchedulerEstimatorPort": {
+			opt: Options{
+				LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
+					LeaderElect: false,
+				},
+				BindAddress:               "127.0.0.1",
+				SecurePort:                9000,
+				KubeAPIQPS:                40,
+				KubeAPIBurst:              30,
+				EnableSchedulerEstimator:  false,
+				SchedulerEstimatorTimeout: metav1.Duration{Duration: 1 * time.Second},
+				SchedulerEstimatorPort:    90000,
+			},
+			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("SchedulerEstimatorPort"), 90000, "must be a valid port between 0 and 65535 inclusive")},
+		},
+		"invalid SchedulerEstimatorTimeout": {
+			opt: Options{
+				LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
+					LeaderElect: false,
+				},
+				BindAddress:               "127.0.0.1",
+				SecurePort:                9000,
+				KubeAPIQPS:                40,
+				KubeAPIBurst:              30,
+				EnableSchedulerEstimator:  false,
+				SchedulerEstimatorTimeout: metav1.Duration{Duration: -1 * time.Second},
+				SchedulerEstimatorPort:    9000,
+			},
+			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("SchedulerEstimatorTimeout"), metav1.Duration{Duration: -1 * time.Second}, "must be greater than or equal to 0")},
+		},
+	}
+
+	for _, testCase := range testCases {
+		errs := testCase.opt.Validate()
+		if len(testCase.expectedErrs) != len(errs) {
+			t.Fatalf("Expected %d errors, got %d errors: %v", len(testCase.expectedErrs), len(errs), errs)
+		}
+		for i, err := range errs {
+			if err.Error() != testCase.expectedErrs[i].Error() {
+				t.Fatalf("Expected error: %s, got %s", testCase.expectedErrs[i], err.Error())
+			}
+		}
+	}
+}

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"os"
+
 	apiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/component-base/logs"
-	"k8s.io/klog/v2"
 
 	"github.com/karmada-io/karmada/cmd/scheduler/app"
 )
@@ -15,6 +16,6 @@ func main() {
 	stopChan := apiserver.SetupSignalHandler()
 
 	if err := app.NewSchedulerCommand(stopChan).Execute(); err != nil {
-		klog.Fatal(err.Error())
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

part of #919

**What this PR does / why we need it**:

If the scheduler command parameter is incorrect, it will exit abnormally and output the entire stack information
so add karmada-scheduler flags verification logic

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

