### PR TITLE
bugfix: update binding status when work's applied condition status changed

### DIFF
--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -27,18 +27,18 @@ var workPredicateFn = builder.WithPredicates(predicate.Funcs{
 		return false
 	},
 	UpdateFunc: func(e event.UpdateEvent) bool {
-		var statusesOld, statusesNew []workv1alpha1.ManifestStatus
+		var statusesOld, statusesNew workv1alpha1.WorkStatus
 
 		switch oldWork := e.ObjectOld.(type) {
 		case *workv1alpha1.Work:
-			statusesOld = oldWork.Status.ManifestStatuses
+			statusesOld = oldWork.Status
 		default:
 			return false
 		}
 
 		switch newWork := e.ObjectNew.(type) {
 		case *workv1alpha1.Work:
-			statusesNew = newWork.Status.ManifestStatuses
+			statusesNew = newWork.Status
 		default:
 			return false
 		}


### PR DESCRIPTION
Signed-off-by: lihanbo <lihanbo2@huawei.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When execution controller update resource failed, the work's fully applied condition will be set to `False`, but the `ManifestStatuses ` won't be changed(as updated failed). Under this circumstance，binding controller also need to aggregate  work status.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-controller-manager`: Fixed RB/CRB controller can't aggregate status in case of work condition update issue.
```

