### PR TITLE
Remove remaining resource when using helm uninstall

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -41,6 +41,14 @@ $ helm uninstall karmada -n karmada-system
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
+> **Note**: There are some RBAC resources that are used by the `preJob` that can not be deleted by the `uninstall` command above. You might have to clean them manually with tools like `kubectl`.  You can clean them by commands:
+
+```console
+$ kubectl delete sa/karmada-pre-job -nkarmada-system
+$ kubectl delete clusterRole/karmada-pre-job 
+$ kubectl delete clusterRoleBinding/karmada-pre-job
+$ kubectl delete ns karmada-system
+```
 
 ## Example
 ### 1. Install agent

--- a/charts/templates/post-delete-job.yaml
+++ b/charts/templates/post-delete-job.yaml
@@ -1,0 +1,48 @@
+{{- if and (eq .Values.installMode "host") (eq .Values.certs.mode "auto") }}
+{{- $name := include "karmada.name" . -}}
+{{- $namespace := include "karmada.namespace" . -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ $name }}-post-delete"
+  namespace: {{ $namespace }}
+  labels:
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  parallelism: 1
+  completions: 1
+  template:
+    metadata:
+      name: {{ $name }}
+      labels:
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      serviceAccountName: {{ $name }}-pre-job
+      restartPolicy: Never
+      containers:
+        - name: post-delete
+          image: {{ .Values.postDeleteJob.postDeleteContainerImage }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              bash <<'EOF'
+              set -ex
+              kubectl delete -f /opt/mount/
+              kubectl delete cm/{{ $name }}-config -n {{ $namespace }}
+              EOF
+          volumeMounts:
+            - name: mount
+              mountPath: /opt/mount
+      volumes:
+        - name: mount
+          configMap:
+            name: {{ $name }}-config
+{{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -26,6 +26,10 @@ preInstallJob:
 postInstallJob:
   postInstallContainerImage: bitnami/kubectl:latest
 
+## post-delete job config
+postDeleteJob:
+  postDeleteContainerImage: bitnami/kubectl:latest
+
 ## karmada certificate config
 certs:
   ## @param certs.mode "auto" and "custom" are provided


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Remove remaining resource (configmaps、secret) when using helm uninstall，but it seems hard to remove resources like sa、clusterrole according to helm cause helm cannot gc those resource in pre/post job.

**Which issue(s) this PR fixes**:
Fixes #1587 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

