### PR TITLE
Automated cherry pick of #1455: delete the karmada data directory before installing with init

### DIFF
--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -70,7 +71,7 @@ type CommandInitOption struct {
 
 // Validate Check that there are enough flags to run the command.
 func (i *CommandInitOption) Validate(parentCommand string) error {
-	if !utils.PathIsExist(i.KubeConfig) {
+	if !utils.IsExist(i.KubeConfig) {
 		return fmt.Errorf("kubeconfig file does not exist.absolute path to the kubeconfig file")
 	}
 
@@ -126,6 +127,13 @@ func (i *CommandInitOption) Complete() error {
 	if i.EtcdStorageMode == "hostPath" && i.EtcdNodeSelectorLabels != "" {
 		if !i.isNodeExist(i.EtcdNodeSelectorLabels) {
 			return fmt.Errorf("no node found by label %s", i.EtcdNodeSelectorLabels)
+		}
+	}
+
+	// Determine whether KarmadaDataPath exists, if so, delete it
+	if utils.IsExist(i.KarmadaDataPath) {
+		if err := os.RemoveAll(i.KarmadaDataPath); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/karmadactl/cmdinit/utils/format.go
+++ b/pkg/karmadactl/cmdinit/utils/format.go
@@ -21,16 +21,10 @@ const (
 	labelSeparator = "="
 )
 
-//PathIsExist Determine whether the path exists
-func PathIsExist(path string) bool {
+// IsExist Determine whether the path exists
+func IsExist(path string) bool {
 	_, err := os.Stat(path)
-
-	if err != nil && os.IsNotExist(err) {
-		if err = os.MkdirAll(path, 0755); err != nil {
-			return false
-		}
-	}
-	return true
+	return err == nil
 }
 
 //StringToNetIP String To NetIP


### PR DESCRIPTION
Cherry pick of #1455 on release-1.0.
#1455: delete the karmada data directory before installing with init
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```release-note
`karmadactl`: Fixed `init` failure due to data path not clean issue.
```