### PR TITLE
[E2E] move cleanup to ginkgo setup node

### DIFF
--- a/test/e2e/clusterpropagationpolicy_test.go
+++ b/test/e2e/clusterpropagationpolicy_test.go
@@ -43,16 +43,20 @@ var _ = ginkgo.Describe("[BasicClusterPropagation] basic cluster propagation tes
 			})
 		})
 
-		ginkgo.It("crd propagation testing", func() {
+		ginkgo.BeforeEach(func() {
 			framework.CreateClusterPropagationPolicy(karmadaClient, crdPolicy)
 			framework.CreateCRD(dynamicClient, crd)
+			ginkgo.DeferCleanup(func() {
+				framework.RemoveClusterPropagationPolicy(karmadaClient, crdPolicy.Name)
+				framework.RemoveCRD(dynamicClient, crd.Name)
+				framework.WaitCRDDisappearedOnClusters(framework.ClusterNames(), crd.Name)
+			})
+		})
+
+		ginkgo.It("crd propagation testing", func() {
 			framework.GetCRD(dynamicClient, crd.Name)
 			framework.WaitCRDPresentOnClusters(karmadaClient, framework.ClusterNames(),
 				fmt.Sprintf("%s/%s", crd.Spec.Group, "v1alpha1"), crd.Spec.Names.Kind)
-
-			framework.RemoveCRD(dynamicClient, crd.Name)
-			framework.WaitCRDDisappearedOnClusters(framework.ClusterNames(), crd.Name)
-			framework.RemoveClusterPropagationPolicy(karmadaClient, crdPolicy.Name)
 		})
 	})
 })

--- a/test/e2e/failover_test.go
+++ b/test/e2e/failover_test.go
@@ -66,10 +66,16 @@ var _ = ginkgo.Describe("failover testing", func() {
 			})
 		})
 
-		ginkgo.It("deployment failover testing", func() {
+		ginkgo.BeforeEach(func() {
 			framework.CreatePropagationPolicy(karmadaClient, policy)
 			framework.CreateDeployment(kubeClient, deployment)
+			ginkgo.DeferCleanup(func() {
+				framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
+				framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
+			})
+		})
 
+		ginkgo.It("deployment failover testing", func() {
 			var disabledClusters []string
 			targetClusterNames := framework.ExtractTargetClustersFrom(controlPlaneClient, deployment)
 
@@ -130,9 +136,6 @@ var _ = ginkgo.Describe("failover testing", func() {
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				}
 			})
-
-			framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
-			framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
 		})
 	})
 })

--- a/test/e2e/fieldselector_test.go
+++ b/test/e2e/fieldselector_test.go
@@ -118,18 +118,21 @@ var _ = ginkgo.Describe("propagation with fieldSelector testing", func() {
 			})
 		})
 
-		ginkgo.It("propagation with fieldSelector testing", func() {
+		ginkgo.BeforeEach(func() {
 			framework.CreatePropagationPolicy(karmadaClient, policy)
 			framework.CreateDeployment(kubeClient, deployment)
+			ginkgo.DeferCleanup(func() {
+				framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
+				framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
+			})
+		})
 
+		ginkgo.It("propagation with fieldSelector testing", func() {
 			ginkgo.By("check whether deployment is scheduled to clusters which meeting the fieldSelector requirements", func() {
 				targetClusterNames := framework.ExtractTargetClustersFrom(controlPlaneClient, deployment)
 				gomega.Expect(len(targetClusterNames) == 1).Should(gomega.BeTrue())
 				gomega.Expect(targetClusterNames[0] == desiredScheduleResult).Should(gomega.BeTrue())
 			})
-
-			framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
-			framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
 		})
 	})
 })

--- a/test/e2e/mcs_test.go
+++ b/test/e2e/mcs_test.go
@@ -219,67 +219,63 @@ var _ = ginkgo.Describe("[MCS] Multi-Cluster Service testing", func() {
 		framework.CreateClusterPropagationPolicy(karmadaClient, serviceImportPolicy)
 		framework.WaitCRDPresentOnClusters(karmadaClient, framework.ClusterNames(), mcsv1alpha1.GroupVersion.String(), util.ServiceExportKind)
 		framework.WaitCRDPresentOnClusters(karmadaClient, framework.ClusterNames(), mcsv1alpha1.GroupVersion.String(), util.ServiceImportKind)
+		ginkgo.DeferCleanup(func() {
+			framework.RemoveClusterPropagationPolicy(karmadaClient, serviceImportPolicy.Name)
+			framework.RemoveClusterPropagationPolicy(karmadaClient, serviceExportPolicy.Name)
+
+			// Now the deletion of ClusterPropagationPolicy will not cause the deletion of related binding and workload on member clusters,
+			// so we do not need to wait the disappearance of ServiceExport CRD and ServiceImport CRD
+		})
 	})
 
