### PR TITLE
remove karmada-system in chart

### DIFF
--- a/charts/templates/_karmada_webhook_configuration.tpl
+++ b/charts/templates/_karmada_webhook_configuration.tpl
@@ -59,7 +59,7 @@ webhooks:
         resources: ["clusteroverridepolicies"]
         scope: "Cluster"
     clientConfig:
-      url: https://karmada-webhook.karmada-system.svc:443/validate-clusteroverridepolicy
+      url: https://{{ $name }}.{{ $namespace }}.svc:443/validate-clusteroverridepolicy
       {{- include "karmada.webhook.caBundle" . | nindent 6 }}
     failurePolicy: Fail
     sideEffects: None


### PR DESCRIPTION
I don't think the 'karmada-system' namespace should be hard-coded in the helm chart


/kind cleanup


