### PR TITLE
set default for clusterCacheSync timeout and make it configurable

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -123,6 +123,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 		ClusterStatusUpdateFrequency:      opts.ClusterStatusUpdateFrequency,
 		ClusterLeaseDuration:              opts.ClusterLeaseDuration,
 		ClusterLeaseRenewIntervalFraction: opts.ClusterLeaseRenewIntervalFraction,
+		ClusterCacheSyncTimeout:           opts.ClusterCacheSyncTimeout,
 	}
 	if err := clusterStatusController.SetupWithManager(mgr); err != nil {
 		klog.Fatalf("Failed to setup cluster status controller: %v", err)
@@ -150,15 +151,16 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 	}
 
 	workStatusController := &status.WorkStatusController{
-		Client:               mgr.GetClient(),
-		EventRecorder:        mgr.GetEventRecorderFor(status.WorkStatusControllerName),
-		RESTMapper:           mgr.GetRESTMapper(),
-		InformerManager:      informermanager.GetInstance(),
-		StopChan:             stopChan,
-		WorkerNumber:         1,
-		ObjectWatcher:        objectWatcher,
-		PredicateFunc:        helper.NewExecutionPredicateOnAgent(),
-		ClusterClientSetFunc: util.NewClusterDynamicClientSetForAgent,
+		Client:                  mgr.GetClient(),
+		EventRecorder:           mgr.GetEventRecorderFor(status.WorkStatusControllerName),
+		RESTMapper:              mgr.GetRESTMapper(),
+		InformerManager:         informermanager.GetInstance(),
+		StopChan:                stopChan,
+		WorkerNumber:            1,
+		ObjectWatcher:           objectWatcher,
+		PredicateFunc:           helper.NewExecutionPredicateOnAgent(),
+		ClusterClientSetFunc:    util.NewClusterDynamicClientSetForAgent,
+		ClusterCacheSyncTimeout: opts.ClusterCacheSyncTimeout,
 	}
 	workStatusController.RunWorkQueue()
 	if err := workStatusController.SetupWithManager(mgr); err != nil {
@@ -174,6 +176,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 		WorkerNumber:                1,
 		PredicateFunc:               helper.NewPredicateForServiceExportControllerOnAgent(opts.ClusterName),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
+		ClusterCacheSyncTimeout:     opts.ClusterCacheSyncTimeout,
 	}
 	serviceExportController.RunWorkQueue()
 	if err := serviceExportController.SetupWithManager(mgr); err != nil {

--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -37,6 +37,8 @@ type Options struct {
 	KubeAPIQPS float32
 	// KubeAPIBurst is the burst to allow while talking with karmada-apiserver.
 	KubeAPIBurst int
+
+	ClusterCacheSyncTimeout metav1.Duration
 }
 
 // NewOptions builds an default scheduler options.
@@ -70,4 +72,5 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&o.ClusterAPIBurst, "cluster-api-burst", 60, "Burst to use while talking with cluster kube-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")
 	fs.Float32Var(&o.KubeAPIQPS, "kube-api-qps", 40.0, "QPS to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")
 	fs.IntVar(&o.KubeAPIBurst, "kube-api-burst", 60, "Burst to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")
+	fs.DurationVar(&o.ClusterCacheSyncTimeout.Duration, "cluster-cache-sync-timeout", util.CacheSyncTimeout, "Timeout period waiting for cluster cache to sync.")
 }

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -62,6 +62,8 @@ type Options struct {
 	KubeAPIQPS float32
 	// KubeAPIBurst is the burst to allow while talking with karmada-apiserver.
 	KubeAPIBurst int
+
+	ClusterCacheSyncTimeout metav1.Duration
 }
 
 // NewOptions builds an empty options.
@@ -109,6 +111,7 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 	flags.IntVar(&o.ClusterAPIBurst, "cluster-api-burst", 60, "Burst to use while talking with cluster kube-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")
 	flags.Float32Var(&o.KubeAPIQPS, "kube-api-qps", 40.0, "QPS to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")
 	flags.IntVar(&o.KubeAPIBurst, "kube-api-burst", 60, "Burst to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")
+	flags.DurationVar(&o.ClusterCacheSyncTimeout.Duration, "cluster-cache-sync-timeout", util.CacheSyncTimeout, "Timeout period waiting for cluster cache to sync.")
 }
 
 // IsControllerEnabled check if a specified controller enabled or not.

