### PR TITLE
fix bug: fix can not use '-v 6' to set log level when run kubectl-karmada

### DIFF
--- a/pkg/karmadactl/karmadactl.go
+++ b/pkg/karmadactl/karmadactl.go
@@ -7,8 +7,10 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
 	"k8s.io/client-go/tools/clientcmd"
 	apiserverflag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog/v2"
 
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit"
 	"github.com/karmada-io/karmada/pkg/version/sharedcommand"
@@ -29,6 +31,9 @@ func NewKarmadaCtlCommand(out io.Writer, cmdUse, parentCommand string) *cobra.Co
 
 		RunE: runHelp,
 	}
+
+	// Init log flags
+	klog.InitFlags(flag.CommandLine)
 
 	// Add the command line flags from other dependencies (e.g., klog), but do not
 	// warn if they contain underscores.


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind bug
**What this PR does / why we need it**:
fix bug: fix can not use '-v 6' to set log level when run kubectl-karmada
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
fix bug: fix can not use '-v 6' to set log level when run kubectl-karmada
```

