### PR TITLE
fix(karmada-search): uncomparable `cache.ResourceEventHandler`

### DIFF
--- a/pkg/search/backendstore/defaultstore.go
+++ b/pkg/search/backendstore/defaultstore.go
@@ -15,14 +15,15 @@ type Default struct {
 func NewDefaultBackend(cluster string) *Default {
 	klog.Infof("create default backend store: %s", cluster)
 	return &Default{
-		resourceEventHander: cache.ResourceEventHandlerFuncs{
+		resourceEventHander: &cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				us, ok := obj.(*unstructured.Unstructured)
 				if !ok {
 					klog.Errorf("unexpected type %T", obj)
 					return
 				}
-				klog.V(4).Infof("add %s %s", cluster, us.GroupVersionKind().String())
+				klog.V(4).Infof("AddFunc Cluster(%s) GVK(%s) Name(%s/%s)",
+					cluster, us.GroupVersionKind().String(), us.GetNamespace(), us.GetName())
 			},
 			UpdateFunc: func(oldObj, curObj interface{}) {
 				us, ok := curObj.(*unstructured.Unstructured)
@@ -30,7 +31,8 @@ func NewDefaultBackend(cluster string) *Default {
 					klog.Errorf("unexpected type %T", curObj)
 					return
 				}
-				klog.V(4).Infof("udpate %s %s", cluster, us.GroupVersionKind().String())
+				klog.V(4).Infof("UpdateFunc Cluster(%s) GVK(%s) Name(%s/%s)",
+					cluster, us.GroupVersionKind().String(), us.GetNamespace(), us.GetName())
 			},
 			DeleteFunc: func(obj interface{}) {
 				us, ok := obj.(*unstructured.Unstructured)
@@ -38,7 +40,8 @@ func NewDefaultBackend(cluster string) *Default {
 					klog.Errorf("unexpected type %T", obj)
 					return
 				}
-				klog.V(4).Infof("delete %s %s", cluster, us.GroupVersionKind().String())
+				klog.V(4).Infof("DeleteFunc Cluster(%s) GVK(%s) Name(%s/%s)",
+					cluster, us.GroupVersionKind().String(), us.GetNamespace(), us.GetName())
 			}}}
 }
 


### PR DESCRIPTION
Co-authored-by: liys87x <liyasong1987x@gmail.com>
Signed-off-by: huntsman_ly <huntsman_ly@sina.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Since `SingleClusterInformerManager.ForResource` uses `==` to determine whether the handler exists, `backendstore.Default` need to return a comparable `cache.ResourceEventHandler`.

**Which issue(s) this PR fixes**:
Fixes #1952  

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-search`: Fixed a panic issue `comparing uncomparable type cache.ResourceEventHandlerFuncs`.
```

