### PR TITLE
Performance improve for karmada-controller-manager

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -229,7 +229,11 @@ func startClusterStatusController(ctx controllerscontext.Context) (bool, error) 
 		ClusterFailureThreshold:           ctx.Opts.ClusterFailureThreshold,
 		ClusterCacheSyncTimeout:           ctx.Opts.ClusterCacheSyncTimeout,
 		RateLimiterOptions:                ctx.Opts.RateLimiterOptions,
+		ClusterSummaryCache:               *status.NewClusterSummaryCache(),
+		WorkerNumber:                      10,
+		RESTMapper:                        ctx.Mgr.GetRESTMapper(),
 	}
+	clusterStatusController.RunWorkQueue()
 	if err := clusterStatusController.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err
 	}

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -237,7 +237,11 @@ func startClusterStatusController(ctx controllerscontext.Context) (enabled bool,
 		ClusterFailureThreshold:           opts.ClusterFailureThreshold,
 		ClusterCacheSyncTimeout:           opts.ClusterCacheSyncTimeout,
 		RateLimiterOptions:                ctx.Opts.RateLimiterOptions,
+		ClusterSummaryCache:               *status.NewClusterSummaryCache(),
+		WorkerNumber:                      10,
+		RESTMapper:                        ctx.Mgr.GetRESTMapper(),
 	}
+	clusterStatusController.RunWorkQueue()
 	if err := clusterStatusController.SetupWithManager(mgr); err != nil {
 		return false, err
 	}

