### PR TITLE
fix ci flake when #1850 has been merged

### DIFF
--- a/test/e2e/karmadactl_test.go
+++ b/test/e2e/karmadactl_test.go
@@ -462,9 +462,7 @@ var _ = framework.SerialDescribe("Karmadactl cordon/uncordon testing", ginkgo.La
 		ginkgo.By(fmt.Sprintf("Joinning cluster: %s", clusterName), func() {
 			karmadaConfig := karmadactl.NewKarmadaConfig(clientcmd.NewDefaultPathOptions())
 			opts := karmadactl.CommandJoinOption{
-				GlobalCommandOptions: options.GlobalCommandOptions{
-					DryRun: false,
-				},
+				DryRun:            false,
 				ClusterNamespace:  "karmada-cluster",
 				ClusterName:       clusterName,
 				ClusterContext:    clusterContext,
@@ -482,9 +480,7 @@ var _ = framework.SerialDescribe("Karmadactl cordon/uncordon testing", ginkgo.La
 		ginkgo.DeferCleanup(func() {
 			ginkgo.By(fmt.Sprintf("Unjoinning cluster: %s", clusterName), func() {
 				opts := karmadactl.CommandUnjoinOption{
-					GlobalCommandOptions: options.GlobalCommandOptions{
-						DryRun: false,
-					},
+					DryRun:            false,
 					ClusterNamespace:  "karmada-cluster",
 					ClusterName:       clusterName,
 					ClusterContext:    clusterContext,
@@ -504,9 +500,7 @@ var _ = framework.SerialDescribe("Karmadactl cordon/uncordon testing", ginkgo.La
 	ginkgo.Context("cordon cluster", func() {
 		ginkgo.BeforeEach(func() {
 			opts := karmadactl.CommandCordonOption{
-				GlobalCommandOptions: options.GlobalCommandOptions{
-					DryRun: false,
-				},
+				DryRun:      false,
 				ClusterName: clusterName,
 			}
 			err := karmadactl.RunCordonOrUncordon(karmadactl.DesiredCordon, karmadaConfig, opts)
@@ -541,9 +535,7 @@ var _ = framework.SerialDescribe("Karmadactl cordon/uncordon testing", ginkgo.La
 
 		ginkgo.It("uncordon cluster", func() {
 			opts := karmadactl.CommandCordonOption{
-				GlobalCommandOptions: options.GlobalCommandOptions{
-					DryRun: false,
-				},
+				DryRun:      false,
 				ClusterName: clusterName,
 			}
 			err := karmadactl.RunCordonOrUncordon(karmadactl.DesiredUnCordon, karmadaConfig, opts)


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind cleanup
/kind failing-test

**What this PR does / why we need it**:

As I comment on https://github.com/karmada-io/karmada/pull/1850#issuecomment-1169494197. When the PR is merged, the PR conflicts with the latest code. However, the CI of the PR is run before the conflicting code is merged. Therefore, the CI is not detected.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

