### PR TITLE
Set timeout configs flexible when run e2e before

### DIFF
--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -31,11 +32,6 @@ import (
 )
 
 const (
-	// pollInterval defines the interval time for a poll operation.
-	pollInterval = 5 * time.Second
-	// pollTimeout defines the time after which the poll operation times out.
-	pollTimeout = 300 * time.Second
-
 	// RandomStrLength represents the random string length to combine names.
 	RandomStrLength = 3
 )
@@ -64,6 +60,13 @@ const (
 )
 
 var (
+	// pollInterval defines the interval time for a poll operation.
+	pollInterval time.Duration
+	// pollTimeout defines the time after which the poll operation times out.
+	pollTimeout time.Duration
+)
+
+var (
 	kubeconfig            string
 	restConfig            *rest.Config
 	karmadaHost           string
@@ -76,6 +79,13 @@ var (
 	clusterLabels         = map[string]string{"location": "CHN"}
 	pushModeClusterLabels = map[string]string{"sync-mode": "Push"}
 )
+
+func init() {
+	// usage ginkgo -- --poll-interval=5s --pollTimeout=5m
+	// eg. ginkgo -v --race --trace --fail-fast -p --randomize-all ./test/e2e/ -- --poll-interval=5s --pollTimeout=5m
+	flag.DurationVar(&pollInterval, "poll-interval", 5*time.Second, "poll-interval defines the interval time for a poll operation")
+	flag.DurationVar(&pollTimeout, "poll-timeout", 300*time.Second, "poll-timeout defines the time which the poll operation times out")
+}
 
 func TestE2E(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)


### PR DESCRIPTION
Signed-off-by: wuyingjun <wuyingjun_yewu@cmss.chinamobile.com>

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When I run e2e test locally , I always failed  because out of time 
before :
<img width="866" alt="image" src="https://user-images.githubusercontent.com/16109961/168229414-430ce892-fe81-44b3-8d6d-5b1dd3f82537.png">
<img width="1240" alt="image" src="https://user-images.githubusercontent.com/16109961/168229436-7d12f521-5df5-4018-9576-fdce59437aa5.png">
We should set the config polltimeout  flexible
After 
<img width="744" alt="image" src="https://user-images.githubusercontent.com/16109961/168229555-6cc52717-f5a1-4992-bc68-0514246915fc.png">

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

