### PR TITLE
add ProxyHeader API

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13126,6 +13126,14 @@
           "description": "Provider represents the cloud provider name of the member cluster.",
           "type": "string"
         },
+        "proxyHeader": {
+          "description": "ProxyHeader is the HTTP header required by proxy server. The key in the key-value pair is HTTP header key and value is the associated header payloads. For the header with multiple values, the values should be separated by comma(e.g. 'k1': 'v1,v2,v3').",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "default": ""
+          }
+        },
         "proxyURL": {
           "description": "ProxyURL is the proxy URL for the cluster. If not empty, the karmada control plane will use this proxy to talk to the cluster. More details please refer to: https://github.com/kubernetes/client-go/issues/351",
           "type": "string"

--- a/pkg/apis/cluster/types.go
+++ b/pkg/apis/cluster/types.go
@@ -61,6 +61,12 @@ type ClusterSpec struct {
 	// +optional
 	ProxyURL string
 
+	// ProxyHeader is the HTTP header required by proxy server.
+	// The key in the key-value pair is HTTP header key and value is the associated header payloads.
+	// For the header with multiple values, the values should be separated by comma(e.g. 'k1': 'v1,v2,v3').
+	// +optional
+	ProxyHeader map[string]string
+
 	// Provider represents the cloud provider name of the member cluster.
 	// +optional
 	Provider string

--- a/pkg/apis/cluster/v1alpha1/types.go
+++ b/pkg/apis/cluster/v1alpha1/types.go
@@ -73,6 +73,12 @@ type ClusterSpec struct {
 	// +optional
 	ProxyURL string `json:"proxyURL,omitempty"`
 
+	// ProxyHeader is the HTTP header required by proxy server.
+	// The key in the key-value pair is HTTP header key and value is the associated header payloads.
+	// For the header with multiple values, the values should be separated by comma(e.g. 'k1': 'v1,v2,v3').
+	// +optional
+	ProxyHeader map[string]string `json:"proxyHeader,omitempty"`
+
 	// Provider represents the cloud provider name of the member cluster.
 	// +optional
 	Provider string `json:"provider,omitempty"`

--- a/pkg/apis/cluster/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/cluster/v1alpha1/zz_generated.conversion.go
@@ -274,6 +274,7 @@ func autoConvert_v1alpha1_ClusterSpec_To_cluster_ClusterSpec(in *ClusterSpec, ou
 	out.ImpersonatorSecretRef = (*cluster.LocalSecretReference)(unsafe.Pointer(in.ImpersonatorSecretRef))
 	out.InsecureSkipTLSVerification = in.InsecureSkipTLSVerification
 	out.ProxyURL = in.ProxyURL
+	out.ProxyHeader = *(*map[string]string)(unsafe.Pointer(&in.ProxyHeader))
 	out.Provider = in.Provider
 	out.Region = in.Region
 	out.Zone = in.Zone
@@ -293,6 +294,7 @@ func autoConvert_cluster_ClusterSpec_To_v1alpha1_ClusterSpec(in *cluster.Cluster
 	out.ImpersonatorSecretRef = (*LocalSecretReference)(unsafe.Pointer(in.ImpersonatorSecretRef))
 	out.InsecureSkipTLSVerification = in.InsecureSkipTLSVerification
 	out.ProxyURL = in.ProxyURL
+	out.ProxyHeader = *(*map[string]string)(unsafe.Pointer(&in.ProxyHeader))
 	out.Provider = in.Provider
 	out.Region = in.Region
 	out.Zone = in.Zone

--- a/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
@@ -147,6 +147,13 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(LocalSecretReference)
 		**out = **in
 	}
+	if in.ProxyHeader != nil {
+		in, out := &in.ProxyHeader, &out.ProxyHeader
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Taints != nil {
 		in, out := &in.Taints, &out.Taints
 		*out = make([]v1.Taint, len(*in))

--- a/pkg/apis/cluster/zz_generated.deepcopy.go
+++ b/pkg/apis/cluster/zz_generated.deepcopy.go
@@ -147,6 +147,13 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(LocalSecretReference)
 		**out = **in
 	}
+	if in.ProxyHeader != nil {
+		in, out := &in.ProxyHeader, &out.ProxyHeader
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Taints != nil {
 		in, out := &in.Taints, &out.Taints
 		*out = make([]v1.Taint, len(*in))

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -682,6 +682,22 @@ func schema_pkg_apis_cluster_v1alpha1_ClusterSpec(ref common.ReferenceCallback) 
 							Format:      "",
 						},
 					},
+					"proxyHeader": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ProxyHeader is the HTTP header required by proxy server. The key in the key-value pair is HTTP header key and value is the associated header payloads. For the header with multiple values, the values should be separated by comma(e.g. 'k1': 'v1,v2,v3').",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 					"provider": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Provider represents the cloud provider name of the member cluster.",


### PR DESCRIPTION
Signed-off-by: lihanbo <lihanbo2@huawei.com>

**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
As described in https://github.com/karmada-io/karmada/issues/257, some member clusters are behind a proxy. And some proxies will request clients to provide necessary headers during a CONNECT request, like authorization information.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
```release-note
`Cluster API`: Added `ProxyHeader` optional field to specify the HTTP header required by the proxy server.
```

