### PR TITLE
Automated cherry pick of #1825: fix karmadactl taint failed

### DIFF
--- a/pkg/karmadactl/taint.go
+++ b/pkg/karmadactl/taint.go
@@ -120,6 +120,12 @@ func (o *CommandTaintOption) Complete(args []string) error {
 	}
 
 	kubeConfigFlags := genericclioptions.NewConfigFlags(false).WithDeprecatedPasswordFlag()
+
+	if o.KubeConfig != "" {
+		kubeConfigFlags.KubeConfig = &o.KubeConfig
+		kubeConfigFlags.Context = &o.KarmadaContext
+	}
+
 	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
 	f := cmdutil.NewFactory(matchVersionKubeConfigFlags)
 


### PR DESCRIPTION
Cherry pick of #1825 on release-1.0.
#1825: fix karmadactl taint failed
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```release-note
`karmadactl`: fixed karmadactl can not taint while karmada control plane config is not located on default path
```