### PR TITLE
Support karmada-search component search interface

### DIFF
--- a/pkg/registry/search/storage/cache.go
+++ b/pkg/registry/search/storage/cache.go
@@ -1,0 +1,107 @@
+package storage
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	genericrequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/klog/v2"
+)
+
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+type reqResponse struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+
+	Items []runtime.Object `json:"items"`
+}
+
+func (r *SearchREST) newCacheHandler(info *genericrequest.RequestInfo, responder rest.Responder) (http.Handler, error) {
+	resourceGVR := schema.GroupVersionResource{
+		Group:    info.APIGroup,
+		Version:  info.APIVersion,
+		Resource: info.Resource,
+	}
+
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		enc := json.NewEncoder(rw)
+
+		clusters, err := r.clusterLister.List(labels.Everything())
+		if err != nil {
+			rw.WriteHeader(http.StatusInternalServerError)
+			_ = enc.Encode(errorResponse{Error: fmt.Sprintf("Failed to list clusters: %v", err)})
+			return
+		}
+
+		items := make([]runtime.Object, 0)
+		for _, cluster := range clusters {
+			singleClusterManger := r.multiClusterInformerManager.GetSingleClusterManager(cluster.Name)
+			if singleClusterManger == nil {
+				klog.Warningf("SingleClusterInformerManager for cluster(%s) is nil.", cluster.Name)
+				continue
+			}
+
+			switch {
+			case len(info.Namespace) > 0 && len(info.Name) > 0:
+				resourceObject, err := singleClusterManger.Lister(resourceGVR).ByNamespace(info.Namespace).Get(info.Name)
+				if err != nil {
+					klog.Errorf("Failed to get %s resource(%s/%s) from cluster(%s)'s informer cache.",
+						resourceGVR, info.Namespace, info.Name, cluster.Name)
+				}
+				items = append(items, addAnnotationWithClusterName([]runtime.Object{resourceObject}, cluster.Name)...)
+			case len(info.Namespace) > 0:
+				resourceObjects, err := singleClusterManger.Lister(resourceGVR).ByNamespace(info.Namespace).List(labels.Everything())
+				if err != nil {
+					klog.Errorf("Failed to list %s resource under namespace(%s) from cluster(%s)'s informer cache.",
+						resourceGVR, info.Namespace, cluster.Name)
+				}
+				items = append(items, addAnnotationWithClusterName(resourceObjects, cluster.Name)...)
+			case len(info.Name) > 0:
+				resourceObject, err := singleClusterManger.Lister(resourceGVR).Get(info.Name)
+				if err != nil {
+					klog.Errorf("Failed to get %s resource(%s) from cluster(%s)'s informer cache.",
+						resourceGVR, info.Name, cluster.Name)
+				}
+				items = append(items, addAnnotationWithClusterName([]runtime.Object{resourceObject}, cluster.Name)...)
+			default:
+				resourceObjects, err := singleClusterManger.Lister(resourceGVR).List(labels.Everything())
+				if err != nil {
+					klog.Errorf("Failed to list %s resource from cluster(%s)'s informer cache.",
+						resourceGVR, cluster.Name)
+				}
+				items = append(items, addAnnotationWithClusterName(resourceObjects, cluster.Name)...)
+			}
+		}
+
+		rr := reqResponse{}
+		rr.APIVersion = fmt.Sprintf("%s/%s", info.APIGroup, info.APIVersion)
+		rr.Kind = "List"
+		rr.Items = items
+		_ = enc.Encode(rr)
+	}), nil
+}
+
+func addAnnotationWithClusterName(resourceObjects []runtime.Object, clusterName string) []runtime.Object {
+	resources := make([]runtime.Object, 0)
+	for index := range resourceObjects {
+		resource := resourceObjects[index].(*unstructured.Unstructured)
+
+		annotations := resource.GetAnnotations()
+		annotations["cluster.karmada.io/name"] = clusterName
+
+		resource.SetAnnotations(annotations)
+		resources = append(resources, resource)
+	}
+
+	return resources
+}

