### PR TITLE
Implementing karmada-webhook of validating ClusterOverridePolicy

### DIFF
--- a/artifacts/deploy/webhook-configuration.yaml
+++ b/artifacts/deploy/webhook-configuration.yaml
@@ -125,6 +125,20 @@ webhooks:
     sideEffects: None
     admissionReviewVersions: ["v1"]
     timeoutSeconds: 3
+  - name: clusteroverridepolicy.karmada.io
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["policy.karmada.io"]
+        apiVersions: ["*"]
+        resources: ["clusteroverridepolicies"]
+        scope: "Cluster"
+    clientConfig:
+      url: https://karmada-webhook.karmada-system.svc:443/validate-clusteroverridepolicy
+      caBundle: {{caBundle}}
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    timeoutSeconds: 3
   - name: config.karmada.io
     rules:
       - operations: ["CREATE", "UPDATE"]

--- a/charts/templates/_karmada_webhook_configuration.tpl
+++ b/charts/templates/_karmada_webhook_configuration.tpl
@@ -51,6 +51,20 @@ webhooks:
     sideEffects: None
     admissionReviewVersions: ["v1"]
     timeoutSeconds: 3
+  - name: clusteroverridepolicy.karmada.io
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["policy.karmada.io"]
+        apiVersions: ["*"]
+        resources: ["clusteroverridepolicies"]
+        scope: "Cluster"
+    clientConfig:
+      url: https://karmada-webhook.karmada-system.svc:443/validate-clusteroverridepolicy
+      caBundle: {{caBundle}}
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    timeoutSeconds: 3
   - name: work.karmada.io
     rules:
       - operations: ["CREATE", "UPDATE"]

--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -19,6 +19,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/version"
 	"github.com/karmada-io/karmada/pkg/version/sharedcommand"
 	"github.com/karmada-io/karmada/pkg/webhook/cluster"
+	"github.com/karmada-io/karmada/pkg/webhook/clusteroverridepolicy"
 	"github.com/karmada-io/karmada/pkg/webhook/clusterpropagationpolicy"
 	"github.com/karmada-io/karmada/pkg/webhook/configuration"
 	"github.com/karmada-io/karmada/pkg/webhook/overridepolicy"
@@ -90,6 +91,7 @@ func Run(ctx context.Context, opts *options.Options) error {
 	hookServer.Register("/validate-clusterpropagationpolicy", &webhook.Admission{Handler: &clusterpropagationpolicy.ValidatingAdmission{}})
 	hookServer.Register("/mutate-overridepolicy", &webhook.Admission{Handler: &overridepolicy.MutatingAdmission{}})
 	hookServer.Register("/validate-overridepolicy", &webhook.Admission{Handler: &overridepolicy.ValidatingAdmission{}})
+	hookServer.Register("/validate-clusteroverridepolicy", &webhook.Admission{Handler: &clusteroverridepolicy.ValidatingAdmission{}})
 	hookServer.Register("/mutate-work", &webhook.Admission{Handler: &work.MutatingAdmission{}})
 	hookServer.Register("/convert", &conversion.Webhook{})
 	hookServer.Register("/validate-resourceinterpreterwebhookconfiguration", &webhook.Admission{Handler: &configuration.ValidatingAdmission{}})

--- a/pkg/webhook/clusteroverridepolicy/validating.go
+++ b/pkg/webhook/clusteroverridepolicy/validating.go
@@ -1,4 +1,4 @@
-package overridepolicy
+package clusteroverridepolicy
 
 import (
 	"context"
@@ -11,7 +11,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/validation"
 )
 
-// ValidatingAdmission validates OverridePolicy object when creating/updating/deleting.
+// ValidatingAdmission validates ClusterOverridePolicy object when creating/updating/deleting.
 type ValidatingAdmission struct {
 	decoder *admission.Decoder
 }
@@ -23,13 +23,13 @@ var _ admission.DecoderInjector = &ValidatingAdmission{}
 // Handle implements admission.Handler interface.
 // It yields a response to an AdmissionRequest.
 func (v *ValidatingAdmission) Handle(ctx context.Context, req admission.Request) admission.Response {
-	policy := &policyv1alpha1.OverridePolicy{}
+	policy := &policyv1alpha1.ClusterOverridePolicy{}
 
 	err := v.decoder.Decode(req, policy)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-	klog.V(2).Infof("Validating OverridePolicy(%s/%s) for request: %s", policy.Namespace, policy.Name, req.Operation)
+	klog.V(2).Infof("Validating ClusterOverridePolicy(%s) for request: %s", policy.Name, req.Operation)
 
 	if err := validation.ValidateOverrideSpec(&policy.Spec); err != nil {
 		klog.Error(err)


### PR DESCRIPTION
Signed-off-by: lonelyCZ <531187475@qq.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
```bash
[root@master67 yaml]# kubectl apply -f clusteroverride.yaml 
Error from server (overrideRules and (overriders or targetCluster) can't co-exist): error when creating "clusteroverride.yaml": admission webhook "clusteroverridepolicy.karmada.io" denied the request: overrideRules and (overriders or targetCluster) can't co-exist
```

**Which issue(s) this PR fixes**:
Part of #1113 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

