### PR TITLE
fix rb spec.Clusters is incorrent in some scenarios

### DIFF
--- a/pkg/scheduler/core/division_algorithm.go
+++ b/pkg/scheduler/core/division_algorithm.go
@@ -57,7 +57,7 @@ func divideReplicasByResource(
 		}
 		return newTargetClusters, nil
 	} else {
-		return spec.Clusters, nil
+		return scheduledClusters, nil
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: huone1 <huwanxing@huawei.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
this fix is a supplement to this fix #1383 .
There is a problem that the rb spec.Clusters is not updated to cluster A finally  in the following scenario:
![image](https://user-images.githubusercontent.com/71266853/157158281-5530bcbe-9a9a-45a5-96e5-32744123e20d.png)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

