### PR TITLE
Cleanup k8s.io/kubernetes from .import-aliases

### DIFF
--- a/hack/.import-aliases
+++ b/hack/.import-aliases
@@ -42,17 +42,12 @@
     "k8s.io/apimachinery/pkg/api/errors": "apierrors",
     "k8s.io/apimachinery/pkg/apis/meta/v1": "metav1",
     "k8s.io/kubelet/apis/stats/v1alpha1": "kubeletstatsv1alpha1",
-    "k8s.io/kubernetes/pkg/controller/apis/config/v1alpha1": "controllerconfigv1alpha1",
-    "k8s.io/kubernetes/pkg/kubelet/apis/config/v1beta1": "kubeletconfigv1beta1",
     "k8s.io/kubelet/pkg/apis/deviceplugin/v1alpha": "kubeletdevicepluginv1alpha",
     "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1": "kubeletdevicepluginv1beta1",
     "k8s.io/kubelet/pkg/apis/pluginregistration/v1": "kubeletpluginregistrationv1",
     "k8s.io/kubelet/pkg/apis/pluginregistration/v1alpha1": "kubeletpluginregistrationv1alpha1",
     "k8s.io/kubelet/pkg/apis/pluginregistration/v1beta1": "kubeletpluginregistrationv1beta1",
     "k8s.io/kubelet/pkg/apis/podresources/v1alpha1": "kubeletpodresourcesv1alpha1",
-    "k8s.io/kubernetes/pkg/kubelet/apis/resourcemetrics/v1alpha1": "kubeletresourcemetricsv1alpha1",
-    "k8s.io/kubernetes/pkg/proxy/apis/config/v1alpha1": "proxyconfigv1alpha1",
-    "k8s.io/kubernetes/pkg/scheduler/apis/config/v1beta1": "schedulerconfigv1beta1",
 
     "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1": "mcsv1alpha1",
 


### PR DESCRIPTION
Signed-off-by: lonelyCZ <531187475@qq.com>

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
We don't rely on this package `k8s.io/kubernetes` in our code, so remove it from .import-aliases.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

