### PR TITLE
Enable multi replicas in CI 

### DIFF
--- a/artifacts/agent/karmada-agent.yaml
+++ b/artifacts/agent/karmada-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: karmada-agent
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: karmada-agent

--- a/artifacts/deploy/controller-manager.yaml
+++ b/artifacts/deploy/controller-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: karmada-controller-manager
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: karmada-controller-manager

--- a/artifacts/deploy/karmada-aggregated-apiserver.yaml
+++ b/artifacts/deploy/karmada-aggregated-apiserver.yaml
@@ -12,7 +12,7 @@ spec:
     matchLabels:
       app: karmada-aggregated-apiserver
       apiserver: "true"
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:

--- a/artifacts/deploy/karmada-scheduler-estimator.yaml
+++ b/artifacts/deploy/karmada-scheduler-estimator.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     cluster: {{member_cluster_name}}
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: karmada-scheduler-estimator-{{member_cluster_name}}

--- a/artifacts/deploy/karmada-scheduler.yaml
+++ b/artifacts/deploy/karmada-scheduler.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: karmada-scheduler
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: karmada-scheduler

--- a/artifacts/deploy/karmada-webhook.yaml
+++ b/artifacts/deploy/karmada-webhook.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: karmada-webhook
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: karmada-webhook


### PR DESCRIPTION
Signed-off-by: carlory <baofa.fan@daocloud.io>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Now, most Karmada components run only 1 replica in our CI environment, but users might deploy more than one replicas in the industry environment.

Enable multi-replica in the CI environment that may help find some issues.

**Which issue(s) this PR fixes**:
Fixes #1078 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

