### PR TITLE
grouping flags for karmada-controller-manager

### DIFF
--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -121,8 +121,6 @@ func NewOptions() *Options {
 
 // AddFlags adds flags to the specified FlagSet.
 func (o *Options) AddFlags(flags *pflag.FlagSet, allControllers []string) {
-	flags.Lookup("kubeconfig").Usage = "Path to karmada control plane kubeconfig file."
-
 	flags.StringSliceVar(&o.Controllers, "controllers", []string{"*"}, fmt.Sprintf(
 		"A list of controllers to enable. '*' enables all on-by-default controllers, 'foo' enables the controller named 'foo', '-foo' disables the controller named 'foo'. All controllers: %s.",
 		strings.Join(allControllers, ", "),

--- a/pkg/sharedcli/commandusage.go
+++ b/pkg/sharedcli/commandusage.go
@@ -1,0 +1,55 @@
+package sharedcli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	cliflag "k8s.io/component-base/cli/flag"
+)
+
+const (
+	usageFmt = "Usage:\n  %s\n"
+)
+
+// generatesAvailableSubCommands generates command's subcommand information which
+// is usually part of a help message. E.g.:
+//
+// Available Commands:
+//   karmada-controller-manager completion                      generate the autocompletion script for the specified shell
+//   karmada-controller-manager help                            Help about any command
+//   karmada-controller-manager version                         Print the version information.
+//
+func generatesAvailableSubCommands(cmd *cobra.Command) []string {
+	if !cmd.HasAvailableSubCommands() {
+		return nil
+	}
+
+	info := []string{"\nAvailable Commands:"}
+	for _, sub := range cmd.Commands() {
+		if !sub.Hidden {
+			info = append(info, fmt.Sprintf("  %s %-30s  %s", cmd.CommandPath(), sub.Name(), sub.Short))
+		}
+	}
+	return info
+}
+
+// SetUsageAndHelpFunc set both usage and help function.
+func SetUsageAndHelpFunc(cmd *cobra.Command, fss cliflag.NamedFlagSets, cols int) {
+	cmd.SetUsageFunc(func(cmd *cobra.Command) error {
+		fmt.Fprintf(cmd.OutOrStderr(), usageFmt, cmd.UseLine())
+		if cmd.HasAvailableSubCommands() {
+			fmt.Fprintf(cmd.OutOrStderr(), "%s\n", strings.Join(generatesAvailableSubCommands(cmd), "\n"))
+		}
+		cliflag.PrintSections(cmd.OutOrStderr(), fss, cols)
+		return nil
+	})
+
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\n\n"+usageFmt, cmd.Long, cmd.UseLine())
+		if cmd.HasAvailableSubCommands() {
+			fmt.Fprintf(cmd.OutOrStdout(), "%s\n", strings.Join(generatesAvailableSubCommands(cmd), "\n"))
+		}
+		cliflag.PrintSections(cmd.OutOrStdout(), fss, cols)
+	})
+}

--- a/pkg/sharedcli/docs.go
+++ b/pkg/sharedcli/docs.go
@@ -1,0 +1,2 @@
+// Package sharedcli is the destination for common commands, flags or utils.
+package sharedcli

--- a/pkg/sharedcli/klogflag/klogflag.go
+++ b/pkg/sharedcli/klogflag/klogflag.go
@@ -1,0 +1,18 @@
+package klogflag
+
+import (
+	"flag"
+	"os"
+
+	"github.com/spf13/pflag"
+	"k8s.io/klog/v2"
+)
+
+// Add used to add klog flags to specified flag set.
+func Add(fs *pflag.FlagSet) {
+	// Since klog only accepts golang flag set, so introduce a shim here.
+	flagSetShim := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	klog.InitFlags(flagSetShim)
+
+	fs.AddGoFlagSet(flagSetShim)
+}

--- a/vendor/k8s.io/component-base/term/OWNERS
+++ b/vendor/k8s.io/component-base/term/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# Currently assigned this directory to sig-cli since the main use of
+# term seems to be for getting terminal size when printing help text.
+
+approvers:
+- sig-cli-maintainers
+reviewers:
+- sig-cli
+
+labels:
+- sig/cli

--- a/vendor/k8s.io/component-base/term/term.go
+++ b/vendor/k8s.io/component-base/term/term.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package term
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/moby/term"
+)
+
+// TerminalSize returns the current width and height of the user's terminal. If it isn't a terminal,
+// nil is returned. On error, zero values are returned for width and height.
+// Usually w must be the stdout of the process. Stderr won't work.
+func TerminalSize(w io.Writer) (int, int, error) {
+	outFd, isTerminal := term.GetFdInfo(w)
+	if !isTerminal {
+		return 0, 0, fmt.Errorf("given writer is no terminal")
+	}
+	winsize, err := term.GetWinsize(outFd)
+	if err != nil {
+		return 0, 0, err
+	}
+	return int(winsize.Width), int(winsize.Height), nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1328,6 +1328,7 @@ k8s.io/component-base/metrics
 k8s.io/component-base/metrics/legacyregistry
 k8s.io/component-base/metrics/prometheus/workqueue
 k8s.io/component-base/metrics/testutil
+k8s.io/component-base/term
 k8s.io/component-base/traces
 k8s.io/component-base/version
 # k8s.io/component-helpers v0.23.4


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Grouping flags for better readability.

Full help info now is:
<details>
<summary>Click here for full output</summary>

-bash-4.2# ./karmada-controller-manager --help 
The karmada controller manager runs a bunch of controllers

Usage:
  karmada-controller-manager [flags]

Available Commands:
  karmada-controller-manager completion                      generate the autocompletion script for the specified shell
  karmada-controller-manager help                            Help about any command
  karmada-controller-manager version                         Print the version information.

Generic flags:

      --bind-address string                                                                                                                                                                                                      
                The IP address on which to listen for the --secure-port port. (default "0.0.0.0")
      --cluster-api-burst int                                                                                                                                                                                                    
                Burst to use while talking with cluster kube-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags. (default 60)
      --cluster-api-context string                                                                                                                                                                                               
                Name of the cluster context in cluster-api management cluster kubeconfig file.
      --cluster-api-kubeconfig string                                                                                                                                                                                            
                Path to the cluster-api management cluster kubeconfig file.
      --cluster-api-qps float32                                                                                                                                                                                                  
                QPS to use while talking with cluster kube-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags. (default 40)
      --cluster-cache-sync-timeout duration                                                                                                                                                                                      
                Timeout period waiting for cluster cache to sync. (default 30s)
      --cluster-lease-duration duration                                                                                                                                                                                          
                Specifies the expiration period of a cluster lease. (default 40s)
      --cluster-lease-renew-interval-fraction float                                                                                                                                                                              
                Specifies the cluster lease renew interval fraction. (default 0.25)
      --cluster-monitor-grace-period duration                                                                                                                                                                                    
                Specifies the grace period of allowing a running cluster to be unresponsive before marking it unhealthy. (default 40s)
      --cluster-monitor-period duration                                                                                                                                                                                          
                Specifies how often karmada-controller-manager monitors cluster health status. (default 5s)
      --cluster-startup-grace-period duration                                                                                                                                                                                    
                Specifies the grace period of allowing a cluster to be unresponsive during startup before marking it unhealthy. (default 1m0s)
      --cluster-status-update-frequency duration                                                                                                                                                                                 
                Specifies how often karmada-controller-manager posts cluster status to karmada-apiserver. (default 10s)
      --concurrent-cluster-syncs int                                                                                                                                                                                             
                The number of Clusters that are allowed to sync concurrently. (default 5)
      --concurrent-clusterresourcebinding-syncs int                                                                                                                                                                              
                The number of ClusterResourceBindings that are allowed to sync concurrently. (default 5)
      --concurrent-namespace-syncs int                                                                                                                                                                                           
                The number of Namespaces that are allowed to sync concurrently. (default 1)
      --concurrent-resource-template-syncs int                                                                                                                                                                                   
                The number of resource templates that are allowed to sync concurrently. (default 5)
      --concurrent-resourcebinding-syncs int                                                                                                                                                                                     
                The number of ResourceBindings that are allowed to sync concurrently. (default 5)
      --concurrent-work-syncs int                                                                                                                                                                                                
                The number of Works that are allowed to sync concurrently. (default 5)
      --controllers strings                                                                                                                                                                                                      
                A list of controllers to enable. '*' enables all on-by-default controllers, 'foo' enables the controller named 'foo', '-foo' disables the controller named 'foo'. All controllers: binding, cluster, clusterStatus,
                endpointSlice, execution, federatedResourceQuotaStatus, federatedResourceQuotaSync, hpa, namespace, serviceExport, serviceImport, unifiedAuth, workStatus. (default [*])
      --feature-gates mapStringBool                                                                                                                                                                                              
                A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
                AllAlpha=true|false (ALPHA - default=false)
                AllBeta=true|false (BETA - default=false)
                Failover=true|false (ALPHA - default=false)
                PropagateDeps=true|false (ALPHA - default=false)
      --kube-api-burst int                                                                                                                                                                                                       
                Burst to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags. (default 60)
      --kube-api-qps float32                                                                                                                                                                                                     
                QPS to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags. (default 40)
      --kubeconfig string                                                                                                                                                                                                        
                Path to karmada control plane kubeconfig file.
      --leader-elect                                                                                                                                                                                                             
                Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability. (default true)
      --leader-elect-resource-namespace string                                                                                                                                                                                   
                The namespace of resource object that is used for locking during leader election. (default "karmada-system")
      --metrics-bind-address string                                                                                                                                                                                              
                The TCP address that the controller should bind to for serving prometheus metrics(e.g. 127.0.0.1:8088, :8088) (default ":8080")
      --rate-limiter-base-delay duration                                                                                                                                                                                         
                The base delay for rate limiter. (default 5ms)
      --rate-limiter-bucket-size int                                                                                                                                                                                             
                The bucket size for rate limier. (default 100)
      --rate-limiter-max-delay duration                                                                                                                                                                                          
                The max delay for rate limiter. (default 16m40s)
      --rate-limiter-qps int                                                                                                                                                                                                     
                The qps for rate limier. (default 10)
      --resync-period duration                                                                                                                                                                                                   
                Base frequency the informers are resynced.
      --secure-port int                                                                                                                                                                                                          
                The secure port on which to serve HTTPS. (default 10357)
      --skipped-propagating-apis string                                                                                                                                                                                          
                Semicolon separated resources that should be skipped from propagating in addition to the default skip list(cluster.karmada.io;policy.karmada.io;work.karmada.io). Supported formats are:
                <group> for skip resources with a specific API group(e.g. networking.k8s.io),
                <group>/<version> for skip resources with a specific API version(e.g. networking.k8s.io/v1beta1),
                <group>/<version>/<kind>,<kind> for skip one or more specific resource(e.g. networking.k8s.io/v1beta1/Ingress,IngressClass) where the kinds are case-insensitive.
      --skipped-propagating-namespaces strings                                                                                                                                                                                   
                Comma-separated namespaces that should be skipped from propagating in addition to the default skipped namespaces(karmada-system, karmada-cluster, namespaces prefixed by kube- and karmada-es-).

Logs flags:

      --add_dir_header                                                                                                                                                                                                           
                If true, adds the file directory to the header of the log messages
      --alsologtostderr                                                                                                                                                                                                          
                log to standard error as well as files
      --kubeconfig string                                                                                                                                                                                                        
                Paths to a kubeconfig. Only required if out-of-cluster.
      --log_backtrace_at traceLocation                                                                                                                                                                                           
                when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                                                                                                                                                                                                           
                If non-empty, write log files in this directory
      --log_file string                                                                                                                                                                                                          
                If non-empty, use this log file
      --log_file_max_size uint                                                                                                                                                                                                   
                Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
      --logtostderr                                                                                                                                                                                                              
                log to standard error instead of files (default true)
      --one_output                                                                                                                                                                                                               
                If true, only write logs to their native severity level (vs also writing to each lower severity level)
      --skip_headers                                                                                                                                                                                                             
                If true, avoid header prefixes in the log messages
      --skip_log_headers                                                                                                                                                                                                         
                If true, avoid headers when opening log files
      --stderrthreshold severity                                                                                                                                                                                                 
                logs at or above this threshold go to stderr (default 2)
  -v, --v Level                                                                                                                                                                                                                  
                number for the log level verbosity
      --vmodule moduleSpec                                                                                                                                                                                                       
                comma-separated list of pattern=N settings for file-filtered logging

</details>

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR focus on grouping klog flags.

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-controller-manager`: The klog flags now have been grouped for better readability.
```

