### PR TITLE
Remove karmada binary in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,18 +19,5 @@ _output/
 .idea/
 .vscode/
 
-# karamada binary
-/karmadactl
-/karmada-agent
-/karmada-aggregated-apiserver
-/karmada-controller-manager
-/karmada-interpreter-webhook-example
-/karmada-scheduler
-/karmada-descheduler
-/karmada-scheduler-estimator
-/karmada-webhook
-/kubectl-karmada
-/karmada-search
-
 # OSX trash
 .DS_Store


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

As #1740 move generated binary to _output directory, the karmada binary statement in `.gitignore` is no longer useful.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

