### PR TITLE
verify crdgen and codegen for examples directory

### DIFF
--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -8,6 +8,8 @@ SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 DIFFROOT="${SCRIPT_ROOT}/pkg"
 TMP_DIFFROOT="${SCRIPT_ROOT}/_tmp/pkg"
+DIFFEXAMPLES="${SCRIPT_ROOT}/examples/customresourceinterpreter/apis"
+TMP_DIFFEXAMPLES="${SCRIPT_ROOT}/_tmp/examples/customresourceinterpreter/apis"
 _tmp="${SCRIPT_ROOT}/_tmp"
 
 cleanup() {
@@ -20,6 +22,9 @@ cleanup
 mkdir -p "${TMP_DIFFROOT}"
 cp -a "${DIFFROOT}"/* "${TMP_DIFFROOT}"
 
+mkdir -p "${TMP_DIFFEXAMPLES}"
+cp -a "${DIFFEXAMPLES}"/* "${TMP_DIFFEXAMPLES}"
+
 bash "${SCRIPT_ROOT}/hack/update-codegen.sh"
 echo "diffing ${DIFFROOT} against freshly generated codegen"
 ret=0
@@ -30,5 +35,17 @@ then
   echo "${DIFFROOT} up to date."
 else
   echo "${DIFFROOT} is out of date. Please run hack/update-codegen.sh"
+  exit 1
+fi
+
+echo "diffing ${DIFFEXAMPLES} against freshly generated codegen"
+ret=0
+diff -Naupr "${DIFFEXAMPLES}" "${TMP_DIFFEXAMPLES}" || ret=$?
+cp -a "${TMP_DIFFEXAMPLES}"/* "${DIFFEXAMPLES}"
+if [[ $ret -eq 0 ]]
+then
+  echo "${DIFFEXAMPLES} up to date."
+else
+  echo "${DIFFEXAMPLES} is out of date. Please run hack/update-codegen.sh"
   exit 1
 fi

--- a/hack/verify-crdgen.sh
+++ b/hack/verify-crdgen.sh
@@ -8,6 +8,8 @@ SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 DIFFROOT="${SCRIPT_ROOT}/charts/_crds/bases"
 TMP_DIFFROOT="${SCRIPT_ROOT}/_tmp/charts/_crds/bases"
+DIFFEXAMPLES="${SCRIPT_ROOT}/examples/customresourceinterpreter/apis"
+TMP_DIFFEXAMPLES="${SCRIPT_ROOT}/_tmp/examples/customresourceinterpreter/apis"
 _tmp="${SCRIPT_ROOT}/_tmp"
 
 cleanup() {
@@ -19,6 +21,9 @@ cleanup
 
 mkdir -p "${TMP_DIFFROOT}"
 cp -a "${DIFFROOT}"/* "${TMP_DIFFROOT}"
+
+mkdir -p "${TMP_DIFFEXAMPLES}"
+cp -a "${DIFFEXAMPLES}"/* "${TMP_DIFFEXAMPLES}"
 
 bash "${SCRIPT_ROOT}/hack/update-crdgen.sh"
 echo "diffing ${DIFFROOT} against freshly generated files"
@@ -32,5 +37,19 @@ then
   echo "${DIFFROOT} up to date."
 else
   echo "${DIFFROOT} is out of date. Please run hack/update-crdgen.sh"
+  exit 1
+fi
+
+echo "diffing ${DIFFEXAMPLES} against freshly generated files"
+
+ret=0
+
+diff -Naupr "${DIFFEXAMPLES}" "${TMP_DIFFEXAMPLES}" || ret=$?
+cp -a "${TMP_DIFFEXAMPLES}"/* "${DIFFEXAMPLES}"
+if [[ $ret -eq 0 ]]
+then
+  echo "${DIFFEXAMPLES} up to date."
+else
+  echo "${DIFFEXAMPLES} is out of date. Please run hack/update-crdgen.sh"
   exit 1
 fi


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

As discussed in https://github.com/karmada-io/karmada/pull/1713#pullrequestreview-960438916, we need to add verify `crdgen` and `codegen` for `examples/customresourceinterpreter/apis` directory.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

