### PR TITLE
Fix karmada-apiserver pending when helm upgrade

### DIFF
--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -250,7 +250,16 @@ apiServer:
   ## @param apiServer.nodeSelector
   nodeSelector: { }
   ## @param apiServer.affinity
-  affinity: { }
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - karmada-apiserver
+          topologyKey: kubernetes.io/hostname
   ## @param apiServer.tolerations
   tolerations: [ ]
     # - key: node-role.kubernetes.io/master
@@ -269,8 +278,8 @@ apiServer:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 50%
+      maxUnavailable: 1
+      maxSurge: 1
 
 ## karmada aggregated apiserver config
 aggregatedApiServer:


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When use `helm upgrade` and upgrade karmada from 1.0.0 to 1.1.0，upgrading karmada-apiserver pod keep pending, because karmada-apiserver use `hostnetwork: true` config and when rolling update new pod cannot run due to port conflict. So update helm templates based on https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/karmada-apiserver.yaml.

**Which issue(s) this PR fixes**:
Fixes #1443 

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
None

