### PR TITLE
add conditions for cluster status

### DIFF
--- a/pkg/util/condition.go
+++ b/pkg/util/condition.go
@@ -1,0 +1,13 @@
+package util
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+// NewCondition returns a new condition object.
+func NewCondition(conditionType, reason, message string, status metav1.ConditionStatus) metav1.Condition {
+	return metav1.Condition{
+		Type:    conditionType,
+		Reason:  reason,
+		Status:  status,
+		Message: message,
+	}
+}


### PR DESCRIPTION
Signed-off-by: lihanbo <lihanbo2@huawei.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
To solve the problem I met in #922 

**Which issue(s) this PR fixes**:
Fixes #922 

**Special notes for your reviewer**:
step1: create an invalid apiservice in member cluster
```
apiVersion: apiregistration.k8s.io/v1beta1
kind: APIService
metadata:
  name: v1alpha1.custom-metrics.metrics.k8s.io
spec:
  insecureSkipTLSVerify: true
  group: custom-metrics.metrics.k8s.io
  groupPriorityMinimum: 1000
  versionPriority: 5
  service:
    name: api
    namespace: custom-metrics
  version: v1alpha1
```
then, you can get the following cluster status:
```
status:
  conditions:
  - lastTransitionTime: "2021-11-23T07:37:54Z"
    message: 'failed to get the list of APIs installed in the member cluster: unable
      to retrieve the complete list of server APIs: custom-metrics.metrics.k8s.io/v1alpha1:
      the server is currently unable to handle the request'
    reason: StatusCollectionFailed
    status: "False"
    type: Ready
```

**Does this PR introduce a user-facing change?**:
"NONE"

