### PR TITLE
wait cluster status to be ready after exec local-up-karmada.sh

### DIFF
--- a/hack/local-up-karmada.sh
+++ b/hack/local-up-karmada.sh
@@ -142,6 +142,11 @@ kind load docker-image "${REGISTRY}/karmada-agent:${VERSION}" --name="${PULL_MOD
 #step7. deploy karmada agent in pull mode member clusters
 "${REPO_ROOT}"/hack/deploy-agent-and-estimator.sh "${MAIN_KUBECONFIG}" "${HOST_CLUSTER_NAME}" "${MAIN_KUBECONFIG}" "${KARMADA_APISERVER_CLUSTER_NAME}" "${MEMBER_CLUSTER_KUBECONFIG}" "${PULL_MODE_CLUSTER_NAME}"
 
+# wait all of clusters member1, member2 and member3 status is ready
+util:wait_cluster_ready "${MEMBER_CLUSTER_1_NAME}"
+util:wait_cluster_ready "${MEMBER_CLUSTER_2_NAME}"
+util:wait_cluster_ready "${PULL_MODE_CLUSTER_NAME}"
+
 function print_success() {
   echo -e "$KARMADA_GREETING"
   echo "Local Karmada is running."

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -352,6 +352,24 @@ function util::wait_apiservice_ready() {
     return ${ret}
 }
 
+# util::wait_cluster_ready waits for cluster state becomes ready until timeout.
+# Parmeters:
+#  - $1: cluster name, such as "member1"
+function util:wait_cluster_ready() {
+  local cluster_name=$1
+
+  echo "wait the cluster $cluster_name onBoard..."
+  set +e
+  util::kubectl_with_retry wait --for=condition=Ready --timeout=60s clusters ${cluster_name}
+  ret=$?
+  set -e
+  if [ $ret -ne 0 ];then
+    echo "kubectl describe info:"
+    kubectl describe clusters ${cluster_name}
+  fi
+  return ${ret}
+}
+
 # util::kubectl_with_retry will retry if execute kubectl command failed
 # tolerate kubectl command failure that may happen before the pod is created by  StatefulSet/Deployment.
 function util::kubectl_with_retry() {


### PR DESCRIPTION
Signed-off-by: calvin0327 <wen.chen@daocloud.io>

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When users or e2e exec `local-up-karmada.sh` to install mutils-cluster karmada env.  We should ensure that the three member(member1,member2,member3) clusters have joined the karmada control cluster and there `condition` are all ready.

**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/karmada/issues/2057

**Special notes for your reviewer**:
please correct me if not.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

