### PR TITLE
update work version in get.go

### DIFF
--- a/pkg/karmadactl/get.go
+++ b/pkg/karmadactl/get.go
@@ -31,7 +31,7 @@ import (
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
-	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/karmadactl/options"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 )
@@ -447,7 +447,7 @@ func (g *CommandGetOptions) transformRequests(req *rest.Request) {
 }
 
 func getRBInKarmada(namespace string, config *rest.Config) error {
-	resourceList := &workv1alpha1.ResourceBindingList{}
+	resourceList := &workv1alpha2.ResourceBindingList{}
 	gClient, err := gclient.NewForConfig(config)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Phil-sun <sunxh0000@163.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
In release 0.9.0, the version of work karmada used is v1alpha2, but in get.go, it's still v1alpha1. And the conversion from alpha1 to alpha2 had certification error like following
```Error: conversion webhook for work.karmada.io/v1alpha2, Kind=ResourceBinding failed: Post "https://karmada-webhook.karmada-system.svc:443/convert?timeout=30s": x509: certificate signed by unknown authority (possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate "ca")```
IMHO, changing it into v1alpha2 will be okay.
**Which issue(s) this PR fixes**:
Fixes #938

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

