### PR TITLE
get replicas with scale subresource

### DIFF
--- a/examples/customresourceinterpreter/apis/workload.example.io_workloads.yaml
+++ b/examples/customresourceinterpreter/apis/workload.example.io_workloads.yaml
@@ -7215,6 +7215,9 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.readyReplicas
       status: {}
 status:
   acceptedNames:

--- a/examples/customresourceinterpreter/apis/workload/v1alpha1/workload_types.go
+++ b/examples/customresourceinterpreter/apis/workload/v1alpha1/workload_types.go
@@ -8,6 +8,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.readyReplicas
 
 // Workload is a simple Deployment.
 type Workload struct {


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

As discussed in #1397, for CRDs that have implemented scale subresource, we can get replicas from scale subresource, as a result, one webhook access can be reduced.

**Which issue(s) this PR fixes**:
Fixes #1397
Part of #2486 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
get replicas with scale subresource
```

## How to verify

1. deploy `karmada-interpreter-webhook-example` and install workload crd:
```
hack/pre-run-e2e.sh
```
2. edit `resourceinterpreterwebhookconfigurations.config.karmada.io` `examples`:
```
kubectl edit resourceinterpreterwebhookconfigurations.config.karmada.io examples
```
update the `rules` to:
```yaml
  rules:
  - apiGroups:
    - workload.example.io
    apiVersions:
    - v1alpha1
    kinds:
    - Workload
    operations:
    - ReviseReplica
    - Retain
    - AggregateStatus
    - InterpretHealth
    - InterpretStatus
```
3. apply workload and propagate it to the member clusters:
```
kubectl apply -f examples/customresourceinterpreter/workload.yaml
kubectl apply -f examples/customresourceinterpreter/workload-propagationpolicy.yaml
```
4. check result in the member clusters:
```
kubectl --kubeconfig /root/.kube/members.config --context member1 get workloads.workload.example.io nginx -oyaml
kubectl --kubeconfig /root/.kube/members.config --context member2 get workloads.workload.example.io nginx -oyaml
```