### PR TITLE
add impersonation config sync controller

### DIFF
--- a/artifacts/agent/clusterrole.yaml
+++ b/artifacts/agent/clusterrole.yaml
@@ -5,6 +5,6 @@ metadata:
 rules:
   - apiGroups: ['*']
     resources: ['*']
-    verbs: ["get", "watch", "list", "create", "update", "delete"]
+    verbs: ['*']
   - nonResourceURLs: ['*']
     verbs: ["get"]

--- a/artifacts/agent/namespace.yaml
+++ b/artifacts/agent/namespace.yaml
@@ -2,3 +2,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: karmada-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: karmada-cluster
+

--- a/artifacts/agent/serviceaccount.yaml
+++ b/artifacts/agent/serviceaccount.yaml
@@ -3,3 +3,11 @@ kind: ServiceAccount
 metadata:
   name: karmada-agent-sa
   namespace: karmada-system
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: karmada-impersonator
+  namespace: karmada-cluster

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -29,6 +29,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/controllers/mcs"
 	"github.com/karmada-io/karmada/pkg/controllers/namespace"
 	"github.com/karmada-io/karmada/pkg/controllers/status"
+	"github.com/karmada-io/karmada/pkg/controllers/unifiedauth"
 	"github.com/karmada-io/karmada/pkg/detector"
 	"github.com/karmada-io/karmada/pkg/karmadactl"
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter"
@@ -150,6 +151,7 @@ func NewControllerInitializers() map[string]InitFunc {
 	controllers["serviceExport"] = startServiceExportController
 	controllers["endpointSlice"] = startEndpointSliceController
 	controllers["serviceImport"] = startServiceImportController
+	controllers["unifiedAuth"] = startUnifiedAuthController
 	return controllers
 }
 
