### PR TITLE
when type wrong etcd-storage-mode throw error

### DIFF
--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -2,6 +2,7 @@ package cmdinit
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
@@ -57,7 +58,7 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 	flags.StringVar(&opts.Context, "context", "", "The name of the kubeconfig context to use")
 	// etcd
 	flags.StringVarP(&opts.EtcdStorageMode, "etcd-storage-mode", "", "emptyDir",
-		"etcd data storage mode(emptyDir,hostPath,PVC). value is PVC, specify --storage-classes-name")
+		fmt.Sprintf("etcd data storage mode(%s). value is PVC, specify --storage-classes-name", strings.Join(kubernetes.SupportedStorageMode(), ",")))
 	flags.StringVarP(&opts.EtcdImage, "etcd-image", "", "", "etcd image")
 	flags.StringVarP(&opts.EtcdInitImage, "etcd-init-image", "", "docker.io/alpine:3.15.1", "etcd init container image")
 	flags.Int32VarP(&opts.EtcdReplicas, "etcd-replicas", "", 1, "etcd replica set, cluster 3,5...singular")

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -47,6 +47,12 @@ var (
 	defaultKubeControllerManagerImage = "kube-controller-manager:v1.21.7"
 )
 
+const (
+	etcdStorageModePVC      = "PVC"
+	etcdStorageModeEmptyDir = "emptyDir"
+	etcdStorageModeHostPath = "hostPath"
+)
+
 // CommandInitOption holds all flags options for init.
 type CommandInitOption struct {
 	KubeImageRegistry                  string
@@ -87,22 +93,31 @@ type CommandInitOption struct {
 
 // Validate Check that there are enough flags to run the command.
 func (i *CommandInitOption) Validate(parentCommand string) error {
-	if i.EtcdStorageMode == "hostPath" && i.EtcdHostDataPath == "" {
+	if i.EtcdStorageMode == etcdStorageModeHostPath && i.EtcdHostDataPath == "" {
 		return fmt.Errorf("when etcd storage mode is hostPath, dataPath is not empty. See '%s init --help'", parentCommand)
 	}
 
-	if i.EtcdStorageMode == "hostPath" && i.EtcdNodeSelectorLabels != "" && utils.StringToMap(i.EtcdNodeSelectorLabels) == nil {
+	if i.EtcdStorageMode == etcdStorageModeHostPath && i.EtcdNodeSelectorLabels != "" && utils.StringToMap(i.EtcdNodeSelectorLabels) == nil {
 		return fmt.Errorf("the label does not seem to be 'key=value'")
 	}
 
-	if i.EtcdStorageMode == "hostPath" && i.EtcdReplicas != 1 {
+	if i.EtcdStorageMode == etcdStorageModeHostPath && i.EtcdReplicas != 1 {
 		return fmt.Errorf("for data security,when etcd storage mode is hostPath,etcd-replicas can only be 1")
 	}
 
-	if i.EtcdStorageMode == "PVC" && i.StorageClassesName == "" {
+	if i.EtcdStorageMode == etcdStorageModePVC && i.StorageClassesName == "" {
 		return fmt.Errorf("when etcd storage mode is PVC, storageClassesName is not empty. See '%s init --help'", parentCommand)
 	}
 
+	supportedStorageMode := SupportedStorageMode()
+	if i.EtcdStorageMode != "" {
+		for _, mode := range supportedStorageMode {
+			if i.EtcdStorageMode == mode {
+				return nil
+			}
+		}
+		return fmt.Errorf("unsupported etcd-storage-mode %s. See '%s init --help'", i.EtcdStorageMode, parentCommand)
+	}
 	return nil
 }
 
@@ -508,4 +523,9 @@ func homeDir() string {
 		return h
 	}
 	return os.Getenv("USERPROFILE") // windows
+}
+
+// SupportedStorageMode Return install etcd supported storage mode
+func SupportedStorageMode() []string {
+	return []string{etcdStorageModeEmptyDir, etcdStorageModeHostPath, etcdStorageModePVC}
 }

--- a/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
@@ -58,7 +58,7 @@ func (i CommandInitOption) etcdVolume() (*[]corev1.Volume, *corev1.PersistentVol
 	Volumes = append(Volumes, secretVolume, configVolume)
 
 	switch i.EtcdStorageMode {
-	case "PVC":
+	case etcdStorageModePVC:
 		mode := corev1.PersistentVolumeFilesystem
 		persistentVolumeClaim := corev1.PersistentVolumeClaim{
 			TypeMeta: metav1.TypeMeta{
@@ -83,7 +83,7 @@ func (i CommandInitOption) etcdVolume() (*[]corev1.Volume, *corev1.PersistentVol
 		}
 		return &Volumes, &persistentVolumeClaim
 
-	case "hostPath":
+	case etcdStorageModeHostPath:
 		t := corev1.HostPathDirectoryOrCreate
 		hostPath := corev1.Volume{
 			Name: etcdContainerDataVolumeMountName,


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
when input wrong `etcd-storage-mode`  like `kubectl karmada init --etcd-storage-mode pvc`  karmada will fallback to `emptyDir`. This does not meet user expectation. May be throw a error to user is better.
```
#  kubectl karmada init --etcd-storage-mode pvc --storage-classes-name test
Error: unsupported etcd-storage-mode pvc. See 'kubectl karmada init --help'
```
when input wrong `etcd-storage-mode`, `statefulset.go` will fallback to `emptyDir` in default branch
```
	switch i.EtcdStorageMode {
	case "PVC":
		mode := corev1.PersistentVolumeFilesystem
		persistentVolumeClaim := corev1.PersistentVolumeClaim{
			TypeMeta: metav1.TypeMeta{
				APIVersion: "v1",
				Kind:       "PersistentVolumeClaim",
			},
			ObjectMeta: metav1.ObjectMeta{
				Namespace: i.Namespace,
				Name:      etcdContainerDataVolumeMountName,
				Labels:    map[string]string{"karmada.io/bootstrapping": "pvc-defaults"},
			},
			Spec: corev1.PersistentVolumeClaimSpec{
				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
				StorageClassName: &i.StorageClassesName,
				VolumeMode:       &mode,
				Resources: corev1.ResourceRequirements{
					Requests: corev1.ResourceList{
						corev1.ResourceStorage: resource.MustParse(i.EtcdPersistentVolumeSize),
					},
				},
			},
		}
		return &Volumes, &persistentVolumeClaim

	case "hostPath":
		t := corev1.HostPathDirectoryOrCreate
		hostPath := corev1.Volume{
			Name: etcdContainerDataVolumeMountName,
			VolumeSource: corev1.VolumeSource{
				HostPath: &corev1.HostPathVolumeSource{
					Path: i.EtcdHostDataPath,
					Type: &t,
				},
			},
		}
		Volumes = append(Volumes, hostPath)
		return &Volumes, nil

	default:
		emptyDir := corev1.Volume{
			Name: etcdContainerDataVolumeMountName,
			VolumeSource: corev1.VolumeSource{
				EmptyDir: &corev1.EmptyDirVolumeSource{},
			},
		}
		Volumes = append(Volumes, emptyDir)
		return &Volumes, nil
	}
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

