### PR TITLE
Add additionalPrinterColumns `KIND` for Work CRD

### DIFF
--- a/charts/karmada/_crds/bases/work/work.karmada.io_works.yaml
+++ b/charts/karmada/_crds/bases/work/work.karmada.io_works.yaml
@@ -20,6 +20,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .spec.workload.manifests[*].kind
+      name: Workload-Kind
+      type: string
     - jsonPath: .status.conditions[?(@.type=="Applied")].status
       name: Applied
       type: string

--- a/pkg/apis/work/v1alpha1/work_types.go
+++ b/pkg/apis/work/v1alpha1/work_types.go
@@ -36,6 +36,7 @@ const (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:categories={karmada-io},shortName=wk
+// +kubebuilder:printcolumn:JSONPath=`.spec.workload.manifests[*].kind`,name="Workload-Kind",type=string
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Applied")].status`,name="Applied",type=string
 // +kubebuilder:printcolumn:JSONPath=`.metadata.creationTimestamp`,name="Age",type=date
 


### PR DESCRIPTION
Signed-off-by: lonelyCZ <531187475@qq.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When we debug, `kubectl get work -A` is only shown the `NAME`, not `KIND`, which will take more time to check the kind of manifests of work.

So directly show the kind by additionalPrinterColumns.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The best is to show all kind of manifests, because it possibly contains multi manifests in one work. But I don't find an easy way to implement it. Now, it only show the first manifests kind.

```
[root@master67 ~]# kapi get work -A
NAMESPACE            NAME                              KIND                 APPLIED   AGE
karmada-es-member1   cert-manager-674b866f4c           Namespace            True      8d
karmada-es-member1   karmada-impersonator-7cbb6bd5c9   ClusterRole          True      8d
karmada-es-member1   karmada-impersonator-84f8c8f8c6   ClusterRoleBinding   True      8d
karmada-es-member1   nginx-7f8d449df9                  Workload             False     8d
karmada-es-member2   cert-manager-674b866f4c           Namespace            True      46d
karmada-es-member2   karmada-impersonator-7cbb6bd5c9   ClusterRole          True      53d
karmada-es-member2   karmada-impersonator-84f8c8f8c6   ClusterRoleBinding   True      53d
karmada-es-member2   nginx-7f8d449df9                  Workload             False     8d
```

/cc @RainbowMango 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Add additionalPrinterColumns KIND for Work CRD
```

