### PR TITLE
[refactor] add release to Makefile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,35 +9,33 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        include:
-          - goarch: amd64
-            goos: linux
-          - goarch: amd64
-            goos: darwin
-          - goarch: arm64
-            goos: linux
-          - goarch: arm64
-            goos: darwin
+        target:
+          - karmadactl
+          - kubectl-karmada
+        os:
+          - linux
+          - darwin
+        arch:
+          - amd64
+          - arm64
     steps:
     - uses: actions/checkout@master
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
         go-version: 1.17.x
-    - name: Making kubectl-karmada
-      run: make kubectl-karmada
+    - name: Making and packaging
       env:
-        GOOS: ${{ matrix.goos }}
-        GOARCH: ${{ matrix.goarch }}
-    - name: Make release directory
-      run: mkdir -p _output/release
-    - name: Packaging...
-      run: tar czf _output/release/kubectl-karmada-${{ matrix.goos }}-${{ matrix.goarch }}.tgz LICENSE -C _output/bin/${{ matrix.goos }}/${{ matrix.goarch }} kubectl-karmada
+        GOOS: ${{ matrix.os }}
+        GOARCH: ${{ matrix.arch }}
+      run: make release-${{ matrix.target }}
     - name: Uploading assets...
       if: ${{ !env.ACT }}
       uses: softprops/action-gh-release@v1
       with:
-        files: _output/release/kubectl-karmada-${{ matrix.goos }}-${{ matrix.goarch }}.tgz
+        files: |
+          _output/release/${{ matrix.target }}-${{ matrix.os }}-${{ matrix.arch }}.tgz
+          _output/release/${{ matrix.target }}-${{ matrix.os }}-${{ matrix.arch }}.tgz.sha256
   update-krew-index:
     needs: release-assests
     name: Update krew-index

--- a/Makefile
+++ b/Makefile
@@ -124,3 +124,31 @@ endif
 	docker push ${REGISTRY}/karmada-interpreter-webhook-example:${VERSION}
 	docker push ${REGISTRY}/karmada-aggregated-apiserver:${VERSION}
 	docker push ${REGISTRY}/karmada-search:${VERSION}
+
+# Build and package binary
+#
+# Example
+#   make release-karmadactl
+#   make release-kubectl-karmada
+#   make release-kubectl-karmada GOOS=darwin GOARCH=amd64
+RELEASE_TARGET=$(addprefix release-, $(CTL_TARGETS))
+.PHONY: $(RELEASE_TARGET)
+$(RELEASE_TARGET):
+	@set -e;\
+	target=$$(echo $(subst release-,,$@));\
+	make $$target;\
+	hack/release.sh $$target $(GOOS) $(GOARCH)
+
+# Build and package binary for all platforms
+#
+# Example
+#   make release
+release:
+	@make release-karmadactl GOOS=linux GOARCH=amd64
+	@make release-karmadactl GOOS=linux GOARCH=arm64
+	@make release-karmadactl GOOS=darwin GOARCH=amd64
+	@make release-karmadactl GOOS=darwin GOARCH=arm64
+	@make release-kubectl-karmada GOOS=linux GOARCH=amd64
+	@make release-kubectl-karmada GOOS=linux GOARCH=arm64
+	@make release-kubectl-karmada GOOS=darwin GOARCH=amd64
+	@make release-kubectl-karmada GOOS=darwin GOARCH=arm64

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${REPO_ROOT}/hack/util.sh"
+
+binary=$1
+os=$2
+arch=$3
+
+release_dir="${REPO_ROOT}/_output/release"
+mkdir -p "${release_dir}"
+
+tar_file="${binary}-${os}-${arch}.tgz"
+echo "!!! Packaging ${tar_file}"
+tar czf "${release_dir}/${tar_file}" "${REPO_ROOT}/LICENSE" -C "${REPO_ROOT}/_output/bin/${os}/${arch}" "${binary}"
+
+cd "${release_dir}"
+sha256sum "${tar_file}" > "${tar_file}.sha256"


### PR DESCRIPTION
Signed-off-by: yingjinhui <yingjinhui@didiglobal.com>

**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
Implement for https://github.com/karmada-io/karmada/pull/1814#issuecomment-1131870145

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
After run `make release`, tars are created in `_output/release` with sha256 checksum.
```
$ ls _output/release/
karmadactl-darwin-amd64.tgz         karmadactl-linux-amd64.tgz         kubectl-karmada-darwin-amd64.tgz         kubectl-karmada-linux-amd64.tgz
karmadactl-darwin-amd64.tgz.sha256  karmadactl-linux-amd64.tgz.sha256  kubectl-karmada-darwin-amd64.tgz.sha256  kubectl-karmada-linux-amd64.tgz.sha256
karmadactl-darwin-arm64.tgz         karmadactl-linux-arm64.tgz         kubectl-karmada-darwin-arm64.tgz         kubectl-karmada-linux-arm64.tgz
karmadactl-darwin-arm64.tgz.sha256  karmadactl-linux-arm64.tgz.sha256  kubectl-karmada-darwin-arm64.tgz.sha256  kubectl-karmada-linux-arm64.tgz.sha256
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

