### PR TITLE
Add leaderelection namespace for helm chart

### DIFF
--- a/charts/karmada/templates/karmada-agent.yaml
+++ b/charts/karmada/templates/karmada-agent.yaml
@@ -110,6 +110,7 @@ spec:
             - --karmada-kubeconfig=/etc/kubeconfig/kubeconfig
             - --cluster-name={{ .Values.agent.clusterName }}
             - --cluster-status-update-frequency=10s
+            - --leader-elect-resource-namespace={{ include "karmada.namespace" . }}
             - --v=4
           volumeMounts:
             - name: kubeconfig

--- a/charts/karmada/templates/karmada-controller-manager.yaml
+++ b/charts/karmada/templates/karmada-controller-manager.yaml
@@ -61,6 +61,7 @@ spec:
             - --bind-address=0.0.0.0
             - --cluster-status-update-frequency=10s
             - --secure-port=10357
+            - --leader-elect-resource-namespace={{ include "karmada.namespace" . }}
             - --v=2
           volumeMounts:
           {{- include "karmada.kubeconfig.volumeMount" . | nindent 12 }}

--- a/charts/karmada/templates/karmada-descheduler.yaml
+++ b/charts/karmada/templates/karmada-descheduler.yaml
@@ -50,6 +50,7 @@ spec:
             - /bin/karmada-descheduler
             - --kubeconfig=/etc/kubeconfig
             - --bind-address=0.0.0.0
+            - --leader-elect-resource-namespace={{ include "karmada.namespace" . }}
             - --v=4
           livenessProbe:
             httpGet:

--- a/charts/karmada/templates/karmada-scheduler.yaml
+++ b/charts/karmada/templates/karmada-scheduler.yaml
@@ -60,6 +60,7 @@ spec:
             - --bind-address=0.0.0.0
             - --secure-port=10351
             - --feature-gates=Failover=true
+            - --leader-elect-resource-namespace={{ include "karmada.namespace" . }}
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Since we support installing Karmada via Helm with configurable namespace，when we use namespace which is not Karmada-system, we met errors below:
```
E0613 02:27:46.329703       1 leaderelection.go:334] error initially creating leader election record: namespaces "karmada-system" not found
E0613 02:27:49.110394       1 leaderelection.go:334] error initially creating leader election record: namespaces "karmada-system" not found
E0613 02:27:51.836602       1 leaderelection.go:334] error initially creating leader election record: namespaces "karmada-system" not found
E0613 02:27:54.912496       1 leaderelection.go:334] error initially creating leader election record: namespaces "karmada-system" not found
```
So add leaderelection namespace meanwhile

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None
