### PR TITLE
Automated cherry pick of #1437: fix `karmadactl init` can not read KUBECONFIG environment variable issue

### DIFF
--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -3,8 +3,6 @@ package cmdinit
 import (
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -46,7 +44,7 @@ func NewCmdInit(cmdOut io.Writer, parentCommand string) *cobra.Command {
 	// Kubernetes
 	flags.StringVarP(&opts.Namespace, "namespace", "n", "karmada-system", "Kubernetes namespace")
 	flags.StringVar(&opts.StorageClassesName, "storage-classes-name", "", "Kubernetes StorageClasses Name")
-	flags.StringVar(&opts.KubeConfig, "kubeconfig", filepath.Join(homeDir(), ".kube", "config"), "absolute path to the kubeconfig file")
+	flags.StringVar(&opts.KubeConfig, "kubeconfig", "", "absolute path to the kubeconfig file")
 	// etcd
 	flags.StringVarP(&opts.EtcdStorageMode, "etcd-storage-mode", "", "emptyDir",
 		"etcd data storage mode(emptyDir,hostPath,PVC). value is PVC, specify --storage-classes-name")
@@ -108,11 +106,4 @@ func getInitExample(parentCommand string) string {
 ` + parentCommand + ` init --cert-external-ip 10.235.1.2 --cert-external-dns www.karmada.io
 `
 	return initExample
-}
-
-func homeDir() string {
-	if h := os.Getenv("HOME"); h != "" {
-		return h
-	}
-	return os.Getenv("USERPROFILE") // windows
 }

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -33,6 +34,8 @@ var certList = []string{
 	options.FrontProxyCaCertAndKeyName,
 	options.FrontProxyClientCertAndKeyName,
 }
+
+var defaultKubeConfig = filepath.Join(homeDir(), ".kube", "config")
 
 // CommandInitOption holds all flags options for init.
 type CommandInitOption struct {
@@ -71,10 +74,6 @@ type CommandInitOption struct {
 
 // Validate Check that there are enough flags to run the command.
 func (i *CommandInitOption) Validate(parentCommand string) error {
-	if !utils.IsExist(i.KubeConfig) {
-		return fmt.Errorf("kubeconfig file does not exist.absolute path to the kubeconfig file")
-	}
-
 	if i.EtcdStorageMode == "hostPath" && i.EtcdHostDataPath == "" {
 		return fmt.Errorf("when etcd storage mode is hostPath, dataPath is not empty. See '%s init --help'", parentCommand)
 	}
@@ -96,6 +95,16 @@ func (i *CommandInitOption) Validate(parentCommand string) error {
 
 // Complete Initialize k8s client
 func (i *CommandInitOption) Complete() error {
+	// check config path of host kubernetes cluster
+	if i.KubeConfig == "" {
+		env := os.Getenv("KUBECONFIG")
+		if env != "" {
+			i.KubeConfig = env
+		} else {
+			i.KubeConfig = defaultKubeConfig
+		}
+	}
+
 	restConfig, err := utils.RestConfig(i.KubeConfig)
 	if err != nil {
 		return err
@@ -435,4 +444,11 @@ func (i *CommandInitOption) RunInit(_ io.Writer, parentCommand string) error {
 
 	utils.GenExamples(i.KarmadaDataPath, parentCommand)
 	return nil
+}
+
+func homeDir() string {
+	if h := os.Getenv("HOME"); h != "" {
+		return h
+	}
+	return os.Getenv("USERPROFILE") // windows
 }


### PR DESCRIPTION
Cherry pick of #1437 on release-1.1.
#1437: can not read KUBECONFIG
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```release-note
Fix `karmadactl init` can not read KUBECONFIG environment variable issue
```