### PR TITLE
Specify the provider manually.

### DIFF
--- a/pkg/karmadactl/join.go
+++ b/pkg/karmadactl/join.go
@@ -99,6 +99,9 @@ type CommandJoinOption struct {
 
 	// ClusterKubeConfig is the cluster's kubeconfig path.
 	ClusterKubeConfig string
+
+	// ClusterProvider is the cluster's provider.
+	ClusterProvider string
 }
 
 // Complete ensures that options are valid and marshals them if necessary.
@@ -134,6 +137,7 @@ func (j *CommandJoinOption) AddFlags(flags *pflag.FlagSet) {
 		"Context name of cluster in kubeconfig. Only works when there are multiple contexts in the kubeconfig.")
 	flags.StringVar(&j.ClusterKubeConfig, "cluster-kubeconfig", "",
 		"Path of the cluster's kubeconfig.")
+	flags.StringVar(&j.ClusterProvider, "cluster-provider", "", "Provider of the joining cluster.")
 }
 
 // RunJoin is the implementation of the 'join' command.
@@ -194,7 +198,7 @@ func JoinCluster(controlPlaneRestConfig, clusterConfig *rest.Config, opts Comman
 		return fmt.Errorf("failed to create secret in control plane. error: %v", err)
 	}
 
-	cluster, err := generateClusterInControllerPlane(controlPlaneRestConfig, clusterConfig, opts.ClusterName, *secret)
+	cluster, err := generateClusterInControllerPlane(controlPlaneRestConfig, clusterConfig, opts, *secret)
 	if err != nil {
 		return err
 	}
@@ -278,14 +282,18 @@ func generateSecretInMemberCluster(clusterKubeClient kubeclient.Interface, clust
 	return clusterSecret, nil
 }
 
-func generateClusterInControllerPlane(controlPlaneConfig, clusterConfig *rest.Config, clusterName string, secret corev1.Secret) (*clusterv1alpha1.Cluster, error) {
+func generateClusterInControllerPlane(controlPlaneConfig, clusterConfig *rest.Config, opts CommandJoinOption, secret corev1.Secret) (*clusterv1alpha1.Cluster, error) {
 	clusterObj := &clusterv1alpha1.Cluster{}
-	clusterObj.Name = clusterName
+	clusterObj.Name = opts.ClusterName
 	clusterObj.Spec.SyncMode = clusterv1alpha1.Push
 	clusterObj.Spec.APIEndpoint = clusterConfig.Host
 	clusterObj.Spec.SecretRef = &clusterv1alpha1.LocalSecretReference{
 		Namespace: secret.Namespace,
 		Name:      secret.Name,
+	}
+
+	if opts.ClusterProvider != "" {
+		clusterObj.Spec.Provider = opts.ClusterProvider
 	}
 
 	if clusterConfig.TLSClientConfig.Insecure {
@@ -303,7 +311,7 @@ func generateClusterInControllerPlane(controlPlaneConfig, clusterConfig *rest.Co
 	controlPlaneKarmadaClient := karmadaclientset.NewForConfigOrDie(controlPlaneConfig)
 	cluster, err := CreateClusterObject(controlPlaneKarmadaClient, clusterObj, false)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create cluster object. cluster name: %s, error: %v", clusterName, err)
+		return nil, fmt.Errorf("failed to create cluster object. cluster name: %s, error: %v", opts.ClusterName, err)
 	}
 
 	return cluster, nil


### PR DESCRIPTION
Signed-off-by: Pilipalaca <85749695@qq.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
In the clusterlist,provider is a display column,so it should be manuall specified when join a member cluster.After manually specifiying the provider,you can get the specified provider throuh apiserver.
**Which issue(s) this PR fixes**:
Fixes #1023

**Special notes for your reviewer**:
![image](https://user-images.githubusercontent.com/31329928/143272150-e0f854e2-426f-4078-9558-baab3e6b0250.png)
Join with provider,then get it from apiserver:
![image](https://user-images.githubusercontent.com/31329928/143272403-11695aca-77e5-4964-91da-cbd8e84a85d5.png)
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

