### PR TITLE
Remove ClusterNamespace from GlobalCommandOptions

### DIFF
--- a/pkg/clusterdiscovery/clusterapi/clusterapi.go
+++ b/pkg/clusterdiscovery/clusterapi/clusterapi.go
@@ -175,10 +175,10 @@ func (d *ClusterDetector) joinClusterAPICluster(clusterWideKey keys.ClusterWideK
 	}
 	opts := karmadactl.CommandJoinOption{
 		GlobalCommandOptions: options.GlobalCommandOptions{
-			ClusterNamespace: options.DefaultKarmadaClusterNamespace,
-			DryRun:           false,
+			DryRun: false,
 		},
-		ClusterName: clusterWideKey.Name,
+		ClusterNamespace: options.DefaultKarmadaClusterNamespace,
+		ClusterName:      clusterWideKey.Name,
 	}
 	err = karmadactl.JoinCluster(d.ControllerPlaneConfig, clusterRestConfig, opts)
 	if err != nil {
@@ -194,11 +194,11 @@ func (d *ClusterDetector) unJoinClusterAPICluster(clusterName string) error {
 	klog.Infof("Begin to unJoin cluster-api's Cluster(%s) to karmada", clusterName)
 	opts := karmadactl.CommandUnjoinOption{
 		GlobalCommandOptions: options.GlobalCommandOptions{
-			ClusterNamespace: options.DefaultKarmadaClusterNamespace,
-			DryRun:           false,
+			DryRun: false,
 		},
-		ClusterName: clusterName,
-		Wait:        options.DefaultKarmadactlCommandDuration,
+		ClusterNamespace: options.DefaultKarmadaClusterNamespace,
+		ClusterName:      clusterName,
+		Wait:             options.DefaultKarmadactlCommandDuration,
 	}
 	err := karmadactl.UnJoinCluster(d.ControllerPlaneConfig, nil, opts)
 	if err != nil {

--- a/pkg/karmadactl/get.go
+++ b/pkg/karmadactl/get.go
@@ -76,6 +76,8 @@ func NewCmdGet(out io.Writer, karmadaConfig KarmadaConfig, parentCommand string)
 	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", "default", "-n=namespace or -n namespace")
 	cmd.Flags().StringVarP(&o.LabelSelector, "labels", "l", "", "-l=label or -l label")
 	cmd.Flags().StringSliceVarP(&o.Clusters, "clusters", "C", []string{}, "-C=member1,member2")
+	cmd.Flags().StringVar(&o.ClusterNamespace, "cluster-namespace", options.DefaultKarmadaClusterNamespace, "Namespace in the control plane where member cluster are stored.")
+
 	o.GlobalCommandOptions.AddFlags(cmd.Flags())
 	return cmd
 }
@@ -84,6 +86,9 @@ func NewCmdGet(out io.Writer, karmadaConfig KarmadaConfig, parentCommand string)
 type CommandGetOptions struct {
 	// global flags
 	options.GlobalCommandOptions
+
+	// ClusterNamespace holds the namespace name where the member cluster objects are stored.
+	ClusterNamespace string
 
 	Clusters []string
 

--- a/pkg/karmadactl/join.go
+++ b/pkg/karmadactl/join.go
@@ -91,6 +91,9 @@ func NewCmdJoin(cmdOut io.Writer, karmadaConfig KarmadaConfig, cmdStr string) *c
 type CommandJoinOption struct {
 	options.GlobalCommandOptions
 
+	// ClusterNamespace holds the namespace name where the member cluster objects are stored.
+	ClusterNamespace string
+
 	// ClusterName is the cluster's name that we are going to join with.
 	ClusterName string
 
@@ -129,6 +132,8 @@ func (j *CommandJoinOption) Validate() error {
 // AddFlags adds flags to the specified FlagSet.
 func (j *CommandJoinOption) AddFlags(flags *pflag.FlagSet) {
 	j.GlobalCommandOptions.AddFlags(flags)
+
+	flags.StringVar(&j.ClusterNamespace, "cluster-namespace", options.DefaultKarmadaClusterNamespace, "Namespace in the control plane where member cluster are stored.")
 
 	flags.StringVar(&j.ClusterContext, "cluster-context", "",
 		"Context name of cluster in kubeconfig. Only works when there are multiple contexts in the kubeconfig.")

--- a/pkg/karmadactl/options/global.go
+++ b/pkg/karmadactl/options/global.go
@@ -22,9 +22,6 @@ type GlobalCommandOptions struct {
 	// Default value is the current-context.
 	KarmadaContext string
 
-	// ClusterNamespace holds the namespace name where the member cluster objects are stored.
-	ClusterNamespace string
-
 	// DryRun tells if run the command in dry-run mode, without making any server requests.
 	DryRun bool
 }
@@ -33,6 +30,5 @@ type GlobalCommandOptions struct {
 func (o *GlobalCommandOptions) AddFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&o.KubeConfig, "kubeconfig", "", "Path to the control plane kubeconfig file.")
 	flags.StringVar(&o.KarmadaContext, "karmada-context", "", "Name of the cluster context in control plane kubeconfig file.")
-	flags.StringVar(&o.ClusterNamespace, "cluster-namespace", DefaultKarmadaClusterNamespace, "Namespace in the control plane where member cluster are stored.")
 	flags.BoolVar(&o.DryRun, "dry-run", false, "Run the command in dry-run mode, without making any server requests.")
 }

--- a/pkg/karmadactl/unjoin.go
+++ b/pkg/karmadactl/unjoin.go
@@ -72,6 +72,9 @@ func getUnjoinExample(cmdStr string) string {
 type CommandUnjoinOption struct {
 	options.GlobalCommandOptions
 
+	// ClusterNamespace holds the namespace name where the member cluster objects are stored.
+	ClusterNamespace string
+
 	// ClusterName is the cluster's name that we are going to join with.
 	ClusterName string
 
@@ -115,6 +118,7 @@ func (j *CommandUnjoinOption) Validate() error {
 func (j *CommandUnjoinOption) AddFlags(flags *pflag.FlagSet) {
 	j.GlobalCommandOptions.AddFlags(flags)
 
+	flags.StringVar(&j.ClusterNamespace, "cluster-namespace", options.DefaultKarmadaClusterNamespace, "Namespace in the control plane where member cluster are stored.")
 	flags.StringVar(&j.ClusterContext, "cluster-context", "",
 		"Context name of cluster in kubeconfig. Only works when there are multiple contexts in the kubeconfig.")
 	flags.StringVar(&j.ClusterKubeConfig, "cluster-kubeconfig", "",

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -145,9 +145,9 @@ var _ = ginkgo.Describe("[namespace auto-provision] namespace auto-provision tes
 				karmadaConfig := karmadactl.NewKarmadaConfig(clientcmd.NewDefaultPathOptions())
 				opts := karmadactl.CommandJoinOption{
 					GlobalCommandOptions: options.GlobalCommandOptions{
-						ClusterNamespace: "karmada-cluster",
-						DryRun:           false,
+						DryRun: false,
 					},
+					ClusterNamespace:  "karmada-cluster",
 					ClusterName:       clusterName,
 					ClusterContext:    clusterContext,
 					ClusterKubeConfig: kubeConfigPath,
@@ -162,9 +162,9 @@ var _ = ginkgo.Describe("[namespace auto-provision] namespace auto-provision tes
 				karmadaConfig := karmadactl.NewKarmadaConfig(clientcmd.NewDefaultPathOptions())
 				opts := karmadactl.CommandUnjoinOption{
 					GlobalCommandOptions: options.GlobalCommandOptions{
-						ClusterNamespace: "karmada-cluster",
-						DryRun:           false,
+						DryRun: false,
 					},
+					ClusterNamespace:  "karmada-cluster",
 					ClusterName:       clusterName,
 					ClusterContext:    clusterContext,
 					ClusterKubeConfig: kubeConfigPath,


### PR DESCRIPTION
Signed-off-by: lonelyCZ <531187475@qq.com>

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
`ClusterNamespace` is not a flag that is need by all commands. iInorder to use `GlobalCommandOptions` in next commands, like `cordon`、`taint`, we should remove it from GlobalCommandOptions.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Like I mention it #946 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

