### PR TITLE
a bad log was found when doing promote

### DIFF
--- a/pkg/karmadactl/promote.go
+++ b/pkg/karmadactl/promote.go
@@ -417,7 +417,7 @@ func createOrUpdatePropagationPolicy(karmadaClient *karmadaclientset.Clientset, 
 	}
 
 	// PropagationPolicy already exists, not to create it
-	return fmt.Errorf("the PropagationPolicy(%s/%s) in control plane: %v", opts.Namespace, name, err)
+	return fmt.Errorf("the PropagationPolicy(%s/%s) already exist, please edit it to propagate resource", opts.Namespace, name)
 }
 
 // createOrUpdateClusterPropagationPolicy create ClusterPropagationPolicy in karmada control plane


### PR DESCRIPTION
Signed-off-by: bruce <zhangyongxi_yewu@cmss.chinamobile.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
when doing promote with propagationPolicy already exists, a bad error report was found.
![promote-log](https://user-images.githubusercontent.com/21099093/170486300-c0e37cbc-9007-485c-9ad4-90c8c019ad2a.png)

this is code:
![promote333](https://user-images.githubusercontent.com/21099093/170486805-033cdae5-aef1-4be6-9de5-5a6ea6a93019.png)
the last err is always nil, and the error report seems very confused to users.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
none
