### PR TITLE
feat: add outOfTree plugin entry when initializing scheduler

### DIFF
--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -24,7 +24,7 @@ var (
 	defaultElectionRetryPeriod   = metav1.Duration{Duration: 2 * time.Second}
 )
 
-// Options contains everything necessary to create and run controller-manager.
+// Options contains everything necessary to create and run scheduler.
 type Options struct {
 	LeaderElection componentbaseconfig.LeaderElectionConfiguration
 	KubeConfig     string


### PR DESCRIPTION
Signed-off-by: kerthcet <kerthcet@gmail.com>

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/karmada/issues/1371

**Special notes for your reviewer**:
Now we can initialize OutOfTree Plugin like below, then we can compile  customized karmada scheduler.
```
command := app.NewSchedulerCommand(stopChan,
    app.WithPlugin(apiinstalled.Name, apiinstalled.New),
)
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
None
```

