### PR TITLE
add plugin clusterLocality to favor cluster

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -115,6 +115,12 @@ func (g *genericScheduler) prioritizeClusters(
 		return result, err
 	}
 
+	if klog.V(4).Enabled() {
+		for plugin, nodeScoreList := range scoresMap {
+			klog.Infof("Plugin %s scores on %v/%v => %v", plugin, spec.Resource.Namespace, spec.Resource.Name, nodeScoreList)
+		}
+	}
+
 	result = make(framework.ClusterScoreList, len(clusters))
 	for i := range clusters {
 		result[i] = framework.ClusterScore{Cluster: clusters[i], Score: 0}

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -10,6 +10,14 @@ import (
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 )
 
+const (
+	// MinClusterScore is the minimum score a Score plugin is expected to return.
+	MinClusterScore int64 = 0
+
+	// MaxClusterScore is the maximum score a Score plugin is expected to return.
+	MaxClusterScore int64 = 100
+)
+
 // Framework manages the set of plugins in use by the scheduling framework.
 // Configured plugins are called at specified points in a scheduling context.
 type Framework interface {

--- a/pkg/scheduler/framework/plugins/clusteraffinity/cluster_affinity.go
+++ b/pkg/scheduler/framework/plugins/clusteraffinity/cluster_affinity.go
@@ -48,7 +48,7 @@ func (p *ClusterAffinity) Filter(ctx context.Context, placement *policyv1alpha1.
 // Score calculates the score on the candidate cluster.
 func (p *ClusterAffinity) Score(ctx context.Context, placement *policyv1alpha1.Placement,
 	spec *workv1alpha2.ResourceBindingSpec, cluster *clusterv1alpha1.Cluster) (int64, *framework.Result) {
-	return 0, framework.NewResult(framework.Success)
+	return framework.MinClusterScore, framework.NewResult(framework.Success)
 }
 
 // ScoreExtensions of the Score plugin.

--- a/pkg/scheduler/framework/plugins/clusterlocality/cluster_locality.go
+++ b/pkg/scheduler/framework/plugins/clusterlocality/cluster_locality.go
@@ -1,0 +1,66 @@
+package clusterlocality
+
+import (
+	"context"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/scheduler/framework"
+	"github.com/karmada-io/karmada/pkg/util"
+)
+
+const (
+	// Name is the name of the plugin used in the plugin registry and configurations.
+	Name = "ClusterLocality"
+)
+
+// ClusterLocality is a score plugin that favors cluster that already have requested.
+type ClusterLocality struct{}
+
+var _ framework.ScorePlugin = &ClusterLocality{}
+
+// New instantiates the clusteraffinity plugin.
+func New() framework.Plugin {
+	return &ClusterLocality{}
+}
+
+// Name returns the plugin name.
+func (p *ClusterLocality) Name() string {
+	return Name
+}
+
+// Score calculates the score on the candidate cluster.
+// if cluster object is exist in resourceBinding.Spec.Clusters, Score is 100, otherwise it is 0.
+func (p *ClusterLocality) Score(ctx context.Context, placement *policyv1alpha1.Placement,
+	spec *workv1alpha2.ResourceBindingSpec, cluster *clusterv1alpha1.Cluster) (int64, *framework.Result) {
+	if len(spec.Clusters) == 0 {
+		return framework.MinClusterScore, framework.NewResult(framework.Success)
+	}
+
+	replicas := util.GetSumOfReplicas(spec.Clusters)
+	if replicas <= 0 {
+		return framework.MinClusterScore, framework.NewResult(framework.Success)
+	}
+
+	if isClusterScheduled(cluster.Name, spec.Clusters) {
+		return framework.MaxClusterScore, framework.NewResult(framework.Success)
+	}
+
+	return framework.MinClusterScore, framework.NewResult(framework.Success)
+}
+
+// ScoreExtensions of the Score plugin.
+func (p *ClusterLocality) ScoreExtensions() framework.ScoreExtensions {
+	return nil
+}
+
+func isClusterScheduled(candidate string, schedulerClusters []workv1alpha2.TargetCluster) bool {
+	for _, cluster := range schedulerClusters {
+		if candidate == cluster.Name {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/scheduler/framework/plugins/registry.go
+++ b/pkg/scheduler/framework/plugins/registry.go
@@ -4,6 +4,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/scheduler/framework"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins/apiinstalled"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins/clusteraffinity"
+	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins/clusterlocality"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins/tainttoleration"
 )
 
@@ -13,5 +14,6 @@ func NewPlugins() map[string]framework.Plugin {
 		clusteraffinity.Name: clusteraffinity.New(),
 		tainttoleration.Name: tainttoleration.New(),
 		apiinstalled.Name:    apiinstalled.New(),
+		clusterlocality.Name: clusterlocality.New(),
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -36,6 +36,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/scheduler/core"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins/apiinstalled"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins/clusteraffinity"
+	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins/clusterlocality"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins/tainttoleration"
 	"github.com/karmada-io/karmada/pkg/scheduler/metrics"
 	"github.com/karmada-io/karmada/pkg/util"
@@ -99,7 +100,7 @@ func NewScheduler(dynamicClient dynamic.Interface, karmadaClient karmadaclientse
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 	schedulerCache := schedulercache.NewCache(clusterLister)
 	// TODO: make plugins as a flag
-	algorithm := core.NewGenericScheduler(schedulerCache, []string{clusteraffinity.Name, tainttoleration.Name, apiinstalled.Name})
+	algorithm := core.NewGenericScheduler(schedulerCache, []string{clusteraffinity.Name, tainttoleration.Name, apiinstalled.Name, clusterlocality.Name})
 	sched := &Scheduler{
 		DynamicClient:            dynamicClient,
 		KarmadaClient:            karmadaClient,


### PR DESCRIPTION
Signed-off-by: huone1 <huwanxing@huawei.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Currently, the spreadConstraint choose clusters just by clusterName.
in the rescheduling scenario, we hope the replicas in the scheduled clusters are not Migrated when they meet the filter conditions.
The plugin clusterlocality is aim to supply the preferred policy to favors cluster that already have requested.
**Which issue(s) this PR fixes**:
a part of https://github.com/karmada-io/karmada/issues/1330

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
add a score plugin clusterLocality to favors cluster that already have requested
```

