### PR TITLE
Example 问题修复：artifacts/example/policy_with_labelSelector.yaml

### DIFF
--- a/artifacts/example/policy_with_labelSelector.yaml
+++ b/artifacts/example/policy_with_labelSelector.yaml
@@ -16,11 +16,10 @@ spec:
     clusterAffinity:
       clusterNames:
         - cluster1
+        - cluster2
         - cluster3
-      exclude:
-        - cluster1
     spreadConstraints:
       - spreadByLabel: failuredomain.kubernetes.io/zone
-        maxGroups: 3
-        minGroups: 3
+        maxGroups: 2
+        minGroups: 2
   schedulerName: default


### PR DESCRIPTION
本意是想比如指定了cluster1,cluster2,cluster3三个集群，maxGroups和minGroups为2，然后当其中一个集群不可用时，会调度到剩下的那个集群上。

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
example bug fix
**Which issue(s) this PR fixes**:
Fixes #  #1045
**Special notes for your reviewer**:
/assign @rainbowmango
**Does this PR introduce a user-facing change?**:
NONE
