### PR TITLE
karmada init: use external ip as karmada apiserver ip

### DIFF
--- a/pkg/karmadactl/cmdinit/kubernetes/node.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/node.go
@@ -20,6 +20,10 @@ var (
 )
 
 func (i *CommandInitOption) getKubeMasterIP() error {
+	if i.ExternalIP != "" {
+		i.KarmadaAPIServerIP = append(i.KarmadaAPIServerIP, utils.FlagsIP(i.ExternalIP)...)
+		return nil
+	}
 	nodeClient := i.KubeClientSet.CoreV1().Nodes()
 	masterNodes, err := nodeClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/master"})
 	if err != nil {


### PR DESCRIPTION

**What type of PR is this?**
use external ip as karmada apiserver ip

<!--
Add one of the following kinds:

/kind bug

-->

**What this PR does / why we need it**:
When installing karmada in an environment like kind, it will fail because karmada uses node ip and cannot access karmada api through it

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

