### PR TITLE
Clean klog errorf in karmadactl

### DIFF
--- a/cmd/kubectl-karmada/kubectl-karmada.go
+++ b/cmd/kubectl-karmada/kubectl-karmada.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"k8s.io/component-base/logs"
@@ -14,7 +13,6 @@ func main() {
 	defer logs.FlushLogs()
 
 	if err := karmadactl.NewKarmadaCtlCommand(os.Stdout, "karmada", "kubectl karmada").Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
 }

--- a/pkg/karmadactl/get.go
+++ b/pkg/karmadactl/get.go
@@ -218,7 +218,7 @@ func (g *CommandGetOptions) Run(karmadaConfig KarmadaConfig, cmd *cobra.Command,
 		}
 
 		if err := g.getSecretTokenInKarmada(karmadaclient, g.Clusters[idx], clusterInfos); err != nil {
-			return fmt.Errorf("Method getSecretTokenInKarmada get Secret info in karmada failed, err is: %w", err)
+			return fmt.Errorf("method getSecretTokenInKarmada get Secret info in karmada failed, err is: %w", err)
 		}
 		f := getFactory(g.Clusters[idx], clusterInfos)
 		go g.getObjInfo(&wg, &mux, f, g.Clusters[idx], &objs, &allErrs, args)
@@ -401,11 +401,11 @@ type ClusterInfo struct {
 func clusterInfoInit(g *CommandGetOptions, karmadaConfig KarmadaConfig, clusterInfos map[string]*ClusterInfo) (*rest.Config, error) {
 	karmadaclient, err := karmadaConfig.GetRestConfig(g.KarmadaContext, g.KubeConfig)
 	if err != nil {
-		return nil, fmt.Errorf("Func GetRestConfig get karmada client failed, err is: %w", err)
+		return nil, fmt.Errorf("func GetRestConfig get karmada client failed, err is: %w", err)
 	}
 
 	if err := getClusterInKarmada(karmadaclient, clusterInfos); err != nil {
-		return nil, fmt.Errorf("Method getClusterInKarmada get cluster info in karmada failed, err is: %w", err)
+		return nil, fmt.Errorf("method getClusterInKarmada get cluster info in karmada failed, err is: %w", err)
 	}
 
 	if err := getRBInKarmada(g.Namespace, karmadaclient); err != nil {


### PR DESCRIPTION
Signed-off-by: lonelyCZ <531187475@qq.com>

**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Because `RunE` could report error, so we don't need `klog.Errorf` in karmadactl. Otherwise, there are repetitive error output.
```
[root@master67 karmada]# karmadactl join memeber69 --karmada-context=test
E1109 22:15:01.842240   12623 join.go:147] failed to get control plane rest config. context: test, kube-config: , error: context "test" does not exist
Error: context "test" does not exist
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
BTW, clearn `fmt.Fprintf(os.Stderr, "%v\n", err)` in `kubectl-karmada.go`, and modify `pkg/karmadactl/get.go` because error strings should not be capitalized.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

