### PR TITLE
Automated cherry pick of #1584: fix: bugfix response's patch and patchType is nil, controller

### DIFF
--- a/pkg/resourceinterpreter/customizedinterpreter/customized.go
+++ b/pkg/resourceinterpreter/customizedinterpreter/customized.go
@@ -252,6 +252,9 @@ func (e *CustomizedInterpreter) callHook(ctx context.Context, hook configmanager
 func applyPatch(object *unstructured.Unstructured, patch []byte, patchType configv1alpha1.PatchType) (*unstructured.Unstructured, error) {
 	switch patchType {
 	case configv1alpha1.PatchTypeJSONPatch:
+		if len(patch) == 0 {
+			return object, nil
+		}
 		patchObj, err := jsonpatch.DecodePatch(patch)
 		if err != nil {
 			return nil, err

--- a/pkg/resourceinterpreter/customizedinterpreter/webhook/resourceinterpretercontext.go
+++ b/pkg/resourceinterpreter/customizedinterpreter/webhook/resourceinterpretercontext.go
@@ -107,7 +107,9 @@ func verifyResourceInterpreterContext(operation configv1alpha1.InterpreterOperat
 			return nil, err
 		}
 		res.Patch = response.Patch
-		res.PatchType = *response.PatchType
+		if response.PatchType != nil {
+			res.PatchType = *response.PatchType
+		}
 		return res, nil
 	case configv1alpha1.InterpreterOperationInterpretStatus:
 		res.RawStatus = *response.RawStatus


### PR DESCRIPTION
Cherry pick of #1584 on release-1.1.
#1584: fix: bugfix response's patch and patchType is nil, controller
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```
`karmada-controller-manager`: Fixed panic in case of interpreter webhook returns nil patch.
```