### PR TITLE
Update HookEnabled interface with resourceinterpreter

### DIFF
--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -102,7 +102,7 @@ func ensureWork(
 
 		workLabel := mergeLabel(clonedWorkload, workNamespace, binding, scope)
 
-		if hasScheduledReplica && resourceInterpreter.HookEnabled(clonedWorkload, configv1alpha1.InterpreterOperationReviseReplica) {
+		if hasScheduledReplica && resourceInterpreter.HookEnabled(clonedWorkload.GroupVersionKind(), configv1alpha1.InterpreterOperationReviseReplica) {
 			clonedWorkload, err = resourceInterpreter.ReviseReplica(clonedWorkload, desireReplicaInfos[targetCluster.Name])
 			if err != nil {
 				klog.Errorf("failed to revise replica for %s/%s/%s in cluster %s, err is: %v",

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -650,7 +650,7 @@ func (d *ResourceDetector) BuildResourceBinding(object *unstructured.Unstructure
 		},
 	}
 
-	if d.ResourceInterpreter.HookEnabled(object, configv1alpha1.InterpreterOperationInterpretReplica) {
+	if d.ResourceInterpreter.HookEnabled(object.GroupVersionKind(), configv1alpha1.InterpreterOperationInterpretReplica) {
 		replicas, replicaRequirements, err := d.ResourceInterpreter.GetReplicas(object)
 		if err != nil {
 			klog.Errorf("Failed to customize replicas for %s(%s), %v", object.GroupVersionKind(), object.GetName(), err)
@@ -686,7 +686,7 @@ func (d *ResourceDetector) BuildClusterResourceBinding(object *unstructured.Unst
 		},
 	}
 
-	if d.ResourceInterpreter.HookEnabled(object, configv1alpha1.InterpreterOperationInterpretReplica) {
+	if d.ResourceInterpreter.HookEnabled(object.GroupVersionKind(), configv1alpha1.InterpreterOperationInterpretReplica) {
 		replicas, replicaRequirements, err := d.ResourceInterpreter.GetReplicas(object)
 		if err != nil {
 			klog.Errorf("Failed to customize replicas for %s(%s), %v", object.GroupVersionKind(), object.GetName(), err)
@@ -1041,7 +1041,7 @@ func (d *ResourceDetector) ReconcileResourceBinding(key util.QueueKey) error {
 		return err
 	}
 
-	if !d.ResourceInterpreter.HookEnabled(obj, configv1alpha1.InterpreterOperationAggregateStatus) {
+	if !d.ResourceInterpreter.HookEnabled(obj.GroupVersionKind(), configv1alpha1.InterpreterOperationAggregateStatus) {
 		return nil
 	}
 	newObj, err := d.ResourceInterpreter.AggregateStatus(obj, binding.Status.AggregatedStatus)

--- a/pkg/util/interpreter/rules.go
+++ b/pkg/util/interpreter/rules.go
@@ -1,7 +1,7 @@
 package interpreter
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	configv1alpha1 "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1"
 )
@@ -13,9 +13,9 @@ const (
 
 // Matcher determines if the Object matches the Rule.
 type Matcher struct {
+	ObjGVK    schema.GroupVersionKind
 	Operation configv1alpha1.InterpreterOperation
 	Rule      configv1alpha1.RuleWithOperations
-	Object    *unstructured.Unstructured
 }
 
 // Matches tells if the Operation, Object matches the Rule.
@@ -33,15 +33,15 @@ func (m *Matcher) operation() bool {
 }
 
 func (m *Matcher) group() bool {
-	return exactOrWildcard(m.Object.GroupVersionKind().Group, m.Rule.APIGroups)
+	return exactOrWildcard(m.ObjGVK.Group, m.Rule.APIGroups)
 }
 
 func (m *Matcher) version() bool {
-	return exactOrWildcard(m.Object.GroupVersionKind().Version, m.Rule.APIVersions)
+	return exactOrWildcard(m.ObjGVK.Version, m.Rule.APIVersions)
 }
 
 func (m *Matcher) kind() bool {
-	return exactOrWildcard(m.Object.GetKind(), m.Rule.Kinds)
+	return exactOrWildcard(m.ObjGVK.Kind, m.Rule.Kinds)
 }
 
 func exactOrWildcard(requested string, items []string) bool {

--- a/pkg/util/objectwatcher/objectwatcher.go
+++ b/pkg/util/objectwatcher/objectwatcher.go
@@ -129,7 +129,7 @@ func (o *objectWatcherImpl) retainClusterFields(desired, observed *unstructured.
 	// and be set by user in karmada-controller-plane.
 	util.MergeAnnotations(desired, observed)
 
-	if o.resourceInterpreter.HookEnabled(desired, configv1alpha1.InterpreterOperationRetain) {
+	if o.resourceInterpreter.HookEnabled(desired.GroupVersionKind(), configv1alpha1.InterpreterOperationRetain) {
 		return o.resourceInterpreter.Retain(desired, observed)
 	}
 


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

`HookEnabled` interface with resource interpreter feature can be refactored to need objectGVK instead of object parameter.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