-	ginkgo.AfterEach(func() {
-		framework.RemoveClusterPropagationPolicy(karmadaClient, serviceImportPolicy.Name)
-		framework.RemoveClusterPropagationPolicy(karmadaClient, serviceExportPolicy.Name)
+	ginkgo.BeforeEach(func() {
+		exportClusterClient := framework.GetClusterClient(serviceExportClusterName)
+		gomega.Expect(exportClusterClient).ShouldNot(gomega.BeNil())
 
-		// Now the deletion of ClusterPropagationPolicy will not cause the deletion of related binding and workload on member clusters,
-		// so we do not need to wait the disappearance of ServiceExport CRD and ServiceImport CRD
-	})
+		klog.Infof("Create Deployment(%s/%s) in %s cluster", demoDeployment.Namespace, demoDeployment.Name, serviceExportClusterName)
+		framework.CreateDeployment(exportClusterClient, &demoDeployment)
 
-	ginkgo.Context("Connectivity testing", func() {
-		ginkgo.BeforeEach(func() {
-			exportClusterClient := framework.GetClusterClient(serviceExportClusterName)
-			gomega.Expect(exportClusterClient).ShouldNot(gomega.BeNil())
+		klog.Infof("Create Service(%s/%s) in %s cluster", demoService.Namespace, demoService.Name, serviceExportClusterName)
+		framework.CreateService(exportClusterClient, &demoService)
 
-			klog.Infof("Create Deployment(%s/%s) in %s cluster", demoDeployment.Namespace, demoDeployment.Name, serviceExportClusterName)
-			framework.CreateDeployment(exportClusterClient, &demoDeployment)
+		ginkgo.By(fmt.Sprintf("Wait Service(%s/%s)'s EndpointSlice exist in %s cluster", demoService.Namespace, demoService.Name, serviceExportClusterName), func() {
+			gomega.Eventually(func(g gomega.Gomega) (int, error) {
+				endpointSlices, err := exportClusterClient.DiscoveryV1().EndpointSlices(demoService.Namespace).List(context.TODO(), metav1.ListOptions{
+					LabelSelector: labels.Set{discoveryv1.LabelServiceName: demoService.Name}.AsSelector().String(),
+				})
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 
-			klog.Infof("Create Service(%s/%s) in %s cluster", demoService.Namespace, demoService.Name, serviceExportClusterName)
-			framework.CreateService(exportClusterClient, &demoService)
-
-			ginkgo.By(fmt.Sprintf("Wait Service(%s/%s)'s EndpointSlice exist in %s cluster", demoService.Namespace, demoService.Name, serviceExportClusterName), func() {
-				gomega.Eventually(func(g gomega.Gomega) (int, error) {
-					endpointSlices, err := exportClusterClient.DiscoveryV1().EndpointSlices(demoService.Namespace).List(context.TODO(), metav1.ListOptions{
-						LabelSelector: labels.Set{discoveryv1.LabelServiceName: demoService.Name}.AsSelector().String(),
-					})
-					g.Expect(err).NotTo(gomega.HaveOccurred())
-
-					epNums := 0
-					for _, slice := range endpointSlices.Items {
-						epNums += len(slice.Endpoints)
-					}
-					return epNums, nil
-				}, pollTimeout, pollInterval).Should(gomega.Equal(1))
-			})
+				epNums := 0
+				for _, slice := range endpointSlices.Items {
+					epNums += len(slice.Endpoints)
+				}
+				return epNums, nil
+			}, pollTimeout, pollInterval).Should(gomega.Equal(1))
 		})
 
-		ginkgo.AfterEach(func() {
-			exportClusterClient := framework.GetClusterClient(serviceExportClusterName)
-			gomega.Expect(exportClusterClient).ShouldNot(gomega.BeNil())
-
+		ginkgo.DeferCleanup(func() {
 			klog.Infof("Delete Deployment(%s/%s) in %s cluster", demoDeployment.Namespace, demoDeployment.Name, serviceExportClusterName)
 			framework.RemoveDeployment(exportClusterClient, demoDeployment.Namespace, demoDeployment.Name)
 
 			klog.Infof("Delete Service(%s/%s) in %s cluster", demoService.Namespace, demoService.Name, serviceExportClusterName)
 			framework.RemoveService(exportClusterClient, demoService.Namespace, demoService.Name)
 		})
+	})
 
-		ginkgo.AfterEach(func() {
-			ginkgo.By("Cleanup", func() {
-				err := controlPlaneClient.Delete(context.TODO(), &serviceExport)
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	ginkgo.AfterEach(func() {
+		ginkgo.By("Cleanup", func() {
+			err := controlPlaneClient.Delete(context.TODO(), &serviceExport)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-				err = controlPlaneClient.Delete(context.TODO(), &serviceImport)
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
-
-			framework.RemovePropagationPolicy(karmadaClient, exportPolicy.Namespace, exportPolicy.Name)
-			framework.RemovePropagationPolicy(karmadaClient, importPolicy.Namespace, importPolicy.Name)
+			err = controlPlaneClient.Delete(context.TODO(), &serviceImport)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		})
 
+		framework.RemovePropagationPolicy(karmadaClient, exportPolicy.Namespace, exportPolicy.Name)
+		framework.RemovePropagationPolicy(karmadaClient, importPolicy.Namespace, importPolicy.Name)
+	})
+
+	ginkgo.Context("Connectivity testing", func() {
 		ginkgo.It("Export Service from source-clusters, import Service to destination-clusters", func() {
 			importClusterClient := framework.GetClusterClient(serviceImportClusterName)
 			gomega.Expect(importClusterClient).ShouldNot(gomega.BeNil())
@@ -373,56 +369,6 @@ var _ = ginkgo.Describe("[MCS] Multi-Cluster Service testing", func() {
 	})
 
 	ginkgo.Context("EndpointSlices change testing", func() {
-		ginkgo.BeforeEach(func() {
-			exportClusterClient := framework.GetClusterClient(serviceExportClusterName)
-			gomega.Expect(exportClusterClient).ShouldNot(gomega.BeNil())
-
-			klog.Infof(fmt.Sprintf("Create Deployment(%s/%s) in %s cluster", demoDeployment.Namespace, demoDeployment.Name, serviceExportClusterName))
-			framework.CreateDeployment(exportClusterClient, &demoDeployment)
-
-			klog.Infof(fmt.Sprintf("Create Service(%s/%s) in %s cluster", demoService.Namespace, demoService.Name, serviceExportClusterName))
-			framework.CreateService(exportClusterClient, &demoService)
-
-			ginkgo.By(fmt.Sprintf("Wait Service(%s/%s)'s EndpointSlice exist in %s cluster", demoService.Namespace, demoService.Name, serviceExportClusterName), func() {
-				gomega.Eventually(func(g gomega.Gomega) (int, error) {
-					endpointSlices, err := exportClusterClient.DiscoveryV1().EndpointSlices(demoService.Namespace).List(context.TODO(), metav1.ListOptions{
-						LabelSelector: labels.Set{discoveryv1.LabelServiceName: demoService.Name}.AsSelector().String(),
-					})
-					g.Expect(err).NotTo(gomega.HaveOccurred())
-
-					epNums := 0
-					for _, slice := range endpointSlices.Items {
-						epNums += len(slice.Endpoints)
-					}
-					return epNums, nil
-				}, pollTimeout, pollInterval).Should(gomega.Equal(1))
-			})
-		})
-
-		ginkgo.AfterEach(func() {
-			exportClusterClient := framework.GetClusterClient(serviceExportClusterName)
-			gomega.Expect(exportClusterClient).ShouldNot(gomega.BeNil())
-
-			klog.Infof(fmt.Sprintf("Delete Deployment(%s/%s) in %s cluster", demoDeployment.Namespace, demoDeployment.Name, serviceExportClusterName))
-			framework.RemoveDeployment(exportClusterClient, demoDeployment.Namespace, demoDeployment.Name)
-
-			klog.Infof(fmt.Sprintf("Delete Service(%s/%s) in %s cluster", demoService.Namespace, demoService.Name, serviceExportClusterName))
-			framework.RemoveService(exportClusterClient, demoService.Namespace, demoService.Name)
-		})
-
-		ginkgo.AfterEach(func() {
-			ginkgo.By("Cleanup", func() {
-				err := controlPlaneClient.Delete(context.TODO(), &serviceExport)
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-
-				err = controlPlaneClient.Delete(context.TODO(), &serviceImport)
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
-
-			framework.RemovePropagationPolicy(karmadaClient, exportPolicy.Namespace, exportPolicy.Name)
-			framework.RemovePropagationPolicy(karmadaClient, importPolicy.Namespace, importPolicy.Name)
-		})
-
 		ginkgo.It("Update Deployment's replicas", func() {
 			exportClusterClient := framework.GetClusterClient(serviceExportClusterName)
 			gomega.Expect(exportClusterClient).ShouldNot(gomega.BeNil())

--- a/test/e2e/overridepolicy_test.go
+++ b/test/e2e/overridepolicy_test.go
@@ -74,16 +74,15 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 		ginkgo.BeforeEach(func() {
 			framework.CreatePropagationPolicy(karmadaClient, propagationPolicy)
 			framework.CreateOverridePolicy(karmadaClient, overridePolicy)
-		})
-
-		ginkgo.AfterEach(func() {
-			framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
-			framework.RemoveOverridePolicy(karmadaClient, overridePolicy.Namespace, overridePolicy.Name)
+			framework.CreateDeployment(kubeClient, deployment)
+			ginkgo.DeferCleanup(func() {
+				framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
+				framework.RemoveOverridePolicy(karmadaClient, overridePolicy.Namespace, overridePolicy.Name)
+				framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
+			})
 		})
 
 		ginkgo.It("deployment imageOverride testing", func() {
-			framework.CreateDeployment(kubeClient, deployment)
-
 			klog.Infof("check if deployment present on member clusters have correct image value")
 			framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
 				func(deployment *appsv1.Deployment) bool {
@@ -94,10 +93,7 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 					}
 					return true
 				})
-
-			framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
 		})
-
 	})
 
 	ginkgo.Context("Pod override all images in container list", func() {
@@ -156,16 +152,15 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 		ginkgo.BeforeEach(func() {
 			framework.CreatePropagationPolicy(karmadaClient, propagationPolicy)
 			framework.CreateOverridePolicy(karmadaClient, overridePolicy)
-		})
-
-		ginkgo.AfterEach(func() {
-			framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
-			framework.RemoveOverridePolicy(karmadaClient, overridePolicy.Namespace, overridePolicy.Name)
+			framework.CreatePod(kubeClient, pod)
+			ginkgo.DeferCleanup(func() {
+				framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
+				framework.RemoveOverridePolicy(karmadaClient, overridePolicy.Namespace, overridePolicy.Name)
+				framework.RemovePod(kubeClient, pod.Namespace, pod.Name)
+			})
 		})
 
 		ginkgo.It("pod imageOverride testing", func() {
-			framework.CreatePod(kubeClient, pod)
-
 			klog.Infof("check if pod present on member clusters have correct image value")
 			framework.WaitPodPresentOnClustersFitWith(framework.ClusterNames(), pod.Namespace, pod.Name, func(pod *corev1.Pod) bool {
 				for _, container := range pod.Spec.Containers {
@@ -175,10 +170,7 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 				}
 				return true
 			})
-
-			framework.RemovePod(kubeClient, pod.Namespace, pod.Name)
 		})
-
 	})
 
 	ginkgo.Context("Deployment override specific images in container list", func() {
@@ -230,25 +222,21 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 		ginkgo.BeforeEach(func() {
 			framework.CreatePropagationPolicy(karmadaClient, propagationPolicy)
 			framework.CreateOverridePolicy(karmadaClient, overridePolicy)
-		})
-
-		ginkgo.AfterEach(func() {
-			framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
-			framework.RemoveOverridePolicy(karmadaClient, overridePolicy.Namespace, overridePolicy.Name)
+			framework.CreateDeployment(kubeClient, deployment)
+			ginkgo.DeferCleanup(func() {
+				framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
+				framework.RemoveOverridePolicy(karmadaClient, overridePolicy.Namespace, overridePolicy.Name)
+				framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
+			})
 		})
 
 		ginkgo.It("deployment imageOverride testing", func() {
-			framework.CreateDeployment(kubeClient, deployment)
-
 			klog.Infof("check if deployment present on member clusters have correct image value")
 			framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
 				func(deployment *appsv1.Deployment) bool {
 					return deployment.Spec.Template.Spec.Containers[0].Image == "fictional.registry.us/nginx:1.19.0"
 				})
-
-			framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
 		})
-
 	})
 })
 
@@ -300,25 +288,21 @@ var _ = ginkgo.Describe("OverridePolicy with nil resourceSelectors", func() {
 		ginkgo.BeforeEach(func() {
 			framework.CreatePropagationPolicy(karmadaClient, propagationPolicy)
 			framework.CreateOverridePolicy(karmadaClient, overridePolicy)
-		})
-
-		ginkgo.AfterEach(func() {
-			framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
-			framework.RemoveOverridePolicy(karmadaClient, overridePolicy.Namespace, overridePolicy.Name)
+			framework.CreateDeployment(kubeClient, deployment)
+			ginkgo.DeferCleanup(func() {
+				framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
+				framework.RemoveOverridePolicy(karmadaClient, overridePolicy.Namespace, overridePolicy.Name)
+				framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
+			})
 		})
 
 		ginkgo.It("deployment imageOverride testing", func() {
-			framework.CreateDeployment(kubeClient, deployment)
-
 			klog.Infof("check if deployment present on member clusters have correct image value")
 			framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
 				func(deployment *appsv1.Deployment) bool {
 					return deployment.Spec.Template.Spec.Containers[0].Image == "fictional.registry.us/nginx:1.19.0"
 				})
-
-			framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
 		})
-
 	})
 })
 
@@ -389,16 +373,15 @@ var _ = ginkgo.Describe("[OverrideRules] apply overriders testing", func() {
 		ginkgo.BeforeEach(func() {
 			framework.CreatePropagationPolicy(karmadaClient, propagationPolicy)
 			framework.CreateOverridePolicy(karmadaClient, overridePolicy)
-		})
-
-		ginkgo.AfterEach(func() {
-			framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
-			framework.RemoveOverridePolicy(karmadaClient, overridePolicy.Namespace, overridePolicy.Name)
+			framework.CreateDeployment(kubeClient, deployment)
+			ginkgo.DeferCleanup(func() {
+				framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
+				framework.RemoveOverridePolicy(karmadaClient, overridePolicy.Namespace, overridePolicy.Name)
+				framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
+			})
 		})
 
 		ginkgo.It("deployment imageOverride testing", func() {
-			framework.CreateDeployment(kubeClient, deployment)
-
 			klog.Infof("check if deployment present on member clusters have correct image value")
 			framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
 				func(deployment *appsv1.Deployment) bool {
@@ -409,10 +392,7 @@ var _ = ginkgo.Describe("[OverrideRules] apply overriders testing", func() {
 					}
 					return true
 				})
-
-			framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
 		})
-
 	})
 
 	ginkgo.Context("Pod override all images in container list", func() {
@@ -476,16 +456,15 @@ var _ = ginkgo.Describe("[OverrideRules] apply overriders testing", func() {
 		ginkgo.BeforeEach(func() {
 			framework.CreatePropagationPolicy(karmadaClient, propagationPolicy)
 			framework.CreateOverridePolicy(karmadaClient, overridePolicy)
-		})
-
-		ginkgo.AfterEach(func() {
-			framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
-			framework.RemoveOverridePolicy(karmadaClient, overridePolicy.Namespace, overridePolicy.Name)
+			framework.CreatePod(kubeClient, pod)
+			ginkgo.DeferCleanup(func() {
+				framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
+				framework.RemoveOverridePolicy(karmadaClient, overridePolicy.Namespace, overridePolicy.Name)
+				framework.RemovePod(kubeClient, pod.Namespace, pod.Name)
+			})
 		})
 
 		ginkgo.It("pod imageOverride testing", func() {
-			framework.CreatePod(kubeClient, pod)
-
 			klog.Infof("check if pod present on member clusters have correct image value")
 			framework.WaitPodPresentOnClustersFitWith(framework.ClusterNames(), pod.Namespace, pod.Name, func(pod *corev1.Pod) bool {
 				for _, container := range pod.Spec.Containers {
@@ -495,10 +474,7 @@ var _ = ginkgo.Describe("[OverrideRules] apply overriders testing", func() {
 				}
 				return true
 			})
-
-			framework.RemovePod(kubeClient, pod.Namespace, pod.Name)
 		})
-
 	})
 
 	ginkgo.Context("Deployment override specific images in container list", func() {
@@ -555,25 +531,21 @@ var _ = ginkgo.Describe("[OverrideRules] apply overriders testing", func() {
 		ginkgo.BeforeEach(func() {
 			framework.CreatePropagationPolicy(karmadaClient, propagationPolicy)
 			framework.CreateOverridePolicy(karmadaClient, overridePolicy)
-		})
-
-		ginkgo.AfterEach(func() {
-			framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
-			framework.RemoveOverridePolicy(karmadaClient, overridePolicy.Namespace, overridePolicy.Name)
+			framework.CreateDeployment(kubeClient, deployment)
+			ginkgo.DeferCleanup(func() {
+				framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
+				framework.RemoveOverridePolicy(karmadaClient, overridePolicy.Namespace, overridePolicy.Name)
+				framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
+			})
 		})
 
 		ginkgo.It("deployment imageOverride testing", func() {
-			framework.CreateDeployment(kubeClient, deployment)
-
 			klog.Infof("check if deployment present on member clusters have correct image value")
 			framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
 				func(deployment *appsv1.Deployment) bool {
 					return deployment.Spec.Template.Spec.Containers[0].Image == "fictional.registry.us/nginx:1.19.0"
 				})
-
-			framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
 		})
-
 	})
 })
 
@@ -631,24 +603,20 @@ var _ = ginkgo.Describe("OverrideRules with nil resourceSelectors", func() {
 		ginkgo.BeforeEach(func() {
 			framework.CreatePropagationPolicy(karmadaClient, propagationPolicy)
 			framework.CreateOverridePolicy(karmadaClient, overridePolicy)
-		})
-
-		ginkgo.AfterEach(func() {
-			framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
-			framework.RemoveOverridePolicy(karmadaClient, overridePolicy.Namespace, overridePolicy.Name)
+			framework.CreateDeployment(kubeClient, deployment)
+			ginkgo.DeferCleanup(func() {
+				framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
+				framework.RemoveOverridePolicy(karmadaClient, overridePolicy.Namespace, overridePolicy.Name)
+				framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
+			})
 		})
 
 		ginkgo.It("deployment imageOverride testing", func() {
-			framework.CreateDeployment(kubeClient, deployment)
-
 			klog.Infof("check if deployment present on member clusters have correct image value")
 			framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
 				func(deployment *appsv1.Deployment) bool {
 					return deployment.Spec.Template.Spec.Containers[0].Image == "fictional.registry.us/nginx:1.19.0"
 				})
-
-			framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
 		})
-
 	})
 })

--- a/test/e2e/porting_workloads_test.go
+++ b/test/e2e/porting_workloads_test.go
@@ -61,6 +61,10 @@ var _ = ginkgo.Describe("porting workloads testing", func() {
 
 			framework.CreatePropagationPolicy(karmadaClient, policy)
 			framework.CreateDeployment(kubeClient, deployment)
+			ginkgo.DeferCleanup(func() {
+				framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
+				framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
+			})
 
 			ginkgo.By("check deployment's replicas", func() {
 				wantedReplicas := *deployment.Spec.Replicas * int32(len(framework.Clusters())-1)
@@ -110,9 +114,6 @@ var _ = ginkgo.Describe("porting workloads testing", func() {
 				})
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
-
-			framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
-			framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
 		})
 	})
 })

--- a/test/e2e/rescheduling_test.go
+++ b/test/e2e/rescheduling_test.go
@@ -108,6 +108,10 @@ var _ = ginkgo.Describe("reschedule testing", func() {
 
 			framework.CreatePropagationPolicy(karmadaClient, policy)
 			framework.CreateDeployment(kubeClient, deployment)
+			ginkgo.DeferCleanup(func() {
+				framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
+				framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
+			})
 
 			targetClusterNames := framework.ExtractTargetClustersFrom(controlPlaneClient, deployment)
 
@@ -141,9 +145,6 @@ var _ = ginkgo.Describe("reschedule testing", func() {
 				})
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
-
-			framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
-			framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
 		})
 	})
 })

--- a/test/e2e/resource_test.go
+++ b/test/e2e/resource_test.go
@@ -44,10 +44,16 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 			})
 		})
 