@@ -347,6 +349,17 @@ func startServiceImportController(ctx ControllerContext) (enabled bool, err erro
 		EventRecorder: ctx.Mgr.GetEventRecorderFor(mcs.ServiceImportControllerName),
 	}
 	if err := serviceImportController.SetupWithManager(ctx.Mgr); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func startUnifiedAuthController(ctx ControllerContext) (enabled bool, err error) {
+	unifiedAuthController := &unifiedauth.Controller{
+		Client:        ctx.Mgr.GetClient(),
+		EventRecorder: ctx.Mgr.GetEventRecorderFor(unifiedauth.ControllerName),
+	}
+	if err := unifiedAuthController.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/pkg/controllers/unifiedauth/unified_auth_controller.go
+++ b/pkg/controllers/unifiedauth/unified_auth_controller.go
@@ -1,0 +1,295 @@
+package unifiedauth
+
+import (
+	"context"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/helper"
+	"github.com/karmada-io/karmada/pkg/util/names"
+)
+
+const (
+	// ControllerName is the controller name that will be used when reporting events.
+	ControllerName         = "unified-auth-controller"
+	rbacAPIVersion         = "rbac.authorization.k8s.io/v1"
+	clusterProxyResource   = "clusters/proxy"
+	clusterProxyAPIGroup   = "cluster.karmada.io"
+	karmadaImpersontorName = "karmada-impersonator"
+)
+
+// Controller is to sync impersonation config to member clusters for unified authentication.
+type Controller struct {
+	client.Client // used to operate Cluster resources.
+	EventRecorder record.EventRecorder
+}
+
+// Reconcile performs a full reconciliation for the object referred to by the Request.
+func (c *Controller) Reconcile(ctx context.Context, req controllerruntime.Request) (controllerruntime.Result, error) {
+	klog.V(4).Infof("Reconciling cluster %s", req.NamespacedName.String())
+
+	cluster := &clusterv1alpha1.Cluster{}
+	if err := c.Client.Get(context.TODO(), req.NamespacedName, cluster); err != nil {
+		// The resource may no longer exist, in which case we stop processing.
+		if apierrors.IsNotFound(err) {
+			return controllerruntime.Result{}, nil
+		}
+
+		return controllerruntime.Result{Requeue: true}, err
+	}
+
+	if !cluster.DeletionTimestamp.IsZero() {
+		// Do nothing, just return as we have added owner reference to Work.
+		// Work will be removed automatically by garbage collector.
+		return controllerruntime.Result{}, nil
+	}
+
+	err := c.syncImpersonationConfig(cluster)
+	if err != nil {
+		klog.Errorf("Failed to sync impersonation config for cluster %s. Error: %v.", cluster.Name, err)
+		return controllerruntime.Result{Requeue: true}, err
+	}
+
+	return controllerruntime.Result{}, nil
+}
+
+func (c *Controller) syncImpersonationConfig(cluster *clusterv1alpha1.Cluster) error {
+	// step1: list all clusterroles
+	clusterRoleList := &rbacv1.ClusterRoleList{}
+	if err := c.Client.List(context.TODO(), clusterRoleList); err != nil {
+		klog.Errorf("Failed to list clusterroles, error: %v", err)
+		return err
+	}
+
+	// step2: found out clusterroles that matches current cluster
+	allMatchedClusterRoles := sets.NewString()
+	for _, clusterRole := range clusterRoleList.Items {
+		for i := range clusterRole.Rules {
+			if util.PolicyRuleAPIGroupMatches(&clusterRole.Rules[i], clusterProxyAPIGroup) &&
+				util.PolicyRuleResourceMatches(&clusterRole.Rules[i], clusterProxyResource) &&
+				util.PolicyRuleResourceNameMatches(&clusterRole.Rules[i], cluster.Name) {
+				allMatchedClusterRoles.Insert(clusterRole.Name)
+			}
+		}
+	}
+
+	// step3: found out reference clusterRolebindings and collecting subjects.
+	clusterRoleBindings := &rbacv1.ClusterRoleBindingList{}
+	var allSubjects []rbacv1.Subject
+	if len(allMatchedClusterRoles) != 0 {
+		if err := c.Client.List(context.TODO(), clusterRoleBindings); err != nil {
+			klog.Errorf("Failed to list clusterrolebindings, error: %v", err)
+			return err
+		}
+
+		for _, clusterRoleBinding := range clusterRoleBindings.Items {
+			if clusterRoleBinding.RoleRef.Kind == util.ClusterRoleKind && allMatchedClusterRoles.Has(clusterRoleBinding.RoleRef.Name) {
+				allSubjects = append(allSubjects, clusterRoleBinding.Subjects...)
+			}
+		}
+	}
+
+	// step4:  generate rules for impersonation
+	rules := util.GenerateImpersonationRules(allSubjects)
+
+	// step5: sync clusterrole to cluster for impersonation
+	if err := c.buildImpersonationClusterRole(cluster, rules); err != nil {
+		klog.Errorf("failed to sync impersonate clusterrole to cluster(%s): %v", cluster.Name, err)
+		return err
+	}
+
+	// step6: sync clusterrolebinding to cluster for impersonation
+	if err := c.buildImpersonationClusterRoleBinding(cluster); err != nil {
+		klog.Errorf("failed to sync impersonate clusterrolebinding to cluster(%s): %v", cluster.Name, err)
+		return err
+	}
+
+	return nil
+}
+
+func (c *Controller) buildImpersonationClusterRole(cluster *clusterv1alpha1.Cluster, rules []rbacv1.PolicyRule) error {
+	impersonationClusterRole := &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: rbacAPIVersion,
+			Kind:       util.ClusterRoleKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: karmadaImpersontorName,
+		},
+		Rules: rules,
+	}
+
+	uncastObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(impersonationClusterRole)
+	if err != nil {
+		klog.Errorf("Failed to transform clusterrole %s. Error: %v", impersonationClusterRole.GetName(), err)
+		return nil
+	}
+
+	clusterRoleObj := &unstructured.Unstructured{Object: uncastObj}
+	return c.buildWorks(cluster, clusterRoleObj)
+}
+
+func (c *Controller) buildImpersonationClusterRoleBinding(cluster *clusterv1alpha1.Cluster) error {
+	impersonatorClusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: rbacAPIVersion,
+			Kind:       util.ClusterRoleBindingKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: karmadaImpersontorName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Namespace: names.NamespaceKarmadaCluster,
+				Name:      names.GenerateServiceAccountName("impersonator"),
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     util.ClusterRoleKind,
+			Name:     karmadaImpersontorName,
+		},
+	}
+
+	uncastObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(impersonatorClusterRoleBinding)
+	if err != nil {
+		klog.Errorf("Failed to transform clusterrolebinding %s. Error: %v", impersonatorClusterRoleBinding.GetName(), err)
+		return nil
+	}
+
+	clusterRoleBindingObj := &unstructured.Unstructured{Object: uncastObj}
+	return c.buildWorks(cluster, clusterRoleBindingObj)
+}
+
+func (c *Controller) buildWorks(cluster *clusterv1alpha1.Cluster, obj *unstructured.Unstructured) error {
+	workNamespace, err := names.GenerateExecutionSpaceName(cluster.Name)
+	if err != nil {
+		klog.Errorf("Failed to generate execution space name for member cluster %s, err is %v", cluster.Name, err)
+		return err
+	}
+
+	clusterRoleBindingWorkName := names.GenerateWorkName(obj.GetKind(), obj.GetName(), obj.GetNamespace())
+	objectMeta := metav1.ObjectMeta{
+		Name:       clusterRoleBindingWorkName,
+		Namespace:  workNamespace,
+		Finalizers: []string{util.ExecutionControllerFinalizer},
+		OwnerReferences: []metav1.OwnerReference{
+			*metav1.NewControllerRef(cluster, cluster.GroupVersionKind()),
+		},
+	}
+
+	util.MergeLabel(obj, workv1alpha1.WorkNamespaceLabel, workNamespace)
+	util.MergeLabel(obj, workv1alpha1.WorkNameLabel, clusterRoleBindingWorkName)
+
+	if err = helper.CreateOrUpdateWork(c.Client, objectMeta, obj); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SetupWithManager creates a controller and register to controller manager.
+func (c *Controller) SetupWithManager(mgr controllerruntime.Manager) error {
+	// clusterPredicateFunc only cares about create events
+	clusterPredicateFunc := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if _, ok := e.ObjectNew.(*clusterv1alpha1.Cluster); ok {
+				return false
+			}
+			if _, ok := e.ObjectOld.(*clusterv1alpha1.Cluster); ok {
+				return false
+			}
+			return true
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			if _, ok := e.Object.(*clusterv1alpha1.Cluster); ok {
+				return false
+			}
+			return true
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
+
+	return controllerruntime.NewControllerManagedBy(mgr).For(&clusterv1alpha1.Cluster{}).WithEventFilter(clusterPredicateFunc).
+		Watches(&source.Kind{Type: &rbacv1.ClusterRole{}}, handler.EnqueueRequestsFromMapFunc(c.newClusterRoleMapFunc())).
+		Watches(&source.Kind{Type: &rbacv1.ClusterRoleBinding{}}, handler.EnqueueRequestsFromMapFunc(c.newClusterRoleBindingMapFunc())).Complete(c)
+}
+
+func (c *Controller) newClusterRoleMapFunc() handler.MapFunc {
+	return func(a client.Object) []reconcile.Request {
+		clusterRole := a.(*rbacv1.ClusterRole)
+		return c.generateRequestsFromClusterRole(clusterRole)
+	}
+}
+
+func (c *Controller) newClusterRoleBindingMapFunc() handler.MapFunc {
+	return func(a client.Object) []reconcile.Request {
+		clusterRoleBinding := a.(*rbacv1.ClusterRoleBinding)
+		if clusterRoleBinding.RoleRef.Kind != util.ClusterRoleKind {
+			return nil
+		}
+
+		clusterRole := &rbacv1.ClusterRole{}
+		if err := c.Client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleBinding.RoleRef.Name}, clusterRole); err != nil {
+			klog.Errorf("Failed to get reference clusterrole, error: %v", err)
+			return nil
+		}
+		return c.generateRequestsFromClusterRole(clusterRole)
+	}
+}
+
+// found out which clusters need to sync impersonation config from rules like:
+//   resources: ["cluster/proxy"]
+//   resourceNmaes: ["cluster1", "cluster2"]
+func (c *Controller) generateRequestsFromClusterRole(clusterRole *rbacv1.ClusterRole) []reconcile.Request {
+	var requests []reconcile.Request
+	for i := range clusterRole.Rules {
+		if util.PolicyRuleAPIGroupMatches(&clusterRole.Rules[i], clusterProxyAPIGroup) &&
+			util.PolicyRuleResourceMatches(&clusterRole.Rules[i], clusterProxyResource) {
+			if len(clusterRole.Rules[i].ResourceNames) == 0 {
+				// if rule.ResourceNames == 0, means to match all clusters
+				clusterList := &clusterv1alpha1.ClusterList{}
+				if err := c.Client.List(context.TODO(), clusterList); err != nil {
+					klog.Errorf("Failed to list clusters, error: %v", err)
+					return nil
+				}
+				for _, cluster := range clusterList.Items {
+					requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+						Name: cluster.Name,
+					}})
+				}
+			} else {
+				for _, ruleName := range clusterRole.Rules[i].ResourceNames {
+					requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+						Name: ruleName,
+					}})
+				}
+			}
+		}
+	}
+	return requests
+}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -98,6 +98,11 @@ const (
 
 	// CRDKind indicated the target resource is a CustomResourceDefinition
 	CRDKind = "CustomResourceDefinition"
+
+	// ClusterRoleKind indicates the target resource is a clusterrole
+	ClusterRoleKind = "ClusterRole"
+	// ClusterRoleBindingKind indicates the target resource is a clusterrolebinding
+	ClusterRoleBindingKind = "ClusterRoleBinding"
 )
 
 // Define resource filed

