### PR TITLE
Revert PR 2082

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,9 +110,9 @@ release-chart:
 
 .PHONY: test
 test:
-	for s in $(go list ./pkg/...); do if ! go test -race -failfast -v -p 1 $s; then break; fi; done
-	for s in $(go list ./cmd/...); do if ! go test -race -failfast -v -p 1 $s; then break; fi; done
-	for s in $(go list ./examples/...); do if ! go test -race -failfast -v -p 1 $s; then break; fi; done
+	go test --race --v ./pkg/...
+	go test --race --v ./cmd/...
+	go test --race --v ./examples/...
 
 upload-images: images
 	@echo "push images to $(REGISTRY)"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
As mentioned by @ikaven1024 at https://github.com/karmada-io/karmada/pull/2082#issuecomment-1172850852,
The UT test is totally disabled now, revert the change to get it back.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

