### PR TITLE
Upgrade for unified auth

### DIFF
--- a/artifacts/agent/namespace.yaml
+++ b/artifacts/agent/namespace.yaml
@@ -2,9 +2,4 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: karmada-system
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: karmada-cluster
 

--- a/artifacts/agent/serviceaccount.yaml
+++ b/artifacts/agent/serviceaccount.yaml
@@ -3,11 +3,3 @@ kind: ServiceAccount
 metadata:
   name: karmada-agent-sa
   namespace: karmada-system
-
----
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: karmada-impersonator
-  namespace: karmada-cluster

--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -13,6 +13,9 @@ import (
 	"github.com/karmada-io/karmada/pkg/util"
 )
 
+// DefaultKarmadaClusterNamespace defines the default namespace where the member cluster secrets are stored.
+const DefaultKarmadaClusterNamespace = "karmada-cluster"
+
 // Options contains everything necessary to create and run controller-manager.
 type Options struct {
 	// Controllers contains all controller names.
@@ -23,7 +26,8 @@ type Options struct {
 	// Default value is the current-context.
 	KarmadaContext string
 	ClusterName    string
-
+	// ClusterNamespace holds the namespace name where the member cluster secrets are stored.
+	ClusterNamespace string
 	// ClusterStatusUpdateFrequency is the frequency that controller computes and report cluster status.
 	// It must work with ClusterMonitorGracePeriod(--cluster-monitor-grace-period) in karmada-controller-manager.
 	ClusterStatusUpdateFrequency metav1.Duration
@@ -71,6 +75,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, allControllers []string) {
 	fs.StringVar(&o.KarmadaKubeConfig, "karmada-kubeconfig", o.KarmadaKubeConfig, "Path to karmada control plane kubeconfig file.")
 	fs.StringVar(&o.KarmadaContext, "karmada-context", "", "Name of the cluster context in karmada control plane kubeconfig file.")
 	fs.StringVar(&o.ClusterName, "cluster-name", o.ClusterName, "Name of member cluster that the agent serves for.")
+	fs.StringVar(&o.ClusterNamespace, "cluster-namespace", DefaultKarmadaClusterNamespace, "Namespace in the control plane where member cluster secrets are stored.")
 	fs.DurationVar(&o.ClusterStatusUpdateFrequency.Duration, "cluster-status-update-frequency", 10*time.Second, "Specifies how often karmada-agent posts cluster status to karmada-apiserver. Note: be cautious when changing the constant, it must work with ClusterMonitorGracePeriod in karmada-controller-manager.")
 	fs.DurationVar(&o.ClusterLeaseDuration.Duration, "cluster-lease-duration", 40*time.Second,
 		"Specifies the expiration period of a cluster lease.")

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -319,8 +319,10 @@ func startServiceImportController(ctx controllerscontext.Context) (enabled bool,
 
 func startUnifiedAuthController(ctx controllerscontext.Context) (enabled bool, err error) {
 	unifiedAuthController := &unifiedauth.Controller{
-		Client:        ctx.Mgr.GetClient(),
-		EventRecorder: ctx.Mgr.GetEventRecorderFor(unifiedauth.ControllerName),
+		Client:                ctx.Mgr.GetClient(),
+		ControllerPlaneConfig: ctx.Mgr.GetConfig(),
+		EventRecorder:         ctx.Mgr.GetEventRecorderFor(unifiedauth.ControllerName),
+		ClusterClientSetFunc:  util.NewClusterClientSet,
 	}
 	if err := unifiedAuthController.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err

--- a/pkg/controllers/unifiedauth/ensure_impersonation_secret.go
+++ b/pkg/controllers/unifiedauth/ensure_impersonation_secret.go
@@ -1,0 +1,103 @@
+package unifiedauth
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeclient "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/names"
+)
+
+// ensureImpersonationSecret make sure create impersonation secret for all Cluster.
+// This logic is used only in the upgrade scenario of the current version
+// and can be deleted in the next version.
+func (c *Controller) ensureImpersonationSecret() {
+	controlPlaneKubeClient := kubeclient.NewForConfigOrDie(c.ControllerPlaneConfig)
+
+	clusterList := &clusterv1alpha1.ClusterList{}
+	if err := c.Client.List(context.TODO(), clusterList); err != nil {
+		klog.Errorf("Failed to list clusterList, error: %v", err)
+		return
+	}
+
+	for index, cluster := range clusterList.Items {
+		err := c.ensureImpersonationSecretForCluster(controlPlaneKubeClient, &clusterList.Items[index])
+		if err != nil {
+			klog.Errorf("Failed to ensure impersonation secret exist for cluster %s", cluster.Name)
+			return
+		}
+	}
+}
+
+func (c *Controller) ensureImpersonationSecretForCluster(karmadaKubeClient kubeclient.Interface, cluster *clusterv1alpha1.Cluster) error {
+	klog.V(4).Infof("Create impersonation secret for cluster %s", cluster.Name)
+	// create a ClusterClient for the given member cluster
+	clusterClient, err := c.ClusterClientSetFunc(cluster.Name, c.Client, nil)
+	if err != nil {
+		klog.Errorf("Failed to create a ClusterClient for the given member cluster: %v, err is : %v", cluster.Name, err)
+		return err
+	}
+
+	// clusterNamespace store namespace where serviceaccount and secret exist.
+	clusterNamespace := cluster.Spec.SecretRef.Namespace
+
+	// create a ServiceAccount for impersonation in cluster.
+	impersonationSA := &corev1.ServiceAccount{}
+	impersonationSA.Namespace = clusterNamespace
+	impersonationSA.Name = names.GenerateServiceAccountName("impersonator")
+	if impersonationSA, err = c.ensureServiceAccountExist(clusterClient.KubeClient, impersonationSA); err != nil {
+		return err
+	}
+
+	clusterImpersonatorSecret, err := util.WaitForServiceAccountSecretCreation(clusterClient.KubeClient, impersonationSA)
+	if err != nil {
+		return fmt.Errorf("failed to get serviceAccount secret for impersonation from cluster(%s), error: %v", cluster.Name, err)
+	}
+
+	// create secret to store impersonation info in control plane
+	impersonationSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: clusterNamespace,
+			Name:      names.GenerateImpersonationSecretName(cluster.Name),
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(cluster, clusterv1alpha1.SchemeGroupVersion.WithKind("Cluster")),
+			},
+		},
+		Data: map[string][]byte{
+			clusterv1alpha1.SecretCADataKey: clusterImpersonatorSecret.Data["ca.crt"],
+			clusterv1alpha1.SecretTokenKey:  clusterImpersonatorSecret.Data[clusterv1alpha1.SecretTokenKey],
+		},
+	}
+
+	_, err = util.CreateSecret(karmadaKubeClient, impersonationSecret)
+	if err != nil {
+		return fmt.Errorf("failed to create impersonator secret in control plane. error: %v", err)
+	}
+
+	return nil
+}
+
+// ensureServiceAccountExist makes sure that the specific service account exist in cluster.
+// If service account not exit, just create it.
+func (c *Controller) ensureServiceAccountExist(client kubeclient.Interface, saObj *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+	exist, err := util.IsServiceAccountExist(client, saObj.Namespace, saObj.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if impersonation service account exist. error: %v", err)
+	}
+	if exist {
+		return saObj, nil
+	}
+
+	createdObj, err := util.CreateServiceAccount(client, saObj)
+	if err != nil {
+		return nil, fmt.Errorf("ensure impersonation service account failed due to create failed, error: %v", err)
+	}
+
+	return createdObj, nil
+}

