### PR TITLE
remove the source for logo

### DIFF
--- a/hack/remote-up-karmada.sh
+++ b/hack/remote-up-karmada.sh
@@ -4,6 +4,20 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+#https://textkool.com/en/ascii-art-generator?hl=default&vl=default&font=DOS%20Rebel&text=KARMADA
+KARMADA_GREETING='
+------------------------------------------------------------------------------------------------------
+ █████   ████   █████████   ███████████   ██████   ██████   █████████   ██████████     █████████
+░░███   ███░   ███░░░░░███ ░░███░░░░░███ ░░██████ ██████   ███░░░░░███ ░░███░░░░███   ███░░░░░███
+ ░███  ███    ░███    ░███  ░███    ░███  ░███░█████░███  ░███    ░███  ░███   ░░███ ░███    ░███
+ ░███████     ░███████████  ░██████████   ░███░░███ ░███  ░███████████  ░███    ░███ ░███████████
+ ░███░░███    ░███░░░░░███  ░███░░░░░███  ░███ ░░░  ░███  ░███░░░░░███  ░███    ░███ ░███░░░░░███
+ ░███ ░░███   ░███    ░███  ░███    ░███  ░███      ░███  ░███    ░███  ░███    ███  ░███    ░███
+ █████ ░░████ █████   █████ █████   █████ █████     █████ █████   █████ ██████████   █████   █████
+░░░░░   ░░░░ ░░░░░   ░░░░░ ░░░░░   ░░░░░ ░░░░░     ░░░░░ ░░░░░   ░░░░░ ░░░░░░░░░░   ░░░░░   ░░░░░
+------------------------------------------------------------------------------------------------------
+'
+
 function usage() {
   echo "This script will deploy karmada control plane to a given cluster."
   echo "Usage: hack/remote-up-karmada.sh <KUBECONFIG> <CONTEXT_NAME> [LOAD_BALANCER]"
@@ -45,7 +59,6 @@ fi
 
 # deploy karmada control plane
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-source "${SCRIPT_ROOT}"/hack/util.sh
 "${SCRIPT_ROOT}"/hack/deploy-karmada.sh "${HOST_CLUSTER_KUBECONFIG}" "${HOST_CLUSTER_NAME}" "remote"
 kubectl config use-context karmada-apiserver --kubeconfig="${HOST_CLUSTER_KUBECONFIG}"
 


### PR DESCRIPTION
/kind bug

When I try to install a Karmada using this script, I get the following error：
```
# ./hack/remote-up-karmada.sh ~/.kube/config local
go install github.com/cloudflare/cfssl/cmd/...@v1.5.0
./hack/../hack/../hack/util.sh:行71: go: 未找到命令
```
Golang needs to be installed, but I found that this script does not need to be compiled by golang, and the reason why this util.sh script is sourced is only because a karmada logo is required. I think it's a bit unreasonable for users to have to install a golang on the client just because of a logo.

About the commit: https://github.com/karmada-io/karmada/commit/003717a0c6b9df6bc1b662c0ac03868bb9fb5e18

