### PR TITLE
[E2E] Declare in container nodes, initialize in setup nodes

### DIFF
--- a/test/e2e/clusterpropagationpolicy_test.go
+++ b/test/e2e/clusterpropagationpolicy_test.go
@@ -14,25 +14,33 @@ import (
 
 var _ = ginkgo.Describe("[BasicClusterPropagation] basic cluster propagation testing", func() {
 	ginkgo.Context("CustomResourceDefinition propagation testing", func() {
-		crdGroup := fmt.Sprintf("example-%s.karmada.io", rand.String(RandomStrLength))
-		randStr := rand.String(RandomStrLength)
-		crdSpecNames := apiextensionsv1.CustomResourceDefinitionNames{
-			Kind:     fmt.Sprintf("Foo%s", randStr),
-			ListKind: fmt.Sprintf("Foo%sList", randStr),
-			Plural:   fmt.Sprintf("foo%ss", randStr),
-			Singular: fmt.Sprintf("foo%s", randStr),
-		}
-		crd := testhelper.NewCustomResourceDefinition(crdGroup, crdSpecNames, apiextensionsv1.NamespaceScoped)
-		crdPolicy := testhelper.NewClusterPropagationPolicy(crd.Name, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: crd.APIVersion,
-				Kind:       crd.Kind,
-				Name:       crd.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: framework.ClusterNames(),
-			},
+		var crdGroup string
+		var randStr string
+		var crdSpecNames apiextensionsv1.CustomResourceDefinitionNames
+		var crd *apiextensionsv1.CustomResourceDefinition
+		var crdPolicy *policyv1alpha1.ClusterPropagationPolicy
+
+		ginkgo.BeforeEach(func() {
+			crdGroup = fmt.Sprintf("example-%s.karmada.io", rand.String(RandomStrLength))
+			randStr = rand.String(RandomStrLength)
+			crdSpecNames = apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:     fmt.Sprintf("Foo%s", randStr),
+				ListKind: fmt.Sprintf("Foo%sList", randStr),
+				Plural:   fmt.Sprintf("foo%ss", randStr),
+				Singular: fmt.Sprintf("foo%s", randStr),
+			}
+			crd = testhelper.NewCustomResourceDefinition(crdGroup, crdSpecNames, apiextensionsv1.NamespaceScoped)
+			crdPolicy = testhelper.NewClusterPropagationPolicy(crd.Name, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: crd.APIVersion,
+					Kind:       crd.Kind,
+					Name:       crd.Name,
+				},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: framework.ClusterNames(),
+				},
+			})
 		})
 
 		ginkgo.It("crd propagation testing", func() {

--- a/test/e2e/federatedresourcequota_test.go
+++ b/test/e2e/federatedresourcequota_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/clientcmd"
 
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/karmadactl"
 	"github.com/karmada-io/karmada/pkg/karmadactl/options"
 	"github.com/karmada-io/karmada/pkg/util"
@@ -20,11 +21,16 @@ import (
 )
 
 var _ = ginkgo.Describe("[FederatedResourceQuota] auto-provision testing", func() {
-	ginkgo.Context("create a federatedResourceQuota", func() {
-		frqNamespace := testNamespace
-		frqName := federatedResourceQuotaPrefix + rand.String(RandomStrLength)
-		federatedResourceQuota := helper.NewFederatedResourceQuota(frqNamespace, frqName)
+	var frqNamespace, frqName string
+	var federatedResourceQuota *policyv1alpha1.FederatedResourceQuota
 
+	ginkgo.BeforeEach(func() {
+		frqNamespace = testNamespace
+		frqName = federatedResourceQuotaPrefix + rand.String(RandomStrLength)
+		federatedResourceQuota = helper.NewFederatedResourceQuota(frqNamespace, frqName)
+	})
+
+	ginkgo.Context("create a federatedResourceQuota", func() {
 		ginkgo.AfterEach(func() {
 			framework.RemoveFederatedResourceQuota(karmadaClient, frqNamespace, frqName)
 		})
@@ -36,10 +42,6 @@ var _ = ginkgo.Describe("[FederatedResourceQuota] auto-provision testing", func(
 	})
 
 	ginkgo.Context("delete a federatedResourceQuota", func() {
-		frqNamespace := testNamespace
-		frqName := federatedResourceQuotaPrefix + rand.String(RandomStrLength)
-		federatedResourceQuota := helper.NewFederatedResourceQuota(frqNamespace, frqName)
-
 		ginkgo.BeforeEach(func() {
 			framework.CreateFederatedResourceQuota(karmadaClient, federatedResourceQuota)
 			framework.WaitResourceQuotaPresentOnClusters(framework.ClusterNames(), frqNamespace, frqName)
@@ -52,15 +54,19 @@ var _ = ginkgo.Describe("[FederatedResourceQuota] auto-provision testing", func(
 	})
 
 	ginkgo.Context("join new cluster", func() {
-		frqNamespace := testNamespace
-		frqName := federatedResourceQuotaPrefix + rand.String(RandomStrLength)
-		federatedResourceQuota := helper.NewFederatedResourceQuota(frqNamespace, frqName)
+		var clusterName string
+		var homeDir string
+		var kubeConfigPath string
+		var controlPlane string
+		var clusterContext string
 
-		clusterName := "member-e2e-" + rand.String(3)
-		homeDir := os.Getenv("HOME")
-		kubeConfigPath := fmt.Sprintf("%s/.kube/%s.config", homeDir, clusterName)
-		controlPlane := fmt.Sprintf("%s-control-plane", clusterName)
-		clusterContext := fmt.Sprintf("kind-%s", clusterName)
+		ginkgo.BeforeEach(func() {
+			clusterName = "member-e2e-" + rand.String(3)
+			homeDir = os.Getenv("HOME")
+			kubeConfigPath = fmt.Sprintf("%s/.kube/%s.config", homeDir, clusterName)
+			controlPlane = fmt.Sprintf("%s-control-plane", clusterName)
+			clusterContext = fmt.Sprintf("kind-%s", clusterName)
+		})
 
 		ginkgo.BeforeEach(func() {
 			framework.CreateFederatedResourceQuota(karmadaClient, federatedResourceQuota)
@@ -134,11 +140,16 @@ var _ = ginkgo.Describe("[FederatedResourceQuota] auto-provision testing", func(
 })
 
 var _ = ginkgo.Describe("[FederatedResourceQuota] status collection testing", func() {
-	ginkgo.Context("collect federatedResourceQuota status", func() {
-		frqNamespace := testNamespace
-		frqName := federatedResourceQuotaPrefix + rand.String(RandomStrLength)
-		federatedResourceQuota := helper.NewFederatedResourceQuota(frqNamespace, frqName)
+	var frqNamespace, frqName string
+	var federatedResourceQuota *policyv1alpha1.FederatedResourceQuota
 
+	ginkgo.BeforeEach(func() {
+		frqNamespace = testNamespace
+		frqName = federatedResourceQuotaPrefix + rand.String(RandomStrLength)
+		federatedResourceQuota = helper.NewFederatedResourceQuota(frqNamespace, frqName)
+	})
+
+	ginkgo.Context("collect federatedResourceQuota status", func() {
 		ginkgo.AfterEach(func() {
 			framework.RemoveFederatedResourceQuota(karmadaClient, frqNamespace, frqName)
 		})

--- a/test/e2e/fieldselector_test.go
+++ b/test/e2e/fieldselector_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,45 +20,56 @@ import (
 
 var _ = ginkgo.Describe("propagation with fieldSelector testing", func() {
 	ginkgo.Context("Deployment propagation testing", func() {
-		policyNamespace := testNamespace
-		policyName := deploymentNamePrefix + rand.String(RandomStrLength)
-		deploymentNamespace := testNamespace
-		deploymentName := policyName
-		deployment := helper.NewDeployment(deploymentNamespace, deploymentName)
+		var policyNamespace, policyName string
+		var deploymentNamespace, deploymentName string
+		var deployment *appsv1.Deployment
+		var originalClusterProviderInfo, originalClusterRegionInfo map[string]string
+		var desiredProvider, undesiredRegion []string
+		var desiredScheduleResult string
+		var filedSelector *policyv1alpha1.FieldSelector
+		var policy *policyv1alpha1.PropagationPolicy
 
-		originalClusterProviderInfo := make(map[string]string)
-		originalClusterRegionInfo := make(map[string]string)
-		desiredProvider := []string{"huaweicloud"}
-		undesiredRegion := []string{"cn-north-1"}
-		desiredScheduleResult := "member1"
+		ginkgo.BeforeEach(func() {
+			policyNamespace = testNamespace
+			policyName = deploymentNamePrefix + rand.String(RandomStrLength)
+			deploymentNamespace = testNamespace
+			deploymentName = policyName
+			deployment = helper.NewDeployment(deploymentNamespace, deploymentName)
 
-		// desire to schedule to clusters of huaweicloud but not in cn-north-1 region
-		filedSelector := &policyv1alpha1.FieldSelector{
-			MatchExpressions: []corev1.NodeSelectorRequirement{
-				{
-					Key:      util.ProviderField,
-					Operator: corev1.NodeSelectorOpIn,
-					Values:   desiredProvider,
+			originalClusterProviderInfo = make(map[string]string)
+			originalClusterRegionInfo = make(map[string]string)
+			desiredProvider = []string{"huaweicloud"}
+			undesiredRegion = []string{"cn-north-1"}
+			desiredScheduleResult = "member1"
+
+			// desire to schedule to clusters of huaweicloud but not in cn-north-1 region
+			filedSelector = &policyv1alpha1.FieldSelector{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      util.ProviderField,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   desiredProvider,
+					},
+					{
+						Key:      util.RegionField,
+						Operator: corev1.NodeSelectorOpNotIn,
+						Values:   undesiredRegion,
+					},
 				},
-				{
-					Key:      util.RegionField,
-					Operator: corev1.NodeSelectorOpNotIn,
-					Values:   undesiredRegion,
-				},
-			},
-		}
+			}
 
-		policy := helper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: deployment.APIVersion,
-				Kind:       deployment.Kind,
-				Name:       deployment.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames:  framework.ClusterNames(),
-				FieldSelector: filedSelector,
-			},
+			policy = helper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: deployment.APIVersion,
+					Kind:       deployment.Kind,
+					Name:       deployment.Name,
+				},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					ClusterNames:  framework.ClusterNames(),
+					FieldSelector: filedSelector,
+				},
+			})
 		})
 
 		ginkgo.BeforeEach(func() {

--- a/test/e2e/mcs_test.go
+++ b/test/e2e/mcs_test.go
@@ -176,30 +176,42 @@ func getPrepareInfo() (serviceExport mcsv1alpha1.ServiceExport, serviceImport mc
 }
 
 var _ = ginkgo.Describe("[MCS] Multi-Cluster Service testing", func() {
-	serviceExportPolicyName := fmt.Sprintf("%s-%s-policy", serviceExportResource, rand.String(RandomStrLength))
-	serviceImportPolicyName := fmt.Sprintf("%s-%s-policy", serviceImportResource, rand.String(RandomStrLength))
+	var serviceExportPolicyName, serviceImportPolicyName string
+	var serviceExportPolicy, serviceImportPolicy *policyv1alpha1.ClusterPropagationPolicy
+	var serviceExport mcsv1alpha1.ServiceExport
+	var serviceImport mcsv1alpha1.ServiceImport
+	var exportPolicy, importPolicy *policyv1alpha1.PropagationPolicy
+	var demoDeployment appsv1.Deployment
+	var demoService corev1.Service
 
-	serviceExportPolicy := testhelper.NewClusterPropagationPolicy(serviceExportPolicyName, []policyv1alpha1.ResourceSelector{
-		{
-			APIVersion: apiextensionsv1.SchemeGroupVersion.String(),
-			Kind:       util.CRDKind,
-			Name:       fmt.Sprintf("%s.%s", serviceExportResource, mcsv1alpha1.GroupName),
-		},
-	}, policyv1alpha1.Placement{
-		ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-			ClusterNames: framework.ClusterNames(),
-		},
-	})
-	serviceImportPolicy := testhelper.NewClusterPropagationPolicy(serviceImportPolicyName, []policyv1alpha1.ResourceSelector{
-		{
-			APIVersion: apiextensionsv1.SchemeGroupVersion.String(),
-			Kind:       util.CRDKind,
-			Name:       fmt.Sprintf("%s.%s", serviceImportResource, mcsv1alpha1.GroupName),
-		},
-	}, policyv1alpha1.Placement{
-		ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-			ClusterNames: framework.ClusterNames(),
-		},
+	ginkgo.BeforeEach(func() {
+		serviceExportPolicyName = fmt.Sprintf("%s-%s-policy", serviceExportResource, rand.String(RandomStrLength))
+		serviceImportPolicyName = fmt.Sprintf("%s-%s-policy", serviceImportResource, rand.String(RandomStrLength))
+
+		serviceExportPolicy = testhelper.NewClusterPropagationPolicy(serviceExportPolicyName, []policyv1alpha1.ResourceSelector{
+			{
+				APIVersion: apiextensionsv1.SchemeGroupVersion.String(),
+				Kind:       util.CRDKind,
+				Name:       fmt.Sprintf("%s.%s", serviceExportResource, mcsv1alpha1.GroupName),
+			},
+		}, policyv1alpha1.Placement{
+			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+				ClusterNames: framework.ClusterNames(),
+			},
+		})
+		serviceImportPolicy = testhelper.NewClusterPropagationPolicy(serviceImportPolicyName, []policyv1alpha1.ResourceSelector{
+			{
+				APIVersion: apiextensionsv1.SchemeGroupVersion.String(),
+				Kind:       util.CRDKind,
+				Name:       fmt.Sprintf("%s.%s", serviceImportResource, mcsv1alpha1.GroupName),
+			},
+		}, policyv1alpha1.Placement{
+			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+				ClusterNames: framework.ClusterNames(),
+			},
+		})
+
+		serviceExport, serviceImport, exportPolicy, importPolicy, demoDeployment, demoService = getPrepareInfo()
 	})
 
 	ginkgo.BeforeEach(func() {
@@ -218,8 +230,6 @@ var _ = ginkgo.Describe("[MCS] Multi-Cluster Service testing", func() {
 	})
 
 	ginkgo.Context("Connectivity testing", func() {
-		serviceExport, serviceImport, exportPolicy, importPolicy, demoDeployment, demoService := getPrepareInfo()
-
 		ginkgo.BeforeEach(func() {
 			exportClusterClient := framework.GetClusterClient(serviceExportClusterName)
 			gomega.Expect(exportClusterClient).ShouldNot(gomega.BeNil())
@@ -363,8 +373,6 @@ var _ = ginkgo.Describe("[MCS] Multi-Cluster Service testing", func() {
 	})
 
 	ginkgo.Context("EndpointSlices change testing", func() {
-		serviceExport, serviceImport, exportPolicy, importPolicy, demoDeployment, demoService := getPrepareInfo()
-
 		ginkgo.BeforeEach(func() {
 			exportClusterClient := framework.GetClusterClient(serviceExportClusterName)
 			gomega.Expect(exportClusterClient).ShouldNot(gomega.BeNil())

--- a/test/e2e/overridepolicy_test.go
+++ b/test/e2e/overridepolicy_test.go
@@ -13,52 +13,62 @@ import (
 )
 
 var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
-	ginkgo.Context("Deployment override all images in container list", func() {
-		deploymentNamespace := testNamespace
-		deploymentName := deploymentNamePrefix + rand.String(RandomStrLength)
-		propagationPolicyNamespace := testNamespace
-		propagationPolicyName := deploymentName
-		overridePolicyNamespace := testNamespace
-		overridePolicyName := deploymentName
+	var propagationPolicyNamespace, propagationPolicyName string
+	var overridePolicyNamespace, overridePolicyName string
+	var propagationPolicy *policyv1alpha1.PropagationPolicy
+	var overridePolicy *policyv1alpha1.OverridePolicy
 
-		deployment := helper.NewDeployment(deploymentNamespace, deploymentName)
-		propagationPolicy := helper.NewPropagationPolicy(propagationPolicyNamespace, propagationPolicyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: deployment.APIVersion,
-				Kind:       deployment.Kind,
-				Name:       deployment.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+	ginkgo.Context("Deployment override all images in container list", func() {
+		var deploymentNamespace, deploymentName string
+		var deployment *appsv1.Deployment
+
+		ginkgo.BeforeEach(func() {
+			deploymentNamespace = testNamespace
+			deploymentName = deploymentNamePrefix + rand.String(RandomStrLength)
+			propagationPolicyNamespace = testNamespace
+			propagationPolicyName = deploymentName
+			overridePolicyNamespace = testNamespace
+			overridePolicyName = deploymentName
+
+			deployment = helper.NewDeployment(deploymentNamespace, deploymentName)
+			propagationPolicy = helper.NewPropagationPolicy(propagationPolicyNamespace, propagationPolicyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: deployment.APIVersion,
+					Kind:       deployment.Kind,
+					Name:       deployment.Name,
+				},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: framework.ClusterNames(),
+				},
+			})
+			overridePolicy = helper.NewOverridePolicy(overridePolicyNamespace, overridePolicyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: deployment.APIVersion,
+					Kind:       deployment.Kind,
+					Name:       deployment.Name,
+				},
+			}, policyv1alpha1.ClusterAffinity{
 				ClusterNames: framework.ClusterNames(),
-			},
-		})
-		overridePolicy := helper.NewOverridePolicy(overridePolicyNamespace, overridePolicyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: deployment.APIVersion,
-				Kind:       deployment.Kind,
-				Name:       deployment.Name,
-			},
-		}, policyv1alpha1.ClusterAffinity{
-			ClusterNames: framework.ClusterNames(),
-		}, policyv1alpha1.Overriders{
-			ImageOverrider: []policyv1alpha1.ImageOverrider{
-				{
-					Component: "Registry",
-					Operator:  "replace",
-					Value:     "fictional.registry.us",
+			}, policyv1alpha1.Overriders{
+				ImageOverrider: []policyv1alpha1.ImageOverrider{
+					{
+						Component: "Registry",
+						Operator:  "replace",
+						Value:     "fictional.registry.us",
+					},
+					{
+						Component: "Repository",
+						Operator:  "replace",
+						Value:     "busybox",
+					},
+					{
+						Component: "Tag",
+						Operator:  "replace",
+						Value:     "1.0",
+					},
 				},
-				{
-					Component: "Repository",
-					Operator:  "replace",
-					Value:     "busybox",
-				},
-				{
-					Component: "Tag",
-					Operator:  "replace",
-					Value:     "1.0",
-				},
-			},
+			})
 		})
 
 		ginkgo.BeforeEach(func() {
@@ -91,51 +101,56 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 	})
 
 	ginkgo.Context("Pod override all images in container list", func() {
-		podNamespace := testNamespace
-		podName := podNamePrefix + rand.String(RandomStrLength)
-		propagationPolicyNamespace := testNamespace
-		propagationPolicyName := podName
-		overridePolicyNamespace := testNamespace
-		overridePolicyName := podName
+		var podNamespace, podName string
+		var pod *corev1.Pod
 
-		pod := helper.NewPod(podNamespace, podName)
-		propagationPolicy := helper.NewPropagationPolicy(propagationPolicyNamespace, propagationPolicyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: pod.APIVersion,
-				Kind:       pod.Kind,
-				Name:       pod.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+		ginkgo.BeforeEach(func() {
+			podNamespace = testNamespace
+			podName = podNamePrefix + rand.String(RandomStrLength)
+			propagationPolicyNamespace = testNamespace
+			propagationPolicyName = podName
+			overridePolicyNamespace = testNamespace
+			overridePolicyName = podName
+
+			pod = helper.NewPod(podNamespace, podName)
+			propagationPolicy = helper.NewPropagationPolicy(propagationPolicyNamespace, propagationPolicyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: pod.APIVersion,
+					Kind:       pod.Kind,
+					Name:       pod.Name,
+				},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: framework.ClusterNames(),
+				},
+			})
+			overridePolicy = helper.NewOverridePolicy(overridePolicyNamespace, overridePolicyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: pod.APIVersion,
+					Kind:       pod.Kind,
+					Name:       pod.Name,
+				},
+			}, policyv1alpha1.ClusterAffinity{
 				ClusterNames: framework.ClusterNames(),
-			},
-		})
-		overridePolicy := helper.NewOverridePolicy(overridePolicyNamespace, overridePolicyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: pod.APIVersion,
-				Kind:       pod.Kind,
-				Name:       pod.Name,
-			},
-		}, policyv1alpha1.ClusterAffinity{
-			ClusterNames: framework.ClusterNames(),
-		}, policyv1alpha1.Overriders{
-			ImageOverrider: []policyv1alpha1.ImageOverrider{
-				{
-					Component: "Registry",
-					Operator:  "replace",
-					Value:     "fictional.registry.us",
+			}, policyv1alpha1.Overriders{
+				ImageOverrider: []policyv1alpha1.ImageOverrider{
+					{
+						Component: "Registry",
+						Operator:  "replace",
+						Value:     "fictional.registry.us",
+					},
+					{
+						Component: "Repository",
+						Operator:  "replace",
+						Value:     "busybox",
+					},
+					{
+						Component: "Tag",
+						Operator:  "replace",
+						Value:     "1.0",
+					},
 				},
-				{
-					Component: "Repository",
-					Operator:  "replace",
-					Value:     "busybox",
-				},
-				{
-					Component: "Tag",
-					Operator:  "replace",
-					Value:     "1.0",
-				},
-			},
+			})
 		})
 
 		ginkgo.BeforeEach(func() {
@@ -167,44 +182,49 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 	})
 
 	ginkgo.Context("Deployment override specific images in container list", func() {
-		deploymentNamespace := testNamespace
-		deploymentName := deploymentNamePrefix + rand.String(RandomStrLength)
-		propagationPolicyNamespace := testNamespace
-		propagationPolicyName := deploymentName
-		overridePolicyNamespace := testNamespace
-		overridePolicyName := deploymentName
+		var deploymentNamespace, deploymentName string
+		var deployment *appsv1.Deployment
 
-		deployment := helper.NewDeployment(deploymentNamespace, deploymentName)
-		propagationPolicy := helper.NewPropagationPolicy(propagationPolicyNamespace, propagationPolicyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: deployment.APIVersion,
-				Kind:       deployment.Kind,
-				Name:       deployment.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: framework.ClusterNames(),
-			},
-		})
-		overridePolicy := helper.NewOverridePolicy(overridePolicyNamespace, overridePolicyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: deployment.APIVersion,
-				Kind:       deployment.Kind,
-				Name:       deployment.Name,
-			},
-		}, policyv1alpha1.ClusterAffinity{
-			ClusterNames: framework.ClusterNames(),
-		}, policyv1alpha1.Overriders{
-			ImageOverrider: []policyv1alpha1.ImageOverrider{
+		ginkgo.BeforeEach(func() {
+			deploymentNamespace = testNamespace
+			deploymentName = deploymentNamePrefix + rand.String(RandomStrLength)
+			propagationPolicyNamespace = testNamespace
+			propagationPolicyName = deploymentName
+			overridePolicyNamespace = testNamespace
+			overridePolicyName = deploymentName
+
+			deployment = helper.NewDeployment(deploymentNamespace, deploymentName)
+			propagationPolicy = helper.NewPropagationPolicy(propagationPolicyNamespace, propagationPolicyName, []policyv1alpha1.ResourceSelector{
 				{
-					Predicate: &policyv1alpha1.ImagePredicate{
-						Path: "/spec/template/spec/containers/0/image",
-					},
-					Component: "Registry",
-					Operator:  "replace",
-					Value:     "fictional.registry.us",
+					APIVersion: deployment.APIVersion,
+					Kind:       deployment.Kind,
+					Name:       deployment.Name,
 				},
-			},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: framework.ClusterNames(),
+				},
+			})
+			overridePolicy = helper.NewOverridePolicy(overridePolicyNamespace, overridePolicyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: deployment.APIVersion,
+					Kind:       deployment.Kind,
+					Name:       deployment.Name,
+				},
+			}, policyv1alpha1.ClusterAffinity{
+				ClusterNames: framework.ClusterNames(),
+			}, policyv1alpha1.Overriders{
+				ImageOverrider: []policyv1alpha1.ImageOverrider{
+					{
+						Predicate: &policyv1alpha1.ImagePredicate{
+							Path: "/spec/template/spec/containers/0/image",
+						},
+						Component: "Registry",
+						Operator:  "replace",
+						Value:     "fictional.registry.us",
+					},
+				},
+			})
 		})
 
 		ginkgo.BeforeEach(func() {
@@ -233,16 +253,23 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 })
 
 var _ = ginkgo.Describe("OverridePolicy with nil resourceSelectors", func() {
-	ginkgo.Context("Deployment override testing", func() {
-		deploymentNamespace := testNamespace
-		deploymentName := deploymentNamePrefix + rand.String(RandomStrLength)
-		propagationPolicyNamespace := testNamespace
-		propagationPolicyName := deploymentName
-		overridePolicyNamespace := testNamespace
-		overridePolicyName := deploymentName
+	var deploymentNamespace, deploymentName string
+	var propagationPolicyNamespace, propagationPolicyName string
+	var overridePolicyNamespace, overridePolicyName string
+	var deployment *appsv1.Deployment
+	var propagationPolicy *policyv1alpha1.PropagationPolicy
+	var overridePolicy *policyv1alpha1.OverridePolicy
 
-		deployment := helper.NewDeployment(deploymentNamespace, deploymentName)
-		propagationPolicy := helper.NewPropagationPolicy(propagationPolicyNamespace, propagationPolicyName, []policyv1alpha1.ResourceSelector{
+	ginkgo.BeforeEach(func() {
+		deploymentNamespace = testNamespace
+		deploymentName = deploymentNamePrefix + rand.String(RandomStrLength)
+		propagationPolicyNamespace = testNamespace
+		propagationPolicyName = deploymentName
+		overridePolicyNamespace = testNamespace
+		overridePolicyName = deploymentName
+
+		deployment = helper.NewDeployment(deploymentNamespace, deploymentName)
+		propagationPolicy = helper.NewPropagationPolicy(propagationPolicyNamespace, propagationPolicyName, []policyv1alpha1.ResourceSelector{
 			{
 				APIVersion: deployment.APIVersion,
 				Kind:       deployment.Kind,
@@ -253,7 +280,7 @@ var _ = ginkgo.Describe("OverridePolicy with nil resourceSelectors", func() {
 				ClusterNames: framework.ClusterNames(),
 			},
 		})
-		overridePolicy := helper.NewOverridePolicy(overridePolicyNamespace, overridePolicyName, nil, policyv1alpha1.ClusterAffinity{
+		overridePolicy = helper.NewOverridePolicy(overridePolicyNamespace, overridePolicyName, nil, policyv1alpha1.ClusterAffinity{
 			ClusterNames: framework.ClusterNames(),
 		}, policyv1alpha1.Overriders{
 			ImageOverrider: []policyv1alpha1.ImageOverrider{
@@ -267,7 +294,9 @@ var _ = ginkgo.Describe("OverridePolicy with nil resourceSelectors", func() {
 				},
 			},
 		})
+	})
 
+	ginkgo.Context("Deployment override testing", func() {
 		ginkgo.BeforeEach(func() {
 			framework.CreatePropagationPolicy(karmadaClient, propagationPolicy)
 			framework.CreateOverridePolicy(karmadaClient, overridePolicy)
@@ -294,57 +323,67 @@ var _ = ginkgo.Describe("OverridePolicy with nil resourceSelectors", func() {
 })
 
 var _ = ginkgo.Describe("[OverrideRules] apply overriders testing", func() {
-	ginkgo.Context("Deployment override all images in container list", func() {
-		deploymentNamespace := testNamespace
-		deploymentName := deploymentNamePrefix + rand.String(RandomStrLength)
-		propagationPolicyNamespace := testNamespace
-		propagationPolicyName := deploymentName
-		overridePolicyNamespace := testNamespace
-		overridePolicyName := deploymentName
+	var propagationPolicyNamespace, propagationPolicyName string
+	var overridePolicyNamespace, overridePolicyName string
+	var propagationPolicy *policyv1alpha1.PropagationPolicy
+	var overridePolicy *policyv1alpha1.OverridePolicy
 
-		deployment := helper.NewDeployment(deploymentNamespace, deploymentName)
-		propagationPolicy := helper.NewPropagationPolicy(propagationPolicyNamespace, propagationPolicyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: deployment.APIVersion,
-				Kind:       deployment.Kind,
-				Name:       deployment.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: framework.ClusterNames(),
-			},
-		})
-		overridePolicy := helper.NewOverridePolicyByOverrideRules(overridePolicyNamespace, overridePolicyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: deployment.APIVersion,
-				Kind:       deployment.Kind,
-				Name:       deployment.Name,
-			},
-		}, []policyv1alpha1.RuleWithCluster{
-			{
-				TargetCluster: &policyv1alpha1.ClusterAffinity{
+	ginkgo.Context("Deployment override all images in container list", func() {
+		var deploymentNamespace, deploymentName string
+		var deployment *appsv1.Deployment
+
+		ginkgo.BeforeEach(func() {
+			deploymentNamespace = testNamespace
+			deploymentName = deploymentNamePrefix + rand.String(RandomStrLength)
+			propagationPolicyNamespace = testNamespace
+			propagationPolicyName = deploymentName
+			overridePolicyNamespace = testNamespace
+			overridePolicyName = deploymentName
+
+			deployment = helper.NewDeployment(deploymentNamespace, deploymentName)
+			propagationPolicy = helper.NewPropagationPolicy(propagationPolicyNamespace, propagationPolicyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: deployment.APIVersion,
+					Kind:       deployment.Kind,
+					Name:       deployment.Name,
+				},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
 					ClusterNames: framework.ClusterNames(),
 				},
-				Overriders: policyv1alpha1.Overriders{
-					ImageOverrider: []policyv1alpha1.ImageOverrider{
-						{
-							Component: "Registry",
-							Operator:  "replace",
-							Value:     "fictional.registry.us",
-						},
-						{
-							Component: "Repository",
-							Operator:  "replace",
-							Value:     "busybox",
-						},
-						{
-							Component: "Tag",
-							Operator:  "replace",
-							Value:     "1.0",
+			})
+			overridePolicy = helper.NewOverridePolicyByOverrideRules(overridePolicyNamespace, overridePolicyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: deployment.APIVersion,
+					Kind:       deployment.Kind,
+					Name:       deployment.Name,
+				},
+			}, []policyv1alpha1.RuleWithCluster{
+				{
+					TargetCluster: &policyv1alpha1.ClusterAffinity{
+						ClusterNames: framework.ClusterNames(),
+					},
+					Overriders: policyv1alpha1.Overriders{
+						ImageOverrider: []policyv1alpha1.ImageOverrider{
+							{
+								Component: "Registry",
+								Operator:  "replace",
+								Value:     "fictional.registry.us",
+							},
+							{
+								Component: "Repository",
+								Operator:  "replace",
+								Value:     "busybox",
+							},
+							{
+								Component: "Tag",
+								Operator:  "replace",
+								Value:     "1.0",
+							},
 						},
 					},
 				},
-			},
+			})
 		})
 
 		ginkgo.BeforeEach(func() {
@@ -377,56 +416,61 @@ var _ = ginkgo.Describe("[OverrideRules] apply overriders testing", func() {
 	})
 
 	ginkgo.Context("Pod override all images in container list", func() {
-		podNamespace := testNamespace
-		podName := podNamePrefix + rand.String(RandomStrLength)
-		propagationPolicyNamespace := testNamespace
-		propagationPolicyName := podName
-		overridePolicyNamespace := testNamespace
-		overridePolicyName := podName
+		var podNamespace, podName string
+		var pod *corev1.Pod
 
-		pod := helper.NewPod(podNamespace, podName)
-		propagationPolicy := helper.NewPropagationPolicy(propagationPolicyNamespace, propagationPolicyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: pod.APIVersion,
-				Kind:       pod.Kind,
-				Name:       pod.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: framework.ClusterNames(),
-			},
-		})
-		overridePolicy := helper.NewOverridePolicyByOverrideRules(overridePolicyNamespace, overridePolicyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: pod.APIVersion,
-				Kind:       pod.Kind,
-				Name:       pod.Name,
-			},
-		}, []policyv1alpha1.RuleWithCluster{
-			{
-				TargetCluster: &policyv1alpha1.ClusterAffinity{
+		ginkgo.BeforeEach(func() {
+			podNamespace = testNamespace
+			podName = podNamePrefix + rand.String(RandomStrLength)
+			propagationPolicyNamespace = testNamespace
+			propagationPolicyName = podName
+			overridePolicyNamespace = testNamespace
+			overridePolicyName = podName
+
+			pod = helper.NewPod(podNamespace, podName)
+			propagationPolicy = helper.NewPropagationPolicy(propagationPolicyNamespace, propagationPolicyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: pod.APIVersion,
+					Kind:       pod.Kind,
+					Name:       pod.Name,
+				},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
 					ClusterNames: framework.ClusterNames(),
 				},
-				Overriders: policyv1alpha1.Overriders{
-					ImageOverrider: []policyv1alpha1.ImageOverrider{
-						{
-							Component: "Registry",
-							Operator:  "replace",
-							Value:     "fictional.registry.us",
-						},
-						{
-							Component: "Repository",
-							Operator:  "replace",
-							Value:     "busybox",
-						},
-						{
-							Component: "Tag",
-							Operator:  "replace",
-							Value:     "1.0",
+			})
+			overridePolicy = helper.NewOverridePolicyByOverrideRules(overridePolicyNamespace, overridePolicyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: pod.APIVersion,
+					Kind:       pod.Kind,
+					Name:       pod.Name,
+				},
+			}, []policyv1alpha1.RuleWithCluster{
+				{
+					TargetCluster: &policyv1alpha1.ClusterAffinity{
+						ClusterNames: framework.ClusterNames(),
+					},
+					Overriders: policyv1alpha1.Overriders{
+						ImageOverrider: []policyv1alpha1.ImageOverrider{
+							{
+								Component: "Registry",
+								Operator:  "replace",
+								Value:     "fictional.registry.us",
+							},
+							{
+								Component: "Repository",
+								Operator:  "replace",
+								Value:     "busybox",
+							},
+							{
+								Component: "Tag",
+								Operator:  "replace",
+								Value:     "1.0",
+							},
 						},
 					},
 				},
-			},
+			})
 		})
 
 		ginkgo.BeforeEach(func() {
@@ -458,49 +502,54 @@ var _ = ginkgo.Describe("[OverrideRules] apply overriders testing", func() {
 	})
 
 	ginkgo.Context("Deployment override specific images in container list", func() {
-		deploymentNamespace := testNamespace
-		deploymentName := deploymentNamePrefix + rand.String(RandomStrLength)
-		propagationPolicyNamespace := testNamespace
-		propagationPolicyName := deploymentName
-		overridePolicyNamespace := testNamespace
-		overridePolicyName := deploymentName
+		var deploymentNamespace, deploymentName string
+		var deployment *appsv1.Deployment
 
-		deployment := helper.NewDeployment(deploymentNamespace, deploymentName)
-		propagationPolicy := helper.NewPropagationPolicy(propagationPolicyNamespace, propagationPolicyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: deployment.APIVersion,
-				Kind:       deployment.Kind,
-				Name:       deployment.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: framework.ClusterNames(),
-			},
-		})
-		overridePolicy := helper.NewOverridePolicyByOverrideRules(overridePolicyNamespace, overridePolicyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: deployment.APIVersion,
-				Kind:       deployment.Kind,
-				Name:       deployment.Name,
-			},
-		}, []policyv1alpha1.RuleWithCluster{
-			{
-				TargetCluster: &policyv1alpha1.ClusterAffinity{
+		ginkgo.BeforeEach(func() {
+			deploymentNamespace = testNamespace
+			deploymentName = deploymentNamePrefix + rand.String(RandomStrLength)
+			propagationPolicyNamespace = testNamespace
+			propagationPolicyName = deploymentName
+			overridePolicyNamespace = testNamespace
+			overridePolicyName = deploymentName
+
+			deployment = helper.NewDeployment(deploymentNamespace, deploymentName)
+			propagationPolicy = helper.NewPropagationPolicy(propagationPolicyNamespace, propagationPolicyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: deployment.APIVersion,
+					Kind:       deployment.Kind,
+					Name:       deployment.Name,
+				},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
 					ClusterNames: framework.ClusterNames(),
 				},
-				Overriders: policyv1alpha1.Overriders{
-					ImageOverrider: []policyv1alpha1.ImageOverrider{
-						{
-							Predicate: &policyv1alpha1.ImagePredicate{
-								Path: "/spec/template/spec/containers/0/image",
+			})
+			overridePolicy = helper.NewOverridePolicyByOverrideRules(overridePolicyNamespace, overridePolicyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: deployment.APIVersion,
+					Kind:       deployment.Kind,
+					Name:       deployment.Name,
+				},
+			}, []policyv1alpha1.RuleWithCluster{
+				{
+					TargetCluster: &policyv1alpha1.ClusterAffinity{
+						ClusterNames: framework.ClusterNames(),
+					},
+					Overriders: policyv1alpha1.Overriders{
+						ImageOverrider: []policyv1alpha1.ImageOverrider{
+							{
+								Predicate: &policyv1alpha1.ImagePredicate{
+									Path: "/spec/template/spec/containers/0/image",
+								},
+								Component: "Registry",
+								Operator:  "replace",
+								Value:     "fictional.registry.us",
 							},
-							Component: "Registry",
-							Operator:  "replace",
-							Value:     "fictional.registry.us",
 						},
 					},
 				},
-			},
+			})
 		})
 
 		ginkgo.BeforeEach(func() {
@@ -529,16 +578,23 @@ var _ = ginkgo.Describe("[OverrideRules] apply overriders testing", func() {
 })
 
 var _ = ginkgo.Describe("OverrideRules with nil resourceSelectors", func() {
-	ginkgo.Context("Deployment override testing", func() {
-		deploymentNamespace := testNamespace
-		deploymentName := deploymentNamePrefix + rand.String(RandomStrLength)
-		propagationPolicyNamespace := testNamespace
-		propagationPolicyName := deploymentName
-		overridePolicyNamespace := testNamespace
-		overridePolicyName := deploymentName
+	var deploymentNamespace, deploymentName string
+	var propagationPolicyNamespace, propagationPolicyName string
+	var overridePolicyNamespace, overridePolicyName string
+	var deployment *appsv1.Deployment
+	var propagationPolicy *policyv1alpha1.PropagationPolicy
+	var overridePolicy *policyv1alpha1.OverridePolicy
 
-		deployment := helper.NewDeployment(deploymentNamespace, deploymentName)
-		propagationPolicy := helper.NewPropagationPolicy(propagationPolicyNamespace, propagationPolicyName, []policyv1alpha1.ResourceSelector{
+	ginkgo.BeforeEach(func() {
+		deploymentNamespace = testNamespace
+		deploymentName = deploymentNamePrefix + rand.String(RandomStrLength)
+		propagationPolicyNamespace = testNamespace
+		propagationPolicyName = deploymentName
+		overridePolicyNamespace = testNamespace
+		overridePolicyName = deploymentName
+
+		deployment = helper.NewDeployment(deploymentNamespace, deploymentName)
+		propagationPolicy = helper.NewPropagationPolicy(propagationPolicyNamespace, propagationPolicyName, []policyv1alpha1.ResourceSelector{
 			{
 				APIVersion: deployment.APIVersion,
 				Kind:       deployment.Kind,
@@ -550,7 +606,7 @@ var _ = ginkgo.Describe("OverrideRules with nil resourceSelectors", func() {
 			},
 		})
 
-		overridePolicy := helper.NewOverridePolicyByOverrideRules(overridePolicyNamespace, overridePolicyName, nil, []policyv1alpha1.RuleWithCluster{
+		overridePolicy = helper.NewOverridePolicyByOverrideRules(overridePolicyNamespace, overridePolicyName, nil, []policyv1alpha1.RuleWithCluster{
 			{
 				TargetCluster: &policyv1alpha1.ClusterAffinity{
 					ClusterNames: framework.ClusterNames(),
@@ -569,7 +625,9 @@ var _ = ginkgo.Describe("OverrideRules with nil resourceSelectors", func() {
 				},
 			},
 		})
+	})
 
+	ginkgo.Context("Deployment override testing", func() {
 		ginkgo.BeforeEach(func() {
 			framework.CreatePropagationPolicy(karmadaClient, propagationPolicy)
 			framework.CreateOverridePolicy(karmadaClient, overridePolicy)

--- a/test/e2e/porting_workloads_test.go
+++ b/test/e2e/porting_workloads_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -19,22 +20,29 @@ import (
 var _ = ginkgo.Describe("porting workloads testing", func() {
 
 	ginkgo.Context("porting workloads from legacy clusters testing", func() {
-		policyNamespace := testNamespace
-		policyName := deploymentNamePrefix + rand.String(RandomStrLength)
-		deploymentNamespace := testNamespace
-		deploymentName := policyName
+		var policyNamespace, policyName string
+		var deploymentNamespace, deploymentName string
+		var deployment *appsv1.Deployment
+		var policy *policyv1alpha1.PropagationPolicy
 
-		deployment := helper.NewDeployment(deploymentNamespace, deploymentName)
-		policy := helper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: deployment.APIVersion,
-				Kind:       deployment.Kind,
-				Name:       deployment.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: framework.ClusterNames(),
-			},
+		ginkgo.BeforeEach(func() {
+			policyNamespace = testNamespace
+			policyName = deploymentNamePrefix + rand.String(RandomStrLength)
+			deploymentNamespace = testNamespace
+			deploymentName = policyName
+
+			deployment = helper.NewDeployment(deploymentNamespace, deploymentName)
+			policy = helper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: deployment.APIVersion,
+					Kind:       deployment.Kind,
+					Name:       deployment.Name,
+				},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: framework.ClusterNames(),
+				},
+			})
 		})
 
 		ginkgo.It("porting Deployments from legacy clusters testing", func() {

--- a/test/e2e/propagationpolicy_test.go
+++ b/test/e2e/propagationpolicy_test.go
@@ -29,22 +29,29 @@ import (
 // BasicPropagation focus on basic propagation functionality testing.
 var _ = ginkgo.Describe("[BasicPropagation] basic propagation testing", func() {
 	ginkgo.Context("Deployment propagation testing", func() {
-		policyNamespace := testNamespace
-		policyName := deploymentNamePrefix + rand.String(RandomStrLength)
-		deploymentNamespace := testNamespace
-		deploymentName := policyName
+		var policyNamespace, policyName string
+		var deploymentNamespace, deploymentName string
+		var deployment *appsv1.Deployment
+		var policy *policyv1alpha1.PropagationPolicy
 
-		deployment := testhelper.NewDeployment(deploymentNamespace, deploymentName)
-		policy := testhelper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: deployment.APIVersion,
-				Kind:       deployment.Kind,
-				Name:       deployment.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: framework.ClusterNames(),
-			},
+		ginkgo.BeforeEach(func() {
+			policyNamespace = testNamespace
+			policyName = deploymentNamePrefix + rand.String(RandomStrLength)
+			deploymentNamespace = testNamespace
+			deploymentName = policyName
+
+			deployment = testhelper.NewDeployment(deploymentNamespace, deploymentName)
+			policy = testhelper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: deployment.APIVersion,
+					Kind:       deployment.Kind,
+					Name:       deployment.Name,
+				},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: framework.ClusterNames(),
+				},
+			})
 		})
 
 		ginkgo.It("deployment propagation testing", func() {
@@ -68,22 +75,29 @@ var _ = ginkgo.Describe("[BasicPropagation] basic propagation testing", func() {
 	})
 
 	ginkgo.Context("Service propagation testing", func() {
-		policyNamespace := testNamespace
-		policyName := serviceNamePrefix + rand.String(RandomStrLength)
-		serviceNamespace := policyNamespace
-		serviceName := policyName
+		var policyNamespace, policyName string
+		var serviceNamespace, serviceName string
+		var service *corev1.Service
+		var policy *policyv1alpha1.PropagationPolicy
 
-		service := testhelper.NewService(serviceNamespace, serviceName)
-		policy := testhelper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: service.APIVersion,
-				Kind:       service.Kind,
-				Name:       service.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: framework.ClusterNames(),
-			},
+		ginkgo.BeforeEach(func() {
+			policyNamespace = testNamespace
+			policyName = serviceNamePrefix + rand.String(RandomStrLength)
+			serviceNamespace = policyNamespace
+			serviceName = policyName
+
+			service = testhelper.NewService(serviceNamespace, serviceName)
+			policy = testhelper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: service.APIVersion,
+					Kind:       service.Kind,
+					Name:       service.Name,
+				},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: framework.ClusterNames(),
+				},
+			})
 		})
 
 		ginkgo.It("service propagation testing", func() {
@@ -109,22 +123,28 @@ var _ = ginkgo.Describe("[BasicPropagation] basic propagation testing", func() {
 	})
 
 	ginkgo.Context("Pod propagation testing", func() {
-		policyNamespace := testNamespace
-		policyName := podNamePrefix + rand.String(RandomStrLength)
-		podNamespace := policyNamespace
-		podName := policyName
+		var policyNamespace, policyName string
+		var podNamespace, podName string
+		var pod *corev1.Pod
+		var policy *policyv1alpha1.PropagationPolicy
+		ginkgo.BeforeEach(func() {
+			policyNamespace = testNamespace
+			policyName = podNamePrefix + rand.String(RandomStrLength)
+			podNamespace = policyNamespace
+			podName = policyName
 
-		pod := testhelper.NewPod(podNamespace, podName)
-		policy := testhelper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: pod.APIVersion,
-				Kind:       pod.Kind,
-				Name:       pod.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: framework.ClusterNames(),
-			},
+			pod = testhelper.NewPod(podNamespace, podName)
+			policy = testhelper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: pod.APIVersion,
+					Kind:       pod.Kind,
+					Name:       pod.Name,
+				},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: framework.ClusterNames(),
+				},
+			})
 		})
 
 		ginkgo.It("pod propagation testing", func() {
@@ -150,43 +170,56 @@ var _ = ginkgo.Describe("[BasicPropagation] basic propagation testing", func() {
 	})
 
 	ginkgo.Context("NamespaceScoped CustomResource propagation testing", func() {
-		crdGroup := fmt.Sprintf("example-%s.karmada.io", rand.String(RandomStrLength))
-		randStr := rand.String(RandomStrLength)
-		crdSpecNames := apiextensionsv1.CustomResourceDefinitionNames{
-			Kind:     fmt.Sprintf("Foo%s", randStr),
-			ListKind: fmt.Sprintf("Foo%sList", randStr),
-			Plural:   fmt.Sprintf("foo%ss", randStr),
-			Singular: fmt.Sprintf("foo%s", randStr),
-		}
-		crd := testhelper.NewCustomResourceDefinition(crdGroup, crdSpecNames, apiextensionsv1.NamespaceScoped)
-		crdPolicy := testhelper.NewClusterPropagationPolicy(crd.Name, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: crd.APIVersion,
-				Kind:       crd.Kind,
-				Name:       crd.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: framework.ClusterNames(),
-			},
-		})
+		var crdGroup string
+		var randStr string
+		var crdSpecNames apiextensionsv1.CustomResourceDefinitionNames
+		var crd *apiextensionsv1.CustomResourceDefinition
+		var crdPolicy *policyv1alpha1.ClusterPropagationPolicy
+		var crNamespace, crName string
+		var crGVR schema.GroupVersionResource
+		var crAPIVersion string
+		var cr *unstructured.Unstructured
+		var crPolicy *policyv1alpha1.PropagationPolicy
 
-		crNamespace := testNamespace
-		crName := crdNamePrefix + rand.String(RandomStrLength)
-		crGVR := schema.GroupVersionResource{Group: crd.Spec.Group, Version: "v1alpha1", Resource: crd.Spec.Names.Plural}
+		ginkgo.BeforeEach(func() {
+			crdGroup = fmt.Sprintf("example-%s.karmada.io", rand.String(RandomStrLength))
+			randStr = rand.String(RandomStrLength)
+			crdSpecNames = apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:     fmt.Sprintf("Foo%s", randStr),
+				ListKind: fmt.Sprintf("Foo%sList", randStr),
+				Plural:   fmt.Sprintf("foo%ss", randStr),
+				Singular: fmt.Sprintf("foo%s", randStr),
+			}
+			crd = testhelper.NewCustomResourceDefinition(crdGroup, crdSpecNames, apiextensionsv1.NamespaceScoped)
+			crdPolicy = testhelper.NewClusterPropagationPolicy(crd.Name, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: crd.APIVersion,
+					Kind:       crd.Kind,
+					Name:       crd.Name,
+				},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: framework.ClusterNames(),
+				},
+			})
 
-		crAPIVersion := fmt.Sprintf("%s/%s", crd.Spec.Group, "v1alpha1")
-		cr := testhelper.NewCustomResource(crAPIVersion, crd.Spec.Names.Kind, crNamespace, crName)
-		crPolicy := testhelper.NewPropagationPolicy(crNamespace, crName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: crAPIVersion,
-				Kind:       crd.Spec.Names.Kind,
-				Name:       crName,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: framework.ClusterNames(),
-			},
+			crNamespace = testNamespace
+			crName = crdNamePrefix + rand.String(RandomStrLength)
+			crGVR = schema.GroupVersionResource{Group: crd.Spec.Group, Version: "v1alpha1", Resource: crd.Spec.Names.Plural}
+
+			crAPIVersion = fmt.Sprintf("%s/%s", crd.Spec.Group, "v1alpha1")
+			cr = testhelper.NewCustomResource(crAPIVersion, crd.Spec.Names.Kind, crNamespace, crName)
+			crPolicy = testhelper.NewPropagationPolicy(crNamespace, crName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: crAPIVersion,
+					Kind:       crd.Spec.Names.Kind,
+					Name:       crName,
+				},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: framework.ClusterNames(),
+				},
+			})
 		})
 
 		ginkgo.It("namespaceScoped cr propagation testing", func() {
@@ -298,22 +331,29 @@ var _ = ginkgo.Describe("[BasicPropagation] basic propagation testing", func() {
 	})
 
 	ginkgo.Context("Job propagation testing", func() {
-		policyNamespace := testNamespace
-		policyName := jobNamePrefix + rand.String(RandomStrLength)
-		jobNamespace := testNamespace
-		jobName := policyName
+		var policyNamespace, policyName string
+		var jobNamespace, jobName string
+		var job *batchv1.Job
+		var policy *policyv1alpha1.PropagationPolicy
 
-		job := testhelper.NewJob(jobNamespace, jobName)
-		policy := testhelper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: job.APIVersion,
-				Kind:       job.Kind,
-				Name:       job.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: framework.ClusterNames(),
-			},
+		ginkgo.BeforeEach(func() {
+			policyNamespace = testNamespace
+			policyName = jobNamePrefix + rand.String(RandomStrLength)
+			jobNamespace = testNamespace
+			jobName = policyName
+
+			job = testhelper.NewJob(jobNamespace, jobName)
+			policy = testhelper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: job.APIVersion,
+					Kind:       job.Kind,
+					Name:       job.Name,
+				},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: framework.ClusterNames(),
+				},
+			})
 		})
 
 		ginkgo.It("job propagation testing", func() {

--- a/test/e2e/rescheduling_test.go
+++ b/test/e2e/rescheduling_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/utils/pointer"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -27,11 +28,19 @@ import (
 // reschedule testing is used to test the rescheduling situation when some initially scheduled clusters are unjoined
 var _ = ginkgo.Describe("reschedule testing", func() {
 	ginkgo.Context("Deployment propagation testing", func() {
-		newClusterName := "member-e2e-" + rand.String(3)
-		homeDir := os.Getenv("HOME")
-		kubeConfigPath := fmt.Sprintf("%s/.kube/%s.config", homeDir, newClusterName)
-		controlPlane := fmt.Sprintf("%s-control-plane", newClusterName)
-		clusterContext := fmt.Sprintf("kind-%s", newClusterName)
+		var newClusterName string
+		var homeDir string
+		var kubeConfigPath string
+		var controlPlane string
+		var clusterContext string
+
+		ginkgo.BeforeEach(func() {
+			newClusterName = "member-e2e-" + rand.String(3)
+			homeDir = os.Getenv("HOME")
+			kubeConfigPath = fmt.Sprintf("%s/.kube/%s.config", homeDir, newClusterName)
+			controlPlane = fmt.Sprintf("%s-control-plane", newClusterName)
+			clusterContext = fmt.Sprintf("kind-%s", newClusterName)
+		})
 
 		ginkgo.BeforeEach(func() {
 			ginkgo.By(fmt.Sprintf("Creating cluster: %s", newClusterName), func() {
@@ -48,25 +57,32 @@ var _ = ginkgo.Describe("reschedule testing", func() {
 			})
 		})
 
-		policyNamespace := testNamespace
-		policyName := deploymentNamePrefix + rand.String(RandomStrLength)
-		deploymentNamespace := testNamespace
-		deploymentName := policyName
-		deployment := testhelper.NewDeployment(deploymentNamespace, deploymentName)
-		deployment.Spec.Replicas = pointer.Int32Ptr(10)
+		var policyNamespace, policyName string
+		var deploymentNamespace, deploymentName string
+		var deployment *appsv1.Deployment
+		var policy *policyv1alpha1.PropagationPolicy
 
-		// set MaxGroups=MinGroups=1, label is sync-mode=Push.
-		policy := testhelper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: deployment.APIVersion,
-				Kind:       deployment.Kind,
-				Name:       deployment.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
-				ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
-				ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceWeighted,
-			},
+		ginkgo.BeforeEach(func() {
+			policyNamespace = testNamespace
+			policyName = deploymentNamePrefix + rand.String(RandomStrLength)
+			deploymentNamespace = testNamespace
+			deploymentName = policyName
+			deployment = testhelper.NewDeployment(deploymentNamespace, deploymentName)
+			deployment.Spec.Replicas = pointer.Int32Ptr(10)
+
+			// set MaxGroups=MinGroups=1, label is sync-mode=Push.
+			policy = testhelper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: deployment.APIVersion,
+					Kind:       deployment.Kind,
+					Name:       deployment.Name,
+				},
+			}, policyv1alpha1.Placement{
+				ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+					ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
+					ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceWeighted,
+				},
+			})
 		})
 
 		ginkgo.It("deployment reschedule testing", func() {

--- a/test/e2e/resource_test.go
+++ b/test/e2e/resource_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -18,22 +19,29 @@ import (
 var _ = ginkgo.Describe("[resource-status collection] resource status collection testing", func() {
 
 	ginkgo.Context("DeploymentStatus collection testing", func() {
-		policyNamespace := testNamespace
-		policyName := deploymentNamePrefix + rand.String(RandomStrLength)
-		deploymentNamespace := testNamespace
-		deploymentName := policyName
+		var policyNamespace, policyName string
+		var deploymentNamespace, deploymentName string
+		var deployment *appsv1.Deployment
+		var policy *policyv1alpha1.PropagationPolicy
 
-		deployment := helper.NewDeployment(deploymentNamespace, deploymentName)
-		policy := helper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: deployment.APIVersion,
-				Kind:       deployment.Kind,
-				Name:       deployment.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: framework.ClusterNames(),
-			},
+		ginkgo.BeforeEach(func() {
+			policyNamespace = testNamespace
+			policyName = deploymentNamePrefix + rand.String(RandomStrLength)
+			deploymentNamespace = testNamespace
+			deploymentName = policyName
+
+			deployment = helper.NewDeployment(deploymentNamespace, deploymentName)
+			policy = helper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: deployment.APIVersion,
+					Kind:       deployment.Kind,
+					Name:       deployment.Name,
+				},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: framework.ClusterNames(),
+				},
+			})
 		})
 
 		ginkgo.It("deployment status collection testing", func() {

--- a/test/e2e/scheduling_test.go
+++ b/test/e2e/scheduling_test.go
@@ -36,34 +36,42 @@ var _ = ginkgo.Describe("propagation with label and group constraints testing", 
 	ginkgo.Context("Deployment propagation testing", func() {
 		var groupMatchedClusters []string
 		var targetClusterNames []string
-		policyNamespace := testNamespace
-		policyName := deploymentNamePrefix + rand.String(RandomStrLength)
-		deploymentNamespace := testNamespace
-		deploymentName := policyName
-		deployment := helper.NewDeployment(deploymentNamespace, deploymentName)
-		maxGroups := rand.Intn(2) + 1
-		minGroups := maxGroups
+		var policyNamespace, policyName string
+		var deploymentNamespace, deploymentName string
+		var deployment *appsv1.Deployment
+		var maxGroups, minGroups int
+		var policy *policyv1alpha1.PropagationPolicy
 
-		// set MaxGroups=MinGroups=1 or 2, label is location=CHN.
-		policy := helper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: deployment.APIVersion,
-				Kind:       deployment.Kind,
-				Name:       deployment.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				LabelSelector: &metav1.LabelSelector{
-					MatchLabels: clusterLabels,
-				},
-			},
-			SpreadConstraints: []policyv1alpha1.SpreadConstraint{
+		ginkgo.BeforeEach(func() {
+			policyNamespace = testNamespace
+			policyName = deploymentNamePrefix + rand.String(RandomStrLength)
+			deploymentNamespace = testNamespace
+			deploymentName = policyName
+			deployment = helper.NewDeployment(deploymentNamespace, deploymentName)
+			maxGroups = rand.Intn(2) + 1
+			minGroups = maxGroups
+
+			// set MaxGroups=MinGroups=1 or 2, label is location=CHN.
+			policy = helper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
 				{
-					SpreadByField: policyv1alpha1.SpreadByFieldCluster,
-					MaxGroups:     maxGroups,
-					MinGroups:     minGroups,
+					APIVersion: deployment.APIVersion,
+					Kind:       deployment.Kind,
+					Name:       deployment.Name,
 				},
-			},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: clusterLabels,
+					},
+				},
+				SpreadConstraints: []policyv1alpha1.SpreadConstraint{
+					{
+						SpreadByField: policyv1alpha1.SpreadByFieldCluster,
+						MaxGroups:     maxGroups,
+						MinGroups:     minGroups,
+					},
+				},
+			})
 		})
 
 		ginkgo.It("deployment propagation with label and group constraints testing", func() {
@@ -109,40 +117,50 @@ var _ = ginkgo.Describe("propagation with label and group constraints testing", 
 	ginkgo.Context("CustomResourceDefinition propagation testing", func() {
 		var groupMatchedClusters []*clusterv1alpha1.Cluster
 		var targetClusterNames []string
-		crdGroup := fmt.Sprintf("example-%s.karmada.io", rand.String(RandomStrLength))
-		randStr := rand.String(RandomStrLength)
-		crdSpecNames := apiextensionsv1.CustomResourceDefinitionNames{
-			Kind:     fmt.Sprintf("Foo%s", randStr),
-			ListKind: fmt.Sprintf("Foo%sList", randStr),
-			Plural:   fmt.Sprintf("foo%ss", randStr),
-			Singular: fmt.Sprintf("foo%s", randStr),
-		}
-		crd := helper.NewCustomResourceDefinition(crdGroup, crdSpecNames, apiextensionsv1.NamespaceScoped)
-		maxGroups := rand.Intn(2) + 1
-		minGroups := maxGroups
+		var crdGroup string
+		var randStr string
+		var crdSpecNames apiextensionsv1.CustomResourceDefinitionNames
+		var crd *apiextensionsv1.CustomResourceDefinition
+		var maxGroups, minGroups int
+		var crdPolicy *policyv1alpha1.ClusterPropagationPolicy
+		var crdGVR schema.GroupVersionResource
 
-		// set MaxGroups=MinGroups=1 or 2, label is location=CHN.
-		crdPolicy := helper.NewClusterPropagationPolicy(crd.Name, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: crd.APIVersion,
-				Kind:       crd.Kind,
-				Name:       crd.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				LabelSelector: &metav1.LabelSelector{
-					MatchLabels: clusterLabels,
-				},
-			},
-			SpreadConstraints: []policyv1alpha1.SpreadConstraint{
+		ginkgo.BeforeEach(func() {
+			crdGroup = fmt.Sprintf("example-%s.karmada.io", rand.String(RandomStrLength))
+			randStr = rand.String(RandomStrLength)
+			crdSpecNames = apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:     fmt.Sprintf("Foo%s", randStr),
+				ListKind: fmt.Sprintf("Foo%sList", randStr),
+				Plural:   fmt.Sprintf("foo%ss", randStr),
+				Singular: fmt.Sprintf("foo%s", randStr),
+			}
+			crd = helper.NewCustomResourceDefinition(crdGroup, crdSpecNames, apiextensionsv1.NamespaceScoped)
+			maxGroups = rand.Intn(2) + 1
+			minGroups = maxGroups
+
+			// set MaxGroups=MinGroups=1 or 2, label is location=CHN.
+			crdPolicy = helper.NewClusterPropagationPolicy(crd.Name, []policyv1alpha1.ResourceSelector{
 				{
-					SpreadByField: policyv1alpha1.SpreadByFieldCluster,
-					MaxGroups:     maxGroups,
-					MinGroups:     minGroups,
+					APIVersion: crd.APIVersion,
+					Kind:       crd.Kind,
+					Name:       crd.Name,
 				},
-			},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: clusterLabels,
+					},
+				},
+				SpreadConstraints: []policyv1alpha1.SpreadConstraint{
+					{
+						SpreadByField: policyv1alpha1.SpreadByFieldCluster,
+						MaxGroups:     maxGroups,
+						MinGroups:     minGroups,
+					},
+				},
+			})
+			crdGVR = schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}
 		})
-		crdGVR := schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}
 
 		ginkgo.It("crd with specified label and group constraints propagation testing", func() {
 			framework.CreateClusterPropagationPolicy(karmadaClient, crdPolicy)
@@ -212,34 +230,42 @@ var _ = ginkgo.Describe("propagation with label and group constraints testing", 
 	ginkgo.Context("Job propagation testing", func() {
 		var groupMatchedClusters []string
 		var targetClusterNames []string
-		policyNamespace := testNamespace
-		policyName := jobNamePrefix + rand.String(RandomStrLength)
-		jobNamespace := testNamespace
-		jobName := policyName
-		job := helper.NewJob(jobNamespace, jobName)
-		maxGroups := rand.Intn(2) + 1
-		minGroups := maxGroups
+		var policyNamespace, policyName string
+		var jobNamespace, jobName string
+		var job *batchv1.Job
+		var maxGroups, minGroups int
+		var policy *policyv1alpha1.PropagationPolicy
 
-		// set MaxGroups=MinGroups=1 or 2, label is location=CHN.
-		policy := helper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: job.APIVersion,
-				Kind:       job.Kind,
-				Name:       job.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				LabelSelector: &metav1.LabelSelector{
-					MatchLabels: clusterLabels,
-				},
-			},
-			SpreadConstraints: []policyv1alpha1.SpreadConstraint{
+		ginkgo.BeforeEach(func() {
+			policyNamespace = testNamespace
+			policyName = jobNamePrefix + rand.String(RandomStrLength)
+			jobNamespace = testNamespace
+			jobName = policyName
+			job = helper.NewJob(jobNamespace, jobName)
+			maxGroups = rand.Intn(2) + 1
+			minGroups = maxGroups
+
+			// set MaxGroups=MinGroups=1 or 2, label is location=CHN.
+			policy = helper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
 				{
-					SpreadByField: policyv1alpha1.SpreadByFieldCluster,
-					MaxGroups:     maxGroups,
-					MinGroups:     minGroups,
+					APIVersion: job.APIVersion,
+					Kind:       job.Kind,
+					Name:       job.Name,
 				},
-			},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: clusterLabels,
+					},
+				},
+				SpreadConstraints: []policyv1alpha1.SpreadConstraint{
+					{
+						SpreadByField: policyv1alpha1.SpreadByFieldCluster,
+						MaxGroups:     maxGroups,
+						MinGroups:     minGroups,
+					},
+				},
+			})
 		})
 
 		ginkgo.It("Job propagation with label and group constraints testing", func() {
@@ -321,15 +347,19 @@ var _ = ginkgo.Describe("propagation with label and group constraints testing", 
 			`ReplicaSchedulingType` value is `Divided`, `ReplicaDivisionPreference` value is `Weighted`, `WeightPreference` isn't nil, trigger rescheduling when replicas have changed.
 */
 var _ = ginkgo.Describe("[ReplicaScheduling] ReplicaSchedulingStrategy testing", func() {
-	// Case 1: `ReplicaSchedulingType` value is `Duplicated`.
-	ginkgo.Context("ReplicaSchedulingType is Duplicated.", func() {
-		policyNamespace := testNamespace
-		policyName := deploymentNamePrefix + rand.String(RandomStrLength)
-		deploymentNamespace := policyNamespace
-		deploymentName := policyName
+	var policyNamespace, policyName string
+	var deploymentNamespace, deploymentName string
+	var deployment *appsv1.Deployment
+	var policy *policyv1alpha1.PropagationPolicy
 
-		deployment := helper.NewDeployment(deploymentNamespace, deploymentName)
-		policy := helper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
+	ginkgo.BeforeEach(func() {
+		policyNamespace = testNamespace
+		policyName = deploymentNamePrefix + rand.String(RandomStrLength)
+		deploymentNamespace = policyNamespace
+		deploymentName = policyName
+
+		deployment = helper.NewDeployment(deploymentNamespace, deploymentName)
+		policy = helper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
 			{
 				APIVersion: deployment.APIVersion,
 				Kind:       deployment.Kind,
@@ -343,7 +373,10 @@ var _ = ginkgo.Describe("[ReplicaScheduling] ReplicaSchedulingStrategy testing",
 				ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDuplicated,
 			},
 		})
+	})
 
+	// Case 1: `ReplicaSchedulingType` value is `Duplicated`.
+	ginkgo.Context("ReplicaSchedulingType is Duplicated.", func() {
 		ginkgo.It("replicas duplicated testing", func() {
 			framework.CreatePropagationPolicy(karmadaClient, policy)
 			framework.CreateDeployment(kubeClient, deployment)
@@ -363,27 +396,6 @@ var _ = ginkgo.Describe("[ReplicaScheduling] ReplicaSchedulingStrategy testing",
 
 	// Case 2: `ReplicaSchedulingType` value is `Duplicated`, trigger rescheduling when replicas have changed.
 	ginkgo.Context("ReplicaSchedulingType is Duplicated, trigger rescheduling when replicas have changed.", func() {
-		policyNamespace := testNamespace
-		policyName := deploymentNamePrefix + rand.String(RandomStrLength)
-		deploymentNamespace := policyNamespace
-		deploymentName := policyName
-
-		deployment := helper.NewDeployment(deploymentNamespace, deploymentName)
-		policy := helper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: deployment.APIVersion,
-				Kind:       deployment.Kind,
-				Name:       deployment.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: framework.ClusterNames(),
-			},
-			ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
-				ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDuplicated,
-			},
-		})
-
 		ginkgo.It("replicas duplicated testing when rescheduling", func() {
 			framework.CreatePropagationPolicy(karmadaClient, policy)
 			framework.CreateDeployment(kubeClient, deployment)
@@ -411,26 +423,11 @@ var _ = ginkgo.Describe("[ReplicaScheduling] ReplicaSchedulingStrategy testing",
 	// Case 3: `ReplicaSchedulingType` value is `Divided`, `ReplicaDivisionPreference` value is `Weighted`,
 	// `WeightPreference` is nil.
 	ginkgo.Context("ReplicaSchedulingType is Divided, ReplicaDivisionPreference is Weighted, WeightPreference is nil.", func() {
-		policyNamespace := testNamespace
-		policyName := deploymentNamePrefix + rand.String(RandomStrLength)
-		deploymentNamespace := policyNamespace
-		deploymentName := policyName
-
-		deployment := helper.NewDeployment(deploymentNamespace, deploymentName)
-		policy := helper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: deployment.APIVersion,
-				Kind:       deployment.Kind,
-				Name:       deployment.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: framework.ClusterNames(),
-			},
-			ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+		ginkgo.BeforeEach(func() {
+			policy.Spec.Placement.ReplicaScheduling = &policyv1alpha1.ReplicaSchedulingStrategy{
 				ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
 				ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceWeighted,
-			},
+			}
 		})
 
 		ginkgo.It("replicas divided and weighted testing", func() {
@@ -457,26 +454,11 @@ var _ = ginkgo.Describe("[ReplicaScheduling] ReplicaSchedulingStrategy testing",
 	// `WeightPreference` is nil, trigger rescheduling when replicas have changed.
 	ginkgo.Context("ReplicaSchedulingType is Divided, ReplicaDivisionPreference is Weighted, WeightPreference is "+
 		"nil, trigger rescheduling when replicas have changed.", func() {
-		policyNamespace := testNamespace
-		policyName := deploymentNamePrefix + rand.String(RandomStrLength)
-		deploymentNamespace := policyNamespace
-		deploymentName := policyName
-
-		deployment := helper.NewDeployment(deploymentNamespace, deploymentName)
-		policy := helper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: deployment.APIVersion,
-				Kind:       deployment.Kind,
-				Name:       deployment.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: framework.ClusterNames(),
-			},
-			ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+		ginkgo.BeforeEach(func() {
+			policy.Spec.Placement.ReplicaScheduling = &policyv1alpha1.ReplicaSchedulingStrategy{
 				ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
 				ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceWeighted,
-			},
+			}
 		})
 
 		ginkgo.It("replicas divided and weighted testing when rescheduling", func() {
@@ -507,27 +489,12 @@ var _ = ginkgo.Describe("[ReplicaScheduling] ReplicaSchedulingStrategy testing",
 	// Case 5: `ReplicaSchedulingType` value is `Divided`, `ReplicaDivisionPreference` value is `Weighted`,
 	// `WeightPreference` isn't nil.
 	ginkgo.Context("ReplicaSchedulingType is Divided, ReplicaDivisionPreference is Weighted, WeightPreference isn't nil.", func() {
-		policyNamespace := testNamespace
-		policyName := deploymentNamePrefix + rand.String(RandomStrLength)
-		deploymentNamespace := policyNamespace
-		deploymentName := policyName
-
-		deployment := helper.NewDeployment(deploymentNamespace, deploymentName)
-		policy := helper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: deployment.APIVersion,
-				Kind:       deployment.Kind,
-				Name:       deployment.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: framework.ClusterNames(),
-			},
-			ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+		ginkgo.BeforeEach(func() {
+			policy.Spec.Placement.ReplicaScheduling = &policyv1alpha1.ReplicaSchedulingStrategy{
 				ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
 				ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceWeighted,
 				WeightPreference:          &policyv1alpha1.ClusterPreferences{},
-			},
+			}
 		})
 
 		ginkgo.It("replicas divided and weighted testing", func() {
@@ -580,27 +547,12 @@ var _ = ginkgo.Describe("[ReplicaScheduling] ReplicaSchedulingStrategy testing",
 	// `WeightPreference` isn't nil, trigger rescheduling when replicas have changed.
 	ginkgo.Context("ReplicaSchedulingType is Divided, ReplicaDivisionPreference is Weighted, WeightPreference isn't "+
 		"nil, trigger rescheduling when replicas have changed.", func() {
-		policyNamespace := testNamespace
-		policyName := deploymentNamePrefix + rand.String(RandomStrLength)
-		deploymentNamespace := policyNamespace
-		deploymentName := policyName
-
-		deployment := helper.NewDeployment(deploymentNamespace, deploymentName)
-		policy := helper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: deployment.APIVersion,
-				Kind:       deployment.Kind,
-				Name:       deployment.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: framework.ClusterNames(),
-			},
-			ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+		ginkgo.BeforeEach(func() {
+			policy.Spec.Placement.ReplicaScheduling = &policyv1alpha1.ReplicaSchedulingStrategy{
 				ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
 				ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceWeighted,
 				WeightPreference:          &policyv1alpha1.ClusterPreferences{},
-			},
+			}
 		})
 
 		ginkgo.BeforeEach(func() {
@@ -671,27 +623,34 @@ var _ = ginkgo.Describe("[JobReplicaScheduling] JobReplicaSchedulingStrategy tes
 	// `ReplicaSchedulingType` value is `Divided`, `ReplicaDivisionPreference` value is `Weighted`,
 	// `WeightPreference` isn't nil, `spec.completions` isn't nil.
 	ginkgo.Context("ReplicaSchedulingType is Divided, ReplicaDivisionPreference is Weighted, WeightPreference isn't nil, spec.completions isn`t nil.", func() {
-		policyNamespace := testNamespace
-		policyName := jobNamePrefix + rand.String(RandomStrLength)
-		jobNamespace := policyNamespace
-		jobName := policyName
+		var policyNamespace, policyName string
+		var jobNamespace, jobName string
+		var job *batchv1.Job
+		var policy *policyv1alpha1.PropagationPolicy
 
-		job := helper.NewJob(jobNamespace, jobName)
-		policy := helper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
-			{
-				APIVersion: job.APIVersion,
-				Kind:       job.Kind,
-				Name:       job.Name,
-			},
-		}, policyv1alpha1.Placement{
-			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-				ClusterNames: framework.ClusterNames(),
-			},
-			ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
-				ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
-				ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceWeighted,
-				WeightPreference:          &policyv1alpha1.ClusterPreferences{},
-			},
+		ginkgo.BeforeEach(func() {
+			policyNamespace = testNamespace
+			policyName = jobNamePrefix + rand.String(RandomStrLength)
+			jobNamespace = policyNamespace
+			jobName = policyName
+
+			job = helper.NewJob(jobNamespace, jobName)
+			policy = helper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: job.APIVersion,
+					Kind:       job.Kind,
+					Name:       job.Name,
+				},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: framework.ClusterNames(),
+				},
+				ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+					ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
+					ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceWeighted,
+					WeightPreference:          &policyv1alpha1.ClusterPreferences{},
+				},
+			})
 		})
 
 		ginkgo.It("job replicas divided and weighted testing", func() {

--- a/test/helper/resource.go
+++ b/test/helper/resource.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 
-	worklodv1alpha1 "github.com/karmada-io/karmada/examples/customresourceinterpreter/apis/workload/v1alpha1"
+	workloadv1alpha1 "github.com/karmada-io/karmada/examples/customresourceinterpreter/apis/workload/v1alpha1"
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 )
 
@@ -430,10 +430,10 @@ func NewClusterWithResource(name string, allocatable, allocating, allocated core
 }
 
 // NewWorkload will build a workload object.
-func NewWorkload(namespace string, name string) *worklodv1alpha1.Workload {
+func NewWorkload(namespace string, name string) *workloadv1alpha1.Workload {
 	podLabels := map[string]string{"app": "nginx"}
 
-	return &worklodv1alpha1.Workload{
+	return &workloadv1alpha1.Workload{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "workload.example.io/v1alpha1",
 			Kind:       "Workload",
@@ -442,7 +442,7 @@ func NewWorkload(namespace string, name string) *worklodv1alpha1.Workload {
 			Namespace: namespace,
 			Name:      name,
 		},
-		Spec: worklodv1alpha1.WorkloadSpec{
+		Spec: workloadv1alpha1.WorkloadSpec{
 			Replicas: pointer.Int32Ptr(3),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Follow the Ginkgo rule [`Declare in container nodes, initialize in setup nodes`](https://onsi.github.io/ginkgo/#extracting-common-setup-beforeeach), so I move the initialize code into `setup nodes`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

