### PR TITLE
Replace go get with go install

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ run:
   # "/" will be replaced by current OS file path separator to properly work
   # on Windows.
   skip-dirs:
+  - hack/tools/preferredimports # This code is directly lifted from the Kubernetes codebase, skip checking
 
   # default is true. Enables skipping of directories:
   #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$

--- a/docs/working-with-submariner.md
+++ b/docs/working-with-submariner.md
@@ -37,7 +37,7 @@ Export `KUBECONFIG` and switch to `karmada apiserver`:
 Then, install `karmadactl` command and join the member cluster:
 
 ```
-# go get github.com/karmada-io/karmada/cmd/karmadactl
+# go install github.com/karmada-io/karmada/cmd/karmadactl
 
 # karmadactl join cluster1 --cluster-kubeconfig=$HOME/.kube/cluster1.config
 ```

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d
 	golang.org/x/tools v0.1.2
 	gomodules.xyz/jsonpatch/v2 v2.2.0
 	google.golang.org/grpc v1.38.0

--- a/hack/tools/preferredimports/preferredimports.go
+++ b/hack/tools/preferredimports/preferredimports.go
@@ -1,0 +1,266 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This code is directly lifted from the Kubernetes codebase in order to avoid relying on the k8s.io/kubernetes package.
+// For reference: https://github.com/kubernetes/kubernetes/blob/release-1.22/cmd/preferredimports/preferredimports.go
+
+// verify that all the imports have our preferred alias(es).
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/build"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+var (
+	importAliases = flag.String("import-aliases", "hack/.import-aliases", "json file with import aliases")
+	confirm       = flag.Bool("confirm", false, "update file with the preferred aliases for imports")
+	regex         = flag.String("include-path", "(test/e2e/|test/e2e_node)", "only files with paths matching this regex is touched")
+	isTerminal    = term.IsTerminal(int(os.Stdout.Fd()))
+	logPrefix     = ""
+	aliases       map[string]string
+)
+
+type analyzer struct {
+	fset      *token.FileSet // positions are relative to fset
+	ctx       build.Context
+	failed    bool
+	donePaths map[string]interface{}
+}
+
+func newAnalyzer() *analyzer {
+	ctx := build.Default
+	ctx.CgoEnabled = true
+
+	a := &analyzer{
+		fset:      token.NewFileSet(),
+		ctx:       ctx,
+		donePaths: make(map[string]interface{}),
+	}
+
+	return a
+}
+
+// collect extracts test metadata from a file.
+func (a *analyzer) collect(dir string) {
+	if _, ok := a.donePaths[dir]; ok {
+		return
+	}
+	a.donePaths[dir] = nil
+
+	// Create the AST by parsing src.
+	fs, err := parser.ParseDir(a.fset, dir, nil, parser.AllErrors|parser.ParseComments)
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ERROR(syntax)", logPrefix, err)
+		a.failed = true
+		return
+	}
+
+	for _, p := range fs {
+		// returns first error, but a.handleError deals with it
+		files := a.filterFiles(p.Files)
+		for _, file := range files {
+			replacements := make(map[string]string)
+			pathToFile := a.fset.File(file.Pos()).Name()
+			for _, imp := range file.Imports {
+				importPath := strings.Replace(imp.Path.Value, "\"", "", -1)
+				pathSegments := strings.Split(importPath, "/")
+				importName := pathSegments[len(pathSegments)-1]
+				if imp.Name != nil {
+					importName = imp.Name.Name
+				}
+				if alias, ok := aliases[importPath]; ok {
+					if alias != importName {
+						if !*confirm {
+							fmt.Fprintf(os.Stderr, "%sERROR wrong alias for import \"%s\" should be %s in file %s\n", logPrefix, importPath, alias, pathToFile)
+							a.failed = true
+						}
+						replacements[importName] = alias
+						if imp.Name != nil {
+							imp.Name.Name = alias
+						} else {
+							imp.Name = ast.NewIdent(alias)
+						}
+					}
+				}
+			}
+
+			if len(replacements) > 0 {
+				if *confirm {
+					fmt.Printf("%sReplacing imports with aliases in file %s\n", logPrefix, pathToFile)
+					for key, value := range replacements {
+						renameImportUsages(file, key, value)
+					}
+					ast.SortImports(a.fset, file)
+					var buffer bytes.Buffer
+					if err = format.Node(&buffer, a.fset, file); err != nil {
+						panic(fmt.Sprintf("Error formatting ast node after rewriting import.\n%s\n", err.Error()))
+					}
+
+					fileInfo, err := os.Stat(pathToFile)
+					if err != nil {
+						panic(fmt.Sprintf("Error stat'ing file: %s\n%s\n", pathToFile, err.Error()))
+					}
+
+					err = ioutil.WriteFile(pathToFile, buffer.Bytes(), fileInfo.Mode())
+					if err != nil {
+						panic(fmt.Sprintf("Error writing file: %s\n%s\n", pathToFile, err.Error()))
+					}
+				}
+			}
+		}
+	}
+}
+
+func renameImportUsages(f *ast.File, old, new string) {
+	// use this to avoid renaming the package declaration, eg:
+	//   given: package foo; import foo "bar"; foo.Baz, rename foo->qux
+	//   yield: package foo; import qux "bar"; qux.Baz
+	var pkg *ast.Ident
+
+	// Rename top-level old to new, both unresolved names
+	// (probably defined in another file) and names that resolve
+	// to a declaration we renamed.
+	ast.Inspect(f, func(node ast.Node) bool {
+		if node == nil {
+			return false
+		}
+		switch id := node.(type) {
+		case *ast.File:
+			pkg = id.Name
+		case *ast.Ident:
+			if pkg != nil && id == pkg {
+				return false
+			}
+			if id.Name == old {
+				id.Name = new
+			}
+		}
+		return true
+	})
+}
+
+func (a *analyzer) filterFiles(fs map[string]*ast.File) []*ast.File {
+	var files []*ast.File
+	for _, f := range fs {
+		files = append(files, f)
+	}
+	return files
+}
+
+type collector struct {
+	dirs  []string
+	regex *regexp.Regexp
+}
+
+// handlePath walks the filesystem recursively, collecting directories,
+// ignoring some unneeded directories (hidden/vendored) that are handled
+// specially later.
+func (c *collector) handlePath(path string, info os.FileInfo, err error) error {
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		// Ignore hidden directories (.git, .cache, etc)
+		if len(path) > 1 && path[0] == '.' ||
+			// Staging code is symlinked from vendor/k8s.io, and uses import
+			// paths as if it were inside of vendor/. It fails typechecking
+			// inside of staging/, but works when typechecked as part of vendor/.
+			path == "staging" ||
+			// OS-specific vendor code tends to be imported by OS-specific
+			// packages. We recursively typecheck imported vendored packages for
+			// each OS, but don't typecheck everything for every OS.
+			path == "vendor" ||
+			path == "_output" ||
+			// This is a weird one. /testdata/ is *mostly* ignored by Go,
+			// and this translates to kubernetes/vendor not working.
+			// edit/record.go doesn't compile without gopkg.in/yaml.v2
+			// in $GOSRC/$GOROOT (both typecheck and the shell script).
+			path == "pkg/kubectl/cmd/testdata/edit" {
+			return filepath.SkipDir
+		}
+		if c.regex.MatchString(path) {
+			c.dirs = append(c.dirs, path)
+		}
+	}
+	return nil
+}
+
+func main() {
+	flag.Parse()
+	args := flag.Args()
+
+	if len(args) == 0 {
+		args = append(args, ".")
+	}
+
+	regex, err := regexp.Compile(*regex)
+	if err != nil {
+		log.Fatalf("Error compiling regex: %v", err)
+	}
+	c := collector{regex: regex}
+	for _, arg := range args {
+		err := filepath.Walk(arg, c.handlePath)
+		if err != nil {
+			log.Fatalf("Error walking: %v", err)
+		}
+	}
+	sort.Strings(c.dirs)
+
+	if len(*importAliases) > 0 {
+		bytes, err := ioutil.ReadFile(*importAliases)
+		if err != nil {
+			log.Fatalf("Error reading import aliases: %v", err)
+		}
+		err = json.Unmarshal(bytes, &aliases)
+		if err != nil {
+			log.Fatalf("Error loading aliases: %v", err)
+		}
+	}
+	if isTerminal {
+		logPrefix = "\r" // clear status bar when printing
+	}
+	fmt.Println("checking-imports: ")
+
+	a := newAnalyzer()
+	for _, dir := range c.dirs {
+		if isTerminal {
+			fmt.Printf("\r\033[0m %-80s", dir)
+		}
+		a.collect(dir)
+	}
+	fmt.Println()
+	if a.failed {
+		os.Exit(1)
+	}
+}

