### PR TITLE
improved the output of 'kubectl get cluster -o wide'

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -19,6 +19,7 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Mode", Type: "string", Description: "SyncMode describes how a cluster sync resources from karmada control plane."},
 		{Name: "Ready", Type: "string", Description: "The aggregate readiness state of this cluster for accepting workloads."},
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
+		{Name: "APIEndpoint", Type: "string", Priority: 1, Description: "The API endpoint of the member cluster."},
 	}
 	// ignore errors because we enable errcheck golangci-lint.
 	_ = h.TableHandler(clusterColumnDefinitions, printClusterList)
@@ -56,6 +57,9 @@ func printCluster(cluster *clusterapis.Cluster, options printers.GenerateOptions
 		cluster.Spec.SyncMode,
 		ready,
 		translateTimestampSince(cluster.CreationTimestamp))
+	if options.Wide {
+		row.Cells = append(row.Cells, cluster.Spec.APIEndpoint)
+	}
 	return []metav1.TableRow{row}, nil
 }
 


### PR DESCRIPTION
Signed-off-by: duanmeng <duanmeng_yewu@cmss.chinamobile.com>

**What type of PR is this?**
Improved the output of `kubectl get cluster -o wide`, add  ApiEndpoint field to `-o wide`
<!--
Add one of the following kinds:
/kind feature
-->

**What this PR does / why we need it**:
When the number of clusters is large, we need `-o wide` to identify the cluster, as `-o yaml` displays long information,make users hard to  recognize the cluster
**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

