### PR TITLE
[scheduler]fix a defer execution sequence problem

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -396,7 +396,7 @@ func (s *Scheduler) doSchedule(key string) error {
 	return s.doScheduleClusterBinding(name)
 }
 
-func (s *Scheduler) doScheduleBinding(namespace, name string) error {
+func (s *Scheduler) doScheduleBinding(namespace, name string) (err error) {
 	rb, err := s.bindingLister.ResourceBindings(namespace).Get(name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -458,7 +458,7 @@ func (s *Scheduler) doScheduleBinding(namespace, name string) error {
 	return nil
 }
 
-func (s *Scheduler) doScheduleClusterBinding(name string) error {
+func (s *Scheduler) doScheduleClusterBinding(name string) (err error) {
 	crb, err := s.clusterBindingLister.Get(name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {


### PR DESCRIPTION
Signed-off-by: huone1 <huwanxing@huawei.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
when **updateBindingScheduledConditionIfNeeded** return error, we should retry it in next loop according to the comments
but the error will not be used as a return value. 
https://github.com/karmada-io/karmada/blob/9167f9bce4fac02634bc3568977f24d0ae4b3213/pkg/scheduler/scheduler.go#L418-L423

just return nil even if **updateBindingScheduledConditionIfNeeded** return error
https://github.com/karmada-io/karmada/blob/9167f9bce4fac02634bc3568977f24d0ae4b3213/pkg/scheduler/scheduler.go#L456-L458

**Special notes for your reviewer**:
NONE
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

