### PR TITLE
clean up metrics package init

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -3,6 +3,15 @@ package main
 import (
 	"os"
 
+	// Note that Kubernetes registers workqueue metrics to default prometheus Registry. And the registry will be
+	// initialized by the package 'k8s.io/apiserver/pkg/server'.
+	// See https://github.com/kubernetes/kubernetes/blob/f61ed439882e34d9dad28b602afdc852feb2337a/staging/src/k8s.io/component-base/metrics/prometheus/workqueue/metrics.go#L25
+	// But the controller-runtime registers workqueue metrics to its own Registry instead of default prometheus Registry.
+	// See https://github.com/kubernetes-sigs/controller-runtime/blob/4d10a0615b11507451ecb58bfd59f0f6ef313a29/pkg/metrics/workqueue.go#L24-L26
+	// However, global workqueue metrics factory will be only initialized once.
+	// See https://github.com/kubernetes/kubernetes/blob/f61ed439882e34d9dad28b602afdc852feb2337a/staging/src/k8s.io/client-go/util/workqueue/metrics.go#L257-L261
+	// So this package should be initialized before 'k8s.io/apiserver/pkg/server', thus the internal registry of
+	// controller-runtime could be set first.
 	_ "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	apiserver "k8s.io/apiserver/pkg/server"

--- a/cmd/controller-manager/controller-manager.go
+++ b/cmd/controller-manager/controller-manager.go
@@ -4,6 +4,17 @@ import (
 	"fmt"
 	"os"
 
+	// Note that Kubernetes registers workqueue metrics to default prometheus Registry. And the registry will be
+	// initialized by the package 'k8s.io/apiserver/pkg/server'.
+	// See https://github.com/kubernetes/kubernetes/blob/f61ed439882e34d9dad28b602afdc852feb2337a/staging/src/k8s.io/component-base/metrics/prometheus/workqueue/metrics.go#L25
+	// But the controller-runtime registers workqueue metrics to its own Registry instead of default prometheus Registry.
+	// See https://github.com/kubernetes-sigs/controller-runtime/blob/4d10a0615b11507451ecb58bfd59f0f6ef313a29/pkg/metrics/workqueue.go#L24-L26
+	// However, global workqueue metrics factory will be only initialized once.
+	// See https://github.com/kubernetes/kubernetes/blob/f61ed439882e34d9dad28b602afdc852feb2337a/staging/src/k8s.io/client-go/util/workqueue/metrics.go#L257-L261
+	// So this package should be initialized before 'k8s.io/apiserver/pkg/server', thus the internal registry of
+	// controller-runtime could be set first.
+	_ "sigs.k8s.io/controller-runtime/pkg/metrics"
+
 	apiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/component-base/logs"
 

--- a/cmd/scheduler-estimator/main.go
+++ b/cmd/scheduler-estimator/main.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	_ "sigs.k8s.io/controller-runtime/pkg/metrics"
-
 	apiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/component-base/logs"
 


### PR DESCRIPTION
Signed-off-by: Garrybest <garrybest@foxmail.com>

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Estimator does not use controller-runtime, so there is no need to initialize `sigs.k8s.io/controller-runtime/pkg/metrics`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