--- a/hack/update-import-aliases.sh
+++ b/hack/update-import-aliases.sh
@@ -8,12 +8,7 @@ SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${SCRIPT_ROOT}"
 ROOT_PATH=$(pwd)
 
-temp_path=$(mktemp -d)
-pushd "${temp_path}" >/dev/null
-cp "${ROOT_PATH}"/go.mod .
-GO111MODULE=on go get "k8s.io/kubernetes/cmd/preferredimports@v1.21.3"
-GO111MODULE=on go get "golang.org/x/tools/cmd/goimports@v0.1.5"
-popd >/dev/null
+GO111MODULE=on go install "golang.org/x/tools/cmd/goimports@v0.1.5"
 
 IMPORT_ALIASES_PATH="${ROOT_PATH}/hack/.import-aliases"
 INCLUDE_PATH="(${ROOT_PATH}/cmd|${ROOT_PATH}/test/e2e|${ROOT_PATH}/test/helper|\
@@ -21,7 +16,12 @@ ${ROOT_PATH}/pkg/clusterdiscovery|${ROOT_PATH}/pkg/controllers|\
 ${ROOT_PATH}/pkg/estimator/server|${ROOT_PATH}/pkg/karmadactl|${ROOT_PATH}/pkg/scheduler|\
 ${ROOT_PATH}/pkg/util|${ROOT_PATH}/pkg/version|${ROOT_PATH}/pkg/webhook)"
 