--- a/pkg/util/names/names.go
+++ b/pkg/util/names/names.go
@@ -116,3 +116,8 @@ func IsReservedNamespace(namespace string) bool {
 		strings.HasPrefix(namespace, ExecutionSpacePrefix) ||
 		strings.HasPrefix(namespace, KubernetesReservedNSPrefix)
 }
+
+// GenerateImpersonationSecretName generates the secret name of impersonation secret.
+func GenerateImpersonationSecretName(clusterName string) string {
+	return fmt.Sprintf("%s-impersonator", clusterName)
+}

--- a/pkg/util/rbac.go
+++ b/pkg/util/rbac.go
@@ -6,6 +6,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiserverserviceaccount "k8s.io/apiserver/pkg/authentication/serviceaccount"
 	kubeclient "k8s.io/client-go/kubernetes"
 )
 
@@ -81,4 +82,81 @@ func DeleteClusterRoleBinding(client kubeclient.Interface, name string) error {
 		return err
 	}
 	return nil
+}
+
+// PolicyRuleAPIGroupMatches determines if the given policy rule is applied for requested group.
+func PolicyRuleAPIGroupMatches(rules *rbacv1.PolicyRule, requestedGroup string) bool {
+	for _, ruleGroup := range rules.APIGroups {
+		if ruleGroup == rbacv1.APIGroupAll {
+			return true
+		}
+		if ruleGroup == requestedGroup {
+			return true
+		}
+	}
+
+	return false
+}
+
+// PolicyRuleResourceMatches determines if the given policy rule is applied for requested resource.
+func PolicyRuleResourceMatches(rules *rbacv1.PolicyRule, requestedResource string) bool {
+	for _, ruleResource := range rules.Resources {
+		if ruleResource == rbacv1.ResourceAll {
+			return true
+		}
+
+		if ruleResource == requestedResource {
+			return true
+		}
+	}
+	return false
+}
+
+// PolicyRuleResourceNameMatches determines if the given policy rule is applied for named resource.
+func PolicyRuleResourceNameMatches(rule *rbacv1.PolicyRule, requestedName string) bool {
+	if len(rule.ResourceNames) == 0 {
+		return true
+	}
+
+	for _, ruleName := range rule.ResourceNames {
+		if ruleName == requestedName {
+			return true
+		}
+	}
+
+	return false
+}
+
+// GenerateImpersonationRules generate PolicyRules from given subjects for impersonation.
+func GenerateImpersonationRules(allSubjects []rbacv1.Subject) []rbacv1.PolicyRule {
+	if len(allSubjects) == 0 {
+		return nil
+	}
+
+	var users, serviceAccounts, groups []string
+	for _, subject := range allSubjects {
+		switch subject.Kind {
+		case rbacv1.UserKind:
+			users = append(users, subject.Name)
+		case rbacv1.ServiceAccountKind:
+			serviceAccounts = append(serviceAccounts, apiserverserviceaccount.MakeUsername(subject.Namespace, subject.Name))
+		case rbacv1.GroupKind:
+			groups = append(groups, subject.Name)
+		}
+	}
+
+	var rules []rbacv1.PolicyRule
+	if len(users) != 0 {
+		rules = append(rules, rbacv1.PolicyRule{Verbs: []string{"impersonate"}, Resources: []string{"users"}, APIGroups: []string{""}, ResourceNames: users})
+	}
+
+	if len(serviceAccounts) != 0 {
+		rules = append(rules, rbacv1.PolicyRule{Verbs: []string{"impersonate"}, Resources: []string{"serviceaccounts"}, APIGroups: []string{""}, ResourceNames: serviceAccounts})
+	}
+
+	if len(groups) != 0 {
+		rules = append(rules, rbacv1.PolicyRule{Verbs: []string{"impersonate"}, Resources: []string{"groups"}, APIGroups: []string{""}, ResourceNames: groups})
+	}
+
+	return rules
 }


