### PR TITLE
fixes gitVersion is missing from the latest image issue

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -14,6 +14,11 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v2
+        with:
+          # fetch-depth:
+          # 0 indicates all history for all branches and tags.
+          # for `git describe --tags` in Makefile.
+          fetch-depth: 0
       - name: install Go
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
Signed-off-by: zach593 <zach_li@outlook.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

fixed some build/CI bugs and **add automated image builds when publish new releases**

**Which issue(s) this PR fixes**:

- latest images didn't carry "GitVersion"
- versioned karmadactl/kubectl-karmada still ref to latest images, it causes https://github.com/karmada-io/karmada/issues/1291#issuecomment-1018307337 

**Special notes for your reviewer**:

just please feel free to let me know if there is anything needs improvements

**Does this PR introduce a user-facing change?**:

```release-note
None
```

