### PR TITLE
update the judgement for setting completions with job

### DIFF
--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -95,12 +95,14 @@ func ensureWork(
 
 		workLabel := mergeLabel(clonedWorkload, workNamespace, binding, scope)
 
-		if hasScheduledReplica && resourceInterpreter.HookEnabled(clonedWorkload.GroupVersionKind(), configv1alpha1.InterpreterOperationReviseReplica) {
-			clonedWorkload, err = resourceInterpreter.ReviseReplica(clonedWorkload, desireReplicaInfos[targetCluster.Name])
-			if err != nil {
-				klog.Errorf("failed to revise replica for %s/%s/%s in cluster %s, err is: %v",
-					workload.GetKind(), workload.GetNamespace(), workload.GetName(), targetCluster.Name, err)
-				return err
+		if hasScheduledReplica {
+			if resourceInterpreter.HookEnabled(clonedWorkload.GroupVersionKind(), configv1alpha1.InterpreterOperationReviseReplica) {
+				clonedWorkload, err = resourceInterpreter.ReviseReplica(clonedWorkload, desireReplicaInfos[targetCluster.Name])
+				if err != nil {
+					klog.Errorf("failed to revise replica for %s/%s/%s in cluster %s, err is: %v",
+						workload.GetKind(), workload.GetNamespace(), workload.GetName(), targetCluster.Name, err)
+					return err
+				}
 			}
 
 			// Set allocated completions for Job only when the '.spec.completions' field not omitted from resource template.


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

For job completions setting, the judgement  `resourceInterpreter.HookEnabled(clonedWorkload.GroupVersionKind(), configv1alpha1.InterpreterOperationReviseReplica)`  is not needed. 

https://github.com/karmada-io/karmada/blob/042762b096a918866f91c6b663962942bb0958c9/pkg/controllers/binding/common.go#L98-L117

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This pr is just a code readability optimization.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

