### PR TITLE
Update judge work contains serviceExport with .spec.workload.manifests

### DIFF
--- a/pkg/util/helper/workstatus.go
+++ b/pkg/util/helper/workstatus.go
@@ -268,20 +268,6 @@ func IsResourceApplied(workStatus *workv1alpha1.WorkStatus) bool {
 	return meta.IsStatusConditionTrue(workStatus.Conditions, workv1alpha1.WorkApplied)
 }
 
-// IsWorkContains checks if the target resource exists in a work.
-// Note: This function checks the Work object's status to detect the target resource, so the Work should be 'Applied',
-// otherwise always returns false.
-func IsWorkContains(workStatus *workv1alpha1.WorkStatus, targetResource schema.GroupVersionKind) bool {
-	for _, manifestStatuses := range workStatus.ManifestStatuses {
-		if targetResource.Group == manifestStatuses.Identifier.Group &&
-			targetResource.Version == manifestStatuses.Identifier.Version &&
-			targetResource.Kind == manifestStatuses.Identifier.Kind {
-			return true
-		}
-	}
-	return false
-}
-
 // BuildStatusRawExtension builds raw JSON by a status map.
 func BuildStatusRawExtension(status interface{}) (*runtime.RawExtension, error) {
 	statusJSON, err := json.Marshal(status)


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The `ServiceExport` resource does not have the status filed. Therefore, the work status of the ServiceExport type should not be collected during work status collection. In this case, the information in work status is not suitable to determine whether the work contains ServiceExport.

So I change to use `.spec.workload.manifests` to judge whether the work contains `ServiceExport`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

