### PR TITLE
Build and push release image to SWR and DockerHub

### DIFF
--- a/.github/workflows/dockerhub-released-image.yml
+++ b/.github/workflows/dockerhub-released-image.yml
@@ -1,0 +1,44 @@
+name: released image to DockerHub
+on:
+  release:
+    types:
+      - published
+jobs:
+  publish-image-to-dockerhub:
+    name: publish to DockerHub
+    strategy:
+      matrix:
+        target:
+          - karmada-controller-manager
+          - karmada-scheduler
+          - karmada-webhook
+          - karmada-agent
+          - karmada-scheduler-estimator
+          - karmada-interpreter-webhook-example
+          - karmada-aggregated-apiserver
+    runs-on: ubuntu-18.04
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+        with:
+          # fetch-depth:
+          # 0 indicates all history for all branches and tags.
+          # for `git describe --tags` in Makefile.
+          fetch-depth: 0
+      - name: install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.x
+      - name: install QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: install Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER_NAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: build and publish images
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: make mp-image-${{ matrix.target }}

--- a/.github/workflows/swr-released-image.yml
+++ b/.github/workflows/swr-released-image.yml
@@ -1,4 +1,4 @@
-name: Release Images
+name: released image to SWR
 on:
   release:
     types:

--- a/Makefile
+++ b/Makefile
@@ -158,10 +158,6 @@ mp-image-karmada-scheduler: karmada-scheduler
 	docker buildx build --push --platform=${PLATFORMS} --tag=karmada/karmada-scheduler:${VERSION} --file=cluster/images/karmada-scheduler/Dockerfile .
 
 # Build and push multi-platform image to DockerHub
-mp-image-karmada-descheduler: karmada-descheduler
-	docker buildx build --push --platform=${PLATFORMS} --tag=karmada/karmada-descheduler:${VERSION} --file=cluster/images/karmada-descheduler/Dockerfile .
-
-# Build and push multi-platform image to DockerHub
 mp-image-karmada-webhook: karmada-webhook
 	docker buildx build --push --platform=${PLATFORMS} --tag=karmada/karmada-webhook:${VERSION} --file=cluster/images/karmada-webhook/Dockerfile .
 
@@ -184,7 +180,6 @@ mp-image-karmada-aggregated-apiserver: karmada-aggregated-apiserver
 # Build and push multi-platform images to DockerHub.
 multi-platform-images: mp-image-karmada-controller-manager \
  mp-image-karmada-scheduler \
- mp-image-karmada-descheduler \
  mp-image-karmada-webhook \
  mp-image-karmada-agent \
  mp-image-karmada-scheduler-estimator \


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Build and push release image to SWR and DockerHub.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Before #1515  we add `mp-image-karmada-descheduler` in Makefile, but `release-1.1` do not have `karmada-descheduler` in Makefile.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Build and push release image to SWR and DockerHub.
```

