### PR TITLE
retain ownerReferences when update member cluster object

### DIFF
--- a/pkg/util/objectwatcher/objectwatcher.go
+++ b/pkg/util/objectwatcher/objectwatcher.go
@@ -121,6 +121,10 @@ func (o *objectWatcherImpl) retainClusterFields(desired, observed *unstructured.
 	// controllers in a member cluster.  It is still possible to set the fields
 	// via overrides.
 	desired.SetFinalizers(observed.GetFinalizers())
+
+	// Retain ownerReferences since they will typically be set by controllers in a member cluster.
+	desired.SetOwnerReferences(observed.GetOwnerReferences())
+
 	// Merge annotations since they will typically be set by controllers in a member cluster
 	// and be set by user in karmada-controller-plane.
 	util.MergeAnnotations(desired, observed)


### PR DESCRIPTION
**What type of PR is this?**


/kind bug
/kind cleanup


**What this PR does / why we need it**:

Retain ownerReferences since they will typically be set by controllers in a member cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

