### PR TITLE
delete the TODO logic with binding labels

### DIFF
--- a/pkg/controllers/binding/binding_controller.go
+++ b/pkg/controllers/binding/binding_controller.go
@@ -162,23 +162,9 @@ func (c *ResourceBindingController) SetupWithManager(mgr controllerruntime.Manag
 	workFn := handler.MapFunc(
 		func(a client.Object) []reconcile.Request {
 			var requests []reconcile.Request
-
-			// TODO: Delete this logic in the next release to prevent incompatibility when upgrading the current release (v0.10.0).
-			labels := a.GetLabels()
-			crNamespace, namespaceExist := labels[workv1alpha2.ResourceBindingNamespaceLabel]
-			crName, nameExist := labels[workv1alpha2.ResourceBindingNameLabel]
-			if namespaceExist && nameExist {
-				requests = append(requests, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Namespace: crNamespace,
-						Name:      crName,
-					},
-				})
-			}
-
 			annotations := a.GetAnnotations()
-			crNamespace, namespaceExist = annotations[workv1alpha2.ResourceBindingNamespaceLabel]
-			crName, nameExist = annotations[workv1alpha2.ResourceBindingNameLabel]
+			crNamespace, namespaceExist := annotations[workv1alpha2.ResourceBindingNamespaceLabel]
+			crName, nameExist := annotations[workv1alpha2.ResourceBindingNameLabel]
 			if namespaceExist && nameExist {
 				requests = append(requests, reconcile.Request{
 					NamespacedName: types.NamespacedName{

--- a/pkg/controllers/binding/cluster_resource_binding_controller.go
+++ b/pkg/controllers/binding/cluster_resource_binding_controller.go
@@ -157,20 +157,8 @@ func (c *ClusterResourceBindingController) SetupWithManager(mgr controllerruntim
 	workFn := handler.MapFunc(
 		func(a client.Object) []reconcile.Request {
 			var requests []reconcile.Request
-
-			// TODO: Delete this logic in the next release to prevent incompatibility when upgrading the current release (v0.10.0).
-			labels := a.GetLabels()
-			crbName, nameExist := labels[workv1alpha2.ClusterResourceBindingLabel]
-			if nameExist {
-				requests = append(requests, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Name: crbName,
-					},
-				})
-			}
-
 			annotations := a.GetAnnotations()
-			crbName, nameExist = annotations[workv1alpha2.ClusterResourceBindingLabel]
+			crbName, nameExist := annotations[workv1alpha2.ClusterResourceBindingLabel]
 			if nameExist {
 				requests = append(requests, reconcile.Request{
 					NamespacedName: types.NamespacedName{

--- a/pkg/util/helper/binding.go
+++ b/pkg/util/helper/binding.go
@@ -97,18 +97,7 @@ func GetUsedBindingClusterNames(targetClusters []workv1alpha2.TargetCluster) []s
 func FindOrphanWorks(c client.Client, bindingNamespace, bindingName string, clusterNames []string, scope apiextensionsv1.ResourceScope) ([]workv1alpha1.Work, error) {
 	var needJudgeWorks []workv1alpha1.Work
 	if scope == apiextensionsv1.NamespaceScoped {
-		// TODO: Delete this logic in the next release to prevent incompatibility when upgrading the current release (v0.10.0).
 		workList, err := GetWorksByLabelSelector(c, labels.SelectorFromSet(labels.Set{
-			workv1alpha2.ResourceBindingNamespaceLabel: bindingNamespace,
-			workv1alpha2.ResourceBindingNameLabel:      bindingName,
-		}))
-		if err != nil {
-			klog.Errorf("Failed to get works by ResourceBinding(%s/%s): %v", bindingNamespace, bindingName, err)
-			return nil, err
-		}
-		needJudgeWorks = append(needJudgeWorks, workList.Items...)
-
-		workList, err = GetWorksByLabelSelector(c, labels.SelectorFromSet(labels.Set{
 			workv1alpha2.ResourceBindingReferenceKey: names.GenerateBindingReferenceKey(bindingNamespace, bindingName),
 		}))
 		if err != nil {
@@ -117,17 +106,7 @@ func FindOrphanWorks(c client.Client, bindingNamespace, bindingName string, clus
 		}
 		needJudgeWorks = append(needJudgeWorks, workList.Items...)
 	} else {
-		// TODO: Delete this logic in the next release to prevent incompatibility when upgrading the current release (v0.10.0).
 		workList, err := GetWorksByLabelSelector(c, labels.SelectorFromSet(labels.Set{
-			workv1alpha2.ClusterResourceBindingLabel: bindingName,
-		}))
-		if err != nil {
-			klog.Errorf("Failed to get works by ClusterResourceBinding(%s): %v", bindingName, err)
-			return nil, err
-		}
-		needJudgeWorks = append(needJudgeWorks, workList.Items...)
-
-		workList, err = GetWorksByLabelSelector(c, labels.SelectorFromSet(labels.Set{
 			workv1alpha2.ClusterResourceBindingReferenceKey: names.GenerateBindingReferenceKey("", bindingName),
 		}))
 		if err != nil {
@@ -238,32 +217,15 @@ func GetWorks(c client.Client, ls labels.Set) (*workv1alpha1.WorkList, error) {
 
 // DeleteWorkByRBNamespaceAndName will delete all Work objects by ResourceBinding namespace and name.
 func DeleteWorkByRBNamespaceAndName(c client.Client, namespace, name string) error {
-	err := DeleteWorks(c, labels.Set{
-		workv1alpha2.ResourceBindingReferenceKey: names.GenerateBindingReferenceKey(namespace, name),
-	})
-	if err != nil {
-		return err
-	}
-
-	// TODO: Delete this logic in the next release to prevent incompatibility when upgrading the current release (v0.10.0).
 	return DeleteWorks(c, labels.Set{
-		workv1alpha2.ResourceBindingNamespaceLabel: namespace,
-		workv1alpha2.ResourceBindingNameLabel:      name,
+		workv1alpha2.ResourceBindingReferenceKey: names.GenerateBindingReferenceKey(namespace, name),
 	})
 }
 
 // DeleteWorkByCRBName will delete all Work objects by ClusterResourceBinding name.
 func DeleteWorkByCRBName(c client.Client, name string) error {
-	err := DeleteWorks(c, labels.Set{
-		workv1alpha2.ClusterResourceBindingReferenceKey: names.GenerateBindingReferenceKey("", name),
-	})
-	if err != nil {
-		return err
-	}
-
-	// TODO: Delete this logic in the next release to prevent incompatibility when upgrading the current release (v0.10.0).
 	return DeleteWorks(c, labels.Set{
-		workv1alpha2.ClusterResourceBindingLabel: name,
+		workv1alpha2.ClusterResourceBindingReferenceKey: names.GenerateBindingReferenceKey("", name),
 	})
 }
 

--- a/pkg/util/helper/workstatus.go
+++ b/pkg/util/helper/workstatus.go
@@ -24,20 +24,7 @@ import (
 func AggregateResourceBindingWorkStatus(c client.Client, binding *workv1alpha2.ResourceBinding, workload *unstructured.Unstructured) error {
 	var targetWorks []workv1alpha1.Work
 
-	// TODO: Delete this logic in the next release to prevent incompatibility when upgrading the current release (v0.10.0).
 	workList, err := GetWorksByLabelSelector(c, labels.SelectorFromSet(
-		labels.Set{
-			workv1alpha2.ResourceBindingNamespaceLabel: binding.Namespace,
-			workv1alpha2.ResourceBindingNameLabel:      binding.Name,
-		},
-	))
-	if err != nil {
-		klog.Errorf("Failed to get works by ResourceBinding(%s/%s): %v", binding.Namespace, binding.Name, err)
-		return err
-	}
-	targetWorks = append(targetWorks, workList.Items...)
-
-	workList, err = GetWorksByLabelSelector(c, labels.SelectorFromSet(
 		labels.Set{
 			workv1alpha2.ResourceBindingReferenceKey: names.GenerateBindingReferenceKey(binding.Namespace, binding.Name),
 		},
@@ -72,19 +59,7 @@ func AggregateResourceBindingWorkStatus(c client.Client, binding *workv1alpha2.R
 func AggregateClusterResourceBindingWorkStatus(c client.Client, binding *workv1alpha2.ClusterResourceBinding, workload *unstructured.Unstructured) error {
 	var targetWorks []workv1alpha1.Work
 
-	// TODO: Delete this logic in the next release to prevent incompatibility when upgrading the current release (v0.10.0).
 	workList, err := GetWorksByLabelSelector(c, labels.SelectorFromSet(
-		labels.Set{
-			workv1alpha2.ClusterResourceBindingLabel: binding.Name,
-		},
-	))
-	if err != nil {
-		klog.Errorf("Failed to get works by ClusterResourceBinding(%s): %v", binding.Name, err)
-		return err
-	}
-	targetWorks = append(targetWorks, workList.Items...)
-
-	workList, err = GetWorksByLabelSelector(c, labels.SelectorFromSet(
 		labels.Set{
 			workv1alpha2.ClusterResourceBindingReferenceKey: names.GenerateBindingReferenceKey("", binding.Name),
 		},


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

In the v0.9.0 version of karmada, in order to prevent incompatibility when upgrading, I kept the resolve logic of the original label, now we have released v0.10.0 version, this logic can be removed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

