### PR TITLE
Add --controllers flag to karmada-agent and move ControllerContext to a separate package

### DIFF
--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -1,6 +1,8 @@
 package options
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -13,6 +15,8 @@ import (
 
 // Options contains everything necessary to create and run controller-manager.
 type Options struct {
+	// Controllers contains all controller names.
+	Controllers       []string
 	LeaderElection    componentbaseconfig.LeaderElectionConfiguration
 	KarmadaKubeConfig string
 	// ClusterContext is the name of the cluster context in control plane KUBECONFIG file.
@@ -53,11 +57,15 @@ func NewOptions() *Options {
 }
 
 // AddFlags adds flags of scheduler to the specified FlagSet
-func (o *Options) AddFlags(fs *pflag.FlagSet) {
+func (o *Options) AddFlags(fs *pflag.FlagSet, allControllers []string) {
 	if o == nil {
 		return
 	}
 
+	fs.StringSliceVar(&o.Controllers, "controllers", []string{"*"}, fmt.Sprintf(
+		"A list of controllers to enable. '*' enables all on-by-default controllers, 'foo' enables the controller named 'foo', '-foo' disables the controller named 'foo'. All controllers: %s.",
+		strings.Join(allControllers, ", "),
+	))
 	fs.BoolVar(&o.LeaderElection.LeaderElect, "leader-elect", true, "Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.")
 	fs.StringVar(&o.LeaderElection.ResourceNamespace, "leader-elect-resource-namespace", util.NamespaceKarmadaSystem, "The namespace of resource object that is used for locking during leader election.")
 	fs.StringVar(&o.KarmadaKubeConfig, "karmada-kubeconfig", o.KarmadaKubeConfig, "Path to karmada control plane kubeconfig file.")

--- a/pkg/controllers/context/context.go
+++ b/pkg/controllers/context/context.go
@@ -1,0 +1,112 @@
+package context
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+
+	"github.com/karmada-io/karmada/pkg/util/informermanager"
+	"github.com/karmada-io/karmada/pkg/util/objectwatcher"
+	"github.com/karmada-io/karmada/pkg/util/overridemanager"
+)
+
+// Options defines all the parameters required by our controllers.
+type Options struct {
+	// Controllers contains all controller names.
+	Controllers []string
+	// ClusterMonitorPeriod represents cluster-controller monitoring period, i.e. how often does
+	// cluster-controller check cluster health signal posted from cluster-status-controller.
+	// This value should be lower than ClusterMonitorGracePeriod.
+	ClusterMonitorPeriod metav1.Duration
+	// ClusterMonitorGracePeriod represents the grace period after last cluster health probe time.
+	// If it doesn't receive update for this amount of time, it will start posting
+	// "ClusterReady==ConditionUnknown".
+	ClusterMonitorGracePeriod metav1.Duration
+	// ClusterStartupGracePeriod specifies the grace period of allowing a cluster to be unresponsive during
+	// startup before marking it unhealthy.
+	ClusterStartupGracePeriod metav1.Duration
+	// ClusterStatusUpdateFrequency is the frequency that controller computes and report cluster status.
+	// It must work with ClusterMonitorGracePeriod.
+	ClusterStatusUpdateFrequency metav1.Duration
+	// ClusterLeaseDuration is a duration that candidates for a lease need to wait to force acquire it.
+	// This is measure against time of last observed lease RenewTime.
+	ClusterLeaseDuration metav1.Duration
+	// ClusterLeaseRenewIntervalFraction is a fraction coordinated with ClusterLeaseDuration that
+	// how long the current holder of a lease has last updated the lease.
+	ClusterLeaseRenewIntervalFraction float64
+	// ClusterCacheSyncTimeout is the timeout period waiting for cluster cache to sync.
+	ClusterCacheSyncTimeout metav1.Duration
+	// ClusterAPIQPS is the QPS to use while talking with cluster kube-apiserver.
+	ClusterAPIQPS float32
+	// ClusterAPIBurst is the burst to allow while talking with cluster kube-apiserver.
+	ClusterAPIBurst int
+	// SkippedPropagatingNamespaces is a list of namespaces that will be skipped for propagating.
+	SkippedPropagatingNamespaces []string
+	// ClusterName is the name of cluster.
+	ClusterName string
+}
+
+// Context defines the context object for controller.
+type Context struct {
+	Mgr                         controllerruntime.Manager
+	ObjectWatcher               objectwatcher.ObjectWatcher
+	Opts                        Options
+	StopChan                    <-chan struct{}
+	DynamicClientSet            dynamic.Interface
+	OverrideManager             overridemanager.OverrideManager
+	ControlPlaneInformerManager informermanager.SingleClusterInformerManager
+}
+
+// IsControllerEnabled check if a specified controller enabled or not.
+func (c Context) IsControllerEnabled(name string) bool {
+	hasStar := false
+	for _, ctrl := range c.Opts.Controllers {
+		if ctrl == name {
+			return true
+		}
+		if ctrl == "-"+name {
+			return false
+		}
+		if ctrl == "*" {
+			hasStar = true
+		}
+	}
+	return hasStar
+}
+
+// InitFunc is used to launch a particular controller.
+// Any error returned will cause the controller process to `Fatal`
+// The bool indicates whether the controller was enabled.
+type InitFunc func(ctx Context) (enabled bool, err error)
+
+// Initializers is a public map of named controller groups
+type Initializers map[string]InitFunc
+
+// ControllerNames returns all known controller names
+func (i Initializers) ControllerNames() []string {
+	return sets.StringKeySet(i).List()
+}
+
+// StartControllers starts a set of controllers with a specified ControllerContext
+func (i Initializers) StartControllers(ctx Context) error {
+	for controllerName, initFn := range i {
+		if !ctx.IsControllerEnabled(controllerName) {
+			klog.Warningf("%q is disabled", controllerName)
+			continue
+		}
+		klog.V(1).Infof("Starting %q", controllerName)
+		started, err := initFn(ctx)
+		if err != nil {
+			klog.Errorf("Error starting %q", controllerName)
+			return err
+		}
+		if !started {
+			klog.Warningf("Skipping %q", controllerName)
+			continue
+		}
+		klog.Infof("Started %q", controllerName)
+	}
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: Xinzhao Xu <z2d@jifangcheng.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add `--controllers` flag to karmada-agent and move `ControllerContext` to a separate package.

```
      --controllers strings                           A list of controllers to enable. '*' enables all on-by-default controllers, 'foo' enables the controller named 'foo', '-foo' disables the controller named 'foo'. All controllers: clusterStatus, execution, serviceExport, workStatus. (default [*])
```

**Which issue(s) this PR fixes**:

close #1127

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Add --controllers flag to karmada-agent.
```

/cc @RainbowMango 