### PR TITLE
fix:  karmada join failed when secret exist

### DIFF
--- a/pkg/util/secret.go
+++ b/pkg/util/secret.go
@@ -43,9 +43,8 @@ func CreateSecret(client kubeclient.Interface, secret *corev1.Secret) (*corev1.S
 	st, err := client.CoreV1().Secrets(secret.Namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
-			return st, nil
+			return client.CoreV1().Secrets(secret.Namespace).Get(context.TODO(), secret.Name, metav1.GetOptions{})
 		}
-
 		return nil, err
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:


-->

**What this PR does / why we need it**:
when secret exist, will return empty secret: https://github.com/karmada-io/karmada/blob/master/pkg/util/secret.go#L46 
it will return error when create cluster:
```
W0123 15:16:21.031729 2061975 cluster.go:106] failed to create cluster(kind-kind-k8s-1-23). error: Cluster.cluster.karmada.io "kind-kind-k8s-1-23" is invalid: [spec.secretRef.namespace: Required value, spec.secretRef.name: Required value, spec.impersonatorSecretRef.namespace: Required value, spec.impersonatorSecretRef.name: Required value]
W0123 15:16:21.031749 2061975 cluster.go:50] failed to create cluster(kind-kind-k8s-1-23). error: Cluster.cluster.karmada.io "kind-kind-k8s-1-23" is invalid: [spec.secretRef.namespace: Required value, spec.secretRef.name: Required value, spec.impersonatorSecretRef.namespace: Required value, spec.impersonatorSecretRef.name: Required value]
Error: failed to create cluster(kind-kind-k8s-1-23) object. error: Cluster.cluster.karmada.io "kind-kind-k8s-1-23" is invalid: [spec.secretRef.namespace: Required value, spec.secretRef.name: Required value, spec.impersonatorSecretRef.namespace: Required value, spec.impersonatorSecretRef.name: Required value]
```

we should return error or secret.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: Fixed cluster fails to join in case of legacy secret exists.
```

