### PR TITLE
Automated cherry pick of #1683: add `leader-elect-resource-namespace` flags

### DIFF
--- a/pkg/karmadactl/cmdinit/kubernetes/deployments.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deployments.go
@@ -486,6 +486,7 @@ func (i *CommandInitOption) makeKarmadaControllerManagerDeployment() *appsv1.Dep
 					"--bind-address=0.0.0.0",
 					"--cluster-status-update-frequency=10s",
 					"--secure-port=10357",
+					fmt.Sprintf("--leader-elect-resource-namespace=%s", i.Namespace),
 					"--v=4",
 				},
 				Ports: []corev1.ContainerPort{


### PR DESCRIPTION
Cherry pick of #1683 on release-1.0.
#1683: add `leader-elect-resource-namespace` flags
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```release-note
`karmadactl: Fixed karmada-controller-manager args not honor customized namespace issue.`
```