### PR TITLE
do proxy setting in China mainland when installing Karmada from source

### DIFF
--- a/hack/local-up-karmada.sh
+++ b/hack/local-up-karmada.sh
@@ -28,26 +28,8 @@ KIND_LOG_FILE=${KIND_LOG_FILE:-"/tmp/karmada"}
 
 #step0: prepare
 # proxy setting in China mainland
-
 if [[ -n ${CHINA_MAINLAND:-} ]]; then
-export GOPROXY=https://goproxy.cn,direct # set domestic go proxy
-# set mirror registry of k8s.gcr.io
-registry_files=( # Yaml files that contain image host 'k8s.gcr.io' need to be replaced
-  "artifacts/deploy/karmada-etcd.yaml"
-  "artifacts/deploy/karmada-apiserver.yaml"
-  "artifacts/deploy/kube-controller-manager.yaml"
-)
-for registry_file in "${registry_files[@]}"; do
-  sed -i'' -e "s#k8s.gcr.io#registry.aliyuncs.com/google_containers#g" ${REPO_ROOT}/${registry_file}
-done
-# set mirror registry in the dockerfile of components of karmada
-dockerfile_list=( # Dockerfile files need to be replaced
-  "cluster/images/Dockerfile"
-  "cluster/images/buildx.Dockerfile"
-)
-for dockerfile in "${dockerfile_list[@]}"; do
-  grep 'mirrors.ustc.edu.cn' ${REPO_ROOT}/${dockerfile} > /dev/null || sed -i'' -e "s#FROM alpine:3.15.1#FROM alpine:3.15.1\nRUN echo -e http://mirrors.ustc.edu.cn/alpine/v3.15/main/ > /etc/apk/repositories#" ${REPO_ROOT}/${dockerfile}
-done
+  util::set_mirror_registry_for_china_mainland ${REPO_ROOT}
 fi
 
 # Make sure go exists and the go version is a viable version.

--- a/hack/remote-up-karmada.sh
+++ b/hack/remote-up-karmada.sh
@@ -46,6 +46,12 @@ fi
 # deploy karmada control plane
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${SCRIPT_ROOT}"/hack/util.sh
+
+# proxy setting in China mainland
+if [[ -n ${CHINA_MAINLAND:-} ]]; then
+  util::set_mirror_registry_for_china_mainland ${SCRIPT_ROOT}
+fi
+
 "${SCRIPT_ROOT}"/hack/deploy-karmada.sh "${HOST_CLUSTER_KUBECONFIG}" "${HOST_CLUSTER_NAME}" "remote"
 kubectl config use-context karmada-apiserver --kubeconfig="${HOST_CLUSTER_KUBECONFIG}"
 

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -626,3 +626,30 @@ function util:create_gopath_tree() {
 function util:host_platform() {
   echo "$(go env GOHOSTOS)/$(go env GOHOSTARCH)"
 }
+
+# util::set_mirror_registry_for_china_mainland will do proxy setting in China mainland
+# Parameters:
+#  - $1: the root path of repo
+function util::set_mirror_registry_for_china_mainland() {
+  local repo_root=${1}
+  export GOPROXY=https://goproxy.cn,direct # set domestic go proxy
+  # set mirror registry of k8s.gcr.io
+  registry_files=( # Yaml files that contain image host 'k8s.gcr.io' need to be replaced
+    "artifacts/deploy/karmada-etcd.yaml"
+    "artifacts/deploy/karmada-apiserver.yaml"
+    "artifacts/deploy/kube-controller-manager.yaml"
+  )
+  for registry_file in "${registry_files[@]}"; do
+    sed -i'' -e "s#k8s.gcr.io#registry.aliyuncs.com/google_containers#g" ${repo_root}/${registry_file}
+  done
+
+  # set mirror registry in the dockerfile of components of karmada
+  dockerfile_list=( # Dockerfile files need to be replaced
+    "cluster/images/Dockerfile"
+    "cluster/images/buildx.Dockerfile"
+  )
+  for dockerfile in "${dockerfile_list[@]}"; do
+    grep 'mirrors.ustc.edu.cn' ${repo_root}/${dockerfile} > /dev/null || sed -i'' -e "s#FROM alpine:3.15.1#FROM alpine:3.15.1\nRUN echo -e http://mirrors.ustc.edu.cn/alpine/v3.15/main/ > /etc/apk/repositories#" ${repo_root}/${dockerfile}
+  done
+}
+


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
when installing Karmada from source, sometimes, it's needed to do proxy setting in China mainland.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`remote-up-karmada.sh`: Support doing proxy setting in China mainland when installing Karmada from source.
```