### PR TITLE
completes ClusterSpec and create impernator secret for pull mode cluster

### DIFF
--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -47,6 +47,11 @@ type Options struct {
 	KubeAPIBurst int
 
 	ClusterCacheSyncTimeout metav1.Duration
+
+	// ClusterAPIEndpoint holds the apiEndpoint of the cluster.
+	ClusterAPIEndpoint string
+	// ProxyServerAddress holds the proxy server address that is used to proxy to the cluster.
+	ProxyServerAddress string
 }
 
 // NewOptions builds an default scheduler options.
@@ -86,4 +91,6 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, allControllers []string) {
 	fs.Float32Var(&o.KubeAPIQPS, "kube-api-qps", 40.0, "QPS to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")
 	fs.IntVar(&o.KubeAPIBurst, "kube-api-burst", 60, "Burst to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")
 	fs.DurationVar(&o.ClusterCacheSyncTimeout.Duration, "cluster-cache-sync-timeout", util.CacheSyncTimeout, "Timeout period waiting for cluster cache to sync.")
+	fs.StringVar(&o.ClusterAPIEndpoint, "cluster-api-endpoint", o.ClusterAPIEndpoint, "APIEndpoint of the cluster.")
+	fs.StringVar(&o.ProxyServerAddress, "proxy-server-address", o.ProxyServerAddress, "Address of the proxy server that is used to proxy to the cluster.")
 }

