### PR TITLE
Log print karmada text logo

### DIFF
--- a/pkg/karmadactl/cmdinit/utils/examples.go
+++ b/pkg/karmadactl/cmdinit/utils/examples.go
@@ -148,6 +148,18 @@ func GenExamples(path string) {
 	}
 
 	fmt.Printf(`
+------------------------------------------------------------------------------------------------------
+ █████   ████   █████████   ███████████   ██████   ██████   █████████   ██████████     █████████
+░░███   ███░   ███░░░░░███ ░░███░░░░░███ ░░██████ ██████   ███░░░░░███ ░░███░░░░███   ███░░░░░███
+ ░███  ███    ░███    ░███  ░███    ░███  ░███░█████░███  ░███    ░███  ░███   ░░███ ░███    ░███
+ ░███████     ░███████████  ░██████████   ░███░░███ ░███  ░███████████  ░███    ░███ ░███████████
+ ░███░░███    ░███░░░░░███  ░███░░░░░███  ░███ ░░░  ░███  ░███░░░░░███  ░███    ░███ ░███░░░░░███
+ ░███ ░░███   ░███    ░███  ░███    ░███  ░███      ░███  ░███    ░███  ░███    ███  ░███    ░███
+ █████ ░░████ █████   █████ █████   █████ █████     █████ █████   █████ ██████████   █████   █████
+░░░░░   ░░░░ ░░░░░   ░░░░░ ░░░░░   ░░░░░ ░░░░░     ░░░░░ ░░░░░   ░░░░░ ░░░░░░░░░░   ░░░░░   ░░░░░
+------------------------------------------------------------------------------------------------------
+Karmada is installed successfully.
+
 Register Kubernetes cluster to Karmada control plane.
 
 Register cluster with 'Push' mode
@@ -158,6 +170,7 @@ Step 1: Use kubectl-karmada join to register the cluster to Karmada control pane
 
 Step 2: Show members of karmada
 (In karmada)~# kubectl  --kubeconfig %s/karmada-apiserver.config get clusters
+
 
 Register cluster with 'Pull' mode
 
@@ -177,5 +190,6 @@ Step 3: Create karmada agent
                                                                                                                                                                              
 Step 4: Show members of karmada                                                                                                                                              
 (In karmada)~# kubectl  --kubeconfig %s/karmada-apiserver.config get clusters
+
 `, "`", "`", path, path, path, path, path)
 }


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Output the karmada logo, karmada is ready.

