### PR TITLE
chart: support global image pull secrets

### DIFF
--- a/charts/karmada/README.md
+++ b/charts/karmada/README.md
@@ -158,7 +158,7 @@ helm install karmada-scheduler-estimator -n karmada-system ./charts/karmada
 | Name                      | Description                                     | Value |
 | ------------------------- | ----------------------------------------------- | ----- |
 | `global.imageRegistry`    | Global Docker image registry                    | `""`  |
-
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
 
 ### Common parameters
 

--- a/charts/karmada/templates/_helpers.tpl
+++ b/charts/karmada/templates/_helpers.tpl
@@ -236,10 +236,24 @@ Return the proper karmada internal etcd image name
 {{- end -}}
 
 {{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "karmada.internal.etcd.imagePullSecrets" -}}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.etcd.internal.image) "global" .Values.global) }}
+{{- end -}}
+
+{{/*
 Return the proper karmada agent image name
 */}}
 {{- define "karmada.agent.image" -}}
 {{ include "common.images.image" (dict "imageRoot" .Values.agent.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "karmada.agent.imagePullSecrets" -}}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.agent.image) "global" .Values.global) }}
 {{- end -}}
 
 {{/*
@@ -250,10 +264,24 @@ Return the proper karmada apiServer image name
 {{- end -}}
 
 {{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "karmada.apiServer.imagePullSecrets" -}}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.apiServer.image) "global" .Values.global) }}
+{{- end -}}
+
+{{/*
 Return the proper karmada controllerManager image name
 */}}
 {{- define "karmada.controllerManager.image" -}}
 {{ include "common.images.image" (dict "imageRoot" .Values.controllerManager.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "karmada.controllerManager.imagePullSecrets" -}}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.controllerManager.image) "global" .Values.global) }}
 {{- end -}}
 
 {{/*
@@ -264,10 +292,24 @@ Return the proper karmada descheduler image name
 {{- end -}}
 
 {{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "karmada.descheduler.imagePullSecrets" -}}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.descheduler.image) "global" .Values.global) }}
+{{- end -}}
+
+{{/*
 Return the proper karmada schedulerEstimator image name
 */}}
 {{- define "karmada.schedulerEstimator.image" -}}
 {{ include "common.images.image" (dict "imageRoot" .Values.schedulerEstimator.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "karmada.schedulerEstimator.imagePullSecrets" -}}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.schedulerEstimator.image) "global" .Values.global) }}
 {{- end -}}
 
 {{/*
@@ -278,10 +320,24 @@ Return the proper karmada scheduler image name
 {{- end -}}
 
 {{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "karmada.scheduler.imagePullSecrets" -}}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.scheduler.image) "global" .Values.global) }}
+{{- end -}}
+
+{{/*
 Return the proper karmada webhook image name
 */}}
 {{- define "karmada.webhook.image" -}}
 {{ include "common.images.image" (dict "imageRoot" .Values.webhook.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "karmada.webhook.imagePullSecrets" -}}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.webhook.image) "global" .Values.global) }}
 {{- end -}}
 
 {{/*
@@ -292,10 +348,24 @@ Return the proper karmada aggregatedApiServer image name
 {{- end -}}
 
 {{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "karmada.aggregatedApiServer.imagePullSecrets" -}}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.aggregatedApiServer.image) "global" .Values.global) }}
+{{- end -}}
+
+{{/*
 Return the proper karmada search image name
 */}}
 {{- define "karmada.search.image" -}}
 {{ include "common.images.image" (dict "imageRoot" .Values.search.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "karmada.search.imagePullSecrets" -}}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.search.image) "global" .Values.global) }}
 {{- end -}}
 
 {{/*
@@ -305,5 +375,9 @@ Return the proper karmada kubeControllerManager image name
 {{ include "common.images.image" (dict "imageRoot" .Values.kubeControllerManager.image "global" .Values.global) }}
 {{- end -}}
 
-
-
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "karmada.kubeControllerManager.imagePullSecrets" -}}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.kubeControllerManager.image) "global" .Values.global) }}
+{{- end -}}

--- a/charts/karmada/templates/etcd.yaml
+++ b/charts/karmada/templates/etcd.yaml
@@ -28,6 +28,7 @@ spec:
       labels:
         app: etcd
     spec:
+      {{- include "karmada.internal.etcd.imagePullSecrets" . | nindent 6 }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/charts/karmada/templates/karmada-agent.yaml
+++ b/charts/karmada/templates/karmada-agent.yaml
@@ -84,10 +84,7 @@ spec:
         {{- include "karmada.agent.labels" . | indent 8 }}
         {{- include "karmada.agent.podLabels" . | indent 8 }}
     spec:
-      {{- with .Values.agent.imagePullSecrets }}
-      imagePullSecrets:
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "karmada.agent.imagePullSecrets" . | nindent 6 }}
       {{- with .Values.agent.nodeSelector }}
       nodeSelector:
       {{- toYaml . | nindent 8 }}

--- a/charts/karmada/templates/karmada-aggregated-apiserver.yaml
+++ b/charts/karmada/templates/karmada-aggregated-apiserver.yaml
@@ -27,6 +27,7 @@ spec:
         {{- include "karmada.aggregatedApiserver.labels" . | nindent 8 }}
         {{- include "karmada.aggregatedApiserver.podLabels" . | nindent 8 }}
     spec:
+      {{- include "karmada.aggregatedApiServer.imagePullSecrets" . | nindent 6 }}
       automountServiceAccountToken: false
       containers:
         - name: {{ $name }}-aggregated-apiserver

--- a/charts/karmada/templates/karmada-apiserver.yaml
+++ b/charts/karmada/templates/karmada-apiserver.yaml
@@ -26,10 +26,7 @@ spec:
         {{- include "karmada.apiserver.labels" . | nindent 8 }}
         {{- include "karmada.apiserver.podLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.apiServer.imagePullSecrets }}
-      imagePullSecrets:
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "karmada.apiServer.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: {{ $name }}-apiserver
           image: {{ template "karmada.apiServer.image" . }}

--- a/charts/karmada/templates/karmada-controller-manager.yaml
+++ b/charts/karmada/templates/karmada-controller-manager.yaml
@@ -32,10 +32,7 @@ spec:
         {{- include "karmada.cm.labels" . | nindent 8 }}
         {{- include "karmada.cm.podLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.controllerManager.imagePullSecrets }}
-      imagePullSecrets:
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "karmada.controllerManager.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ $name }}-controller-manager
       {{- with .Values.controllerManager.nodeSelector }}
       nodeSelector:

--- a/charts/karmada/templates/karmada-descheduler.yaml
+++ b/charts/karmada/templates/karmada-descheduler.yaml
@@ -26,10 +26,7 @@ spec:
         {{- include "karmada.descheduler.labels" . | nindent 8 }}
         {{- include "karmada.descheduler.podLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.descheduler.imagePullSecrets }}
-      imagePullSecrets:
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "karmada.descheduler.imagePullSecrets" . | nindent 6 }}
       {{- with .Values.descheduler.nodeSelector }}
       nodeSelector:
       {{- toYaml . | nindent 8 }}

--- a/charts/karmada/templates/karmada-scheduler-estimator.yaml
+++ b/charts/karmada/templates/karmada-scheduler-estimator.yaml
@@ -31,6 +31,7 @@ spec:
         {{- include "karmada.schedulerEstimator.labels" . | nindent 8 }}
         {{- include "karmada.schedulerEstimator.podLabels" . | nindent 8 }}
     spec:
+      {{- include "karmada.schedulerEstimator.imagePullSecrets" . | nindent 6 }}
       {{- with .Values.schedulerEstimator.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}

--- a/charts/karmada/templates/karmada-scheduler.yaml
+++ b/charts/karmada/templates/karmada-scheduler.yaml
@@ -33,10 +33,7 @@ spec:
         {{- include "karmada.scheduler.labels" . | nindent 8 }}
         {{- include "karmada.scheduler.podLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.scheduler.imagePullSecrets }}
-      imagePullSecrets:
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "karmada.scheduler.imagePullSecrets" . | nindent 6 }}
       {{- with .Values.scheduler.nodeSelector }}
       nodeSelector:
       {{- toYaml . | nindent 8 }}

--- a/charts/karmada/templates/karmada-search.yaml
+++ b/charts/karmada/templates/karmada-search.yaml
@@ -23,10 +23,7 @@ spec:
       {{- include "karmada.search.labels" . | nindent 8 }}
       {{- include "karmada.search.podLabels" . | indent 8 }}
     spec:
-      {{- with .Values.search.imagePullSecrets }}
-      imagePullSecrets:
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "karmada.search.imagePullSecrets" . | nindent 6 }}
       {{- with .Values.search.nodeSelector }}
       nodeSelector:
       {{- toYaml . | nindent 8 }}

--- a/charts/karmada/templates/karmada-webhook.yaml
+++ b/charts/karmada/templates/karmada-webhook.yaml
@@ -34,10 +34,7 @@ spec:
         {{- include "karmada.webhook.labels" . | nindent 8 }}
         {{- include "karmada.webhook.podLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.webhook.imagePullSecrets }}
-      imagePullSecrets:
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "karmada.webhook.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ $name }}-webhook
       {{- with .Values.webhook.nodeSelector }}
       nodeSelector:

--- a/charts/karmada/templates/kube-controller-manager.yaml
+++ b/charts/karmada/templates/kube-controller-manager.yaml
@@ -33,10 +33,7 @@ spec:
         {{- include "karmada.kube-cm.labels" . | nindent 8 }}
         {{- include "karmada.kube-cm.podLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.kubeControllerManager.imagePullSecrets }}
-      imagePullSecrets:
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "karmada.kubeControllerManager.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ $name }}-kube-controller-manager
       {{- with .Values.kubeControllerManager.nodeSelector }}
       nodeSelector:

--- a/charts/karmada/templates/pre-install-job.yaml
+++ b/charts/karmada/templates/pre-install-job.yaml
@@ -119,7 +119,7 @@ data:
         {{- include "karmada.crd.patch.webhook.clusterresourcebinding" . | nindent 8 }}
       {{- print "webhook_in_resourcebindings.yaml: " | nindent 6 }} |-
         {{- include "karmada.crd.patch.webhook.resourcebinding" . | nindent 8 }}
-      
+
 ---
 apiVersion: batch/v1
 kind: Job

--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -6,6 +6,10 @@
 global:
   ## @param global.imageRegistry Global Docker image registry
   imageRegistry: ""
+  ## E.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  imagePullSecrets: []
 
 ## @param installMode "host" and "agent" are provided
 ## "host" means install karmada in the control-cluster
@@ -102,12 +106,11 @@ scheduler:
   podAnnotations: {}
   ## @param scheduler.podLabels labels of the scheduler pods
   podLabels: {}
-  ## @param scheduler.imagePullSecrets image pull secret of the scheduler
-  imagePullSecrets: []
   ## @param image.registry karmada scheduler image registry
   ## @param image.repository karmada scheduler image repository
   ## @param image.tag karmada scheduler image tag (immutable tags are recommended)
   ## @param image.pullPolicy karmada scheduler image pull policy
+  ## @param image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
     registry: swr.ap-southeast-1.myhuaweicloud.com
@@ -117,6 +120,13 @@ scheduler:
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##
     pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
   ## @param scheduler.resources resource quota of the scheduler
   resources: {}
     # If you do want to specify resources, uncomment the following
@@ -153,12 +163,11 @@ webhook:
   podAnnotations: {}
   ## @param webhook.podLabels labels of the webhook pods
   podLabels: {}
-  ## @param webhook.imagePullSecrets image pull secret of the webhook
-  imagePullSecrets: []
   ## @param image.registry karmada webhook image registry
   ## @param image.repository karmada webhook image repository
   ## @param image.tag karmada webhook image tag (immutable tags are recommended)
   ## @param image.pullPolicy karmada webhook image pull policy
+  ## @param image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
     registry: swr.ap-southeast-1.myhuaweicloud.com
@@ -168,6 +177,13 @@ webhook:
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##
     pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
   ## @param webhook.resources resource quota of the webhook
   resources: {}
     # If you do want to specify resources, uncomment the following
@@ -204,12 +220,11 @@ controllerManager:
   podAnnotations: {}
   ## @param controllerManager.podLabels labels of the karmada-controller-manager pods
   podLabels: {}
-  ## @param controllerManager.imagePullSecrets image pull secret of the karmada-controller-manager
-  imagePullSecrets: []
   ## @param image.registry karmada controller manager image registry
   ## @param image.repository karmada controller manager image repository
   ## @param image.tag karmada controller manager image tag (immutable tags are recommended)
   ## @param image.pullPolicy karmada controller manager image pull policy
+  ## @param image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
     registry: swr.ap-southeast-1.myhuaweicloud.com
@@ -219,6 +234,13 @@ controllerManager:
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##
     pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
   ## @param controllerManager.resources resource quota of the karmada-controller-manager
   resources: {}
     # If you do want to specify resources, uncomment the following
@@ -255,12 +277,11 @@ apiServer:
   podAnnotations: {}
   ## @param apiServer.podLabels labels of the karmada-apiserver pods
   podLabels: {}
-  ## @param apiServer.imagePullSecrets image pull secret of the karmada-apiserver
-  imagePullSecrets: []
   ## @param image.registry keube-apiserver image registry
   ## @param image.repository keube-apiserver image repository
   ## @param image.tag keube-apiserver image tag (immutable tags are recommended)
   ## @param image.pullPolicy keube-apiserver image pull policy
+  ## @param image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
     registry: k8s.gcr.io
@@ -270,6 +291,13 @@ apiServer:
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##
     pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
   ## @param apiServer.resources resource quota of the karmada-apiserver
   resources: {}
     # If you do want to specify resources, uncomment the following
@@ -330,12 +358,11 @@ aggregatedApiServer:
   podAnnotations: {}
   ## @param aggregatedApiServer.podLabels labels of the karmada-aggregated-apiserver pods
   podLabels: {}
-  ## @param aggregatedApiServer.imagePullSecrets image of the karmada-aggregated-apiserver
-  imagePullSecrets: []
   ## @param image.registry karmada aggregatedApiServer image registry
   ## @param image.repository karmada aggregatedApiServer image repository
   ## @param image.tag karmada aggregatedApiServer image tag (immutable tags are recommended)
   ## @param image.pullPolicy karmada aggregatedApiServer image pull policy
+  ## @param image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
     registry: swr.ap-southeast-1.myhuaweicloud.com
@@ -345,6 +372,13 @@ aggregatedApiServer:
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##
     pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
   ## @param aggregatedApiServer.resources resource quota of the karmada-aggregated-apiserver
   resources:
     requests:
@@ -383,12 +417,11 @@ kubeControllerManager:
   podAnnotations: {}
   ## @param kubeControllerManager.podLabels labels of the kube-controller-manager pods
   podLabels: {}
-  ## @param kubeControllerManager.imagePullSecrets image pull secret of the kube-controller-manager
-  imagePullSecrets: []
   ## @param image.registry kubeControllerManager image registry
   ## @param image.repository kubeControllerManager image repository
   ## @param image.tag kubeControllerManager image tag (immutable tags are recommended)
   ## @param image.pullPolicy kubeControllerManager image pull policy
+  ## @param image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
     registry: k8s.gcr.io
@@ -398,6 +431,13 @@ kubeControllerManager:
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##
     pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
   ## @param kubeControllerManager.resources resource quota of the kube-controller-manager
   resources:
     # If you do want to specify resources, uncomment the following
@@ -519,12 +559,11 @@ agent:
   podAnnotations: {}
   ## @param agent.podLabels labels of the agent pods
   podLabels: {}
-  ## @param agent.imagePullSecrets image pull secret of the agent
-  imagePullSecrets: []
   ## @param image.registry karmada agent image registry
   ## @param image.repository karmada agent image repository
   ## @param image.tag karmada agent image tag (immutable tags are recommended)
   ## @param image.pullPolicy karmada agent image pull policy
+  ## @param image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
     registry: swr.ap-southeast-1.myhuaweicloud.com
@@ -534,6 +573,13 @@ agent:
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##
     pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
   ## @param agent.resources
   resources: {}
     # If you do want to specify resources, uncomment the following
@@ -590,12 +636,11 @@ schedulerEstimator:
   podAnnotations: {}
   ## @param schedulerEstimator.podLabels labels of the scheduler-estimator pods
   podLabels: {}
-  ## @param schedulerEstimator.imagePullSecrets image pull secret of the scheduler-estimator
-  imagePullSecrets: []
   ## @param image.registry karmada schedulerEstimator image registry
   ## @param image.repository karmada schedulerEstimator image repository
   ## @param image.tag karmada schedulerEstimator image tag (immutable tags are recommended)
   ## @param image.pullPolicy karmada schedulerEstimator image pull policy
+  ## @param image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
     registry: swr.ap-southeast-1.myhuaweicloud.com
@@ -605,6 +650,13 @@ schedulerEstimator:
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##
     pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
   ## @param schedulerEstimator.resources resource quota of the scheduler-estimator
   resources: {}
     # If you do want to specify resources, uncomment the following
@@ -641,12 +693,11 @@ descheduler:
   podAnnotations: {}
   ## @param descheduler.podLabels labels of the descheduler pods
   podLabels: {}
-  ## @param descheduler.imagePullSecrets image pull secret of the descheduler
-  imagePullSecrets: []
   ## @param image.registry karmada descheduler image registry
   ## @param image.repository karmada descheduler image repository
   ## @param image.tag karmada descheduler image tag (immutable tags are recommended)
   ## @param image.pullPolicy karmada descheduler image pull policy
+  ## @param image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
     registry: swr.ap-southeast-1.myhuaweicloud.com
@@ -656,6 +707,13 @@ descheduler:
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##
     pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
   ## @param descheduler.resources resource quota of the descheduler
   resources: {}
     # If you do want to specify resources, uncomment the following
@@ -693,12 +751,11 @@ search:
   podAnnotations: {}
   ## @param search.podLabels labels of the search pods
   podLabels: {}
-  ## @param search.imagePullSecrets image pull secret of the search
-  imagePullSecrets: []
   ## @param image.registry karmada search image registry
   ## @param image.repository karmada search image repository
   ## @param image.tag karmada search image tag (immutable tags are recommended)
   ## @param image.pullPolicy karmada search image pull policy
+  ## @param image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
     registry: swr.ap-southeast-1.myhuaweicloud.com
@@ -708,6 +765,13 @@ search:
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##
     pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
   ## @param search.resources resource quota of the search
   resources: {}
     # If you do want to specify resources, uncomment the following


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
If set global image registry, we yet need support global images pull recret.

Test:
<img width="1425" alt="image" src="https://user-images.githubusercontent.com/45745657/176845222-a5804646-e1bf-4849-aaf3-d0c565b7788b.png">

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Please correct me if not

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

