### PR TITLE
fix pull mode example bug

### DIFF
--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -81,7 +81,7 @@ Step 2:  Create karmada kubeconfig secret
 Step 3: Create karmada agent
 (In member kubernetes)~#  MEMBER_CLUSTER_NAME="demo"
 (In member kubernetes)~#  sed -i "s/{member_cluster_name}/${MEMBER_CLUSTER_NAME}/g" karmada-agent.yaml
-(In member kubernetes)~#  kubectl create -f karmada-agent.yaml
+(In member kubernetes)~#  kubectl apply -f karmada-agent.yaml
                                                                                                                                                                              
 Step 4: Show members of karmada                                                                                                                                              
 (In karmada)~# kubectl  --kubeconfig /etc/karmada/karmada-apiserver.config get clusters

--- a/pkg/karmadactl/cmdinit/utils/examples.go
+++ b/pkg/karmadactl/cmdinit/utils/examples.go
@@ -186,7 +186,7 @@ Step 2:  Create karmada kubeconfig secret
 Step 3: Create karmada agent
 (In member kubernetes)~#  MEMBER_CLUSTER_NAME="demo"
 (In member kubernetes)~#  sed -i "s/{member_cluster_name}/${MEMBER_CLUSTER_NAME}/g" karmada-agent.yaml
-(In member kubernetes)~#  kubectl create -f karmada-agent.yaml
+(In member kubernetes)~#  kubectl apply -f karmada-agent.yaml
                                                                                                                                                                              
 Step 4: Show members of karmada                                                                                                                                              
 (In karmada)~# kubectl  --kubeconfig %s/karmada-apiserver.config get clusters


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
After Karmada installed. The show example has a error. In 'Pull' mode example step 2 create a karmada-system namespace. In step 3 use `kubectl create -f karmada-agent.yaml` create agent will generate an error that the karmada-system already exist.In step 3 should use this command  `kubectl create -f karmada-agent.yaml` create agent.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl: fixed the `karmada-system` namespace already existing issue when deploying `karmada-agent` issue.
```

