### PR TITLE
karmadactl:modify the cluster parameter from lowercase to uppercase

### DIFF
--- a/pkg/karmadactl/promote.go
+++ b/pkg/karmadactl/promote.go
@@ -41,7 +41,7 @@ func NewCmdPromote(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Com
 	opts.JSONYamlPrintFlags = genericclioptions.NewJSONYamlPrintFlags()
 
 	cmd := &cobra.Command{
-		Use:          "promote <RESOURCE_TYPE> <RESOURCE_NAME> -n <NAME_SPACE> -c <CLUSTER_NAME>",
+		Use:          "promote <RESOURCE_TYPE> <RESOURCE_NAME> -n <NAME_SPACE> -C <CLUSTER_NAME>",
 		Short:        promoteShort,
 		Long:         promoteLong,
 		Example:      promoteExample(parentCommand),
@@ -69,22 +69,22 @@ func NewCmdPromote(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Com
 func promoteExample(parentCommand string) string {
 	example := `
 # Promote deployment(default/nginx) from cluster1 to Karmada` + "\n" +
-		fmt.Sprintf("%s promote deployment nginx -n default -c cluster1", parentCommand) + `
+		fmt.Sprintf("%s promote deployment nginx -n default -C cluster1", parentCommand) + `
 
 # Promote deployment((default/nginx) with gvk from cluster1 to Karmada` + "\n" +
-		fmt.Sprintf("%s promote deployment.v1.apps nginx -n default -c cluster1", parentCommand) + `
+		fmt.Sprintf("%s promote deployment.v1.apps nginx -n default -C cluster1", parentCommand) + `
 
 # Dumps the artifacts but does not deploy them to Karmada, same as 'dry run'` + "\n" +
-		fmt.Sprintf("%s promote deployment nginx -n default -c cluster1 -o yaml|json", parentCommand) + `
+		fmt.Sprintf("%s promote deployment nginx -n default -C cluster1 -o yaml|json", parentCommand) + `
 
 # Promote secret(default/default-token) from cluster1 to Karmada` + "\n" +
-		fmt.Sprintf("%s promote secret default-token -n default -c cluster1", parentCommand) + `
+		fmt.Sprintf("%s promote secret default-token -n default -C cluster1", parentCommand) + `
 		
 # Support to use '--cluster-kubeconfig' to specify the configuration of member cluster` + "\n" +
-		fmt.Sprintf("%s promote deployment nginx -n default -c cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH>", parentCommand) + `
+		fmt.Sprintf("%s promote deployment nginx -n default -C cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH>", parentCommand) + `
 		
 # Support to use '--cluster-kubeconfig' and '--cluster-context' to specify the configuration of member cluster` + "\n" +
-		fmt.Sprintf("%s promote deployment nginx -n default -c cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH> --cluster-context=<CLUSTER_CONTEXT>", parentCommand)
+		fmt.Sprintf("%s promote deployment nginx -n default -C cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH> --cluster-context=<CLUSTER_CONTEXT>", parentCommand)
 	return example
 }
 
@@ -128,7 +128,7 @@ func (o *CommandPromoteOption) AddFlags(flags *pflag.FlagSet) {
 	flags.StringVarP(&o.OutputFormat, "output", "o", "", "Output format. One of: json|yaml")
 
 	flags.StringVarP(&o.Namespace, "namespace", "n", "default", "-n=namespace or -n namespace")
-	flags.StringVarP(&o.Cluster, "cluster", "c", "", "the name of legacy cluster (eg -c=member1)")
+	flags.StringVarP(&o.Cluster, "cluster", "C", "", "the name of legacy cluster (eg -C=member1)")
 	flags.StringVar(&o.ClusterNamespace, "cluster-namespace", options.DefaultKarmadaClusterNamespace, "Namespace in the control plane where member cluster secrets are stored.")
 	flags.StringVar(&o.ClusterContext, "cluster-context", "",
 		"Context name of legacy cluster in kubeconfig. Only works when there are multiple contexts in the kubeconfig.")


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The short usage of cluster parameters lowercase in karmadactl promote different from other modules, all uppercase now
run `karmadactl promote -h`
```
➜  karmada git:(fix-option-lowercase) go run cmd/karmadactl/karmadactl.go promote -h
Promote resources from legacy clusters to karmada control plane. Requires the cluster be joined or registered.

Usage:
  karmadactl promote <RESOURCE_TYPE> <RESOURCE_NAME> -n <NAME_SPACE> -C <CLUSTER_NAME> [flags]

Examples:

# Promote deployment(default/nginx) from cluster1 to Karmada
karmadactl promote deployment nginx -n default -C cluster1

# Promote deployment((default/nginx) with gvk from cluster1 to Karmada
karmadactl promote deployment.v1.apps nginx -n default -C cluster1

# Dumps the artifacts but does not deploy them to Karmada, same as 'dry run'
karmadactl promote deployment nginx -n default -C cluster1 -o yaml|json

# Promote secret(default/default-token) from cluster1 to Karmada
karmadactl promote secret default-token -n default -C cluster1

# Support to use '--cluster-kubeconfig' to specify the configuration of member cluster
karmadactl promote deployment nginx -n default -C cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH>

# Support to use '--cluster-kubeconfig' and '--cluster-context' to specify the configuration of member cluster
karmadactl promote deployment nginx -n default -C cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH> --cluster-context=<CLUSTER_CONTEXT>

Flags:
  -C, --cluster string              the name of legacy cluster (eg -C=member1)
      --cluster-context string      Context name of legacy cluster in kubeconfig. Only works when there are multiple contexts in the kubeconfig.
      --cluster-kubeconfig string   Path of the legacy cluster's kubeconfig.
      --cluster-namespace string    Namespace in the control plane where member cluster secrets are stored. (default "karmada-cluster")
      --dry-run                     Run the command in dry-run mode, without making any server requests.
  -h, --help                        help for promote
      --karmada-context string      Name of the cluster context in control plane kubeconfig file.
  -n, --namespace string            -n=namespace or -n namespace (default "default")
  -o, --output string               Output format. One of: json|yaml

Global Flags:
      --add-dir-header                   If true, adds the file directory to the header of the log messages
      --alsologtostderr                  log to standard error as well as files
      --kubeconfig string                Paths to a kubeconfig. Only required if out-of-cluster.
      --log-backtrace-at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log-dir string                   If non-empty, write log files in this directory
      --log-file string                  If non-empty, use this log file
      --log-file-max-size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
      --logtostderr                      log to standard error instead of files (default true)
      --one-output                       If true, only write logs to their native severity level (vs also writing to each lower severity level)
      --skip-headers                     If true, avoid header prefixes in the log messages
      --skip-log-headers                 If true, avoid headers when opening log files
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
  -v, --v Level                          number for the log level verbosity
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
```

**Which issue(s) this PR fixes**:
Fixes #2131

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: The flag `-c` of sub-command `promote` now has been changed to uppercase `-C`.
```

