### PR TITLE
remove the karmada client from aggregated-apiserver

### DIFF
--- a/cmd/aggregated-apiserver/app/options/options.go
+++ b/cmd/aggregated-apiserver/app/options/options.go
@@ -21,7 +21,6 @@ import (
 	"github.com/karmada-io/karmada/pkg/aggregatedapiserver"
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	clientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
-	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
 	informers "github.com/karmada-io/karmada/pkg/generated/informers/externalversions"
 )
 
@@ -87,9 +86,8 @@ func (o *Options) Run(ctx context.Context) error {
 	}
 	restConfig.QPS, restConfig.Burst = o.KubeAPIQPS, o.KubeAPIBurst
 	kubeClientSet := kubernetes.NewForConfigOrDie(restConfig)
-	karmadaClient := karmadaclientset.NewForConfigOrDie(restConfig)
 
-	server, err := config.Complete().New(kubeClientSet, karmadaClient)
+	server, err := config.Complete().New(kubeClientSet)
 	if err != nil {
 		return err
 	}

--- a/pkg/aggregatedapiserver/apiserver.go
+++ b/pkg/aggregatedapiserver/apiserver.go
@@ -13,7 +13,6 @@ import (
 
 	clusterapis "github.com/karmada-io/karmada/pkg/apis/cluster"
 	clusterinstall "github.com/karmada-io/karmada/pkg/apis/cluster/install"
-	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
 	clusterstorage "github.com/karmada-io/karmada/pkg/registry/cluster/storage"
 )
 
@@ -86,7 +85,7 @@ func (cfg *Config) Complete() CompletedConfig {
 	return CompletedConfig{&c}
 }
 
-func (c completedConfig) New(kubeClient kubernetes.Interface, karmadaClient karmadaclientset.Interface) (*APIServer, error) {
+func (c completedConfig) New(kubeClient kubernetes.Interface) (*APIServer, error) {
 	genericServer, err := c.GenericConfig.New("aggregated-apiserver", genericapiserver.NewEmptyDelegate())
 	if err != nil {
 		return nil, err
@@ -98,7 +97,7 @@ func (c completedConfig) New(kubeClient kubernetes.Interface, karmadaClient karm
 
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(clusterapis.GroupName, Scheme, ParameterCodec, Codecs)
 
-	clusterStorage, err := clusterstorage.NewStorage(Scheme, kubeClient, karmadaClient, c.GenericConfig.RESTOptionsGetter)
+	clusterStorage, err := clusterstorage.NewStorage(Scheme, kubeClient, c.GenericConfig.RESTOptionsGetter)
 	if err != nil {
 		klog.Errorf("unable to create REST storage for a resource due to %v, will die", err)
 		return nil, err


### PR DESCRIPTION
Signed-off-by: carlory <baofa.fan@daocloud.io>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

In the `pkg/registry` package, we should use the internal API version for cluster resources instead of a specific API version. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

