### PR TITLE
introduce --tls-min-version flag to karmada-webhook

### DIFF
--- a/cmd/webhook/app/options/options.go
+++ b/cmd/webhook/app/options/options.go
@@ -5,9 +5,10 @@ import (
 )
 
 const (
-	defaultBindAddress = "0.0.0.0"
-	defaultPort        = 8443
-	defaultCertDir     = "/tmp/k8s-webhook-server/serving-certs"
+	defaultBindAddress   = "0.0.0.0"
+	defaultPort          = 8443
+	defaultCertDir       = "/tmp/k8s-webhook-server/serving-certs"
+	defaultTLSMinVersion = "1.3"
 )
 
 // Options contains everything necessary to create and run webhook server.
@@ -22,6 +23,11 @@ type Options struct {
 	// if not set, webhook server would look up the server key and certificate in {TempDir}/k8s-webhook-server/serving-certs.
 	// The server key and certificate must be named `tls.key` and `tls.crt`, respectively.
 	CertDir string
+	// TLSMinVersion is the minimum version of TLS supported. Possible values: 1.0, 1.1, 1.2, 1.3.
+	// Some environments have automated security scans that trigger on TLS versions or insecure cipher suites, and
+	// setting TLS to 1.3 would solve both problems.
+	// Defaults to 1.3.
+	TLSMinVersion string
 	// KubeAPIQPS is the QPS to use while talking with karmada-apiserver.
 	KubeAPIQPS float32
 	// KubeAPIBurst is the burst to allow while talking with karmada-apiserver.
@@ -41,6 +47,7 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 		"The secure port on which to serve HTTPS.")
 	flags.StringVar(&o.CertDir, "cert-dir", defaultCertDir,
 		"The directory that contains the server key(named tls.key) and certificate(named tls.crt).")
+	flags.StringVar(&o.TLSMinVersion, "tls-min-version", defaultTLSMinVersion, "Minimum TLS version supported. Possible values: 1.0, 1.1, 1.2, 1.3.")
 	flags.Float32Var(&o.KubeAPIQPS, "kube-api-qps", 40.0, "QPS to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")
 	flags.IntVar(&o.KubeAPIBurst, "kube-api-burst", 60, "Burst to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")
 }

--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -70,10 +70,13 @@ func Run(ctx context.Context, opts *options.Options) error {
 	config.QPS, config.Burst = opts.KubeAPIQPS, opts.KubeAPIBurst
 
 	hookManager, err := controllerruntime.NewManager(config, controllerruntime.Options{
-		Scheme:         gclient.NewSchema(),
-		Host:           opts.BindAddress,
-		Port:           opts.SecurePort,
-		CertDir:        opts.CertDir,
+		Scheme: gclient.NewSchema(),
+		WebhookServer: &webhook.Server{
+			Host:          opts.BindAddress,
+			Port:          opts.SecurePort,
+			CertDir:       opts.CertDir,
+			TLSMinVersion: opts.TLSMinVersion,
+		},
 		LeaderElection: false,
 	})
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Some users want to config the [TLS MinVersion](https://github.com/golang/go/blob/897b3da2e079b9b940b309747305a5379fffa6ec/src/crypto/tls/common.go#L685-L695) for karmada-webhook.

**Which issue(s) this PR fixes**:
Fixes #1272 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmadactl: Introduced `--tls-min-version` flag to specify the minimum TLS version.
```
