### PR TITLE
feat: add `clusterName` parameter for interperter webhook `retain`

### DIFF
--- a/pkg/apis/config/v1alpha1/interpretercontext_types.go
+++ b/pkg/apis/config/v1alpha1/interpretercontext_types.go
@@ -64,6 +64,10 @@ type ResourceInterpreterRequest struct {
 	// AggregatedStatus represents status list of the resource running in each member cluster.
 	// +optional
 	AggregatedStatus []workv1alpha2.AggregatedStatusItem `json:"aggregatedStatus,omitempty"`
+
+	// ClusterName represents member cluster incoming request
+	// +optional
+	ClusterName string `json:"clusterName,omitempty"`
 }
 
 // ResourceInterpreterResponse describes an interpreter response.

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -1096,6 +1096,13 @@ func schema_pkg_apis_config_v1alpha1_ResourceInterpreterRequest(ref common.Refer
 							},
 						},
 					},
+					"clusterName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ClusterName represents member cluster incoming request",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"uid", "kind", "name", "operation"},
 			},

--- a/pkg/resourceinterpreter/customizedinterpreter/webhook/attributes.go
+++ b/pkg/resourceinterpreter/customizedinterpreter/webhook/attributes.go
@@ -15,6 +15,7 @@ type RequestAttributes struct {
 	ObservedObj      *unstructured.Unstructured
 	ReplicasSet      int32
 	AggregatedStatus []workv1alpha2.AggregatedStatusItem
+	ClusterName      string
 }
 
 // ResponseAttributes contains the attributes that response by the webhook.

--- a/pkg/resourceinterpreter/customizedinterpreter/webhook/resourceinterpretercontext.go
+++ b/pkg/resourceinterpreter/customizedinterpreter/webhook/resourceinterpretercontext.go
@@ -45,6 +45,7 @@ func CreateV1alpha1ResourceInterpreterContext(uid types.UID, attributes *Request
 			},
 			DesiredReplicas:  &attributes.ReplicasSet,
 			AggregatedStatus: attributes.AggregatedStatus,
+			ClusterName:      attributes.ClusterName,
 		},
 	}
 

--- a/pkg/resourceinterpreter/interpreter.go
+++ b/pkg/resourceinterpreter/interpreter.go
@@ -31,7 +31,7 @@ type ResourceInterpreter interface {
 	ReviseReplica(object *unstructured.Unstructured, replica int64) (*unstructured.Unstructured, error)
 
 	// Retain returns the objects that based on the "desired" object but with values retained from the "observed" object.
-	Retain(desired *unstructured.Unstructured, observed *unstructured.Unstructured) (retained *unstructured.Unstructured, err error)
+	Retain(clusterName string, desired *unstructured.Unstructured, observed *unstructured.Unstructured) (retained *unstructured.Unstructured, err error)
 
 	// AggregateStatus returns the objects that based on the 'object' but with status aggregated.
 	AggregateStatus(object *unstructured.Unstructured, aggregatedStatusItems []workv1alpha2.AggregatedStatusItem) (*unstructured.Unstructured, error)
@@ -124,13 +124,14 @@ func (i *customResourceInterpreterImpl) ReviseReplica(object *unstructured.Unstr
 }
 
 // Retain returns the objects that based on the "desired" object but with values retained from the "observed" object.
-func (i *customResourceInterpreterImpl) Retain(desired *unstructured.Unstructured, observed *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+func (i *customResourceInterpreterImpl) Retain(clusterName string, desired *unstructured.Unstructured, observed *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	klog.V(4).Infof("Begin to retain object: %v %s/%s.", desired.GroupVersionKind(), desired.GetNamespace(), desired.GetName())
 
 	obj, hookEnabled, err := i.customizedInterpreter.Patch(context.TODO(), &webhook.RequestAttributes{
 		Operation:   configv1alpha1.InterpreterOperationRetain,
 		Object:      desired,
 		ObservedObj: observed,
+		ClusterName: clusterName,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/util/objectwatcher/objectwatcher.go
+++ b/pkg/util/objectwatcher/objectwatcher.go
@@ -107,7 +107,7 @@ func (o *objectWatcherImpl) Create(clusterName string, desireObj *unstructured.U
 	return nil
 }
 
-func (o *objectWatcherImpl) retainClusterFields(desired, observed *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+func (o *objectWatcherImpl) retainClusterFields(clusterName string, desired, observed *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	// Pass the same ResourceVersion as in the cluster object for update operation, otherwise operation will fail.
 	desired.SetResourceVersion(observed.GetResourceVersion())
 
@@ -124,7 +124,7 @@ func (o *objectWatcherImpl) retainClusterFields(desired, observed *unstructured.
 	util.MergeAnnotations(desired, observed)
 
 	if o.resourceInterpreter.HookEnabled(desired.GroupVersionKind(), configv1alpha1.InterpreterOperationRetain) {
-		return o.resourceInterpreter.Retain(desired, observed)
+		return o.resourceInterpreter.Retain(clusterName, desired, observed)
 	}
 
 	return desired, nil
@@ -143,7 +143,7 @@ func (o *objectWatcherImpl) Update(clusterName string, desireObj, clusterObj *un
 		return err
 	}
 
-	desireObj, err = o.retainClusterFields(desireObj, clusterObj)
+	desireObj, err = o.retainClusterFields(clusterName, desireObj, clusterObj)
 	if err != nil {
 		klog.Errorf("Failed to retain fields for resource(kind=%s, %s/%s) in cluster %s: %v", clusterObj.GetKind(), clusterObj.GetNamespace(), clusterObj.GetName(), clusterName, err)
 		return err


### PR DESCRIPTION
Signed-off-by: charlesQQ <charles_ali@qq.com>

**What type of PR is this?**
/kind api-change
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
interterter webhook server should know cluster name , and decide to  retain spec.replicas field
**Which issue(s) this PR fixes**:
Fixes  https://github.com/karmada-io/karmada/issues/1573

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```
interperter-webhook server

```

