### PR TITLE
Update notes for Pull mode cluster in AA document

### DIFF
--- a/docs/userguide/aggregated-api-endpoint.md
+++ b/docs/userguide/aggregated-api-endpoint.md
@@ -80,7 +80,7 @@ Or append `/apis/cluster.karmada.io/v1alpha1/clusters/{clustername}/proxy ` to t
 kubectl --kubeconfig karmada-apiserver.config get node
 ```
 
-> Note: For a member cluster that joins karmada in pull mode, we can [deploy apiserver-network-proxy (ANP)](../working-with-anp.md) to access it.
+> Note: For a member cluster that joins karmada in pull mode and allows only cluster-to-karmada access, we can [deploy apiserver-network-proxy (ANP)](../working-with-anp.md) to access it.
 
 ## Unified authentication
 
@@ -253,4 +253,4 @@ Or we can append `/apis/cluster.karmada.io/v1alpha1/clusters/member1/proxy ` to 
 kubectl --kubeconfig tom.config get node
 ```
 
-> Note: For a member cluster that joins karmada in pull mode,  we can [deploy apiserver-network-proxy (ANP)](../working-with-anp.md) to access it.
+> Note: For a member cluster that joins karmada in pull mode and allows only cluster-to-karmada access, we can [deploy apiserver-network-proxy (ANP)](../working-with-anp.md) to access it.


### PR DESCRIPTION
Signed-off-by: lonelyCZ <531187475@qq.com>

**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Network plug-ins need to be deployed only if the network is one-way.

The reason for using PULL mode may also be to relieve pressure on the Karmada control plane, not necessarily because of network failure, so it should be described more accurately.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @XiShanYongYe-Chang 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

