### PR TITLE
Automated cherry pick of #1926: update perl image for latest image run err

### DIFF
--- a/test/helper/resource.go
+++ b/test/helper/resource.go
@@ -246,7 +246,7 @@ func NewJob(namespace string, name string) *batchv1.Job {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name:    "pi",
-						Image:   "perl",
+						Image:   "perl:5.34.0",
 						Command: []string{"perl", "-Mbignum=bpi", "-wle", "print bpi(2000)"},
 					}},
 					RestartPolicy: corev1.RestartPolicyNever,


### PR DESCRIPTION
Cherry pick of #1926 on release-1.0.
#1926: update perl image for latest image run err
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```release-note
NONE
```