-		ginkgo.It("deployment status collection testing", func() {
+		ginkgo.BeforeEach(func() {
 			framework.CreatePropagationPolicy(karmadaClient, policy)
 			framework.CreateDeployment(kubeClient, deployment)
+			ginkgo.DeferCleanup(func() {
+				framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
+				framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
+			})
+		})
 
+		ginkgo.It("deployment status collection testing", func() {
 			ginkgo.By("check whether the deployment status can be correctly collected", func() {
 				wantedReplicas := *deployment.Spec.Replicas * int32(len(framework.Clusters()))
 
@@ -90,9 +96,6 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 				})
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
-
-			framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
-			framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
 		})
 	})
 })

--- a/test/e2e/resourceinterpreter_test.go
+++ b/test/e2e/resourceinterpreter_test.go
@@ -46,11 +46,18 @@ var _ = ginkgo.Describe("Resource interpreter webhook testing", func() {
 		})
 	})
 
+	ginkgo.JustBeforeEach(func() {
+		framework.CreatePropagationPolicy(karmadaClient, policy)
+		framework.CreateWorkload(dynamicClient, workload)
+		ginkgo.DeferCleanup(func() {
+			framework.RemoveWorkload(dynamicClient, workload.Namespace, workload.Name)
+			framework.WaitWorkloadDisappearOnClusters(framework.ClusterNames(), workload.Namespace, workload.Name)
+			framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
+		})
+	})
+
 	ginkgo.Context("InterpreterOperation InterpretReplica testing", func() {
 		ginkgo.It("InterpretReplica testing", func() {
-			framework.CreatePropagationPolicy(karmadaClient, policy)
-			framework.CreateWorkload(dynamicClient, workload)
-
 			ginkgo.By("check if workload's replica is interpreted", func() {
 				resourceBindingName := names.GenerateBindingName(workload.Kind, workload.Name)
 				expectedReplicas := *workload.Spec.Replicas
@@ -64,10 +71,6 @@ var _ = ginkgo.Describe("Resource interpreter webhook testing", func() {
 					return resourceBinding.Spec.Replicas, nil
 				}, pollTimeout, pollInterval).Should(gomega.Equal(expectedReplicas))
 			})
-
-			framework.RemoveWorkload(dynamicClient, workload.Namespace, workload.Name)
-			framework.WaitWorkloadDisappearOnClusters(framework.ClusterNames(), workload.Namespace, workload.Name)
-			framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
 		})
 	})
 
