### PR TITLE
Add ReflectStatus ResourceInterperter interface to grab workload status

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -192,7 +192,8 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 			ConcurrentWorkSyncs:               opts.ConcurrentWorkSyncs,
 			RateLimiterOptions:                opts.RateLimiterOpts,
 		},
-		StopChan: stopChan,
+		StopChan:            stopChan,
+		ResourceInterpreter: resourceInterpreter,
 	}
 
 	if err := controllers.StartControllers(controllerContext, controllersDisabledByDefault); err != nil {
@@ -261,6 +262,7 @@ func startWorkStatusController(ctx controllerscontext.Context) (bool, error) {
 		ClusterCacheSyncTimeout:   ctx.Opts.ClusterCacheSyncTimeout,
 		ConcurrentWorkStatusSyncs: ctx.Opts.ConcurrentWorkSyncs,
 		RateLimiterOptions:        ctx.Opts.RateLimiterOptions,
+		ResourceInterpreter:       ctx.ResourceInterpreter,
 	}
 	workStatusController.RunWorkQueue()
 	if err := workStatusController.SetupWithManager(ctx.Mgr); err != nil {

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -318,6 +318,7 @@ func startWorkStatusController(ctx controllerscontext.Context) (enabled bool, er
 		ClusterCacheSyncTimeout:   opts.ClusterCacheSyncTimeout,
 		ConcurrentWorkStatusSyncs: opts.ConcurrentWorkSyncs,
 		RateLimiterOptions:        ctx.Opts.RateLimiterOptions,
+		ResourceInterpreter:       ctx.ResourceInterpreter,
 	}
 	workStatusController.RunWorkQueue()
 	if err := workStatusController.SetupWithManager(ctx.Mgr); err != nil {

--- a/pkg/resourceinterpreter/customizedinterpreter/customized.go
+++ b/pkg/resourceinterpreter/customizedinterpreter/customized.go
@@ -10,6 +10,7 @@ import (
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	webhookutil "k8s.io/apiserver/pkg/util/webhook"
 	"k8s.io/klog/v2"
@@ -292,4 +293,19 @@ func (e *CustomizedInterpreter) GetDependencies(ctx context.Context, attributes 
 	}
 
 	return response.Dependencies, matched, nil
+}
+
+// ReflectStatus returns the cluster object's running status after the grab.
+// return matched value to indicate whether there is a matching hook.
+func (e *CustomizedInterpreter) ReflectStatus(ctx context.Context, attributes *webhook.RequestAttributes) (status *runtime.RawExtension, matched bool, err error) {
+	var response *webhook.ResponseAttributes
+	response, matched, err = e.interpret(ctx, attributes)
+	if err != nil {
+		return
+	}
+	if !matched {
+		return
+	}
+
+	return &response.RawStatus, matched, nil
 }

--- a/pkg/resourceinterpreter/customizedinterpreter/customized.go
+++ b/pkg/resourceinterpreter/customizedinterpreter/customized.go
@@ -295,7 +295,7 @@ func (e *CustomizedInterpreter) GetDependencies(ctx context.Context, attributes 
 	return response.Dependencies, matched, nil
 }
 
-// ReflectStatus returns the cluster object's running status after the grab.
+// ReflectStatus returns the status of the object.
 // return matched value to indicate whether there is a matching hook.
 func (e *CustomizedInterpreter) ReflectStatus(ctx context.Context, attributes *webhook.RequestAttributes) (status *runtime.RawExtension, matched bool, err error) {
 	var response *webhook.ResponseAttributes

--- a/pkg/resourceinterpreter/customizedinterpreter/webhook/resourceinterpretercontext.go
+++ b/pkg/resourceinterpreter/customizedinterpreter/webhook/resourceinterpretercontext.go
@@ -112,6 +112,9 @@ func verifyResourceInterpreterContext(operation configv1alpha1.InterpreterOperat
 		}
 		return res, nil
 	case configv1alpha1.InterpreterOperationInterpretStatus:
+		if response.RawStatus == nil {
+			return nil, fmt.Errorf("webhook returned nill response.rawStatus")
+		}
 		res.RawStatus = *response.RawStatus
 		return res, nil
 	case configv1alpha1.InterpreterOperationInterpretHealthy:

--- a/pkg/resourceinterpreter/defaultinterpreter/default.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/default.go
@@ -121,5 +121,5 @@ func (e *DefaultInterpreter) ReflectStatus(object *unstructured.Unstructured) (s
 	}
 
 	// for resource types that don't have a build-in handler, try to collect the whole status from '.status' filed.
-	return getWholeStatus(object)
+	return reflectWholeStatus(object)
 }

--- a/pkg/resourceinterpreter/defaultinterpreter/default_test.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/default_test.go
@@ -1,0 +1,72 @@
+package defaultinterpreter
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/karmada-io/karmada/pkg/util/helper"
+)
+
+func Test_getEntireStatus(t *testing.T) {
+	testMap := map[string]interface{}{"key": "value"}
+	wantRawExtension, _ := helper.BuildStatusRawExtension(testMap)
+	type args struct {
+		object *unstructured.Unstructured
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *runtime.RawExtension
+		wantErr bool
+	}{
+		{
+			"object doesn't have status",
+			args{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{},
+				},
+			},
+			nil,
+			false,
+		},
+		{
+			"object have wrong format status",
+			args{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"status": "a string",
+					},
+				},
+			},
+			nil,
+			true,
+		},
+		{
+			"object have correct format status",
+			args{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"status": testMap,
+					},
+				},
+			},
+			wantRawExtension,
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getEntireStatus(tt.args.object)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getEntireStatus() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getEntireStatus() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/resourceinterpreter/defaultinterpreter/reflectstatus.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/reflectstatus.go
@@ -1,0 +1,8 @@
+package defaultinterpreter
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type reflectStatusInterpreter func(object *unstructured.Unstructured) (*runtime.RawExtension, error)

