### PR TITLE
Add resource interpreter webhook example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,12 @@ karmada-scheduler-estimator: $(SOURCES)
 		-o karmada-scheduler-estimator \
 		cmd/scheduler-estimator/main.go
 
+karmada-interpreter-webhook-example: $(SOURCES)
+	CGO_ENABLED=0 GOOS=$(GOOS) go build \
+		-ldflags $(LDFLAGS) \
+		-o karmada-interpreter-webhook-example \
+		examples/customresourceinterpreter/webhook/main.go
+
 clean:
 	rm -rf karmada-controller-manager karmada-scheduler karmadactl kubectl-karmada karmada-webhook karmada-agent karmada-scheduler-estimator
 
@@ -116,6 +122,9 @@ image-karmada-agent: karmada-agent
 image-karmada-scheduler-estimator: karmada-scheduler-estimator
 	VERSION=$(VERSION) hack/docker.sh karmada-scheduler-estimator
 
+image-karmada-interpreter-webhook-example: karmada-interpreter-webhook-example
+	VERSION=$(VERSION) hack/docker.sh karmada-interpreter-webhook-example
+
 upload-images: images
 	@echo "push images to $(REGISTRY)"
 ifneq ($(REGISTRY_USER_NAME), "")
@@ -126,3 +135,4 @@ endif
 	docker push ${REGISTRY}/karmada-webhook:${VERSION}
 	docker push ${REGISTRY}/karmada-agent:${VERSION}
 	docker push ${REGISTRY}/karmada-scheduler-estimator:${VERSION}
+	docker push ${REGISTRY}/karmada-interpreter-webhook-example:${VERSION}

--- a/cluster/images/karmada-interpreter-webhook-example/Dockerfile
+++ b/cluster/images/karmada-interpreter-webhook-example/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.7
+
+RUN apk add --no-cache ca-certificates
+
+ADD karmada-interpreter-webhook-example /bin/
+
+CMD ["/bin/karmada-interpreter-webhook-example"]

--- a/examples/customresourceinterpreter/karmada-interpreter-webhook-example.yaml
+++ b/examples/customresourceinterpreter/karmada-interpreter-webhook-example.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: karmada-interpreter-webhook-example
+  namespace: karmada-system
+  labels:
+    app: karmada-interpreter-webhook-example
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: karmada-interpreter-webhook-example
+  template:
+    metadata:
+      labels:
+        app: karmada-interpreter-webhook-example
+    spec:
+      serviceAccountName: karmada-interpreter-webhook-example
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+      containers:
+        - name: karmada-interpreter-webhook-example
+          image: swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-interpreter-webhook-example:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/karmada-interpreter-webhook-example
+            - --kubeconfig=/etc/kubeconfig
+            - --bind-address=0.0.0.0
+            - --secure-port=8445
+            - --cert-dir=/var/serving-cert
+            - --v=4
+          ports:
+            - containerPort: 8445
+          volumeMounts:
+            - name: kubeconfig
+              subPath: kubeconfig
+              mountPath: /etc/kubeconfig
+            - name: cert
+              mountPath: /var/serving-cert
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8445
+              scheme: HTTPS
+      volumes:
+        - name: kubeconfig
+          secret:
+            secretName: kubeconfig
+        - name: cert
+          secret:
+            secretName: webhook-cert
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: karmada-interpreter-webhook-example
+  namespace: karmada-system
+spec:
+  selector:
+    app: karmada-interpreter-webhook-example
+  ports:
+    - port: 443
+      targetPort: 8445
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: karmada-interpreter-webhook-example
+  namespace: karmada-system

--- a/examples/customresourceinterpreter/webhook-configuration.yaml
+++ b/examples/customresourceinterpreter/webhook-configuration.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: config.karmada.io/v1alpha1
+kind: ResourceInterpreterWebhookConfiguration
+metadata:
+  name: examples
+webhooks:
+  - name: workloads.example.com
+    rules:
+      - operations: [ "InterpretReplica","Retain" ]
+        apiGroups: [ "workload.example.io" ]
+        apiVersions: [ "v1alpha1" ]
+        kinds: [ "Workload" ]
+    clientConfig:
+      url: https://karmada-interpreter-webhook-example.karmada-system.svc:443/interpreter-workload
+      caBundle: {{caBundle}}
+    interpreterContextVersions: [ "v1alpha1" ]
+    timeoutSeconds: 3

