### PR TITLE
Optimization the process of getting PropagationPolicy with higher priority

### DIFF
--- a/pkg/detector/compare.go
+++ b/pkg/detector/compare.go
@@ -1,0 +1,27 @@
+package detector
+
+import policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+
+// GetHigherPriorityPropagationPolicy compare two PropagationPolicies with some priority comparison logic
+func GetHigherPriorityPropagationPolicy(a, b *policyv1alpha1.PropagationPolicy) *policyv1alpha1.PropagationPolicy {
+	if a == nil {
+		return b
+	}
+	// logic of priority comparison
+	if a.Name < b.Name {
+		return a
+	}
+	return b
+}
+
+// GetHigherPriorityClusterPropagationPolicy compare two ClusterPropagationPolicies with some priority comparison logic
+func GetHigherPriorityClusterPropagationPolicy(a, b *policyv1alpha1.ClusterPropagationPolicy) *policyv1alpha1.ClusterPropagationPolicy {
+	if a == nil {
+		return b
+	}
+	// logic of priority comparison
+	if a.Name < b.Name {
+		return a
+	}
+	return b
+}

--- a/pkg/detector/compare_test.go
+++ b/pkg/detector/compare_test.go
@@ -1,0 +1,171 @@
+package detector
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+)
+
+func Test_GetHigherPriorityPropagationPolicy(t *testing.T) {
+	type args struct {
+		a *policyv1alpha1.PropagationPolicy
+		b *policyv1alpha1.PropagationPolicy
+	}
+	tests := []struct {
+		name string
+		args args
+		want *policyv1alpha1.PropagationPolicy
+	}{
+		{
+			name: "Test 1",
+			args: args{
+				a: &policyv1alpha1.PropagationPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "A",
+					},
+				},
+				b: &policyv1alpha1.PropagationPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "B",
+					},
+				},
+			},
+			want: &policyv1alpha1.PropagationPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "A",
+				},
+			},
+		},
+		{
+			name: "Test 2",
+			args: args{
+				a: &policyv1alpha1.PropagationPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "abc",
+					},
+				},
+				b: &policyv1alpha1.PropagationPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ab",
+					},
+				},
+			},
+			want: &policyv1alpha1.PropagationPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ab",
+				},
+			},
+		},
+		{
+			name: "Test 3",
+			args: args{
+				a: &policyv1alpha1.PropagationPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "",
+					},
+				},
+				b: &policyv1alpha1.PropagationPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ab",
+					},
+				},
+			},
+			want: &policyv1alpha1.PropagationPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetHigherPriorityPropagationPolicy(tt.args.a, tt.args.b)
+			if result.Name != tt.want.Name {
+				t.Errorf("divideRemainingReplicas() got = %v, want %v", result.Name, tt.want.Name)
+			}
+		})
+	}
+}
+
+func Test_GetHigherPriorityClusterPropagationPolicy(t *testing.T) {
+	type args struct {
+		a *policyv1alpha1.ClusterPropagationPolicy
+		b *policyv1alpha1.ClusterPropagationPolicy
+	}
+	tests := []struct {
+		name string
+		args args
+		want *policyv1alpha1.ClusterPropagationPolicy
+	}{
+		{
+			name: "Test 1",
+			args: args{
+				a: &policyv1alpha1.ClusterPropagationPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "A",
+					},
+				},
+				b: &policyv1alpha1.ClusterPropagationPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "B",
+					},
+				},
+			},
+			want: &policyv1alpha1.ClusterPropagationPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "A",
+				},
+			},
+		},
+		{
+			name: "Test 2",
+			args: args{
+				a: &policyv1alpha1.ClusterPropagationPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "abc",
+					},
+				},
+				b: &policyv1alpha1.ClusterPropagationPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ab",
+					},
+				},
+			},
+			want: &policyv1alpha1.ClusterPropagationPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ab",
+				},
+			},
+		},
+		{
+			name: "Test 3",
+			args: args{
+				a: &policyv1alpha1.ClusterPropagationPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "",
+					},
+				},
+				b: &policyv1alpha1.ClusterPropagationPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ab",
+					},
+				},
+			},
+			want: &policyv1alpha1.ClusterPropagationPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetHigherPriorityClusterPropagationPolicy(tt.args.a, tt.args.b)
+			if result.Name != tt.want.Name {
+				t.Errorf("divideRemainingReplicas() got = %v, want %v", result.Name, tt.want.Name)
+			}
+		})
+	}
+}


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

- The logic of function **LookForMatchedPolicy** (**LookForMatchedClusterPolicy** is the same) is to filter `PropagationPolicy` and select the smallest lexicographical one among the matched `PropagationPolicies`, but there is no need to sort.

- It optimizes the time complexity from `O(nlogn)` to `O(n)`, accelerating the process of matching. 

- Furthermore, more strategies of selecting `PropagationPolicy` can be added to function **getHigherPriorityPropagationPolicy** in the future.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

