### PR TITLE
print pod's log when waiting pod ready timeout

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -279,6 +279,8 @@ function util::wait_pod_ready() {
     if [ $ret -ne 0 ];then
       echo "kubectl describe info:"
       kubectl describe pod -l app=${pod_label} -n ${pod_namespace}
+      echo "kubectl logs info:"
+      kubectl logs -l app=${pod_label} -n ${pod_namespace}
     fi
     return ${ret}
 }


### PR DESCRIPTION
Signed-off-by: carlory <baofa.fan@daocloud.io>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

When the pod is in crashloopback state and there are no events to help troubleshoot the error, we need to query the pod's log to get more debug information.

for example: the webhook program fails to start due to a code logic error

```
kubectl logs info:
386
      --skip_headers                     If true, avoid header prefixes in the log messages
387
      --skip_log_headers                 If true, avoid headers when opening log files
388
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
389
      --tls-min-version string           Minimum TLS version supported. Possible values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13. (default "VersionTLS13")
390
  -v, --v Level                          number for the log level verbosity (default 0)
391
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
392

393
ada-webhook [command] --help" for more information about a command.
394

395
invalid TLSMinVersion VersionTLS13: expects 1.0, 1.1, 1.2, 1.3 or empty
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

