### PR TITLE
improve karmadactl description

### DIFF
--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	initShort = `install karmada in kubernetes.`
-	initLong  = `install karmada in kubernetes.`
+	initShort = `Install karmada in kubernetes.`
+	initLong  = `Install karmada in kubernetes.`
 )
 
 // NewCmdInit install karmada on kubernetes

--- a/pkg/karmadactl/deinit.go
+++ b/pkg/karmadactl/deinit.go
@@ -38,8 +38,8 @@ func NewCmdDeInit(parentCommand string) *cobra.Command {
 	opts := CommandDeInitOption{}
 	cmd := &cobra.Command{
 		Use:          "deinit",
-		Short:        "removes Karmada from Kubernetes",
-		Long:         "removes Karmada from Kubernetes",
+		Short:        "Removes Karmada from Kubernetes",
+		Long:         "Removes Karmada from Kubernetes",
 		Example:      deInitExample(parentCommand),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Unify the style of command line descriptions:

```
(⎈ |karmada:kube-system)➜  karmada git:(fix-karmadactl) go run cmd/karmadactl/karmadactl.go
karmadactl controls a Kubernetes Cluster Federation.

Usage:
  karmadactl [flags]
  karmadactl [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  cordon      Mark cluster as unschedulable
  deinit      removes Karmada from Kubernetes
  describe    Show details of a specific resource or group of resources in a cluster
  exec        Execute a command in a container in a cluster
  get         Display one or many resources
  help        Help about any command
  init        install karmada in kubernetes.
  join        Register a cluster to control plane
  logs        Print the logs for a container in a pod in a cluster
  promote     Promote resources from legacy clusters to karmada control plane.
  taint       Update the taints on one or more clusters.
  uncordon    Mark cluster as schedulable
  unjoin      Remove the registration of a cluster from control plane
  version     Print the version information.
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

