### PR TITLE
enable aggregateStatusInterpreter for daemonSet and statefulSet

### DIFF
--- a/docs/userguide/customizing-resource-interpreter.md
+++ b/docs/userguide/customizing-resource-interpreter.md
@@ -93,6 +93,8 @@ Supported resources:
 - Service(v1)
 - Ingress(extensions/v1beta1)
 - Job(batch/v1)
+- DaemonSet(apps/v1)
+- StatefulSet(apps/v1)
 
 ## Customized Interpreter
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
add aggregateStatusInterpreter for daemonSet and statefulSet， so we can get status of ds and sts from controller plane.
![1](https://user-images.githubusercontent.com/26862112/162103567-a0c6ff9c-bc7c-4542-9848-1f640b52b4dd.png)
![image](https://user-images.githubusercontent.com/26862112/162103708-ba28a0a9-945a-4323-9978-5f33015c704c.png)

**Which issue(s) this PR fixes**:
Fixes #1544 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```
`karmada-controller-manager`: Added default `AggregateStatus` webhook for `DaemonSet` and `StatefulSet`.
```


