### PR TITLE
create namespace using Clientset instead of crd client

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -192,11 +192,12 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 
 func registerWithControlPlaneAPIServer(controlPlaneRestConfig *restclient.Config, memberClusterName string) error {
 	client := gclient.NewForConfigOrDie(controlPlaneRestConfig)
+	kubeClient := kubeclientset.NewForConfigOrDie(controlPlaneRestConfig)
 
 	namespaceObj := &corev1.Namespace{}
 	namespaceObj.Name = util.NamespaceClusterLease
 
-	if err := util.CreateNamespaceIfNotExist(client, namespaceObj); err != nil {
+	if _, err := util.CreateNamespace(kubeClient, namespaceObj); err != nil {
 		klog.Errorf("Failed to create namespace(%s) object, error: %v", namespaceObj.Name, err)
 		return err
 	}

--- a/pkg/util/namespace.go
+++ b/pkg/util/namespace.go
@@ -6,9 +6,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	kubeclient "k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // IsNamespaceExist tells if specific already exists.
@@ -44,20 +42,6 @@ func DeleteNamespace(client kubeclient.Interface, namespace string) error {
 	err := client.CoreV1().Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
-	}
-	return nil
-}
-
-// CreateNamespaceIfNotExist try to create the namespace if it does not exist.
-func CreateNamespaceIfNotExist(client client.Client, namespaceObj *corev1.Namespace) error {
-	namespace := &corev1.Namespace{}
-	if err := client.Get(context.TODO(), types.NamespacedName{Name: namespaceObj.Name}, namespace); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return err
-		}
-		if err := client.Create(context.TODO(), namespaceObj); err != nil {
-			return err
-		}
 	}
 	return nil
 }

--- a/pkg/util/secret.go
+++ b/pkg/util/secret.go
@@ -65,7 +65,7 @@ func DeleteSecret(client kubeclient.Interface, namespace, name string) error {
 func PatchSecret(client kubeclient.Interface, namespace, name string, pt types.PatchType, patchSecretBody *corev1.Secret) error {
 	patchSecretByte, err := json.Marshal(patchSecretBody)
 	if err != nil {
-		klog.Errorf("failed to marshal patch body of secret object %v into JSON: %v", patchSecretByte, err)
+		klog.Errorf("failed to marshal patch body of secret object %v into JSON: %v", patchSecretBody, err)
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: guoyao <1015105054@qq.com>

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind cleanup
/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
better using k8s client to create namespace, rather than using crd client(from "sigs.k8s.io/controller-runtime/pkg/client") .
and fucntion `CreateNamespaceIfNotExist` and `CreateNamespace` in functionality are almost the same, except for input parameter client types. So keep the one left.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

