### PR TITLE
Remove redundant sort in scale up schedule

### DIFF
--- a/pkg/scheduler/core/division_algorithm.go
+++ b/pkg/scheduler/core/division_algorithm.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"fmt"
-	"sort"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -223,7 +222,6 @@ func scaleUpScheduleByReplicaDivisionPreference(
 
 	// Step 3: Calculate available replicas of all candidates
 	clusterAvailableReplicas := calAvailableReplicas(clusters, newSpec)
-	sort.Sort(TargetClustersList(clusterAvailableReplicas))
 
 	// Step 4: Begin dividing.
 	// Only the new replicas are considered during this scheduler, the old replicas will not be moved.


### PR DESCRIPTION
Signed-off-by: dddddai <dddwq@foxmail.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Remove redundant sort in `scaleUpScheduleByReplicaDivisionPreference` as the target clusters have been sorted in `calAvailableReplicas`
https://github.com/karmada-io/karmada/blob/f7b2a91eed08c65c2d534b31068dd19dffdbca30/pkg/scheduler/core/util.go#L73
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