-preferredimports -confirm -import-aliases "${IMPORT_ALIASES_PATH}" -include-path "${INCLUDE_PATH}"  "${ROOT_PATH}"
+# We can't directly install preferredimports by `go install` due to the go.mod issue:
+# go install k8s.io/kubernetes/cmd/preferredimports@v1.21.3: k8s.io/kubernetes@v1.21.3
+#   The go.mod file for the module providing named packages contains one or
+#   more replace directives. It must not contain directives that would cause
+#   it to be interpreted differently than if it were the main module.
+go run "${ROOT_PATH}/hack/tools/preferredimports/preferredimports.go" -confirm -import-aliases "${IMPORT_ALIASES_PATH}" -include-path "${INCLUDE_PATH}"  "${ROOT_PATH}"
 
 len=${#INCLUDE_PATH}
 INCLUDE_PATH=${INCLUDE_PATH:1:len-2}
@@ -32,4 +32,3 @@ do
    echo "Sorting importing in file" "${var}"
    goimports -local "github.com/karmada-io/karmada" -w "${var}"
 done
-

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -17,24 +17,17 @@ AGENT_POD_LABEL="karmada-agent"
 
 MIN_Go_VERSION=go1.16.0
 
-# This function installs a Go tools by 'go get' command.
+# This function installs a Go tools by 'go install' command.
 # Parameters:
 #  - $1: package name, such as "sigs.k8s.io/controller-tools/cmd/controller-gen"
 #  - $2: package version, such as "v0.4.1"
-# Note:
-#   Since 'go get' command will resolve and add dependencies to current module, that may update 'go.mod' and 'go.sum' file.
-#   So we use a temporary directory to install the tools.
 function util::install_tools() {
 	local package="$1"
 	local version="$2"
 
-	temp_path=$(mktemp -d)
-	pushd "${temp_path}" >/dev/null
-	GO111MODULE=on go get "${package}"@"${version}"
+	GO111MODULE=on go install "${package}"@"${version}"
 	GOPATH=$(go env GOPATH | awk -F ':' '{print $1}')
 	export PATH=$PATH:$GOPATH/bin
-	popd >/dev/null
-	rm -rf "${temp_path}"
 }
 
 
@@ -82,7 +75,7 @@ function util::cmd_must_exist_cfssl {
     CFSSLJSON_BIN="${GOPATH}/bin/cfssljson"
     if [[ ! -x ${CFSSL_BIN} || ! -x ${CFSSLJSON_BIN} ]]; then
       echo "Failed to download 'cfssl'. Please install cfssl and cfssljson and verify they are in \$PATH."
-      echo "Hint: export PATH=\$PATH:\$GOPATH/bin; go get -u github.com/cloudflare/cfssl/cmd/..."
+      echo "Hint: export PATH=\$PATH:\$GOPATH/bin; go install github.com/cloudflare/cfssl/cmd/..."
       exit 1
     fi
 }

--- a/hack/verify-import-aliases.sh
+++ b/hack/verify-import-aliases.sh
@@ -8,44 +8,6 @@ SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${SCRIPT_ROOT}"
 ROOT_PATH=$(pwd)
 
-temp_path=$(mktemp -d)
-pushd "${temp_path}" >/dev/null
-cat > go.mod <<EOF
-module github.com/karmada-io/karmada
-
-go 1.16
-
-replace (
-	k8s.io/api => k8s.io/api v0.22.2
-	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.22.2
-	k8s.io/apimachinery => k8s.io/apimachinery v0.22.2
-	k8s.io/apiserver => k8s.io/apiserver v0.22.2
-	k8s.io/cli-runtime => k8s.io/cli-runtime v0.22.2
-	k8s.io/client-go => k8s.io/client-go v0.22.2
-	k8s.io/cloud-provider => k8s.io/cloud-provider v0.22.2
-	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.22.2
-	k8s.io/code-generator => k8s.io/code-generator v0.22.2
-	k8s.io/component-base => k8s.io/component-base v0.22.2
-	k8s.io/component-helpers => k8s.io/component-helpers v0.22.2
-	k8s.io/controller-manager => k8s.io/controller-manager v0.22.2
-	k8s.io/cri-api => k8s.io/cri-api v0.22.2
-	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.22.2
-	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.22.2
-	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.22.2
-	k8s.io/kube-proxy => k8s.io/kube-proxy v0.22.2
-	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.22.2
-	k8s.io/kubectl => k8s.io/kubectl v0.22.2
-	k8s.io/kubelet => k8s.io/kubelet v0.22.2
-	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.22.2
-	k8s.io/metrics => k8s.io/metrics v0.22.2
-	k8s.io/mount-utils => k8s.io/mount-utils v0.22.2
-	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.22.2
-	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.22.2
-)
-EOF
-GO111MODULE=on go get "k8s.io/kubernetes/cmd/preferredimports@v1.21.3"
-popd >/dev/null
-
 IMPORT_ALIASES_PATH="${ROOT_PATH}/hack/.import-aliases"
 INCLUDE_PATH="(${ROOT_PATH}/cmd|${ROOT_PATH}/test/e2e|${ROOT_PATH}/test/helper|\
 ${ROOT_PATH}/pkg/clusterdiscovery|${ROOT_PATH}/pkg/controllers|\
@@ -53,7 +15,12 @@ ${ROOT_PATH}/pkg/estimator/server|${ROOT_PATH}/pkg/karmadactl|${ROOT_PATH}/pkg/s
 ${ROOT_PATH}/pkg/util|${ROOT_PATH}/pkg/version|${ROOT_PATH}/pkg/webhook)"
 
 ret=0
