### PR TITLE
fix add annotation when annotation is nil

### DIFF
--- a/pkg/registry/search/storage/cache.go
+++ b/pkg/registry/search/storage/cache.go
@@ -97,6 +97,9 @@ func addAnnotationWithClusterName(resourceObjects []runtime.Object, clusterName 
 		resource := resourceObjects[index].(*unstructured.Unstructured)
 
 		annotations := resource.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
 		annotations["cluster.karmada.io/name"] = clusterName
 
 		resource.SetAnnotations(annotations)


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

In karmada search feature, fix panic when adding a new key in nil annotation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-search`: Fixed panic when the resource annotation is nil.
```

