### PR TITLE
Replace clusterIP with hostIP in karmada-kubeconfig when using remote-up-karmada.sh

### DIFF
--- a/docs/installation/fromsource.md
+++ b/docs/installation/fromsource.md
@@ -19,23 +19,20 @@ your clusters based on the codebase.
 
 The `hack/remote-up-karmada.sh` will install `karmada-apiserver` and provide two ways to expose the server:
 
-### 1. expose by service with `LoadBalancer` type
+### 1. expose by `HostNetwork` type
 
-By default, the `hack/remote-up-karmada.sh` will expose `karmada-apiserver` by a service with `LoadBalancer`
-type, and continue the installation progress after the `Load Balancer` allocates an external IP for the
-`karmada-apiserver`.
+By default, the `hack/remote-up-karmada.sh` will expose `karmada-apiserver` by `HostNetwork`.
 
-No extra operations needed with this type, but that *requires your cluster have deployed the `Load Balancer`*.
+No extra operations needed with this type.
 
-### 2. expose by service with `ClusterIP` type
-If you don't want to use the `Load Balancer`, you can ask `hack/remote-up-karmada.sh` to expose `karmada-apiserver`
-by a service with `ClusterIP` type. All you need to do is set an environment:
+### 2. expose by service with `LoadBalancer` type
+
+If you don't want to use the `HostNetwork`, you can ask `hack/remote-up-karmada.sh` to expose `karmada-apiserver`
+by a service with `LoadBalancer` type that *requires your cluster have deployed the `Load Balancer`*.
+All you need to do is set an environment:
 ```bash
-export CLUSTER_IP_ONLY=true
+export LOAD_BALANCER=true
 ```
-
-> Note: You should run `hack/remote-up-karmada.sh` on one of the nodes of the cluster, otherwise the `hack/remote-up-karmada.sh`
-> can't access the `karmada-apiserver` exposed by a `cluster IP`.
 
 ## Install
 From the `root` directory the `karmada` repo, install Karmada by command:

--- a/hack/README.md
+++ b/hack/README.md
@@ -14,7 +14,7 @@ ensures development quality.
 
 - [`remote-up-karmada.sh`](remote-up-karmada.sh) This script will install Karmada to a standalone K8s cluster, this cluster
   may be real, remote , and even for production. It is worth noting for the connectivity from your client to Karmada API server,
-  it will create a load balancer service with an external IP by default, else type `export CLUSTER_IP_ONLY=true` with the `ClusterIP` type service before the following script.
+  it will directly use host network by default, else `export LOAD_BALANCER=true` with the `LoadBalancer` type service before the following script.
   If your want to customize a load balancer service, you may add the annotations at the metadata part of service `karmada-apiserver` in
   [`../artifacts/deploy/karmada-apiserver.yaml`](../artifacts/deploy/karmada-apiserver.yaml) before the installing. The
   following is an example.

