### PR TITLE
add OSX trash to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@
 /karmada-scheduler-estimator
 /karmada-webhook
 /kubectl-karmada
+
+# OSX trash
+.DS_Store


### PR DESCRIPTION
**What type of PR is this?**
Add OSX trash to gitignore file
<!--
Add one of the following kinds:


/kind cleanup

-->

**What this PR does / why we need it**:
There will be .DS_Store file produced in the karmada project that should be ignored when work on macos  

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->

```release-note
NONE
```

