### PR TITLE
[E2E] log more err info when wait resource exist on member clusters

### DIFF
--- a/test/e2e/framework/deployment.go
+++ b/test/e2e/framework/deployment.go
@@ -65,10 +65,18 @@ func WaitDeploymentDisappearOnCluster(cluster, namespace, name string) {
 	clusterClient := GetClusterClient(cluster)
 	gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
 
-	klog.Infof("Waiting for deployment disappear on cluster(%s)", cluster)
+	klog.Infof("Waiting for deployment(%s/%s) disappear on cluster(%s)", namespace, name, cluster)
 	gomega.Eventually(func() bool {
 		_, err := clusterClient.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-		return apierrors.IsNotFound(err)
+		if err == nil {
+			return false
+		}
+		if apierrors.IsNotFound(err) {
+			return true
+		}
+
+		klog.Errorf("Failed to get deployment(%s/%s) on cluster(%s), err: %v", namespace, name, cluster, err)
+		return false
 	}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 }
 

--- a/test/e2e/framework/job.go
+++ b/test/e2e/framework/job.go
@@ -68,10 +68,18 @@ func WaitJobDisappearOnCluster(cluster, namespace, name string) {
 	clusterClient := GetClusterClient(cluster)
 	gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
 
-	klog.Infof("Waiting for job disappear on cluster(%s)", cluster)
+	klog.Infof("Waiting for job(%s/%s) disappear on cluster(%s)", namespace, name, cluster)
 	gomega.Eventually(func() bool {
 		_, err := clusterClient.BatchV1().Jobs(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-		return apierrors.IsNotFound(err)
+		if err == nil {
+			return false
+		}
+		if apierrors.IsNotFound(err) {
+			return true
+		}
+
+		klog.Errorf("Failed to get job(%s/%s) on cluster(%s), err: %v", namespace, name, cluster, err)
+		return false
 	}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 }
 

--- a/test/e2e/framework/namespace.go
+++ b/test/e2e/framework/namespace.go
@@ -66,10 +66,18 @@ func WaitNamespaceDisappearOnCluster(cluster, name string) {
 	clusterClient := GetClusterClient(cluster)
 	gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
 
-	klog.Infof("Waiting for namespace disappear on cluster(%s)", cluster)
+	klog.Infof("Waiting for namespace(%s) disappear on cluster(%s)", name, cluster)
 	gomega.Eventually(func() bool {
 		_, err := clusterClient.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
-		return apierrors.IsNotFound(err)
+		if err == nil {
+			return false
+		}
+		if apierrors.IsNotFound(err) {
+			return true
+		}
+
+		klog.Errorf("Failed to get namespace(%s) on cluster(%s), err: %v", name, cluster, err)
+		return false
 	}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 }
 

--- a/test/e2e/framework/pod.go
+++ b/test/e2e/framework/pod.go
@@ -60,10 +60,18 @@ func WaitPodDisappearOnCluster(cluster, namespace, name string) {
 	clusterClient := GetClusterClient(cluster)
 	gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
 
-	klog.Infof("Waiting for pod disappear on cluster(%s)", cluster)
+	klog.Infof("Waiting for pod(%s/%s) disappear on cluster(%s)", namespace, name, cluster)
 	gomega.Eventually(func() bool {
 		_, err := clusterClient.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-		return apierrors.IsNotFound(err)
+		if err == nil {
+			return false
+		}
+		if apierrors.IsNotFound(err) {
+			return true
+		}
+
+		klog.Errorf("Failed to get pod(%s/%s) on cluster(%s), err: %v", namespace, name, cluster, err)
+		return false
 	}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 }
 

--- a/test/e2e/framework/resourcequota.go
+++ b/test/e2e/framework/resourcequota.go
@@ -50,6 +50,14 @@ func WaitResourceQuotaDisappearOnCluster(cluster, namespace, name string) {
 	klog.Infof("Waiting for resourceQuota(%s/%s) disappear on cluster(%s)", namespace, name, cluster)
 	gomega.Eventually(func() bool {
 		_, err := clusterClient.CoreV1().ResourceQuotas(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-		return apierrors.IsNotFound(err)
+		if err == nil {
+			return false
+		}
+		if apierrors.IsNotFound(err) {
+			return true
+		}
+
+		klog.Errorf("Failed to get resourceQuota(%s/%s) on cluster(%s), err: %v", namespace, name, cluster, err)
+		return false
 	}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 }

--- a/test/e2e/framework/service.go
+++ b/test/e2e/framework/service.go
@@ -60,10 +60,18 @@ func WaitServiceDisappearOnCluster(cluster, namespace, name string) {
 	clusterClient := GetClusterClient(cluster)
 	gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
 
-	klog.Infof("Waiting for service disappear on cluster(%s)", cluster)
+	klog.Infof("Waiting for service(%s/%s) disappear on cluster(%s)", namespace, name, cluster)
 	gomega.Eventually(func() bool {
 		_, err := clusterClient.CoreV1().Services(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-		return apierrors.IsNotFound(err)
+		if err == nil {
+			return false
+		}
+		if apierrors.IsNotFound(err) {
+			return true
+		}
+
+		klog.Errorf("Failed to get service(%s/%s) on cluster(%s), err: %v", namespace, name, cluster, err)
+		return false
 	}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 }
 

--- a/test/e2e/resource_test.go
+++ b/test/e2e/resource_test.go
@@ -119,7 +119,7 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 
 		ginkgo.BeforeEach(func() {
 			policyNamespace = testNamespace
-			policyName = deploymentNamePrefix + rand.String(RandomStrLength)
+			policyName = serviceNamePrefix + rand.String(RandomStrLength)
 			serviceNamespace = testNamespace
 			serviceName = policyName
 


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind flake
/kind cleanup

**What this PR does / why we need it**:

Add more detailed error info to help us determine whether the abnormal running of the `clusterClient` when wait resource exist on the member clusters.

**Which issue(s) this PR fixes**:
Part of #1841 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