--- a/pkg/controllers/unifiedauth/ensure_impersonation_secret.go
+++ b/pkg/controllers/unifiedauth/ensure_impersonation_secret.go
@@ -27,10 +27,12 @@ func (c *Controller) ensureImpersonationSecret() {
 	}
 
 	for index, cluster := range clusterList.Items {
+		if cluster.Spec.SyncMode == clusterv1alpha1.Pull {
+			continue
+		}
 		err := c.ensureImpersonationSecretForCluster(controlPlaneKubeClient, &clusterList.Items[index])
 		if err != nil {
 			klog.Errorf("Failed to ensure impersonation secret exist for cluster %s", cluster.Name)
-			return
 		}
 	}
 }

--- a/pkg/controllers/unifiedauth/unified_auth_controller.go
+++ b/pkg/controllers/unifiedauth/unified_auth_controller.go
@@ -9,7 +9,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -38,8 +40,10 @@ const (
 
 // Controller is to sync impersonation config to member clusters for unified authentication.
 type Controller struct {
-	client.Client // used to operate Cluster resources.
-	EventRecorder record.EventRecorder
+	client.Client         // used to operate Cluster resources.
+	ControllerPlaneConfig *rest.Config
+	EventRecorder         record.EventRecorder
+	ClusterClientSetFunc  func(string, client.Client, *util.ClientOption) (*util.ClusterClient, error)
 }
 
 // Reconcile performs a full reconciliation for the object referred to by the Request.
@@ -69,6 +73,12 @@ func (c *Controller) Reconcile(ctx context.Context, req controllerruntime.Reques
 	}
 
 	return controllerruntime.Result{}, nil
+}
+
+// Start starts a goroutine to ensure impersonation secret for upgrade scenario.
+func (c *Controller) Start(ctx context.Context) error {
+	go c.ensureImpersonationSecret()
+	return nil
 }
 
 func (c *Controller) syncImpersonationConfig(cluster *clusterv1alpha1.Cluster) error {
@@ -234,9 +244,13 @@ func (c *Controller) SetupWithManager(mgr controllerruntime.Manager) error {
 		},
 	}
 
