### PR TITLE
[bugfix]Return err when create resource failed

### DIFF
--- a/pkg/util/objectwatcher/objectwatcher.go
+++ b/pkg/util/objectwatcher/objectwatcher.go
@@ -85,7 +85,7 @@ func (o *objectWatcherImpl) Create(clusterName string, desireObj *unstructured.U
 		clusterObj, err := dynamicClusterClient.DynamicClientSet.Resource(gvr).Namespace(desireObj.GetNamespace()).Create(context.TODO(), desireObj, metav1.CreateOptions{})
 		if err != nil {
 			klog.Errorf("Failed to create resource(kind=%s, %s/%s) in cluster %s, err is %v ", desireObj.GetKind(), desireObj.GetNamespace(), desireObj.GetName(), clusterName, err)
-			return nil
+			return err
 		}
 
 		klog.Infof("Created resource(kind=%s, %s/%s) on cluster: %s", desireObj.GetKind(), desireObj.GetNamespace(), desireObj.GetName(), clusterName)


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind bug
/kind failing-test

**What this PR does / why we need it**:

When create failed we need to return error in `objectwatcher.go`.

**Which issue(s) this PR fixes**:
Fixes #2072 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
bugfix: return err when create resource failed
```

