### PR TITLE
Automated cherry pick of #1681: remove arch for dockerhub image ci

### DIFF
--- a/.github/workflows/dockerhub-released-image.yml
+++ b/.github/workflows/dockerhub-released-image.yml
@@ -8,9 +8,6 @@ jobs:
     name: publish to DockerHub
     strategy:
       matrix:
-        arch:
-          - amd64
-          - arm64
         target:
           - karmada-controller-manager
           - karmada-scheduler
@@ -28,10 +25,6 @@ jobs:
           # 0 indicates all history for all branches and tags.
           # for `git describe --tags` in Makefile.
           fetch-depth: 0
-      - name: install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.16.x
       - name: install QEMU
         uses: docker/setup-qemu-action@v1
       - name: install Buildx
@@ -42,10 +35,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER_NAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: build and publish images
-        env:
+        env: 
           VERSION: ${{ github.ref_name }}
-          GOARCH: ${{ matrix.arch }}
-        # When we build binary for multiple platform, `go build` may be skipped as `$(SOURCES)` unchanged.
-        # So we clean the binary at first, and force to run `go build`.
-        # See https://github.com/karmada-io/karmada/pull/1649#issuecomment-1107959879 for more info.
-        run: make clean mp-image-${{ matrix.target }}
+        run: make mp-image-${{ matrix.target }}


### PR DESCRIPTION
Cherry pick of #1681 on release-1.0.
#1681: remove arch for dockerhub image ci
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```release-note
```