### PR TITLE
Optimize dependent resourcebinding label. it is easy to over 63 characters. split it into three labels.

### DIFF
--- a/pkg/util/names/names.go
+++ b/pkg/util/names/names.go
@@ -58,6 +58,17 @@ func GenerateBindingName(kind, name string) string {
 	return strings.ToLower(name + "-" + kind)
 }
 
+// SplitBindingName will split binding name to name and kind
+func SplitBindingName(bindingName string) (string, string, error)  {
+	splits := strings.Split(bindingName, "-")
+	if len(splits) < 2 {
+		return "", "", fmt.Errorf("illegal binding name")
+	}
+	kind := splits[len(splits) - 1]
+	name := bindingName[:len(bindingName) - len(kind) - 1]
+	return name, kind, nil
+}
+
 // GenerateBindingReferenceKey will generate the key of binding object with the hash of its namespace and name.
 func GenerateBindingReferenceKey(namespace, name string) string {
 	var bindingName string

--- a/pkg/util/names/names_test.go
+++ b/pkg/util/names/names_test.go
@@ -344,3 +344,53 @@ func TestGenerateImpersonationSecretName(t *testing.T) {
 		}
 	}
 }
+
+func TestSplitBindingName(t *testing.T) {
+	type args struct {
+		bindingName string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		want1   string
+		wantErr bool
+	}{
+		{
+			name:    "test",
+			args:    args{bindingName: "test-Deployment"},
+			want:    "test",
+			want1:   "Deployment",
+			wantErr: false,
+		},
+		{
+			name:    "test1",
+			args:    args{bindingName: "Deployment"},
+			want:    "",
+			want1:   "",
+			wantErr: true,
+		},
+		{
+			name:    "test2",
+			args:    args{bindingName: "test-1-Job"},
+			want:    "test-1",
+			want1:   "Job",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := SplitBindingName(tt.args.bindingName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SplitBindingName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("SplitBindingName() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("SplitBindingName() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

The dependent resourcebinding label value consists of three components namspace+"_"+name+"-"+kind. it is easy to over 63 characters. we need to split it into three labels

**Which issue(s) this PR fixes**:
Fixes #1741

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

