### PR TITLE
Skip reflect work status when resource has empty status

### DIFF
--- a/pkg/controllers/status/workstatus_controller.go
+++ b/pkg/controllers/status/workstatus_controller.go
@@ -283,6 +283,10 @@ func (c *WorkStatusController) reflectStatus(work *workv1alpha1.Work, clusterObj
 			clusterObj.GetKind(), clusterObj.GetNamespace(), clusterObj.GetName(), err)
 	}
 
+	if statusRaw == nil {
+		return nil
+	}
+
 	identifier, err := c.buildStatusIdentifier(work, clusterObj)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

For resources that do not have status(such as Secret, Configmap, etc), we can do not collect resource status in `Work` object to avoid unnecessary work status updates.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

