### PR TITLE
feat: allow propagate workload to cluster but replicas is zero

### DIFF
--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -45,6 +45,9 @@ type Options struct {
 	SchedulerEstimatorTimeout metav1.Duration
 	// SchedulerEstimatorPort is the port that the accurate scheduler estimator server serves at.
 	SchedulerEstimatorPort int
+
+	// EnableEmptyWorkloadPropagation represents whether workload with 0 replicas could be propagated to member clusters.
+	EnableEmptyWorkloadPropagation bool
 }
 
 // NewOptions builds an default scheduler options.
@@ -79,5 +82,6 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.EnableSchedulerEstimator, "enable-scheduler-estimator", false, "Enable calling cluster scheduler estimator for adjusting replicas.")
 	fs.DurationVar(&o.SchedulerEstimatorTimeout.Duration, "scheduler-estimator-timeout", 3*time.Second, "Specifies the timeout period of calling the scheduler estimator service.")
 	fs.IntVar(&o.SchedulerEstimatorPort, "scheduler-estimator-port", defaultEstimatorPort, "The secure port on which to connect the accurate scheduler estimator.")
+	fs.BoolVar(&o.EnableEmptyWorkloadPropagation, "enable-empty-workload-propagation", false, "Enable workload with replicas 0 to be propagated to member clusters.")
 	features.FeatureGate.AddFlag(fs)
 }

--- a/cmd/scheduler/app/scheduler.go
+++ b/cmd/scheduler/app/scheduler.go
@@ -99,6 +99,7 @@ func run(opts *options.Options, stopChan <-chan struct{}) error {
 		scheduler.WithEnableSchedulerEstimator(opts.EnableSchedulerEstimator),
 		scheduler.WithSchedulerEstimatorPort(opts.SchedulerEstimatorPort),
 		scheduler.WithSchedulerEstimatorTimeout(opts.SchedulerEstimatorTimeout),
+		scheduler.WithEnableEmptyWorkloadPropagation(opts.EnableEmptyWorkloadPropagation),
 	)
 	if err != nil {
 		return fmt.Errorf("couldn't create scheduler: %w", err)

--- a/pkg/scheduler/core/division_algorithm.go
+++ b/pkg/scheduler/core/division_algorithm.go
@@ -48,6 +48,7 @@ func divideReplicasByResource(
 		if err != nil {
 			return nil, fmt.Errorf("failed to scale down: %v", err)
 		}
+
 		return newTargetClusters, nil
 	} else if assignedReplicas < spec.Replicas {
 		// We need to enlarge the replicas in terms of the previous result (if exists).

--- a/pkg/scheduler/core/util.go
+++ b/pkg/scheduler/core/util.go
@@ -118,3 +118,18 @@ func resortClusterList(clusterAvailableReplicas []workv1alpha2.TargetCluster, sc
 	klog.V(4).Infof("Resorted target cluster: %v", clusterAvailableReplicas)
 	return clusterAvailableReplicas
 }
+
+// attachZeroReplicasCluster  attach cluster in clusters into targetCluster
+// The purpose is to avoid workload not appeared in rb's spec.clusters field
+func attachZeroReplicasCluster(clusters []*clusterv1alpha1.Cluster, targetClusters []workv1alpha2.TargetCluster) []workv1alpha2.TargetCluster {
+	targetClusterSet := sets.NewString()
+	for i := range targetClusters {
+		targetClusterSet.Insert(targetClusters[i].Name)
+	}
+	for i := range clusters {
+		if !targetClusterSet.Has(clusters[i].Name) {
+			targetClusters = append(targetClusters, workv1alpha2.TargetCluster{Name: clusters[i].Name, Replicas: 0})
+		}
+	}
+	return targetClusters
+}

--- a/pkg/scheduler/core/util_test.go
+++ b/pkg/scheduler/core/util_test.go
@@ -1,0 +1,169 @@
+package core
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/test/helper"
+)
+
+func Test_findOutScheduledCluster(t *testing.T) {
+	type args struct {
+		tcs        []workv1alpha2.TargetCluster
+		candidates []*clusterv1alpha1.Cluster
+	}
+	tests := []struct {
+		name string
+		args args
+		want []workv1alpha2.TargetCluster
+	}{
+		{
+			name: "tcs: member1,member2,member3, candidates: member1,member2",
+			args: args{
+				tcs: []workv1alpha2.TargetCluster{
+					{
+						Name:     ClusterMember1,
+						Replicas: 1,
+					},
+					{
+						Name:     ClusterMember2,
+						Replicas: 1,
+					},
+					{
+						Name:     ClusterMember3,
+						Replicas: 1,
+					},
+				},
+				candidates: []*clusterv1alpha1.Cluster{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: ClusterMember1,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: ClusterMember2,
+						},
+					},
+				},
+			},
+			want: []workv1alpha2.TargetCluster{
+				{
+					Name:     ClusterMember1,
+					Replicas: 1,
+				},
+				{
+					Name:     ClusterMember2,
+					Replicas: 1,
+				},
+			},
+		},
+		{
+			name: "tcs: member1,member2, candidates: member1,member2,member3",
+			args: args{
+				tcs: []workv1alpha2.TargetCluster{
+					{
+						Name:     ClusterMember1,
+						Replicas: 1,
+					},
+					{
+						Name:     ClusterMember2,
+						Replicas: 1,
+					},
+				},
+				candidates: []*clusterv1alpha1.Cluster{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: ClusterMember1,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: ClusterMember2,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: ClusterMember3,
+						},
+					},
+				},
+			},
+			want: []workv1alpha2.TargetCluster{
+				{
+					Name:     ClusterMember1,
+					Replicas: 1,
+				},
+				{
+					Name:     ClusterMember2,
+					Replicas: 1,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := findOutScheduledCluster(tt.args.tcs, tt.args.candidates); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("findOutScheduledCluster() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_attachZeroReplicasCluster(t *testing.T) {
+	type args struct {
+		clusters       []*clusterv1alpha1.Cluster
+		targetClusters []workv1alpha2.TargetCluster
+	}
+	tests := []struct {
+		name string
+		args args
+		want []workv1alpha2.TargetCluster
+	}{
+		{
+			name: "clusters: member1,member2,member3, targetClusters:member1,member2",
+			args: args{
+				clusters: []*clusterv1alpha1.Cluster{
+					helper.NewCluster(ClusterMember1),
+					helper.NewCluster(ClusterMember2),
+					helper.NewCluster(ClusterMember3),
+				},
+				targetClusters: []workv1alpha2.TargetCluster{
+					{
+						Name:     ClusterMember1,
+						Replicas: 1,
+					},
+					{
+						Name:     ClusterMember2,
+						Replicas: 2,
+					},
+				},
+			},
+			want: []workv1alpha2.TargetCluster{
+				{
+					Name:     ClusterMember1,
+					Replicas: 1,
+				},
+				{
+					Name:     ClusterMember2,
+					Replicas: 2,
+				},
+				{
+					Name:     ClusterMember3,
+					Replicas: 0,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := attachZeroReplicasCluster(tt.args.clusters, tt.args.targetClusters); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("attachZeroReplicasCluster() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: charlesQQ <charles_ali@qq.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
allow propagate workload to cluster but replicas is zero; if don't want to do that, cluster should not exist in PP spec.clusterAffinity.clusterNames field
**Which issue(s) this PR fixes**:
Fixes #1573

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```
rb's spec.clusters have cluster that replicas is zero

scheduler  add a  new command line  option  enable-propagate-empty-workLoad
```

