### PR TITLE
Remove unused policyLister in the genericScheduler

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -11,7 +11,6 @@ import (
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
-	lister "github.com/karmada-io/karmada/pkg/generated/listers/policy/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/scheduler/cache"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework/runtime"
@@ -32,21 +31,17 @@ type ScheduleResult struct {
 }
 
 type genericScheduler struct {
-	schedulerCache cache.Cache
-	// TODO: move it into schedulerCache
-	policyLister      lister.PropagationPolicyLister
+	schedulerCache    cache.Cache
 	scheduleFramework framework.Framework
 }
 
 // NewGenericScheduler creates a genericScheduler object.
 func NewGenericScheduler(
 	schedCache cache.Cache,
-	policyLister lister.PropagationPolicyLister,
 	plugins []string,
 ) ScheduleAlgorithm {
 	return &genericScheduler{
 		schedulerCache:    schedCache,
-		policyLister:      policyLister,
 		scheduleFramework: runtime.NewFramework(plugins),
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -112,7 +112,7 @@ func NewScheduler(dynamicClient dynamic.Interface, karmadaClient karmadaclientse
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 	schedulerCache := schedulercache.NewCache(clusterLister)
 	// TODO: make plugins as a flag
-	algorithm := core.NewGenericScheduler(schedulerCache, policyLister, []string{clusteraffinity.Name, tainttoleration.Name, apiinstalled.Name})
+	algorithm := core.NewGenericScheduler(schedulerCache, []string{clusteraffinity.Name, tainttoleration.Name, apiinstalled.Name})
 	sched := &Scheduler{
 		DynamicClient:            dynamicClient,
 		KarmadaClient:            karmadaClient,


### PR DESCRIPTION
Signed-off-by: Xinzhao Xu <z2d@jifangcheng.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

the `policyLister` was introduced in #108, after #213 we don't need this lister anymore so I think we should remove it to avoid misunderstanding for people reading the code.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

/cc @mrlihanbo @RainbowMango 

