### PR TITLE
replace klog.Fatal with klog.Exit

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -123,7 +123,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 		ClusterLeaseRenewIntervalFraction: opts.ClusterLeaseRenewIntervalFraction,
 	}
 	if err := clusterStatusController.SetupWithManager(mgr); err != nil {
-		klog.Fatalf("Failed to setup cluster status controller: %v", err)
+		klog.Exitf("Failed to setup cluster status controller: %v", err)
 	}
 
 	objectWatcher := objectwatcher.NewObjectWatcher(mgr.GetClient(), mgr.GetRESTMapper(), util.NewClusterDynamicClientSetForAgent)
@@ -136,7 +136,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 		InformerManager: informermanager.GetInstance(),
 	}
 	if err := executionController.SetupWithManager(mgr); err != nil {
-		klog.Fatalf("Failed to setup execution controller: %v", err)
+		klog.Exitf("Failed to setup execution controller: %v", err)
 	}
 
 	workStatusController := &status.WorkStatusController{
@@ -152,7 +152,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 	}
 	workStatusController.RunWorkQueue()
 	if err := workStatusController.SetupWithManager(mgr); err != nil {
-		klog.Fatalf("Failed to setup work status controller: %v", err)
+		klog.Exitf("Failed to setup work status controller: %v", err)
 	}
 
 	serviceExportController := &mcs.ServiceExportController{
@@ -167,7 +167,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 	}
 	serviceExportController.RunWorkQueue()
 	if err := serviceExportController.SetupWithManager(mgr); err != nil {
-		klog.Fatalf("Failed to setup ServiceExport controller: %v", err)
+		klog.Exitf("Failed to setup ServiceExport controller: %v", err)
 	}
 
 	// Ensure the InformerManager stops when the stop channel closes

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -133,7 +133,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 		SkippedPropagatingNamespaces: skippedPropagatingNamespaces,
 	}
 	if err := mgr.Add(resourceDetector); err != nil {
-		klog.Fatalf("Failed to setup resource detector: %v", err)
+		klog.Exitf("Failed to setup resource detector: %v", err)
 	}
 
 	setupClusterAPIClusterDetector(mgr, opts, stopChan)
@@ -146,7 +146,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 		ClusterStartupGracePeriod: opts.ClusterStartupGracePeriod.Duration,
 	}
 	if err := clusterController.SetupWithManager(mgr); err != nil {
-		klog.Fatalf("Failed to setup cluster controller: %v", err)
+		klog.Exitf("Failed to setup cluster controller: %v", err)
 	}
 
 	clusterPredicateFunc := predicate.Funcs{
@@ -182,7 +182,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 		ClusterLeaseRenewIntervalFraction: opts.ClusterLeaseRenewIntervalFraction,
 	}
 	if err := clusterStatusController.SetupWithManager(mgr); err != nil {
-		klog.Fatalf("Failed to setup cluster status controller: %v", err)
+		klog.Exitf("Failed to setup cluster status controller: %v", err)
 	}
 
 	hpaController := &hpa.HorizontalPodAutoscalerController{
@@ -193,7 +193,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 		InformerManager: controlPlaneInformerManager,
 	}
 	if err := hpaController.SetupWithManager(mgr); err != nil {
-		klog.Fatalf("Failed to setup hpa controller: %v", err)
+		klog.Exitf("Failed to setup hpa controller: %v", err)
 	}
 
 	bindingController := &binding.ResourceBindingController{
@@ -205,7 +205,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 		InformerManager: controlPlaneInformerManager,
 	}
 	if err := bindingController.SetupWithManager(mgr); err != nil {
-		klog.Fatalf("Failed to setup binding controller: %v", err)
+		klog.Exitf("Failed to setup binding controller: %v", err)
 	}
 
 	clusterResourceBindingController := &binding.ClusterResourceBindingController{
@@ -217,7 +217,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 		InformerManager: controlPlaneInformerManager,
 	}
 	if err := clusterResourceBindingController.SetupWithManager(mgr); err != nil {
-		klog.Fatalf("Failed to setup cluster resource binding controller: %v", err)
+		klog.Exitf("Failed to setup cluster resource binding controller: %v", err)
 	}
 
 	executionController := &execution.Controller{
@@ -229,7 +229,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 		InformerManager: informermanager.GetInstance(),
 	}
 	if err := executionController.SetupWithManager(mgr); err != nil {
-		klog.Fatalf("Failed to setup execution controller: %v", err)
+		klog.Exitf("Failed to setup execution controller: %v", err)
 	}
 
 	workStatusController := &status.WorkStatusController{
@@ -245,7 +245,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 	}
 	workStatusController.RunWorkQueue()
 	if err := workStatusController.SetupWithManager(mgr); err != nil {
-		klog.Fatalf("Failed to setup work status controller: %v", err)
+		klog.Exitf("Failed to setup work status controller: %v", err)
 	}
 
 	namespaceSyncController := &namespace.Controller{
@@ -254,7 +254,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 		SkippedPropagatingNamespaces: skippedPropagatingNamespaces,
 	}
 	if err := namespaceSyncController.SetupWithManager(mgr); err != nil {
-		klog.Fatalf("Failed to setup namespace sync controller: %v", err)
+		klog.Exitf("Failed to setup namespace sync controller: %v", err)
 	}
 
 	serviceExportController := &mcs.ServiceExportController{
@@ -269,7 +269,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 	}
 	serviceExportController.RunWorkQueue()
 	if err := serviceExportController.SetupWithManager(mgr); err != nil {
-		klog.Fatalf("Failed to setup ServiceExport controller: %v", err)
+		klog.Exitf("Failed to setup ServiceExport controller: %v", err)
 	}
 
 	endpointSliceController := &mcs.EndpointSliceController{
@@ -277,7 +277,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 		EventRecorder: mgr.GetEventRecorderFor(mcs.EndpointSliceControllerName),
 	}
 	if err := endpointSliceController.SetupWithManager(mgr); err != nil {
-		klog.Fatalf("Failed to setup EndpointSlice controller: %v", err)
+		klog.Exitf("Failed to setup EndpointSlice controller: %v", err)
 	}
 
 	serviceImportController := &mcs.ServiceImportController{
@@ -285,7 +285,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 		EventRecorder: mgr.GetEventRecorderFor(mcs.ServiceImportControllerName),
 	}
 	if err := serviceImportController.SetupWithManager(mgr); err != nil {
-		klog.Fatalf("Failed to setup ServiceImport controller: %v", err)
+		klog.Exitf("Failed to setup ServiceImport controller: %v", err)
 	}
 
 	// Ensure the InformerManager stops when the stop channel closes