--- a/pkg/registry/search/storage/opensearch.go
+++ b/pkg/registry/search/storage/opensearch.go
@@ -1,0 +1,14 @@
+package storage
+
+import (
+	"net/http"
+
+	genericrequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+)
+
+func (r *SearchREST) newOpenSearchHandler(info *genericrequest.RequestInfo, responder rest.Responder) (http.Handler, error) {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Construct a handler and send the request to the ES.
+	}), nil
+}

--- a/pkg/registry/search/storage/requestinfo.go
+++ b/pkg/registry/search/storage/requestinfo.go
@@ -1,0 +1,76 @@
+package storage
+
+import (
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	genericrequest "k8s.io/apiserver/pkg/endpoints/request"
+)
+
+var (
+	apiPrefixes          = sets.NewString("api", "apis")
+	groupLessAPIPrefixes = sets.NewString("api")
+)
+
+func parseK8sNativeResourceInfo(reqParts []string) (*genericrequest.RequestInfo, error) {
+	requestInfo := &genericrequest.RequestInfo{
+		IsResourceRequest: false,
+		Path:              strings.Join(reqParts, "/"),
+	}
+
+	if len(reqParts) < 3 {
+		// return a non-resource request
+		return requestInfo, nil
+	}
+
+	if !apiPrefixes.Has(reqParts[0]) {
+		// return a non-resource request
+		return requestInfo, nil
+	}
+
+	requestInfo.APIPrefix = reqParts[0]
+	currentParts := reqParts[1:]
+
+	if !groupLessAPIPrefixes.Has(requestInfo.APIPrefix) {
+		if len(currentParts) < 3 {
+			// return a non-resource request
+			return requestInfo, nil
+		}
+
+		requestInfo.APIGroup = currentParts[0]
+		currentParts = currentParts[1:]
+	}
+
+	requestInfo.IsResourceRequest = true
+	requestInfo.APIVersion = currentParts[0]
+	currentParts = currentParts[1:]
+
+	// URL forms: /namespaces/{namespace}/{kind}/*, where parts are adjusted to be relative to kind
+	if currentParts[0] == "namespaces" {
+		if len(currentParts) > 1 {
+			requestInfo.Namespace = currentParts[1]
+			if len(currentParts) > 2 {
+				currentParts = currentParts[2:]
+			}
+		}
+	} else {
+		requestInfo.Namespace = metav1.NamespaceNone
+	}
+
+	switch {
+	case len(currentParts) >= 3:
+		return nil, fmt.Errorf("invalid request parts(%s) for k8s native request URL", currentParts)
+	case len(currentParts) >= 2:
+		requestInfo.Name = currentParts[1]
+		fallthrough
+	case len(currentParts) >= 1:
+		requestInfo.Resource = currentParts[0]
+	}
+
+	if requestInfo.Resource == "namespace" {
+		requestInfo.Namespace = ""
+	}
+	return requestInfo, nil
+}


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Support `karmada-search` component search interface.

**Which issue(s) this PR fixes**:
Part of #1794

**Special notes for your reviewer**:

The k/v `cluster.karmada.io/name` is added to the response resource's annotation to indicate that which cluster it comes from.
What are the suggestions for naming this keyword?

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Support karmada-search component search interface.
```

**How to use it**:

- Create a `ResourceRegistry` cr:
```yaml
apiVersion: search.karmada.io/v1alpha1
kind: ResourceRegistry
metadata:
  name: test
spec:
  targetCluster:
    clusterNames:
      - member1
  resourceSelectors:
    - apiVersion: apps/v1
      kind: Deployment
```
- search with cmd: `kubectl get --raw /apis/search.karmada.io/v1alpha1/search/cache/apis/apps/v1/deployments`
```json
{
	"apiVersion": "v1",
	"kind": "List",
	"metadata": {},
	"items": [{
		"apiVersion": "apps/v1",
		"kind": "Deployment",
		"metadata": {
			"annotations": {
				"cluster.karmada.io/name": "member1",
			},
		}
	},
	]
}
```

/cc @RainbowMango @GitHubxsy 
