### PR TITLE
disable `hpa` controller by default

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/dynamic"
 	kubeclientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
@@ -89,6 +90,8 @@ func NewAgentCommand(ctx context.Context) *cobra.Command {
 }
 
 var controllers = make(controllerscontext.Initializers)
+
+var controllersDisabledByDefault = sets.NewString()
 
 func init() {
 	controllers["clusterStatus"] = startClusterStatusController
@@ -192,7 +195,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 		StopChan: stopChan,
 	}
 
-	if err := controllers.StartControllers(controllerContext); err != nil {
+	if err := controllers.StartControllers(controllerContext, controllersDisabledByDefault); err != nil {
 		return fmt.Errorf("error starting controllers: %w", err)
 	}
 

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -115,10 +115,10 @@ func NewOptions() *Options {
 }
 
 // AddFlags adds flags to the specified FlagSet.
-func (o *Options) AddFlags(flags *pflag.FlagSet, allControllers []string) {
+func (o *Options) AddFlags(flags *pflag.FlagSet, allControllers, disabledByDefaultControllers []string) {
 	flags.StringSliceVar(&o.Controllers, "controllers", []string{"*"}, fmt.Sprintf(
-		"A list of controllers to enable. '*' enables all on-by-default controllers, 'foo' enables the controller named 'foo', '-foo' disables the controller named 'foo'. All controllers: %s.",
-		strings.Join(allControllers, ", "),
+		"A list of controllers to enable. '*' enables all on-by-default controllers, 'foo' enables the controller named 'foo', '-foo' disables the controller named 'foo'. \nAll controllers: %s.\nDisabled-by-default controllers: %s",
+		strings.Join(allControllers, ", "), strings.Join(disabledByDefaultControllers, ", "),
 	))
 	flags.StringVar(&o.BindAddress, "bind-address", defaultBindAddress,
 		"The IP address on which to listen for the --secure-port port.")

--- a/pkg/controllers/context/context.go
+++ b/pkg/controllers/context/context.go
@@ -67,7 +67,7 @@ type Context struct {
 }
 
 // IsControllerEnabled check if a specified controller enabled or not.
-func (c Context) IsControllerEnabled(name string) bool {
+func (c Context) IsControllerEnabled(name string, disabledByDefaultControllers sets.String) bool {
 	hasStar := false
 	for _, ctrl := range c.Opts.Controllers {
 		if ctrl == name {
@@ -80,7 +80,13 @@ func (c Context) IsControllerEnabled(name string) bool {
 			hasStar = true
 		}
 	}
-	return hasStar
+	// if we get here, there was no explicit choice
+	if !hasStar {
+		// nothing on by default
+		return false
+	}
+
+	return !disabledByDefaultControllers.Has(name)
 }
 
 // InitFunc is used to launch a particular controller.
@@ -97,9 +103,9 @@ func (i Initializers) ControllerNames() []string {
 }
 
 // StartControllers starts a set of controllers with a specified ControllerContext
-func (i Initializers) StartControllers(ctx Context) error {
+func (i Initializers) StartControllers(ctx Context, controllersDisabledByDefault sets.String) error {
 	for controllerName, initFn := range i {
-		if !ctx.IsControllerEnabled(controllerName) {
+		if !ctx.IsControllerEnabled(controllerName, controllersDisabledByDefault) {
 			klog.Warningf("%q is disabled", controllerName)
 			continue
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind deprecation

**What this PR does / why we need it**:
disable hpa controller by default
![1](https://user-images.githubusercontent.com/26862112/161884211-b9f42b39-ac9b-4d5b-aaa9-318319c609c8.png)

**Which issue(s) this PR fixes**:
Fixes #1569 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-controller-manager`: The `hpa` controller is disabled by default now.
```

