### PR TITLE
[E2E] Set e2e to run in parallel

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -29,7 +29,7 @@ mkdir -p "$ARTIFACTS_PATH"
 # Install ginkgo
 GO111MODULE=on go install github.com/onsi/ginkgo/v2/ginkgo
 
-# Pre run e2e for install extra conponents
+# Pre run e2e for install extra components
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 "${REPO_ROOT}"/hack/pre-run-e2e.sh
 
@@ -38,7 +38,7 @@ export KUBECONFIG=${KARMADA_APISERVER_KUBECONFIG}
 export PULL_BASED_CLUSTERS=${PULL_BASED_CLUSTERS}
 
 set +e
-ginkgo -v -race -fail-fast ./test/e2e/
+ginkgo -v --race --trace --fail-fast -p --randomize-all ./test/e2e/
 TESTING_RESULT=$?
 
 # Collect logs
@@ -54,7 +54,7 @@ fi
 echo "Collected logs at $ARTIFACTS_PATH:"
 ls -al "$ARTIFACTS_PATH"
 
-# Post run e2e for delete extra conponents
+# Post run e2e for delete extra components
 "${REPO_ROOT}"/hack/post-run-e2e.sh
 
 exit $TESTING_RESULT

--- a/test/e2e/failover_test.go
+++ b/test/e2e/failover_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 // failover testing is used to test the rescheduling situation when some initially scheduled clusters fail
-var _ = ginkgo.Describe("failover testing", func() {
+var _ = framework.SerialDescribe("failover testing", func() {
 	ginkgo.Context("Deployment propagation testing", func() {
 		var policyNamespace, policyName string
 		var deploymentNamespace, deploymentName string

--- a/test/e2e/federatedresourcequota_test.go
+++ b/test/e2e/federatedresourcequota_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/karmada-io/karmada/test/helper"
 )
 
-var _ = ginkgo.Describe("[FederatedResourceQuota] auto-provision testing", func() {
+var _ = ginkgo.Describe("FederatedResourceQuota auto-provision testing", func() {
 	var frqNamespace, frqName string
 	var federatedResourceQuota *policyv1alpha1.FederatedResourceQuota
 
@@ -53,7 +53,7 @@ var _ = ginkgo.Describe("[FederatedResourceQuota] auto-provision testing", func(
 		})
 	})
 
-	ginkgo.Context("join new cluster", func() {
+	framework.SerialContext("join new cluster", ginkgo.Labels{NeedCreateCluster}, func() {
 		var clusterName string
 		var homeDir string
 		var kubeConfigPath string

--- a/test/e2e/framework/ginkgo_decorator.go
+++ b/test/e2e/framework/ginkgo_decorator.go
@@ -1,0 +1,18 @@
+package framework
+
+import "github.com/onsi/ginkgo/v2"
+
+// SerialDescribe is wrapper function for ginkgo.Describe with ginkgo.Serial decorator.
+func SerialDescribe(text string, args ...interface{}) bool {
+	return ginkgo.Describe(text, ginkgo.Serial, args)
+}
+
+// SerialContext is wrapper function for ginkgo.Context with ginkgo.Serial decorator.
+func SerialContext(text string, args ...interface{}) bool {
+	return ginkgo.Context(text, ginkgo.Serial, args)
+}
+
+// SerialWhen is wrapper function for ginkgo.When with ginkgo.Serial decorator.
+func SerialWhen(text string, args ...interface{}) bool {
+	return ginkgo.When(text, ginkgo.Serial, args)
+}

--- a/test/e2e/mcs_test.go
+++ b/test/e2e/mcs_test.go
@@ -175,7 +175,7 @@ func getPrepareInfo() (serviceExport mcsv1alpha1.ServiceExport, serviceImport mc
 	return
 }
 
-var _ = ginkgo.Describe("[MCS] Multi-Cluster Service testing", func() {
+var _ = ginkgo.Describe("Multi-Cluster Service testing", func() {
 	var serviceExportPolicyName, serviceImportPolicyName string
 	var serviceExportPolicy, serviceImportPolicy *policyv1alpha1.ClusterPropagationPolicy
 	var serviceExport mcsv1alpha1.ServiceExport

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -55,7 +55,7 @@ var _ = ginkgo.Describe("[namespace auto-provision] namespace auto-provision tes
 		})
 	})
 
-	ginkgo.When("joining new cluster", func() {
+	framework.SerialWhen("joining new cluster", ginkgo.Labels{NeedCreateCluster}, func() {
 		var clusterName string
 		var homeDir string
 		var kubeConfigPath string

--- a/test/e2e/rescheduling_test.go
+++ b/test/e2e/rescheduling_test.go
@@ -7,14 +7,13 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/utils/pointer"
-
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
@@ -27,7 +26,7 @@ import (
 
 // reschedule testing is used to test the rescheduling situation when some initially scheduled clusters are unjoined
 var _ = ginkgo.Describe("reschedule testing", func() {
-	ginkgo.Context("Deployment propagation testing", func() {
+	framework.SerialContext("Deployment propagation testing", ginkgo.Label(NeedCreateCluster), func() {
 		var newClusterName string
 		var homeDir string
 		var kubeConfigPath string

--- a/test/e2e/resourceinterpreter_test.go
+++ b/test/e2e/resourceinterpreter_test.go
@@ -51,7 +51,6 @@ var _ = ginkgo.Describe("Resource interpreter webhook testing", func() {
 		framework.CreateWorkload(dynamicClient, workload)
 		ginkgo.DeferCleanup(func() {
 			framework.RemoveWorkload(dynamicClient, workload.Namespace, workload.Name)
-			framework.WaitWorkloadDisappearOnClusters(framework.ClusterNames(), workload.Namespace, workload.Name)
 			framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
 		})
 	})

--- a/test/e2e/suite.go
+++ b/test/e2e/suite.go
@@ -1,0 +1,6 @@
+package e2e
+
+const (
+	// NeedCreateCluster define the spec label that need to create a cluster.
+	NeedCreateCluster = "needCreateCluster"
+)

--- a/test/e2e/tainttoleration_test.go
+++ b/test/e2e/tainttoleration_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/karmada-io/karmada/test/helper"
 )
 
-var _ = ginkgo.Describe("propagation with taint and toleration testing", func() {
+var _ = framework.SerialDescribe("propagation with taint and toleration testing", func() {
 	ginkgo.Context("Deployment propagation testing", func() {
 		var policyNamespace, policyName string
 		var deploymentNamespace, deploymentName string

--- a/test/e2e/unjoin_test.go
+++ b/test/e2e/unjoin_test.go
@@ -22,8 +22,8 @@ import (
 	"github.com/karmada-io/karmada/test/helper"
 )
 
-var _ = ginkgo.Describe("test unjoin testing", func() {
-	ginkgo.Context(" unjoining not ready cluster", func() {
+var _ = framework.SerialDescribe("unJoin testing", ginkgo.Labels{NeedCreateCluster}, func() {
+	ginkgo.Context(" unJoining not ready cluster", func() {
 		var clusterName string
 		var homeDir string
 		var kubeConfigPath string


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

 Set e2e to run in parallel. Speed up e2e running.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Use ginkgo `--randomize-all` to randomize all specs together, 
Use ginkgo `-p` flags to run in parallel.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

