### PR TITLE
Introduce `--metrics-bind-address` and `--health-probe-bind-address` flags to `karmada-webhook`

### DIFF
--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -131,5 +131,5 @@ func (o *Options) AddFlags(flags *pflag.FlagSet, allControllers []string) {
 	flags.IntVar(&o.KubeAPIBurst, "kube-api-burst", 60, "Burst to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")
 	flags.DurationVar(&o.ClusterCacheSyncTimeout.Duration, "cluster-cache-sync-timeout", util.CacheSyncTimeout, "Timeout period waiting for cluster cache to sync.")
 	flags.DurationVar(&o.ResyncPeriod.Duration, "resync-period", 0, "Base frequency the informers are resynced.")
-	flags.StringVar(&o.MetricsBindAddress, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flags.StringVar(&o.MetricsBindAddress, "metrics-bind-address", ":8080", "The TCP address that the controller should bind to for serving prometheus metrics(e.g. 127.0.0.1:8088, :8088)")
 }

--- a/cmd/webhook/app/options/options.go
+++ b/cmd/webhook/app/options/options.go
@@ -32,6 +32,15 @@ type Options struct {
 	KubeAPIQPS float32
 	// KubeAPIBurst is the burst to allow while talking with karmada-apiserver.
 	KubeAPIBurst int
+	// MetricsBindAddress is the TCP address that the controller should bind to
+	// for serving prometheus metrics.
+	// It can be set to "0" to disable the metrics serving.
+	// Defaults to ":8080".
+	MetricsBindAddress string
+	// HealthProbeBindAddress is the TCP address that the controller should bind to
+	// for serving health probes
+	// Defaults to ":8000".
+	HealthProbeBindAddress string
 }
 
 // NewOptions builds an empty options.
@@ -50,4 +59,6 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&o.TLSMinVersion, "tls-min-version", defaultTLSMinVersion, "Minimum TLS version supported. Possible values: 1.0, 1.1, 1.2, 1.3.")
 	flags.Float32Var(&o.KubeAPIQPS, "kube-api-qps", 40.0, "QPS to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")
 	flags.IntVar(&o.KubeAPIBurst, "kube-api-burst", 60, "Burst to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")
+	flags.StringVar(&o.MetricsBindAddress, "metrics-bind-address", ":8080", "The TCP address that the controller should bind to for serving prometheus metrics(e.g. 127.0.0.1:8088, :8088)")
+	flags.StringVar(&o.HealthProbeBindAddress, "health-probe-bind-address", ":8000", "The TCP address that the controller should bind to for serving health probes(e.g. 127.0.0.1:8000, :8000)")
 }

--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -77,7 +77,9 @@ func Run(ctx context.Context, opts *options.Options) error {
 			CertDir:       opts.CertDir,
 			TLSMinVersion: opts.TLSMinVersion,
 		},
-		LeaderElection: false,
+		LeaderElection:         false,
+		MetricsBindAddress:     opts.MetricsBindAddress,
+		HealthProbeBindAddress: opts.HealthProbeBindAddress,
 	})
 	if err != nil {
 		klog.Errorf("failed to build webhook server: %v", err)


### PR DESCRIPTION
Signed-off-by: lihanbo <lihanbo2@huawei.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Some users want to config the MetricsBindAddress and HealthProbeBindAddress for karmada-webhook.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
It can be set to "0" to disable the metrics serving and health probe serving.

**Does this PR introduce a user-facing change?**:
```release-note
karmada-webhook: Introduced --metrics-bind-address and --health-probe-bind-address flags.
```

