### PR TITLE
[fix] Add docker existence check

### DIFF
--- a/hack/local-up-karmada.sh
+++ b/hack/local-up-karmada.sh
@@ -58,6 +58,9 @@ fi
 util::cmd_must_exist "go"
 util::verify_go_version
 
+# Make sure docker exists
+util::cmd_must_exist "docker"
+
 # install kind and kubectl
 kind_version=v0.12.0
 echo -n "Preparing: 'kind' existence check - "


### PR DESCRIPTION
/kind bug

If you do not install docker, you must execute it later to report an error，But before the error was reported, kind was already trying to use docker to create a cluster.
like:

$./hack/local-up-karmada.sh
Creating cluster karmada-host
Creating cluster member1
Creating cluster member2
Creating cluster member3
make: 进入目录“/root/karmada”
VERSION=latest hack/docker.sh karmada-aggregated-apiserver
hack/docker.sh:行15: docker: 未找到命令
make: *** [image-karmada-aggregated-apiserver] 错误 127

I think a detection of whether docker is installed should be added in font