--- a/pkg/registry/cluster/storage/proxy.go
+++ b/pkg/registry/cluster/storage/proxy.go
@@ -71,17 +71,9 @@ func (r *ProxyREST) Connect(ctx context.Context, id string, options runtime.Obje
 }
 
 func (r *ProxyREST) getImpersonateToken(clusterName string) (string, error) {
-	cluster, err := r.karmadaClient.ClusterV1alpha1().Clusters().Get(context.TODO(), clusterName, metav1.GetOptions{})
-	if err != nil {
-		return "", err
-	}
-
-	if cluster.Spec.SecretRef == nil {
-		return "", fmt.Errorf("the secretRef of cluster %s is nil", clusterName)
-	}
-
-	secret, err := r.kubeClient.CoreV1().Secrets(cluster.Spec.SecretRef.Namespace).Get(context.TODO(),
-		names.GenerateImpersonationSecretName(cluster.Spec.SecretRef.Name), metav1.GetOptions{})
+	// TODO: add impersonation secretRef to Cluster api to indicate impersonation secret.
+	secret, err := r.kubeClient.CoreV1().Secrets(names.NamespaceKarmadaCluster).Get(context.TODO(),
+		names.GenerateImpersonationSecretName(clusterName), metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/pkg/util/cluster.go
+++ b/pkg/util/cluster.go
@@ -2,13 +2,18 @@ package util
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
 )
 
 const (
@@ -30,16 +35,87 @@ func GetCluster(hostClient client.Client, clusterName string) (*clusterv1alpha1.
 	return cluster, nil
 }
 
-// CreateClusterIfNotExist try to create the cluster if it does not exist.
-func CreateClusterIfNotExist(client client.Client, clusterObj *clusterv1alpha1.Cluster) error {
-	cluster := &clusterv1alpha1.Cluster{}
-	if err := client.Get(context.TODO(), types.NamespacedName{Name: clusterObj.Name}, cluster); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return err
-		}
-		if err := client.Create(context.TODO(), clusterObj); err != nil {
-			return err
-		}
+// CreateClusterObject create cluster object in karmada control plane
+func CreateClusterObject(controlPlaneClient *karmadaclientset.Clientset, clusterObj *clusterv1alpha1.Cluster) (*clusterv1alpha1.Cluster, error) {
+	cluster, exist, err := GetClusterWithKarmadaClient(controlPlaneClient, clusterObj.Name)
+	if err != nil {
+		return nil, err
 	}
-	return nil
+
+	if exist {
+		return cluster, fmt.Errorf("cluster(%s) already exist", clusterObj.Name)
+	}
+
+	if cluster, err = createCluster(controlPlaneClient, clusterObj); err != nil {
+		klog.Warningf("failed to create cluster(%s). error: %v", clusterObj.Name, err)
+		return nil, err
+	}
+
+	return cluster, nil
+}
+
+// CreateOrUpdateClusterObject create cluster object in karmada control plane,
+// if cluster object has been existed and different from input clusterObj, update it.
+func CreateOrUpdateClusterObject(controlPlaneClient *karmadaclientset.Clientset, clusterObj *clusterv1alpha1.Cluster) (*clusterv1alpha1.Cluster, error) {
+	cluster, exist, err := GetClusterWithKarmadaClient(controlPlaneClient, clusterObj.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	if exist {
+		if reflect.DeepEqual(cluster.Spec, clusterObj.Spec) {
+			klog.Warningf("cluster(%s) already exist and newest", clusterObj.Name)
+			return cluster, nil
+		}
+
+		cluster.Spec = clusterObj.Spec
+		cluster, err = updateCluster(controlPlaneClient, cluster)
+		if err != nil {
+			klog.Warningf("failed to create cluster(%s). error: %v", clusterObj.Name, err)
+			return nil, err
+		}
+		return cluster, nil
+	}
+
+	if cluster, err = createCluster(controlPlaneClient, clusterObj); err != nil {
+		klog.Warningf("failed to create cluster(%s). error: %v", clusterObj.Name, err)
+		return nil, err
+	}
+
+	return cluster, nil
+}
+
+// GetClusterWithKarmadaClient tells if a cluster already joined to control plane.
+func GetClusterWithKarmadaClient(client karmadaclientset.Interface, name string) (*clusterv1alpha1.Cluster, bool, error) {
+	cluster, err := client.ClusterV1alpha1().Clusters().Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, false, nil
+		}
+
+		klog.Warningf("failed to retrieve cluster(%s). error: %v", cluster.Name, err)
+		return nil, false, err
+	}
+
+	return cluster, true, nil
+}
+
+func createCluster(controlPlaneClient karmadaclientset.Interface, cluster *clusterv1alpha1.Cluster) (*clusterv1alpha1.Cluster, error) {
+	newCluster, err := controlPlaneClient.ClusterV1alpha1().Clusters().Create(context.TODO(), cluster, metav1.CreateOptions{})
+	if err != nil {
+		klog.Warningf("failed to create cluster(%s). error: %v", cluster.Name, err)
+		return nil, err
+	}
+
+	return newCluster, nil
+}
+
+func updateCluster(controlPlaneClient karmadaclientset.Interface, cluster *clusterv1alpha1.Cluster) (*clusterv1alpha1.Cluster, error) {
+	newCluster, err := controlPlaneClient.ClusterV1alpha1().Clusters().Update(context.TODO(), cluster, metav1.UpdateOptions{})
+	if err != nil {
+		klog.Warningf("failed to update cluster(%s). error: %v", cluster.Name, err)
+		return nil, err
+	}
+
+	return newCluster, nil
 }

--- a/pkg/util/namespace.go
+++ b/pkg/util/namespace.go
@@ -7,9 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	kubeclient "k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // IsNamespaceExist tells if specific already exists.
@@ -45,20 +43,6 @@ func DeleteNamespace(client kubeclient.Interface, namespace string) error {
 	err := client.CoreV1().Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
-	}
-	return nil
-}
-
-// CreateNamespaceIfNotExist try to create the namespace if it does not exist.
-func CreateNamespaceIfNotExist(client client.Client, namespaceObj *corev1.Namespace) error {
-	namespace := &corev1.Namespace{}
-	if err := client.Get(context.TODO(), types.NamespacedName{Name: namespaceObj.Name}, namespace); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return err
-		}
-		if err := client.Create(context.TODO(), namespaceObj); err != nil {
-			return err
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

After #1122, #1158, we need to access `pull` Cluster through karmada wit AA, first of all, we need to complete ClusterSpec(proxy server and API endpoint) and create related impersonator secret for impersonation(#1104).

**Which issue(s) this PR fixes**:
Fixes #1077 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

/cc @mrlihanbo @RainbowMango 