### PR TITLE
update `kubectl-karmada init`

### DIFF
--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -2,76 +2,112 @@ package cmdinit
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/kubernetes"
-	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
 	"github.com/karmada-io/karmada/pkg/version"
 )
 
-// NewCmdInit init karmada.
-func NewCmdInit() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "init",
-		Short: "bootstrap install karmada (default in kubernetes)",
-		Long:  `Installation options.`,
-		Run: func(cmd *cobra.Command, args []string) {
-			kubernetes.Deploy()
-		},
-		Example: `
-# This master IP is any node IP of kubernetes.
-kubectl karmada init --master=192.168.1.2
+const (
+	initShort   = `install karmada in kubernetes.`
+	initLong    = `install karmada in kubernetes.`
+	initExample = `
+# Install karmada in kubernetes
+# The default karmada-apiserver IP is kubernetes master IP. If kubernetes has no master role set, 3 node IPs will be randomly executed.
+kubectl karmada init 
 
-# In the Intranet, CRDs resources specify local files.
-kubectl karmada init --master=192.168.1.2 --crd /root/crds.tar.gz
+# The karmada crds resource is downloaded from the karmada releases page by default. Any crds URL can be passed in.
+kubectl karmada init --crds https://github.com/karmada-io/karmada/releases/download/v0.10.1/crds.tar.gz
+
+# karmada crds can also specify local files.
+kubectl karmada init --crds /root/crds.tar.gz
+
+# Use PVC to persistent storage etcd data.
+kubectl karmada init --etcd-storage-mode PVC --storage-classes-name {StorageClassesName}
+
+# Use hostPath to persistent storage etcd data. For data security, only 1 etcd pod can run in hostPath mode.
+kubectl karmada init --etcd-storage-mode hostPath  --etcd-replicas 1
+
+# Use hostPath to persistent storage etcd data. by default, a healthy node is selected to run etcd, and the node can be selected through --etcd-node-selector-labels
+kubectl karmada init --etcd-storage-mode hostPath --etcd-node-selector-labels karmada.io/etcd=true
 
 # Private registry can be specified for all images.
-kubectl karmada init --master=192.168.1.2 --etcd-image local.registry.com/library/etcd:3.5.1-0
+kubectl karmada init --etcd-image local.registry.com/library/etcd:3.5.1-0
 
 # Deploy highly available(HA) karmada.
-kubectl karmada init --master=192.168.1.2,192.168.1.3,192.168.1.4 --karmada-apiserver-replicas 3 --etcd-replicas 3
+kubectl karmada init --karmada-apiserver-replicas 3 --etcd-replicas 3 --storage-classes-name PVC --storage-classes-name {StorageClassesName}
 
-# Karmada uses external load balancing or HAip, and karmada certificate needs to join the IP.
-kubectl karmada init --master=192.168.1.2,192.168.1.3,192.168.1.4 --cert-external-ip 10.235.1.2
-`,
+# Karmada-apiserver uses external load balancing or haip, karmada certificate needs to join the IP or DNS.Otherwise, you cannot access Karmada-apiserver through it
+kubectl karmada init --cert-external-ip 10.235.1.2 --cert-external-dns www.karmada.io
+`
+)
+
+// NewCmdInit install karmada on kubernetes
+func NewCmdInit(cmdOut io.Writer) *cobra.Command {
+	opts := kubernetes.CommandInitOption{}
+	cmd := &cobra.Command{
+		Use:     "init",
+		Short:   initShort,
+		Long:    initLong,
+		Example: initExample,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			if err := opts.Complete(); err != nil {
+				return err
+			}
+			if err := opts.RunInit(cmdOut); err != nil {
+				return err
+			}
+			return nil
+		},
 	}
-
+	flags := cmd.PersistentFlags()
 	// cert
-	cmd.PersistentFlags().StringVar(&options.ExternalIP, "cert-external-ip", "", "the external IP of Karmada certificate (e.g 192.168.1.2,172.16.1.2)")
-
+	flags.StringVar(&opts.ExternalIP, "cert-external-ip", "", "the external IP of Karmada certificate (e.g 192.168.1.2,172.16.1.2)")
+	flags.StringVar(&opts.ExternalDNS, "cert-external-dns", "", "the external DNS of Karmada certificate (e.g localhost,localhost.com)")
 	// Kubernetes
-	cmd.PersistentFlags().StringVarP(&options.Namespace, "namespace", "n", "karmada-system", "Kubernetes namespace")
-	cmd.PersistentFlags().StringVar(&options.StorageClassesName, "storage-classes-name", "", "Kubernetes StorageClasses Name")
-
+	flags.StringVarP(&opts.Namespace, "namespace", "n", "karmada-system", "Kubernetes namespace")
+	flags.StringVar(&opts.StorageClassesName, "storage-classes-name", "", "Kubernetes StorageClasses Name")
+	flags.StringVar(&opts.KubeConfig, "kubeconfig", filepath.Join(homeDir(), ".kube", "config"), "absolute path to the kubeconfig file")
 	// etcd