--- a/examples/customresourceinterpreter/webhook/app/options/options.go
+++ b/examples/customresourceinterpreter/webhook/app/options/options.go
@@ -1,0 +1,30 @@
+package options
+
+import (
+	"github.com/spf13/pflag"
+)
+
+const (
+	defaultBindAddress = "0.0.0.0"
+	defaultPort        = 8445
+	defaultCertDir     = "/tmp/k8s-webhook-server/serving-certs"
+)
+
+// Options contains everything necessary to create and run webhook server.
+type Options struct {
+	BindAddress string
+	SecurePort  int
+	CertDir     string
+}
+
+// NewOptions builds an empty options.
+func NewOptions() *Options {
+	return &Options{}
+}
+
+// AddFlags adds flags to the specified FlagSet.
+func (o *Options) AddFlags(flags *pflag.FlagSet) {
+	flags.StringVar(&o.BindAddress, "bind-address", defaultBindAddress, "The IP address on which to listen for the --secure-port port.")
+	flags.IntVar(&o.SecurePort, "secure-port", defaultPort, "The secure port on which to serve HTTPS.")
+	flags.StringVar(&o.CertDir, "cert-dir", defaultCertDir, "The directory that contains the server key(named tls.key) and certificate(named tls.crt).")
+}

--- a/examples/customresourceinterpreter/webhook/app/webhook.go
+++ b/examples/customresourceinterpreter/webhook/app/webhook.go
@@ -1,0 +1,73 @@
+package app
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+
+	"github.com/karmada-io/karmada/examples/customresourceinterpreter/webhook/app/options"
+	"github.com/karmada-io/karmada/pkg/util/gclient"
+	"github.com/karmada-io/karmada/pkg/version/sharedcommand"
+	"github.com/karmada-io/karmada/pkg/webhook/interpreter"
+)
+
+// NewWebhookCommand creates a *cobra.Command object with default parameters
+func NewWebhookCommand(ctx context.Context) *cobra.Command {
+	opts := options.NewOptions()
+
+	cmd := &cobra.Command{
+		Use: "karmada-interpreter-webhook-example",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := Run(ctx, opts); err != nil {
+				fmt.Fprintf(os.Stderr, "%v\n", err)
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.Flags().AddGoFlagSet(flag.CommandLine)
+	cmd.AddCommand(sharedcommand.NewCmdVersion(os.Stdout, "karmada-interpreter-webhook-example"))
+	opts.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// Run runs the webhook server with options. This should never exit.
+func Run(ctx context.Context, opts *options.Options) error {
+	config, err := controllerruntime.GetConfig()
+	if err != nil {
+		panic(err)
+	}
+
+	hookManager, err := controllerruntime.NewManager(config, controllerruntime.Options{
+		Host:           opts.BindAddress,
+		Port:           opts.SecurePort,
+		CertDir:        opts.CertDir,
+		LeaderElection: false,
+	})
+	if err != nil {
+		klog.Errorf("failed to build webhook server: %v", err)
+		return err
+	}
+
+	klog.Info("registering webhooks to the webhook server")
+	hookServer := hookManager.GetWebhookServer()
+	hookServer.Register("/interpreter-workload", interpreter.NewWebhook(&workloadInterpreter{}, interpreter.NewDecoder(gclient.NewSchema())))
+	hookServer.WebhookMux.Handle("/readyz/", http.StripPrefix("/readyz/", &healthz.Handler{}))
+
+	// blocks until the context is done.
+	if err := hookManager.Start(ctx); err != nil {
+		klog.Errorf("webhook server exits unexpectedly: %v", err)
+		return err
+	}
+
+	// never reach here
+	return nil
+}

--- a/examples/customresourceinterpreter/webhook/main.go
+++ b/examples/customresourceinterpreter/webhook/main.go
@@ -1,7 +1,23 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+
+	apiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/component-base/logs"
+
+	"github.com/karmada-io/karmada/examples/customresourceinterpreter/webhook/app"
+)
 
 func main() {
-	fmt.Printf("Place holder of the webhook.")
+	logs.InitLogs()
+	defer logs.FlushLogs()
+
+	ctx := apiserver.SetupSignalContext()
+
+	if err := app.NewWebhookCommand(ctx).Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add webhook demo for crd resource explorer.

**Which issue(s) this PR fixes**:
Part of #923 

**Special notes for your reviewer**:

How to use this demo:
1. make image
   ```
   export VERSION=latest
   make image-karmada-interpreter-webhook-example
   ```
2. load image with kind
   ```
   kind load docker-image swr.ap-southeast-1.myhuaweicloud.com/karmada/example-interpreter-webhook:latest --name karmada-host
   ```
3. create deployment
   ```
   kubectl --context karmada-host create -f examples/customresourceinterpreter/example-interpreter-webhook.yaml
   ```
4. create resource-explore-webhook-configuration(need to replace CA)
   ```
   kubectl create -f examples/customresourceinterpreter/webhook-configuration.yaml
   ```
5. create workload crd and propagate to member cluster

6. create workload cr and propagate to member cluster

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

