### PR TITLE
remove duplicated `GetWorks` function

### DIFF
--- a/pkg/controllers/federatedresourcequota/federated_resource_quota_status_controller.go
+++ b/pkg/controllers/federatedresourcequota/federated_resource_quota_status_controller.go
@@ -127,7 +127,7 @@ func (c *StatusController) SetupWithManager(mgr controllerruntime.Manager) error
 }
 
 func (c *StatusController) collectQuotaStatus(quota *policyv1alpha1.FederatedResourceQuota) error {
-	workList, err := helper.GetWorks(c.Client, labels.Set{
+	workList, err := helper.GetWorksByLabelsSet(c.Client, labels.Set{
 		util.FederatedResourceQuotaNamespaceLabel: quota.Namespace,
 		util.FederatedResourceQuotaNameLabel:      quota.Name,
 	})

--- a/pkg/util/helper/binding.go
+++ b/pkg/util/helper/binding.go
@@ -89,18 +89,18 @@ func GetBindingClusterNames(targetClusters []workv1alpha2.TargetCluster, binding
 func FindOrphanWorks(c client.Client, bindingNamespace, bindingName string, clusterNames []string, scope apiextensionsv1.ResourceScope) ([]workv1alpha1.Work, error) {
 	var needJudgeWorks []workv1alpha1.Work
 	if scope == apiextensionsv1.NamespaceScoped {
-		workList, err := GetWorksByLabelSelector(c, labels.SelectorFromSet(labels.Set{
+		workList, err := GetWorksByLabelsSet(c, labels.Set{
 			workv1alpha2.ResourceBindingReferenceKey: names.GenerateBindingReferenceKey(bindingNamespace, bindingName),
-		}))
+		})
 		if err != nil {
 			klog.Errorf("Failed to get works by ResourceBinding(%s/%s): %v", bindingNamespace, bindingName, err)
 			return nil, err
 		}
 		needJudgeWorks = append(needJudgeWorks, workList.Items...)
 	} else {
-		workList, err := GetWorksByLabelSelector(c, labels.SelectorFromSet(labels.Set{
+		workList, err := GetWorksByLabelsSet(c, labels.Set{
 			workv1alpha2.ClusterResourceBindingReferenceKey: names.GenerateBindingReferenceKey("", bindingName),
-		}))
+		})
 		if err != nil {
 			klog.Errorf("Failed to get works by ClusterResourceBinding(%s): %v", bindingName, err)
 			return nil, err
@@ -199,14 +199,6 @@ func GetResourceBindings(c client.Client, ls labels.Set) (*workv1alpha2.Resource
 	return bindings, c.List(context.TODO(), bindings, listOpt)
 }
 
-// GetWorks returns a WorkList by labels
-func GetWorks(c client.Client, ls labels.Set) (*workv1alpha1.WorkList, error) {
-	works := &workv1alpha1.WorkList{}
-	listOpt := &client.ListOptions{LabelSelector: labels.SelectorFromSet(ls)}
-
-	return works, c.List(context.TODO(), works, listOpt)
-}
-
 // DeleteWorkByRBNamespaceAndName will delete all Work objects by ResourceBinding namespace and name.
 func DeleteWorkByRBNamespaceAndName(c client.Client, namespace, name string) error {
 	return DeleteWorks(c, labels.Set{
@@ -223,7 +215,7 @@ func DeleteWorkByCRBName(c client.Client, name string) error {
 
 // DeleteWorks will delete all Work objects by labels.
 func DeleteWorks(c client.Client, selector labels.Set) error {
-	workList, err := GetWorks(c, selector)
+	workList, err := GetWorksByLabelsSet(c, selector)
 	if err != nil {
 		klog.Errorf("Failed to get works by label %v: %v", selector, err)
 		return err

--- a/pkg/util/helper/work.go
+++ b/pkg/util/helper/work.go
@@ -69,13 +69,10 @@ func CreateOrUpdateWork(client client.Client, workMeta metav1.ObjectMeta, resour
 	return nil
 }
 
-// GetWorksByLabelSelector get WorkList by matching label selector.
-func GetWorksByLabelSelector(c client.Client, selector labels.Selector) (*workv1alpha1.WorkList, error) {
+// GetWorksByLabelsSet get WorkList by matching labels.Set.
+func GetWorksByLabelsSet(c client.Client, ls labels.Set) (*workv1alpha1.WorkList, error) {
 	workList := &workv1alpha1.WorkList{}
-	err := c.List(context.TODO(), workList, &client.ListOptions{LabelSelector: selector})
-	if err != nil {
-		return nil, err
-	}
+	listOpt := &client.ListOptions{LabelSelector: labels.SelectorFromSet(ls)}
 
-	return workList, nil
+	return workList, c.List(context.TODO(), workList, listOpt)
 }

--- a/pkg/util/helper/workstatus.go
+++ b/pkg/util/helper/workstatus.go
@@ -36,11 +36,9 @@ const (
 // AggregateResourceBindingWorkStatus will collect all work statuses with current ResourceBinding objects,
 // then aggregate status info to current ResourceBinding status.
 func AggregateResourceBindingWorkStatus(c client.Client, binding *workv1alpha2.ResourceBinding, workload *unstructured.Unstructured) error {
-	workList, err := GetWorksByLabelSelector(c, labels.SelectorFromSet(
-		labels.Set{
-			workv1alpha2.ResourceBindingReferenceKey: names.GenerateBindingReferenceKey(binding.Namespace, binding.Name),
-		},
-	))
+	workList, err := GetWorksByLabelsSet(c, labels.Set{
+		workv1alpha2.ResourceBindingReferenceKey: names.GenerateBindingReferenceKey(binding.Namespace, binding.Name),
+	})
 	if err != nil {
 		klog.Errorf("Failed to get works by ResourceBinding(%s/%s): %v", binding.Namespace, binding.Name, err)
 		return err
@@ -83,11 +81,9 @@ func AggregateResourceBindingWorkStatus(c client.Client, binding *workv1alpha2.R
 // AggregateClusterResourceBindingWorkStatus will collect all work statuses with current ClusterResourceBinding objects,
 // then aggregate status info to current ClusterResourceBinding status.
 func AggregateClusterResourceBindingWorkStatus(c client.Client, binding *workv1alpha2.ClusterResourceBinding, workload *unstructured.Unstructured) error {
-	workList, err := GetWorksByLabelSelector(c, labels.SelectorFromSet(
-		labels.Set{
-			workv1alpha2.ClusterResourceBindingReferenceKey: names.GenerateBindingReferenceKey("", binding.Name),
-		},
-	))
+	workList, err := GetWorksByLabelsSet(c, labels.Set{
+		workv1alpha2.ClusterResourceBindingReferenceKey: names.GenerateBindingReferenceKey("", binding.Name),
+	})
 	if err != nil {
 		klog.Errorf("Failed to get works by ClusterResourceBinding(%s): %v", binding.Name, err)
 		return err


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Functions `func GetWorks(c client.Client, ls labels.Set) (*workv1alpha1.WorkList, error)` and `func GetWorksByLabelSelector(c client.Client, selector labels.Selector) (*workv1alpha1.WorkList, error)` have the same effect, eliminating one of them.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

