### PR TITLE
Add ObservedObject field to ExploreRequest

### DIFF
--- a/pkg/apis/config/v1alpha1/explorereview_types.go
+++ b/pkg/apis/config/v1alpha1/explorereview_types.go
@@ -52,6 +52,11 @@ type ExploreRequest struct {
 	// +optional
 	Object runtime.RawExtension `json:"object,omitempty"`
 
+	// ObservedObject is the object observed from the kube-apiserver of member clusters.
+	// Not nil only when OperationType is ExploreRetaining.
+	// +optional
+	ObservedObject *runtime.RawExtension `json:"observedObject,omitempty"`
+
 	// DesiredReplicas represents the desired pods number which webhook should revise with.
 	// It'll be set only if OperationType is ExploreReplicaRevising.
 	// +optional

--- a/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -32,6 +32,11 @@ func (in *ExploreRequest) DeepCopyInto(out *ExploreRequest) {
 	*out = *in
 	out.Kind = in.Kind
 	in.Object.DeepCopyInto(&out.Object)
+	if in.ObservedObject != nil {
+		in, out := &in.ObservedObject, &out.ObservedObject
+		*out = new(runtime.RawExtension)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.DesiredReplicas != nil {
 		in, out := &in.DesiredReplicas, &out.DesiredReplicas
 		*out = new(int32)

--- a/pkg/crdexplorer/crdexplorer.go
+++ b/pkg/crdexplorer/crdexplorer.go
@@ -25,8 +25,8 @@ type CustomResourceExplorer interface {
 	// GetReplicas returns the desired replicas of the object as well as the requirements of each replica.
 	GetReplicas(object *unstructured.Unstructured) (replica int32, replicaRequires *workv1alpha2.ReplicaRequirements, err error)
 
-	// Retain returns the objects that based on the "desired" object but with values retained from the "cluster" object.
-	Retain(desired *unstructured.Unstructured, cluster *unstructured.Unstructured) (retained *unstructured.Unstructured, err error)
+	// Retain returns the objects that based on the "desired" object but with values retained from the "observed" object.
+	Retain(desired *unstructured.Unstructured, observed *unstructured.Unstructured) (retained *unstructured.Unstructured, err error)
 
 	// other common method
 }
@@ -93,6 +93,7 @@ func (i *customResourceExplorerImpl) GetReplicas(object *unstructured.Unstructur
 	return
 }
 
+// Retain returns the objects that based on the "desired" object but with values retained from the "observed" object.
 func (i *customResourceExplorerImpl) Retain(desired *unstructured.Unstructured, cluster *unstructured.Unstructured) (retained *unstructured.Unstructured, err error) {
 	// TODO(RainbowMango): consult to the dynamic webhooks first.
 

--- a/pkg/crdexplorer/defaultexplorer/default.go
+++ b/pkg/crdexplorer/defaultexplorer/default.go
@@ -51,12 +51,12 @@ func (e *DefaultExplorer) GetReplicas(object *unstructured.Unstructured) (int32,
 	return handler(object)
 }
 
-// Retain returns the objects that based on the "desired" object but with values retained from the "cluster" object.
-func (e *DefaultExplorer) Retain(desired *unstructured.Unstructured, cluster *unstructured.Unstructured) (retained *unstructured.Unstructured, err error) {
+// Retain returns the objects that based on the "desired" object but with values retained from the "observed" object.
+func (e *DefaultExplorer) Retain(desired *unstructured.Unstructured, observed *unstructured.Unstructured) (retained *unstructured.Unstructured, err error) {
 	handler, exist := e.retentionHandlers[desired.GroupVersionKind()]
 	if !exist {
 		return nil, fmt.Errorf("default explorer for operation %s not found", configv1alpha1.ExploreRetaining)
 	}
 
-	return handler(desired, cluster)
+	return handler(desired, observed)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add `ObservedObject` field to ExploreRequest, and it will be set in case of retaining fields from an observed object to the desired object.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

cc @XiShanYongYe-Chang @gy95 