### PR TITLE
bump alpine base image from v3.7 to v3.15.1

### DIFF
--- a/cluster/images/karmada-agent/Dockerfile
+++ b/cluster/images/karmada-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.15.1
 
 RUN apk add --no-cache ca-certificates
 

--- a/cluster/images/karmada-aggregated-apiserver/Dockerfile
+++ b/cluster/images/karmada-aggregated-apiserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.15.1
 
 RUN apk add --no-cache ca-certificates
 

--- a/cluster/images/karmada-controller-manager/Dockerfile
+++ b/cluster/images/karmada-controller-manager/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.15.1
 
 RUN apk add --no-cache ca-certificates
 

--- a/cluster/images/karmada-descheduler/Dockerfile
+++ b/cluster/images/karmada-descheduler/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.15.1
 
 RUN apk add --no-cache ca-certificates
 

--- a/cluster/images/karmada-interpreter-webhook-example/Dockerfile
+++ b/cluster/images/karmada-interpreter-webhook-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.15.1
 
 RUN apk add --no-cache ca-certificates
 

--- a/cluster/images/karmada-scheduler-estimator/Dockerfile
+++ b/cluster/images/karmada-scheduler-estimator/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.15.1
 
 RUN apk add --no-cache ca-certificates
 

--- a/cluster/images/karmada-scheduler/Dockerfile
+++ b/cluster/images/karmada-scheduler/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.15.1
 
 RUN apk add --no-cache ca-certificates
 

--- a/cluster/images/karmada-webhook/Dockerfile
+++ b/cluster/images/karmada-webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.15.1
 
 RUN apk add --no-cache ca-certificates
 

--- a/hack/local-up-karmada.sh
+++ b/hack/local-up-karmada.sh
@@ -50,7 +50,7 @@ dockerfile_list=( # Dockerfile files need to be replaced
   "cluster/images/karmada-aggregated-apiserver/Dockerfile"
 )
 for dockerfile in "${dockerfile_list[@]}"; do
-  grep 'mirrors.ustc.edu.cn' ${REPO_ROOT}/${dockerfile} > /dev/null || sed -i'' -e "s#FROM alpine:3.7#FROM alpine:3.7\nRUN echo -e http://mirrors.ustc.edu.cn/alpine/v3.7/main/ > /etc/apk/repositories#" ${REPO_ROOT}/${dockerfile}
+  grep 'mirrors.ustc.edu.cn' ${REPO_ROOT}/${dockerfile} > /dev/null || sed -i'' -e "s#FROM alpine:3.15.1#FROM alpine:3.15.1\nRUN echo -e http://mirrors.ustc.edu.cn/alpine/v3.15/main/ > /etc/apk/repositories#" ${REPO_ROOT}/${dockerfile}
 done
 fi
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR updated the alpine base image from v3.7 to v3.15.1 because v3.7 is not supported now.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

