### PR TITLE
Automated cherry pick of #1632: Fix pod exec through cluster/proxy

### DIFF
--- a/pkg/registry/cluster/storage/proxy.go
+++ b/pkg/registry/cluster/storage/proxy.go
@@ -109,6 +109,10 @@ func newProxyHandler(location *url.URL, transport http.RoundTripper, impersonate
 
 		req.Header.Set("Authorization", fmt.Sprintf("bearer %s", impersonateToken))
 
+		// Retain RawQuery in location because upgrading the request will use it.
+		// See https://github.com/karmada-io/karmada/issues/1618#issuecomment-1103793290 for more info.
+		location.RawQuery = req.URL.RawQuery
+
 		handler := newThrottledUpgradeAwareProxyHandler(location, transport, true, false, responder)
 		handler.ServeHTTP(rw, req)
 	}), nil


### PR DESCRIPTION
Cherry pick of #1632 on release-1.0.
#1632: Fix pod exec through cluster/proxy
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```release-note
 `karmada-aggregate-apiserver`: Fixed exec failed: `error: unable to upgrade connection: you must specify at least 1 of stdin, stdout, stderr`
```