### PR TITLE
Add the validation for ResourceExploringWebhookConfiguration

### DIFF
--- a/artifacts/deploy/webhook-configuration.yaml
+++ b/artifacts/deploy/webhook-configuration.yaml
@@ -111,3 +111,17 @@ webhooks:
     sideEffects: None
     admissionReviewVersions: ["v1"]
     timeoutSeconds: 3
+  - name: config.karmada.io
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["config.karmada.io"]
+        apiVersions: ["*"]
+        resources: ["resourceexploringwebhookconfigurations"]
+        scope: "Cluster"
+    clientConfig:
+      url: https://karmada-webhook.karmada-system.svc:443/validate-resourceexploringwebhookconfiguration
+      caBundle: {{caBundle}}
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    timeoutSeconds: 3

--- a/charts/templates/_karmada_webhook_configuration.tpl
+++ b/charts/templates/_karmada_webhook_configuration.tpl
@@ -115,4 +115,18 @@ webhooks:
     sideEffects: None
     admissionReviewVersions: ["v1"]
     timeoutSeconds: 3
+  - name: config.karmada.io
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["config.karmada.io"]
+        apiVersions: ["*"]
+        resources: ["resourceexploringwebhookconfigurations"]
+        scope: "Cluster"
+    clientConfig:
+      url: https://{{ $name }}-webhook.{{ $namespace }}.svc:443/validate-resourceexploringwebhookconfiguration
+      {{- include "karmada.webhook.caBundle" . | nindent 6 }}
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    timeoutSeconds: 3
 {{- end -}}

--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -20,6 +20,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/version/sharedcommand"
 	"github.com/karmada-io/karmada/pkg/webhook/cluster"
 	"github.com/karmada-io/karmada/pkg/webhook/clusterpropagationpolicy"
+	"github.com/karmada-io/karmada/pkg/webhook/crdexplorer"
 	"github.com/karmada-io/karmada/pkg/webhook/overridepolicy"
 	"github.com/karmada-io/karmada/pkg/webhook/propagationpolicy"
 	"github.com/karmada-io/karmada/pkg/webhook/work"
