### PR TITLE
add more validations for cluster name

### DIFF
--- a/cmd/agent/app/options/validation.go
+++ b/cmd/agent/app/options/validation.go
@@ -1,7 +1,11 @@
 package options
 
 import (
+	"strings"
+
 	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/karmada-io/karmada/pkg/util/validation"
 )
 
 // Validate checks Options and return a slice of found errs.
@@ -9,9 +13,10 @@ func (o *Options) Validate() field.ErrorList {
 	errs := field.ErrorList{}
 
 	newPath := field.NewPath("Options")
-	if len(o.ClusterName) == 0 {
-		errs = append(errs, field.Invalid(newPath.Child("ClusterName"), o.ClusterName, "clusterName cannot be empty"))
+	if errMsgs := validation.ValidateClusterName(o.ClusterName); len(errMsgs) > 0 {
+		errs = append(errs, field.Invalid(newPath.Child("ClusterName"), o.ClusterName, strings.Join(errMsgs, ",")))
 	}
+
 	if o.ClusterStatusUpdateFrequency.Duration < 0 {
 		errs = append(errs, field.Invalid(newPath.Child("ClusterStatusUpdateFrequency"), o.ClusterStatusUpdateFrequency, "must be greater than or equal to 0"))
 	}

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -25,6 +25,9 @@ const LabelValueMaxLength int = 63
 // - Length must be less than 48 characters.
 //   * Since cluster name used to generate execution namespace by adding a prefix, so reserve 15 characters for the prefix.
 func ValidateClusterName(name string) []string {
+	if len(name) == 0 {
+		return []string{"must be not empty"}
+	}
 	if len(name) > clusterNameMaxLength {
 		return []string{fmt.Sprintf("must be no more than %d characters", clusterNameMaxLength)}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
add more validations for cluster name, using function `validation.ValidateClusterName` to validate cluster name.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

