### PR TITLE
Creating Loadbalancer Type Service by Installing the Metallb

### DIFF
--- a/examples/customresourceinterpreter/karmada-interpreter-webhook-example.yaml
+++ b/examples/customresourceinterpreter/karmada-interpreter-webhook-example.yaml
@@ -63,6 +63,7 @@ spec:
   ports:
     - port: 443
       targetPort: 8445
+  type: LoadBalancer
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/examples/customresourceinterpreter/webhook-configuration.yaml
+++ b/examples/customresourceinterpreter/webhook-configuration.yaml
@@ -11,7 +11,7 @@ webhooks:
         apiVersions: [ "v1alpha1" ]
         kinds: [ "Workload" ]
     clientConfig:
-      url: https://karmada-interpreter-webhook-example.karmada-system.svc:443/interpreter-workload
+      url: https://{{karmada-interpreter-webhook-example-svc-address}}:443/interpreter-workload
       caBundle: {{caBundle}}
     interpreterContextVersions: [ "v1alpha1" ]
     timeoutSeconds: 3

--- a/hack/post-run-e2e.sh
+++ b/hack/post-run-e2e.sh
@@ -20,6 +20,15 @@ export KUBECONFIG="${MAIN_KUBECONFIG}"
 kubectl config use-context "${HOST_CLUSTER_NAME}"
 kubectl delete -f "${REPO_ROOT}"/examples/customresourceinterpreter/karmada-interpreter-webhook-example.yaml
 
+# uninstall metallb
+kubectl delete configmap config -n metallb-system
+kubectl delete -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/metallb.yaml
+kubectl delete -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/namespace.yaml
+
+kubectl get configmap kube-proxy -n kube-system -o yaml | \
+sed -e "s/strictARP: true/strictARP: false/" | \
+kubectl apply -f - -n kube-system
+
 # delete interpreter workload webhook configuration
 kubectl config use-context "${KARMADA_APISERVER}"
 kubectl delete ResourceInterpreterWebhookConfiguration examples

--- a/hack/pre-run-e2e.sh
+++ b/hack/pre-run-e2e.sh
@@ -25,15 +25,51 @@ ROOT_CA_FILE=${CERT_DIR}/server-ca.crt
 # load interpreter webhook example image
 kind load docker-image "${REGISTRY}/karmada-interpreter-webhook-example:${VERSION}" --name="${HOST_CLUSTER_NAME}"
 
-# deploy interpreter webhook example in karmada-host
 export KUBECONFIG="${MAIN_KUBECONFIG}"
 kubectl config use-context "${HOST_CLUSTER_NAME}"
+
+# Due to we are using kube-proxy in IPVS mode, we have to enable strict ARP mode.
+# refer to https://metallb.universe.tf/installation/#preparation
+kubectl get configmap kube-proxy -n kube-system -o yaml | \
+sed -e "s/strictARP: false/strictARP: true/" | \
+kubectl apply -f - -n kube-system
+
+# install metallb by manifest, refer to https://metallb.universe.tf/installation/#installation-by-manifest
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/metallb.yaml
+util::wait_pod_ready metallb metallb-system
+
+# Use x.x.x.6 IP address, which is the same CIDR with the node address of the Kind cluster,
+# as the loadBalancer service address of component karmada-interpreter-webhook-example.
+interpreter_webhook_example_service_external_ip_prefix=$(echo $(util::get_apiserver_ip_from_kubeconfig "${HOST_CLUSTER_NAME}") | awk -F. '{printf "%s.%s.%s",$1,$2,$3}')
+interpreter_webhook_example_service_external_ip_address=${interpreter_webhook_example_service_external_ip_prefix}.6
+
+# config with layer 2 configuration. refer to https://metallb.universe.tf/configuration/#layer-2-configuration
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - ${interpreter_webhook_example_service_external_ip_address}-${interpreter_webhook_example_service_external_ip_address}
+EOF
+
+# deploy interpreter webhook example in karmada-host
 kubectl apply -f "${REPO_ROOT}"/examples/customresourceinterpreter/karmada-interpreter-webhook-example.yaml
 util::wait_pod_ready "${INTERPRETER_WEBHOOK_EXAMPLE_LABEL}" "${KARMADA_SYSTEM_NAMESPACE}"
 
 # deploy interpreter workload webhook-configuration.yaml
 kubectl config use-context "${KARMADA_APISERVER}"
-util::deploy_webhook_configuration "${ROOT_CA_FILE}" "${REPO_ROOT}/examples/customresourceinterpreter/webhook-configuration.yaml"
+cp -rf "${REPO_ROOT}/examples/customresourceinterpreter/webhook-configuration.yaml" "${REPO_ROOT}/examples/customresourceinterpreter/webhook-configuration-temp.yaml"
+sed -i'' -e "s/{{karmada-interpreter-webhook-example-svc-address}}/${interpreter_webhook_example_service_external_ip_address}/g" "${REPO_ROOT}/examples/customresourceinterpreter/webhook-configuration-temp.yaml"
+util::deploy_webhook_configuration "${ROOT_CA_FILE}" "${REPO_ROOT}/examples/customresourceinterpreter/webhook-configuration-temp.yaml"
+rm -rf "${REPO_ROOT}/examples/customresourceinterpreter/webhook-configuration-temp.yaml"
 
 # install interpreter example workload CRD in karamada-apiserver and member clusters
 kubectl apply -f "${REPO_ROOT}/examples/customresourceinterpreter/apis/workload.example.io_workloads.yaml"


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Install the [metallb](https://github.com/metallb/metallb) when we run with `hack/pre-run-e2e.sh`. As a result we can create a `LoadBalancer` type service for `karmada-interpreter-webhook-example`, in this way, in a CI test environment built with Kind, the service can be accessed directly from the member cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