--- a/pkg/controllers/mcs/service_export_controller.go
+++ b/pkg/controllers/mcs/service_export_controller.go
@@ -51,6 +51,8 @@ type ServiceExportController struct {
 	// "member1": instance of ResourceEventHandler
 	eventHandlers sync.Map
 	worker        util.AsyncWorker // worker process resources periodic from rateLimitingQueue.
+
+	ClusterCacheSyncTimeout metav1.Duration
 }
 
 var (
@@ -182,7 +184,7 @@ func (c *ServiceExportController) registerInformersAndStart(cluster *clusterv1al
 	c.InformerManager.Start(cluster.Name)
 
 	if err := func() error {
-		synced := c.InformerManager.WaitForCacheSyncWithTimeout(cluster.Name, util.CacheSyncTimeout)
+		synced := c.InformerManager.WaitForCacheSyncWithTimeout(cluster.Name, c.ClusterCacheSyncTimeout.Duration)
 		if synced == nil {
 			return fmt.Errorf("no informerFactory for cluster %s exist", cluster.Name)
 		}

--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -78,6 +78,8 @@ type ClusterStatusController struct {
 	ClusterLeaseRenewIntervalFraction float64
 	// ClusterLeaseControllers store clusters and their corresponding lease controllers.
 	ClusterLeaseControllers sync.Map
+
+	ClusterCacheSyncTimeout metav1.Duration
 }
 
 // Reconcile syncs status of the given member cluster.
@@ -238,7 +240,7 @@ func (c *ClusterStatusController) buildInformerForCluster(cluster *clusterv1alph
 	c.InformerManager.Start(cluster.Name)
 
 	if err := func() error {
-		synced := c.InformerManager.WaitForCacheSyncWithTimeout(cluster.Name, util.CacheSyncTimeout)
+		synced := c.InformerManager.WaitForCacheSyncWithTimeout(cluster.Name, c.ClusterCacheSyncTimeout.Duration)
 		if synced == nil {
 			return fmt.Errorf("no informerFactory for cluster %s exist", cluster.Name)
 		}

--- a/pkg/controllers/status/workstatus_controller.go
+++ b/pkg/controllers/status/workstatus_controller.go
@@ -8,6 +8,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -46,6 +47,8 @@ type WorkStatusController struct {
 	ObjectWatcher        objectwatcher.ObjectWatcher
 	PredicateFunc        predicate.Predicate
 	ClusterClientSetFunc func(clusterName string, client client.Client) (*util.DynamicClusterClient, error)
+
+	ClusterCacheSyncTimeout metav1.Duration
 }
 
 // Reconcile performs a full reconciliation for the object referred to by the Request.
@@ -387,7 +390,7 @@ func (c *WorkStatusController) registerInformersAndStart(cluster *clusterv1alpha
 	c.InformerManager.Start(cluster.Name)
 
 	if err := func() error {
-		synced := c.InformerManager.WaitForCacheSyncWithTimeout(cluster.Name, util.CacheSyncTimeout)
+		synced := c.InformerManager.WaitForCacheSyncWithTimeout(cluster.Name, c.ClusterCacheSyncTimeout.Duration)
 		if synced == nil {
 			return fmt.Errorf("no informerFactory for cluster %s exist", cluster.Name)
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:
```
I1215 12:51:03.337598       1 cluster_status_controller.go:87] Syncing cluster status: ntgxh-d
E1215 12:51:33.343648       1 cluster_status_controller.go:252] Failed to sync cache for cluster: ntgxh-d, error: informer for /v1, Resource=pods hasn't synced
E1215 12:51:33.343680       1 cluster_status_controller.go:149] Failed to get or create informer for Cluster ntgxh-d. Error: informer for /v1, Resource=pods hasn't synced.
```

```
synced := c.InformerManager.WaitForCacheSyncWithTimeout(cluster.Name, util.CacheSyncTimeout)
if synced == nil {
	return fmt.Errorf("no informerFactory for cluster %s exist", cluster.Name)
}
for _, gvr := range gvrs {
	if !synced[gvr] {
		return fmt.Errorf("informer for %s hasn't synced", gvr)
	}
}
```
here `util.CacheSyncTimeout = 30 * time.Second`

The  `CacheSyncTimeout`  should be configurable  according to cluster size.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

