### PR TITLE
fix default image tags for `<karmadactl/kubectl-karmada> init`

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -29,6 +29,6 @@ jobs:
           REGISTRY_USER_NAME: ${{secrets.SWR_REGISTRY_USER_NAME}}
           REGISTRY_PASSWORD: ${{secrets.SWR_REGISTRY_PASSWORD}}
           REGISTRY_SERVER_ADDRESS: ${{secrets.SWR_REGISTRY_SERVER_ADDRESS}}
-          VERSION: latest
+          IMAGE_PUSH_VERSION: latest
 
         run: make upload-images

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
             goos: darwin
     steps:
     - uses: actions/checkout@master
+      with:
+        # we might need history and tag info for `git describe --tags` in Makefile, especially when publishing
+        fetch-depth: 0
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
@@ -29,6 +32,7 @@ jobs:
       env:
         GOOS: ${{ matrix.goos }}
         GOARCH: ${{ matrix.goarch }}
+        VERSION: ${{ github.ref_name }}
     - name: Packaging...
       run: tar czf kubectl-karmada-${{ matrix.goos }}-${{ matrix.goarch }}.tgz kubectl-karmada LICENSE
     - name: Uploading assets...

--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -39,6 +39,7 @@ func NewCmdInit(cmdOut io.Writer, parentCommand string) *cobra.Command {
 			return nil
 		},
 	}
+	karmadaImageVersion := version.ImageVersion()
 	flags := cmd.PersistentFlags()
 	// cert
 	flags.StringVar(&opts.ExternalIP, "cert-external-ip", "", "the external IP of Karmada certificate (e.g 192.168.1.2,172.16.1.2)")
@@ -63,15 +64,15 @@ func NewCmdInit(cmdOut io.Writer, parentCommand string) *cobra.Command {
 	flags.StringVarP(&opts.KarmadaDataPath, "karmada-data", "d", "/etc/karmada", "karmada data path. kubeconfig cert and crds files")
 	flags.StringVarP(&opts.KarmadaAPIServerImage, "karmada-apiserver-image", "", "k8s.gcr.io/kube-apiserver:v1.21.7", "Kubernetes apiserver image")
 	flags.Int32VarP(&opts.KarmadaAPIServerReplicas, "karmada-apiserver-replicas", "", 1, "karmada apiserver replica set")
-	flags.StringVarP(&opts.KarmadaSchedulerImage, "karmada-scheduler-image", "", "swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-scheduler:latest", "karmada scheduler image")
+	flags.StringVarP(&opts.KarmadaSchedulerImage, "karmada-scheduler-image", "", fmt.Sprintf("swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-scheduler:%s", karmadaImageVersion), "karmada scheduler image")
 	flags.Int32VarP(&opts.KarmadaSchedulerReplicas, "karmada-scheduler-replicas", "", 1, "karmada scheduler replica set")
 	flags.StringVarP(&opts.KubeControllerManagerImage, "karmada-kube-controller-manager-image", "", "k8s.gcr.io/kube-controller-manager:v1.21.7", "Kubernetes controller manager image")
 	flags.Int32VarP(&opts.KubeControllerManagerReplicas, "karmada-kube-controller-manager-replicas", "", 1, "karmada kube controller manager replica set")
-	flags.StringVarP(&opts.KarmadaControllerManagerImage, "karmada-controller-manager-image", "", "swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-controller-manager:latest", "karmada controller manager  image")
+	flags.StringVarP(&opts.KarmadaControllerManagerImage, "karmada-controller-manager-image", "", fmt.Sprintf("swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-controller-manager:%s", karmadaImageVersion), "karmada controller manager image")
 	flags.Int32VarP(&opts.KarmadaControllerManagerReplicas, "karmada-controller-manager-replicas", "", 1, "karmada controller manager replica set")
-	flags.StringVarP(&opts.KarmadaWebhookImage, "karmada-webhook-image", "", "swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-webhook:latest", "karmada webhook image")
+	flags.StringVarP(&opts.KarmadaWebhookImage, "karmada-webhook-image", "", fmt.Sprintf("swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-webhook:%s", karmadaImageVersion), "karmada webhook image")
 	flags.Int32VarP(&opts.KarmadaWebhookReplicas, "karmada-webhook-replicas", "", 1, "karmada webhook replica set")
-	flags.StringVarP(&opts.KarmadaAggregatedAPIServerImage, "karmada-aggregated-apiserver-image", "", "swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-aggregated-apiserver:latest", "karmada aggregated apiserver image")
+	flags.StringVarP(&opts.KarmadaAggregatedAPIServerImage, "karmada-aggregated-apiserver-image", "", fmt.Sprintf("swr.ap-southeast-1.myhuaweicloud.com/karmada/karmada-aggregated-apiserver:%s", karmadaImageVersion), "karmada aggregated apiserver image")
 	flags.Int32VarP(&opts.KarmadaAggregatedAPIServerReplicas, "karmada-aggregated-apiserver-replicas", "", 1, "karmada aggregated apiserver replica set")
 
 	return cmd

--- a/pkg/karmadactl/karmadactl.go
+++ b/pkg/karmadactl/karmadactl.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit"
+	"github.com/karmada-io/karmada/pkg/version"
 	"github.com/karmada-io/karmada/pkg/version/sharedcommand"
 )
 
@@ -50,7 +51,14 @@ func NewKarmadaCtlCommand(out io.Writer, cmdUse, parentCommand string) *cobra.Co
 	karmadaConfig := NewKarmadaConfig(clientcmd.NewDefaultPathOptions())
 	rootCmd.AddCommand(NewCmdJoin(out, karmadaConfig, parentCommand))
 	rootCmd.AddCommand(NewCmdUnjoin(out, karmadaConfig, parentCommand))
-	rootCmd.AddCommand(sharedcommand.NewCmdVersion(out, parentCommand))
+	ver := sharedcommand.NewCmdVersion(out, parentCommand)
+	// print karmada image tags used by `karmadactl/kubectl-karmada init`.
+	inheritedRun := ver.Run
+	ver.Run = func(cmd *cobra.Command, args []string) {
+		inheritedRun(cmd, args)
+		fmt.Fprintf(out, "%s init images version: %s\n", parentCommand, version.ImageVersion())
+	}
+	rootCmd.AddCommand(ver)
 	rootCmd.AddCommand(NewCmdCordon(out, karmadaConfig, parentCommand))
 	rootCmd.AddCommand(NewCmdUncordon(out, karmadaConfig, parentCommand))
 	rootCmd.AddCommand(NewCmdGet(out, karmadaConfig, parentCommand))

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -12,4 +12,11 @@ var (
 	gitTreeState = "unknown" // state of git tree, either "clean" or "dirty"
 
 	buildDate = "unknown" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+	imageVersion = "latest"
 )
+
+// ImageVersion get karmada images tags for karmadactl/kubectl-karmada init.
+func ImageVersion() string {
+	return imageVersion
+}


### PR DESCRIPTION
Signed-off-by: zach593 <zach_li@outlook.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

- kubectl-karmada/karmadactl from releases will refer to other karmada components with static version when `<bin> init` by default

**Which issue(s) this PR fixes**:

- versioned karmadactl/kubectl-karmada still ref to latest images, it causes https://github.com/karmada-io/karmada/issues/1291#issuecomment-1018307337

**Special notes for your reviewer**:

these changes are split from https://github.com/karmada-io/karmada/pull/1345

**Does this PR introduce a user-facing change?**:

```release-note
kubectl-karmada/karmadactl from release will pull karmada components with the same version instead of "latest"
```

