### PR TITLE
Automated cherry pick of #1265: set resync period to 0

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -115,8 +116,11 @@ func run(ctx context.Context, karmadaConfig karmadactl.KarmadaConfig, opts *opti
 		return err
 	}
 
+	// TODO(Garrybest): add resyncPeriod to options
+	resyncPeriod := time.Duration(0)
 	controllerManager, err := controllerruntime.NewManager(controlPlaneRestConfig, controllerruntime.Options{
 		Scheme:                     gclient.NewSchema(),
+		SyncPeriod:                 &resyncPeriod,
 		Namespace:                  executionSpace,
 		LeaderElection:             opts.LeaderElection.LeaderElect,
 		LeaderElectionID:           fmt.Sprintf("karmada-agent-%s", opts.ClusterName),

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/discovery"
@@ -74,8 +75,11 @@ func Run(ctx context.Context, opts *options.Options) error {
 		panic(err)
 	}
 	config.QPS, config.Burst = opts.KubeAPIQPS, opts.KubeAPIBurst
+	// TODO(Garrybest): add resyncPeriod to options
+	resyncPeriod := time.Duration(0)
 	controllerManager, err := controllerruntime.NewManager(config, controllerruntime.Options{
 		Scheme:                     gclient.NewSchema(),
+		SyncPeriod:                 &resyncPeriod,
 		LeaderElection:             opts.LeaderElection.LeaderElect,
 		LeaderElectionID:           opts.LeaderElection.ResourceName,
 		LeaderElectionNamespace:    opts.LeaderElection.ResourceNamespace,


### PR DESCRIPTION
Cherry pick of #1265 on release-1.0.
#1265: set resync period to 0
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```release-note
Fixed controller resync slow down reconcile issue.
```