@@ -87,9 +90,6 @@ var _ = ginkgo.Describe("Resource interpreter webhook testing", func() {
 		})
 
 		ginkgo.It("Retain testing", func() {
-			framework.CreatePropagationPolicy(karmadaClient, policy)
-			framework.CreateWorkload(dynamicClient, workload)
-
 			ginkgo.By("update workload's spec.paused to true", func() {
 				for _, cluster := range pushModeClusters {
 					clusterDynamicClient := framework.GetClusterDynamicClient(cluster)
@@ -115,15 +115,11 @@ var _ = ginkgo.Describe("Resource interpreter webhook testing", func() {
 					}, pollTimeout, pollInterval).Should(gomega.Equal(updatedPaused))
 				}
 			})
-
-			framework.RemoveWorkload(dynamicClient, workload.Namespace, workload.Name)
-			framework.WaitWorkloadDisappearOnClusters(pushModeClusters, workload.Namespace, workload.Name)
-			framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
 		})
 	})
 
 	ginkgo.Context("InterpreterOperation ReviseReplica testing", func() {
-		ginkgo.It("ReviseReplica testing", func() {
+		ginkgo.BeforeEach(func() {
 			sumWeight := 0
 			staticWeightLists := make([]policyv1alpha1.StaticClusterWeight, 0)
 			for index, clusterName := range framework.ClusterNames() {
@@ -155,27 +151,19 @@ var _ = ginkgo.Describe("Resource interpreter webhook testing", func() {
 					},
 				},
 			})
+		})
 
-			framework.CreateWorkload(dynamicClient, workload)
-			framework.CreatePropagationPolicy(karmadaClient, policy)
-
+		ginkgo.It("ReviseReplica testing", func() {
 			for index, clusterName := range framework.ClusterNames() {
 				framework.WaitWorkloadPresentOnClusterFitWith(clusterName, workload.Namespace, workload.Name, func(workload *workloadv1alpha1.Workload) bool {
 					return *workload.Spec.Replicas == int32(index+1)
 				})
 			}
-
-			framework.RemoveWorkload(dynamicClient, workload.Namespace, workload.Name)
-			framework.WaitWorkloadDisappearOnClusters(framework.ClusterNames(), workload.Namespace, workload.Name)
-			framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
 		})
 	})
 
 	ginkgo.Context("InterpreterOperation AggregateStatus testing", func() {
 		ginkgo.It("AggregateStatus testing", func() {
-			framework.CreatePropagationPolicy(karmadaClient, policy)
-			framework.CreateWorkload(dynamicClient, workload)
-
 			ginkgo.By("check whether the workload status can be correctly collected", func() {
 				// Simulate the workload resource controller behavior, update the status information of workload resources of member clusters manually.
 				for _, cluster := range framework.ClusterNames() {
@@ -201,10 +189,6 @@ var _ = ginkgo.Describe("Resource interpreter webhook testing", func() {
 				})
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
-
-			framework.RemoveWorkload(dynamicClient, workload.Namespace, workload.Name)
-			framework.WaitWorkloadDisappearOnClusters(framework.ClusterNames(), workload.Namespace, workload.Name)
-			framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
 		})
 	})
 })

--- a/test/e2e/tainttoleration_test.go
+++ b/test/e2e/tainttoleration_test.go
@@ -106,9 +106,16 @@ var _ = ginkgo.Describe("propagation with taint and toleration testing", func() 
 			})
 		})
 
