### PR TITLE
update perl image for latest image run err

### DIFF
--- a/test/helper/resource.go
+++ b/test/helper/resource.go
@@ -313,7 +313,7 @@ func NewJob(namespace string, name string) *batchv1.Job {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name:    "pi",
-						Image:   "perl",
+						Image:   "perl:5.34.0",
 						Command: []string{"perl", "-Mbignum=bpi", "-wle", "print bpi(2000)"},
 					}},
 					RestartPolicy: corev1.RestartPolicyNever,


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

The [CI run failed](https://github.com/karmada-io/karmada/runs/6663713820?check_suite_focus=true) with E2E `JobStatus collection testing`, related `karmada-controller-manager` log info:

```log
2022-05-31T02:03:09.607149676Z stderr F I0531 02:03:09.606420       1 job.go:32] Grab job(karmadatest-682/job-mr4) status from cluster(member1), active: 1, succeeded 0, failed: 2
2022-05-31T02:03:09.607168476Z stderr F I0531 02:03:09.606492       1 job.go:32] Grab job(karmadatest-682/job-mr4) status from cluster(member2), active: 1, succeeded 0, failed: 2
2022-05-31T02:03:09.607194776Z stderr F I0531 02:03:09.606550       1 job.go:32] Grab job(karmadatest-682/job-mr4) status from cluster(member3), active: 1, succeeded 0, failed: 2
```

This is because when we use the latest perl image(5.36.0) for testing, the pod of job runs incorrectly: `Can't use an undefined value as an ARRAY reference at /usr/local/lib/perl5/5.36.0/Math/BigInt/Calc.pm line 1049.`. As a result, the job fails.

So I decided to use the previous perl image(5.34.0) for testing.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

