### PR TITLE
fix division bugs when pod request zero scalar resource

### DIFF
--- a/pkg/util/resource.go
+++ b/pkg/util/resource.go
@@ -215,10 +215,7 @@ func (r *Resource) MaxDivided(rl corev1.ResourceList) int64 {
 			}
 		default:
 			if resourcehelper.IsScalarResourceName(rName) {
-				rScalar, ok := r.ScalarResources[rName]
-				if !ok {
-					return 0
-				}
+				rScalar := r.ScalarResources[rName]
 				if scalar := rQuant.Value(); scalar > 0 {
 					res = MinInt64(res, rScalar/scalar)
 				}


### PR DESCRIPTION
Signed-off-by: Garrybest <garrybest@foxmail.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
If a pod request zero scalar resource, like `alpha.kubernetes.io/nvidia-gpu: '0'`, but the node does not have a resource called `alpha.kubernetes.io/nvidia-gpu`, scheduler-estimator will return 0 max replicas. It does not match what kubernetes does. In kubernetes, the zero scalar resource would be ignored even the node does not have this type of resource.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