-		ginkgo.It("deployment with cluster tolerations testing", func() {
+		ginkgo.BeforeEach(func() {
 			framework.CreatePropagationPolicy(karmadaClient, policy)
 			framework.CreateDeployment(kubeClient, deployment)
+			ginkgo.DeferCleanup(func() {
+				framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
+				framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
+			})
+		})
+
+		ginkgo.It("deployment with cluster tolerations testing", func() {
 
 			ginkgo.By(fmt.Sprintf("check if deployment(%s/%s) only scheduled to tolerated cluster(%s)", deploymentNamespace, deploymentName, tolerationValue), func() {
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -117,9 +124,6 @@ var _ = ginkgo.Describe("propagation with taint and toleration testing", func() 
 					g.Expect(targetClusterNames[0] == tolerationValue).Should(gomega.BeTrue())
 				}, pollTimeout, pollInterval).Should(gomega.Succeed())
 			})
-
-			framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
-			framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
 		})
 	})
 })

--- a/test/helper/resource.go
+++ b/test/helper/resource.go
@@ -459,8 +459,8 @@ func NewWorkload(namespace string, name string) *workloadv1alpha1.Workload {
 	}
 }
 
-// NewDeploymentReferencesConfigMap will build a deployment object that reference configmap.
-func NewDeploymentReferencesConfigMap(namespace, deploymentName, configMapName string) *appsv1.Deployment {
+// NewDeploymentWithVolumes will build a deployment object that with reference volumes.
+func NewDeploymentWithVolumes(namespace, deploymentName string, volumes []corev1.Volume) *appsv1.Deployment {
 	podLabels := map[string]string{"app": "nginx"}
 
 	return &appsv1.Deployment{
@@ -486,61 +486,7 @@ func NewDeploymentReferencesConfigMap(namespace, deploymentName, configMapName s
 						Name:  "nginx",
 						Image: "nginx:1.19.0",
 					}},
-					Volumes: []corev1.Volume{
-						{
-							Name: "vol-configmap",
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: configMapName,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-// NewDeploymentReferencesSecret will build a deployment object that reference secret.
-func NewDeploymentReferencesSecret(namespace, deploymentName, secretName string) *appsv1.Deployment {
-	podLabels := map[string]string{"app": "nginx"}
-
-	return &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apps/v1",
-			Kind:       "Deployment",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      deploymentName,
-		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32Ptr(3),
-			Selector: &metav1.LabelSelector{
-				MatchLabels: podLabels,
-			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: podLabels,
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{
-						Name:  "nginx",
-						Image: "nginx:1.19.0",
-					}},
-					Volumes: []corev1.Volume{
-						{
-							Name: "vol-secret",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: secretName,
-								},
-							},
-						},
-					},
+					Volumes: volumes,
 				},
 			},
 		},


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Move cleanup to ginkgo setup node, and try to make each ginkgo spec independent of each other. Prepare for parallel E2E running.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

