### PR TITLE
fix bugs of aggregating job status

### DIFF
--- a/pkg/resourceinterpreter/defaultinterpreter/aggregatestatus.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/aggregatestatus.go
@@ -160,6 +160,11 @@ func aggregateJobStatus(object *unstructured.Unstructured, aggregatedStatusItems
 		return nil, err
 	}
 
+	// If a job is finished, we should never update status again.
+	if finished, _ := helper.GetJobFinishedStatus(&job.Status); finished {
+		return object, nil
+	}
+
 	newStatus, err := helper.ParsingJobStatus(job, aggregatedStatusItems)
 	if err != nil {
 		return nil, err

--- a/pkg/resourceinterpreter/interpreter.go
+++ b/pkg/resourceinterpreter/interpreter.go
@@ -146,6 +146,11 @@ func (i *customResourceInterpreterImpl) Retain(desired *unstructured.Unstructure
 func (i *customResourceInterpreterImpl) AggregateStatus(object *unstructured.Unstructured, aggregatedStatusItems []workv1alpha2.AggregatedStatusItem) (*unstructured.Unstructured, error) {
 	klog.V(4).Infof("Begin to aggregate status for object: %v %s/%s.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 
+	// If status has not been collected, there is no need to aggregate.
+	if len(aggregatedStatusItems) == 0 {
+		return object, nil
+	}
+
 	obj, hookEnabled, err := i.customizedInterpreter.Patch(context.TODO(), &webhook.RequestAttributes{
 		Operation:        configv1alpha1.InterpreterOperationAggregateStatus,
 		Object:           object.DeepCopy(),

--- a/pkg/util/helper/job.go
+++ b/pkg/util/helper/job.go
@@ -36,7 +36,7 @@ func ParsingJobStatus(obj *batchv1.Job, status []workv1alpha2.AggregatedStatusIt
 		newStatus.Succeeded += temp.Succeeded
 		newStatus.Failed += temp.Failed
 
-		isFinished, finishedStatus := getJobFinishedStatus(temp)
+		isFinished, finishedStatus := GetJobFinishedStatus(temp)
 		if isFinished && finishedStatus == batchv1.JobComplete {
 			successfulJobs++
 		} else if isFinished && finishedStatus == batchv1.JobFailed {
@@ -88,9 +88,9 @@ func ParsingJobStatus(obj *batchv1.Job, status []workv1alpha2.AggregatedStatusIt
 	return newStatus, nil
 }
 
-// getJobFinishedStatus checks whether the given Job has finished execution.
+// GetJobFinishedStatus checks whether the given Job has finished execution.
 // It does not discriminate between successful and failed terminations.
-func getJobFinishedStatus(jobStatus *batchv1.JobStatus) (bool, batchv1.JobConditionType) {
+func GetJobFinishedStatus(jobStatus *batchv1.JobStatus) (bool, batchv1.JobConditionType) {
 	for _, c := range jobStatus.Conditions {
 		if (c.Type == batchv1.JobComplete || c.Type == batchv1.JobFailed) && c.Status == corev1.ConditionTrue {
 			return true, c.Type


### PR DESCRIPTION
Signed-off-by: Garrybest <garrybest@foxmail.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When a job is propagated but the status has not been collected, resource interpreter may reflect job status as `Completed`, so we should not reflect status in this circumstance. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Fixed `Job` status might be incorrectly marked as `Completed` issue.
```