-	cmd.PersistentFlags().StringVarP(&options.EtcdStorageMode, "etcd-storage-mode", "", "emptyDir",
+	flags.StringVarP(&opts.EtcdStorageMode, "etcd-storage-mode", "", "emptyDir",
 		"etcd data storage mode(emptyDir,hostPath,PVC). value is PVC, specify --storage-classes-name")
-	cmd.PersistentFlags().StringVarP(&options.EtcdImage, "etcd-image", "", "k8s.gcr.io/etcd:3.5.1-0", "etcd image")
-	cmd.PersistentFlags().StringVarP(&options.EtcdInitImage, "etcd-init-image", "", "docker.io/alpine:3.14.3", "etcd init container image")
-	cmd.PersistentFlags().Int32VarP(&options.EtcdReplicas, "etcd-replicas", "", 1, "etcd replica set, cluster 3,5...singular")
-	cmd.PersistentFlags().StringVarP(&options.EtcdDataPath, "etcd-data", "", "/var/lib/karmada-etcd", "etcd data path,valid in hostPath mode.")
-	cmd.PersistentFlags().StringVarP(&options.EtcdStorageSize, "etcd-storage-size", "", "5Gi", "etcd data path,valid in pvc mode.")
-
+	flags.StringVarP(&opts.EtcdImage, "etcd-image", "", "k8s.gcr.io/etcd:3.5.1-0", "etcd image")
+	flags.StringVarP(&opts.EtcdInitImage, "etcd-init-image", "", "docker.io/alpine:3.14.3", "etcd init container image")
+	flags.Int32VarP(&opts.EtcdReplicas, "etcd-replicas", "", 1, "etcd replica set, cluster 3,5...singular")
+	flags.StringVarP(&opts.EtcdHostDataPath, "etcd-data", "", "/var/lib/karmada-etcd", "etcd data path,valid in hostPath mode.")
+	flags.StringVarP(&opts.EtcdNodeSelectorLabels, "etcd-node-selector-labels", "", "", "etcd pod select the labels of the node. valid in hostPath mode ( e.g. --etcd-node-selector-labels karmada.io/etcd=true)")
+	flags.StringVarP(&opts.EtcdPersistentVolumeSize, "etcd-pvc-size", "", "5Gi", "etcd data path,valid in pvc mode.")
 	// karmada
 	crdURL := fmt.Sprintf("https://github.com/karmada-io/karmada/releases/download/%s/crds.tar.gz", version.Get().GitVersion)
-	cmd.PersistentFlags().StringVar(&options.KarmadaMasterIP, "master", "", "Karmada master ip. (e.g. --master 192.168.1.2,192.168.1.3)")
-	cmd.PersistentFlags().StringVar(&options.CRDs, "crds", crdURL, "Karmada crds resource.(local file  e.g. --crds /root/crds.tar.gz)")
-	cmd.PersistentFlags().Int32VarP(&options.KarmadaMasterPort, "port", "p", 5443, "Karmada apiserver port")
-	cmd.PersistentFlags().StringVarP(&options.DataPath, "karmada-data", "d", "/etc/karmada", "karmada data path. kubeconfig cert and crds files")
-	cmd.PersistentFlags().StringVarP(&options.APIServerImage, "karmada-apiserver-image", "", "k8s.gcr.io/kube-apiserver:v1.21.7", "Kubernetes apiserver image")
-	cmd.PersistentFlags().Int32VarP(&options.APIServerReplicas, "karmada-apiserver-replicas", "", 1, "karmada apiserver replica set")
-	cmd.PersistentFlags().StringVarP(&options.SchedulerImage, "karmada-scheduler-image", "", "swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-scheduler:latest", "karmada scheduler image")
-	cmd.PersistentFlags().Int32VarP(&options.SchedulerReplicas, "karmada-scheduler-replicas", "", 1, "karmada scheduler replica set")
-	cmd.PersistentFlags().StringVarP(&options.KubeControllerManagerImage, "karmada-kube-controller-manager-image", "", "k8s.gcr.io/kube-controller-manager:v1.21.7", "Kubernetes controller manager image")
-	cmd.PersistentFlags().Int32VarP(&options.KubeControllerManagerReplicas, "karmada-kube-controller-manager-replicas", "", 1, "karmada kube controller manager replica set")
-	cmd.PersistentFlags().StringVarP(&options.ControllerManagerImage, "karmada-controller-manager-image", "", "swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-controller-manager:latest", "karmada controller manager  image")
-	cmd.PersistentFlags().Int32VarP(&options.ControllerManagerReplicas, "karmada-controller-manager-replicas", "", 1, "karmada controller manager replica set")
-	cmd.PersistentFlags().StringVarP(&options.WebhookImage, "karmada-webhook-image", "", "swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-webhook:latest", "karmada webhook image")
-	cmd.PersistentFlags().Int32VarP(&options.WebhookReplicas, "karmada-webhook-replicas", "", 1, "karmada webhook replica set")
-	cmd.PersistentFlags().StringVarP(&options.AggregatedAPIServerImage, "karmada-aggregated-apiserver-image", "", "swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-aggregated-apiserver:latest", "karmada aggregated apiserver image")
-	cmd.PersistentFlags().Int32VarP(&options.AggregatedAPIServerReplicas, "karmada-aggregated-apiserver-replicas", "", 1, "karmada aggregated apiserver replica set")
+	flags.StringVar(&opts.CRDs, "crds", crdURL, "Karmada crds resource.(local file e.g. --crds /root/crds.tar.gz)")
+	flags.Int32VarP(&opts.KarmadaAPIServerNodePort, "port", "p", 5443, "Karmada apiserver service node port")
+	flags.StringVarP(&opts.KarmadaDataPath, "karmada-data", "d", "/etc/karmada", "karmada data path. kubeconfig cert and crds files")
+	flags.StringVarP(&opts.KarmadaAPIServerImage, "karmada-apiserver-image", "", "k8s.gcr.io/kube-apiserver:v1.21.7", "Kubernetes apiserver image")
+	flags.Int32VarP(&opts.KarmadaAPIServerReplicas, "karmada-apiserver-replicas", "", 1, "karmada apiserver replica set")
+	flags.StringVarP(&opts.KarmadaSchedulerImage, "karmada-scheduler-image", "", "swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-scheduler:latest", "karmada scheduler image")
+	flags.Int32VarP(&opts.KarmadaSchedulerReplicas, "karmada-scheduler-replicas", "", 1, "karmada scheduler replica set")
+	flags.StringVarP(&opts.KubeControllerManagerImage, "karmada-kube-controller-manager-image", "", "k8s.gcr.io/kube-controller-manager:v1.21.7", "Kubernetes controller manager image")
+	flags.Int32VarP(&opts.KubeControllerManagerReplicas, "karmada-kube-controller-manager-replicas", "", 1, "karmada kube controller manager replica set")
+	flags.StringVarP(&opts.KarmadaControllerManagerImage, "karmada-controller-manager-image", "", "swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-controller-manager:latest", "karmada controller manager  image")
+	flags.Int32VarP(&opts.KarmadaControllerManagerReplicas, "karmada-controller-manager-replicas", "", 1, "karmada controller manager replica set")
+	flags.StringVarP(&opts.KarmadaWebhookImage, "karmada-webhook-image", "", "swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-webhook:latest", "karmada webhook image")
+	flags.Int32VarP(&opts.KarmadaWebhookReplicas, "karmada-webhook-replicas", "", 1, "karmada webhook replica set")
+	flags.StringVarP(&opts.KarmadaAggregatedAPIServerImage, "karmada-aggregated-apiserver-image", "", "swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-aggregated-apiserver:latest", "karmada aggregated apiserver image")
+	flags.Int32VarP(&opts.KarmadaAggregatedAPIServerReplicas, "karmada-aggregated-apiserver-replicas", "", 1, "karmada aggregated apiserver replica set")
 
-	options.AddFlags(cmd.Flags())
 	return cmd
+}
+
+func homeDir() string {
+	if h := os.Getenv("HOME"); h != "" {
+		return h
+	}
+	return os.Getenv("USERPROFILE") // windows
 }

--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -16,14 +16,14 @@ const (
 	initShort   = `install karmada in kubernetes.`
 	initLong    = `install karmada in kubernetes.`
 	initExample = `
-# Install karmada in kubernetes
-# The default karmada-apiserver IP is kubernetes master IP. If kubernetes has no master role set, 3 node IPs will be randomly executed.
+# Install Karmada in Kubernetes cluster.
+# The karmada-apiserver binds the master node's IP by default.
 kubectl karmada init 
 
-# The karmada crds resource is downloaded from the karmada releases page by default. Any crds URL can be passed in.
+# Specify the URL to download CRD tarball.
 kubectl karmada init --crds https://github.com/karmada-io/karmada/releases/download/v0.10.1/crds.tar.gz
 
-# karmada crds can also specify local files.
+# Specify the local CRD tarball.
 kubectl karmada init --crds /root/crds.tar.gz
 
 # Use PVC to persistent storage etcd data.
@@ -32,7 +32,7 @@ kubectl karmada init --etcd-storage-mode PVC --storage-classes-name {StorageClas
 # Use hostPath to persistent storage etcd data. For data security, only 1 etcd pod can run in hostPath mode.
 kubectl karmada init --etcd-storage-mode hostPath  --etcd-replicas 1
 
-# Use hostPath to persistent storage etcd data. by default, a healthy node is selected to run etcd, and the node can be selected through --etcd-node-selector-labels
+# Use hostPath to persistent storage etcd data but select nodes by labels.
 kubectl karmada init --etcd-storage-mode hostPath --etcd-node-selector-labels karmada.io/etcd=true
 
 # Private registry can be specified for all images.
@@ -41,7 +41,7 @@ kubectl karmada init --etcd-image local.registry.com/library/etcd:3.5.1-0
 # Deploy highly available(HA) karmada.
 kubectl karmada init --karmada-apiserver-replicas 3 --etcd-replicas 3 --storage-classes-name PVC --storage-classes-name {StorageClassesName}
 
-# Karmada-apiserver uses external load balancing or haip, karmada certificate needs to join the IP or DNS.Otherwise, you cannot access Karmada-apiserver through it
+# Specify external IPs(load balancer or HA IP) which used to sign the certificate.
 kubectl karmada init --cert-external-ip 10.235.1.2 --cert-external-dns www.karmada.io
 `
 )

