### PR TITLE
Enable karmadactl unjoin support pull mode cluster

### DIFF
--- a/pkg/util/deployment.go
+++ b/pkg/util/deployment.go
@@ -1,0 +1,47 @@
+package util
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeclient "k8s.io/client-go/kubernetes"
+)
+
+// IsDeploymentExist tells if specific already exists.
+func IsDeploymentExist(client kubeclient.Interface, namespace, name string) (bool, error) {
+	_, err := client.AppsV1().Deployments(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
+}
+
+// CreateDeployment just try to create the Deployment.
+func CreateDeployment(client kubeclient.Interface, deploymentObj *appsv1.Deployment) (*appsv1.Deployment, error) {
+	_, err := client.AppsV1().Deployments(deploymentObj.Namespace).Create(context.TODO(), deploymentObj, metav1.CreateOptions{})
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return deploymentObj, nil
+		}
+
+		return nil, err
+	}
+
+	return deploymentObj, nil
+}
+
+// DeleteDeployment just try to delete the Deployment.
+func DeleteDeployment(client kubeclient.Interface, namespace, name string) error {
+	err := client.AppsV1().Deployments(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: lonelyCZ <531187475@qq.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Every time I want to unjoin agent, I need to delete the remaining resource like agent, rbac, namespace. It is so tedious. 

**Which issue(s) this PR fixes**:
Fixes #801 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
None
```