@@ -78,6 +79,7 @@ func Run(ctx context.Context, opts *options.Options) error {
 	hookServer.Register("/mutate-overridepolicy", &webhook.Admission{Handler: &overridepolicy.MutatingAdmission{}})
 	hookServer.Register("/mutate-work", &webhook.Admission{Handler: &work.MutatingAdmission{}})
 	hookServer.Register("/convert", &conversion.Webhook{})
+	hookServer.Register("/validate-resourceexploringwebhookconfiguration", &webhook.Admission{Handler: &crdexplorer.ValidatingAdmission{}})
 	hookServer.WebhookMux.Handle("/readyz/", http.StripPrefix("/readyz/", &healthz.Handler{}))
 
 	// blocks until the context is done.

--- a/pkg/apis/config/v1alpha1/explorewebhook_types.go
+++ b/pkg/apis/config/v1alpha1/explorewebhook_types.go
@@ -77,6 +77,9 @@ type RuleWithOperations struct {
 type OperationType string
 
 const (
+	// OperationAll indicates math all OperationType.
+	OperationAll OperationType = "*"
+
 	// ExploreReplica indicates that karmada want to figure out the replica declaration of a specific object.
 	// Only necessary for those resource types that have replica declaration, like Deployment or similar custom resources.
 	ExploreReplica OperationType = "ExploreReplica"

--- a/pkg/webhook/crdexplorer/helper.go
+++ b/pkg/webhook/crdexplorer/helper.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+@CHANGELOG
+Karmada Authors: To validate the creating/update of crd ResourceExploringWebhookConfiguration,
+This file is derived from K8S admissionregistration/validation code with reduced set of methods.
+*/
+
+package crdexplorer
+
+import (
+	"fmt"
+	"strings"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+var validScopes = sets.NewString(
+	string(admissionregistrationv1.ClusterScope),
+	string(admissionregistrationv1.NamespacedScope),
+	string(admissionregistrationv1.AllScopes),
+)
+
+var supportedFailurePolicies = sets.NewString(
+	string(admissionregistrationv1.Ignore),
+	string(admissionregistrationv1.Fail),
+)
+
+func hasWildcard(slice []string) bool {
+	for _, s := range slice {
+		if s == "*" {
+			return true
+		}
+	}
+	return false
+}
+
+func validateRule(rule *admissionregistrationv1.Rule, fldPath *field.Path, allowSubResource bool) field.ErrorList {
+	var allErrors field.ErrorList
+	if len(rule.APIGroups) == 0 {
+		allErrors = append(allErrors, field.Required(fldPath.Child("apiGroups"), ""))
+	}
+	if len(rule.APIGroups) > 1 && hasWildcard(rule.APIGroups) {
+		allErrors = append(allErrors, field.Invalid(fldPath.Child("apiGroups"), rule.APIGroups, "if '*' is present, must not specify other API groups"))
+	}
+	// Note: group could be empty, e.g., the legacy "v1" API
+	if len(rule.APIVersions) == 0 {
+		allErrors = append(allErrors, field.Required(fldPath.Child("apiVersions"), ""))
+	}
+	if len(rule.APIVersions) > 1 && hasWildcard(rule.APIVersions) {
+		allErrors = append(allErrors, field.Invalid(fldPath.Child("apiVersions"), rule.APIVersions, "if '*' is present, must not specify other API versions"))
+	}
+	for i, version := range rule.APIVersions {
+		if version == "" {
+			allErrors = append(allErrors, field.Required(fldPath.Child("apiVersions").Index(i), ""))
+		}
+	}
+	if allowSubResource {
+		allErrors = append(allErrors, validateResources(rule.Resources, fldPath.Child("resources"))...)
+	} else {
+		allErrors = append(allErrors, validateResourcesNoSubResources(rule.Resources, fldPath.Child("resources"))...)
+	}
+	if rule.Scope != nil && !validScopes.Has(string(*rule.Scope)) {
+		allErrors = append(allErrors, field.NotSupported(fldPath.Child("scope"), *rule.Scope, validScopes.List()))
+	}
+	return allErrors
+}
+
+func validateResources(resources []string, fldPath *field.Path) field.ErrorList {
+	var allErrors field.ErrorList
+	if len(resources) == 0 {
+		allErrors = append(allErrors, field.Required(fldPath, ""))
+	}
+
+	// */x
+	resourcesWithWildcardSubresoures := sets.String{}
+	// x/*
+	subResourcesWithWildcardResource := sets.String{}
+	// */*
+	hasDoubleWildcard := false
+	// *
+	hasSingleWildcard := false
+	// x
+	hasResourceWithoutSubresource := false
+
+	for i, resSub := range resources {
+		if resSub == "" {
+			allErrors = append(allErrors, field.Required(fldPath.Index(i), ""))
+			continue
+		}
+		if resSub == "*/*" {
+			hasDoubleWildcard = true
+		}
+		if resSub == "*" {
+			hasSingleWildcard = true
+		}
+		parts := strings.SplitN(resSub, "/", 2)
+		if len(parts) == 1 {
+			hasResourceWithoutSubresource = resSub != "*"
+			continue
+		}
+		res, sub := parts[0], parts[1]
+		if _, ok := resourcesWithWildcardSubresoures[res]; ok {
+			allErrors = append(allErrors, field.Invalid(fldPath.Index(i), resSub, fmt.Sprintf("if '%s/*' is present, must not specify %s", res, resSub)))
+		}
+		if _, ok := subResourcesWithWildcardResource[sub]; ok {
+			allErrors = append(allErrors, field.Invalid(fldPath.Index(i), resSub, fmt.Sprintf("if '*/%s' is present, must not specify %s", sub, resSub)))
+		}
+		if sub == "*" {
+			resourcesWithWildcardSubresoures[res] = struct{}{}
+		}
+		if res == "*" {
+			subResourcesWithWildcardResource[sub] = struct{}{}
+		}
+	}
+	if len(resources) > 1 && hasDoubleWildcard {
+		allErrors = append(allErrors, field.Invalid(fldPath, resources, "if '*/*' is present, must not specify other resources"))
+	}
+	if hasSingleWildcard && hasResourceWithoutSubresource {
+		allErrors = append(allErrors, field.Invalid(fldPath, resources, "if '*' is present, must not specify other resources without subresources"))
+	}
+	return allErrors
+}
+
+func validateResourcesNoSubResources(resources []string, fldPath *field.Path) field.ErrorList {
+	var allErrors field.ErrorList
+	if len(resources) == 0 {
+		allErrors = append(allErrors, field.Required(fldPath, ""))
+	}
+	for i, resource := range resources {
+		if resource == "" {
+			allErrors = append(allErrors, field.Required(fldPath.Index(i), ""))
+		}
+		if strings.Contains(resource, "/") {
+			allErrors = append(allErrors, field.Invalid(fldPath.Index(i), resource, "must not specify subresources"))
+		}
+	}
+	if len(resources) > 1 && hasWildcard(resources) {
+		allErrors = append(allErrors, field.Invalid(fldPath, resources, "if '*' is present, must not specify other resources"))
+	}
+	return allErrors
+}

--- a/pkg/webhook/crdexplorer/validating.go
+++ b/pkg/webhook/crdexplorer/validating.go
@@ -1,0 +1,174 @@
+package crdexplorer
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/util/webhook"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	configv1alpha1 "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1"
+)
+
+// ValidatingAdmission validates ResourceExploringWebhookConfiguration object when creating/updating.
+type ValidatingAdmission struct {
+	decoder *admission.Decoder
+}
+
+// Check if our ValidatingAdmission implements necessary interface
+var _ admission.Handler = &ValidatingAdmission{}
+var _ admission.DecoderInjector = &ValidatingAdmission{}
+
+// Handle implements admission.Handler interface.
+// It yields a response to an AdmissionRequest.
+func (v *ValidatingAdmission) Handle(ctx context.Context, req admission.Request) admission.Response {
+	configuration := &configv1alpha1.ResourceExploringWebhookConfiguration{}
+
+	err := v.decoder.Decode(req, configuration)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	klog.V(2).Infof("Validating ResourceExploringWebhookConfiguration(%s) for request: %s", configuration.Name, req.Operation)
+
+	var allErrors field.ErrorList
+	hookNames := sets.NewString()
+	for i, hook := range configuration.Webhooks {
+		allErrors = append(allErrors, validateWebhook(&configuration.Webhooks[i], field.NewPath("webhooks").Index(i))...)
+		if hookNames.Has(hook.Name) {
+			allErrors = append(allErrors, field.Duplicate(field.NewPath("webhooks").Index(i).Child("name"), hook.Name))
+			continue
+		}
+		hookNames.Insert(hook.Name)
+	}
+
+	if len(allErrors) != 0 {
+		klog.Error(allErrors.ToAggregate())
+		return admission.Denied(allErrors.ToAggregate().Error())
+	}
+
+	return admission.Allowed("")
+}
+
+// InjectDecoder implements admission.DecoderInjector interface.
+// A decoder will be automatically injected.
+func (v *ValidatingAdmission) InjectDecoder(d *admission.Decoder) error {
+	v.decoder = d
+	return nil
+}
+
+var supportedOperationType = sets.NewString(
+	string(configv1alpha1.OperationAll),
+	string(configv1alpha1.ExploreReplica),
+	string(configv1alpha1.ExploreStatus),
+	string(configv1alpha1.ExplorePacking),
+	string(configv1alpha1.ExploreReplicaRevising),
+	string(configv1alpha1.ExploreRetaining),
+	string(configv1alpha1.ExploreStatusAggregating),
+	string(configv1alpha1.ExploreHealthy),
+	string(configv1alpha1.ExploreDependencies),
+)
+
+var acceptedExploreReviewVersions = []string{configv1alpha1.GroupVersion.Version}
+
+func validateWebhook(hook *configv1alpha1.ResourceExploringWebhook, fldPath *field.Path) field.ErrorList {
+	var allErrors field.ErrorList
+	// hook.Name must be fully qualified
+	allErrors = append(allErrors, validation.IsFullyQualifiedDomainName(fldPath.Child("name"), hook.Name)...)
+
+	for i := range hook.Rules {
+		allErrors = append(allErrors, validateRuleWithOperations(&hook.Rules[i], fldPath.Child("rules").Index(i))...)
+	}
+
+	if hook.FailurePolicy != nil && !supportedFailurePolicies.Has(string(*hook.FailurePolicy)) {
+		allErrors = append(allErrors, field.NotSupported(fldPath.Child("matchPolicy"), *hook.FailurePolicy, supportedFailurePolicies.List()))
+	}
+
+	if hook.TimeoutSeconds != nil && (*hook.TimeoutSeconds > 30 || *hook.TimeoutSeconds < 1) {
+		allErrors = append(allErrors, field.Invalid(fldPath.Child("timeoutSeconds"), *hook.TimeoutSeconds, "the timeout value must be between 1 and 30 seconds"))
+	}
+
+	cc := hook.ClientConfig
+	switch {
+	case (cc.URL == nil) == (cc.Service == nil):
+		allErrors = append(allErrors, field.Required(fldPath.Child("clientConfig"), "exactly one of url or service is required"))
+	case cc.URL != nil:
+		allErrors = append(allErrors, webhook.ValidateWebhookURL(fldPath.Child("clientConfig").Child("url"), *cc.URL, true)...)
+	case cc.Service != nil:
+		allErrors = append(allErrors, webhook.ValidateWebhookService(fldPath.Child("clientConfig").Child("service"), cc.Service.Name, cc.Service.Namespace, cc.Service.Path, *cc.Service.Port)...)
+	}
+
+	allErrors = append(allErrors, validateExploreReviewVersions(hook.ExploreReviewVersions, fldPath.Child("exploreReviewVersions"))...)
+	return allErrors
+}
+
+func hasWildcardOperation(operations []configv1alpha1.OperationType) bool {
+	for _, o := range operations {
+		if o == configv1alpha1.OperationAll {
+			return true
+		}
+	}
+	return false
+}
+
+func validateRuleWithOperations(ruleWithOperations *configv1alpha1.RuleWithOperations, fldPath *field.Path) field.ErrorList {
+	var allErrors field.ErrorList
+	if len(ruleWithOperations.Operations) == 0 {
+		allErrors = append(allErrors, field.Required(fldPath.Child("operations"), ""))
+	}
+	if len(ruleWithOperations.Operations) > 1 && hasWildcardOperation(ruleWithOperations.Operations) {
+		allErrors = append(allErrors, field.Invalid(fldPath.Child("operations"), ruleWithOperations.Operations, "if '*' is present, must not specify other operations"))
+	}
+	for i, operation := range ruleWithOperations.Operations {
+		if !supportedOperationType.Has(string(operation)) {
+			allErrors = append(allErrors, field.NotSupported(fldPath.Child("operations").Index(i), operation, supportedOperationType.List()))
+		}
+	}
+	allErrors = append(allErrors, validateRule(&ruleWithOperations.Rule, fldPath, false)...)
+	return allErrors
+}
+
+func validateExploreReviewVersions(versions []string, fldPath *field.Path) field.ErrorList {
+	allErrors := field.ErrorList{}
+
+	// Currently, only v1alpha1 accepted in ExploreReviewVersions
+	if len(versions) < 1 {
+		allErrors = append(allErrors, field.Required(fldPath, fmt.Sprintf("must specify one of %v", strings.Join(acceptedExploreReviewVersions, ", "))))
+	} else {
+		visited := map[string]bool{}
+		hasAcceptedVersion := false
+		for i, v := range versions {
+			if visited[v] {
+				allErrors = append(allErrors, field.Invalid(fldPath.Index(i), v, "duplicate version"))
+				continue
+			}
+			visited[v] = true
+			for _, errString := range validation.IsDNS1035Label(v) {
+				allErrors = append(allErrors, field.Invalid(fldPath.Index(i), v, errString))
+			}
+			if isAcceptedExploreReviewVersions(v) {
+				hasAcceptedVersion = true
+			}
+		}
+		if !hasAcceptedVersion {
+			allErrors = append(allErrors, field.Invalid(
+				fldPath, versions,
+				fmt.Sprintf("must include at least one of %v", strings.Join(acceptedExploreReviewVersions, ", "))))
+		}
+	}
+	return allErrors
+}
+
+func isAcceptedExploreReviewVersions(v string) bool {
+	for _, version := range acceptedExploreReviewVersions {
+		if v == version {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add the validation for `ResourceExploringWebhookConfiguration` creation/update, the restriction complies with the API definition.

For example, when I create a `ResourceExploringWebhookConfiguration` object with following yaml:
```yaml
// example-rewc.yaml
apiVersion: config.karmada.io/v1alpha1
kind: ResourceExploringWebhookConfiguration
metadata:
  name: example
webhooks:
  - name: foo.example.com
    rules:
      - operations: ["ExploreRetaining", "ExploreHealthy", "ExploreTest"]
        apiGroups: ["foo.example.com"]
        apiVersions: ["*"]
        resources: ["foos"]
        scope: "Namespaced"
    clientConfig:
      url: https://xxx:443/explore-foo
      caBundle: xxx
    failurePolicy: Fail
    exploreReviewVersions: ["v1alpha1"]
    timeoutSeconds: 3
```
Run `kubectl` to create a command prompt:
```
# kubectl create -f example-rewc.yaml 
Error from server (webhooks[0].rules[0].operations[2]: Unsupported value: "ExploreTest": supported values: "*", "ExploreDependencies", "ExploreHealthy", "ExplorePacking", "ExploreReplica", "ExploreReplicaRevising", "ExploreRetaining", "ExploreStatus", "ExploreStatusAggregating"): error when creating "example-rewc.yaml": admission webhook "config.karmada.io" denied the request: webhooks[0].rules[0].operations[2]: Unsupported value: "ExploreTest": supported values: "*", "ExploreDependencies", "ExploreHealthy", "ExplorePacking", "ExploreReplica", "ExploreReplicaRevising", "ExploreRetaining", "ExploreStatus", "ExploreStatusAggregating"
```


**Which issue(s) this PR fixes**:
Part of #923 

**Special notes for your reviewer**:

Some codes are copy from `https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/admissionregistration/validation/validation.go`, it has been explained.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

