### PR TITLE
Add warnings when config cluster-namespace as karmada-system

### DIFF
--- a/pkg/karmadactl/join.go
+++ b/pkg/karmadactl/join.go
@@ -125,6 +125,9 @@ func (j *CommandJoinOption) Validate() error {
 		return fmt.Errorf("invalid cluster name(%s): %s", j.ClusterName, strings.Join(errMsgs, ";"))
 	}
 
+	if j.ClusterNamespace == util.NamespaceKarmadaSystem {
+		klog.Warningf("karmada-system is always reserved for Karmada control plane. We do not recommend using karmada-system to store secrets of member clusters. It may cause mistaken cleanup of resources.")
+	}
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As is talked in #1350,  add warnings when config cluster-namespace as karmada-system.

```
root@ecs-3fa1:~/karmada/cmd/karmadactl# ./karmadactl join member3 --cluster-namespace=karmada-system
W0711 14:26:46.498568 1809697 join.go:140] karmada-system is always reserved for Karmada control plane. We do not recommend using karmada-system to store secrets of member clusters. It may cause mistaken cleanup of resources.
```

**Which issue(s) this PR fixes**:
Fixes #1350 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

