### PR TITLE
fix empty resource selectors which result to policy will not be consi…

### DIFF
--- a/pkg/util/overridemanager/overridemanager.go
+++ b/pkg/util/overridemanager/overridemanager.go
@@ -167,7 +167,7 @@ func (o *overrideManagerImpl) applyNamespacedOverrides(rawObj *unstructured.Unst
 func (o *overrideManagerImpl) getOverridersFromOverridePolicies(policies []GeneralOverridePolicy, resource *unstructured.Unstructured, cluster *clusterv1alpha1.Cluster) []policyOverriders {
 	resourceMatchingPolicies := make([]GeneralOverridePolicy, 0)
 	for _, policy := range policies {
-		if policy.GetOverrideSpec().ResourceSelectors == nil {
+		if len(policy.GetOverrideSpec().ResourceSelectors) == 0 {
 			resourceMatchingPolicies = append(resourceMatchingPolicies, policy)
 			continue
 		}

--- a/pkg/util/overridemanager/overridemanager_test.go
+++ b/pkg/util/overridemanager/overridemanager_test.go
@@ -93,6 +93,23 @@ func TestGetMatchingOverridePolicies(t *testing.T) {
 			},
 		},
 	}
+	overridePolicy3 := &policyv1alpha1.OverridePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: metav1.NamespaceDefault,
+			Name:      "overridePolicy3",
+		},
+		Spec: policyv1alpha1.OverrideSpec{
+			ResourceSelectors: []policyv1alpha1.ResourceSelector{},
+			OverrideRules: []policyv1alpha1.RuleWithCluster{
+				{
+					TargetCluster: &policyv1alpha1.ClusterAffinity{
+						ClusterNames: []string{cluster1.Name, cluster2.Name},
+					},
+					Overriders: overriders3,
+				},
+			},
+		},
+	}
 	oldOverridePolicy := &policyv1alpha1.ClusterOverridePolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: metav1.NamespaceDefault,
@@ -151,6 +168,19 @@ func TestGetMatchingOverridePolicies(t *testing.T) {
 				{
 					name:       overridePolicy2.Name,
 					namespace:  overridePolicy2.Namespace,
+					overriders: overriders3,
+				},
+			},
+		},
+		{
+			name:     "OverrideRules test 3",
+			policies: []GeneralOverridePolicy{overridePolicy3},
+			resource: deploymentObj,
+			cluster:  cluster2,
+			wantedOverriders: []policyOverriders{
+				{
+					name:       overridePolicy3.Name,
+					namespace:  overridePolicy3.Namespace,
 					overriders: overriders3,
 				},
 			},


### PR DESCRIPTION
…dered matched

Signed-off-by: likakuli <1154584512@qq.com>

**What type of PR is this?**

/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Override policy with empty resourceselectors should effective as nil which means match every resource.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
override policy with empty resourceselectors will be considered to match all resource like with nil resourceselectors
```

