### PR TITLE
add syncEvent from execution_controller to resource

### DIFF
--- a/pkg/apis/work/v1alpha2/well_known_labels.go
+++ b/pkg/apis/work/v1alpha2/well_known_labels.go
@@ -40,3 +40,13 @@ const (
 	// ResourceConflictResolutionOverwrite is the value of ResourceConflictResolutionAnnotation, indicating the overwrite strategy.
 	ResourceConflictResolutionOverwrite = "overwrite"
 )
+
+// Define annotations that are added to the resource template.
+const (
+	// ResourceTemplateUIDAnnotation is the annotation that is added to the manifest in the Work object.
+	// The annotation is used to identify the resource template which the manifest is derived from.
+	// The annotation can also be used to fire events when syncing Work to member clusters.
+	// For more details about UID, please refer to:
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+	ResourceTemplateUIDAnnotation = "resourcetemplate.karmada.io/uid"
+)

--- a/pkg/util/helper/work.go
+++ b/pkg/util/helper/work.go
@@ -2,22 +2,28 @@ package helper
 
 import (
 	"context"
+	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/util"
 )
 
 // CreateOrUpdateWork creates a Work object if not exist, or updates if it already exist.
 func CreateOrUpdateWork(client client.Client, workMeta metav1.ObjectMeta, resource *unstructured.Unstructured) error {
 	workload := resource.DeepCopy()
+	util.MergeAnnotation(workload, workv1alpha2.ResourceTemplateUIDAnnotation, string(workload.GetUID()))
 	workloadJSON, err := workload.MarshalJSON()
 	if err != nil {
 		klog.Errorf("Failed to marshal workload(%s/%s), Error: %v", workload.GetNamespace(), workload.GetName(), err)
@@ -75,4 +81,35 @@ func GetWorksByLabelsSet(c client.Client, ls labels.Set) (*workv1alpha1.WorkList
 	listOpt := &client.ListOptions{LabelSelector: labels.SelectorFromSet(ls)}
 
 	return workList, c.List(context.TODO(), workList, listOpt)
+}
+
+// GenEventRef returns the event reference. sets the UID(.spec.uid) that might be missing for fire events.
+// Do nothing if the UID already exist, otherwise set the UID from annotation.
+func GenEventRef(resource *unstructured.Unstructured) (*corev1.ObjectReference, error) {
+	ref := &corev1.ObjectReference{
+		Kind:       resource.GetKind(),
+		Namespace:  resource.GetNamespace(),
+		Name:       resource.GetName(),
+		UID:        resource.GetUID(),
+		APIVersion: resource.GetAPIVersion(),
+	}
+
+	if len(resource.GetUID()) == 0 {
+		uid := util.GetAnnotationValue(resource.GetAnnotations(), workv1alpha2.ResourceTemplateUIDAnnotation)
+		ref.UID = types.UID(uid)
+	}
+
+	if len(ref.UID) == 0 {
+		return nil, fmt.Errorf("missing mandatory uid")
+	}
+
+	if len(ref.Name) == 0 {
+		return nil, fmt.Errorf("missing mandatory name")
+	}
+
+	if len(ref.Kind) == 0 {
+		return nil, fmt.Errorf("missing mandatory kind")
+	}
+
+	return ref, nil
 }

--- a/pkg/util/helper/work_test.go
+++ b/pkg/util/helper/work_test.go
@@ -1,0 +1,93 @@
+package helper
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestGenEventRef(t *testing.T) {
+	tests := []struct {
+		name    string
+		obj     *unstructured.Unstructured
+		want    *corev1.ObjectReference
+		wantErr bool
+	}{
+		{
+			name: "has metadata.uid",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "demo-deployment",
+						"uid":  "9249d2e7-3169-4c5f-be82-163bd80aa3cf",
+					},
+					"spec": map[string]interface{}{
+						"replicas": 2,
+					},
+				},
+			},
+			want: &corev1.ObjectReference{
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+				Name:       "demo-deployment",
+				UID:        "9249d2e7-3169-4c5f-be82-163bd80aa3cf",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing metadata.uid but has resourcetemplate.karmada.io/uid annontation",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":        "demo-deployment",
+						"annotations": map[string]interface{}{"resourcetemplate.karmada.io/uid": "9249d2e7-3169-4c5f-be82-163bd80aa3cf"},
+					},
+					"spec": map[string]interface{}{
+						"replicas": 2,
+					},
+				},
+			},
+			want: &corev1.ObjectReference{
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+				Name:       "demo-deployment",
+				UID:        "9249d2e7-3169-4c5f-be82-163bd80aa3cf",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing metadata.uid and metadata.annotations",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "demo-deployment",
+					},
+					"spec": map[string]interface{}{
+						"replicas": 2,
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := GenEventRef(tt.obj)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GenEventRef() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(actual, tt.want) {
+				t.Errorf("GenEventRef() = %v, want %v", actual, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: hanweisen <hanweisen_yewu@cmss.chinamobile.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
add syncEvent from execution_controller to resource.
For example if we describe deployment we can see event from execution-controller
```
#  kubectl --kubeconfig .kube/karmada.config describe deployment nginx
...
Events:
  Type     Reason                  Age                 From                  Message
  ----     ------                  ----                ----                  -------
  Warning  ApplyPolicyFailed       22s                 resource-detector     No policy match for resource
  Normal   ApplyPolicySucceed      22s (x3 over 22s)   resource-detector     Apply policy(default/nginx-propagation) succeed
  Normal   SyncWorkSucceed         22s (x9 over 22s)   binding-controller    Sync work of resourceBinding(default/nginx-deployment) successful.
  Normal   AggregateStatusSucceed  22s (x9 over 22s)   binding-controller    Update resourceBinding(default/nginx-deployment) with AggregatedStatus successfully.
  Normal   ScheduleBindingSucceed  22s (x11 over 22s)  karmada-scheduler     Binding has been scheduled
  Normal   SyncSucceed             22s                 execution-controller  Successfully applied resource(default/nginx) to cluster member1
  Normal   SyncSucceed             22s                 execution-controller  Successfully applied resource(default/nginx) to cluster member2
```
**Which issue(s) this PR fixes**:
Fixes #1898

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

