### PR TITLE
support update object annotations

### DIFF
--- a/pkg/util/annotation.go
+++ b/pkg/util/annotation.go
@@ -8,8 +8,11 @@ func MergeAnnotation(obj *unstructured.Unstructured, annotationKey string, annot
 	if objectAnnotation == nil {
 		objectAnnotation = make(map[string]string, 1)
 	}
-	objectAnnotation[annotationKey] = annotationValue
-	obj.SetAnnotations(objectAnnotation)
+
+	if _, exist := objectAnnotation[annotationKey]; !exist {
+		objectAnnotation[annotationKey] = annotationValue
+		obj.SetAnnotations(objectAnnotation)
+	}
 }
 
 // MergeAnnotations merges the annotations from 'src' to 'dst'.


### PR DESCRIPTION
Signed-off-by: lihanbo <lihanbo2@huawei.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
For annotations set by controllers in a member cluster we won't overwrite them. But for annotations set by user in resource template, we should support to update them.  Before this commit, annotations can't update if resource has been propagated which is unreasonable.


**Which issue(s) this PR fixes**:
Fixes #794 #650

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
"NONE"

