### PR TITLE
add NoExecute taint manager

### DIFF
--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -111,6 +111,9 @@ type Options struct {
 	ConcurrentNamespaceSyncs int
 	// ConcurrentResourceTemplateSyncs is the number of resource templates that are allowed to sync concurrently.
 	ConcurrentResourceTemplateSyncs int
+	// If set to true enables NoExecute Taints and will evict all not-tolerating
+	// objects propagating on Clusters tainted with this kind of Taints.
+	EnableTaintManager bool
 
 	RateLimiterOpts ratelimiterflag.Options
 	ProfileOpts     profileflag.Options
@@ -190,6 +193,7 @@ func (o *Options) AddFlags(flags *pflag.FlagSet, allControllers, disabledByDefau
 	flags.IntVar(&o.ConcurrentWorkSyncs, "concurrent-work-syncs", 5, "The number of Works that are allowed to sync concurrently.")
 	flags.IntVar(&o.ConcurrentNamespaceSyncs, "concurrent-namespace-syncs", 1, "The number of Namespaces that are allowed to sync concurrently.")
 	flags.IntVar(&o.ConcurrentResourceTemplateSyncs, "concurrent-resource-template-syncs", 5, "The number of resource templates that are allowed to sync concurrently.")
+	flags.BoolVar(&o.EnableTaintManager, "enable-taint-manager", true, "If set to true enables NoExecute Taints and will evict all not-tolerating objects propagating on Clusters tainted with this kind of Taints.")
 
 	o.RateLimiterOpts.AddFlags(flags)
 	o.ProfileOpts.AddFlags(flags)

--- a/pkg/apis/cluster/mutation/mutation.go
+++ b/pkg/apis/cluster/mutation/mutation.go
@@ -1,0 +1,23 @@
+package mutation
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	clusterapis "github.com/karmada-io/karmada/pkg/apis/cluster"
+)
+
+// MutateCluster mutates required fields of the Cluster.
+func MutateCluster(cluster *clusterapis.Cluster) {
+	MutateClusterTaints(cluster.Spec.Taints)
+}
+
+// MutateClusterTaints add TimeAdded field for cluster NoExecute taints only if TimeAdded not set.
+func MutateClusterTaints(taints []corev1.Taint) {
+	for i := range taints {
+		if taints[i].Effect == corev1.TaintEffectNoExecute && taints[i].TimeAdded == nil {
+			now := metav1.Now()
+			taints[i].TimeAdded = &now
+		}
+	}
+}

--- a/pkg/controllers/cluster/common.go
+++ b/pkg/controllers/cluster/common.go
@@ -1,0 +1,41 @@
+package cluster
+
+import (
+	"context"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/util"
+)
+
+const (
+	rbClusterKeyIndex  = "rbSpec.clusters"
+	crbClusterKeyIndex = "crbSpec.clusters"
+)
+
+// IndexField registers Indexer functions to controller manager.
+func IndexField(mgr controllerruntime.Manager) error {
+	rbIndexerFunc := func(obj client.Object) []string {
+		rb, ok := obj.(*workv1alpha2.ResourceBinding)
+		if !ok {
+			return nil
+		}
+		return util.GetBindingClusterNames(&rb.Spec)
+	}
+
+	crbIndexerFunc := func(obj client.Object) []string {
+		crb, ok := obj.(*workv1alpha2.ClusterResourceBinding)
+		if !ok {
+			return nil
+		}
+		return util.GetBindingClusterNames(&crb.Spec)
+	}
+
+	return utilerrors.NewAggregate([]error{
+		mgr.GetFieldIndexer().IndexField(context.TODO(), &workv1alpha2.ResourceBinding{}, rbClusterKeyIndex, rbIndexerFunc),
+		mgr.GetFieldIndexer().IndexField(context.TODO(), &workv1alpha2.ClusterResourceBinding{}, crbClusterKeyIndex, crbIndexerFunc),
+	})
+}

--- a/pkg/controllers/cluster/taint_manager.go
+++ b/pkg/controllers/cluster/taint_manager.go
@@ -152,15 +152,13 @@ func (tc *NoExecuteTaintManager) syncBindingEviction(key util.QueueKey) error {
 	// Case 2: Need eviction after toleration time. If time is up, do eviction right now.
 	// Case 3: Tolerate forever, we do nothing.
 	if needEviction || tolerationTime == 0 {
-		if result := util.RemoveTargetCluster(binding.Spec.Clusters, cluster); len(result) < len(binding.Spec.Clusters) {
-			// update final result to evict the target cluster
-			binding.Spec.Clusters = result
-			if err = tc.Update(context.TODO(), binding); err != nil {
-				klog.ErrorS(err, "Failed to update binding", "binding", klog.KObj(binding))
-				return err
-			}
-			tc.emitClusterEvictionEventForResourceBinding(binding, cluster)
+		// update final result to evict the target cluster
+		binding.Spec.Clusters = util.RemoveTargetCluster(binding.Spec.Clusters, cluster)
+		if err = tc.Update(context.TODO(), binding); err != nil {
+			klog.ErrorS(err, "Failed to update binding", "binding", klog.KObj(binding))
+			return err
 		}
+		tc.emitClusterEvictionEventForResourceBinding(binding, cluster)
 	} else if tolerationTime > 0 {
 		tc.bindingEvictionWorker.AddAfter(fedKey, tolerationTime)
 	}
@@ -199,15 +197,13 @@ func (tc *NoExecuteTaintManager) syncClusterBindingEviction(key util.QueueKey) e
 	// Case 2: Need eviction after toleration time. If time is up, do eviction right now.
 	// Case 3: Tolerate forever, we do nothing.
 	if needEviction || tolerationTime == 0 {
-		if result := util.RemoveTargetCluster(binding.Spec.Clusters, cluster); len(result) < len(binding.Spec.Clusters) {
-			// update final result to evict the target cluster
-			binding.Spec.Clusters = result
-			if err = tc.Update(context.TODO(), binding); err != nil {
-				klog.ErrorS(err, "Failed to update cluster binding", "binding", binding.Name)
-				return err
-			}
-			tc.emitClusterEvictionEventForClusterResourceBinding(binding, cluster)
+		// update final result to evict the target cluster
+		binding.Spec.Clusters = util.RemoveTargetCluster(binding.Spec.Clusters, cluster)
+		if err = tc.Update(context.TODO(), binding); err != nil {
+			klog.ErrorS(err, "Failed to update cluster binding", "binding", binding.Name)
+			return err
 		}
+		tc.emitClusterEvictionEventForClusterResourceBinding(binding, cluster)
 	} else if tolerationTime > 0 {
 		tc.clusterBindingEvictionWorker.AddAfter(fedKey, tolerationTime)
 		return nil

--- a/pkg/controllers/cluster/taint_manager.go
+++ b/pkg/controllers/cluster/taint_manager.go
@@ -1,0 +1,289 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/helper"
+	"github.com/karmada-io/karmada/pkg/util/informermanager/keys"
+)
+
+// TaintManagerName is the controller name that will be used for taint management.
+const TaintManagerName = "taint-manager"
+
+// NoExecuteTaintManager listens to Taint/Toleration changes and is responsible for removing objects
+// from Clusters tainted with NoExecute Taints.
+type NoExecuteTaintManager struct {
+	client.Client // used to operate Cluster resources.
+	EventRecorder record.EventRecorder
+
+	ClusterTaintEvictionRetryFrequency time.Duration
+	ConcurrentReconciles               int
+
+	bindingEvictionWorker        util.AsyncWorker
+	clusterBindingEvictionWorker util.AsyncWorker
+}
+
+// Reconcile performs a full reconciliation for the object referred to by the Request.
+// The Controller will requeue the Request to be processed again if an error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (tc *NoExecuteTaintManager) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	klog.V(4).Infof("Reconciling cluster %s for taint manager", req.NamespacedName.Name)
+
+	cluster := &clusterv1alpha1.Cluster{}
+	if err := tc.Client.Get(context.TODO(), req.NamespacedName, cluster); err != nil {
+		// The resource may no longer exist, in which case we stop processing.
+		if apierrors.IsNotFound(err) {
+			return controllerruntime.Result{}, nil
+		}
+		return controllerruntime.Result{Requeue: true}, err
+	}
+
+	// Check whether the target cluster has no execute taints.
+	if !helper.HasNoExecuteTaints(cluster.Spec.Taints) {
+		return controllerruntime.Result{}, nil
+	}
+
+	return tc.syncCluster(ctx, cluster)
+}
+
+func (tc *NoExecuteTaintManager) syncCluster(ctx context.Context, cluster *clusterv1alpha1.Cluster) (reconcile.Result, error) {
+	// List all ResourceBindings which are assigned to this cluster.
+	rbList := &workv1alpha2.ResourceBindingList{}
+	if err := tc.List(ctx, rbList, client.MatchingFieldsSelector{
+		Selector: fields.OneTermEqualSelector(rbClusterKeyIndex, cluster.Name),
+	}); err != nil {
+		klog.ErrorS(err, "Failed to list ResourceBindings", "cluster", cluster.Name)
+		return controllerruntime.Result{Requeue: true}, err
+	}
+	for i := range rbList.Items {
+		key, err := keys.FederatedKeyFunc(cluster.Name, &rbList.Items[i])
+		if err != nil {
+			klog.Warningf("Failed to generate key for obj: %s", rbList.Items[i].GetObjectKind().GroupVersionKind())
+			continue
+		}
+		tc.bindingEvictionWorker.Add(key)
+	}
+
+	// List all ClusterResourceBindings which are assigned to this cluster.
+	crbList := &workv1alpha2.ClusterResourceBindingList{}
+	if err := tc.List(ctx, crbList, client.MatchingFieldsSelector{
+		Selector: fields.OneTermEqualSelector(crbClusterKeyIndex, cluster.Name),
+	}); err != nil {
+		klog.ErrorS(err, "Failed to list ClusterResourceBindings", "cluster", cluster.Name)
+		return controllerruntime.Result{Requeue: true}, err
+	}
+	for i := range crbList.Items {
+		key, err := keys.FederatedKeyFunc(cluster.Name, &crbList.Items[i])
+		if err != nil {
+			klog.Warningf("Failed to generate key for obj: %s", crbList.Items[i].GetObjectKind().GroupVersionKind())
+			continue
+		}
+		tc.clusterBindingEvictionWorker.Add(key)
+	}
+	return controllerruntime.Result{RequeueAfter: tc.ClusterTaintEvictionRetryFrequency}, nil
+}
+
+// Start starts an asynchronous loop that handle evictions.
+func (tc *NoExecuteTaintManager) Start(ctx context.Context) error {
+	bindingEvictionWorkerOptions := util.Options{
+		Name:          "binding-eviction",
+		KeyFunc:       nil,
+		ReconcileFunc: tc.syncBindingEviction,
+	}
+	tc.bindingEvictionWorker = util.NewAsyncWorker(bindingEvictionWorkerOptions)
+	tc.bindingEvictionWorker.Run(tc.ConcurrentReconciles, ctx.Done())
+
+	clusterBindingEvictionWorkerOptions := util.Options{
+		Name:          "cluster-binding-eviction",
+		KeyFunc:       nil,
+		ReconcileFunc: tc.syncClusterBindingEviction,
+	}
+	tc.clusterBindingEvictionWorker = util.NewAsyncWorker(clusterBindingEvictionWorkerOptions)
+	tc.clusterBindingEvictionWorker.Run(tc.ConcurrentReconciles, ctx.Done())
+
+	<-ctx.Done()
+	return nil
+}
+
+func (tc *NoExecuteTaintManager) syncBindingEviction(key util.QueueKey) error {
+	fedKey, ok := key.(keys.FederatedKey)
+	if !ok {
+		klog.Errorf("Failed to sync binding eviction as invalid key: %v", key)
+		return fmt.Errorf("invalid key")
+	}
+	cluster := fedKey.Cluster
+
+	binding := &workv1alpha2.ResourceBinding{}
+	if err := tc.Client.Get(context.TODO(), types.NamespacedName{Namespace: fedKey.Namespace, Name: fedKey.Name}, binding); err != nil {
+		// The resource no longer exist, in which case we stop processing.
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get binding %s: %v", fedKey.NamespaceKey(), err)
+	}
+
+	if !binding.DeletionTimestamp.IsZero() || !binding.Spec.TargetContains(cluster) {
+		return nil
+	}
+
+	needEviction, tolerationTime, err := tc.needEviction(cluster, binding.Annotations)
+	if err != nil {
+		klog.ErrorS(err, "Failed to check if binding needs eviction", "binding", fedKey.ClusterWideKey.NamespaceKey())
+		return err
+	}
+
+	// Case 1: Need eviction now.
+	// Case 2: Need eviction after toleration time. If time is up, do eviction right now.
+	// Case 3: Tolerate forever, we do nothing.
+	if needEviction || tolerationTime == 0 {
+		if result := util.RemoveTargetCluster(binding.Spec.Clusters, cluster); len(result) < len(binding.Spec.Clusters) {
+			// update final result to evict the target cluster
+			binding.Spec.Clusters = result
+			if err = tc.Update(context.TODO(), binding); err != nil {
+				klog.ErrorS(err, "Failed to update binding", "binding", klog.KObj(binding))
+				return err
+			}
+			tc.emitClusterEvictionEventForResourceBinding(binding, cluster)
+		}
+	} else if tolerationTime > 0 {
+		tc.bindingEvictionWorker.AddAfter(fedKey, tolerationTime)
+	}
+
+	return nil
+}
+
+func (tc *NoExecuteTaintManager) syncClusterBindingEviction(key util.QueueKey) error {
+	fedKey, ok := key.(keys.FederatedKey)
+	if !ok {
+		klog.Errorf("Failed to sync cluster binding eviction as invalid key: %v", key)
+		return fmt.Errorf("invalid key")
+	}
+	cluster := fedKey.Cluster
+
+	binding := &workv1alpha2.ClusterResourceBinding{}
+	if err := tc.Client.Get(context.TODO(), types.NamespacedName{Name: fedKey.Name}, binding); err != nil {
+		// The resource no longer exist, in which case we stop processing.
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get cluster binding %s: %v", fedKey.Name, err)
+	}
+
+	if !binding.DeletionTimestamp.IsZero() || !binding.Spec.TargetContains(cluster) {
+		return nil
+	}
+
+	needEviction, tolerationTime, err := tc.needEviction(cluster, binding.Annotations)
+	if err != nil {
+		klog.ErrorS(err, "Failed to check if cluster binding needs eviction", "binding", binding.Name)
+		return err
+	}
+
+	// Case 1: Need eviction now.
+	// Case 2: Need eviction after toleration time. If time is up, do eviction right now.
+	// Case 3: Tolerate forever, we do nothing.
+	if needEviction || tolerationTime == 0 {
+		if result := util.RemoveTargetCluster(binding.Spec.Clusters, cluster); len(result) < len(binding.Spec.Clusters) {
+			// update final result to evict the target cluster
+			binding.Spec.Clusters = result
+			if err = tc.Update(context.TODO(), binding); err != nil {
+				klog.ErrorS(err, "Failed to update cluster binding", "binding", binding.Name)
+				return err
+			}
+			tc.emitClusterEvictionEventForClusterResourceBinding(binding, cluster)
+		}
+	} else if tolerationTime > 0 {
+		tc.clusterBindingEvictionWorker.AddAfter(fedKey, tolerationTime)
+		return nil
+	}
+
+	return nil
+}
+
+// needEviction returns whether the binding should be evicted from target cluster right now.
+// If a toleration time is found, we return false along with a minimum toleration time as the
+// second return value.
+func (tc *NoExecuteTaintManager) needEviction(clusterName string, appliedPlacement map[string]string) (bool, time.Duration, error) {
+	placement, err := helper.GetAppliedPlacement(appliedPlacement)
+	if err != nil {
+		return false, -1, err
+	}
+
+	cluster := &clusterv1alpha1.Cluster{}
+	if err = tc.Client.Get(context.TODO(), types.NamespacedName{Name: clusterName}, cluster); err != nil {
+		// The resource may no longer exist, in which case we stop processing.
+		if apierrors.IsNotFound(err) {
+			return false, -1, nil
+		}
+		return false, -1, err
+	}
+
+	taints := helper.GetNoExecuteTaints(cluster.Spec.Taints)
+	if len(taints) == 0 {
+		return false, -1, nil
+	}
+	tolerations := placement.ClusterTolerations
+
+	allTolerated, usedTolerations := helper.GetMatchingTolerations(taints, tolerations)
+	if !allTolerated {
+		return true, 0, nil
+	}
+
+	return false, helper.GetMinTolerationTime(taints, usedTolerations), nil
+}
+
+// SetupWithManager creates a controller and register to controller manager.
+func (tc *NoExecuteTaintManager) SetupWithManager(mgr controllerruntime.Manager) error {
+	return utilerrors.NewAggregate([]error{
+		controllerruntime.NewControllerManagedBy(mgr).For(&clusterv1alpha1.Cluster{}).Complete(tc),
+		mgr.Add(tc),
+	})
+}
+
+func (tc *NoExecuteTaintManager) emitClusterEvictionEventForResourceBinding(binding *workv1alpha2.ResourceBinding, cluster string) {
+	if binding == nil {
+		return
+	}
+
+	ref := &corev1.ObjectReference{
+		Kind:       binding.Spec.Resource.Kind,
+		APIVersion: binding.Spec.Resource.APIVersion,
+		Namespace:  binding.Spec.Resource.Namespace,
+		Name:       binding.Spec.Resource.Name,
+		UID:        binding.Spec.Resource.UID,
+	}
+	tc.EventRecorder.Eventf(binding, corev1.EventTypeNormal, "TaintManagerEviction", "Evict from cluster %s", cluster)
+	tc.EventRecorder.Eventf(ref, corev1.EventTypeNormal, "TaintManagerEviction", "Evict from cluster %s", cluster)
+}
+
+func (tc *NoExecuteTaintManager) emitClusterEvictionEventForClusterResourceBinding(binding *workv1alpha2.ClusterResourceBinding, cluster string) {
+	if binding == nil {
+		return
+	}
+
+	ref := &corev1.ObjectReference{
+		Kind:       binding.Spec.Resource.Kind,
+		APIVersion: binding.Spec.Resource.APIVersion,
+		Namespace:  binding.Spec.Resource.Namespace,
+		Name:       binding.Spec.Resource.Name,
+		UID:        binding.Spec.Resource.UID,
+	}
+	tc.EventRecorder.Eventf(binding, corev1.EventTypeNormal, "TaintManagerEviction", "Evict from cluster %s", cluster)
+	tc.EventRecorder.Eventf(ref, corev1.EventTypeNormal, "TaintManagerEviction", "Evict from cluster %s", cluster)
+}

--- a/pkg/controllers/context/context.go
+++ b/pkg/controllers/context/context.go
@@ -58,6 +58,9 @@ type Options struct {
 	ConcurrentWorkSyncs int
 	// RateLimiterOptions contains the options for rate limiter.
 	RateLimiterOptions ratelimiterflag.Options
+	// If set to true enables NoExecute Taints and will evict all not-tolerating
+	// objects propagating on Clusters tainted with this kind of Taints.
+	EnableTaintManager bool
 }
 
 // Context defines the context object for controller.

--- a/pkg/controllers/hpa/hpa_controller.go
+++ b/pkg/controllers/hpa/hpa_controller.go
@@ -148,7 +148,7 @@ func (c *HorizontalPodAutoscalerController) getTargetPlacement(objRef autoscalin
 	if err := c.Client.Get(context.TODO(), namespacedName, binding); err != nil {
 		return nil, err
 	}
-	return util.GetBindingClusterNames(binding), nil
+	return util.GetBindingClusterNames(&binding.Spec), nil
 }
 
 // SetupWithManager creates a controller and register to controller manager.

--- a/pkg/registry/cluster/strategy.go
+++ b/pkg/registry/cluster/strategy.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 
 	clusterapis "github.com/karmada-io/karmada/pkg/apis/cluster"
+	"github.com/karmada-io/karmada/pkg/apis/cluster/mutation"
 	"github.com/karmada-io/karmada/pkg/apis/cluster/validation"
 )
 
@@ -98,6 +99,8 @@ func (Strategy) AllowUnconditionalUpdate() bool {
 
 // Canonicalize allows an object to be mutated into a canonical form.
 func (Strategy) Canonicalize(obj runtime.Object) {
+	cluster := obj.(*clusterapis.Cluster)
+	mutation.MutateCluster(cluster)
 }
 
 // ValidateUpdate is invoked after default fields in the object have been

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -36,9 +36,7 @@ func (p *TaintToleration) Name() string {
 // Filter checks if the given tolerations in placement tolerate cluster's taints.
 func (p *TaintToleration) Filter(ctx context.Context, placement *policyv1alpha1.Placement, resource *workv1alpha2.ObjectReference, cluster *clusterv1alpha1.Cluster) *framework.Result {
 	filterPredicate := func(t *corev1.Taint) bool {
-		// now only interested in NoSchedule taint which means do not allow new resource to schedule onto the cluster unless they tolerate the taint
-		// todo: supprot NoExecute taint
-		return t.Effect == corev1.TaintEffectNoSchedule
+		return t.Effect == corev1.TaintEffectNoSchedule || t.Effect == corev1.TaintEffectNoExecute
 	}
 
 	taint, isUntolerated := v1helper.FindMatchingUntoleratedTaint(cluster.Spec.Taints, placement.ClusterTolerations, filterPredicate)

--- a/pkg/util/binding.go
+++ b/pkg/util/binding.go
@@ -8,9 +8,9 @@ import (
 )
 
 // GetBindingClusterNames will get clusterName list from bind clusters field
-func GetBindingClusterNames(binding *workv1alpha2.ResourceBinding) []string {
+func GetBindingClusterNames(spec *workv1alpha2.ResourceBindingSpec) []string {
 	var clusterNames []string
-	for _, targetCluster := range binding.Spec.Clusters {
+	for _, targetCluster := range spec.Clusters {
 		clusterNames = append(clusterNames, targetCluster.Name)
 	}
 	return clusterNames
@@ -110,4 +110,15 @@ func MergeTargetClusters(old, new []workv1alpha2.TargetCluster) []workv1alpha2.T
 		new = append(new, workv1alpha2.TargetCluster{Name: key, Replicas: value})
 	}
 	return new
+}
+
+// RemoveTargetCluster will delete a target cluster from cluster list.
+func RemoveTargetCluster(clusters []workv1alpha2.TargetCluster, target string) []workv1alpha2.TargetCluster {
+	res := make([]workv1alpha2.TargetCluster, 0, len(clusters)-1)
+	for _, cluster := range clusters {
+		if cluster.Name != target {
+			res = append(res, cluster)
+		}
+	}
+	return res
 }

--- a/pkg/util/binding_test.go
+++ b/pkg/util/binding_test.go
@@ -211,7 +211,7 @@ func TestGetBindingClusterNames(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetBindingClusterNames(tt.binding)
+			got := GetBindingClusterNames(&tt.binding.Spec)
 			if !reflect.DeepEqual(got, tt.expected) {
 				t.Errorf("GetBindingClusterNames() = %v, want %v", got, tt.expected)
 			}

--- a/pkg/util/helper/policy.go
+++ b/pkg/util/helper/policy.go
@@ -1,6 +1,7 @@
 package helper
 
 import (
+	"encoding/json"
 	"fmt"
 
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -152,4 +153,17 @@ func IsReplicaDynamicDivided(strategy *policyv1alpha1.ReplicaSchedulingStrategy)
 	default:
 		return false
 	}
+}
+
+// GetAppliedPlacement will get applied placement from annotations.
+func GetAppliedPlacement(annotations map[string]string) (*policyv1alpha1.Placement, error) {
+	appliedPlacement := util.GetLabelValue(annotations, util.PolicyPlacementAnnotation)
+	if len(appliedPlacement) == 0 {
+		return nil, nil
+	}
+	placement := &policyv1alpha1.Placement{}
+	if err := json.Unmarshal([]byte(appliedPlacement), placement); err != nil {
+		return nil, err
+	}
+	return placement, nil
 }

--- a/pkg/util/helper/taint.go
+++ b/pkg/util/helper/taint.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"context"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,4 +60,99 @@ func UpdateClusterControllerTaint(ctx context.Context, client client.Client, tai
 	cluster.Spec.Taints = taints
 
 	return client.Update(ctx, cluster)
+}
+
+// HasNoExecuteTaints check if NoExecute taints exist.
+func HasNoExecuteTaints(taints []corev1.Taint) bool {
+	for i := range taints {
+		if taints[i].Effect == corev1.TaintEffectNoExecute {
+			return true
+		}
+	}
+	return false
+}
+
+// GetNoExecuteTaints will get all NoExecute taints.
+func GetNoExecuteTaints(taints []corev1.Taint) []corev1.Taint {
+	var result []corev1.Taint
+	for i := range taints {
+		if taints[i].Effect == corev1.TaintEffectNoExecute {
+			result = append(result, taints[i])
+		}
+	}
+	return result
+}
+
+// GetMinTolerationTime returns minimal toleration time from the given slice, or -1 if it's infinite.
+func GetMinTolerationTime(noExecuteTaints []corev1.Taint, usedTolerations []corev1.Toleration) time.Duration {
+	if len(noExecuteTaints) == 0 {
+		return -1
+	}
+	if len(usedTolerations) == 0 {
+		return 0
+	}
+
+	// Get all trigger time.
+	var triggerTimes []time.Time
+	for i := range usedTolerations {
+		if usedTolerations[i].TolerationSeconds == nil {
+			continue
+		}
+		tolerationSeconds := *(usedTolerations[i].TolerationSeconds)
+		for j := range noExecuteTaints {
+			// should not happen
+			if noExecuteTaints[j].TimeAdded == nil {
+				continue
+			}
+			timeAdded := *noExecuteTaints[j].TimeAdded
+			if usedTolerations[i].ToleratesTaint(&noExecuteTaints[j]) {
+				triggerTimes = append(triggerTimes, timeAdded.Add(time.Duration(tolerationSeconds)*time.Second))
+			}
+		}
+	}
+
+	// If triggerTimes is empty, it means all taints would be tolerated forever.
+	if len(triggerTimes) == 0 {
+		return -1
+	}
+
+	// Find the latest trigger time.
+	t := triggerTimes[0]
+	for i := 1; i < len(triggerTimes); i++ {
+		if triggerTimes[i].Before(t) {
+			t = triggerTimes[i]
+		}
+	}
+
+	// If trigger time is up, don't tolerate.
+	if t.Before(time.Now()) {
+		return 0
+	}
+
+	return time.Until(t)
+}
+
+// GetMatchingTolerations returns true and list of Tolerations matching all Taints if all are tolerated, or false otherwise.
+func GetMatchingTolerations(taints []corev1.Taint, tolerations []corev1.Toleration) (bool, []corev1.Toleration) {
+	if len(taints) == 0 {
+		return true, []corev1.Toleration{}
+	}
+	if len(tolerations) == 0 && len(taints) > 0 {
+		return false, []corev1.Toleration{}
+	}
+	var result []corev1.Toleration
+	for i := range taints {
+		tolerated := false
+		for j := range tolerations {
+			if tolerations[j].ToleratesTaint(&taints[i]) {
+				result = append(result, tolerations[j])
+				tolerated = true
+				break
+			}
+		}
+		if !tolerated {
+			return false, []corev1.Toleration{}
+		}
+	}
+	return true, result
 }

--- a/pkg/util/worker.go
+++ b/pkg/util/worker.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"time"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
@@ -25,6 +27,9 @@ const (
 type AsyncWorker interface {
 	// Add adds the 'item' to queue immediately(without any delay).
 	Add(item interface{})
+
+	// AddAfter adds an item to the workqueue after the indicated duration has passed
+	AddAfter(item interface{}, duration time.Duration)
 
 	// Enqueue generates the key of 'obj' according to a 'KeyFunc' then adds the key as an item to queue by 'Add'.
 	Enqueue(obj runtime.Object)
@@ -97,6 +102,15 @@ func (w *asyncWorker) Add(item interface{}) {
 	}
 
 	w.queue.Add(item)
+}
+
+func (w *asyncWorker) AddAfter(item interface{}, duration time.Duration) {
+	if item == nil {
+		klog.Warningf("Ignore nil item from queue")
+		return
+	}
+
+	w.queue.AddAfter(item, duration)
 }
 
 func (w *asyncWorker) handleError(err error, key interface{}) {


### PR DESCRIPTION
Signed-off-by: Garrybest <garrybest@foxmail.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Add taint manager for NoExecute manager.

**Which issue(s) this PR fixes**:
Fixes part of #1762

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Introduced `taint manager` to cluster controller to evict workloads from clusters with `no-execute` taint. 
```

