### PR TITLE
sync status of pvc

### DIFF
--- a/docs/userguide/customizing-resource-interpreter.md
+++ b/docs/userguide/customizing-resource-interpreter.md
@@ -98,6 +98,7 @@ Supported resources:
 - DaemonSet(apps/v1)
 - StatefulSet(apps/v1)
 - Pod(v1)
+- PersistentVolumeClaim(v1)
 
 ### InterpretStatus
 

--- a/pkg/util/helper/unstructured.go
+++ b/pkg/util/helper/unstructured.go
@@ -55,6 +55,16 @@ func ConvertToPod(obj *unstructured.Unstructured) (*corev1.Pod, error) {
 	return typedObj, nil
 }
 
+// ConvertToPersistentVolumeClaim converts a pvc object from unstructured to typed.
+func ConvertToPersistentVolumeClaim(obj *unstructured.Unstructured) (*corev1.PersistentVolumeClaim, error) {
+	typedObj := &corev1.PersistentVolumeClaim{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
+		return nil, err
+	}
+
+	return typedObj, nil
+}
+
 // ConvertToNode converts a Node object from unstructured to typed.
 func ConvertToNode(obj *unstructured.Unstructured) (*corev1.Node, error) {
 	typedObj := &corev1.Node{}


### PR DESCRIPTION
Signed-off-by: chaunceyjiang <chaunceyjiang@gmail.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
PVC used frequently. I think that build-in interpreter aggregatestatus should contain PVC

**Which issue(s) this PR fixes**:
Fixes #2065 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`:  `interpreter framework` start to support PVC status aggregation.  
```

