### PR TITLE
use underscode instead of hyphen while defined function in cherry_pick shell

### DIFF
--- a/hack/cherry_pick_pull.sh
+++ b/hack/cherry_pick_pull.sh
@@ -134,7 +134,7 @@ function return_to_kansas {
 trap return_to_kansas EXIT
 
 SUBJECTS=()
-function make-a-pr() {
+function make_a_pr() {
   local rel
   rel="$(basename "${BRANCH}")"
   echo
@@ -224,7 +224,7 @@ if git remote -v | grep ^"${FORK_REMOTE}" | grep "${MAIN_REPO_ORG}/${MAIN_REPO_N
   echo "where REMOTE is your personal fork (maybe ${UPSTREAM_REMOTE}? Consider swapping those.)."
   echo "OR consider setting UPSTREAM_REMOTE and FORK_REMOTE to different values."
   echo
-  make-a-pr
+  make_a_pr
   cleanbranch=""
   exit 0
 fi
@@ -241,4 +241,4 @@ if ! [[ "${REPLY}" =~ ^[yY]$ ]]; then
 fi
 
 git push "${FORK_REMOTE}" -f "${NEWBRANCHUNIQ}:${NEWBRANCH}"
-make-a-pr
+make_a_pr


### PR DESCRIPTION
Signed-off-by: wuyingjun <wuyingjun_yewu@cmss.chinamobile.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
-->

**What this PR does / why we need it**:
I met a problem when I used sh but not bash executing check_pick_pull.sh 
<img width="800" alt="image" src="https://user-images.githubusercontent.com/16109961/166187455-f5eab652-0c2f-431e-a2e3-b834ac64b2c4.png">
In the shell command language, a word consisting solely of underscores, digits, and alphabetics from the portable character set. The first character of a name is not a digit.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```NONE

```

