### PR TITLE
delete the karmada data directory before installing with init

### DIFF
--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -70,7 +71,7 @@ type CommandInitOption struct {
 
 // Validate Check that there are enough flags to run the command.
 func (i *CommandInitOption) Validate(parentCommand string) error {
-	if !utils.PathIsExist(i.KubeConfig) {
+	if !utils.IsExist(i.KubeConfig) {
 		return fmt.Errorf("kubeconfig file does not exist.absolute path to the kubeconfig file")
 	}
 
@@ -126,6 +127,13 @@ func (i *CommandInitOption) Complete() error {
 	if i.EtcdStorageMode == "hostPath" && i.EtcdNodeSelectorLabels != "" {
 		if !i.isNodeExist(i.EtcdNodeSelectorLabels) {
 			return fmt.Errorf("no node found by label %s", i.EtcdNodeSelectorLabels)
+		}
+	}
+
+	// Determine whether KarmadaDataPath exists, if so, delete it
+	if utils.IsExist(i.KarmadaDataPath) {
+		if err := os.RemoveAll(i.KarmadaDataPath); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/karmadactl/cmdinit/utils/format.go
+++ b/pkg/karmadactl/cmdinit/utils/format.go
@@ -21,16 +21,10 @@ const (
 	labelSeparator = "="
 )
 
-// PathIsExist Determine whether the path exists
-func PathIsExist(path string) bool {
+// IsExist Determine whether the path exists
+func IsExist(path string) bool {
 	_, err := os.Stat(path)
-
-	if err != nil && os.IsNotExist(err) {
-		if err = os.MkdirAll(path, 0755); err != nil {
-			return false
-		}
-	}
-	return true
+	return err == nil
 }
 
 // StringToNetIP String To NetIP


### PR DESCRIPTION
Signed-off-by: prodan <pengshihaoren@gmail.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When the current host uses init to install karmada multiple times, the installation fails because the data directory of karmada is not empty.
**Which issue(s) this PR fixes**:
Fixes #1454 
Fixes #1467

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: Fixed `init` failure due to data path not clean issue.
```

