### PR TITLE
Automated cherry pick of #1207: Fix karmadactl init not found v1alpha1.cluster.karmada.io

### DIFF
--- a/pkg/karmadactl/cmdinit/kubernetes/deployments.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deployments.go
@@ -709,6 +709,7 @@ func (i *CommandInitOption) makeKarmadaAggregatedAPIServerDeployment() *appsv1.D
 					"--kubeconfig=/etc/kubeconfig",
 					"--authentication-kubeconfig=/etc/kubeconfig",
 					"--authorization-kubeconfig=/etc/kubeconfig",
+					"--karmada-config=/etc/kubeconfig",
 					fmt.Sprintf("--etcd-servers=%s", strings.TrimRight(i.etcdServers(), ",")),
 					fmt.Sprintf("--etcd-cafile=%s/%s.crt", karmadaCertsVolumeMountPath, options.CaCertAndKeyName),
 					fmt.Sprintf("--etcd-certfile=%s/%s.crt", karmadaCertsVolumeMountPath, options.EtcdClientCertAndKeyName),


### PR DESCRIPTION
Cherry pick of #1207 on release-1.0.
#1207: Fix karmadactl init not found v1alpha1.cluster.karmada.io
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/userguide/cherry-picks.md) page.
```release-note
karmadactl: fixed `init` can not update APIService issue.
```