### PR TITLE
change the default path of `karmadactl init`

### DIFF
--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -43,7 +43,7 @@ func NewCmdInit() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&options.KarmadaMasterIP, "master", "", "Karmada master ip. (e.g. --master 192.168.1.2,192.168.1.3)")
 	cmd.PersistentFlags().StringVar(&options.CRDs, "crds", crdURL, "Karmada crds resource.local file (e.g. --crds /root/crds.tar.gz)")
 	cmd.PersistentFlags().Int32VarP(&options.KarmadaMasterPort, "port", "p", 5443, "Karmada apiserver port")
-	cmd.PersistentFlags().StringVarP(&options.DataPath, "karmada-data", "d", "/var/lib/karmada", "karmada data path. kubeconfig and cert files")
+	cmd.PersistentFlags().StringVarP(&options.DataPath, "karmada-data", "d", "/etc/karmada", "karmada data path. kubeconfig cert and crds files")
 	cmd.PersistentFlags().StringVarP(&options.APIServerImage, "karmada-apiserver-image", "", "k8s.gcr.io/kube-apiserver:v1.20.11", "Kubernetes apiserver image")
 	cmd.PersistentFlags().Int32VarP(&options.APIServerReplicas, "karmada-apiserver-replicas", "", 1, "karmada apiserver replica set")
 	cmd.PersistentFlags().StringVarP(&options.SchedulerImage, "karmada-scheduler-image", "", "swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-scheduler:latest", "karmada scheduler image")

--- a/pkg/karmadactl/cmdinit/utils/examples.go
+++ b/pkg/karmadactl/cmdinit/utils/examples.go
@@ -149,7 +149,7 @@ func GenExamples(path string) {
 | Step 1: Member kubernetes join karmada control plane                                                                                                                         |
 |                                                                                                                                                                              |
 | (In karmada)~#  cat ~/.kube/config  | grep current-context | sed 's/: /\n/g'| sed '1d' #MEMBER_CLUSTER_NAME                                                                  |
-| (In karmada)~# kubectl-karmada  --kubeconfig /var/lib/karmada/karmada-apiserver.config  join ${MEMBER_CLUSTER_NAME} --cluster-kubeconfig=$HOME/.kube/config                  |
+| (In karmada)~# kubectl-karmada  --kubeconfig /etc/karmada/karmada-apiserver.config  join ${MEMBER_CLUSTER_NAME} --cluster-kubeconfig=$HOME/.kube/config                      |
 |                                                                                                                                                                              |
 | Step 2: Create member kubernetes kubeconfig secret                                                                                                                           |
 |                                                                                                                                                                              |
@@ -158,19 +158,19 @@ func GenExamples(path string) {
 |                                                                                                                                                                              |
 | Step 3: Create karmada scheduler estimator                                                                                                                                   |
 |                                                                                                                                                                              |
-| (In member kubernetes)~# sed -i "s/{{member_cluster_name}}/${MEMBER_CLUSTER_NAME}/g" /var/lib/karmada/karmada-scheduler-estimator.yaml                                       |
-| (In member kubernetes)~# kubectl create -f  /var/lib/karmada/karmada-scheduler-estimator.yaml                                                                                |
+| (In member kubernetes)~# sed -i "s/{{member_cluster_name}}/${MEMBER_CLUSTER_NAME}/g" /etc/karmada/karmada-scheduler-estimator.yaml                                           |
+| (In member kubernetes)~# kubectl create -f  /etc/karmada/karmada-scheduler-estimator.yaml                                                                                    |
 |                                                                                                                                                                              |
 | Step 4: Show members of karmada                                                                                                                                              |
 |                                                                                                                                                                              |
-| (In karmada)~# kubectl  --kubeconfig /var/lib/karmada/karmada-apiserver.config get clusters                                                                                  |
+| (In karmada)~# kubectl  --kubeconfig /etc/karmada/karmada-apiserver.config get clusters                                                                                      |
 |                                                                                                                                                                              |
 ├── —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— —— ┤
 | Pull mode                                                                                                                                                                    |
 |                                                                                                                                                                              |
 | Step 1:  Send karmada kubeconfig and karmada-agent.yaml to member kubernetes                                                                                                 |
 |                                                                                                                                                                              |
-| (In karmada)~# scp /var/lib/karmada/karmada-apiserver.config /var/lib/karmada/karmada-agent.yaml {member kubernetes}:~                                                       |
+| (In karmada)~# scp /etc/karmada/karmada-apiserver.config /etc/karmada/karmada-agent.yaml {member kubernetes}:~                                                               |
 |                                                                                                                                                                              |
 | Step 2:  Create karmada kubeconfig secret                                                                                                                                    |
 |  Notice:                                                                                                                                                                     |
@@ -187,7 +187,7 @@ func GenExamples(path string) {
 |                                                                                                                                                                              |
 | Step 4: Show members of karmada                                                                                                                                              |
 |                                                                                                                                                                              |
-| (In karmada)~# kubectl  --kubeconfig /var/lib/karmada/karmada-apiserver.config get clusters                                                                                  |
+| (In karmada)~# kubectl  --kubeconfig /etc/karmada/karmada-apiserver.config get clusters                                                                                      |
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 `))
 }


### PR DESCRIPTION
Signed-off-by: prodan <pengshihaoren@gmail.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

change the default path to `/etc/karmada`
```
root@dev-k8s-master01:~# ./kubectl-karmada init -h
...
  -d, --karmada-data string                              karmada data path. kubeconfig cert and crds files (default "/etc/karmada")
...

root@dev-k8s-master01:~# ls -lrt /etc/karmada/
total 76
-rw------- 1 root root  1675 Dec 21 15:19 ca.key
-rw-r--r-- 1 root root  1115 Dec 21 15:19 ca.crt
-rw------- 1 root root  1679 Dec 21 15:19 etcd-server.key
-rw-r--r-- 1 root root  1269 Dec 21 15:19 etcd-server.crt
-rw------- 1 root root  1675 Dec 21 15:19 etcd-client.key
-rw-r--r-- 1 root root  1168 Dec 21 15:19 etcd-client.crt
-rw------- 1 root root  1675 Dec 21 15:19 karmada.key
-rw-r--r-- 1 root root  1610 Dec 21 15:19 karmada.crt
-rw-r--r-- 1 root root 24385 Dec 21 15:19 crds.tar.gz
drwxr-xr-x 4 root root  4096 Dec 21 15:19 crds
-rw-r--r-- 1 root root  6204 Dec 21 15:19 karmada-apiserver.config
-rw-r--r-- 1 root root  1676 Dec 21 15:20 karmada-agent.yaml
-rw-r--r-- 1 root root  1368 Dec 21 15:23 karmada-scheduler-estimator.yaml
```

**Which issue(s) this PR fixes**:
Fixes #1134

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

