### PR TITLE
add chart lint ci workflow

### DIFF
--- a/.github/workflows/lint-chart.yaml
+++ b/.github/workflows/lint-chart.yaml
@@ -1,0 +1,64 @@
+# validate any chart changes under charts directory
+name: Chart Lint
+
+env:
+  HELM_VERSION: v3.8.1
+  KIND_VERSION: v0.12.0
+  KIND_NODE_IMAGE: kindest/node:v1.23.4
+  K8S_VERSION: v1.23.4
+
+on:
+  push:
+  pull_request:
+    paths:
+      - "charts/karmada/**"
+
+jobs:
+  chart-lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v2.1
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
+      # yamllint (https://github.com/adrienverge/yamllint) which require Python
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+          architecture: x64
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.2.1
+        with:
+          version: v3.6.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$( ct list-changed )
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --debug --check-version-increment=false
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
+        if: steps.list-changed.outputs.changed == 'true'
+        with:
+          wait: 120s
+          version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_NODE_IMAGE }}
+          kubectl_version: ${{ env.K8S_VERSION }}
+
+      - name: Run chart-testing (install)
+        run: ct install --debug --helm-extra-args "--timeout 400s"

--- a/charts/karmada/Chart.yaml
+++ b/charts/karmada/Chart.yaml
@@ -12,17 +12,23 @@ description: A Helm chart for karmada
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-# The optional kubeVersion field can define semver constraints on supported Kubernetes versions. 
-# Helm will validate the version constraints when installing the chart and fail if the cluster 
+# The optional kubeVersion field can define semver constraints on supported Kubernetes versions.
+# Helm will validate the version constraints when installing the chart and fail if the cluster
 # runs an unsupported Kubernetes version.
 kubeVersion: ">= 1.16.0-0"
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: v1.1.0
+
+maintainers:
+  - name: jrkeen
+    email: jrkeen@hotmail.com
+  - name: pidb
+    email: jackson.cloudnative@gmail.com

--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -277,7 +277,7 @@ apiServer:
   ## "ClusterIP" means using ClusterIP
   ## "NodePort" means using NodePort
   serviceType: ClusterIP
-  ## @param apiServer.nodePort node port for apiserver service, 
+  ## @param apiServer.nodePort node port for apiserver service,
   ## will take effect when 'apiServer.serviceType' is 'NodePort'.
   ## If no port is specified, the nodePort will be automatically assigned.
   nodePort: 0
@@ -293,7 +293,7 @@ apiServer:
 ## karmada aggregated apiserver config
 aggregatedApiServer:
   ## @param aggregatedApiServer.labels labels of the karmada-aggregated-apiserver pods
-  labels: 
+  labels:
     app: karmada-aggregated-apiserver
   ## @param aggregatedApiServer.replicaCount target replicas of the karmada-aggregated-apiserver
   replicaCount: 1
@@ -311,7 +311,7 @@ aggregatedApiServer:
     ## @param aggregatedApiServer.image.tag overrides the image tag whose default is the latest
     tag: latest
   ## @param aggregatedApiServer.resources resource quota of the karmada-aggregated-apiserver
-  resources: 
+  resources:
     requests:
       cpu: 100m
     # If you do want to specify resources, uncomment the following
@@ -385,7 +385,7 @@ kubeControllerManager:
 ## etcd config
 etcd:
   ## @param etcd.mode "external" and "internal" are provided
-  ## "external" means use external ectd 
+  ## "external" means use external ectd
   ## "internal" means install a etcd in the cluster
   mode: "internal"
   external:
@@ -481,7 +481,7 @@ agent:
     pullPolicy: IfNotPresent
     ## @param agent.image.tag overrides the image tag whose default is the latest
     tag: latest
-  ## @param agent.resources 
+  ## @param agent.resources
   resources: {}
     # If you do want to specify resources, uncomment the following
     # lines, adjust them as necessary, and remove the curly braces after 'resources:'.


### PR DESCRIPTION
Signed-off-by: calvin0327 <wen.chen@daocloud.io>

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
use [CT](https://github.com/helm/chart-testing)  to validate  chart:
there are three phase:
* `ct changed`:  check the chart file change of chart on target branch
* `ct lint`: check the yaml file format of chart under charts directory
* `ct install`: install chart instant on a kind cluster

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Please correct me if not.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

