### PR TITLE
feat: add cluster agent register flag

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -125,6 +125,8 @@ func run(ctx context.Context, karmadaConfig karmadactl.KarmadaConfig, opts *opti
 		ReportSecrets:      opts.ReportSecrets,
 		ClusterAPIEndpoint: opts.ClusterAPIEndpoint,
 		ProxyServerAddress: opts.ProxyServerAddress,
+		ClusterProvider:    opts.ClusterProvider,
+		ClusterRegion:      opts.ClusterRegion,
 		DryRun:             false,
 		ControlPlaneConfig: controlPlaneRestConfig,
 		ClusterConfig:      clusterConfig,

--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -101,6 +101,12 @@ type Options struct {
 	// - "KubeCredentials,KubeImpersonator": Report both KubeCredentials and KubeImpersonator.
 	// Defaults to "KubeCredentials,KubeImpersonator".
 	ReportSecrets []string
+
+	// ClusterProvider is the cluster's provider.
+	ClusterProvider string
+
+	// ClusterRegion represents the region of the cluster locate in.
+	ClusterRegion string
 }
 
 // NewOptions builds an default scheduler options.
@@ -166,6 +172,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, allControllers []string) {
 	fs.IntVar(&o.ConcurrentWorkSyncs, "concurrent-work-syncs", 5, "The number of Works that are allowed to sync concurrently.")
 	fs.StringSliceVar(&o.ReportSecrets, "report-secrets", []string{"KubeCredentials", "KubeImpersonator"}, "The secrets that are allowed to be reported to the Karmada control plane during registering. Valid values are 'KubeCredentials', 'KubeImpersonator' and 'None'. e.g 'KubeCredentials,KubeImpersonator' or 'None'.")
 	fs.StringVar(&o.MetricsBindAddress, "metrics-bind-address", ":8080", "The TCP address that the controller should bind to for serving prometheus metrics(e.g. 127.0.0.1:8088, :8088)")
+	fs.StringVar(&o.ClusterProvider, "cluster-provider", "", "Provider of the joining cluster. The Karmada scheduler can use this information to spread workloads across providers for higher availability.")
+	fs.StringVar(&o.ClusterRegion, "cluster-region", "", "The region of the joining cluster. The Karmada scheduler can use this information to spread workloads across regions for higher availability.")
 	o.RateLimiterOpts.AddFlags(fs)
 	o.ProfileOpts.AddFlags(fs)
 }

--- a/pkg/karmadactl/join.go
+++ b/pkg/karmadactl/join.go
@@ -124,8 +124,8 @@ func (j *CommandJoinOption) AddFlags(flags *pflag.FlagSet) {
 		"Context name of cluster in kubeconfig. Only works when there are multiple contexts in the kubeconfig.")
 	flags.StringVar(&j.ClusterKubeConfig, "cluster-kubeconfig", "",
 		"Path of the cluster's kubeconfig.")
-	flags.StringVar(&j.ClusterProvider, "cluster-provider", "", "Provider of the joining cluster.")
-	flags.StringVar(&j.ClusterRegion, "cluster-region", "", "The region of the joining cluster.")
+	flags.StringVar(&j.ClusterProvider, "cluster-provider", "", "Provider of the joining cluster. The Karmada scheduler can use this information to spread workloads across providers for higher availability.")
+	flags.StringVar(&j.ClusterRegion, "cluster-region", "", "The region of the joining cluster. The Karmada scheduler can use this information to spread workloads across regions for higher availability.")
 	flags.StringVar(&j.ClusterZone, "cluster-zone", "", "The zone of the joining cluster")
 	flags.BoolVar(&j.DryRun, "dry-run", false, "Run the command in dry-run mode, without making any server requests.")
 }


### PR DESCRIPTION
Signed-off-by: charlesQQ <charles_ali@qq.com>

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
karmada-agent add new flag for registering cluster 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```
`karmada-agent`: Introduced `--cluster-provider` and `--cluster-region` flags to specify cluster-provider and cluster-region during registering.
```