--- a/hack/deploy-karmada-agent.sh
+++ b/hack/deploy-karmada-agent.sh
@@ -8,7 +8,7 @@ REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 function usage() {
   echo "This script will deploy karmada agent to a cluster."
   echo "Usage: hack/deploy-karmada-agent.sh <KARMADA_APISERVER_KUBECONFIG> <KARMADA_APISERVER_CONTEXT_NAME> <MEMBER_CLUSTER_KUBECONFIG> <MEMBER_CLUSTER_CONTEXT_NAME>"
-  echo "Example: hack/deploy-karmada-agent.sh ~/.kube/karmada.config karmada-apiserver ~/.kube/karmada.config member1"
+  echo "Example: hack/deploy-karmada-agent.sh ~/.kube/karmada.config karmada-apiserver ~/.kube/members.config member1"
 }
 
 if [[ $# -ne 4 ]]; then

--- a/hack/remote-up-karmada.sh
+++ b/hack/remote-up-karmada.sh
@@ -6,13 +6,13 @@ set -o pipefail
 
 function usage() {
   echo "This script will deploy karmada control plane to a given cluster."
-  echo "Usage: hack/remote-up-karmada.sh <KUBECONFIG> <CONTEXT_NAME> [CLUSTER_IP_ONLY]"
+  echo "Usage: hack/remote-up-karmada.sh <KUBECONFIG> <CONTEXT_NAME> [LOAD_BALANCER]"
   echo "Example: hack/remote-up-karmada.sh ~/.kube/config karmada-host"
   echo -e "Parameters:\n\tKUBECONFIG\tYour cluster's kubeconfig that you want to install to"
   echo -e "\tCONTEXT_NAME\tThe name of context in 'kubeconfig'"
-  echo -e "\tCLUSTER_IP_ONLY\tThis option default is 'false', and there will create a 'LoadBalancer' type service
-  \t\t\tfor karmada apiserver so that it can easy communicate outside the karmada-host cluster,
-  \t\t\tif you want only a 'ClusterIP' type service for karmada apiserver, set as 'true'."
+  echo -e "\tLOAD_BALANCER\tThis option default is 'false', and there will directly use 'hostNetwork' to communicate
+  \t\t\toutside the karmada-host cluster
+  \t\t\tif you want to create a 'LoadBalancer' type service for karmada apiserver, set as 'true'."
 }
 
 if [[ $# -lt 2 ]]; then
@@ -39,8 +39,8 @@ then
 fi
 
 if [ "${3:-false}" = true ]; then
-  CLUSTER_IP_ONLY=true
-  export CLUSTER_IP_ONLY
+  LOAD_BALANCER=true
+  export LOAD_BALANCER
 fi
 
 # deploy karmada control plane

--- a/hack/undeploy-karmada.sh
+++ b/hack/undeploy-karmada.sh
@@ -4,32 +4,38 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+
 function usage() {
   echo "This script will remove karmada control plane from a cluster."
   echo "Usage: hack/undeploy-karmada.sh [KUBECONFIG] [CONTEXT_NAME]"
   echo "Example: hack/undeploy-karmada.sh ~/.kube/karmada.config karmada-host"
 }
 
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+if [[ $# -ne 2 ]]; then
+  usage
+  exit 1
+fi
+
+# check kube config file existence
+if [[ ! -f "${1}" ]]; then
+  echo -e "ERROR: failed to get kubernetes config file: '${1}', not existed.\n"
+  usage
+  exit 1
+fi
+HOST_CLUSTER_KUBECONFIG=$1
+
+# check context existence
+if ! kubectl config use-context "${2}" --kubeconfig="${HOST_CLUSTER_KUBECONFIG}" > /dev/null 2>&1;
+then
+  echo -e "ERROR: failed to use context: '${2}' not in ${HOST_CLUSTER_KUBECONFIG}. \n"
+  usage
+  exit 1
+fi
+HOST_CLUSTER_NAME=$2
+
 # delete all keys and certificates
 rm -fr "${HOME}/.karmada"
-# set default host cluster's kubeconfig file (created by kind)
-KUBECONFIG_PATH=${KUBECONFIG_PATH:-"${HOME}/.kube"}
-HOST_CLUSTER_KUBECONFIG="${KUBECONFIG_PATH}/karmada.config"
-HOST_CLUSTER_NAME=${HOST_CLUSTER_NAME:-"karmada-host"}
-
-# if provider the custom kubeconfig and context name
-if [[ -f "${1:-}" ]]; then
-  if ! kubectl config get-contexts "${2:-}" --kubeconfig="${1}" > /dev/null 2>&1;
-  then
-    echo -e "ERROR: failed to get context: '${2:-}' not in ${1}. \n"
-    usage
-    exit 1
-  else
-    HOST_CLUSTER_KUBECONFIG=${1:-}
-    HOST_CLUSTER_NAME=${2:-}
-  fi
-fi
 
 kubectl config use-context "${HOST_CLUSTER_NAME}" --kubeconfig="${HOST_CLUSTER_KUBECONFIG}"
 


### PR DESCRIPTION
Signed-off-by: lonelyCZ <531187475@qq.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When users deploy karmada by `remote-up-karmada.sh`, if the karmada-apiserver is the `clusterIP`, the agent can't be joined. And the network mode of `karmada-apiserver` pod is `hostNetwork`, so directly assigning this IP as karmada-apiserver ip.

Because `undeploy-karmada.sh` is suited for two mode, it needn't default for kind mode.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I have tested it in my environment.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