--- a/pkg/controllers/status/cluster_resource_summary_cache.go
+++ b/pkg/controllers/status/cluster_resource_summary_cache.go
@@ -1,0 +1,190 @@
+package status
+
+import (
+	"fmt"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/helper"
+	"github.com/karmada-io/karmada/pkg/util/informermanager/keys"
+)
+
+type nodeSummary struct {
+	isReady         bool
+	nodeAllocatable corev1.ResourceList
+}
+
+type podSummary struct {
+	isAllocating bool
+	isAllocated  bool
+	podResource  *util.Resource
+}
+
+type singleClusterSummaryCache struct {
+	nodeSummaryMap map[keys.ClusterWideKey]nodeSummary
+	podSummaryMap  map[keys.ClusterWideKey]podSummary
+}
+
+func newSingleClusterSummaryCache() *singleClusterSummaryCache {
+	return &singleClusterSummaryCache{
+		nodeSummaryMap: make(map[keys.ClusterWideKey]nodeSummary),
+		podSummaryMap:  make(map[keys.ClusterWideKey]podSummary),
+	}
+}
+
+func (s *singleClusterSummaryCache) set(clusterWideKey keys.ClusterWideKey, object runtime.Object) error {
+	switch clusterWideKey.Kind {
+	case util.NodeKind:
+		node, err := helper.ConvertToNode(object.(*unstructured.Unstructured))
+		if err != nil {
+			return fmt.Errorf("failed to convert unstructured to typed object: %v", err)
+		}
+
+		s.nodeSummaryMap[clusterWideKey] = nodeSummary{isReady: helper.NodeReady(node), nodeAllocatable: node.Status.Allocatable}
+	case util.PodKind:
+		pod, err := helper.ConvertToPod(object.(*unstructured.Unstructured))
+		if err != nil {
+			return fmt.Errorf("failed to convert unstructured to typed object: %v", err)
+		}
+		s.podSummaryMap[clusterWideKey] = podSummary{isAllocating: isPodAllocating(pod), isAllocated: isPodAllocated(pod), podResource: getPodResource(pod)}
+	}
+
+	return nil
+}
+
+func (s *singleClusterSummaryCache) delete(clusterWideKey keys.ClusterWideKey) {
+	switch clusterWideKey.Kind {
+	case util.NodeKind:
+		delete(s.nodeSummaryMap, clusterWideKey)
+	case util.PodKind:
+		delete(s.podSummaryMap, clusterWideKey)
+	}
+}
+
+// ClusterSummaryCache stores the summary data of nodes and pods in member clusters.
+type ClusterSummaryCache struct {
+	sync.RWMutex
+	clusterSummary map[string]*singleClusterSummaryCache
+}
+
+// NewClusterSummaryCache returns a ClusterSummaryCache for the member clusters.
+func NewClusterSummaryCache() *ClusterSummaryCache {
+	return &ClusterSummaryCache{
+		clusterSummary: make(map[string]*singleClusterSummaryCache),
+	}
+}
+
+func (n *ClusterSummaryCache) set(fedKey keys.FederatedKey, object runtime.Object) error {
+	n.Lock()
+	defer n.Unlock()
+
+	if _, ok := n.clusterSummary[fedKey.Cluster]; !ok {
+		n.clusterSummary[fedKey.Cluster] = newSingleClusterSummaryCache()
+	}
+	if err := n.clusterSummary[fedKey.Cluster].set(fedKey.ClusterWideKey, object); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (n *ClusterSummaryCache) delete(fedKey keys.FederatedKey) {
+	n.Lock()
+	defer n.Unlock()
+
+	if _, ok := n.clusterSummary[fedKey.Cluster]; !ok {
+		return
+	}
+	n.clusterSummary[fedKey.Cluster].delete(fedKey.ClusterWideKey)
+}
+
+func (n *ClusterSummaryCache) deleteCluster(clusterName string) {
+	n.Lock()
+	defer n.Unlock()
+
+	delete(n.clusterSummary, clusterName)
+}
+
+func (n *ClusterSummaryCache) getNodeSummary(clusterName string) (*clusterv1alpha1.NodeSummary, corev1.ResourceList) {
+	n.Lock()
+	defer n.Unlock()
+
+	if _, ok := n.clusterSummary[clusterName]; !ok {
+		return nil, nil
+	}
+
+	totalNum := len(n.clusterSummary[clusterName].nodeSummaryMap)
+	readyNum := 0
+	allocatable := make(corev1.ResourceList)
+
+	for _, node := range n.clusterSummary[clusterName].nodeSummaryMap {
+		if node.isReady {
+			readyNum++
+		}
+		for key, val := range node.nodeAllocatable {
+			tmpCap, ok := allocatable[key]
+			if ok {
+				tmpCap.Add(val)
+			} else {
+				tmpCap = val
+			}
+			allocatable[key] = tmpCap
+		}
+	}
+
+	ns := clusterv1alpha1.NodeSummary{
+		TotalNum: int32(totalNum),
+		ReadyNum: int32(readyNum),
+	}
+	return &ns, allocatable
+}
+
+func (n *ClusterSummaryCache) getPodSummary(clusterName string) (corev1.ResourceList, corev1.ResourceList) {
+	n.Lock()
+	defer n.Unlock()
+
+	if _, ok := n.clusterSummary[clusterName]; !ok {
+		return nil, nil
+	}
+
+	allocatedPodNum := int64(0)
+	allocatingPodNum := int64(0)
+	allocating := util.EmptyResource()
+	allocated := util.EmptyResource()
+
+	for _, pod := range n.clusterSummary[clusterName].podSummaryMap {
+		if pod.isAllocating {
+			allocating.AddResource(pod.podResource)
+			allocatingPodNum++
+		}
+		if pod.isAllocated {
+			allocated.AddResource(pod.podResource)
+			allocatedPodNum++
+		}
+	}
+
+	allocating.AddResourcePods(allocatingPodNum)
+	allocated.AddResourcePods(allocatedPodNum)
+	return allocating.ResourceList(), allocated.ResourceList()
+}
+
+func getPodResource(pod *corev1.Pod) *util.Resource {
+	resource := util.EmptyResource()
+	resource.AddPodRequest(&pod.Spec)
+	return resource
+}
+
+func isPodAllocating(pod *corev1.Pod) bool {
+	return len(pod.Spec.NodeName) == 0
+}
+
+func isPodAllocated(pod *corev1.Pod) bool {
+	if len(pod.Spec.NodeName) != 0 && pod.Status.Phase != corev1.PodSucceeded && pod.Status.Phase != corev1.PodFailed {
+		return true
+	}
+	return false
+}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -72,6 +72,8 @@ const (
 
 // Define resource kind.
 const (
+	// NodeKind indicates the target resource is a node
+	NodeKind = "Node"
 	// DeploymentKind indicates the target resource is a deployment
 	DeploymentKind = "Deployment"
 	// ServiceKind indicates the target resource is a service

--- a/pkg/util/helper/unstructured.go
+++ b/pkg/util/helper/unstructured.go
@@ -6,6 +6,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -227,4 +228,21 @@ func ToUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
 		return nil, err
 	}
 	return &unstructured.Unstructured{Object: uncastObj}, nil
+}
+
+// HasObjUpdated judges whether the object has updated.
+func HasObjUpdated(oldObj interface{}, newObj interface{}) bool {
+	oldMetaInfo, err := meta.Accessor(oldObj)
+	if err != nil { //should not happen
+		return false
+	}
+	newMetaInfo, err := meta.Accessor(newObj)
+	if err != nil { //should not happen
+		return false
+	}
+
+	if oldMetaInfo.GetResourceVersion() != newMetaInfo.GetResourceVersion() {
+		return true
+	}
+	return false
 }

--- a/pkg/util/resource.go
+++ b/pkg/util/resource.go
@@ -72,6 +72,21 @@ func (r *Resource) Add(rl corev1.ResourceList) {
 	}
 }
 
+// AddResource is used to add two resources.
+func (r *Resource) AddResource(r1 *Resource) {
+	if r == nil {
+		return
+	}
+
+	r.MilliCPU += r1.MilliCPU
+	r.Memory += r1.Memory
+	r.AllowedPodNumber += r1.AllowedPodNumber
+	r.EphemeralStorage += r1.EphemeralStorage
+	for name, quantity := range r1.ScalarResources {
+		r.AddScalar(name, quantity)
+	}
+}
+
 // Sub is used to subtract two resources.
 // Return error when the minuend is less than the subtrahend.
 func (r *Resource) Sub(rl corev1.ResourceList) error {


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
As is talked in #1858，when member cluster is large(3k nodes, 10w pods), karmada-controller-manager is easy to be OOMkilled and retry to sync nodes and pods again and again.

Based on #2008, I tested the two clusters with 100 nodes and almost 300 pods. We can easily see that in cluster status controllers, list nodes and pods periodicly cost a lot when the cluster is large(a lot of unmarshal works)  according to the frame graph.
![1](https://user-images.githubusercontent.com/26862112/174546135-10ca5731-d532-4fa9-9c4d-d27e331f67dd.PNG)

So I modified the mechanism from full amount list to `watch based on event` to make the memory increase more stable.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

