### PR TITLE
[E2E] fix failing e2e case for namespace not found

### DIFF
--- a/test/e2e/aggregatedapi_test.go
+++ b/test/e2e/aggregatedapi_test.go
@@ -56,6 +56,9 @@ var _ = ginkgo.Describe("Aggregated Kubernetes API Endpoint testing", func() {
 		})
 
 		ginkgo.BeforeEach(func() {
+			// Wait for namespace present before creating resources in it.
+			framework.WaitNamespacePresentOnCluster(member1, tomServiceAccount.Namespace)
+
 			klog.Infof("Create ServiceAccount(%s) in the cluster(%s)", klog.KObj(tomServiceAccount).String(), member1)
 			clusterClient := framework.GetClusterClient(member1)
 			gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

For failing test: https://github.com/karmada-io/karmada/runs/5700580290?check_suite_focus=true

The failing reason: when a serviceAccount is created in the member cluster, the namespace where the resource resides has not been propagated by the karmada control-plane.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
[E2E] fix failing e2e case for namespace not found
```

