### PR TITLE
Automated cherry pick of #1512:  fix the fulluapplied status is wrong in some scenario

### DIFF
--- a/pkg/util/helper/workstatus_test.go
+++ b/pkg/util/helper/workstatus_test.go
@@ -1,0 +1,108 @@
+package helper
+
+import (
+	"testing"
+
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+)
+
+func TestWorksFullyApplied(t *testing.T) {
+	type args struct {
+		aggregatedStatuses []workv1alpha2.AggregatedStatusItem
+		targetClusters     []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "no cluster",
+			args: args{
+				aggregatedStatuses: []workv1alpha2.AggregatedStatusItem{
+					{
+						ClusterName: "member1",
+						Applied:     true,
+					},
+				},
+				targetClusters: nil,
+			},
+			want: false,
+		},
+		{
+			name: "no aggregatedStatuses",
+			args: args{
+				aggregatedStatuses: nil,
+				targetClusters:     []string{"member1"},
+			},
+			want: false,
+		},
+		{
+			name: "cluster size is not equal to aggregatedStatuses",
+			args: args{
+				aggregatedStatuses: []workv1alpha2.AggregatedStatusItem{
+					{
+						ClusterName: "member1",
+						Applied:     true,
+					},
+				},
+				targetClusters: []string{"member1", "member2"},
+			},
+			want: false,
+		},
+		{
+			name: "aggregatedStatuses is equal to clusterNames and all applied",
+			args: args{
+				aggregatedStatuses: []workv1alpha2.AggregatedStatusItem{
+					{
+						ClusterName: "member1",
+						Applied:     true,
+					},
+					{
+						ClusterName: "member2",
+						Applied:     true,
+					},
+				},
+				targetClusters: []string{"member1", "member2"},
+			},
+			want: true,
+		},
+		{
+			name: "aggregatedStatuses is equal to clusterNames but not all applied",
+			args: args{
+				aggregatedStatuses: []workv1alpha2.AggregatedStatusItem{
+					{
+						ClusterName: "member1",
+						Applied:     true,
+					},
+					{
+						ClusterName: "member2",
+						Applied:     false,
+					},
+				},
+				targetClusters: []string{"member1", "member2"},
+			},
+			want: false,
+		},
+		{
+			name: "target clusters not match expected status",
+			args: args{
+				aggregatedStatuses: []workv1alpha2.AggregatedStatusItem{
+					{
+						ClusterName: "member1",
+						Applied:     true,
+					},
+				},
+				targetClusters: []string{"member2"},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := worksFullyApplied(tt.args.aggregatedStatuses, tt.args.targetClusters); got != tt.want {
+				t.Errorf("worksFullyApplied() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cherry pick of #1512 on release-1.1.
#1512:  fix the fulluapplied status is wrong in some scenario
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```release-note
`karmada-controller-manager`: Fixed the `FullyApplied` condition of `ResourceBinding/ClusterResourceBinding` mislabeling issue in case of non-scheduled. 
```