### PR TITLE
chart: add startup probe to kube controller

### DIFF
--- a/charts/karmada/templates/kube-controller-manager.yaml
+++ b/charts/karmada/templates/kube-controller-manager.yaml
@@ -73,17 +73,22 @@ spec:
             - --use-service-account-credentials=true
             - --v=5
           image: {{ template "karmada.kubeControllerManager.image" . }}
-          livenessProbe:
-            failureThreshold: 8
+          {{- if .Values.kubeControllerManager.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kubeControllerManager.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               host: 127.0.0.1
               path: /healthz
               port: 10257
               scheme: HTTPS
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 15
+          {{- end }}
+          {{- if .Values.kubeControllerManager.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kubeControllerManager.startupProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              host: 127.0.0.1
+              path: /healthz
+              port: 10257
+              scheme: HTTPS
+          {{- end }}
           imagePullPolicy: {{ .Values.kubeControllerManager.image.pullPolicy }}
           name: kube-controller-manager
           resources:

--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -414,6 +414,39 @@ kubeControllerManager:
   affinity: {}
   ## @param kubeControllerManager.tolerations tolerations of the kube-controller-manager
   tolerations: []
+  ## Karmada(&reg;) pods' liveness probe. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ## @param livenessProbe.enabled Enable livenessProbe
+  ## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  ## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param livenessProbe.successThreshold Success threshold for livenessProbe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 15
+    failureThreshold: 8
+    successThreshold: 1
+  ## Slow starting containers can be protected through startup probes
+  ## Startup probes are available in Kubernetes version 1.16 and above
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes
+  ## @param startupProbe.enabled Enable startupProbe
+  ## @param startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    failureThreshold: 24
     # - key: node-role.kubernetes.io/master
     #   operator: Exists
   ## @param kubeControllerManager.strategy strategy of the kube controller manager


### PR DESCRIPTION
Signed-off-by: calvin <wen.chen@daocloud.io>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Kube controller manager server is not running really and the liveness probe start work already.

**Which issue(s) this PR fixes**:
Fixes # https://github.com/karmada-io/karmada/issues/2110

**Special notes for your reviewer**:
There are test result:
Before:
![](https://user-images.githubusercontent.com/45745657/177084621-2367a211-0585-4bb0-a1f4-845689e4a38c.png)

Now:
<img width="1266" alt="image" src="https://user-images.githubusercontent.com/45745657/177093603-54892b6f-328b-4d22-8928-2586a0474494.png">



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

