### PR TITLE
Manually specify the Zone and Region of the cluster

### DIFF
--- a/pkg/karmadactl/join.go
+++ b/pkg/karmadactl/join.go
@@ -104,6 +104,12 @@ type CommandJoinOption struct {
 	// ClusterProvider is the cluster's provider.
 	ClusterProvider string
 
+	// ClusterRegion represents the region of the cluster locate in.
+	ClusterRegion string
+
+	// ClusterZone represents the zone of the cluster locate in.
+	ClusterZone string
+
 	// DryRun tells if run the command in dry-run mode, without making any server requests.
 	DryRun bool
 }
@@ -144,6 +150,8 @@ func (j *CommandJoinOption) AddFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&j.ClusterKubeConfig, "cluster-kubeconfig", "",
 		"Path of the cluster's kubeconfig.")
 	flags.StringVar(&j.ClusterProvider, "cluster-provider", "", "Provider of the joining cluster.")
+	flags.StringVar(&j.ClusterRegion, "cluster-region", "", "The region of the joining cluster.")
+	flags.StringVar(&j.ClusterZone, "cluster-zone", "", "The zone of the joining cluster")
 	flags.BoolVar(&j.DryRun, "dry-run", false, "Run the command in dry-run mode, without making any server requests.")
 }
 
@@ -333,6 +341,14 @@ func generateClusterInControllerPlane(controlPlaneConfig, clusterConfig *rest.Co
 
 	if opts.ClusterProvider != "" {
 		clusterObj.Spec.Provider = opts.ClusterProvider
+	}
+
+	if opts.ClusterZone != "" {
+		clusterObj.Spec.Zone = opts.ClusterZone
+	}
+
+	if opts.ClusterRegion != "" {
+		clusterObj.Spec.Region = opts.ClusterRegion
 	}
 
 	if clusterConfig.TLSClientConfig.Insecure {


### PR DESCRIPTION
Signed-off-by: chaunceyjiang <chaunceyjiang@gmail.com>

**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

`kubectl-karmada` & `karmadactl`: Introduced `--cluster-zone` and `--cluster-region` flag to `join` command to specify zone and region of joining cluster. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`kubectl-karmada` & `karmadactl`: Introduced `--cluster-zone` and `--cluster-region` flag to `join` command to specify zone and region of joining cluster. 
```

