### PR TITLE
Introduce `--resync-period` flag to specify reflector resync period

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -116,11 +115,9 @@ func run(ctx context.Context, karmadaConfig karmadactl.KarmadaConfig, opts *opti
 		return err
 	}
 
-	// TODO(Garrybest): add resyncPeriod to options
-	resyncPeriod := time.Duration(0)
 	controllerManager, err := controllerruntime.NewManager(controlPlaneRestConfig, controllerruntime.Options{
 		Scheme:                     gclient.NewSchema(),
-		SyncPeriod:                 &resyncPeriod,
+		SyncPeriod:                 &opts.ResyncPeriod.Duration,
 		Namespace:                  executionSpace,
 		LeaderElection:             opts.LeaderElection.LeaderElect,
 		LeaderElectionID:           fmt.Sprintf("karmada-agent-%s", opts.ClusterName),

--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -47,6 +47,9 @@ type Options struct {
 	KubeAPIBurst int
 
 	ClusterCacheSyncTimeout metav1.Duration
+	// ResyncPeriod is the base frequency the informers are resynced.
+	// Defaults to 0, which means the created informer will never do resyncs.
+	ResyncPeriod metav1.Duration
 
 	// ClusterAPIEndpoint holds the apiEndpoint of the cluster.
 	ClusterAPIEndpoint string
@@ -93,4 +96,5 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, allControllers []string) {
 	fs.DurationVar(&o.ClusterCacheSyncTimeout.Duration, "cluster-cache-sync-timeout", util.CacheSyncTimeout, "Timeout period waiting for cluster cache to sync.")
 	fs.StringVar(&o.ClusterAPIEndpoint, "cluster-api-endpoint", o.ClusterAPIEndpoint, "APIEndpoint of the cluster.")
 	fs.StringVar(&o.ProxyServerAddress, "proxy-server-address", o.ProxyServerAddress, "Address of the proxy server that is used to proxy to the cluster.")
+	fs.DurationVar(&o.ResyncPeriod.Duration, "resync-period", 0, "Base frequency the informers are resynced.")
 }

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"os"
 	"strconv"
-	"time"
 
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/discovery"
@@ -75,11 +74,9 @@ func Run(ctx context.Context, opts *options.Options) error {
 		panic(err)
 	}
 	config.QPS, config.Burst = opts.KubeAPIQPS, opts.KubeAPIBurst
-	// TODO(Garrybest): add resyncPeriod to options
-	resyncPeriod := time.Duration(0)
 	controllerManager, err := controllerruntime.NewManager(config, controllerruntime.Options{
 		Scheme:                     gclient.NewSchema(),
-		SyncPeriod:                 &resyncPeriod,
+		SyncPeriod:                 &opts.ResyncPeriod.Duration,
 		LeaderElection:             opts.LeaderElection.LeaderElect,
 		LeaderElectionID:           opts.LeaderElection.ResourceName,
 		LeaderElectionNamespace:    opts.LeaderElection.ResourceNamespace,

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -71,6 +71,9 @@ type Options struct {
 	KubeAPIBurst int
 	// ClusterCacheSyncTimeout is the timeout period waiting for cluster cache to sync
 	ClusterCacheSyncTimeout metav1.Duration
+	// ResyncPeriod is the base frequency the informers are resynced.
+	// Defaults to 0, which means the created informer will never do resyncs.
+	ResyncPeriod metav1.Duration
 }
 
 // NewOptions builds an empty options.
@@ -122,4 +125,5 @@ func (o *Options) AddFlags(flags *pflag.FlagSet, allControllers []string) {
 	flags.Float32Var(&o.KubeAPIQPS, "kube-api-qps", 40.0, "QPS to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")
 	flags.IntVar(&o.KubeAPIBurst, "kube-api-burst", 60, "Burst to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")
 	flags.DurationVar(&o.ClusterCacheSyncTimeout.Duration, "cluster-cache-sync-timeout", util.CacheSyncTimeout, "Timeout period waiting for cluster cache to sync.")
+	flags.DurationVar(&o.ResyncPeriod.Duration, "resync-period", 0, "Base frequency the informers are resynced.")
 }


### PR DESCRIPTION
Signed-off-by: Garrybest <garrybest@foxmail.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes part of #1260

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`/`karmada-agent`: introduced `--resync-period` flag to specify reflectors resync period(defaults to 0 means no resync)
```

