### PR TITLE
Skip updating lease for push mode clusters

### DIFF
--- a/pkg/controllers/cluster/cluster_controller.go
+++ b/pkg/controllers/cluster/cluster_controller.go
@@ -420,6 +420,10 @@ func (c *Controller) tryUpdateClusterHealth(ctx context.Context, cluster *cluste
 		}
 	}
 
+	if cluster.Spec.SyncMode == clusterv1alpha1.Push {
+		return observedReadyCondition, currentReadyCondition, nil
+	}
+
 	// Always update the probe time if cluster lease is renewed.
 	// Note: If cluster-status-controller never posted the cluster status, but continues renewing the
 	// heartbeat leases, the cluster controller will assume the cluster is healthy and take no action.

--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -156,8 +156,10 @@ func (c *ClusterStatusController) syncClusterStatus(cluster *clusterv1alpha1.Clu
 			klog.Errorf("Failed to get or create informer for Cluster %s. Error: %v.", cluster.GetName(), err)
 		}
 
-		// init the lease controller for every cluster
-		c.initLeaseController(clusterInformerManager.Context(), cluster)
+		if cluster.Spec.SyncMode == clusterv1alpha1.Pull {
+			// init the lease controller for pull mode clusters
+			c.initLeaseController(clusterInformerManager.Context(), cluster)
+		}
 
 		clusterVersion, err := getKubernetesVersion(clusterClient)
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
It's pointless to update lease for push mode clusters since the cluster status controller is at the control-plane
Meanwhile it's consuming goroutines

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Stopped reporting and refreshing `lease` for clusters with `Push` mode.
```

