### PR TITLE
Automated cherry pick of #2023: remove dry-run from GlobalCommandOptions

### DIFF
--- a/pkg/clusterdiscovery/clusterapi/clusterapi.go
+++ b/pkg/clusterdiscovery/clusterapi/clusterapi.go
@@ -187,9 +187,7 @@ func (d *ClusterDetector) joinClusterAPICluster(clusterWideKey keys.ClusterWideK
 		klog.Fatalf("Failed to get cluster-api management cluster rest config. kubeconfig: %s, err: %v", kubeconfigPath, err)
 	}
 	opts := karmadactl.CommandJoinOption{
-		GlobalCommandOptions: options.GlobalCommandOptions{
-			DryRun: false,
-		},
+		DryRun:           false,
 		ClusterNamespace: options.DefaultKarmadaClusterNamespace,
 		ClusterName:      clusterWideKey.Name,
 	}
@@ -206,9 +204,7 @@ func (d *ClusterDetector) joinClusterAPICluster(clusterWideKey keys.ClusterWideK
 func (d *ClusterDetector) unJoinClusterAPICluster(clusterName string) error {
 	klog.Infof("Begin to unJoin cluster-api's Cluster(%s) to karmada", clusterName)
 	opts := karmadactl.CommandUnjoinOption{
-		GlobalCommandOptions: options.GlobalCommandOptions{
-			DryRun: false,
-		},
+		DryRun:           false,
 		ClusterNamespace: options.DefaultKarmadaClusterNamespace,
 		ClusterName:      clusterName,
 		Wait:             options.DefaultKarmadactlCommandDuration,

--- a/pkg/karmadactl/cordon.go
+++ b/pkg/karmadactl/cordon.go
@@ -53,6 +53,8 @@ func NewCmdCordon(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Comm
 	flags := cmd.Flags()
 	opts.GlobalCommandOptions.AddFlags(flags)
 
+	flags.BoolVar(&opts.DryRun, "dry-run", false, "Run the command in dry-run mode, without making any server requests.")
+
 	return cmd
 }
 
@@ -103,6 +105,9 @@ type CommandCordonOption struct {
 
 	// ClusterName is the cluster's name that we are going to join with.
 	ClusterName string
+
+	// DryRun tells if run the command in dry-run mode, without making any server requests.
+	DryRun bool
 }
 
 // Complete ensures that options are valid and marshals them if necessary.

--- a/pkg/karmadactl/join.go
+++ b/pkg/karmadactl/join.go
@@ -103,6 +103,9 @@ type CommandJoinOption struct {
 
 	// ClusterProvider is the cluster's provider.
 	ClusterProvider string
+
+	// DryRun tells if run the command in dry-run mode, without making any server requests.
+	DryRun bool
 }
 
 // Complete ensures that options are valid and marshals them if necessary.
@@ -141,6 +144,7 @@ func (j *CommandJoinOption) AddFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&j.ClusterKubeConfig, "cluster-kubeconfig", "",
 		"Path of the cluster's kubeconfig.")
 	flags.StringVar(&j.ClusterProvider, "cluster-provider", "", "Provider of the joining cluster.")
+	flags.BoolVar(&j.DryRun, "dry-run", false, "Run the command in dry-run mode, without making any server requests.")
 }
 
 // RunJoin is the implementation of the 'join' command.

--- a/pkg/karmadactl/options/global.go
+++ b/pkg/karmadactl/options/global.go
@@ -20,14 +20,10 @@ type GlobalCommandOptions struct {
 	// ClusterContext is the name of the cluster context in control plane KUBECONFIG file.
 	// Default value is the current-context.
 	KarmadaContext string
-
-	// DryRun tells if run the command in dry-run mode, without making any server requests.
-	DryRun bool
 }
 
 // AddFlags adds flags to the specified FlagSet.
 func (o *GlobalCommandOptions) AddFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&o.KubeConfig, "kubeconfig", "", "Path to the control plane kubeconfig file.")
 	flags.StringVar(&o.KarmadaContext, "karmada-context", "", "Name of the cluster context in control plane kubeconfig file.")
-	flags.BoolVar(&o.DryRun, "dry-run", false, "Run the command in dry-run mode, without making any server requests.")
 }

