### PR TITLE
unify IsNodeReady function

### DIFF
--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -431,7 +431,7 @@ func getNodeSummary(nodes []*corev1.Node) *clusterv1alpha1.NodeSummary {
 	readyNum := 0
 
 	for _, node := range nodes {
-		if getReadyStatusForNode(node.Status) {
+		if helper.NodeReady(node) {
 			readyNum++
 		}
 	}
@@ -478,17 +478,6 @@ func convertObjectsToPods(podList []runtime.Object) ([]*corev1.Pod, error) {
 		pods = append(pods, pod)
 	}
 	return pods, nil
-}
-
-func getReadyStatusForNode(nodeStatus corev1.NodeStatus) bool {
-	for _, condition := range nodeStatus.Conditions {
-		if condition.Type == corev1.NodeReady {
-			if condition.Status == corev1.ConditionTrue {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func getClusterAllocatable(nodeList []*corev1.Node) (allocatable corev1.ResourceList) {

--- a/pkg/estimator/server/nodes/filter.go
+++ b/pkg/estimator/server/nodes/filter.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
 
 	"github.com/karmada-io/karmada/pkg/estimator/pb"
+	"github.com/karmada-io/karmada/pkg/util/helper"
 )
 
 // ListNodesByNodeClaim returns all nodes that match the node claim.
@@ -76,7 +77,7 @@ func FilterSchedulableNodes(nodes []*corev1.Node, tolerations []corev1.Toleratio
 		if node.Spec.Unschedulable {
 			continue
 		}
-		if !IsNodeReady(node.Status.Conditions) {
+		if !helper.NodeReady(node) {
 			continue
 		}
 		if _, isUntolerated := schedcorev1.FindMatchingUntoleratedTaint(node.Spec.Taints, tolerations, filterPredicate); isUntolerated {
@@ -85,14 +86,4 @@ func FilterSchedulableNodes(nodes []*corev1.Node, tolerations []corev1.Toleratio
 		matchedNodes = append(matchedNodes, node)
 	}
 	return matchedNodes, nil
-}
-
-// IsNodeReady checks whether the node condition is ready.
-func IsNodeReady(nodeStatus []corev1.NodeCondition) bool {
-	for i := range nodeStatus {
-		if nodeStatus[i].Type == corev1.NodeReady {
-			return nodeStatus[i].Status == corev1.ConditionTrue
-		}
-	}
-	return false
 }

--- a/pkg/scheduler/framework/plugins/apiinstalled/api_installed.go
+++ b/pkg/scheduler/framework/plugins/apiinstalled/api_installed.go
@@ -36,7 +36,7 @@ func (p *APIInstalled) Name() string {
 // Filter checks if the API(CRD) of the resource is installed in the target cluster.
 func (p *APIInstalled) Filter(ctx context.Context, placement *policyv1alpha1.Placement, resource *workv1alpha2.ObjectReference, cluster *clusterv1alpha1.Cluster) *framework.Result {
 	if !helper.IsAPIEnabled(cluster.Status.APIEnablements, resource.APIVersion, resource.Kind) {
-		klog.V(2).Infof("cluster(%s) not fit as missing API(%s, kind=%s)", cluster.Name, resource.APIVersion, resource.Kind)
+		klog.V(2).Infof("Cluster(%s) not fit as missing API(%s, kind=%s)", cluster.Name, resource.APIVersion, resource.Kind)
 		return framework.NewResult(framework.Unschedulable, "no such API resource")
 	}
 

--- a/pkg/util/helper/node.go
+++ b/pkg/util/helper/node.go
@@ -1,0 +1,13 @@
+package helper
+
+import corev1 "k8s.io/api/core/v1"
+
+// NodeReady checks whether the node condition is ready.
+func NodeReady(node *corev1.Node) bool {
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
function `getReadyStatusForNode` and function `IsNodeReady` implement the function to predict whether node is ready or not, the two functions are the same, so just keep only one and move it to the common file.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

