### PR TITLE
add service sync controller

### DIFF
--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -28,6 +28,7 @@ import (
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/clusterdiscovery/clusterapi"
+	"github.com/karmada-io/karmada/pkg/controllers/autopropagation"
 	"github.com/karmada-io/karmada/pkg/controllers/binding"
 	"github.com/karmada-io/karmada/pkg/controllers/cluster"
 	controllerscontext "github.com/karmada-io/karmada/pkg/controllers/context"
@@ -166,6 +167,7 @@ func init() {
 	controllers["unifiedAuth"] = startUnifiedAuthController
 	controllers["federatedResourceQuotaSync"] = startFederatedResourceQuotaSyncController
 	controllers["federatedResourceQuotaStatus"] = startFederatedResourceQuotaStatusController
+	controllers["serviceSyncController"] = startServiceSyncController
 }
 
 func startClusterController(ctx controllerscontext.Context) (enabled bool, err error) {
@@ -398,6 +400,17 @@ func startFederatedResourceQuotaStatusController(ctx controllerscontext.Context)
 	controller := federatedresourcequota.StatusController{
 		Client:        ctx.Mgr.GetClient(),
 		EventRecorder: ctx.Mgr.GetEventRecorderFor(federatedresourcequota.StatusControllerName),
+	}
+	if err = controller.SetupWithManager(ctx.Mgr); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func startServiceSyncController(ctx controllerscontext.Context) (enabled bool, err error) {
+	controller := autopropagation.ServiceController{
+		Client:        ctx.Mgr.GetClient(),
+		EventRecorder: ctx.Mgr.GetEventRecorderFor(autopropagation.ServiceControllerName),
 	}
 	if err = controller.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err

--- a/pkg/controllers/autopropagation/service_sync_controller.go
+++ b/pkg/controllers/autopropagation/service_sync_controller.go
@@ -1,0 +1,187 @@
+package autopropagation
+
+import (
+	"context"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+)
+
+const (
+	// ServiceControllerName is the controller name that will be used when reporting events.
+	ServiceControllerName     = "service-sync-controller"
+	annotationsGlobalKEYName  = "karmada.io/global"
+	annotationsMembersKEYName = "karmada.io/members"
+)
+
+// ServiceController is to sync service.
+type ServiceController struct {
+	client.Client
+	EventRecorder record.EventRecorder
+}
+
+// Reconcile performs a full reconciliation for the object referred to by the Request.
+// The Controller will requeue the Request to be processed again if an error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (c *ServiceController) Reconcile(ctx context.Context, req controllerruntime.Request) (controllerruntime.Result, error) {
+	service := &corev1.Service{}
+	if err := c.Client.Get(ctx, req.NamespacedName, service); err != nil {
+		if apierrors.IsNotFound(err) {
+			return controllerruntime.Result{}, nil
+		}
+
+		return controllerruntime.Result{Requeue: true}, err
+	}
+
+	if !service.DeletionTimestamp.IsZero() {
+		// Do nothing, just return as we have added owner reference to PropagationPolicy.
+		// Work will be removed automatically by garbage collector.
+		return reconcile.Result{}, nil
+	}
+
+	annotations := service.GetAnnotations()
+	if annotations == nil {
+		klog.Warningf("service %q of namespace %q has no annotations. skip", service.Name, service.Namespace)
+		return reconcile.Result{}, nil
+	}
+
+	clusterList := &clusterv1alpha1.ClusterList{}
+	if err := c.Client.List(context.TODO(), clusterList); err != nil {
+		klog.Errorf("Failed to list clusters, error: %v", err)
+		return reconcile.Result{Requeue: true}, err
+	}
+
+	deployClusters := c.syncClusters(service.Namespace, service.Name, annotations, clusterList.Items)
+	if deployClusters == nil {
+		return reconcile.Result{}, nil
+	}
+
+	if err := c.buildPropagationPolicy(service, deployClusters); err != nil {
+		return controllerruntime.Result{Requeue: true}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (c *ServiceController) syncClusters(namespace, service string, annotations map[string]string, clusters []clusterv1alpha1.Cluster) []string {
+	var deployClusters []string
+
+	if v, ok := annotations[annotationsGlobalKEYName]; ok && v == "true" {
+		klog.Infof("service %q propagation policy for namespace %q is global.", service, namespace)
+		for _, cluster := range clusters {
+			deployClusters = append(deployClusters, cluster.Name)
+		}
+		return deployClusters
+	}
+
+	v, ok := annotations[annotationsMembersKEYName]
+	if !ok {
+		klog.Infof("The propagation policy of service %q of namespace %q is not global, and no cluster is specified. Skip", service, namespace)
+		return nil
+	}
+
+	members := strings.Split(v, ",")
+	for _, cluster := range clusters {
+		for _, member := range members {
+			if cluster.Name == member {
+				deployClusters = append(deployClusters, cluster.Name)
+				continue
+			}
+		}
+	}
+
+	klog.V(4).Infof("member clusters: %v,valid number of deploy clusters: %v", members, deployClusters)
+	return deployClusters
+}
+
+// buildPropagationPolicy create service PropagationPolicy
+func (c *ServiceController) buildPropagationPolicy(service *corev1.Service, clusters []string) error {
+	pp := &policyv1alpha1.PropagationPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: policyv1alpha1.GroupVersion.String(),
+			Kind:       policyv1alpha1.ResourceKindPropagationPolicy,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      service.Name,
+			Namespace: service.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(service, service.GroupVersionKind()),
+			},
+		},
+		Spec: policyv1alpha1.PropagationSpec{
+			ResourceSelectors: []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: service.APIVersion,
+					Kind:       service.Kind,
+					Name:       service.Name,
+					Namespace:  service.Namespace,
+				},
+			},
+			Placement: policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: clusters,
+				},
+			},
+		},
+	}
+
+	result, err := controllerutil.CreateOrUpdate(context.TODO(), c.Client, pp, func() error { return nil })
+	if err != nil {
+		return err
+	}
+	if result == controllerutil.OperationResultCreated {
+		klog.Infof("Namespace %q Create PropagationPolicy %q successfully.", pp.GetNamespace(), pp.GetName())
+	} else if result == controllerutil.OperationResultUpdated {
+		klog.Infof("Namespace %q Update PropagationPolicy %q successfully.", pp.GetNamespace(), pp.GetName())
+	} else {
+		klog.V(4).Infof("Namespace %q Update PropagationPolicy %q is up to date.", pp.GetNamespace(), pp.GetName())
+	}
+
+	return nil
+}
+
+// SetupWithManager creates a controller and register to controller manager.
+func (c *ServiceController) SetupWithManager(mgr controllerruntime.Manager) error {
+	// Setup Scheme for k8s core/v1 resources
+	if err := corev1.AddToScheme(mgr.GetScheme()); err != nil {
+		return err
+	}
+	// Setup Scheme for karmada cluster/v1alpha1 resources
+	if err := clusterv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
+		return err
+	}
+	// Setup Scheme for karmada policy/v1alpha1 resources
+	if err := policyv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
+		return err
+	}
+
+	predicate := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return true
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return true
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
+	return controllerruntime.NewControllerManagedBy(mgr).
+		For(&corev1.Service{}).WithEventFilter(predicate).Complete(c)
+}


