### PR TITLE
Enable `karmadactl promote` command to support AA

### DIFF
--- a/pkg/karmadactl/get.go
+++ b/pkg/karmadactl/get.go
@@ -832,8 +832,6 @@ type ClusterInfo struct {
 	Context    string
 
 	APIEndpoint     string
-	BearerToken     string
-	CAData          string
 	ClusterSyncMode clusterv1alpha1.ClusterSyncMode
 }
 
@@ -865,16 +863,10 @@ func getFactory(clusterName string, clusterInfos map[string]*ClusterInfo) cmduti
 	// Build member cluster kubeConfigFlags
 	kubeConfigFlags.APIServer = stringptr(clusterInfos[clusterName].APIEndpoint)
 
-	if clusterInfos[clusterName].KubeConfig != "" {
-		// Use kubeconfig to access member cluster
-		kubeConfigFlags.KubeConfig = stringptr(clusterInfos[clusterName].KubeConfig)
-		kubeConfigFlags.Context = stringptr(clusterInfos[clusterName].Context)
-		kubeConfigFlags.usePersistentConfig = true
-	} else {
-		// Use BearerToken to access member cluster
-		kubeConfigFlags.BearerToken = stringptr(clusterInfos[clusterName].BearerToken)
-		kubeConfigFlags.CaBundle = stringptr(clusterInfos[clusterName].CAData)
-	}
+	// Use kubeconfig to access member cluster
+	kubeConfigFlags.KubeConfig = stringptr(clusterInfos[clusterName].KubeConfig)
+	kubeConfigFlags.Context = stringptr(clusterInfos[clusterName].Context)
+	kubeConfigFlags.usePersistentConfig = true
 
 	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
 	return cmdutil.NewFactory(matchVersionKubeConfigFlags)


### PR DESCRIPTION
Signed-off-by: lonelyCZ <531187475@qq.com>

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Enable `karmadactl promote` command to support AA, not to directly use `secret`. Meanwhile, retain `--cluster-kubeconfig` and `--cluster-context` to allow users to use this command when AA is not enabled.

**Which issue(s) this PR fixes**:
Fixes #1695 

**Special notes for your reviewer**:
/cc @RainbowMango 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Enable `karmadactl promote` command to support AA
```

