### PR TITLE
[CI] support k8s v1.24 in ci test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        k8s: [v1.21.10, v1.22.7, v1.23.4]
+        k8s: [v1.21.10, v1.22.7, v1.23.4, v1.24.0]
     steps:
       - name: checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Support Kubernetes v1.24 in our CI E2E test.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