@@ -306,12 +306,12 @@ func setupClusterAPIClusterDetector(mgr controllerruntime.Manager, opts *options
 	karmadaConfig := karmadactl.NewKarmadaConfig(clientcmd.NewDefaultPathOptions())
 	clusterAPIRestConfig, err := karmadaConfig.GetRestConfig(opts.ClusterAPIContext, opts.ClusterAPIKubeconfig)
 	if err != nil {
-		klog.Fatalf("Failed to get cluster-api management cluster rest config. context: %s, kubeconfig: %s, err: %v", opts.ClusterAPIContext, opts.ClusterAPIKubeconfig, err)
+		klog.Exitf("Failed to get cluster-api management cluster rest config. context: %s, kubeconfig: %s, err: %v", opts.ClusterAPIContext, opts.ClusterAPIKubeconfig, err)
 	}
 
 	clusterAPIClient, err := gclient.NewForConfig(clusterAPIRestConfig)
 	if err != nil {
-		klog.Fatalf("Failed to get config from clusterAPIRestConfig: %v", err)
+		klog.Exitf("Failed to get config from clusterAPIRestConfig: %v", err)
 	}
 
 	clusterAPIClusterDetector := &clusterapi.ClusterDetector{
@@ -322,7 +322,7 @@ func setupClusterAPIClusterDetector(mgr controllerruntime.Manager, opts *options
 		InformerManager:       informermanager.NewSingleClusterInformerManager(dynamic.NewForConfigOrDie(clusterAPIRestConfig), 0, stopChan),
 	}
 	if err := mgr.Add(clusterAPIClusterDetector); err != nil {
-		klog.Fatalf("Failed to setup cluster-api cluster detector: %v", err)
+		klog.Exitf("Failed to setup cluster-api cluster detector: %v", err)
 	}
 
 	klog.Infof("Success to setup cluster-api cluster detector")

--- a/cmd/scheduler-estimator/app/scheduler-estimator.go
+++ b/cmd/scheduler-estimator/app/scheduler-estimator.go
@@ -67,5 +67,5 @@ func serveHealthz(address string) {
 		_, _ = w.Write([]byte("ok"))
 	})
 
-	klog.Fatal(http.ListenAndServe(address, nil))
+	klog.Exit(http.ListenAndServe(address, nil))
 }

--- a/cmd/scheduler/app/scheduler.go
+++ b/cmd/scheduler/app/scheduler.go
@@ -115,7 +115,7 @@ func run(opts *options.Options, stopChan <-chan struct{}) error {
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: sched.Run,
 			OnStoppedLeading: func() {
-				klog.Fatalf("leaderelection lost")
+				klog.Exitf("leaderelection lost")
 			},
 		},
 	})
@@ -131,5 +131,5 @@ func serveHealthzAndMetrics(address string) {
 
 	http.Handle("/metrics", promhttp.Handler())
 
-	klog.Fatal(http.ListenAndServe(address, nil))
+	klog.Exit(http.ListenAndServe(address, nil))
 }

--- a/pkg/clusterdiscovery/clusterapi/clusterapi.go
+++ b/pkg/clusterdiscovery/clusterapi/clusterapi.go
@@ -171,7 +171,7 @@ func (d *ClusterDetector) joinClusterAPICluster(clusterWideKey keys.ClusterWideK
 
 	clusterRestConfig, err := d.KarmadaConfig.GetRestConfig("", kubeconfigPath)
 	if err != nil {
-		klog.Fatalf("Failed to get cluster-api management cluster rest config. kubeconfig: %s, err: %v", kubeconfigPath, err)
+		klog.Exitf("Failed to get cluster-api management cluster rest config. kubeconfig: %s, err: %v", kubeconfigPath, err)
 	}
 	opts := karmadactl.CommandJoinOption{
 		GlobalCommandOptions: options.GlobalCommandOptions{


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
`klog.Fatal` will print error info, including a stack trace of all running goroutines, then calls os.Exit(255).
trace contains too much info, about hundreds of lines, and these trace are helpless for us to find and debug why component progress start failed.
But `klog.Exit` will only print logs, and calls os.Exit(1). And dont print stack trace.
And so it's helpful and more easily for us to find the definite reason why component start failed.
So we replace log functions as below
```
klog.Fatal => klog.Exit
klog.Fatalf => klog.Exitf
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

