### PR TITLE
add events to resource template

### DIFF
--- a/charts/_crds/bases/work.karmada.io_clusterresourcebindings.yaml
+++ b/charts/_crds/bases/work.karmada.io_clusterresourcebindings.yaml
@@ -455,6 +455,9 @@ spec:
                       the referenced object, that can be used by clients to determine
                       when object has changed.
                     type: string
+                  uid:
+                    description: UID of the referent.
+                    type: string
                 required:
                 - apiVersion
                 - kind

--- a/charts/_crds/bases/work.karmada.io_resourcebindings.yaml
+++ b/charts/_crds/bases/work.karmada.io_resourcebindings.yaml
@@ -455,6 +455,9 @@ spec:
                       the referenced object, that can be used by clients to determine
                       when object has changed.
                     type: string
+                  uid:
+                    description: UID of the referent.
+                    type: string
                 required:
                 - apiVersion
                 - kind

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -387,6 +387,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 		SkippedResourceConfig:        skippedResourceConfig,
 		SkippedPropagatingNamespaces: skippedPropagatingNamespaces,
 		ResourceInterpreter:          resourceInterpreter,
+		EventRecorder:                mgr.GetEventRecorderFor("resource-detector"),
 	}
 	if err := mgr.Add(resourceDetector); err != nil {
 		klog.Fatalf("Failed to setup resource detector: %v", err)

--- a/pkg/apis/work/v1alpha2/binding_types.go
+++ b/pkg/apis/work/v1alpha2/binding_types.go
@@ -4,6 +4,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // +genclient
@@ -63,6 +64,10 @@ type ObjectReference struct {
 
 	// Name represents the name of the referent.
 	Name string `json:"name"`
+
+	// UID of the referent.
+	// +optional
+	UID types.UID `json:"uid,omitempty"`
 
 	// ResourceVersion represents the internal version of the referenced object, that can be used by clients to
 	// determine when object has changed.

--- a/pkg/apis/work/v1alpha2/events.go
+++ b/pkg/apis/work/v1alpha2/events.go
@@ -12,4 +12,12 @@ const (
 	EventReasonAggregateStatusFailed = "AggregateStatusFailed"
 	// EventReasonAggregateStatusSucceed indicates that aggregate status succeed.
 	EventReasonAggregateStatusSucceed = "AggregateStatusSucceed"
+	// EventReasonApplyPolicyFailed indicates that apply policy for resource failed.
+	EventReasonApplyPolicyFailed = "ApplyPolicyFailed"
+	// EventReasonApplyPolicySucceed indicates that apply policy for resource succeed.
+	EventReasonApplyPolicySucceed = "ApplyPolicySucceed"
+	// EventReasonScheduleBindingFailed indicates that schedule binding failed.
+	EventReasonScheduleBindingFailed = "ScheduleBindingFailed"
+	// EventReasonScheduleBindingSucceed indicates that schedule binding succeed.
+	EventReasonScheduleBindingSucceed = "ScheduleBindingSucceed"
 )

--- a/pkg/controllers/binding/binding_controller.go
+++ b/pkg/controllers/binding/binding_controller.go
@@ -115,22 +115,26 @@ func (c *ResourceBindingController) syncBinding(binding *workv1alpha2.ResourceBi
 		klog.Errorf("Failed to transform resourceBinding(%s/%s) to works. Error: %v.",
 			binding.GetNamespace(), binding.GetName(), err)
 		c.EventRecorder.Event(binding, corev1.EventTypeWarning, workv1alpha2.EventReasonSyncWorkFailed, err.Error())
+		c.EventRecorder.Event(workload, corev1.EventTypeWarning, workv1alpha2.EventReasonSyncWorkFailed, err.Error())
 		errs = append(errs, err)
 	} else {
 		msg := fmt.Sprintf("Sync work of resourceBinding(%s/%s) successful.", binding.Namespace, binding.Name)
 		klog.V(4).Infof(msg)
 		c.EventRecorder.Event(binding, corev1.EventTypeNormal, workv1alpha2.EventReasonSyncWorkSucceed, msg)
+		c.EventRecorder.Event(workload, corev1.EventTypeNormal, workv1alpha2.EventReasonSyncWorkSucceed, msg)
 	}
 	err = helper.AggregateResourceBindingWorkStatus(c.Client, binding, workload)
 	if err != nil {
 		klog.Errorf("Failed to aggregate workStatuses to resourceBinding(%s/%s). Error: %v.",
 			binding.GetNamespace(), binding.GetName(), err)
 		c.EventRecorder.Event(binding, corev1.EventTypeWarning, workv1alpha2.EventReasonAggregateStatusFailed, err.Error())
+		c.EventRecorder.Event(workload, corev1.EventTypeWarning, workv1alpha2.EventReasonAggregateStatusFailed, err.Error())
 		errs = append(errs, err)
 	} else {
 		msg := fmt.Sprintf("Update resourceBinding(%s/%s) with AggregatedStatus successfully.", binding.Namespace, binding.Name)
 		klog.V(4).Infof(msg)
 		c.EventRecorder.Event(binding, corev1.EventTypeNormal, workv1alpha2.EventReasonAggregateStatusSucceed, msg)
+		c.EventRecorder.Event(workload, corev1.EventTypeNormal, workv1alpha2.EventReasonAggregateStatusSucceed, msg)
 	}
 	if len(errs) > 0 {
 		return controllerruntime.Result{Requeue: true}, errors.NewAggregate(errs)

--- a/pkg/controllers/execution/execution_controller.go
+++ b/pkg/controllers/execution/execution_controller.go
@@ -165,6 +165,7 @@ func (c *Controller) syncToClusters(clusterName string, work *workv1alpha1.Work)
 			err = c.tryUpdateWorkload(clusterName, workload)
 			if err != nil {
 				klog.Errorf("Failed to update resource(%v/%v) in the given member cluster %s, err is %v", workload.GetNamespace(), workload.GetName(), clusterName, err)
+				c.EventRecorder.Eventf(workload, corev1.EventTypeWarning, workv1alpha1.EventReasonSyncWorkFailed, "Failed to update resource(%v/%v) in the given member cluster %s, err is %v", workload.GetNamespace(), workload.GetName(), clusterName, err)
 				errs = append(errs, err)
 				continue
 			}
@@ -172,10 +173,12 @@ func (c *Controller) syncToClusters(clusterName string, work *workv1alpha1.Work)
 			err = c.tryCreateWorkload(clusterName, workload)
 			if err != nil {
 				klog.Errorf("Failed to create resource(%v/%v) in the given member cluster %s, err is %v", workload.GetNamespace(), workload.GetName(), clusterName, err)
+				c.EventRecorder.Eventf(workload, corev1.EventTypeWarning, workv1alpha1.EventReasonSyncWorkFailed, "Failed to create resource(%v/%v) in the given member cluster %s, err is %v", workload.GetNamespace(), workload.GetName(), clusterName, err)
 				errs = append(errs, err)
 				continue
 			}
 		}
+		c.EventRecorder.Eventf(workload, corev1.EventTypeNormal, workv1alpha1.EventReasonSyncWorkSucceed, "Successfully applied resource(%v/%v) to cluster %s", workload.GetNamespace(), workload.GetName(), clusterName)
 		syncSucceedNum++
 	}
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -15,10 +15,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+
+	"github.com/karmada-io/karmada/pkg/util/gclient"
 
 	"github.com/karmada-io/karmada/cmd/scheduler/app/options"
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
@@ -57,7 +61,7 @@ const (
 const (
 	scheduleSuccessReason  = "BindingScheduled"
 	scheduleFailedReason   = "BindingFailedScheduling"
-	scheduleSuccessMessage = "the binding has been scheduled"
+	scheduleSuccessMessage = "Binding has been scheduled"
 )
 
 // Scheduler is the scheduler schema, which is used to schedule a specific resource to specific clusters
@@ -81,6 +85,8 @@ type Scheduler struct {
 
 	Algorithm      core.ScheduleAlgorithm
 	schedulerCache schedulercache.Cache
+
+	eventRecorder record.EventRecorder
 
 	enableSchedulerEstimator bool
 	schedulerEstimatorCache  *estimatorclient.SchedulerEstimatorCache
@@ -159,6 +165,11 @@ func NewScheduler(dynamicClient dynamic.Interface, karmadaClient karmadaclientse
 			DeleteFunc: sched.deleteCluster,
 		},
 	)
+
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartStructuredLogging(0)
+	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
+	sched.eventRecorder = eventBroadcaster.NewRecorder(gclient.NewSchema(), corev1.EventSource{Component: "karmada-scheduler"})
 
 	return sched
 }
@@ -397,6 +408,7 @@ func (s *Scheduler) doScheduleBinding(namespace, name string) error {
 
 	// Update "Scheduled" condition according to schedule result.
 	defer func() {
+		s.recordScheduleResultEventForResourceBinding(rb, err)
 		var condition metav1.Condition
 		if err == nil {
 			condition = util.NewCondition(workv1alpha2.Scheduled, scheduleSuccessReason, scheduleSuccessMessage, metav1.ConditionTrue)
@@ -458,6 +470,7 @@ func (s *Scheduler) doScheduleClusterBinding(name string) error {
 
 	// Update "Scheduled" condition according to schedule result.
 	defer func() {
+		s.recordScheduleResultEventForClusterResourceBinding(crb, err)
 		var condition metav1.Condition
 		if err == nil {
 			condition = util.NewCondition(workv1alpha2.Scheduled, scheduleSuccessReason, scheduleSuccessMessage, metav1.ConditionTrue)
@@ -852,4 +865,48 @@ func (s *Scheduler) updateClusterBindingScheduledConditionIfNeeded(crb *workv1al
 
 		return updateErr
 	})
+}
+
+func (s *Scheduler) recordScheduleResultEventForResourceBinding(rb *workv1alpha2.ResourceBinding, schedulerErr error) {
+	if rb == nil {
+		return
+	}
+
+	ref := &corev1.ObjectReference{
+		Kind:       rb.Spec.Resource.Kind,
+		APIVersion: rb.Spec.Resource.APIVersion,
+		Namespace:  rb.Spec.Resource.Namespace,
+		Name:       rb.Spec.Resource.Name,
+		UID:        rb.Spec.Resource.UID,
+	}
+
+	if schedulerErr == nil {
+		s.eventRecorder.Event(rb, corev1.EventTypeNormal, workv1alpha2.EventReasonScheduleBindingSucceed, scheduleSuccessMessage)
+		s.eventRecorder.Event(ref, corev1.EventTypeNormal, workv1alpha2.EventReasonScheduleBindingSucceed, scheduleSuccessMessage)
+	} else {
+		s.eventRecorder.Event(rb, corev1.EventTypeWarning, workv1alpha2.EventReasonScheduleBindingFailed, schedulerErr.Error())
+		s.eventRecorder.Event(ref, corev1.EventTypeWarning, workv1alpha2.EventReasonScheduleBindingFailed, schedulerErr.Error())
+	}
+}
+
+func (s *Scheduler) recordScheduleResultEventForClusterResourceBinding(crb *workv1alpha2.ClusterResourceBinding, schedulerErr error) {
+	if crb == nil {
+		return
+	}
+
+	ref := &corev1.ObjectReference{
+		Kind:       crb.Spec.Resource.Kind,
+		APIVersion: crb.Spec.Resource.APIVersion,
+		Namespace:  crb.Spec.Resource.Namespace,
+		Name:       crb.Spec.Resource.Name,
+		UID:        crb.Spec.Resource.UID,
+	}
+
+	if schedulerErr == nil {
+		s.eventRecorder.Event(crb, corev1.EventTypeNormal, workv1alpha2.EventReasonScheduleBindingSucceed, scheduleSuccessMessage)
+		s.eventRecorder.Event(ref, corev1.EventTypeNormal, workv1alpha2.EventReasonScheduleBindingSucceed, scheduleSuccessMessage)
+	} else {
+		s.eventRecorder.Event(crb, corev1.EventTypeWarning, workv1alpha2.EventReasonScheduleBindingFailed, schedulerErr.Error())
+		s.eventRecorder.Event(ref, corev1.EventTypeWarning, workv1alpha2.EventReasonScheduleBindingFailed, schedulerErr.Error())
+	}
 }


### PR DESCRIPTION
Signed-off-by: lihanbo <lihanbo2@huawei.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Most of users are more familiar with native kubernetes resources, add events to resource template is more friendly for users to use karmada.

**Which issue(s) this PR fixes**:
Fixes #1016 

**Special notes for your reviewer**:
```
[root@karmada-lhb ~]#  kubectl describe deployments.apps nginx 
Name:                   nginx
Namespace:              default
CreationTimestamp:      Sun, 05 Dec 2021 14:53:00 +0800
Labels:                 app=nginx
                        propagationpolicy.karmada.io/name=nginx-propagation
                        propagationpolicy.karmada.io/namespace=default
Annotations:            <none>
Selector:               app=nginx
Replicas:               2 desired | 2 updated | 2 total | 2 available | 0 unavailable
StrategyType:           RollingUpdate
MinReadySeconds:        0
RollingUpdateStrategy:  25% max unavailable, 25% max surge
Pod Template:
  Labels:  app=nginx
  Containers:
   nginx:
    Image:        nginx
    Port:         <none>
    Host Port:    <none>
    Environment:  <none>
    Mounts:       <none>
  Volumes:        <none>
OldReplicaSets:   <none>
NewReplicaSet:    <none>
Events:
  Type     Reason                  Age                 From                Message
  ----     ------                  ----                ----                -------
  Warning  ApplyPolicyFailed       59s                 resource-detector   no policy match for resource
  Warning  ApplyPolicySucceed      16s (x7 over 29s)   resource-detector   Applying policy(default/nginx-propagation) succeed
  Normal   ScheduleBindingSucceed  16s (x16 over 29s)  karmada-scheduler   the binding has been scheduled
  Normal   SyncWorkSucceed         16s (x11 over 29s)  binding-controller  Sync work of resourceBinding(default/nginx-deployment) successful.
  Normal   AggregateStatusSucceed  16s (x12 over 29s)  binding-controller  Update resourceBinding(default/nginx-deployment) with AggregatedStatus successfully.

```

**Does this PR introduce a user-facing change?**:
"NONE"