--- a/pkg/karmadactl/cmdinit/karmada/deploy.go
+++ b/pkg/karmadactl/cmdinit/karmada/deploy.go
@@ -29,8 +29,8 @@ import (
 const namespace = "karmada-system"
 
 //InitKarmadaResources Initialize karmada resource
-func InitKarmadaResources(caBase64 string) error {
-	restConfig, err := utils.RestConfig(filepath.Join(options.DataPath, options.KarmadaKubeConfigName))
+func InitKarmadaResources(dir, caBase64 string) error {
+	restConfig, err := utils.RestConfig(filepath.Join(dir, options.KarmadaKubeConfigName))
 	if err != nil {
 		return err
 	}
@@ -56,8 +56,8 @@ func InitKarmadaResources(caBase64 string) error {
 	}
 
 	// Initialize crd
-	basesCRDsFiles := utils.ListFiles(options.DataPath + "/crds/bases")
-	klog.Infof("Initialize karmada bases crd resource `%s/crds/bases`", options.DataPath)
+	basesCRDsFiles := utils.ListFiles(dir + "/crds/bases")
+	klog.Infof("Initialize karmada bases crd resource `%s/crds/bases`", dir)
 	for _, v := range basesCRDsFiles {
 		if path.Ext(v) != ".yaml" {
 			continue
@@ -67,8 +67,8 @@ func InitKarmadaResources(caBase64 string) error {
 		}
 	}
 
-	patchesCRDsFiles := utils.ListFiles(options.DataPath + "/crds/patches")
-	klog.Infof("Initialize karmada patches crd resource `%s/crds/patches`", options.DataPath)
+	patchesCRDsFiles := utils.ListFiles(dir + "/crds/patches")
+	klog.Infof("Initialize karmada patches crd resource `%s/crds/patches`", dir)
 	for _, v := range patchesCRDsFiles {
 		if path.Ext(v) != ".yaml" {
 			continue
@@ -181,7 +181,7 @@ func initAPIService(clientSet *kubernetes.Clientset, restConfig *rest.Config) er
 		},
 		Spec: corev1.ServiceSpec{
 			Type:         corev1.ServiceTypeExternalName,
-			ExternalName: fmt.Sprintf("karmada-aggregated-apiserver.%s.svc.cluster.local", options.Namespace),
+			ExternalName: fmt.Sprintf("karmada-aggregated-apiserver.%s.svc.cluster.local", namespace),
 		},
 	}
 	if _, err := clientSet.CoreV1().Services(namespace).Create(context.TODO(), aaService, metav1.CreateOptions{}); err != nil {

--- a/pkg/karmadactl/cmdinit/kubernetes/check.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/check.go
@@ -10,8 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
-
-	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
 )
 
 func podStatus(pod *corev1.Pod) string {
@@ -90,17 +88,17 @@ func WaitPodReady(c *kubernetes.Clientset, namespace, selector string, timeout i
 }
 
 // WaitEtcdReplicasetInDesired Wait Etcd Ready
-func WaitEtcdReplicasetInDesired(c *kubernetes.Clientset, namespace, selector string, timeout int) error {
+func WaitEtcdReplicasetInDesired(replicas int32, c *kubernetes.Clientset, namespace, selector string, timeout int) error {
 	if err := wait.PollImmediate(time.Second, time.Duration(timeout)*time.Second, func() (done bool, err error) {
 		pods, e := c.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: selector})
 		if e != nil {
 			return false, nil
 		}
-		if int32(len(pods.Items)) == options.EtcdReplicas {
-			klog.Infof("etcd desired replicaset is %v, currently: %v", options.EtcdReplicas, len(pods.Items))
+		if int32(len(pods.Items)) == replicas {
+			klog.Infof("etcd desired replicaset is %v, currently: %v", replicas, len(pods.Items))
 			return true, nil
 		}
-		klog.Warningf("etcd desired replicaset is %v, currently: %v", options.EtcdReplicas, len(pods.Items))
+		klog.Warningf("etcd desired replicaset is %v, currently: %v", replicas, len(pods.Items))
 		return false, nil
 	}); err != nil {
 		return err

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"net"
-	"os"
 	"path"
 	"strings"
 	"time"
@@ -24,7 +24,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/utils"
 )
 
-var certSlice = []string{
+var certList = []string{
 	options.CaCertAndKeyName,
 	options.EtcdServerCertAndKeyName,
 	options.EtcdClientCertAndKeyName,
@@ -33,31 +33,116 @@ var certSlice = []string{
 	options.FrontProxyClientCertAndKeyName,
 }
 
-//InstallOptions kubernetes options
-type InstallOptions struct {
-	Namespace          string
-	KubeClientSet      *kubernetes.Clientset
-	CertAndKeyFileData map[string][]byte
-	RestConfig         *rest.Config
-	MasterIP           []net.IP
+//CommandInitOption holds all flags options for init.
+type CommandInitOption struct {
+	EtcdImage                          string
+	EtcdReplicas                       int32
+	EtcdInitImage                      string
+	EtcdStorageMode                    string
+	EtcdHostDataPath                   string
+	EtcdNodeSelectorLabels             string
+	EtcdPersistentVolumeSize           string
+	KarmadaAPIServerImage              string
+	KarmadaAPIServerReplicas           int32
+	KarmadaAPIServerNodePort           int32
+	KarmadaSchedulerImage              string
+	KarmadaSchedulerReplicas           int32
+	KubeControllerManagerImage         string
+	KubeControllerManagerReplicas      int32
+	KarmadaControllerManagerImage      string
+	KarmadaControllerManagerReplicas   int32
+	KarmadaWebhookImage                string
+	KarmadaWebhookReplicas             int32
+	KarmadaAggregatedAPIServerImage    string
+	KarmadaAggregatedAPIServerReplicas int32
+	Namespace                          string
+	KubeConfig                         string
+	StorageClassesName                 string
+	KarmadaDataPath                    string
+	CRDs                               string
+	ExternalIP                         string
+	ExternalDNS                        string
+	KubeClientSet                      *kubernetes.Clientset
+	CertAndKeyFileData                 map[string][]byte
+	RestConfig                         *rest.Config
+	KarmadaAPIServerIP                 []net.IP
+}
+
+// Validate Check that there are enough flags to run the command.
+func (i *CommandInitOption) Validate() error {
+	if !utils.PathIsExist(i.KubeConfig) {
+		return fmt.Errorf("kubeconfig file does not exist.absolute path to the kubeconfig file")
+	}
+
+	if i.EtcdStorageMode == "hostPath" && i.EtcdHostDataPath == "" {
+		return fmt.Errorf("when etcd storage mode is hostPath, dataPath is not empty. See 'kubectl karmada init --help'")
+	}
+
+	if i.EtcdStorageMode == "hostPath" && i.EtcdNodeSelectorLabels != "" && utils.StringToMap(i.EtcdNodeSelectorLabels) == nil {
+		return fmt.Errorf("the label does not seem to be 'key=value'")
+	}
+
+	if i.EtcdStorageMode == "hostPath" && i.EtcdReplicas != 1 {
+		return fmt.Errorf("for data security,when etcd storage mode is hostPath,etcd-replicas can only be 1")
+	}
+
+	if i.EtcdStorageMode == "PVC" && i.StorageClassesName == "" {
+		return fmt.Errorf("when etcd storage mode is PVC, storageClassesName is not empty. See 'kubectl karmada init --help'")
+	}
+
+	return nil
+}
+
+// Complete Initialize k8s client
+func (i *CommandInitOption) Complete() error {
+	restConfig, err := utils.RestConfig(i.KubeConfig)
+	if err != nil {
+		return err
+	}
+	i.RestConfig = restConfig
+
+	klog.Infof("kubeconfig file: %s, kubernetes: %s", i.KubeConfig, restConfig.Host)
+	clientSet, err := utils.NewClientSet(restConfig)
+	if err != nil {
+		return err
+	}
+	i.KubeClientSet = clientSet
+
+	if i.EtcdStorageMode == "hostPath" && i.EtcdNodeSelectorLabels == "" {
+		if err := i.AddNodeSelectorLabels(); err != nil {
+			return err
+		}
+	}
+
+	if err := i.getKubeMasterIP(); err != nil {
+		return err
+	}
+	klog.Infof("karmada apiserver ip: %s", i.KarmadaAPIServerIP)
+
+	if i.EtcdStorageMode == "hostPath" && i.EtcdNodeSelectorLabels != "" {
+		if !i.isNodeExist(i.EtcdNodeSelectorLabels) {
+			return fmt.Errorf("no node found by label %s", i.EtcdNodeSelectorLabels)
+		}
+	}
+
+	return nil
 }
 
 //  genCerts create ca etcd karmada cert
-func genCerts() error {
+func (i *CommandInitOption) genCerts() error {
 	notAfter := time.Now().Add(cert.Duration365d * 10).UTC()
+
 	var etcdServerCertDNS = []string{
 		"localhost",
 	}
-
-	for i := int32(0); i < options.EtcdReplicas; i++ {
-		etcdServerCertDNS = append(etcdServerCertDNS, fmt.Sprintf("%s-%v.%s.%s.svc.cluster.local", etcdStatefulSetAndServiceName, i, etcdStatefulSetAndServiceName, options.Namespace))
+	for number := int32(0); number < i.EtcdReplicas; number++ {
+		etcdServerCertDNS = append(etcdServerCertDNS, fmt.Sprintf("%s-%v.%s.%s.svc.cluster.local", etcdStatefulSetAndServiceName, number, etcdStatefulSetAndServiceName, i.Namespace))
 	}
 	etcdServerAltNames := certutil.AltNames{
 		DNSNames: etcdServerCertDNS,
 		IPs:      []net.IP{utils.StringToNetIP("127.0.0.1")},
 	}
 	etcdServerCertConfig := cert.NewCertConfig("karmada-etcd-server", []string{"karmada"}, etcdServerAltNames, &notAfter)
-
 	etcdClientCertCfg := cert.NewCertConfig("karmada-etcd-client", []string{"karmada"}, certutil.AltNames{}, &notAfter)
 
 	var karmadaDNS = []string{
@@ -68,25 +153,22 @@ func genCerts() error {
 		karmadaAPIServerDeploymentAndServiceName,
 		webhookDeploymentAndServiceAccountAndServiceName,
 		karmadaAggregatedAPIServerDeploymentAndServiceName,
-		fmt.Sprintf("%s.%s.svc.cluster.local", karmadaAPIServerDeploymentAndServiceName, options.Namespace),
-		fmt.Sprintf("%s.%s.svc.cluster.local", webhookDeploymentAndServiceAccountAndServiceName, options.Namespace),
-		fmt.Sprintf("%s.%s.svc.cluster.local", karmadaAggregatedAPIServerDeploymentAndServiceName, options.Namespace),
-		fmt.Sprintf("*.%s.svc.cluster.local", options.Namespace),
-		fmt.Sprintf("*.%s.svc", options.Namespace),
+		fmt.Sprintf("%s.%s.svc.cluster.local", karmadaAPIServerDeploymentAndServiceName, i.Namespace),
+		fmt.Sprintf("%s.%s.svc.cluster.local", webhookDeploymentAndServiceAccountAndServiceName, i.Namespace),
+		fmt.Sprintf("%s.%s.svc", webhookDeploymentAndServiceAccountAndServiceName, i.Namespace),
+		fmt.Sprintf("%s.%s.svc.cluster.local", karmadaAggregatedAPIServerDeploymentAndServiceName, i.Namespace),
+		fmt.Sprintf("*.%s.svc.cluster.local", i.Namespace),
+		fmt.Sprintf("*.%s.svc", i.Namespace),
 	}
-	if hostName, err := os.Hostname(); err != nil {
-		klog.Warningln("Failed to get the current hostname.", err)
-	} else {
-		karmadaDNS = append(karmadaDNS, hostName)
-	}
+	karmadaDNS = append(karmadaDNS, utils.FlagsDNS(i.ExternalDNS)...)
 
-	karmadaIPs := utils.FlagsIP(options.KarmadaMasterIP)
+	karmadaIPs := utils.FlagsIP(i.ExternalIP)
 	karmadaIPs = append(
 		karmadaIPs,
 		utils.StringToNetIP("127.0.0.1"),
 		utils.StringToNetIP("10.254.0.1"),
 	)
-	karmadaIPs = append(karmadaIPs, utils.FlagsIP(options.ExternalIP)...)
+	karmadaIPs = append(karmadaIPs, i.KarmadaAPIServerIP...)
 
 	internetIP, err := utils.InternetIP()
 	if err != nil {
@@ -102,85 +184,42 @@ func genCerts() error {
 	karmadaCertCfg := cert.NewCertConfig("system:admin", []string{"system:masters"}, karmadaAltNames, &notAfter)
 
 	frontProxyClientCertCfg := cert.NewCertConfig("front-proxy-client", []string{"karmada"}, certutil.AltNames{}, &notAfter)
-	if err = cert.GenCerts(options.DataPath, etcdServerCertConfig, etcdClientCertCfg, karmadaCertCfg, frontProxyClientCertCfg); err != nil {
+	if err = cert.GenCerts(i.KarmadaDataPath, etcdServerCertConfig, etcdClientCertCfg, karmadaCertCfg, frontProxyClientCertCfg); err != nil {
 		return err
 	}
 	return nil
 }
 
 //prepareCRD download or unzip `crds.tar.gz` to `options.DataPath`
-func prepareCRD() error {
-	if strings.HasPrefix(options.CRDs, "http") {
-		filename := options.DataPath + "/" + path.Base(options.CRDs)
-		klog.Infoln("crds file name:", filename)
-		if err := utils.DownloadFile(options.CRDs, filename); err != nil {
+func (i *CommandInitOption) prepareCRD() error {
+	if strings.HasPrefix(i.CRDs, "http") {
+		filename := i.KarmadaDataPath + "/" + path.Base(i.CRDs)
+		klog.Infoln("download crds file name:", filename)
+		if err := utils.DownloadFile(i.CRDs, filename); err != nil {
 			return err
 		}
-		if err := utils.DeCompress(filename, options.DataPath); err != nil {
+		if err := utils.DeCompress(filename, i.KarmadaDataPath); err != nil {
 			return err
 		}
 		return nil
 	}
-	klog.Infoln("crds file name:", options.CRDs)
-	return utils.DeCompress(options.CRDs, options.DataPath)
+	klog.Infoln("local crds file name:", i.CRDs)
+	return utils.DeCompress(i.CRDs, i.KarmadaDataPath)
 }
 
-func (i *InstallOptions) initialization() error {
-	i.CertAndKeyFileData = map[string][]byte{}
-
-	for _, v := range certSlice {
-		certs, err := utils.FileToBytes(options.DataPath, fmt.Sprintf("%s.crt", v))
-		if err != nil {
-			return fmt.Errorf("'%s.crt' conversion failed. %v", v, err)
-		}
-		i.CertAndKeyFileData[fmt.Sprintf("%s.crt", v)] = certs
-
-		key, err := utils.FileToBytes(options.DataPath, fmt.Sprintf("%s.key", v))
-		if err != nil {
-			return fmt.Errorf("'%s.key' conversion failed. %v", v, err)
-		}
-		i.CertAndKeyFileData[fmt.Sprintf("%s.key", v)] = key
-	}
-
-	if !utils.PathIsExist(options.KubeConfig) {
-		klog.Exitln("kubeconfig file does not exist.")
-	}
-	klog.Infof("kubeconfig file: %s", options.KubeConfig)
-
-	i.Namespace = options.Namespace
-
-	restConfig, err := utils.RestConfig(options.KubeConfig)
-	if err != nil {
-		return err
-	}
-	i.RestConfig = restConfig
-
-	clientSet, err := utils.NewClientSet(restConfig)
-	if err != nil {
-		return err
-	}
-	i.KubeClientSet = clientSet
-
-	i.MasterIP = utils.FlagsIP(options.KarmadaMasterIP)
-
-	klog.Infof("master ip: %s", i.MasterIP)
-
-	return nil
-}
-
-func (i *InstallOptions) createCertsSecrets() {
+func (i *CommandInitOption) createCertsSecrets() error {
 	//Create kubeconfig Secret
-	karmadaServerURL := fmt.Sprintf("https://%s.%s.svc.cluster.local:%v", karmadaAPIServerDeploymentAndServiceName, i.Namespace, options.KarmadaMasterPort)
+	karmadaServerURL := fmt.Sprintf("https://%s.%s.svc.cluster.local:%v", karmadaAPIServerDeploymentAndServiceName, i.Namespace, karmadaAPIServerContainerPort)
 	config := utils.CreateWithCerts(karmadaServerURL, options.UserName, options.UserName, i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.CaCertAndKeyName)],
 		i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaCertAndKeyName)], i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaCertAndKeyName)])
 	configBytes, err := clientcmd.Write(*config)
 	if err != nil {
-		klog.Exitln("failure while serializing admin kubeConfig", err)
+		return fmt.Errorf("failure while serializing admin kubeConfig. %v", err)
 	}
 
 	kubeConfigSecret := i.SecretFromSpec(kubeConfigSecretAndMountName, corev1.SecretTypeOpaque, map[string]string{kubeConfigSecretAndMountName: string(configBytes)})
 	if err = i.CreateSecret(kubeConfigSecret); err != nil {
-		klog.Exitln(err)
+		return err
 	}
 	// Create certs Secret
 	etcdCert := map[string]string{
@@ -191,17 +230,17 @@ func (i *InstallOptions) createCertsSecrets() {
 	}
 	etcdSecret := i.SecretFromSpec(etcdCertName, corev1.SecretTypeOpaque, etcdCert)
 	if err := i.CreateSecret(etcdSecret); err != nil {
-		klog.Exitln(err)
+		return err
 	}
 
 	karmadaCert := map[string]string{}
-	for _, v := range certSlice {
+	for _, v := range certList {
 		karmadaCert[fmt.Sprintf("%s.crt", v)] = string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", v)])
 		karmadaCert[fmt.Sprintf("%s.key", v)] = string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", v)])
 	}
 	karmadaSecret := i.SecretFromSpec(karmadaCertsName, corev1.SecretTypeOpaque, karmadaCert)
 	if err := i.CreateSecret(karmadaSecret); err != nil {
-		klog.Exitln(err)
+		return err
 	}
 
 	karmadaWebhookCert := map[string]string{
@@ -210,50 +249,53 @@ func (i *InstallOptions) createCertsSecrets() {
 	}
 	karmadaWebhookSecret := i.SecretFromSpec(webhookCertsName, corev1.SecretTypeOpaque, karmadaWebhookCert)
 	if err := i.CreateSecret(karmadaWebhookSecret); err != nil {
-		klog.Exitln(err)
+		return err
 	}
+
+	return nil
 }
 
-func (i *InstallOptions) initKarmadaAPIServer() {
+func (i *CommandInitOption) initKarmadaAPIServer() error {
+	if err := i.CreateService(i.makeEtcdService(etcdStatefulSetAndServiceName)); err != nil {
+		return err
+	}
+	klog.Info("create etcd StatefulSets")
+	if _, err := i.KubeClientSet.AppsV1().StatefulSets(i.Namespace).Create(context.TODO(), i.makeETCDStatefulSet(), metav1.CreateOptions{}); err != nil {
+		klog.Warning(err)
+	}
+	if err := WaitEtcdReplicasetInDesired(i.EtcdReplicas, i.KubeClientSet, i.Namespace, utils.MapToString(etcdLabels), 30); err != nil {
+		klog.Warning(err)
+	}
+	if err := WaitPodReady(i.KubeClientSet, i.Namespace, utils.MapToString(etcdLabels), 30); err != nil {
+		klog.Warning(err)
+	}
+
 	klog.Info("create karmada ApiServer Deployment")
 	if err := i.CreateService(i.makeKarmadaAPIServerService()); err != nil {
-		klog.Exitln(err)
+		return err
 	}
 
 	if _, err := i.KubeClientSet.AppsV1().Deployments(i.Namespace).Create(context.TODO(), i.makeKarmadaAPIServerDeployment(), metav1.CreateOptions{}); err != nil {
 		klog.Warning(err)
 	}
 	if err := WaitPodReady(i.KubeClientSet, i.Namespace, utils.MapToString(apiServerLabels), 120); err != nil {
-		klog.Exitln(err)
+		return err
 	}
+	return nil
 }
 
-func (i *InstallOptions) initEtcd() {
-	if err := i.CreateService(i.makeEtcdService(etcdStatefulSetAndServiceName)); err != nil {
-		klog.Exitln(err)
-	}
-	klog.Info("create etcd StatefulSets")
-	if _, err := i.KubeClientSet.AppsV1().StatefulSets(i.Namespace).Create(context.TODO(), i.makeETCDStatefulSet(), metav1.CreateOptions{}); err != nil {
-		klog.Warning(err)
-	}
-	if err := WaitEtcdReplicasetInDesired(i.KubeClientSet, i.Namespace, utils.MapToString(etcdLabels), 30); err != nil {
-		klog.Warning(err)
-	}
-	if err := WaitPodReady(i.KubeClientSet, i.Namespace, utils.MapToString(etcdLabels), 30); err != nil {
-		klog.Warning(err)
-	}
-}
-
-func (i *InstallOptions) initComponent() {
+func (i *CommandInitOption) initKarmadaComponent() error {
 	//wait pod ready timeout 30s
 	waitPodReadyTimeout := 30
+
+	deploymentClient := i.KubeClientSet.AppsV1().Deployments(i.Namespace)
 	// Create karmada-kube-controller-manager
 	// https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/kube-controller-manager.yaml
 	klog.Info("create karmada kube controller manager Deployment")
 	if err := i.CreateService(i.kubeControllerManagerService()); err != nil {
 		klog.Exitln(err)
 	}
-	if _, err := i.KubeClientSet.AppsV1().Deployments(i.Namespace).Create(context.TODO(), i.makeKarmadaKubeControllerManagerDeployment(), metav1.CreateOptions{}); err != nil {
+	if _, err := deploymentClient.Create(context.TODO(), i.makeKarmadaKubeControllerManagerDeployment(), metav1.CreateOptions{}); err != nil {
 		klog.Warning(err)
 	}
 	if err := WaitPodReady(i.KubeClientSet, i.Namespace, utils.MapToString(kubeControllerManagerLabels), waitPodReadyTimeout); err != nil {
@@ -263,7 +305,7 @@ func (i *InstallOptions) initComponent() {
 	// Create karmada-scheduler
 	// https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/karmada-scheduler.yaml
 	klog.Info("create karmada scheduler Deployment")
-	if _, err := i.KubeClientSet.AppsV1().Deployments(i.Namespace).Create(context.TODO(), i.makeKarmadaSchedulerDeployment(), metav1.CreateOptions{}); err != nil {
+	if _, err := deploymentClient.Create(context.TODO(), i.makeKarmadaSchedulerDeployment(), metav1.CreateOptions{}); err != nil {
 		klog.Warning(err)
 	}
 	if err := WaitPodReady(i.KubeClientSet, i.Namespace, utils.MapToString(schedulerLabels), waitPodReadyTimeout); err != nil {
@@ -273,7 +315,7 @@ func (i *InstallOptions) initComponent() {
 	// Create karmada-controller-manager
 	// https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/controller-manager.yaml
 	klog.Info("create karmada controller manager Deployment")
-	if _, err := i.KubeClientSet.AppsV1().Deployments(i.Namespace).Create(context.TODO(), i.makeKarmadaControllerManagerDeployment(), metav1.CreateOptions{}); err != nil {
+	if _, err := deploymentClient.Create(context.TODO(), i.makeKarmadaControllerManagerDeployment(), metav1.CreateOptions{}); err != nil {
 		klog.Warning(err)
 	}
 	if err := WaitPodReady(i.KubeClientSet, i.Namespace, utils.MapToString(controllerManagerLabels), waitPodReadyTimeout); err != nil {
@@ -286,7 +328,7 @@ func (i *InstallOptions) initComponent() {
 	if err := i.CreateService(i.karmadaWebhookService()); err != nil {
 		klog.Exitln(err)
 	}
-	if _, err := i.KubeClientSet.AppsV1().Deployments(i.Namespace).Create(context.TODO(), i.makeKarmadaWebhookDeployment(), metav1.CreateOptions{}); err != nil {
+	if _, err := deploymentClient.Create(context.TODO(), i.makeKarmadaWebhookDeployment(), metav1.CreateOptions{}); err != nil {
 		klog.Warning(err)
 	}
 	if err := WaitPodReady(i.KubeClientSet, i.Namespace, utils.MapToString(webhookLabels), waitPodReadyTimeout); err != nil {
@@ -298,49 +340,60 @@ func (i *InstallOptions) initComponent() {
 	if err := i.CreateService(i.karmadaAggregatedAPIServerService()); err != nil {
 		klog.Exitln(err)
 	}
-	if _, err := i.KubeClientSet.AppsV1().Deployments(i.Namespace).Create(context.TODO(), i.makeKarmadaAggregatedAPIServerDeployment(), metav1.CreateOptions{}); err != nil {
+	if _, err := deploymentClient.Create(context.TODO(), i.makeKarmadaAggregatedAPIServerDeployment(), metav1.CreateOptions{}); err != nil {
 		klog.Warning(err)
 	}
 	if err := WaitPodReady(i.KubeClientSet, i.Namespace, utils.MapToString(aggregatedAPIServerLabels), waitPodReadyTimeout); err != nil {
 		klog.Warning(err)
 	}
+	return nil
 }
 
-//Deploy karmada in kubernetes
-func Deploy() {
-	verify()
+//RunInit Deploy karmada in kubernetes
+func (i *CommandInitOption) RunInit(_ io.Writer) error {
 	//generate certificate
-	if err := genCerts(); err != nil {
-		klog.Exitln("certificate generation failed", err)
+	if err := i.genCerts(); err != nil {
+		return fmt.Errorf("certificate generation failed.%v", err)
+	}
+
+	i.CertAndKeyFileData = map[string][]byte{}
+
+	for _, v := range certList {
+		certs, err := utils.FileToBytes(i.KarmadaDataPath, fmt.Sprintf("%s.crt", v))
+		if err != nil {
+			return fmt.Errorf("'%s.crt' conversion failed. %v", v, err)
+		}
+		i.CertAndKeyFileData[fmt.Sprintf("%s.crt", v)] = certs
+
+		key, err := utils.FileToBytes(i.KarmadaDataPath, fmt.Sprintf("%s.key", v))
+		if err != nil {
+			return fmt.Errorf("'%s.key' conversion failed. %v", v, err)
+		}
+		i.CertAndKeyFileData[fmt.Sprintf("%s.key", v)] = key
 	}
 
 	//prepare karmada CRD resources
-	if err := prepareCRD(); err != nil {
-		klog.Exitln("prepare karmada failed.", err)
-	}
-
-	i := &InstallOptions{}
-	if err := i.initialization(); err != nil {
-		klog.Exitln(err)
+	if err := i.prepareCRD(); err != nil {
+		return fmt.Errorf("prepare karmada failed.%v", err)
 	}
 
 	// Create karmada kubeconfig
-	serverURL := fmt.Sprintf("https://%s:%v", i.MasterIP[0].String(), options.KarmadaMasterPort)
-	if err := utils.WriteKubeConfigFromSpec(serverURL, options.UserName, options.ClusterName, options.DataPath, options.KarmadaKubeConfigName,
+	serverURL := fmt.Sprintf("https://%s:%v", i.KarmadaAPIServerIP[0].String(), i.KarmadaAPIServerNodePort)
+	if err := utils.WriteKubeConfigFromSpec(serverURL, options.UserName, options.ClusterName, i.KarmadaDataPath, options.KarmadaKubeConfigName,
 		i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.CaCertAndKeyName)], i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaCertAndKeyName)],
 		i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaCertAndKeyName)]); err != nil {
-		klog.Exitln("Failed to create karmada kubeconfig file.", err)
+		return fmt.Errorf("failed to create karmada kubeconfig file. %v", err)
 	}
 	klog.Info("Create karmada kubeconfig success.")
 
 	//	create ns
 	if err := i.CreateNamespace(); err != nil {
-		klog.Exitln(err)
+		return fmt.Errorf("create namespace %s failed: %v", i.Namespace, err)
 	}
 
 	// Create sa
 	if err := i.CreateServiceAccount(); err != nil {
-		klog.Exitln(err)
+		return err
 	}
 
 	// Create karmada-controller-manager ClusterRole and ClusterRoleBinding
@@ -349,41 +402,26 @@ func Deploy() {
 	}
 
 	// Create Secrets
-	i.createCertsSecrets()
-
-	// add node labels
-	if err := i.AddNodeSelectorLabels(); err != nil {
-		klog.Exitf("Node failed to add '%s' label. %v", NodeSelectorLabels, err)
+	if err := i.createCertsSecrets(); err != nil {
+		return err
 	}
 
-	// install etcd
-	i.initEtcd()
-
 	// install karmada-apiserver
-	i.initKarmadaAPIServer()
+	if err := i.initKarmadaAPIServer(); err != nil {
+		return err
+	}
 
 	//Create CRDs in karmada
 	caBase64 := base64.StdEncoding.EncodeToString(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.CaCertAndKeyName)])
-	if err := karmada.InitKarmadaResources(caBase64); err != nil {
-		klog.Exitln(err)
+	if err := karmada.InitKarmadaResources(i.KarmadaDataPath, caBase64); err != nil {
+		return err
 	}
 
 	//install karmada Component
-	i.initComponent()
-
-	utils.GenExamples(options.DataPath)
-}
-
-func verify() {
-	if options.KarmadaMasterIP == "" {
-		klog.Exitln("error verifying flag, master is missing. See 'kubectl karmada init --help'.")
+	if err := i.initKarmadaComponent(); err != nil {
+		return err
 	}
 
-	if options.EtcdStorageMode == "hostPath" && options.EtcdDataPath == "" {
-		klog.Exitln("When etcd storage mode is hostPath, dataPath is not empty. See 'kubectl karmada init --help'.")
-	}
-
-	if options.EtcdStorageMode == "PVC" && options.StorageClassesName == "" {
-		klog.Exitln("When etcd storage mode is PVC, storageClassesName is not empty. See 'kubectl karmada init --help'.")
-	}
+	utils.GenExamples(i.KarmadaDataPath)
+	return nil
 }

--- a/pkg/karmadactl/cmdinit/kubernetes/namespace.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/namespace.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	"context"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -10,7 +9,7 @@ import (
 )
 
 // CreateNamespace namespace IfNotExist
-func (i *InstallOptions) CreateNamespace() error {
+func (i *CommandInitOption) CreateNamespace() error {
 	namespaceClient := i.KubeClientSet.CoreV1().Namespaces()
 	namespaceList, err := namespaceClient.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
@@ -32,7 +31,7 @@ func (i *InstallOptions) CreateNamespace() error {
 
 	_, err = namespaceClient.Create(context.TODO(), n, metav1.CreateOptions{})
 	if err != nil {
-		return fmt.Errorf("Create namespace %s failed: %v", i.Namespace, err)
+		return err
 	}
 	klog.Infof("Create Namespace '%s' successfully.", i.Namespace)
 	return nil

--- a/pkg/karmadactl/cmdinit/kubernetes/node.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/node.go
@@ -3,47 +3,126 @@ package kubernetes
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+
+	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/utils"
 )
 
-func getNodeName(nodes *corev1.NodeList, nodeIP string) string {
-	for _, v := range nodes.Items {
-		for _, ip := range v.Status.Addresses {
-			if nodeIP == ip.Address {
-				return v.GetName()
+var (
+	etcdNodeName       string
+	etcdSelectorLabels map[string]string
+)
+
+func (i *CommandInitOption) getKubeMasterIP() error {
+	nodeClient := i.KubeClientSet.CoreV1().Nodes()
+	masterNodes, err := nodeClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/master"})
+	if err != nil {
+		return err
+	}
+
+	if len(masterNodes.Items) == 0 {
+		klog.Warning("the kubernetes cluster does not have a Master role.")
+	} else {
+		for _, v := range masterNodes.Items {
+			i.KarmadaAPIServerIP = append(i.KarmadaAPIServerIP, utils.StringToNetIP(v.Status.Addresses[0].Address))
+		}
+		return nil
+	}
+
+	klog.Info("randomly select 3 Node IPs in the kubernetes cluster.")
+	nodes, err := nodeClient.List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for number := 0; number < 3; number++ {
+		if number >= len(nodes.Items) {
+			break
+		}
+		i.KarmadaAPIServerIP = append(i.KarmadaAPIServerIP, utils.StringToNetIP(nodes.Items[number].Status.Addresses[0].Address))
+	}
+
+	if len(i.KarmadaAPIServerIP) == 0 {
+		return fmt.Errorf("karmada apiserver ip is empty")
+	}
+	return nil
+}
+
+// nodeStatus Check the node status, if it is an unhealthy node, return false.
+func nodeStatus(node []corev1.NodeCondition) bool {
+	for _, v := range node {
+		switch v.Type {
+		case corev1.NodeReady:
+			if v.Status != corev1.ConditionTrue {
+				return false
+			}
+		case corev1.NodeMemoryPressure:
+			if v.Status != corev1.ConditionFalse {
+				return false
+			}
+		case corev1.NodeDiskPressure:
+			if v.Status != corev1.ConditionFalse {
+				return false
+			}
+		case corev1.NodeNetworkUnavailable:
+			if v.Status != corev1.ConditionFalse {
+				return false
+			}
+		case corev1.NodePIDPressure:
+			if v.Status != corev1.ConditionFalse {
+				return false
 			}
 		}
 	}
-	return ""
+	return true
 }
 
-//AddNodeSelectorLabels Find the node through the master IP and label it
-func (i *InstallOptions) AddNodeSelectorLabels() error {
+// AddNodeSelectorLabels When EtcdStorageMode is hostPath, and EtcdNodeSelectorLabels is empty.
+// Select a healthy node to add labels, and schedule etcd to that node
+func (i *CommandInitOption) AddNodeSelectorLabels() error {
 	nodes, err := i.KubeClientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
 
-	for _, v := range i.MasterIP {
-		nodeName := getNodeName(nodes, v.String())
-		node, err := i.KubeClientSet.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
-		if err != nil {
-			return err
+	for _, v := range nodes.Items {
+		if v.Spec.Taints != nil {
+			continue
 		}
-		NodeSelectorLabels = map[string]string{"karmada.io/master": ""}
-		labels := node.Labels
-		labels["karmada.io/master"] = ""
-		patchData := map[string]interface{}{"metadata": map[string]map[string]string{"labels": labels}}
 
-		playLoadBytes, _ := json.Marshal(patchData)
-
-		if _, err := i.KubeClientSet.CoreV1().Nodes().Patch(context.TODO(), nodeName, types.StrategicMergePatchType, playLoadBytes, metav1.PatchOptions{}); err != nil {
-			return err
+		if nodeStatus(v.Status.Conditions) {
+			etcdNodeName = v.Name
+			etcdSelectorLabels = v.Labels
+			break
 		}
 	}
 
+	etcdSelectorLabels["karmada.io/etcd"] = ""
+	patchData := map[string]interface{}{"metadata": map[string]map[string]string{"labels": etcdSelectorLabels}}
+	playLoadBytes, _ := json.Marshal(patchData)
+	if _, err := i.KubeClientSet.CoreV1().Nodes().Patch(context.TODO(), etcdNodeName, types.StrategicMergePatchType, playLoadBytes, metav1.PatchOptions{}); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func (i *CommandInitOption) isNodeExist(labels string) bool {
+	l := strings.Split(labels, "=")
+	node, err := i.KubeClientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: l[0]})
+	if err != nil {
+		return false
+	}
+
+	if len(node.Items) == 0 {
+		return false
+	}
+	klog.Infof("Find the node [ %s ] by label %s", node.Items[0].Name, labels)
+	return true
 }

--- a/pkg/karmadactl/cmdinit/kubernetes/rbac.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/rbac.go
@@ -10,7 +10,7 @@ import (
 )
 
 //ClusterRoleFromSpec ClusterRole spec
-func (i *InstallOptions) ClusterRoleFromSpec(name string, rules []rbacv1.PolicyRule) *rbacv1.ClusterRole {
+func (i *CommandInitOption) ClusterRoleFromSpec(name string, rules []rbacv1.PolicyRule) *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "rbac.authorization.k8s.io/v1",
@@ -19,13 +19,14 @@ func (i *InstallOptions) ClusterRoleFromSpec(name string, rules []rbacv1.PolicyR
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: i.Namespace,
+			Labels:    map[string]string{"karmada.io/bootstrapping": "rbac-defaults"},
 		},
 		Rules: rules,
 	}
 }
 
 //ClusterRoleBindingFromSpec ClusterRoleBinding spec
-func (i *InstallOptions) ClusterRoleBindingFromSpec(clusterRoleBindingName, clusterRoleName, saName string) *rbacv1.ClusterRoleBinding {
+func (i *CommandInitOption) ClusterRoleBindingFromSpec(clusterRoleBindingName, clusterRoleName, saName string) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "rbac.authorization.k8s.io/v1",
@@ -34,6 +35,7 @@ func (i *InstallOptions) ClusterRoleBindingFromSpec(clusterRoleBindingName, clus
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterRoleBindingName,
 			Namespace: i.Namespace,
+			Labels:    map[string]string{"karmada.io/bootstrapping": "rbac-defaults"},
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
@@ -51,7 +53,7 @@ func (i *InstallOptions) ClusterRoleBindingFromSpec(clusterRoleBindingName, clus
 }
 
 //CreateClusterRole receive ClusterRoleFromSpec ClusterRole
-func (i *InstallOptions) CreateClusterRole() error {
+func (i *CommandInitOption) CreateClusterRole() error {
 	clusterRole := i.ClusterRoleFromSpec(kubeControllerManagerClusterRoleAndDeploymentAndServiceName, []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{"*"},
@@ -86,7 +88,7 @@ func (i *InstallOptions) CreateClusterRole() error {
 }
 
 //CreateClusterRoleBinding receive ClusterRoleBindingFromSpec ClusterRoleBinding
-func (i *InstallOptions) CreateClusterRoleBinding(clusterRole *rbacv1.ClusterRoleBinding) error {
+func (i *CommandInitOption) CreateClusterRoleBinding(clusterRole *rbacv1.ClusterRoleBinding) error {
 	crbClient := i.KubeClientSet.RbacV1().ClusterRoleBindings()
 
 	crbList, err := crbClient.List(context.TODO(), metav1.ListOptions{})

--- a/pkg/karmadactl/cmdinit/kubernetes/secret.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/secret.go
@@ -12,7 +12,7 @@ import (
 )
 
 //SecretFromSpec secret spec
-func (i *InstallOptions) SecretFromSpec(name string, secretType corev1.SecretType, data map[string]string) *corev1.Secret {
+func (i *CommandInitOption) SecretFromSpec(name string, secretType corev1.SecretType, data map[string]string) *corev1.Secret {
 	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -21,6 +21,7 @@ func (i *InstallOptions) SecretFromSpec(name string, secretType corev1.SecretTyp
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: i.Namespace,
+			Labels:    map[string]string{"karmada.io/bootstrapping": "secret-defaults"},
 		},
 		//Immutable:  immutable,
 		Type:       secretType,
@@ -29,7 +30,7 @@ func (i *InstallOptions) SecretFromSpec(name string, secretType corev1.SecretTyp
 }
 
 //CreateSecret receive SecretFromSpec create secret
-func (i *InstallOptions) CreateSecret(secret *corev1.Secret) error {
+func (i *CommandInitOption) CreateSecret(secret *corev1.Secret) error {
 	secretClient := i.KubeClientSet.CoreV1().Secrets(i.Namespace)
 
 	secretList, err := secretClient.List(context.TODO(), metav1.ListOptions{})

--- a/pkg/karmadactl/cmdinit/kubernetes/serviceaccount.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/serviceaccount.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -9,7 +10,7 @@ import (
 )
 
 //ServiceAccountFromSpec sa spec
-func (i *InstallOptions) ServiceAccountFromSpec(name []string) []corev1.ServiceAccount {
+func (i *CommandInitOption) ServiceAccountFromSpec(name []string) []corev1.ServiceAccount {
 	var sa []corev1.ServiceAccount
 
 	for _, v := range name {
@@ -29,7 +30,7 @@ func (i *InstallOptions) ServiceAccountFromSpec(name []string) []corev1.ServiceA
 }
 
 //CreateServiceAccount receive ServiceAccountFromSpec create sa
-func (i *InstallOptions) CreateServiceAccount() error {
+func (i *CommandInitOption) CreateServiceAccount() error {
 	serviceAccount := i.ServiceAccountFromSpec([]string{controllerManagerDeploymentAndServiceName, schedulerDeploymentNameAndServiceAccountName, webhookDeploymentAndServiceAccountAndServiceName})
 	saClient := i.KubeClientSet.CoreV1().ServiceAccounts(i.Namespace)
 
@@ -39,8 +40,7 @@ func (i *InstallOptions) CreateServiceAccount() error {
 			continue
 		}
 		if _, err := saClient.Create(context.TODO(), &serviceAccount[v], metav1.CreateOptions{}); err != nil {
-			klog.Errorf("Create ServiceAccount %s failed: %v", serviceAccount[v].Name)
-			return err
+			return fmt.Errorf("create ServiceAccount %s failed: %v", serviceAccount[v].Name, err)
 		}
 	}
 

--- a/pkg/karmadactl/cmdinit/options/global.go
+++ b/pkg/karmadactl/cmdinit/options/global.go
@@ -1,12 +1,5 @@
 package options
 
-import (
-	"os"
-	"path/filepath"
-
-	"github.com/spf13/pflag"
-)
-
 const (
 	//CaCertAndKeyName ca certificate key name
 	CaCertAndKeyName = "ca"
@@ -27,70 +20,3 @@ const (
 	//KarmadaKubeConfigName karmada kubeconfig name
 	KarmadaKubeConfigName = "karmada-apiserver.config"
 )
-
-var (
-	//EtcdImage etcd image
-	EtcdImage string
-	//EtcdInitImage etcd init image
-	EtcdInitImage string
-	//APIServerImage karmada kube-apiserver image
-	APIServerImage string
-	//SchedulerImage karmada scheduler image
-	SchedulerImage string
-	//KubeControllerManagerImage karmada kube-controllermanager image
-	KubeControllerManagerImage string
-	//ControllerManagerImage karmada controllermanager image
-	ControllerManagerImage string
-	//WebhookImage karmada webhook image
-	WebhookImage string
-	//AggregatedAPIServerImage karmada aggregated aposerver image
-	AggregatedAPIServerImage string
-	//Namespace kubernetes namespace
-	Namespace string
-	//KubeConfig kubernetes config
-	KubeConfig string
-	//StorageClassesName kubernetes storage classes name
-	StorageClassesName string
-	//EtcdStorageMode etcd storage mode
-	EtcdStorageMode string
-	//EtcdReplicas etcd replicas
-	EtcdReplicas int32
-	//EtcdDataPath etcd host data path
-	EtcdDataPath string
-	//EtcdStorageSize etcd storage pvc size
-	EtcdStorageSize string
-	//APIServerReplicas karmada apiserver replicas
-	APIServerReplicas int32
-	//ControllerManagerReplicas  karmada controller manager replicas
-	ControllerManagerReplicas int32
-	//KubeControllerManagerReplicas kube controller manager replicas
-	KubeControllerManagerReplicas int32
-	//SchedulerReplicas karmada scheduler replicas
-	SchedulerReplicas int32
-	//WebhookReplicas karmada webhook replicas
-	WebhookReplicas int32
-	//AggregatedAPIServerReplicas karmada aggregated aposerver replicas
-	AggregatedAPIServerReplicas int32
-	//DataPath karmada data path
-	DataPath string
-	//CRDs karmada crds
-	CRDs string
-	//KarmadaMasterIP karmada apiserver ip
-	KarmadaMasterIP string
-	//KarmadaMasterPort karmada apiserver port
-	KarmadaMasterPort int32
-	//ExternalIP the external IP of Karmada certificate
-	ExternalIP string
-)
-
-// AddFlags adds flags to the specified FlagSet.
-func AddFlags(flags *pflag.FlagSet) {
-	flags.StringVar(&KubeConfig, "kubeconfig", filepath.Join(homeDir(), ".kube", "config"), "absolute path to the kubeconfig file")
-}
-
-func homeDir() string {
-	if h := os.Getenv("HOME"); h != "" {
-		return h
-	}
-	return os.Getenv("USERPROFILE") // windows
-}

--- a/pkg/karmadactl/cmdinit/utils/format.go
+++ b/pkg/karmadactl/cmdinit/utils/format.go
@@ -17,7 +17,8 @@ const (
 	// Query the IP address of the current host accessing the Internet
 	getInternetIPUrl = "https://myexternalip.com/raw"
 	// A split symbol that receives multiple values from a command flag
-	separator = ","
+	separator      = ","
+	labelSeparator = "="
 )
 
 //PathIsExist Determine whether the path exists
@@ -49,6 +50,11 @@ func FlagsIP(ip string) []net.IP {
 		ips = append(ips, StringToNetIP(v))
 	}
 	return ips
+}
+
+// FlagsDNS Receive master external DNS from command flags
+func FlagsDNS(dns string) []string {
+	return strings.Split(dns, separator)
 }
 
 // InternetIP Current host Internet IP.
@@ -122,6 +128,18 @@ func MapToString(labels map[string]string) string {
 		fmt.Fprintf(v, "%s=%s,", key, value)
 	}
 	return strings.TrimRight(v.String(), ",")
+}
+
+// StringToMap  string to label
+func StringToMap(labels string) map[string]string {
+	l := map[string]string{}
+	slice := strings.Split(labels, labelSeparator)
+	if len(slice) != 2 {
+		return nil
+	}
+
+	l[slice[0]] = slice[1]
+	return l
 }
 
 //StaticYamlToJSONByte  Static yaml file conversion JSON Byte

--- a/pkg/karmadactl/karmadactl.go
+++ b/pkg/karmadactl/karmadactl.go
@@ -51,7 +51,7 @@ func NewKarmadaCtlCommand(out io.Writer, cmdUse, parentCommand string) *cobra.Co
 	rootCmd.AddCommand(NewCmdGet(out, karmadaConfig, parentCommand))
 	rootCmd.AddCommand(NewCmdTaint(out, karmadaConfig, parentCommand))
 	rootCmd.AddCommand(NewCmdPromote(out, karmadaConfig, parentCommand))
-	rootCmd.AddCommand(cmdinit.NewCmdInit())
+	rootCmd.AddCommand(cmdinit.NewCmdInit(out))
 
 	return rootCmd
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Simplify command flags.
No need to specify master IP, the default karmada-apiserver IP is kubernetes master IP. If kubernetes has no master role set, 3 node IPs will be randomly select.

```
W1223 15:31:31.404221 1585024 node.go:29] the kubernetes cluster does not have a Master role.
I1223 15:31:31.404258 1585024 node.go:37] randomly select 3 Node IPs in the kubernetes cluster.
I1223 15:31:31.406495 1585024 deploy.go:120] karmada apiserver ip: [172.31.6.145 172.31.6.147 172.31.6.148]
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
```
prodan@ubuntu:/opt/workspaces/karmada$ ./kubectl-karmada init -h
install karmada in kubernetes.

Usage:
  karmada init [flags]

Examples:

# Install karmada in kubernetes
# The default karmada-apiserver IP is kubernetes master IP. If kubernetes has no master role set, 3 node IPs will be randomly executed.
kubectl karmada init 

# The karmada crds resource is downloaded from the karmada releases page by default. Any crds URL can be passed in.
kubectl karmada init --crds https://github.com/karmada-io/karmada/releases/download/v0.10.1/crds.tar.gz

# karmada crds can also specify local files.
kubectl karmada init --crds /root/crds.tar.gz

# Use PVC to persistent storage etcd data.
kubectl karmada init --etcd-storage-mode PVC --storage-classes-name {StorageClassesName}

# Use hostPath to persistent storage etcd data. For data security, only 1 etcd pod can run in hostPath mode.
kubectl karmada init --etcd-storage-mode hostPath  --etcd-replicas 1

# Use hostPath to persistent storage etcd data. by default, a healthy node is selected to run etcd, and the node can be selected through --etcd-node-selector-labels
kubectl karmada init --etcd-storage-mode hostPath --etcd-node-selector-labels karmada.io/etcd=true

# Private registry can be specified for all images.
kubectl karmada init --etcd-image local.registry.com/library/etcd:3.5.1-0

# Deploy highly available(HA) karmada.
kubectl karmada init --karmada-apiserver-replicas 3 --etcd-replicas 3 --storage-classes-name PVC --storage-classes-name {StorageClassesName}

# Karmada-apiserver uses external load balancing or haip, karmada certificate needs to join the IP or DNS.Otherwise, you cannot access Karmada-apiserver through it
kubectl karmada init --cert-external-ip 10.235.1.2 --cert-external-dns www.karmada.io


Flags:
      --cert-external-dns string                         the external DNS of Karmada certificate (e.g localhost,localhost.com)
      --cert-external-ip string                          the external IP of Karmada certificate (e.g 192.168.1.2,172.16.1.2)
      --crds string                                      Karmada crds resource.(local file e.g. --crds /root/crds.tar.gz) (default "https://github.com/karmada-io/karmada/releases/download/v0.10.1-180-g93aab287/crds.tar.gz")
      --etcd-data string                                 etcd data path,valid in hostPath mode. (default "/var/lib/karmada-etcd")
      --etcd-image string                                etcd image (default "k8s.gcr.io/etcd:3.5.1-0")
      --etcd-init-image string                           etcd init container image (default "docker.io/alpine:3.14.3")
      --etcd-node-selector-labels string                 etcd pod select the labels of the node. valid in hostPath mode ( e.g. --etcd-node-selector-labels karmada.io/etcd=true)
      --etcd-pvc-size string                             etcd data path,valid in pvc mode. (default "5Gi")
      --etcd-replicas int32                              etcd replica set, cluster 3,5...singular (default 1)
      --etcd-storage-mode string                         etcd data storage mode(emptyDir,hostPath,PVC). value is PVC, specify --storage-classes-name (default "emptyDir")
  -h, --help                                             help for init
      --karmada-aggregated-apiserver-image string        karmada aggregated apiserver image (default "swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-aggregated-apiserver:latest")
      --karmada-aggregated-apiserver-replicas int32      karmada aggregated apiserver replica set (default 1)
      --karmada-apiserver-image string                   Kubernetes apiserver image (default "k8s.gcr.io/kube-apiserver:v1.21.7")
      --karmada-apiserver-replicas int32                 karmada apiserver replica set (default 1)
      --karmada-controller-manager-image string          karmada controller manager  image (default "swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-controller-manager:latest")
      --karmada-controller-manager-replicas int32        karmada controller manager replica set (default 1)
  -d, --karmada-data string                              karmada data path. kubeconfig cert and crds files (default "/etc/karmada")
      --karmada-kube-controller-manager-image string     Kubernetes controller manager image (default "k8s.gcr.io/kube-controller-manager:v1.21.7")
      --karmada-kube-controller-manager-replicas int32   karmada kube controller manager replica set (default 1)
      --karmada-scheduler-image string                   karmada scheduler image (default "swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-scheduler:latest")
      --karmada-scheduler-replicas int32                 karmada scheduler replica set (default 1)
      --karmada-webhook-image string                     karmada webhook image (default "swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-webhook:latest")
      --karmada-webhook-replicas int32                   karmada webhook replica set (default 1)
  -n, --namespace string                                 Kubernetes namespace (default "karmada-system")
  -p, --port int32                                       Karmada apiserver service node port (default 5443)
      --storage-classes-name string                      Kubernetes StorageClasses Name
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

