### PR TITLE
Update default kube-apiserver from v1.21 to v1.22

### DIFF
--- a/artifacts/deploy/karmada-apiserver.yaml
+++ b/artifacts/deploy/karmada-apiserver.yaml
@@ -64,7 +64,7 @@ spec:
             - --tls-cert-file=/etc/kubernetes/pki/karmada.crt
             - --tls-private-key-file=/etc/kubernetes/pki/karmada.key
           name: karmada-apiserver
-          image: k8s.gcr.io/kube-apiserver:v1.21.7
+          image: k8s.gcr.io/kube-apiserver:v1.22.10
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 8

--- a/artifacts/deploy/karmada-etcd.yaml
+++ b/artifacts/deploy/karmada-etcd.yaml
@@ -32,7 +32,7 @@ spec:
         - operator: Exists
       containers:
         - name: etcd
-          image: k8s.gcr.io/etcd:3.4.13-0
+          image: k8s.gcr.io/etcd:3.5.3-0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             exec:

--- a/artifacts/deploy/kube-controller-manager.yaml
+++ b/artifacts/deploy/kube-controller-manager.yaml
@@ -52,7 +52,7 @@ spec:
             - --service-cluster-ip-range=10.96.0.0/12
             - --use-service-account-credentials=true
             - --v=4
-          image: k8s.gcr.io/kube-controller-manager:v1.21.7
+          image: k8s.gcr.io/kube-controller-manager:v1.22.10
           imagePullPolicy: IfNotPresent
           name: kube-controller-manager
           resources:

--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -113,7 +113,7 @@ func initExample(parentCommand string) string {
 		fmt.Sprintf("%s init --etcd-storage-mode hostPath --etcd-node-selector-labels karmada.io/etcd=true", parentCommand) + `
 
 # Private registry can be specified for all images` + "\n" +
-		fmt.Sprintf("%s init --etcd-image local.registry.com/library/etcd:3.5.1-0", parentCommand) + `
+		fmt.Sprintf("%s init --etcd-image local.registry.com/library/etcd:3.5.3-0", parentCommand) + `
 
 # Deploy highly available(HA) karmada` + "\n" +
 		fmt.Sprintf("%s init --karmada-apiserver-replicas 3 --etcd-replicas 3 --etcd-storage-mode PVC --storage-classes-name {StorageClassesName}", parentCommand) + `

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -42,9 +42,9 @@ var (
 
 	defaultKubeConfig = filepath.Join(homeDir(), ".kube", "config")
 
-	defaultEtcdImage                  = "etcd:3.4.13-0"
-	defaultKubeAPIServerImage         = "kube-apiserver:v1.21.7"
-	defaultKubeControllerManagerImage = "kube-controller-manager:v1.21.7"
+	defaultEtcdImage                  = "etcd:3.5.3-0"
+	defaultKubeAPIServerImage         = "kube-apiserver:v1.22.10"
+	defaultKubeControllerManagerImage = "kube-controller-manager:v1.22.10"
 )
 
 // CommandInitOption holds all flags options for init.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Update default kube-apiserver from v1.21 to v1.22 
**Which issue(s) this PR fixes**:
Fixes #1923

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Update default kube-apiserver from v1.21 to v1.22
```

