### PR TITLE
modify output for deinit

### DIFF
--- a/pkg/karmadactl/deinit.go
+++ b/pkg/karmadactl/deinit.go
@@ -260,7 +260,7 @@ func removeLabels(node *corev1.Node, removesLabel string) {
 
 // deleteConfirmation delete karmada confirmation
 func deleteConfirmation() bool {
-	fmt.Println("Please type (y)es or (n)o and then press enter:")
+	fmt.Print("Please type (y)es or (n)o and then press enter:")
 	var response string
 	_, err := fmt.Scanln(&response)
 	if err != nil {


### PR DESCRIPTION
/kind cleanup

When deinit for karmada:`kubectl karmada deinit`, the output for yes or no is:

<img width="615" alt="image" src="https://user-images.githubusercontent.com/76980726/171181036-2f203321-37bf-4444-92c8-c47bf03742fd.png">

Mybe it shoud be:
<img width="787" alt="image" src="https://user-images.githubusercontent.com/76980726/171181286-aa613b1c-7b6c-4ff3-acc2-1275600754fc.png">

