### PR TITLE
Print pointer variables correctly in the scheduler log

### DIFF
--- a/pkg/apis/cluster/v1alpha1/cluster_utils.go
+++ b/pkg/apis/cluster/v1alpha1/cluster_utils.go
@@ -1,0 +1,6 @@
+package v1alpha1
+
+// String returns a well-formatted string for the Cluster object.
+func (c *Cluster) String() string {
+	return c.Name
+}

--- a/pkg/apis/cluster/v1alpha1/cluster_utils_test.go
+++ b/pkg/apis/cluster/v1alpha1/cluster_utils_test.go
@@ -1,0 +1,57 @@
+package v1alpha1
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestString(t *testing.T) {
+	clusterName := "cluster1"
+	cluster1 := &Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterName},
+	}
+
+	tests := []struct {
+		name    string
+		fmtFunc func() string
+		want    string
+	}{
+		{
+			name: "%s pointer test",
+			fmtFunc: func() string {
+				return fmt.Sprintf("%s", cluster1) // nolint
+			},
+			want: clusterName,
+		},
+		{
+			name: "%v variable test",
+			fmtFunc: func() string {
+				return fmt.Sprintf("%v", *cluster1)
+			},
+			want: "{{ } {cluster1      0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] []  []} {  <nil> false     []} { [] [] <nil> <nil>}}",
+		},
+		{
+			name: "%v pointer test",
+			fmtFunc: func() string {
+				return fmt.Sprintf("%v", cluster1)
+			},
+			want: clusterName,
+		},
+		{
+			name: "%v pointer array test",
+			fmtFunc: func() string {
+				return fmt.Sprintf("%v", []*Cluster{cluster1})
+			},
+			want: fmt.Sprintf("[%s]", clusterName),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.fmtFunc(); got != tt.want {
+				t.Errorf("%s String() = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

https://github.com/karmada-io/karmada/blob/85920e7ef49afc66325b85a37de97a662a7913c1/pkg/scheduler/core/generic_scheduler.go#L62

Currently we printed the `feasibleClusters` information in the generic_scheduler, but the `feasibleClusters` is an array of pointers, which makes the printed log completely unreadable:

```
I1206 06:22:54.370778       1 generic_scheduler.go:62] feasible clusters found: [0xc000858000 0xc000858200]
```

So I added a `String()` method to the `Cluster` object to make the log readable:

```
I1206 06:51:59.916405       1 generic_scheduler.go:62] feasible clusters found: [member1 member2]
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

/assign @RainbowMango 