### PR TITLE
make webhook server certificate name and key name configurable

### DIFF
--- a/cmd/webhook/app/options/options.go
+++ b/cmd/webhook/app/options/options.go
@@ -21,8 +21,11 @@ type Options struct {
 	SecurePort int
 	// CertDir is the directory that contains the server key and certificate.
 	// if not set, webhook server would look up the server key and certificate in {TempDir}/k8s-webhook-server/serving-certs.
-	// The server key and certificate must be named `tls.key` and `tls.crt`, respectively.
 	CertDir string
+	// CertName is the server certificate name. Defaults to tls.crt.
+	CertName string
+	// KeyName is the server key name. Defaults to tls.key.
+	KeyName string
 	// TLSMinVersion is the minimum version of TLS supported. Possible values: 1.0, 1.1, 1.2, 1.3.
 	// Some environments have automated security scans that trigger on TLS versions or insecure cipher suites, and
 	// setting TLS to 1.3 would solve both problems.
@@ -57,7 +60,9 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 	flags.IntVar(&o.SecurePort, "secure-port", defaultPort,
 		"The secure port on which to serve HTTPS.")
 	flags.StringVar(&o.CertDir, "cert-dir", defaultCertDir,
-		"The directory that contains the server key(named tls.key) and certificate(named tls.crt).")
+		"The directory that contains the server key and certificate.")
+	flags.StringVar(&o.CertName, "tls-cert-file-name", "tls.crt", "The name of server certificate.")
+	flags.StringVar(&o.KeyName, "tls-private-key-file-name", "tls.key", "The name of server key.")
 	flags.StringVar(&o.TLSMinVersion, "tls-min-version", defaultTLSMinVersion, "Minimum TLS version supported. Possible values: 1.0, 1.1, 1.2, 1.3.")
 	flags.Float32Var(&o.KubeAPIQPS, "kube-api-qps", 40.0, "QPS to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")
 	flags.IntVar(&o.KubeAPIBurst, "kube-api-burst", 60, "Burst to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")

--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -80,6 +80,8 @@ func Run(ctx context.Context, opts *options.Options) error {
 			Host:          opts.BindAddress,
 			Port:          opts.SecurePort,
 			CertDir:       opts.CertDir,
+			CertName:      opts.CertName,
+			KeyName:       opts.KeyName,
 			TLSMinVersion: opts.TLSMinVersion,
 		},
 		LeaderElection:         false,


### PR DESCRIPTION
Signed-off-by: lihanbo <lihanbo2@huawei.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Make webhook server certificate name and key name configurable. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-webhook`: introduced `--tls-cert-file-name` and `--tls-private-key-file-name` flags to specify server certificate and private key.
```

