### PR TITLE
Fix karmadactl init  karmada-controller-manager leader elect failure

### DIFF
--- a/pkg/karmadactl/cmdinit/kubernetes/deployments.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deployments.go
@@ -487,6 +487,7 @@ func (i *CommandInitOption) makeKarmadaControllerManagerDeployment() *appsv1.Dep
 					"--bind-address=0.0.0.0",
 					"--cluster-status-update-frequency=10s",
 					"--secure-port=10357",
+					fmt.Sprintf("--leader-elect-resource-namespace=%s", i.Namespace),
 					"--v=4",
 				},
 				Ports: []corev1.ContainerPort{


### PR DESCRIPTION
Signed-off-by: prodan <pengshihaoren@gmail.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

The default namespace of karmada-controller-manager is `karmada-system`. Installing karmada in a namespace other than `karmada-system` will cause karmada-controller-manager to fail to elect a leader.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl: Fixed karmada-controller-manager args not honor customized namespace issue.`
```