--- a/pkg/karmadactl/promote.go
+++ b/pkg/karmadactl/promote.go
@@ -107,6 +107,9 @@ type CommandPromoteOption struct {
 	// ClusterKubeConfig is the cluster's kubeconfig path.
 	ClusterKubeConfig string
 
+	// DryRun tells if run the command in dry-run mode, without making any server requests.
+	DryRun bool
+
 	resource.FilenameOptions
 
 	JSONYamlPrintFlags *genericclioptions.JSONYamlPrintFlags
@@ -131,6 +134,7 @@ func (o *CommandPromoteOption) AddFlags(flags *pflag.FlagSet) {
 		"Context name of legacy cluster in kubeconfig. Only works when there are multiple contexts in the kubeconfig.")
 	flags.StringVar(&o.ClusterKubeConfig, "cluster-kubeconfig", "",
 		"Path of the legacy cluster's kubeconfig.")
+	flags.BoolVar(&o.DryRun, "dry-run", false, "Run the command in dry-run mode, without making any server requests.")
 }
 
 // Complete ensures that options are valid and marshals them if necessary

--- a/pkg/karmadactl/taint.go
+++ b/pkg/karmadactl/taint.go
@@ -88,6 +88,9 @@ func taintExample(parentCommand string) string {
 type CommandTaintOption struct {
 	options.GlobalCommandOptions
 
+	// DryRun tells if run the command in dry-run mode, without making any server requests.
+	DryRun bool
+
 	resources      []string
 	taintsToAdd    []corev1.Taint
 	taintsToRemove []corev1.Taint
@@ -175,6 +178,7 @@ func (o *CommandTaintOption) AddFlags(flags *pflag.FlagSet) {
 	o.GlobalCommandOptions.AddFlags(flags)
 
 	flags.BoolVar(&o.overwrite, "overwrite", o.overwrite, "If true, allow taints to be overwritten, otherwise reject taint updates that overwrite existing taints.")
+	flags.BoolVar(&o.DryRun, "dry-run", false, "Run the command in dry-run mode, without making any server requests.")
 }
 
 // RunTaint set taints for the clusters

--- a/pkg/karmadactl/unjoin.go
+++ b/pkg/karmadactl/unjoin.go
@@ -85,6 +85,9 @@ type CommandUnjoinOption struct {
 	// ClusterKubeConfig is the cluster's kubeconfig path.
 	ClusterKubeConfig string
 
+	// DryRun tells if run the command in dry-run mode, without making any server requests.
+	DryRun bool
+
 	forceDeletion bool
 
 	// Wait tells maximum command execution time
@@ -126,8 +129,8 @@ func (j *CommandUnjoinOption) AddFlags(flags *pflag.FlagSet) {
 		"Path of the cluster's kubeconfig.")
 	flags.BoolVar(&j.forceDeletion, "force", false,
 		"Delete cluster and secret resources even if resources in the cluster targeted for unjoin are not removed successfully.")
-
 	flags.DurationVar(&j.Wait, "wait", 60*time.Second, "wait for the unjoin command execution process(default 60s), if there is no success after this time, timeout will be returned.")
+	flags.BoolVar(&j.DryRun, "dry-run", false, "Run the command in dry-run mode, without making any server requests.")
 }
 
 // RunUnjoin is the implementation of the 'unjoin' command.

--- a/test/e2e/federatedresourcequota_test.go
+++ b/test/e2e/federatedresourcequota_test.go
@@ -83,9 +83,7 @@ var _ = ginkgo.Describe("FederatedResourceQuota auto-provision testing", func() 
 			ginkgo.By(fmt.Sprintf("Unjoinning cluster: %s", clusterName), func() {
 				karmadaConfig := karmadactl.NewKarmadaConfig(clientcmd.NewDefaultPathOptions())
 				opts := karmadactl.CommandUnjoinOption{
-					GlobalCommandOptions: options.GlobalCommandOptions{
-						DryRun: false,
-					},
+					DryRun:            false,
 					ClusterNamespace:  "karmada-cluster",
 					ClusterName:       clusterName,
 					ClusterContext:    clusterContext,
@@ -113,9 +111,7 @@ var _ = ginkgo.Describe("FederatedResourceQuota auto-provision testing", func() 
 			ginkgo.By(fmt.Sprintf("Joinning cluster: %s", clusterName), func() {
 				karmadaConfig := karmadactl.NewKarmadaConfig(clientcmd.NewDefaultPathOptions())
 				opts := karmadactl.CommandJoinOption{
-					GlobalCommandOptions: options.GlobalCommandOptions{
-						DryRun: false,
-					},
+					DryRun:            false,
 					ClusterNamespace:  "karmada-cluster",
 					ClusterName:       clusterName,
 					ClusterContext:    clusterContext,

--- a/test/e2e/karmadactl_test.go
+++ b/test/e2e/karmadactl_test.go
@@ -294,9 +294,7 @@ var _ = framework.SerialDescribe("Karmadactl unjoin testing", ginkgo.Labels{Need
 		ginkgo.It("Test unjoining not ready cluster", func() {
 			ginkgo.By(fmt.Sprintf("Joinning cluster: %s", clusterName), func() {
 				opts := karmadactl.CommandJoinOption{
-					GlobalCommandOptions: options.GlobalCommandOptions{
-						DryRun: false,
-					},
+					DryRun:            false,
 					ClusterNamespace:  "karmada-cluster",
 					ClusterName:       clusterName,
 					ClusterContext:    clusterContext,
@@ -324,9 +322,7 @@ var _ = framework.SerialDescribe("Karmadactl unjoin testing", ginkgo.Labels{Need
 
 			ginkgo.By(fmt.Sprintf("Unjoinning cluster: %s", clusterName), func() {
 				opts := karmadactl.CommandUnjoinOption{
-					GlobalCommandOptions: options.GlobalCommandOptions{
-						DryRun: false,
-					},
+					DryRun:            false,
 					ClusterNamespace:  "karmada-cluster",
 					ClusterName:       clusterName,
 					ClusterContext:    clusterContext,

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -85,9 +85,7 @@ var _ = ginkgo.Describe("[namespace auto-provision] namespace auto-provision tes
 			ginkgo.By(fmt.Sprintf("Joinning cluster: %s", clusterName), func() {
 				karmadaConfig := karmadactl.NewKarmadaConfig(clientcmd.NewDefaultPathOptions())
 				opts := karmadactl.CommandJoinOption{
-					GlobalCommandOptions: options.GlobalCommandOptions{
-						DryRun: false,
-					},
+					DryRun:            false,
 					ClusterNamespace:  "karmada-cluster",
 					ClusterName:       clusterName,
 					ClusterContext:    clusterContext,
@@ -102,9 +100,7 @@ var _ = ginkgo.Describe("[namespace auto-provision] namespace auto-provision tes
 			ginkgo.By(fmt.Sprintf("Unjoinning cluster: %s", clusterName), func() {
 				karmadaConfig := karmadactl.NewKarmadaConfig(clientcmd.NewDefaultPathOptions())
 				opts := karmadactl.CommandUnjoinOption{
-					GlobalCommandOptions: options.GlobalCommandOptions{
-						DryRun: false,
-					},
+					DryRun:            false,
 					ClusterNamespace:  "karmada-cluster",
 					ClusterName:       clusterName,
 					ClusterContext:    clusterContext,

--- a/test/e2e/rescheduling_test.go
+++ b/test/e2e/rescheduling_test.go
@@ -88,9 +88,7 @@ var _ = ginkgo.Describe("reschedule testing", func() {
 			ginkgo.By(fmt.Sprintf("Joinning cluster: %s", newClusterName), func() {
 				karmadaConfig := karmadactl.NewKarmadaConfig(clientcmd.NewDefaultPathOptions())
 				opts := karmadactl.CommandJoinOption{
-					GlobalCommandOptions: options.GlobalCommandOptions{
-						DryRun: false,
-					},
+					DryRun:            false,
 					ClusterNamespace:  "karmada-cluster",
 					ClusterName:       newClusterName,
 					ClusterContext:    clusterContext,


### PR DESCRIPTION
Cherry pick of #2023 on release-1.2.
#2023: remove dry-run from GlobalCommandOptions
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```release-note
`karmadactl`: Removed `--dry-run` flag from `describe`, `exec` and `log` commands.
```
