### PR TITLE
Automated cherry pick of #1519: bump alpine base image from v3.7 tov3.15.1

### DIFF
--- a/cluster/images/karmada-agent/Dockerfile
+++ b/cluster/images/karmada-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.15.1
 
 RUN apk add --no-cache ca-certificates
 

--- a/cluster/images/karmada-aggregated-apiserver/Dockerfile
+++ b/cluster/images/karmada-aggregated-apiserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.15.1
 
 RUN apk add --no-cache ca-certificates
 

--- a/cluster/images/karmada-controller-manager/Dockerfile
+++ b/cluster/images/karmada-controller-manager/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.15.1
 
 RUN apk add --no-cache ca-certificates
 

--- a/cluster/images/karmada-interpreter-webhook-example/Dockerfile
+++ b/cluster/images/karmada-interpreter-webhook-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.15.1
 
 RUN apk add --no-cache ca-certificates
 

--- a/cluster/images/karmada-scheduler-estimator/Dockerfile
+++ b/cluster/images/karmada-scheduler-estimator/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.15.1
 
 RUN apk add --no-cache ca-certificates
 

--- a/cluster/images/karmada-scheduler/Dockerfile
+++ b/cluster/images/karmada-scheduler/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.15.1
 
 RUN apk add --no-cache ca-certificates
 

--- a/cluster/images/karmada-webhook/Dockerfile
+++ b/cluster/images/karmada-webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.15.1
 
 RUN apk add --no-cache ca-certificates
 

--- a/hack/local-up-karmada.sh
+++ b/hack/local-up-karmada.sh
@@ -50,7 +50,7 @@ dockerfile_list=( # Dockerfile files need to be replaced
   "cluster/images/karmada-aggregated-apiserver/Dockerfile"
 )
 for dockerfile in "${dockerfile_list[@]}"; do
-  grep 'mirrors.ustc.edu.cn' ${REPO_ROOT}/${dockerfile} > /dev/null || sed -i'' -e "s#FROM alpine:3.7#FROM alpine:3.7\nRUN echo -e http://mirrors.ustc.edu.cn/alpine/v3.7/main/ > /etc/apk/repositories#" ${REPO_ROOT}/${dockerfile}
+  grep 'mirrors.ustc.edu.cn' ${REPO_ROOT}/${dockerfile} > /dev/null || sed -i'' -e "s#FROM alpine:3.15.1#FROM alpine:3.15.1\nRUN echo -e http://mirrors.ustc.edu.cn/alpine/v3.15/main/ > /etc/apk/repositories#" ${REPO_ROOT}/${dockerfile}
 done
 fi
 


### PR DESCRIPTION
Cherry pick of #1519 on release-1.0.
#1519: bump alpine base image from v3.7 tov3.15.1
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```release-note
The base image `alpine` has been promoted to `v3.15.1`.
```