### PR TITLE
[fix] Add a log reminder for creating a cluster

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -357,7 +357,7 @@ function util::create_cluster() {
   rm -rf "${log_path}/${cluster_name}.log"
   rm -f "${kubeconfig}"
   nohup kind delete cluster --name="${cluster_name}" >> "${log_path}"/"${cluster_name}".log 2>&1 && kind create cluster --name "${cluster_name}" --kubeconfig="${kubeconfig}" --image="${kind_image}" --config="${cluster_config}" >> "${log_path}"/"${cluster_name}".log 2>&1 &
-  echo "Creating cluster ${cluster_name}"
+  echo "Creating cluster ${cluster_name} and the log file is in ${log_path}/${cluster_name}.log"
 }
 
 # This function returns the IP address of a docker instance


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

When I used hack/local-up-karmada.sh to install karmada for the first time in local, the k8s cluster was not created due to the image. Since there was no reminder and I didn’t know where the log file was, I had to look at the docker log for query reasons. I think it is necessary to remind the user in the script where the cluster creation log is located