### PR TITLE
karmada agent can't find context of karmada-apiserver.config

### DIFF
--- a/pkg/karmadactl/cmdinit/utils/examples.go
+++ b/pkg/karmadactl/cmdinit/utils/examples.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"k8s.io/klog/v2"
+
+	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
 )
 
 const (
@@ -71,7 +73,7 @@ spec:
           command:
             - /bin/karmada-agent
             - --karmada-kubeconfig=/etc/kubeconfig/karmada-kubeconfig
-            - --karmada-context=karmada
+            - --karmada-context=%s
             - --cluster-name={member_cluster_name}
             - --cluster-status-update-frequency=10s
             - --v=4
@@ -138,7 +140,8 @@ spec:
 
 //GenExamples Generate sample files
 func GenExamples(path, parentCommand string) {
-	if err := BytesToFile(path, "karmada-agent.yaml", []byte(karmadaAgent)); err != nil {
+	karmadaAgentStr := fmt.Sprintf(karmadaAgent, options.ClusterName)
+	if err := BytesToFile(path, "karmada-agent.yaml", []byte(karmadaAgentStr)); err != nil {
 		klog.Warning(err)
 	}
 


### PR DESCRIPTION
Signed-off-by: bruce <zhangyongxi_yewu@cmss.chinamobile.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
when I Register cluster with 'Pull' mode，I find that an Error that "error building kubeconfig of karmada control plane: context "karmada" does not exist" in the log of karmada-agent pod, and the karmada-agent pod is CrashLoopBackOff. The reason is that the arg "karmada-context" of karmada-agent is hardcoded as a wrong value "karmada".
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

