### PR TITLE
Enable `karmadactl get` command to leverage aggregated API

### DIFF
--- a/pkg/karmadactl/get_flags.go
+++ b/pkg/karmadactl/get_flags.go
@@ -42,7 +42,8 @@ const (
 )
 
 var (
-	defaultCacheDir = filepath.Join(homedir.HomeDir(), ".kube", "cache")
+	defaultKubeConfig = filepath.Join(homedir.HomeDir(), ".kube", "config")
+	defaultCacheDir   = filepath.Join(homedir.HomeDir(), ".kube", "cache")
 	// ErrEmptyConfig is the error message to be displayed if the configuration info is missing or incomplete
 	ErrEmptyConfig = clientcmd.NewEmptyConfigError(
 		`Missing or incomplete configuration info.  Please point to an existing, complete config file:
@@ -170,6 +171,7 @@ func (f *ConfigFlags) ToRawKubeConfigLoader() clientcmd.ClientConfig {
 	return f.toRawKubeConfigLoader()
 }
 
+//nolint:gocyclo
 func (f *ConfigFlags) toRawKubeConfigLoader() clientcmd.ClientConfig {
 	//loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	loadingRules := &clientcmd.ClientConfigLoadingRules{}
@@ -182,7 +184,10 @@ func (f *ConfigFlags) toRawKubeConfigLoader() clientcmd.ClientConfig {
 	}
 
 	clusterOverrides := clientcmd.ClusterDefaults
-	clusterOverrides.CertificateAuthorityData = []byte(*f.CaBundle)
+	if f.CaBundle != nil {
+		clusterOverrides.CertificateAuthorityData = []byte(*f.CaBundle)
+	}
+
 	overrides := &clientcmd.ConfigOverrides{ClusterDefaults: clusterOverrides}
 
 	// bind auth info flag values to overrides


### PR DESCRIPTION
Signed-off-by: lonelyCZ <531187475@qq.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
step1: Use `cluster/proxy` to access resources of member clusters.

step2: Authorize `system:admin` to use `cluster/proxy` when join a member cluster to control plane.

When users don't have right to use `cluster/proxy` resource:
```
[root@master67 karmada]# ./karmadactl get pod
Error: users "system:admin" is forbidden: User "system:serviceaccount:karmada-cluster:karmada-impersonator" cannot impersonate resource "users" in API group "" at the cluster scope
```

**Which issue(s) this PR fixes**:
Fixes #1329 

**Special notes for your reviewer**:
There are some key points needing to resolve.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Enable `karmadactl get` command to leverage aggregated API
```

