### PR TITLE
Automated cherry pick of #1449: replace hard coded namespace with custom namespace

### DIFF
--- a/pkg/karmadactl/cmdinit/karmada/deploy.go
+++ b/pkg/karmadactl/cmdinit/karmada/deploy.go
@@ -25,8 +25,6 @@ import (
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/utils"
 )
 
-const namespace = "karmada-system"
-
 // InitKarmadaResources Initialize karmada resource
 func InitKarmadaResources(dir, caBase64 string, systemNamespace string) error {
 	restConfig, err := utils.RestConfig(filepath.Join(dir, options.KarmadaKubeConfigName))
@@ -42,7 +40,7 @@ func InitKarmadaResources(dir, caBase64 string, systemNamespace string) error {
 	// create namespace
 	if _, err := clientSet.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace,
+			Name: systemNamespace,
 		},
 	}, metav1.CreateOptions{}); err != nil {
 		klog.Exitln(err)
@@ -162,7 +160,7 @@ func getName(str, start, end string) string {
 	return str
 }
 
-func initAPIService(clientSet *kubernetes.Clientset, restConfig *rest.Config, externalNamespace string) error {
+func initAPIService(clientSet *kubernetes.Clientset, restConfig *rest.Config, systemNamespace string) error {
 	// https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/apiservice.yaml
 	aaService := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
@@ -171,14 +169,14 @@ func initAPIService(clientSet *kubernetes.Clientset, restConfig *rest.Config, ex
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "karmada-aggregated-apiserver",
-			Namespace: namespace,
+			Namespace: systemNamespace,
 		},
 		Spec: corev1.ServiceSpec{
 			Type:         corev1.ServiceTypeExternalName,
-			ExternalName: fmt.Sprintf("karmada-aggregated-apiserver.%s.svc", externalNamespace),
+			ExternalName: fmt.Sprintf("karmada-aggregated-apiserver.%s.svc", systemNamespace),
 		},
 	}
-	if _, err := clientSet.CoreV1().Services(namespace).Create(context.TODO(), aaService, metav1.CreateOptions{}); err != nil {
+	if _, err := clientSet.CoreV1().Services(systemNamespace).Create(context.TODO(), aaService, metav1.CreateOptions{}); err != nil {
 		return err
 	}
 	// new apiRegistrationClient
@@ -203,7 +201,7 @@ func initAPIService(clientSet *kubernetes.Clientset, restConfig *rest.Config, ex
 			GroupPriorityMinimum:  2000,
 			Service: &apiregistrationv1.ServiceReference{
 				Name:      "karmada-aggregated-apiserver",
-				Namespace: namespace,
+				Namespace: systemNamespace,
 			},
 			Version:         "v1alpha1",
 			VersionPriority: 10,

--- a/pkg/karmadactl/cmdinit/kubernetes/deployments.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deployments.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
-	"github.com/karmada-io/karmada/pkg/util"
 )
 
 const (
@@ -269,7 +268,7 @@ func (i *CommandInitOption) makeKarmadaKubeControllerManagerDeployment() *appsv1
 					"--controllers=namespace,garbagecollector,serviceaccount-token",
 					"--kubeconfig=/etc/kubeconfig",
 					"--leader-elect=true",
-					fmt.Sprintf("--leader-elect-resource-namespace=%s", util.NamespaceKarmadaSystem),
+					fmt.Sprintf("--leader-elect-resource-namespace=%s", i.Namespace),
 					"--node-cidr-mask-size=24",
 					"--port=0",
 					fmt.Sprintf("--root-ca-file=%s/%s.crt", karmadaCertsVolumeMountPath, options.CaCertAndKeyName),
@@ -390,7 +389,7 @@ func (i *CommandInitOption) makeKarmadaSchedulerDeployment() *appsv1.Deployment 
 					"--feature-gates=Failover=true",
 					"--enable-scheduler-estimator=true",
 					"--leader-elect=true",
-					fmt.Sprintf("--leader-elect-resource-namespace=%s", util.NamespaceKarmadaSystem),
+					fmt.Sprintf("--leader-elect-resource-namespace=%s", i.Namespace),
 					"--v=4",
 				},
 				VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
Cherry pick of #1449 on release-1.1.
#1449: replace hard coded namespace with custom namespace
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```release-note
```