### PR TITLE
Fix pod exec through cluster/proxy

### DIFF
--- a/pkg/registry/cluster/storage/proxy.go
+++ b/pkg/registry/cluster/storage/proxy.go
@@ -109,6 +109,10 @@ func newProxyHandler(location *url.URL, transport http.RoundTripper, impersonate
 
 		req.Header.Set("Authorization", fmt.Sprintf("bearer %s", impersonateToken))
 
+		// Retain RawQuery in location because upgrading the request will use it.
+		// See https://github.com/karmada-io/karmada/issues/1618#issuecomment-1103793290 for more info.
+		location.RawQuery = req.URL.RawQuery
+
 		handler := newThrottledUpgradeAwareProxyHandler(location, transport, true, false, responder)
 		handler.ServeHTTP(rw, req)
 	}), nil


### PR DESCRIPTION
Signed-off-by: pangshaoqiang <pangsq9413@gmail.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`location` is used when the proxy dial on the upstream server for upgrade requests. Without the query params 
 in`RawQuery`, `exec` request will be rejected by the upstream apiserver. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/karmada/issues/1618

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
 `karmada-aggregate-apiserver`: Fixed exec failed: `error: unable to upgrade connection: you must specify at least 1 of stdin, stdout, stderr`
```