### PR DESCRIPTION
Signed-off-by: lihanbo <lihanbo2@huawei.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
1. create a service account for impersonation when joining clusters.
2. add impersonation config sync controller

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
self test:
step1: create a clusterrole in karmada control plane
```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: karmada-cluster-proxy
rules:
- apiGroups:
  - '*'
  resources:
  - cluster/proxy
  resourceNames:
  - member1
  - member2
  verbs:
  - '*'
- nonResourceURLs:
  - '*'
  verbs:
  - get
```
step2: create a clusterrolebinding in karmada control plane
```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: karmada-cluster-proxy
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: karmada-cluster-proxy
subjects:
  - kind: User
    name: karmada-users
  - kind: ServiceAccount
    name: default
    namespace: karmada-cluster
```
step3: check clusterrole and clusterrolebinding in member cluster
```
kubectl --kubeconfig=/root/.kube/members.config --context=member1 get clusterrole karmada-impersonator -oyaml 
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  creationTimestamp: "2021-12-14T08:56:33Z"
  labels:
    work.karmada.io/name: karmada-impersonator-7cbb6bd5c9
    work.karmada.io/namespace: karmada-es-member1
  name: karmada-impersonator
  resourceVersion: "742"
  uid: a037eede-7893-4be9-8182-e968844541f3
rules:
- apiGroups:
  - ""
  resourceNames:
  - karmada-users
  resources:
  - users
  verbs:
  - impersonate
- apiGroups:
  - ""
  resourceNames:
  - system:serviceaccount:karmada-cluster:default
  resources:
  - serviceaccounts
  verbs:
  - impersonate
```

**Does this PR introduce a user-facing change?**:
"NONE"

