### PR TITLE
adjust etcd version

### DIFF
--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -42,7 +42,7 @@ var (
 
 	defaultKubeConfig = filepath.Join(homeDir(), ".kube", "config")
 
-	defaultEtcdImage                  = "etcd:3.5.1-0"
+	defaultEtcdImage                  = "etcd:3.4.13-0"
 	defaultKubeAPIServerImage         = "kube-apiserver:v1.21.7"
 	defaultKubeControllerManagerImage = "kube-controller-manager:v1.21.7"
 )


### PR DESCRIPTION
The etcd in `karmadactl init` looks like it's already using version 3.5.1-0 :https://github.com/karmada-io/karmada/blob/master/pkg/karmadactl/cmdinit/kubernetes/deploy.go#L45 .

Perhaps these two places should also be consistent.

/kind cleanup