### PR TITLE
Bump controller-tools to v0.8.0

### DIFF
--- a/charts/_crds/bases/config.karmada.io_resourceinterpreterwebhookconfigurations.yaml
+++ b/charts/_crds/bases/config.karmada.io_resourceinterpreterwebhookconfigurations.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: resourceinterpreterwebhookconfigurations.config.karmada.io
 spec:
@@ -127,8 +126,8 @@ spec:
                       apiGroups:
                         description: "APIGroups is the API groups the resources belong
                           to. '*' is all groups. If '*' is present, the length of
-                          the slice must be one. For example:  [\"apps\", \"batch\",
-                          \"example.io\"] means matches 3 groups.  [\"*\"] means matches
+                          the slice must be one. For example: [\"apps\", \"batch\",
+                          \"example.io\"] means matches 3 groups. [\"*\"] means matches
                           all group \n Note: The group cloud be empty, e.g the 'core'
                           group of kubernetes, in that case use [\"\"]."
                         items:
@@ -137,8 +136,8 @@ spec:
                       apiVersions:
                         description: 'APIVersions is the API versions the resources
                           belong to. ''*'' is all versions. If ''*'' is present, the
-                          length of the slice must be one. For example:  ["v1alpha1",
-                          "v1beta1"] means matches 2 versions.  ["*"] means matches
+                          length of the slice must be one. For example: ["v1alpha1",
+                          "v1beta1"] means matches 2 versions. ["*"] means matches
                           all versions.'
                         items:
                           type: string
@@ -146,8 +145,8 @@ spec:
                       kinds:
                         description: 'Kinds is a list of resources this rule applies
                           to. If ''*'' is present, the length of the slice must be
-                          one. For example:  ["Deployment", "Pod"] means matches Deployment
-                          and Pod.  ["*"] means apply to all resources.'
+                          one. For example: ["Deployment", "Pod"] means matches Deployment
+                          and Pod. ["*"] means apply to all resources.'
                         items:
                           type: string
                         type: array

--- a/charts/_crds/bases/networking.karmada.io_multiclusteringresses.yaml
+++ b/charts/_crds/bases/networking.karmada.io_multiclusteringresses.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: multiclusteringresses.networking.karmada.io
 spec:
@@ -123,25 +122,25 @@ spec:
                         host, as defined by RFC 3986. Note the following deviations
                         from the \"host\" part of the URI as defined in RFC 3986:
                         1. IPs are not allowed. Currently an IngressRuleValue can
-                        only apply to    the IP in the Spec of the parent Ingress.
-                        2. The `:` delimiter is not respected because ports are not
-                        allowed. \t  Currently the port of an Ingress is implicitly
-                        :80 for http and \t  :443 for https. Both these may change
-                        in the future. Incoming requests are matched against the host
-                        before the IngressRuleValue. If the host is unspecified, the
-                        Ingress routes all traffic based on the specified IngressRuleValue.
-                        \n Host can be \"precise\" which is a domain name without
-                        the terminating dot of a network host (e.g. \"foo.bar.com\")
-                        or \"wildcard\", which is a domain name prefixed with a single
-                        wildcard label (e.g. \"*.foo.com\"). The wildcard character
-                        '*' must appear by itself as the first DNS label and matches
-                        only a single label. You cannot have a wildcard label by itself
-                        (e.g. Host == \"*\"). Requests will be matched against the
-                        Host field in the following way: 1. If Host is precise, the
-                        request matches this rule if the http host header is equal
-                        to Host. 2. If Host is a wildcard, then the request matches
-                        this rule if the http host header is to equal to the suffix
-                        (removing the first label) of the wildcard rule."
+                        only apply to the IP in the Spec of the parent Ingress. 2.
+                        The `:` delimiter is not respected because ports are not allowed.
+                        Currently the port of an Ingress is implicitly :80 for http
+                        and :443 for https. Both these may change in the future. Incoming
+                        requests are matched against the host before the IngressRuleValue.
+                        If the host is unspecified, the Ingress routes all traffic
+                        based on the specified IngressRuleValue. \n Host can be \"precise\"
+                        which is a domain name without the terminating dot of a network
+                        host (e.g. \"foo.bar.com\") or \"wildcard\", which is a domain
+                        name prefixed with a single wildcard label (e.g. \"*.foo.com\").
+                        The wildcard character '*' must appear by itself as the first
+                        DNS label and matches only a single label. You cannot have
+                        a wildcard label by itself (e.g. Host == \"*\"). Requests
+                        will be matched against the Host field in the following way:
+                        1. If Host is precise, the request matches this rule if the
+                        http host header is equal to Host. 2. If Host is a wildcard,
+                        then the request matches this rule if the http host header
+                        is to equal to the suffix (removing the first label) of the
+                        wildcard rule."
                       type: string
                     http:
                       description: 'HTTPIngressRuleValue is a list of http selectors
@@ -234,20 +233,20 @@ spec:
                                   of the Path matching. PathType can be one of the
                                   following values: * Exact: Matches the URL path
                                   exactly. * Prefix: Matches based on a URL path prefix
-                                  split by ''/''. Matching is   done on a path element
-                                  by element basis. A path element refers is the   list
+                                  split by ''/''. Matching is done on a path element
+                                  by element basis. A path element refers is the list
                                   of labels in the path split by the ''/'' separator.
-                                  A request is a   match for path p if every p is
-                                  an element-wise prefix of p of the   request path.
-                                  Note that if the last element of the path is a substring   of
-                                  the last element in request path, it is not a match
-                                  (e.g. /foo/bar   matches /foo/bar/baz, but does
+                                  A request is a match for path p if every p is an
+                                  element-wise prefix of p of the request path. Note
+                                  that if the last element of the path is a substring
+                                  of the last element in request path, it is not a
+                                  match (e.g. /foo/bar matches /foo/bar/baz, but does
                                   not match /foo/barbaz). * ImplementationSpecific:
-                                  Interpretation of the Path matching is up to   the
+                                  Interpretation of the Path matching is up to the
                                   IngressClass. Implementations can treat this as
-                                  a separate PathType   or treat it identically to
-                                  Prefix or Exact path types. Implementations are
-                                  required to support all path types.'
+                                  a separate PathType or treat it identically to Prefix
+                                  or Exact path types. Implementations are required
+                                  to support all path types.'
                                 type: string
                             required:
                             - backend
@@ -326,8 +325,8 @@ spec:
                                   the service port The format of the error shall comply
                                   with the following rules: - built-in error values
                                   shall be specified in this file and those shall
-                                  use   CamelCase names - cloud provider specific
-                                  error values must have names that comply with the   format
+                                  use CamelCase names - cloud provider specific error
+                                  values must have names that comply with the format
                                   foo.example.com/CamelCase. --- The regex it matches
                                   is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
                                 maxLength: 316

--- a/charts/_crds/bases/policy.karmada.io_clusteroverridepolicies.yaml
+++ b/charts/_crds/bases/policy.karmada.io_clusteroverridepolicies.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: clusteroverridepolicies.policy.karmada.io
 spec:
@@ -144,10 +143,10 @@ spec:
                                   the rule. \n Defaults to nil, in that case, the
                                   system will automatically detect image fields if
                                   the resource type is Pod, ReplicaSet, Deployment
-                                  or StatefulSet by following rule:   - Pod: spec/containers/<N>/image
-                                  \  - ReplicaSet: spec/template/spec/containers/<N>/image
-                                  \  - Deployment: spec/template/spec/containers/<N>/image
-                                  \  - StatefulSet: spec/template/spec/containers/<N>/image
+                                  or StatefulSet by following rule: - Pod: spec/containers/<N>/image
+                                  - ReplicaSet: spec/template/spec/containers/<N>/image
+                                  - Deployment: spec/template/spec/containers/<N>/image
+                                  - StatefulSet: spec/template/spec/containers/<N>/image
                                   In addition, all images will be processed if the
                                   resource object has more than one containers. \n
                                   If not nil, only images matches the filters will
@@ -406,13 +405,12 @@ spec:
                             rule. \n Defaults to nil, in that case, the system will
                             automatically detect image fields if the resource type
                             is Pod, ReplicaSet, Deployment or StatefulSet by following
-                            rule:   - Pod: spec/containers/<N>/image   - ReplicaSet:
-                            spec/template/spec/containers/<N>/image   - Deployment:
-                            spec/template/spec/containers/<N>/image   - StatefulSet:
-                            spec/template/spec/containers/<N>/image In addition, all
-                            images will be processed if the resource object has more
-                            than one containers. \n If not nil, only images matches
-                            the filters will be processed."
+                            rule: - Pod: spec/containers/<N>/image - ReplicaSet: spec/template/spec/containers/<N>/image
+                            - Deployment: spec/template/spec/containers/<N>/image
+                            - StatefulSet: spec/template/spec/containers/<N>/image
+                            In addition, all images will be processed if the resource
+                            object has more than one containers. \n If not nil, only
+                            images matches the filters will be processed."
                           properties:
                             path:
                               description: Path indicates the path of target field

--- a/charts/_crds/bases/policy.karmada.io_clusterpropagationpolicies.yaml
+++ b/charts/_crds/bases/policy.karmada.io_clusterpropagationpolicies.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: clusterpropagationpolicies.policy.karmada.io
 spec:

--- a/charts/_crds/bases/policy.karmada.io_federatedresourcequotas.yaml
+++ b/charts/_crds/bases/policy.karmada.io_federatedresourcequotas.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: federatedresourcequotas.policy.karmada.io
 spec:

--- a/charts/_crds/bases/policy.karmada.io_overridepolicies.yaml
+++ b/charts/_crds/bases/policy.karmada.io_overridepolicies.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: overridepolicies.policy.karmada.io
 spec:
@@ -144,10 +143,10 @@ spec:
                                   the rule. \n Defaults to nil, in that case, the
                                   system will automatically detect image fields if
                                   the resource type is Pod, ReplicaSet, Deployment
-                                  or StatefulSet by following rule:   - Pod: spec/containers/<N>/image
-                                  \  - ReplicaSet: spec/template/spec/containers/<N>/image
-                                  \  - Deployment: spec/template/spec/containers/<N>/image
-                                  \  - StatefulSet: spec/template/spec/containers/<N>/image
+                                  or StatefulSet by following rule: - Pod: spec/containers/<N>/image
+                                  - ReplicaSet: spec/template/spec/containers/<N>/image
+                                  - Deployment: spec/template/spec/containers/<N>/image
+                                  - StatefulSet: spec/template/spec/containers/<N>/image
                                   In addition, all images will be processed if the
                                   resource object has more than one containers. \n
                                   If not nil, only images matches the filters will
@@ -406,13 +405,12 @@ spec:
                             rule. \n Defaults to nil, in that case, the system will
                             automatically detect image fields if the resource type
                             is Pod, ReplicaSet, Deployment or StatefulSet by following
-                            rule:   - Pod: spec/containers/<N>/image   - ReplicaSet:
-                            spec/template/spec/containers/<N>/image   - Deployment:
-                            spec/template/spec/containers/<N>/image   - StatefulSet:
-                            spec/template/spec/containers/<N>/image In addition, all
-                            images will be processed if the resource object has more
-                            than one containers. \n If not nil, only images matches
-                            the filters will be processed."
+                            rule: - Pod: spec/containers/<N>/image - ReplicaSet: spec/template/spec/containers/<N>/image
+                            - Deployment: spec/template/spec/containers/<N>/image
+                            - StatefulSet: spec/template/spec/containers/<N>/image
+                            In addition, all images will be processed if the resource
+                            object has more than one containers. \n If not nil, only
+                            images matches the filters will be processed."
                           properties:
                             path:
                               description: Path indicates the path of target field

--- a/charts/_crds/bases/policy.karmada.io_propagationpolicies.yaml
+++ b/charts/_crds/bases/policy.karmada.io_propagationpolicies.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: propagationpolicies.policy.karmada.io
 spec:

--- a/charts/_crds/bases/search.karmada.io_resourceregistries.yaml
+++ b/charts/_crds/bases/search.karmada.io_resourceregistries.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: resourceregistries.search.karmada.io
 spec:
@@ -177,13 +176,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+                    type FooStatus struct{ // Represents the observations of a foo's
+                    current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition

--- a/charts/_crds/bases/work.karmada.io_clusterresourcebindings.yaml
+++ b/charts/_crds/bases/work.karmada.io_clusterresourcebindings.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: clusterresourcebindings.work.karmada.io
 spec:
@@ -143,13 +142,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+                    type FooStatus struct{ // Represents the observations of a foo's
+                    current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -546,13 +544,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+                    type FooStatus struct{ // Represents the observations of a foo's
+                    current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition

--- a/charts/_crds/bases/work.karmada.io_resourcebindings.yaml
+++ b/charts/_crds/bases/work.karmada.io_resourcebindings.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: resourcebindings.work.karmada.io
 spec:
@@ -143,13 +142,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+                    type FooStatus struct{ // Represents the observations of a foo's
+                    current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -546,13 +544,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+                    type FooStatus struct{ // Represents the observations of a foo's
+                    current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition

--- a/charts/_crds/bases/work.karmada.io_works.yaml
+++ b/charts/_crds/bases/work.karmada.io_works.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: works.work.karmada.io
 spec:
@@ -74,13 +73,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+                    type FooStatus struct{ // Represents the observations of a foo's
+                    current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition

--- a/examples/customresourceinterpreter/apis/workload.example.io_workloads.yaml
+++ b/examples/customresourceinterpreter/apis/workload.example.io_workloads.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: workloads.workload.example.io
 spec:
@@ -5448,13 +5447,13 @@ spec:
                                 with a pod if it doesn''t satisfy the spread constraint.
                                 - DoNotSchedule (default) tells the scheduler not
                                 to schedule it. - ScheduleAnyway tells the scheduler
-                                to schedule the pod in any location,   but giving
-                                higher precedence to topologies that would help reduce
-                                the   skew. A constraint is considered "Unsatisfiable"
-                                for an incoming pod if and only if every possible
-                                node assignment for that pod would violate "MaxSkew"
-                                on some topology. For example, in a 3-zone cluster,
-                                MaxSkew is set to 1, and pods with the same labelSelector
+                                to schedule the pod in any location, but giving higher
+                                precedence to topologies that would help reduce the
+                                skew. A constraint is considered "Unsatisfiable" for
+                                an incoming pod if and only if every possible node
+                                assignment for that pod would violate "MaxSkew" on
+                                some topology. For example, in a 3-zone cluster, MaxSkew
+                                is set to 1, and pods with the same labelSelector
                                 spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P
                                 |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule,
                                 incoming pod can only be scheduled to zone2(zone3)
@@ -5891,13 +5890,12 @@ spec:
                                 when the pod is removed. \n Use this if: a) the volume
                                 is only needed while the pod runs, b) features of
                                 normal volumes like restoring from snapshot or capacity
-                                \   tracking are needed, c) the storage driver is
-                                specified through a storage class, and d) the storage
-                                driver supports dynamic volume provisioning through
-                                \   a PersistentVolumeClaim (see EphemeralVolumeSource
-                                for more    information on the connection between
-                                this volume type    and PersistentVolumeClaim). \n
-                                Use PersistentVolumeClaim or one of the vendor-specific
+                                tracking are needed, c) the storage driver is specified
+                                through a storage class, and d) the storage driver
+                                supports dynamic volume provisioning through a PersistentVolumeClaim
+                                (see EphemeralVolumeSource for more information on
+                                the connection between this volume type and PersistentVolumeClaim).
+                                \n Use PersistentVolumeClaim or one of the vendor-specific
                                 APIs for volumes that persist for longer than the
                                 lifecycle of an individual pod. \n Use CSI for light-weight
                                 local ephemeral volumes if the CSI driver is meant
@@ -6005,14 +6003,15 @@ spec:
                                             are two important differences between
                                             DataSource and DataSourceRef: * While
                                             DataSource only allows two specific types
-                                            of objects, DataSourceRef   allows any
-                                            non-core object, as well as PersistentVolumeClaim
+                                            of objects, DataSourceRef allows any non-core
+                                            object, as well as PersistentVolumeClaim
                                             objects. * While DataSource ignores disallowed
-                                            values (dropping them), DataSourceRef   preserves
-                                            all values, and generates an error if
-                                            a disallowed value is   specified. (Alpha)
-                                            Using this field requires the AnyVolumeDataSource
-                                            feature gate to be enabled.'
+                                            values (dropping them), DataSourceRef
+                                            preserves all values, and generates an
+                                            error if a disallowed value is specified.
+                                            (Alpha) Using this field requires the
+                                            AnyVolumeDataSource feature gate to be
+                                            enabled.'
                                           properties:
                                             apiGroup:
                                               description: APIGroup is the group for

--- a/hack/update-crdgen.sh
+++ b/hack/update-crdgen.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 CONTROLLER_GEN_PKG="sigs.k8s.io/controller-tools/cmd/controller-gen"
-CONTROLLER_GEN_VER="v0.6.2"
+CONTROLLER_GEN_VER="v0.8.0"
 
 source hack/util.sh
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
[controller-tools@v0.8.0] is built with Kubernetes@v1.23, which is consistent with Karmada dependencies.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/hold
wait for #1674

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

