### PR TITLE
Fix `karmadactl get -o yaml|json` reporting null error

### DIFF
--- a/pkg/karmadactl/get.go
+++ b/pkg/karmadactl/get.go
@@ -232,6 +232,11 @@ func (g *CommandGetOptions) Run(karmadaConfig KarmadaConfig, cmd *cobra.Command,
 	}
 	wg.Wait()
 
+	if !g.IsHumanReadablePrinter {
+		// have printed objects in yaml or json format above
+		return nil
+	}
+
 	// sort objects by resource kind to classify them
 	sort.Slice(objs, func(i, j int) bool {
 		return objs[i].Info.Mapping.Resource.String() < objs[j].Info.Mapping.Resource.String()
@@ -385,15 +390,15 @@ func (g *CommandGetOptions) getObjInfo(wg *sync.WaitGroup, mux *sync.Mutex, f cm
 	}
 
 	if !g.IsHumanReadablePrinter {
-		err := fmt.Errorf("cluster(%s): %s", cluster, g.printGeneric(r))
-		*allErrs = append(*allErrs, err)
+		if err := g.printGeneric(r); err != nil {
+			*allErrs = append(*allErrs, fmt.Errorf("cluster(%s): %s", cluster, err))
+		}
 		return
 	}
 
 	infos, err := r.Infos()
 	if err != nil {
-		err := fmt.Errorf("cluster(%s): %s", cluster, err)
-		*allErrs = append(*allErrs, err)
+		*allErrs = append(*allErrs, fmt.Errorf("cluster(%s): %s", cluster, err))
 		return
 	}
 


### PR DESCRIPTION
Signed-off-by: lonelyCZ <531187475@qq.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Fix
```
[root@master67 karmada]# ./karmadactl get deploy nginx -C member1 -o yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
  ......
  observedGeneration: 1
  readyReplicas: 1
  replicas: 1
  updatedReplicas: 1
Error: cluster(member1): %!s(<nil>)
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Found an oversight.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

