### PR TITLE
add karmada-wehook flags verification logic

### DIFF
--- a/cmd/webhook/app/options/validation.go
+++ b/cmd/webhook/app/options/validation.go
@@ -1,0 +1,23 @@
+package options
+
+import (
+	"net"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// Validate checks Options and return a slice of found errs.
+func (o *Options) Validate() field.ErrorList {
+	errs := field.ErrorList{}
+
+	newPath := field.NewPath("Options")
+	if net.ParseIP(o.BindAddress) == nil {
+		errs = append(errs, field.Invalid(newPath.Child("BindAddress"), o.BindAddress, "not a valid textual representation of an IP address"))
+	}
+
+	if o.SecurePort < 0 || o.SecurePort > 65535 {
+		errs = append(errs, field.Invalid(newPath.Child("SecurePort"), o.SecurePort, "must be a valid port between 0 and 65535 inclusive"))
+	}
+
+	return errs
+}

--- a/cmd/webhook/app/options/validation_test.go
+++ b/cmd/webhook/app/options/validation_test.go
@@ -1,0 +1,59 @@
+package options
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateKarmadaWebhookConfiguration(t *testing.T) {
+	successCases := []Options{
+		{
+			BindAddress:  "127.0.0.1",
+			SecurePort:   9000,
+			KubeAPIQPS:   40,
+			KubeAPIBurst: 30,
+		},
+	}
+	for _, successCases := range successCases {
+		if errs := successCases.Validate(); len(errs) != 0 {
+			t.Errorf("expected success: %v", errs)
+		}
+	}
+	newPath := field.NewPath("Options")
+	testCases := map[string]struct {
+		opt          Options
+		expectedErrs field.ErrorList
+	}{
+		"invalid BindAddress": {
+			opt: Options{
+				BindAddress:  "127.0.0.1:8080",
+				SecurePort:   9000,
+				KubeAPIQPS:   40,
+				KubeAPIBurst: 30,
+			},
+			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("BindAddress"), "127.0.0.1:8080", "not a valid textual representation of an IP address")},
+		},
+		"invalid SecurePort": {
+			opt: Options{
+				BindAddress:  "127.0.0.1",
+				SecurePort:   900000,
+				KubeAPIQPS:   40,
+				KubeAPIBurst: 30,
+			},
+			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("SecurePort"), 900000, "must be a valid port between 0 and 65535 inclusive")},
+		},
+	}
+
+	for _, testCase := range testCases {
+		errs := testCase.opt.Validate()
+		if len(testCase.expectedErrs) != len(errs) {
+			t.Fatalf("Expected %d errors, got %d errors: %v", len(testCase.expectedErrs), len(errs), errs)
+		}
+		for i, err := range errs {
+			if err.Error() != testCase.expectedErrs[i].Error() {
+				t.Fatalf("Expected error: %s, got %s", testCase.expectedErrs[i], err.Error())
+			}
+		}
+	}
+}

--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -33,11 +33,23 @@ func NewWebhookCommand(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:  "karmada-webhook",
 		Long: `Start a karmada webhook server`,
-		Run: func(cmd *cobra.Command, args []string) {
-			if err := Run(ctx, opts); err != nil {
-				fmt.Fprintf(os.Stderr, "%v\n", err)
-				os.Exit(1)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// validate options
+			if errs := opts.Validate(); len(errs) != 0 {
+				return errs.ToAggregate()
 			}
+			if err := Run(ctx, opts); err != nil {
+				return err
+			}
+			return nil
+		},
+		Args: func(cmd *cobra.Command, args []string) error {
+			for _, arg := range args {
+				if len(arg) > 0 {
+					return fmt.Errorf("%q does not take any arguments, got %q", cmd.CommandPath(), args)
+				}
+			}
+			return nil
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
part of #919
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
If the scheduler command parameter is incorrect, it will exit abnormally and output the entire stack information so add karmada-wehook flags verification logic
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

