### PR TITLE
Add more printcolumn for rb, crb and work when executing kubectl get

### DIFF
--- a/charts/_crds/bases/work.karmada.io_clusterresourcebindings.yaml
+++ b/charts/_crds/bases/work.karmada.io_clusterresourcebindings.yaml
@@ -215,7 +215,17 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1alpha2
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Scheduled")].status
+      name: Scheduled
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="FullyApplied")].status
+      name: FullyApplied
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
     schema:
       openAPIV3Schema:
         description: ClusterResourceBinding represents a binding of a kubernetes resource

--- a/charts/_crds/bases/work.karmada.io_resourcebindings.yaml
+++ b/charts/_crds/bases/work.karmada.io_resourcebindings.yaml
@@ -215,7 +215,17 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1alpha2
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Scheduled")].status
+      name: Scheduled
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="FullyApplied")].status
+      name: FullyApplied
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
     schema:
       openAPIV3Schema:
         description: ResourceBinding represents a binding of a kubernetes resource

--- a/charts/_crds/bases/work.karmada.io_works.yaml
+++ b/charts/_crds/bases/work.karmada.io_works.yaml
@@ -16,7 +16,14 @@ spec:
     singular: work
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Applied")].status
+      name: Applied
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Work defines a list of resources to be deployed on the member

--- a/pkg/apis/work/v1alpha1/work_types.go
+++ b/pkg/apis/work/v1alpha1/work_types.go
@@ -8,6 +8,8 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Applied")].status`,name="Applied",type=string
+// +kubebuilder:printcolumn:JSONPath=`.metadata.creationTimestamp`,name="Age",type=date
 
 // Work defines a list of resources to be deployed on the member cluster.
 type Work struct {

--- a/pkg/apis/work/v1alpha2/binding_types.go
+++ b/pkg/apis/work/v1alpha2/binding_types.go
@@ -11,6 +11,9 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=rb
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Scheduled")].status`,name="Scheduled",type=string
+// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="FullyApplied")].status`,name="FullyApplied",type=string
+// +kubebuilder:printcolumn:JSONPath=`.metadata.creationTimestamp`,name="Age",type=date
 
 // ResourceBinding represents a binding of a kubernetes resource with a propagation policy.
 type ResourceBinding struct {
@@ -162,6 +165,9 @@ type ResourceBindingList struct {
 // +kubebuilder:resource:scope="Cluster",shortName=crb
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Scheduled")].status`,name="Scheduled",type=string
+// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="FullyApplied")].status`,name="FullyApplied",type=string
+// +kubebuilder:printcolumn:JSONPath=`.metadata.creationTimestamp`,name="Age",type=date
 
 // ClusterResourceBinding represents a binding of a kubernetes resource with a ClusterPropagationPolicy.
 type ClusterResourceBinding struct {


### PR DESCRIPTION
Signed-off-by: lonelyCZ <531187475@qq.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
```bash
[root@master67 karmada]# kubectl get work -A
NAMESPACE          NAME               APPLIED   AGE
karmada-es-bj-47   nginx-687f7fb96f   True      19m
[root@master67 karmada]# kubectl get rb -A
NAMESPACE   NAME               SCHEDULED   FULLYAPPLIED   AGE
default     nginx-deployment   True        True           19m
```

**Which issue(s) this PR fixes**:
Fixes #1101 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

