### PR TITLE
avoid required label override by overridepolicy

### DIFF
--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -93,8 +93,6 @@ func ensureWork(
 			return err
 		}
 
-		workLabel := mergeLabel(clonedWorkload, workNamespace, binding, scope)
-
 		if hasScheduledReplica {
 			if resourceInterpreter.HookEnabled(clonedWorkload.GroupVersionKind(), configv1alpha1.InterpreterOperationReviseReplica) {
 				clonedWorkload, err = resourceInterpreter.ReviseReplica(clonedWorkload, desireReplicaInfos[targetCluster.Name])
@@ -124,6 +122,7 @@ func ensureWork(
 			klog.Errorf("Failed to apply overrides for %s/%s/%s, err is: %v", clonedWorkload.GetKind(), clonedWorkload.GetNamespace(), clonedWorkload.GetName(), err)
 			return err
 		}
+		workLabel := mergeLabel(clonedWorkload, workNamespace, binding, scope)
 
 		annotations := mergeAnnotations(clonedWorkload, binding, scope)
 		annotations, err = recordAppliedOverrides(cops, ops, annotations)


### PR DESCRIPTION
Signed-off-by: hanweisen <hanweisen_yewu@cmss.chinamobile.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
label ` work.karmada.io/namespace` is used by `workstatus_controller::getClusterNameFromLabel` for aggregate workload status is possible to be overwritten by `overridepolicy`
here is the example
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  labels:
    app: nginx
spec:
  replicas: 1
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - image: nginx
        name: nginx
---
apiVersion: policy.karmada.io/v1alpha1
kind: PropagationPolicy
metadata:
  name: nginx-propagation
spec:
  resourceSelectors:
    - apiVersion: apps/v1
      kind: Deployment
      name: nginx
  placement:
    clusterAffinity:
      clusterNames:
        - suzhou-app1
```
reference `ClusterOverridePolicy`
```
apiVersion: policy.karmada.io/v1alpha1
kind: ClusterOverridePolicy
metadata:
  name: label-override
spec:
  overrideRules:
  - overriders:
      plaintext:
      - operator: add
        path: /spec/template/metadata/labels
        value:
          cluster: suzhou-app1
      - operator: add
        path: /metadata/labels
        value:
          cluster: suzhou-app1
      - operator: add
        path: /spec/selector/matchLabels
        value:
          cluster: suzhou-app1
    targetCluster:
      clusterNames:
      - suzhou-app1
  - overriders:
      plaintext:
      - operator: add
        path: /spec/template/metadata/labels
        value:
          cluster: shanghai-app1
      - operator: add
        path: /metadata/labels
        value:
          cluster: shanghai-app1
      - operator: add
        path: /spec/selector/matchLabels
        value:
          cluster: shanghai-app1
    targetCluster:
      clusterNames:
      - shanghai-app1
  - overriders:
      plaintext:
      - operator: add
        path: /spec/template/metadata/labels
        value:
          cluster: beijing-app1
      - operator: add
        path: /metadata/labels
        value:
          cluster: beijing-app1
      - operator: add
        path: /spec/selector/matchLabels
        value:
          cluster: beijing-app1
    targetCluster:
      clusterNames:
      - beijing-app1
  resourceSelectors:
  - apiVersion: apps/v1
    kind: Deployment
```
The work generated by Karmada is
```
apiVersion: work.karmada.io/v1alpha1
kind: Work
metadata:
  annotations:
    policy.karmada.io/applied-cluster-overrides: '[{"policyName":"label-override","overriders":{"plaintext":[{"path":"/spec/template/metadata/labels","operator":"add","value":{"cluster":"suzhou-app1"}},{"path":"/metadata/labels","operator":"add","value":{"cluster":"suzhou-app1"}},{"path":"/spec/selector/matchLabels","operator":"add","value":{"cluster":"suzhou-app1"}}]}}]'
    resourcebinding.karmada.io/name: nginx-deployment
    resourcebinding.karmada.io/namespace: default
  creationTimestamp: "2022-06-28T15:57:52Z"
  finalizers:
  - karmada.io/execution-controller
  generation: 1
  labels:
    resourcebinding.karmada.io/key: 687f7fb96f
  name: nginx-687f7fb96f
  namespace: karmada-es-suzhou-app1
  resourceVersion: "281441"
  uid: 8eb0969d-6be9-423b-a0ef-ad081b258b3d
spec:
  workload:
    manifests:
    - apiVersion: apps/v1
      kind: Deployment
      metadata:
        annotations:
          resourcebinding.karmada.io/name: nginx-deployment
          resourcebinding.karmada.io/namespace: default
        labels:
          cluster: suzhou-app1
        name: nginx
        namespace: default
      spec:
        progressDeadlineSeconds: 600
        replicas: 1
        revisionHistoryLimit: 10
        selector:
          matchLabels:
            cluster: suzhou-app1
        strategy:
          rollingUpdate:
            maxSurge: 25%
            maxUnavailable: 25%
          type: RollingUpdate
        template:
          metadata:
            creationTimestamp: null
            labels:
              cluster: suzhou-app1
          spec:
            containers:
            - image: registry.nexus.com:30031/k8s/library/nginx:1.21.4
              imagePullPolicy: IfNotPresent
              name: nginx
              resources: {}
              terminationMessagePath: /dev/termination-log
              terminationMessagePolicy: File
            dnsPolicy: ClusterFirst
            restartPolicy: Always
            schedulerName: default-scheduler
            securityContext: {}
            terminationGracePeriodSeconds: 30
...
```
we expected is
```
apiVersion: work.karmada.io/v1alpha1
kind: Work
metadata:
  annotations:
    resourcebinding.karmada.io/name: nginx-deployment
    resourcebinding.karmada.io/namespace: default
  creationTimestamp: "2022-06-28T16:17:50Z"
  finalizers:
  - karmada.io/execution-controller
  generation: 1
  labels:
    resourcebinding.karmada.io/key: 687f7fb96f
  name: nginx-687f7fb96f
  namespace: karmada-es-suzhou-app1
  resourceVersion: "283563"
  uid: 9ffa46b4-9876-48b9-a2b0-2a4cb123c840
spec:
  workload:
    manifests:
    - apiVersion: apps/v1
      kind: Deployment
      metadata:
        annotations:
          resourcebinding.karmada.io/name: nginx-deployment
          resourcebinding.karmada.io/namespace: default
        labels:
          cluster: suzhou-app1
          resourcebinding.karmada.io/key: 687f7fb96f
          work.karmada.io/name: nginx-687f7fb96f
          work.karmada.io/namespace: karmada-es-suzhou-app1
        name: nginx
        namespace: default
      spec:
        progressDeadlineSeconds: 600
        replicas: 1
        revisionHistoryLimit: 10
        selector:
          matchLabels:
            cluster: suzhou-app1
        strategy:
          rollingUpdate:
            maxSurge: 25%
            maxUnavailable: 25%
          type: RollingUpdate
        template:
          metadata:
            creationTimestamp: null
            labels:
              cluster: suzhou-app1
          spec:
            containers:
            - image: registry.nexus.com:30031/k8s/library/nginx:1.21.4
              imagePullPolicy: IfNotPresent
              name: nginx
              resources: {}
              terminationMessagePath: /dev/termination-log
              terminationMessagePolicy: File
            dnsPolicy: ClusterFirst
            restartPolicy: Always
            schedulerName: default-scheduler
            securityContext: {}
            terminationGracePeriodSeconds: 30
...
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```