-	return controllerruntime.NewControllerManagedBy(mgr).For(&clusterv1alpha1.Cluster{}).WithEventFilter(clusterPredicateFunc).
-		Watches(&source.Kind{Type: &rbacv1.ClusterRole{}}, handler.EnqueueRequestsFromMapFunc(c.newClusterRoleMapFunc())).
-		Watches(&source.Kind{Type: &rbacv1.ClusterRoleBinding{}}, handler.EnqueueRequestsFromMapFunc(c.newClusterRoleBindingMapFunc())).Complete(c)
+	return utilerrors.NewAggregate([]error{
+		controllerruntime.NewControllerManagedBy(mgr).For(&clusterv1alpha1.Cluster{}).WithEventFilter(clusterPredicateFunc).
+			Watches(&source.Kind{Type: &rbacv1.ClusterRole{}}, handler.EnqueueRequestsFromMapFunc(c.newClusterRoleMapFunc())).
+			Watches(&source.Kind{Type: &rbacv1.ClusterRoleBinding{}}, handler.EnqueueRequestsFromMapFunc(c.newClusterRoleBindingMapFunc())).Complete(c),
+		mgr.Add(c),
+	})
+
 }
 
 func (c *Controller) newClusterRoleMapFunc() handler.MapFunc {

--- a/pkg/controllers/unifiedauth/unified_auth_controller.go
+++ b/pkg/controllers/unifiedauth/unified_auth_controller.go
@@ -250,7 +250,6 @@ func (c *Controller) SetupWithManager(mgr controllerruntime.Manager) error {
 			Watches(&source.Kind{Type: &rbacv1.ClusterRoleBinding{}}, handler.EnqueueRequestsFromMapFunc(c.newClusterRoleBindingMapFunc())).Complete(c),
 		mgr.Add(c),
 	})
-
 }
 
 func (c *Controller) newClusterRoleMapFunc() handler.MapFunc {

--- a/pkg/util/serviceaccount.go
+++ b/pkg/util/serviceaccount.go
@@ -2,10 +2,13 @@ package util
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	kubeclient "k8s.io/client-go/kubernetes"
 )
 
@@ -44,4 +47,54 @@ func DeleteServiceAccount(client kubeclient.Interface, namespace, name string) e
 		return err
 	}
 	return nil
+}
+
+// EnsureServiceAccountExist makes sure that the specific service account exist in cluster.
+// If service account not exit, just create it.
+func EnsureServiceAccountExist(client kubeclient.Interface, serviceAccountObj *corev1.ServiceAccount, dryRun bool) (*corev1.ServiceAccount, error) {
+	if dryRun {
+		return serviceAccountObj, nil
+	}
+
+	exist, err := IsServiceAccountExist(client, serviceAccountObj.Namespace, serviceAccountObj.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if service account exist. service account: %s/%s, error: %v", serviceAccountObj.Namespace, serviceAccountObj.Name, err)
+	}
+	if exist {
+		return serviceAccountObj, nil
+	}
+
+	createdObj, err := CreateServiceAccount(client, serviceAccountObj)
+	if err != nil {
+		return nil, fmt.Errorf("ensure service account failed due to create failed. service account: %s/%s, error: %v", serviceAccountObj.Namespace, serviceAccountObj.Name, err)
+	}
+
+	return createdObj, nil
+}
+
+// WaitForServiceAccountSecretCreation wait the ServiceAccount's secret has been created.
+func WaitForServiceAccountSecretCreation(client kubeclient.Interface, asObj *corev1.ServiceAccount) (*corev1.Secret, error) {
+	var clusterSecret *corev1.Secret
+	err := wait.Poll(1*time.Second, 30*time.Second, func() (done bool, err error) {
+		serviceAccount, err := client.CoreV1().ServiceAccounts(asObj.Namespace).Get(context.TODO(), asObj.Name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to retrieve service account(%s/%s) from cluster, err: %v", asObj.Namespace, asObj.Name, err)
+		}
+		clusterSecret, err = GetTargetSecret(client, serviceAccount.Secrets, corev1.SecretTypeServiceAccountToken, asObj.Namespace)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get serviceAccount secret, error: %v", err)
+	}
+	return clusterSecret, nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

#1104 add a new feature `unified auth`, it will create an impersonation serviceaccount in member clusters and collect related secret from member cluster to karmada control-plane.

Based on this, consider the upgrade scenario, for member clusters that have been added to karmada, we need to do the same things.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

For the push mod cluster, the logic for the upgrade can be deleted in the next version.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

