### PR TITLE
Automated cherry pick of #2147: Fix check whether deployment propagated to member cluster

### DIFF
--- a/test/e2e/karmadactl_test.go
+++ b/test/e2e/karmadactl_test.go
@@ -262,7 +262,7 @@ var _ = framework.SerialDescribe("Karmadactl unjoin testing", ginkgo.Labels{Need
 				},
 			}, policyv1alpha1.Placement{
 				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-					ClusterNames: []string{deploymentName},
+					ClusterNames: []string{clusterName},
 				},
 			})
 			karmadaConfig = karmadactl.NewKarmadaConfig(clientcmd.NewDefaultPathOptions())
@@ -305,8 +305,13 @@ var _ = framework.SerialDescribe("Karmadactl unjoin testing", ginkgo.Labels{Need
 			})
 			ginkgo.By("Waiting for deployment have been propagated to the member cluster.", func() {
 				klog.Infof("Waiting for deployment(%s/%s) synced on cluster(%s)", deploymentNamespace, deploymentName, clusterName)
+
+				clusterConfig, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				clusterClient := kubernetes.NewForConfigOrDie(clusterConfig)
+
 				gomega.Eventually(func() bool {
-					_, err := kubeClient.AppsV1().Deployments(deploymentNamespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+					_, err := clusterClient.AppsV1().Deployments(deploymentNamespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
 					return err == nil
 				}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 			})


### PR DESCRIPTION
Cherry pick of #2147 on release-1.2.
#2147: Fix check whether deployment propagated to member cluster
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```release-note
NONE
```