### PR DESCRIPTION
Signed-off-by: prodan <pengshihaoren@gmail.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Automatically create service `PropagationPolicy` through annotations.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The `deployments`, `services`, etc. of our production environment are automatically created through annotations to spread strategies. I don't know if anyone is interested in this feature, maybe this feature is just our personalized needs :)


#### test
##### global propagation policies
```yaml
---
apiVersion: v1
kind: Service
metadata:
  labels:
    app: nginx-global
  name: nginx-global
  annotations:
    karmada.io/global: "true"
spec:
  type: ClusterIP
  ports:
  - port: 80
    targetPort: 80
    name: http
  selector:
    app: nginx-global
```
crate service
```
root@dev-k8s-master01:~# kubectl --kubeconfig /etc/karmada/karmada-apiserver.config create -f demo-global.yaml
service/nginx-global created
root@dev-k8s-master01:~# kubectl --kubeconfig /etc/karmada/karmada-apiserver.config get propagationpolicies
NAME           AGE
nginx-global   101s
```

member1
```
root@dev-k8s-master01:~# kubectl get svc nginx-global
NAME           TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
nginx-global   ClusterIP   10.254.206.22   <none>        80/TCP    112s
```

member2
```
root@k8s-backup-master01:~# kubectl get svc nginx-global 
NAME           TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
nginx-global   ClusterIP   10.254.192.71   <none>        80/TCP    2m22s
```

##### specified cluster propagationpolicies
```yaml
---
apiVersion: v1
kind: Service
metadata:
  labels:
    app: nginx-members
  name: nginx-members
  annotations:
#    karmada.io/members: "member1,member2"
    karmada.io/members: "member1"
spec:
  type: ClusterIP
  ports:
  - port: 80
    targetPort: 80
    name: http
  selector:
    app: nginx-members
```
create service
```
root@dev-k8s-master01:~# kubectl  --kubeconfig /etc/karmada/karmada-apiserver.config create -f demo-members.yaml
service/nginx-members created
root@dev-k8s-master01:~# kubectl --kubeconfig /etc/karmada/karmada-apiserver.config get propagationpolicies
NAME            AGE
nginx-global    5m50s
nginx-members   29s
```

member1
```
root@dev-k8s-master01:~# kubectl get svc | grep nginx-
nginx-global    ClusterIP   10.254.206.22    <none>        80/TCP    6m21s
nginx-members   ClusterIP   10.254.53.90     <none>        80/TCP    60s
```
member2
```
root@k8s-backup-master01:~# kubectl get svc | grep nginx-
nginx-global   ClusterIP   10.254.192.71    <none>        80/TCP    7m22s
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

