### PR TITLE
Automated cherry pick of #1444: Fix helm charts k8s version check

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # The optional kubeVersion field can define semver constraints on supported Kubernetes versions. 
 # Helm will validate the version constraints when installing the chart and fail if the cluster 
 # runs an unsupported Kubernetes version.
-kubeVersion: ">=1.16.0"
+kubeVersion: ">= 1.16.0-0"
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.


### PR DESCRIPTION
Cherry pick of #1444 on release-1.1.
#1444: Fix helm charts k8s version check
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```release-note
`helm chart`: fix version constraints skip pre-releases issue.
```