### PR TITLE
mark override policy spec.targetCluster and spec.overriders deprecated

### DIFF
--- a/charts/_crds/bases/policy.karmada.io_clusteroverridepolicies.yaml
+++ b/charts/_crds/bases/policy.karmada.io_clusteroverridepolicies.yaml
@@ -309,8 +309,9 @@ spec:
                   type: object
                 type: array
               overriders:
-                description: Overriders represents the override rules that would apply
-                  on resources
+                description: "Overriders represents the override rules that would
+                  apply on resources \n Deprecated: This filed is deprecated in v1.0
+                  and please use the OverrideRules instead."
                 properties:
                   argsOverrider:
                     description: ArgsOverrider represents the rules dedicated to handling
@@ -529,9 +530,10 @@ spec:
                   type: object
                 type: array
               targetCluster:
-                description: TargetCluster defines restrictions on this override policy
-                  that only applies to resources propagated to the matching clusters.
-                  nil means matching all clusters.
+                description: "TargetCluster defines restrictions on this override
+                  policy that only applies to resources propagated to the matching
+                  clusters. nil means matching all clusters. \n Deprecated: This filed
+                  is deprecated in v1.0 and please use the OverrideRules instead."
                 properties:
                   clusterNames:
                     description: ClusterNames is the list of clusters to be selected.

--- a/charts/_crds/bases/policy.karmada.io_overridepolicies.yaml
+++ b/charts/_crds/bases/policy.karmada.io_overridepolicies.yaml
@@ -309,8 +309,9 @@ spec:
                   type: object
                 type: array
               overriders:
-                description: Overriders represents the override rules that would apply
-                  on resources
+                description: "Overriders represents the override rules that would
+                  apply on resources \n Deprecated: This filed is deprecated in v1.0
+                  and please use the OverrideRules instead."
                 properties:
                   argsOverrider:
                     description: ArgsOverrider represents the rules dedicated to handling
@@ -529,9 +530,10 @@ spec:
                   type: object
                 type: array
               targetCluster:
-                description: TargetCluster defines restrictions on this override policy
-                  that only applies to resources propagated to the matching clusters.
-                  nil means matching all clusters.
+                description: "TargetCluster defines restrictions on this override
+                  policy that only applies to resources propagated to the matching
+                  clusters. nil means matching all clusters. \n Deprecated: This filed
+                  is deprecated in v1.0 and please use the OverrideRules instead."
                 properties:
                   clusterNames:
                     description: ClusterNames is the list of clusters to be selected.

--- a/pkg/apis/policy/v1alpha1/override_types.go
+++ b/pkg/apis/policy/v1alpha1/override_types.go
@@ -32,10 +32,14 @@ type OverrideSpec struct {
 	// TargetCluster defines restrictions on this override policy
 	// that only applies to resources propagated to the matching clusters.
 	// nil means matching all clusters.
+	//
+	// Deprecated: This filed is deprecated in v1.0 and please use the OverrideRules instead.
 	// +optional
 	TargetCluster *ClusterAffinity `json:"targetCluster,omitempty"`
 
 	// Overriders represents the override rules that would apply on resources
+	//
+	// Deprecated: This filed is deprecated in v1.0 and please use the OverrideRules instead.
 	// +optional
 	Overriders Overriders `json:"overriders"`
 }

--- a/pkg/util/overridemanager/overridemanager.go
+++ b/pkg/util/overridemanager/overridemanager.go
@@ -185,8 +185,12 @@ func (o *overrideManagerImpl) getOverridersFromOverridePolicies(policies []Gener
 		if len(overrideRules) == 0 {
 			overrideRules = []policyv1alpha1.RuleWithCluster{
 				{
+					//nolint:staticcheck
+					// disable `deprecation` check for backward compatibility.
 					TargetCluster: policy.GetOverrideSpec().TargetCluster,
-					Overriders:    policy.GetOverrideSpec().Overriders,
+					//nolint:staticcheck
+					// disable `deprecation` check for backward compatibility.
+					Overriders: policy.GetOverrideSpec().Overriders,
 				},
 			}
 		}

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -85,6 +85,8 @@ func ValidateOverrideSpec(overrideSpec *policyv1alpha1.OverrideSpec) error {
 		return nil
 	}
 
+	//nolint:staticcheck
+	// disable `deprecation` check for backward compatibility.
 	if overrideSpec.TargetCluster != nil || !EmptyOverrides(overrideSpec.Overriders) {
 		return fmt.Errorf("overrideRules and (overriders or targetCluster) can't co-exist")
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind deprecation

**What this PR does / why we need it**:
Mark `spec.targetCluster` and `spec.overriders` deprecated in favor of `.spec.overrideRules`.

**Which issue(s) this PR fixes**:
Fixes #1113 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
OverridePolicy/ClusterOverridePolicy: The `.spec.targetCluster` and `spec.overriders` have been deprecated in favor of `spec.overrideRules`.
```

