### PR TITLE
Add cluster proxy rbac for admin when deploy Karmada control plane

### DIFF
--- a/artifacts/deploy/cluster-proxy-admin-rbac.yaml
+++ b/artifacts/deploy/cluster-proxy-admin-rbac.yaml
@@ -1,0 +1,26 @@
+# This configuration is used to authorize system:admin to proxy member clusters,
+# if you don't need it, you can remove it from karmada control plane.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-proxy-admin
+rules:
+- apiGroups:
+  - 'cluster.karmada.io'
+  resources:
+  - clusters/proxy
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-proxy-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-proxy-admin
+subjects:
+  - kind: User
+    name: "system:admin"

--- a/hack/deploy-karmada.sh
+++ b/hack/deploy-karmada.sh
@@ -227,6 +227,9 @@ kubectl apply -f "${REPO_ROOT}/artifacts/deploy/apiservice.yaml"
 # make sure apiservice for v1alpha1.cluster.karmada.io is Available
 util::wait_apiservice_ready "${KARMADA_AGGREGATION_APISERVER_LABEL}"
 
+# deploy cluster proxy rbac for admin
+kubectl apply -f "${REPO_ROOT}/artifacts/deploy/cluster-proxy-admin-rbac.yaml"
+
 kubectl config use-context "${HOST_CLUSTER_NAME}"
 
 # deploy controller-manager on host cluster


### PR DESCRIPTION
Signed-off-by: lonelyCZ <531187475@qq.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
`system:admin` should have highest authority to access all member cluster, so add rbac for admin when deploy Karmada control plane.

**Which issue(s) this PR fixes**:
Part of #1329 

**Special notes for your reviewer**:
For this https://github.com/karmada-io/karmada/pull/1478#issuecomment-1076274176 , we need to discuss where to put notifications to users.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

