### PR TITLE
os.Exit will not wait for the defer function

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -10,12 +10,20 @@ import (
 )
 
 func main() {
+	if err := runSchedulerCmd(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func runSchedulerCmd() error {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
 	stopChan := apiserver.SetupSignalHandler()
-
-	if err := app.NewSchedulerCommand(stopChan).Execute(); err != nil {
-		os.Exit(1)
+	command := app.NewSchedulerCommand(stopChan)
+	if err := command.Execute(); err != nil {
+		return err
 	}
+
+	return nil
 }


### PR DESCRIPTION
Signed-off-by: kerthcet <kerthcet@gmail.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
os.Exit will not wait for the defer function

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Fix failed flushing logs when scheduler os.Exit(1).
```

