### PR TITLE
update Scheduled conditon when failed scheduling

### DIFF
--- a/pkg/controllers/binding/binding_controller.go
+++ b/pkg/controllers/binding/binding_controller.go
@@ -69,12 +69,6 @@ func (c *ResourceBindingController) Reconcile(ctx context.Context, req controlle
 		return c.removeFinalizer(binding)
 	}
 
-	isReady := helper.IsBindingReady(&binding.Status)
-	if !isReady {
-		klog.Infof("ResourceBinding(%s/%s) is not ready to sync", binding.GetNamespace(), binding.GetName())
-		return controllerruntime.Result{}, nil
-	}
-
 	return c.syncBinding(binding)
 }
 

--- a/pkg/controllers/binding/cluster_resource_binding_controller.go
+++ b/pkg/controllers/binding/cluster_resource_binding_controller.go
@@ -69,12 +69,6 @@ func (c *ClusterResourceBindingController) Reconcile(ctx context.Context, req co
 		return c.removeFinalizer(clusterResourceBinding)
 	}
 
-	isReady := helper.IsBindingReady(&clusterResourceBinding.Status)
-	if !isReady {
-		klog.Infof("ClusterResourceBinding %s is not ready to sync", clusterResourceBinding.GetName())
-		return controllerruntime.Result{}, nil
-	}
-
 	return c.syncBinding(clusterResourceBinding)
 }
 

--- a/pkg/util/condition.go
+++ b/pkg/util/condition.go
@@ -11,3 +11,10 @@ func NewCondition(conditionType, reason, message string, status metav1.Condition
 		Message: message,
 	}
 }
+
+// IsConditionsEqual compares the given condition's Status, Reason and Message.
+func IsConditionsEqual(newCondition, oldCondition metav1.Condition) bool {
+	return newCondition.Status == oldCondition.Status &&
+		newCondition.Reason == oldCondition.Reason &&
+		newCondition.Message == oldCondition.Message
+}

--- a/pkg/util/helper/binding.go
+++ b/pkg/util/helper/binding.go
@@ -57,8 +57,8 @@ func SortClusterByWeight(m map[string]int64) ClusterWeightInfoList {
 	return p
 }
 
-// IsBindingReady will check if resourceBinding/clusterResourceBinding is ready to build Work.
-func IsBindingReady(status *workv1alpha2.ResourceBindingStatus) bool {
+// IsBindingScheduled will check if resourceBinding/clusterResourceBinding is successfully scheduled.
+func IsBindingScheduled(status *workv1alpha2.ResourceBindingStatus) bool {
 	return meta.IsStatusConditionTrue(status.Conditions, workv1alpha2.Scheduled)
 }
 

--- a/test/e2e/framework/deployment.go
+++ b/test/e2e/framework/deployment.go
@@ -99,7 +99,7 @@ func ExtractTargetClustersFrom(c client.Client, deployment *appsv1.Deployment) [
 		err := c.Get(context.TODO(), client.ObjectKey{Namespace: deployment.Namespace, Name: bindingName}, binding)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
-		if !helper.IsBindingReady(&binding.Status) {
+		if !helper.IsBindingScheduled(&binding.Status) {
 			klog.Infof("The ResourceBinding(%s/%s) hasn't been scheduled.", binding.Namespace, binding.Name)
 			return false, nil
 		}


### PR DESCRIPTION
Signed-off-by: lihanbo <lihanbo2@huawei.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
1. update `Scheduled` conditon when failed scheduling
2. remove `FirstSchedule`, reconcile schedule once applied policy is different from the latest propogation policy.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
```
  conditions:
  - lastTransitionTime: "2021-11-19T07:34:38Z"
    message: 'failed to assignReplicas: failed to scaleUp: clusters resources are
      not enough to schedule, max 6 replicas are support'
    reason: BindingFailedScheduling
    status: "False"
    type: Scheduled
```

**Does this PR introduce a user-facing change?**:
"NONE"

