### PR TITLE
feature: `deinit` add param of `force`

### DIFF
--- a/pkg/karmadactl/deinit.go
+++ b/pkg/karmadactl/deinit.go
@@ -28,6 +28,7 @@ type CommandDeInitOption struct {
 
 	// DryRun tells if run the command in dry-run mode, without making any server requests.
 	DryRun bool
+	Force  bool
 
 	KubeClientSet *kubernetes.Clientset
 }
@@ -57,6 +58,7 @@ func NewCmdDeInit(parentCommand string) *cobra.Command {
 	flags.StringVar(&opts.KubeConfig, "kubeconfig", "", "Path to the host cluster kubeconfig file.")
 	flags.StringVar(&opts.Context, "context", "", "The name of the kubeconfig context to use")
 	flags.BoolVar(&opts.DryRun, "dry-run", false, "Run the command in dry-run mode, without making any server requests.")
+	flags.BoolVarP(&opts.Force, "force", "f", false, "Reset cluster without prompting for confirmation.")
 	return cmd
 }
 
@@ -282,7 +284,7 @@ func deleteConfirmation() bool {
 func (o *CommandDeInitOption) Run() error {
 	fmt.Println("removes Karmada from Kubernetes")
 	// delete confirmation,exit the delete action when false.
-	if !deleteConfirmation() {
+	if !o.Force && !deleteConfirmation() {
 		return nil
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature
**What this PR does / why we need it**:
`deinit` add param of `force`

Easy automation tool integration

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: Added `--force` flag to `deinit` to skip confirmation.
```

