### PR TITLE
Logic patch for dividing remaining replicas to clusters

### DIFF
--- a/pkg/scheduler/core/division_algorithm_test.go
+++ b/pkg/scheduler/core/division_algorithm_test.go
@@ -172,6 +172,107 @@ func Test_divideReplicasByStaticWeight(t *testing.T) {
 	}
 }
 
+func Test_divideRemainingReplicas(t *testing.T) {
+	type args struct {
+		remainingReplicas   int
+		desiredReplicaInfos map[string]int64
+		clusterNames        []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]int64
+	}{
+		{
+			name: "remainingReplicas 13",
+			args: args{
+				remainingReplicas: 13,
+				desiredReplicaInfos: map[string]int64{
+					ClusterMember1: 2,
+					ClusterMember2: 3,
+					ClusterMember3: 4,
+				},
+				clusterNames: []string{
+					ClusterMember1, ClusterMember2, ClusterMember3,
+				},
+			},
+			want: map[string]int64{
+				ClusterMember1: 7,
+				ClusterMember2: 7,
+				ClusterMember3: 8,
+			},
+		},
+		{
+			name: "remainingReplicas 17",
+			args: args{
+				remainingReplicas: 17,
+				desiredReplicaInfos: map[string]int64{
+					ClusterMember1: 4,
+					ClusterMember2: 3,
+					ClusterMember3: 2,
+				},
+				clusterNames: []string{
+					ClusterMember1, ClusterMember2, ClusterMember3,
+				},
+			},
+			want: map[string]int64{
+				ClusterMember1: 10,
+				ClusterMember2: 9,
+				ClusterMember3: 7,
+			},
+		},
+		{
+			name: "remainingReplicas 2",
+			args: args{
+				remainingReplicas: 2,
+				desiredReplicaInfos: map[string]int64{
+					ClusterMember1: 1,
+					ClusterMember2: 1,
+					ClusterMember3: 1,
+				},
+				clusterNames: []string{
+					ClusterMember1, ClusterMember2, ClusterMember3,
+				},
+			},
+			want: map[string]int64{
+				ClusterMember1: 2,
+				ClusterMember2: 2,
+				ClusterMember3: 1,
+			},
+		},
+		{
+			name: "remainingReplicas 0",
+			args: args{
+				remainingReplicas: 0,
+				desiredReplicaInfos: map[string]int64{
+					ClusterMember1: 3,
+					ClusterMember2: 3,
+					ClusterMember3: 3,
+				},
+				clusterNames: []string{
+					ClusterMember1, ClusterMember2, ClusterMember3,
+				},
+			},
+			want: map[string]int64{
+				ClusterMember1: 3,
+				ClusterMember2: 3,
+				ClusterMember3: 3,
+			},
+		},
+	}
+	IsTwoMapEqual := func(a, b map[string]int64) bool {
+		return a[ClusterMember1] == b[ClusterMember1] && a[ClusterMember2] == b[ClusterMember2] && a[ClusterMember3] == b[ClusterMember3]
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			divideRemainingReplicas(tt.args.remainingReplicas, tt.args.desiredReplicaInfos, tt.args.clusterNames)
+			if !IsTwoMapEqual(tt.args.desiredReplicaInfos, tt.want) {
+				t.Errorf("divideRemainingReplicas() got = %v, want %v", tt.args.desiredReplicaInfos, tt.want)
+			}
+		})
+	}
+}
+
 func Test_divideReplicasByPreference(t *testing.T) {
 	type args struct {
 		clusterAvailableReplicas []workv1alpha2.TargetCluster


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

There are a lot of code logic to be optimized, the following is an example:

1. This makes the program not run the way as we want 

![1 0](https://user-images.githubusercontent.com/47907508/142158596-c5bff1f1-e4ae-4d09-a23e-5dee94dcdd6e.jpg)

Change the location of the code block will solve the problem 

![1 1](https://user-images.githubusercontent.com/47907508/142159063-37141348-a9b3-4554-914e-f735db0268a2.jpg)


2. Furthermore, the running time of the program written in this way will depend on the value of `remainReplicas`. But if `remainReplicas` is much larger than the length of `desireReplicaInfos`, the first method runs  obviously not as fast as the second method.

First method:

![2 0](https://user-images.githubusercontent.com/47907508/142158452-7df7b998-f039-4bb6-8142-cdf1f605b431.jpg)

Second method:

![2 1](https://user-images.githubusercontent.com/47907508/142161814-5df1aaff-08b6-4ed1-b8f1-05aa432360a1.jpg)

3. So we can choose the faster method based on the size relationship between the value of `remainReplicas` and the length of `desireReplicaInfos`:

![3 0](https://user-images.githubusercontent.com/47907508/142162077-cc8dcc3b-5ca2-4063-a077-874a2151f7a9.jpg)

**Which issue(s) this PR fixes**:

A part of issue #972

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