--- a/pkg/resourceinterpreter/defaultinterpreter/reflectstatus.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/reflectstatus.go
@@ -1,8 +1,63 @@
 package defaultinterpreter
 
 import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
+
+	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/helper"
 )
 
 type reflectStatusInterpreter func(object *unstructured.Unstructured) (*runtime.RawExtension, error)
+
+func getAllDefaultReflectStatusInterpreter() map[schema.GroupVersionKind]reflectStatusInterpreter {
+	s := make(map[schema.GroupVersionKind]reflectStatusInterpreter)
+	s[appsv1.SchemeGroupVersion.WithKind(util.DeploymentKind)] = reflectDeploymentStatus
+	return s
+}
+
+func reflectDeploymentStatus(object *unstructured.Unstructured) (*runtime.RawExtension, error) {
+	statusMap, exist, err := unstructured.NestedMap(object.Object, "status")
+	if err != nil {
+		klog.Errorf("Failed to get status field from %s(%s/%s), error: %v",
+			object.GetKind(), object.GetNamespace(), object.GetName(), err)
+		return nil, err
+	}
+	if !exist {
+		klog.Errorf("Failed to grab status from %s(%s/%s) which should have status field.",
+			object.GetKind(), object.GetNamespace(), object.GetName())
+		return nil, nil
+	}
+
+	deploymentStatus, err := helper.ConvertToDeploymentStatus(statusMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert DeploymentStatus from map[string]interface{}: %v", err)
+	}
+
+	grabStatus := appsv1.DeploymentStatus{
+		Replicas:            deploymentStatus.Replicas,
+		UpdatedReplicas:     deploymentStatus.UpdatedReplicas,
+		ReadyReplicas:       deploymentStatus.ReadyReplicas,
+		AvailableReplicas:   deploymentStatus.AvailableReplicas,
+		UnavailableReplicas: deploymentStatus.UnavailableReplicas,
+	}
+	return helper.BuildStatusRawExtension(grabStatus)
+}
+
+func getWholeStatus(object *unstructured.Unstructured) (*runtime.RawExtension, error) {
+	statusMap, exist, err := unstructured.NestedMap(object.Object, "status")
+	if err != nil {
+		klog.Errorf("Failed to get status field from %s(%s/%s), error: %v",
+			object.GetKind(), object.GetNamespace(), object.GetName(), err)
+		return nil, err
+	}
+	if exist {
+		return helper.BuildStatusRawExtension(statusMap)
+	}
+	return nil, nil
+}

