### PR TITLE
feature: change namespace filter rule

### DIFF
--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -99,7 +99,7 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 		"<group>/<version> for skip resources with a specific API version(e.g. networking.k8s.io/v1beta1),\n"+
 		"<group>/<version>/<kind>,<kind> for skip one or more specific resource(e.g. networking.k8s.io/v1beta1/Ingress,IngressClass) where the kinds are case-insensitive.")
 	flags.StringSliceVar(&o.SkippedPropagatingNamespaces, "skipped-propagating-namespaces", []string{},
-		"Comma-separated namespaces that should be skipped from propagating in addition to the default skipped namespaces(namespaces prefixed by kube- and karmada-).")
+		"Comma-separated namespaces that should be skipped from propagating in addition to the default skipped namespaces(karmada-system, karmada-cluster, namespaces prefixed by kube- and karmada-es-).")
 	flags.StringVar(&o.ClusterAPIContext, "cluster-api-context", "", "Name of the cluster context in cluster-api management cluster kubeconfig file.")
 	flags.StringVar(&o.ClusterAPIKubeconfig, "cluster-api-kubeconfig", "", "Path to the cluster-api management cluster kubeconfig file.")
 	flags.Float32Var(&o.ClusterAPIQPS, "cluster-api-qps", 40.0, "QPS to use while talking with cluster kube-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")

--- a/pkg/controllers/namespace/namespace_sync_controller.go
+++ b/pkg/controllers/namespace/namespace_sync_controller.go
@@ -2,7 +2,6 @@ package namespace
 
 import (
 	"context"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -30,12 +29,7 @@ import (
 
 const (
 	// ControllerName is the controller name that will be used when reporting events.
-	ControllerName              = "namespace-sync-controller"
-	namespaceKarmadaSystem      = "karmada-system"
-	namespaceKarmadaCluster     = "karmada-cluster"
-	namespaceDefault            = "default"
-	karmadaExecutionSpacePrefix = "karmada-es-"
-	kubeSystemNamespacePrefix   = "kube-"
+	ControllerName = "namespace-sync-controller"
 )
 
 // Controller is to sync Work.
@@ -86,8 +80,7 @@ func (c *Controller) Reconcile(ctx context.Context, req controllerruntime.Reques
 }
 
 func (c *Controller) namespaceShouldBeSynced(namespace string) bool {
-	if namespace == namespaceKarmadaCluster || namespace == namespaceKarmadaSystem || namespace == namespaceDefault ||
-		strings.HasPrefix(namespace, karmadaExecutionSpacePrefix) || strings.HasPrefix(namespace, kubeSystemNamespacePrefix) {
+	if names.IsReservedNamespace(namespace) || namespace == names.NamespaceDefault {
 		return false
 	}
 

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -3,7 +3,6 @@ package detector
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -283,8 +282,7 @@ func (d *ResourceDetector) EventFilter(obj interface{}) bool {
 		return false
 	}
 
-	if strings.HasPrefix(clusterWideKey.Namespace, names.KubernetesReservedNSPrefix) ||
-		strings.HasPrefix(clusterWideKey.Namespace, names.KarmadaReservedNSPrefix) {
+	if names.IsReservedNamespace(clusterWideKey.Namespace) {
 		return false
 	}
 

--- a/pkg/util/names/names.go
+++ b/pkg/util/names/names.go
@@ -16,16 +16,16 @@ const (
 	// - kube-public
 	// - kube-node-lease
 	KubernetesReservedNSPrefix = "kube-"
-
-	// KarmadaReservedNSPrefix is the prefix of namespace which reserved by Karmada system, such as:
-	// - karmada-system
-	// - karmada-cluster
-	// - karmada-es-*
-	KarmadaReservedNSPrefix = "karmada-"
+	//NamespaceKarmadaSystem is reserved namespace
+	NamespaceKarmadaSystem = "karmada-system"
+	//NamespaceKarmadaCluster is reserved namespace
+	NamespaceKarmadaCluster = "karmada-cluster"
+	//NamespaceDefault is reserved namespace
+	NamespaceDefault = "default"
 )
 
-// executionSpacePrefix is the prefix of execution space
-const executionSpacePrefix = "karmada-es-"
+// ExecutionSpacePrefix is the prefix of execution space
+const ExecutionSpacePrefix = "karmada-es-"
 
 // endpointSlicePrefix is the prefix of collected EndpointSlice from member clusters.
 const endpointSlicePrefix = "imported"
@@ -41,16 +41,16 @@ func GenerateExecutionSpaceName(clusterName string) (string, error) {
 	if clusterName == "" {
 		return "", fmt.Errorf("the member cluster name is empty")
 	}
-	executionSpace := executionSpacePrefix + clusterName
+	executionSpace := ExecutionSpacePrefix + clusterName
 	return executionSpace, nil
 }
 
 // GetClusterName returns member cluster name for the given execution space
 func GetClusterName(executionSpaceName string) (string, error) {
-	if !strings.HasPrefix(executionSpaceName, executionSpacePrefix) {
+	if !strings.HasPrefix(executionSpaceName, ExecutionSpacePrefix) {
 		return "", fmt.Errorf("the execution space name is in wrong format")
 	}
-	return strings.TrimPrefix(executionSpaceName, executionSpacePrefix), nil
+	return strings.TrimPrefix(executionSpaceName, ExecutionSpacePrefix), nil
 }
 
 // GenerateBindingName will generate binding name by kind and name
@@ -107,4 +107,12 @@ func GenerateDerivedServiceName(serviceName string) string {
 // GenerateEstimatorServiceName generates the gRPC scheduler estimator service name which belongs to a cluster.
 func GenerateEstimatorServiceName(clusterName string) string {
 	return fmt.Sprintf("%s-%s", estimatorServicePrefix, clusterName)
+}
+
+// IsReservedNamespace return whether it is a reserved namespace
+func IsReservedNamespace(namespace string) bool {
+	return namespace == NamespaceKarmadaSystem ||
+		namespace == NamespaceKarmadaCluster ||
+		strings.HasPrefix(namespace, ExecutionSpacePrefix) ||
+		strings.HasPrefix(namespace, KubernetesReservedNSPrefix)
 }


### PR DESCRIPTION
some namespaces(like karmada-test, karmada-dev, kube-test, etc.) will be propagated

Signed-off-by: huangminjie <minjie.huang@daocloud.io>

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
change namespace filter rule
some namespaces(like karmada-test, karmada-dev, kube-test, etc.) should be propagated.
reslove this issue [985](https://github.com/karmada-io/karmada/issues/985)


**Which issue(s) this PR fixes**:
Refer to #985

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