-preferredimports -import-aliases "${IMPORT_ALIASES_PATH}" -include-path "${INCLUDE_PATH}"  "${ROOT_PATH}" || ret=$?
+# We can't directly install preferredimports by `go install` due to the go.mod issue:
+# go install k8s.io/kubernetes/cmd/preferredimports@v1.21.3: k8s.io/kubernetes@v1.21.3
+#   The go.mod file for the module providing named packages contains one or
+#   more replace directives. It must not contain directives that would cause
+#   it to be interpreted differently than if it were the main module.
+go run "${ROOT_PATH}/hack/tools/preferredimports/preferredimports.go" -import-aliases "${IMPORT_ALIASES_PATH}" -include-path "${INCLUDE_PATH}"  "${ROOT_PATH}" || ret=$?
 if [[ $ret -ne 0 ]]; then
   echo "!!! Please see hack/.import-aliases for the preferred aliases for imports." >&2
   exit 1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -386,6 +386,7 @@ golang.org/x/sys/plan9
 golang.org/x/sys/unix
 golang.org/x/sys/windows
 # golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d
+## explicit
 golang.org/x/term
 # golang.org/x/text v0.3.6
 golang.org/x/text/encoding


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead.

**Which issue(s) this PR fixes**:
Fixes #918 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

