### PR TITLE
sync status of pod

### DIFF
--- a/docs/userguide/customizing-resource-interpreter.md
+++ b/docs/userguide/customizing-resource-interpreter.md
@@ -97,6 +97,7 @@ Supported resources:
 - Job(batch/v1)
 - DaemonSet(apps/v1)
 - StatefulSet(apps/v1)
+- Pod(v1)
 
 ### InterpretStatus
 


### PR DESCRIPTION
Signed-off-by: bruce <zhangyongxi_yewu@cmss.chinamobile.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
When I try to propagate or promote a pod, I found that the status of pod is always pending and never changed. 
![5c31](https://user-images.githubusercontent.com/21099093/170948593-c0c5c88a-c8e9-4fdd-9887-fa51bf11e99d.png)

**Which issue(s) this PR fixes**:
Fixes #1988

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`:  `interpreter framework` starts to support Pod status aggregation.  
```

