### PR TITLE
rename cache resource annotation

### DIFF
--- a/pkg/apis/cluster/v1alpha1/well_known_constants.go
+++ b/pkg/apis/cluster/v1alpha1/well_known_constants.go
@@ -4,7 +4,6 @@ const (
 	// TaintClusterUnscheduler will be added when cluster becomes unschedulable
 	// and removed when cluster becomes scheduable.
 	TaintClusterUnscheduler = "cluster.karmada.io/unschedulable"
-
 	// TaintClusterNotReady will be added when cluster is not ready
 	// and removed when cluster becomes ready.
 	TaintClusterNotReady = "cluster.karmada.io/not-ready"
@@ -12,4 +11,8 @@ const (
 	// (corresponding to ClusterConditionReady status ConditionUnknown)
 	// and removed when cluster becomes reachable (ClusterConditionReady status ConditionTrue).
 	TaintClusterUnreachable = "cluster.karmada.io/unreachable"
+
+	// CacheSourceAnnotationKey is the annotation that added to a resource to
+	// represent which cluster it cached from.
+	CacheSourceAnnotationKey = "resource.karmada.io/cached-from-cluster"
 )

--- a/pkg/registry/search/storage/cache.go
+++ b/pkg/registry/search/storage/cache.go
@@ -140,8 +140,8 @@ func addAnnotationWithClusterName(resourceObjects []runtime.Object, clusterName 
 		if annotations == nil {
 			annotations = make(map[string]string)
 		}
-		// TODO: move this annotation key `cluster.karmada.io/name` to the Cluster API.
-		annotations["cluster.karmada.io/name"] = clusterName
+
+		annotations[clusterv1alpha1.CacheSourceAnnotationKey] = clusterName
 
 		resource.SetAnnotations(annotations)
 		resources = append(resources, resource)

--- a/pkg/search/backendstore/opensearch.go
+++ b/pkg/search/backendstore/opensearch.go
@@ -175,7 +175,8 @@ func (os *OpenSearch) upsert(obj interface{}) {
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
-	annotations["cluster.karmada.io/name"] = os.cluster
+
+	annotations[clusterv1alpha1.CacheSourceAnnotationKey] = os.cluster
 	us.SetAnnotations(annotations)
 
 	doc := map[string]interface{}{


### PR DESCRIPTION
Signed-off-by: calvin0327 <wen.chen@daocloud.io>

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Minor modification for code specification.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I've been learning karmada's code, please correct me if not.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-search`: The annotation `cluster.karmada.io/name` which is used to represent the source of cache now has been changed to `resource.karmada.io/cached-from-cluster`.
```

