### PR TITLE
Replace all the retry.DefaultBackoff with retry.DefaultRetry

### DIFF
--- a/pkg/controllers/execution/execution_controller.go
+++ b/pkg/controllers/execution/execution_controller.go
@@ -270,7 +270,7 @@ func (c *Controller) updateAppliedCondition(work *workv1alpha1.Work, status meta
 		LastTransitionTime: metav1.Now(),
 	}
 
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() (err error) {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() (err error) {
 		if err = c.Get(context.TODO(), client.ObjectKey{Namespace: work.Namespace, Name: work.Name}, work); err != nil {
 			return err
 		}

--- a/pkg/controllers/status/workstatus_controller.go
+++ b/pkg/controllers/status/workstatus_controller.go
@@ -292,7 +292,7 @@ func (c *WorkStatusController) reflectStatus(work *workv1alpha1.Work, clusterObj
 		manifestStatus.Status = rawExtension
 	}
 
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() (err error) {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() (err error) {
 		if err = c.Get(context.TODO(), client.ObjectKey{Namespace: work.Namespace, Name: work.Name}, work); err != nil {
 			return err
 		}

--- a/pkg/util/helper/workstatus.go
+++ b/pkg/util/helper/workstatus.go
@@ -59,7 +59,7 @@ func AggregateResourceBindingWorkStatus(c client.Client, binding *workv1alpha2.R
 		return nil
 	}
 
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() (err error) {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() (err error) {
 		if err = c.Get(context.TODO(), client.ObjectKey{Namespace: binding.Namespace, Name: binding.Name}, binding); err != nil {
 			return err
 		}
@@ -95,7 +95,7 @@ func AggregateClusterResourceBindingWorkStatus(c client.Client, binding *workv1a
 		return nil
 	}
 
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() (err error) {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() (err error) {
 		if err = c.Get(context.TODO(), client.ObjectKey{Name: binding.Name}, binding); err != nil {
 			return err
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
There are two backoff options for `retry.RetryOnConflict`:

```go
// DefaultRetry is the recommended retry for a conflict where multiple clients
// are making changes to the same resource.
var DefaultRetry = wait.Backoff{
 	Steps:    5,
 	Duration: 10 * time.Millisecond,
 	Factor:   1.0,
 	Jitter:   0.1,
 }
 
 // DefaultBackoff is the recommended backoff for a conflict where a client
 // may be attempting to make an unrelated modification to a resource under
 // active management by one or more controllers.
 var DefaultBackoff = wait.Backoff{
 	Steps:    4,
 	Duration: 10 * time.Millisecond,
 	Factor:   5.0,
 	Jitter:   0.1,
 }
 ```
 
The main difference between the two `backoff` is the retry interval(different `Factor`).
 
In our cases, we should use `DefaultRetry`, as we want the retry could be done as soon as possible.

**Which issue(s) this PR fixes**:
Fixes #1233

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