```
root@dev-k8s-master01:~# ./kubectl-karmada init --karmada-data /etc/karmada-test -p 7443 --crds https://github.com/karmada-io/karmada/releases/download/v0.10.1/crds.tar.gz --etcd-storage-mode hostPath 
I1227 22:32:27.984272 2323359 deploy.go:104] kubeconfig file: /root/.kube/config, kubernetes: https://172.31.6.145:6443
W1227 22:32:28.013674 2323359 node.go:30] the kubernetes cluster does not have a Master role.
I1227 22:32:28.013708 2323359 node.go:38] randomly select 3 Node IPs in the kubernetes cluster.
I1227 22:32:28.015578 2323359 deploy.go:124] karmada apiserver ip: [172.31.6.145 172.31.6.147 172.31.6.148]
I1227 22:32:28.401439 2323359 cert.go:230] Generate ca certificate success.
I1227 22:32:28.812753 2323359 cert.go:230] Generate etcd-server certificate success.
I1227 22:32:29.031693 2323359 cert.go:230] Generate etcd-client certificate success.
I1227 22:32:29.314846 2323359 cert.go:230] Generate karmada certificate success.
I1227 22:32:29.494570 2323359 cert.go:230] Generate front-proxy-ca certificate success.
I1227 22:32:29.698760 2323359 cert.go:230] Generate front-proxy-client certificate success.
I1227 22:32:29.698920 2323359 deploy.go:201] download crds file name: /etc/karmada-test/crds.tar.gz
Downloading...[ 100.00% ]
Downloading...[ 100.00% ]
Download complete.I1227 22:32:30.776963 2323359 deploy.go:390] Create karmada kubeconfig success.
I1227 22:32:30.791199 2323359 namespace.go:36] Create Namespace 'karmada-system' successfully.
W1227 22:32:30.842298 2323359 rbac.go:78] ClusterRole kube-controller-manager already exists.
I1227 22:32:30.983620 2323359 secret.go:78] secret kubeconfig Create successfully.
I1227 22:32:31.381807 2323359 secret.go:78] secret etcd-cert Create successfully.
I1227 22:32:31.783494 2323359 secret.go:78] secret karmada-cert Create successfully.
I1227 22:32:32.182883 2323359 secret.go:78] secret karmada-webhook-cert Create successfully.
I1227 22:32:32.583737 2323359 services.go:66] service etcd create successfully.
I1227 22:32:32.583763 2323359 deploy.go:266] create etcd StatefulSets
I1227 22:32:32.992910 2323359 check.go:98] etcd desired replicaset is 1, currently: 1
W1227 22:32:36.004239 2323359 check.go:52] pod: etcd-0 not ready. status: PodInitializing
I1227 22:32:37.011373 2323359 check.go:49] pod: etcd-0 is ready. status: Running
I1227 22:32:37.011414 2323359 deploy.go:277] create karmada ApiServer Deployment
I1227 22:32:37.026840 2323359 services.go:66] service karmada-apiserver create successfully.
W1227 22:32:40.054510 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:32:41.058602 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:32:42.058933 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:32:43.064959 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:32:44.059047 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:32:45.058705 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:32:46.058504 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:32:47.058706 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:32:48.058074 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:32:49.058232 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:32:50.058592 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:32:51.058459 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:32:52.059170 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:32:53.058967 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:32:54.059856 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:32:55.059065 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:32:56.058605 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:32:57.058301 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:32:58.059304 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:32:59.060383 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:33:00.059446 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:33:01.058417 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:33:02.060259 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:33:03.062144 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:33:04.060850 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:33:05.058743 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:33:06.058934 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
W1227 22:33:07.058580 2323359 check.go:52] pod: karmada-apiserver-6dc4cf6964-cpsnl not ready. status: Running
I1227 22:33:08.058322 2323359 check.go:49] pod: karmada-apiserver-6dc4cf6964-cpsnl is ready. status: Running
I1227 22:33:08.077846 2323359 deploy.go:60] Initialize karmada bases crd resource `/etc/karmada-test/crds/bases`
I1227 22:33:08.520213 2323359 deploy.go:71] Initialize karmada patches crd resource `/etc/karmada-test/crds/patches`
I1227 22:33:08.916070 2323359 deploy.go:83] Crate MutatingWebhookConfiguration mutating-config.
I1227 22:33:08.928468 2323359 deploy.go:87] Crate ValidatingWebhookConfiguration validating-config.
I1227 22:33:08.953002 2323359 deploy.go:217] Update APIService 'v1alpha1.cluster.karmada.io'
I1227 22:33:08.956052 2323359 deploy.go:297] create karmada kube controller manager Deployment
I1227 22:33:08.972074 2323359 services.go:66] service kube-controller-manager create successfully.
I1227 22:33:12.026716 2323359 check.go:49] pod: kube-controller-manager-85c789dcfc-6lgrs is ready. status: Running
I1227 22:33:12.026746 2323359 deploy.go:310] create karmada scheduler Deployment
W1227 22:33:15.040384 2323359 check.go:52] pod: karmada-scheduler-7b9d8b5764-vhvll not ready. status: ContainerCreating
W1227 22:33:16.044019 2323359 check.go:52] pod: karmada-scheduler-7b9d8b5764-vhvll not ready. status: ContainerCreating
I1227 22:33:17.043097 2323359 check.go:49] pod: karmada-scheduler-7b9d8b5764-vhvll is ready. status: Running
I1227 22:33:17.043150 2323359 deploy.go:320] create karmada controller manager Deployment
W1227 22:33:20.056103 2323359 check.go:52] pod: karmada-controller-manager-556cf896bc-qrltd not ready. status: ContainerCreating
W1227 22:33:21.259198 2323359 check.go:52] pod: karmada-controller-manager-556cf896bc-qrltd not ready. status: ContainerCreating
W1227 22:33:22.060850 2323359 check.go:52] pod: karmada-controller-manager-556cf896bc-qrltd not ready. status: ContainerCreating
I1227 22:33:23.059964 2323359 check.go:49] pod: karmada-controller-manager-556cf896bc-qrltd is ready. status: Running
I1227 22:33:23.059998 2323359 deploy.go:330] create karmada webhook Deployment
I1227 22:33:23.094915 2323359 services.go:66] service karmada-webhook create successfully.
W1227 22:33:26.474354 2323359 check.go:52] pod: karmada-webhook-7cf7986866-r5zr5 not ready. status: ContainerCreating
W1227 22:33:27.478863 2323359 check.go:52] pod: karmada-webhook-7cf7986866-r5zr5 not ready. status: Running
I1227 22:33:28.478586 2323359 check.go:49] pod: karmada-webhook-7cf7986866-r5zr5 is ready. status: Running
I1227 22:33:28.478628 2323359 deploy.go:342] create karmada aggregated apiserver Deployment
I1227 22:33:28.492131 2323359 services.go:66] service karmada-aggregated-apiserver create successfully.
W1227 22:33:31.518597 2323359 check.go:52] pod: karmada-aggregated-apiserver-6b46dcb9c6-ks4g6 not ready. status: ContainerCreating
W1227 22:33:32.608484 2323359 check.go:52] pod: karmada-aggregated-apiserver-6b46dcb9c6-ks4g6 not ready. status: ContainerCreating
I1227 22:33:33.522849 2323359 check.go:49] pod: karmada-aggregated-apiserver-6b46dcb9c6-ks4g6 is ready. status: Running

------------------------------------------------------------------------------------------------------
 █████   ████   █████████   ███████████   ██████   ██████   █████████   ██████████     █████████
░░███   ███░   ███░░░░░███ ░░███░░░░░███ ░░██████ ██████   ███░░░░░███ ░░███░░░░███   ███░░░░░███
 ░███  ███    ░███    ░███  ░███    ░███  ░███░█████░███  ░███    ░███  ░███   ░░███ ░███    ░███
 ░███████     ░███████████  ░██████████   ░███░░███ ░███  ░███████████  ░███    ░███ ░███████████
 ░███░░███    ░███░░░░░███  ░███░░░░░███  ░███ ░░░  ░███  ░███░░░░░███  ░███    ░███ ░███░░░░░███
 ░███ ░░███   ░███    ░███  ░███    ░███  ░███      ░███  ░███    ░███  ░███    ███  ░███    ░███
 █████ ░░████ █████   █████ █████   █████ █████     █████ █████   █████ ██████████   █████   █████
░░░░░   ░░░░ ░░░░░   ░░░░░ ░░░░░   ░░░░░ ░░░░░     ░░░░░ ░░░░░   ░░░░░ ░░░░░░░░░░   ░░░░░   ░░░░░
------------------------------------------------------------------------------------------------------
Register Kubernetes cluster to Karmada control plane.

Register cluster with 'Push' mode
                                                                                                                                                                             
Step 1: Use kubectl-karmada join to register the cluster to Karmada control panel. --cluster-kubeconfig is members kubeconfig.
(In karmada)~# MEMBER_CLUSTER_NAME=`cat ~/.kube/config  | grep current-context | sed 's/: /\n/g'| sed '1d'`
(In karmada)~# kubectl-karmada  --kubeconfig /etc/karmada-test/karmada-apiserver.config  join ${MEMBER_CLUSTER_NAME} --cluster-kubeconfig=$HOME/.kube/config

Step 2: Show members of karmada
(In karmada)~# kubectl  --kubeconfig /etc/karmada-test/karmada-apiserver.config get clusters

Register cluster with 'Pull' mode

Step 1:  Send karmada kubeconfig and karmada-agent.yaml to member kubernetes
(In karmada)~# scp /etc/karmada-test/karmada-apiserver.config /etc/karmada-test/karmada-agent.yaml {member kubernetes}:~
                                                                                                                                                                             
Step 2:  Create karmada kubeconfig secret
 Notice:
   Cross-network, need to change the config server address.
(In member kubernetes)~#  kubectl create ns karmada-system
(In member kubernetes)~#  kubectl create secret generic karmada-kubeconfig --from-file=karmada-kubeconfig=/root/karmada-apiserver.config  -n karmada-system                  

Step 3: Create karmada agent
(In member kubernetes)~#  MEMBER_CLUSTER_NAME="demo"
(In member kubernetes)~#  sed -i "s/{member_cluster_name}/${MEMBER_CLUSTER_NAME}/g" karmada-agent.yaml
(In member kubernetes)~#  kubectl create -f karmada-agent.yaml
                                                                                                                                                                             
Step 4: Show members of karmada                                                                                                                                              
(In karmada)~# kubectl  --kubeconfig /etc/karmada-test/karmada-apiserver.config get clusters
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