--- a/pkg/resourceinterpreter/defaultinterpreter/reflectstatus.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/reflectstatus.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -18,6 +21,11 @@ type reflectStatusInterpreter func(object *unstructured.Unstructured) (*runtime.
 func getAllDefaultReflectStatusInterpreter() map[schema.GroupVersionKind]reflectStatusInterpreter {
 	s := make(map[schema.GroupVersionKind]reflectStatusInterpreter)
 	s[appsv1.SchemeGroupVersion.WithKind(util.DeploymentKind)] = reflectDeploymentStatus
+	s[corev1.SchemeGroupVersion.WithKind(util.ServiceKind)] = reflectServiceStatus
+	s[extensionsv1beta1.SchemeGroupVersion.WithKind(util.IngressKind)] = reflectIngressStatus
+	s[batchv1.SchemeGroupVersion.WithKind(util.JobKind)] = reflectJobStatus
+	s[appsv1.SchemeGroupVersion.WithKind(util.DaemonSetKind)] = reflectDaemonSetStatus
+	s[appsv1.SchemeGroupVersion.WithKind(util.StatefulSetKind)] = reflectStatefulSetStatus
 	return s
 }
 
@@ -49,7 +57,135 @@ func reflectDeploymentStatus(object *unstructured.Unstructured) (*runtime.RawExt
 	return helper.BuildStatusRawExtension(grabStatus)
 }
 
-func getWholeStatus(object *unstructured.Unstructured) (*runtime.RawExtension, error) {
+func reflectServiceStatus(object *unstructured.Unstructured) (*runtime.RawExtension, error) {
+	serviceType, exist, err := unstructured.NestedString(object.Object, "spec", "type")
+	if err != nil {
+		klog.Errorf("Failed to get spec.type field from %s(%s/%s)")
+	}
+	if !exist {
+		klog.Errorf("Failed to get spec.type from %s(%s/%s) which should have spec.type field.",
+			object.GetKind(), object.GetNamespace(), object.GetName())
+		return nil, nil
+	}
+	if serviceType != string(corev1.ServiceTypeLoadBalancer) {
+		return nil, nil
+	}
+
+	statusMap, exist, err := unstructured.NestedMap(object.Object, "status")
+	if err != nil {
+		klog.Errorf("Failed to get status field from %s(%s/%s), error: %v",
+			object.GetKind(), object.GetNamespace(), object.GetName(), err)
+		return nil, err
+	}
+	if !exist {
+		klog.Errorf("Failed to grab status from %s(%s/%s) which should have status field.",
+			object.GetKind(), object.GetNamespace(), object.GetName())
+		return nil, nil
+	}
+
+	serviceStatus, err := helper.ConvertToServiceStatus(statusMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert ServiceStatus from map[string]interface{}: %v", err)
+	}
+
+	grabStatus := corev1.ServiceStatus{
+		LoadBalancer: serviceStatus.LoadBalancer,
+	}
+	return helper.BuildStatusRawExtension(grabStatus)
+}
+
+func reflectIngressStatus(object *unstructured.Unstructured) (*runtime.RawExtension, error) {
+	return reflectWholeStatus(object)
+}
+
+func reflectJobStatus(object *unstructured.Unstructured) (*runtime.RawExtension, error) {
+	statusMap, exist, err := unstructured.NestedMap(object.Object, "status")
+	if err != nil {
+		klog.Errorf("Failed to get status field from %s(%s/%s), error: %v",
+			object.GetKind(), object.GetNamespace(), object.GetName(), err)
+		return nil, err
+	}
+	if !exist {
+		klog.Errorf("Failed to grab status from %s(%s/%s) which should have status field.",
+			object.GetKind(), object.GetNamespace(), object.GetName())
+		return nil, nil
+	}
+
+	jobStatus, err := helper.ConvertToJobStatus(statusMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert JobStatus from map[string]interface{}: %v", err)
+	}
+
+	grabStatus := batchv1.JobStatus{
+		Active:         jobStatus.Active,
+		Succeeded:      jobStatus.Succeeded,
+		Failed:         jobStatus.Failed,
+		Conditions:     jobStatus.Conditions,
+		StartTime:      jobStatus.StartTime,
+		CompletionTime: jobStatus.CompletionTime,
+	}
+	return helper.BuildStatusRawExtension(grabStatus)
+}
+
+func reflectDaemonSetStatus(object *unstructured.Unstructured) (*runtime.RawExtension, error) {
+	statusMap, exist, err := unstructured.NestedMap(object.Object, "status")
+	if err != nil {
+		klog.Errorf("Failed to get status field from %s(%s/%s), error: %v",
+			object.GetKind(), object.GetNamespace(), object.GetName(), err)
+		return nil, err
+	}
+	if !exist {
+		klog.Errorf("Failed to grab status from %s(%s/%s) which should have status field.",
+			object.GetKind(), object.GetNamespace(), object.GetName())
+		return nil, nil
+	}
+
+	daemonSetStatus, err := helper.ConvertToDaemonSetStatus(statusMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert DaemonSetStatus from map[string]interface{}: %v", err)
+	}
+
+	grabStatus := appsv1.DaemonSetStatus{
+		CurrentNumberScheduled: daemonSetStatus.CurrentNumberScheduled,
+		DesiredNumberScheduled: daemonSetStatus.DesiredNumberScheduled,
+		NumberAvailable:        daemonSetStatus.NumberAvailable,
+		NumberMisscheduled:     daemonSetStatus.NumberMisscheduled,
+		NumberReady:            daemonSetStatus.NumberReady,
+		UpdatedNumberScheduled: daemonSetStatus.UpdatedNumberScheduled,
+		NumberUnavailable:      daemonSetStatus.NumberUnavailable,
+	}
+	return helper.BuildStatusRawExtension(grabStatus)
+}
+
+func reflectStatefulSetStatus(object *unstructured.Unstructured) (*runtime.RawExtension, error) {
+	statusMap, exist, err := unstructured.NestedMap(object.Object, "status")
+	if err != nil {
+		klog.Errorf("Failed to get status field from %s(%s/%s), error: %v",
+			object.GetKind(), object.GetNamespace(), object.GetName(), err)
+		return nil, err
+	}
+	if !exist {
+		klog.Errorf("Failed to grab status from %s(%s/%s) which should have status field.",
+			object.GetKind(), object.GetNamespace(), object.GetName())
+		return nil, nil
+	}
+
+	statefulSetStatus, err := helper.ConvertToStatefulSetStatus(statusMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert StatefulSetStatus from map[string]interface{}: %v", err)
+	}
+
+	grabStatus := appsv1.StatefulSetStatus{
+		AvailableReplicas: statefulSetStatus.AvailableReplicas,
+		CurrentReplicas:   statefulSetStatus.CurrentReplicas,
+		ReadyReplicas:     statefulSetStatus.ReadyReplicas,
+		Replicas:          statefulSetStatus.Replicas,
+		UpdatedReplicas:   statefulSetStatus.UpdatedReplicas,
+	}
+	return helper.BuildStatusRawExtension(grabStatus)
+}
+
+func reflectWholeStatus(object *unstructured.Unstructured) (*runtime.RawExtension, error) {
 	statusMap, exist, err := unstructured.NestedMap(object.Object, "status")
 	if err != nil {
 		klog.Errorf("Failed to get status field from %s(%s/%s), error: %v",

--- a/pkg/resourceinterpreter/defaultinterpreter/reflectstatus_test.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/reflectstatus_test.go
@@ -59,13 +59,13 @@ func Test_getEntireStatus(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getEntireStatus(tt.args.object)
+			got, err := getWholeStatus(tt.args.object)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("getEntireStatus() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("getWholeStatus() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getEntireStatus() got = %v, want %v", got, tt.want)
+				t.Errorf("getWholeStatus() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/resourceinterpreter/defaultinterpreter/reflectstatus_test.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/reflectstatus_test.go
@@ -59,13 +59,13 @@ func Test_getEntireStatus(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getWholeStatus(tt.args.object)
+			got, err := reflectWholeStatus(tt.args.object)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("getWholeStatus() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("reflectWholeStatus() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getWholeStatus() got = %v, want %v", got, tt.want)
+				t.Errorf("reflectWholeStatus() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/resourceinterpreter/interpreter.go
+++ b/pkg/resourceinterpreter/interpreter.go
@@ -39,7 +39,7 @@ type ResourceInterpreter interface {
 	// GetDependencies returns the dependent resources of the given object.
 	GetDependencies(object *unstructured.Unstructured) (dependencies []configv1alpha1.DependentObjectReference, err error)
 
-	// ReflectStatus returns the cluster object's running status after the grab.
+	// ReflectStatus returns the status of the object.
 	ReflectStatus(object *unstructured.Unstructured) (status *runtime.RawExtension, err error)
 
 	// other common method
@@ -180,7 +180,7 @@ func (i *customResourceInterpreterImpl) GetDependencies(object *unstructured.Uns
 	return
 }
 
-// ReflectStatus returns the cluster object's running status after the grab.
+// ReflectStatus returns the status of the object.
 func (i *customResourceInterpreterImpl) ReflectStatus(object *unstructured.Unstructured) (status *runtime.RawExtension, err error) {
 	klog.V(4).Info("Begin to grab status for object: %v %s/%s.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 

--- a/pkg/util/helper/unstructured.go
+++ b/pkg/util/helper/unstructured.go
@@ -105,6 +105,16 @@ func ConvertToDaemonSet(obj *unstructured.Unstructured) (*appsv1.DaemonSet, erro
 	return typedObj, nil
 }
 
+// ConvertToDaemonSetStatus converts a DaemonSetStatus object from unstructured to typed.
+func ConvertToDaemonSetStatus(obj map[string]interface{}) (*appsv1.DaemonSetStatus, error) {
+	typedObj := &appsv1.DaemonSetStatus{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj, typedObj); err != nil {
+		return nil, err
+	}
+
+	return typedObj, nil
+}
+
 // ConvertToStatefulSet converts a StatefulSet object from unstructured to typed.
 func ConvertToStatefulSet(obj *unstructured.Unstructured) (*appsv1.StatefulSet, error) {
 	typedObj := &appsv1.StatefulSet{}
@@ -115,10 +125,30 @@ func ConvertToStatefulSet(obj *unstructured.Unstructured) (*appsv1.StatefulSet, 
 	return typedObj, nil
 }
 
+// ConvertToStatefulSetStatus converts a StatefulSetStatus object from unstructured to typed.
+func ConvertToStatefulSetStatus(obj map[string]interface{}) (*appsv1.StatefulSetStatus, error) {
+	typedObj := &appsv1.StatefulSetStatus{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj, typedObj); err != nil {
+		return nil, err
+	}
+
+	return typedObj, nil
+}
+
 // ConvertToJob converts a Job object from unstructured to typed.
 func ConvertToJob(obj *unstructured.Unstructured) (*batchv1.Job, error) {
 	typedObj := &batchv1.Job{}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
+		return nil, err
+	}
+
+	return typedObj, nil
+}
+
+// ConvertToJobStatus converts a JobStatus from unstructured to typed.
+func ConvertToJobStatus(obj map[string]interface{}) (*batchv1.JobStatus, error) {
+	typedObj := &batchv1.JobStatus{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj, typedObj); err != nil {
 		return nil, err
 	}
 
@@ -155,7 +185,17 @@ func ConvertToService(obj *unstructured.Unstructured) (*corev1.Service, error) {
 	return typedObj, nil
 }
 
-// ConvertToIngress converts a Service object from unstructured to typed.
+// ConvertToServiceStatus converts a ServiceStatus object from unstructured to typed.
+func ConvertToServiceStatus(obj map[string]interface{}) (*corev1.ServiceStatus, error) {
+	typedObj := &corev1.ServiceStatus{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj, typedObj); err != nil {
+		return nil, err
+	}
+
+	return typedObj, nil
+}
+
+// ConvertToIngress converts an Ingress object from unstructured to typed.
 func ConvertToIngress(obj *unstructured.Unstructured) (*extensionsv1beta1.Ingress, error) {
 	typedObj := &extensionsv1beta1.Ingress{}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {

--- a/pkg/util/helper/unstructured.go
+++ b/pkg/util/helper/unstructured.go
@@ -85,6 +85,16 @@ func ConvertToDeployment(obj *unstructured.Unstructured) (*appsv1.Deployment, er
 	return typedObj, nil
 }
 
+// ConvertToDeploymentStatus converts a DeploymentStatus object from unstructured to typed.
+func ConvertToDeploymentStatus(obj map[string]interface{}) (*appsv1.DeploymentStatus, error) {
+	typedObj := &appsv1.DeploymentStatus{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj, typedObj); err != nil {
+		return nil, err
+	}
+
+	return typedObj, nil
+}
+
 // ConvertToDaemonSet converts a DaemonSet object from unstructured to typed.
 func ConvertToDaemonSet(obj *unstructured.Unstructured) (*appsv1.DaemonSet, error) {
 	typedObj := &appsv1.DaemonSet{}

--- a/pkg/util/helper/workstatus.go
+++ b/pkg/util/helper/workstatus.go
@@ -283,7 +283,7 @@ func IsWorkContains(workStatus *workv1alpha1.WorkStatus, targetResource schema.G
 }
 
 // BuildStatusRawExtension builds raw JSON by a status map.
-func BuildStatusRawExtension(status map[string]interface{}) (*runtime.RawExtension, error) {
+func BuildStatusRawExtension(status interface{}) (*runtime.RawExtension, error) {
 	statusJSON, err := json.Marshal(status)
 	if err != nil {
 		klog.Errorf("Failed to marshal status. Error: %v.", statusJSON)


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add ReflectStatus ResourceInterperter interface to grab workload status, so as to support granularity control of workload status collection.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The default implementation of some resources kind(such as `deployment`) is not added. 

Add default reflectstatus implementation with:
- Deployment kind
- Service kind
- Ingress kind
- Job kind
- DaemonSet kind
- StatefulSet kind

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Supports granularity control of workload status collection with InterpretStatus InterpreterOperation.
```

