### PR TITLE
karmadactl:modify join and unjoin validation

### DIFF
--- a/pkg/karmadactl/unjoin.go
+++ b/pkg/karmadactl/unjoin.go
@@ -2,7 +2,6 @@ package karmadactl
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -50,7 +49,7 @@ func NewCmdUnjoin(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Comm
 			if err := opts.Complete(args); err != nil {
 				return err
 			}
-			if err := opts.Validate(); err != nil {
+			if err := opts.Validate(args); err != nil {
 				return err
 			}
 			if err := RunUnjoin(karmadaConfig, opts); err != nil {
@@ -94,10 +93,9 @@ type CommandUnjoinOption struct {
 // Complete ensures that options are valid and marshals them if necessary.
 func (j *CommandUnjoinOption) Complete(args []string) error {
 	// Get cluster name from the command args.
-	if len(args) == 0 {
-		return errors.New("cluster name is required")
+	if len(args) > 0 {
+		j.ClusterName = args[0]
 	}
-	j.ClusterName = args[0]
 
 	// If '--cluster-context' not specified, take the cluster name as the context.
 	if len(j.ClusterContext) == 0 {
@@ -108,7 +106,13 @@ func (j *CommandUnjoinOption) Complete(args []string) error {
 }
 
 // Validate ensures that command unjoin options are valid.
-func (j *CommandUnjoinOption) Validate() error {
+func (j *CommandUnjoinOption) Validate(args []string) error {
+	if len(args) > 1 {
+		return fmt.Errorf("only the cluster name is allowed as an argument")
+	}
+	if len(j.ClusterName) == 0 {
+		return fmt.Errorf("cluster name is required")
+	}
 	if j.Wait < 0 {
 		return fmt.Errorf(" --wait %v  must be a positive duration, e.g. 1m0s ", j.Wait)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

When we perform join or unjoin, we can enter two or more path parameters, as shown below
```
➜  karmada git:(master) go run cmd/karmadactl/karmadactl.go join foo bar
E0705 21:47:46.045738   75252 run.go:74] "command failed" err="failed to get joining cluster config. error: context \"foo\" does not exist"
exit status 1
```
However, we only allow the user to enter the cluster name, and I understand that Complete() is used to complete the parameter and Validate() is used to check whether the user input is valid, so I put the validation of args into Validate(). errors.New() is no longer used,just use fmt.Errorf().

in this PR, it can be
```
➜  karmada git:(fix-args-validate) go run cmd/karmadactl/karmadactl.go join foo bar
E0705 21:54:21.197735   75411 run.go:74] "command failed" err="only the cluster name is allowed as an argument"
exit status 1

➜  karmada git:(fix-args-validate) go run cmd/karmadactl/karmadactl.go join foo%%% bar
E0705 21:55:13.595812   75475 run.go:74] "command failed" err="[only the cluster name is allowed as an argument, invalid cluster name(foo%%%): a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]"
exit status 1
```
Validate() return aggregate err,It contains error information for validation of multiple parameters

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

