### PR TITLE
When ServiceImportType is Headless, it should be ignored

### DIFF
--- a/pkg/controllers/mcs/service_import_controller.go
+++ b/pkg/controllers/mcs/service_import_controller.go
@@ -39,7 +39,7 @@ func (c *ServiceImportController) Reconcile(ctx context.Context, req controllerr
 		return controllerruntime.Result{Requeue: true}, err
 	}
 
-	if !svcImport.DeletionTimestamp.IsZero() {
+	if !svcImport.DeletionTimestamp.IsZero() || svcImport.Spec.Type != mcsv1alpha1.ClusterSetIP {
 		return controllerruntime.Result{}, nil
 	}
 


### PR DESCRIPTION
Signed-off-by: chaunceyjiang <chaunceyjiang@gmail.com>

**What type of PR is this?**

/kind bug


<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

When ServiceImportType is Headless, it should be ignored

Refer to [shouldIgnoreImport](https://github.com/kubernetes-sigs/mcs-api/blob/e851d9e462/pkg/controllers/serviceimport.go#L76)



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

