### PR TITLE
Automated cherry pick of #1513: bugfix: aggregate status to binding when work's applied condition status changed

### DIFF
--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -27,18 +27,18 @@ var workPredicateFn = builder.WithPredicates(predicate.Funcs{
 		return false
 	},
 	UpdateFunc: func(e event.UpdateEvent) bool {
-		var statusesOld, statusesNew []workv1alpha1.ManifestStatus
+		var statusesOld, statusesNew workv1alpha1.WorkStatus
 
 		switch oldWork := e.ObjectOld.(type) {
 		case *workv1alpha1.Work:
-			statusesOld = oldWork.Status.ManifestStatuses
+			statusesOld = oldWork.Status
 		default:
 			return false
 		}
 
 		switch newWork := e.ObjectNew.(type) {
 		case *workv1alpha1.Work:
-			statusesNew = newWork.Status.ManifestStatuses
+			statusesNew = newWork.Status
 		default:
 			return false
 		}


### PR DESCRIPTION
Cherry pick of #1513 on release-1.0.
#1513: bugfix: aggregate status to binding when work's applied condition status changed
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```release-note
`karmada-controller-manager`: Fixed RB/CRB controller can't aggregate status in case of work condition update issue.
```