### PR TITLE
Fix panic: invalid memory address or nil pointer dereference

### DIFF
--- a/pkg/util/objectwatcher/objectwatcher.go
+++ b/pkg/util/objectwatcher/objectwatcher.go
@@ -135,7 +135,7 @@ func (o *objectWatcherImpl) Update(clusterName string, desireObj, clusterObj *un
 
 	desireObj, err = o.retainClusterFields(desireObj, clusterObj)
 	if err != nil {
-		klog.Errorf("Failed to retain fields for resource(kind=%s, %s/%s) in cluster %s: %v", desireObj.GetKind(), desireObj.GetNamespace(), desireObj.GetName(), clusterName, err)
+		klog.Errorf("Failed to retain fields for resource(kind=%s, %s/%s) in cluster %s: %v", clusterObj.GetKind(), clusterObj.GetNamespace(), clusterObj.GetName(), clusterName, err)
 		return err
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixed a panic: (shouldn't use the return pointer if there is an error)
```
W1120 12:20:23.134396       1 customized.go:143] Failed calling webhook examples/workloads.example.com: failed calling webhook "examples/workloads.example.com": failed to call webhook: Post "https://karmada-interpreter-webhook-example.karmada-system.svc:443/interpreter-workload?timeout=3s": dial tcp: lookup karmada-interpreter-webhook-example.karmada-system.svc on 10.96.0.10:53: no such host
E1120 12:20:23.134524       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 275 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x1e049a0, 0x31f7860)
	/root/go/src/github.com/karmada-io/karmada/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x95
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/root/go/src/github.com/karmada-io/karmada/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x86
panic(0x1e049a0, 0x31f7860)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.(*Unstructured).GetKind(...)
	/root/go/src/github.com/karmada-io/karmada/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go:226
github.com/karmada-io/karmada/pkg/util/objectwatcher.(*objectWatcherImpl).Update(0xc0002241e0, 0xc00154893b, 0x7, 0xc002ca29d0, 0xc002ca2990, 0x1, 0x0)
	/root/go/src/github.com/karmada-io/karmada/pkg/util/objectwatcher/objectwatcher.go:138 +0x6d6
github.com/karmada-io/karmada/pkg/controllers/status.(*WorkStatusController).syncWorkStatus(0xc0002d65a0, 0x1ed02a0, 0xc001b3daa0, 0xc001b3daa0, 0x0)
	/root/go/src/github.com/karmada-io/karmada/pkg/controllers/status/workstatus_controller.go:203 +0xe5f
github.com/karmada-io/karmada/pkg/util.(*asyncWorker).worker(0xc0001f42a0)
	/root/go/src/github.com/karmada-io/karmada/pkg/util/worker.go:105 +0xad
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc000081290)
	/root/go/src/github.com/karmada-io/karmada/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x5f
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc000081290, 0x2351de0, 0xc0001fa5d0, 0x1, 0xc000156b40)
	/root/go/src/github.com/karmada-io/karmada/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0x9b
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000081290, 0x0, 0x0, 0x1, 0xc000156b40)
	/root/go/src/github.com/karmada-io/karmada/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x98
k8s.io/apimachinery/pkg/util/wait.Until(0xc000081290, 0x0, 0xc000156b40)
	/root/go/src/github.com/karmada-io/karmada/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90 +0x4d
created by github.com/karmada-io/karmada/pkg/util.(*asyncWorker).Run
	/root/go/src/github.com/karmada-io/karmada/pkg/util/worker.go:111 +0x55
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1b9ab56]
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE(Feature haven't been released.)
```

