### PR TITLE
fixed a panic which due to nil annotation during promote resources to Karmada

### DIFF
--- a/pkg/karmadactl/promote.go
+++ b/pkg/karmadactl/promote.go
@@ -379,6 +379,9 @@ func preprocessResource(obj *unstructured.Unstructured) error {
 // addOverwriteAnnotation add annotation "work.karmada.io/conflict-resolution" to the resource
 func addOverwriteAnnotation(obj *unstructured.Unstructured) {
 	annotations := obj.DeepCopy().GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
 	if _, exist := annotations[workv1alpha2.ResourceConflictResolutionAnnotation]; !exist {
 		annotations[workv1alpha2.ResourceConflictResolutionAnnotation] = workv1alpha2.ResourceConflictResolutionOverwrite
 		obj.SetAnnotations(annotations)


### PR DESCRIPTION
…d overwrite annotation

Signed-off-by: duanmeng <duanmeng_yewu@cmss.chinamobile.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Partof #1758

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl: fixed a panic which due to nil annotation during promote resources to Karmada.`
```

