### PR TITLE
support to promote dependency resources automatically by using '-d=true'

### DIFF
--- a/pkg/resourceinterpreter/defaultinterpreter/default.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/default.go
@@ -123,3 +123,8 @@ func (e *DefaultInterpreter) ReflectStatus(object *unstructured.Unstructured) (s
 	// for resource types that don't have a build-in handler, try to collect the whole status from '.status' filed.
 	return reflectWholeStatus(object)
 }
+
+// GetDependenciesHandlers returns the dependenciesHandlers of the defaultInterpreter.
+func (e *DefaultInterpreter) GetDependenciesHandlers() map[schema.GroupVersionKind]dependenciesInterpreter {
+	return e.dependenciesHandlers
+}

--- a/test/e2e/karmadactl_test.go
+++ b/test/e2e/karmadactl_test.go
@@ -69,7 +69,7 @@ var _ = ginkgo.Describe("Karmadactl promote testing", func() {
 				}
 				args := []string{"namespace", deploymentNamespace}
 				// init args: place namespace name to CommandPromoteOption.name
-				err := opts.Complete(args)
+				err := opts.Complete(karmadaConfig, args)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 				// use karmadactl to promote a namespace from member1
@@ -88,7 +88,7 @@ var _ = ginkgo.Describe("Karmadactl promote testing", func() {
 				}
 				args := []string{"deployment", deploymentName}
 				// init args: place deployment name to CommandPromoteOption.name
-				err := opts.Complete(args)
+				err := opts.Complete(karmadaConfig, args)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 				// use karmadactl to promote a deployment from member1
@@ -165,7 +165,7 @@ var _ = ginkgo.Describe("Karmadactl promote testing", func() {
 
 				args := []string{"clusterrole", clusterRoleName}
 				// init args: place clusterrole name to CommandPromoteOption.name
-				err := opts.Complete(args)
+				err := opts.Complete(karmadaConfig, args)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 				// use karmadactl to promote clusterrole from member1
@@ -174,7 +174,7 @@ var _ = ginkgo.Describe("Karmadactl promote testing", func() {
 
 				args = []string{"clusterrolebinding", clusterRoleBindingName}
 				// init args: place clusterrolebinding name to CommandPromoteOption.name
-				err = opts.Complete(args)
+				err = opts.Complete(karmadaConfig, args)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 				// use karmadactl to promote clusterrolebinding from member1


### PR DESCRIPTION
Signed-off-by: duanmeng <duanmeng_yewu@cmss.chinamobile.com>

**What type of PR is this?**
support to promote dependency resources automatically by using '-d=true'
<!--
Add one of the following kinds:

/kind feature

-->

**What this PR does / why we need it**:

If users use promote resource from member cluster to control plane,he may need promote relevant resources  automatically.

**Which issue(s) this PR fixes**:
Fixes #1862

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Support to use '--deps=true' or '-d true' to promote the relevant resources automatically`
example:
  kubectl karmada  promote deployments test -d=true  -c member1
```

