### PR TITLE
Automated cherry pick of #1921: fix add annotation when annotation is nil

### DIFF
--- a/pkg/registry/search/storage/cache.go
+++ b/pkg/registry/search/storage/cache.go
@@ -97,6 +97,9 @@ func addAnnotationWithClusterName(resourceObjects []runtime.Object, clusterName 
 		resource := resourceObjects[index].(*unstructured.Unstructured)
 
 		annotations := resource.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
 		annotations["cluster.karmada.io/name"] = clusterName
 
 		resource.SetAnnotations(annotations)


### PR DESCRIPTION
Cherry pick of #1921 on release-1.2.
#1921: fix add annotation when annotation is nil
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```release-note
`karmada-search`: Fixed panic when the resource annotation is nil.
```