### PR TITLE
karmadactl describe support the --namespace flag

### DIFF
--- a/pkg/karmadactl/describe.go
+++ b/pkg/karmadactl/describe.go
@@ -54,6 +54,7 @@ func NewCmdDescribe(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Co
 	usage := "containing the resource to describe"
 	cmdutil.AddFilenameOptionFlags(cmd, o.FilenameOptions, usage)
 	cmd.Flags().StringVarP(&o.Cluster, "cluster", "C", "", "Specify a member cluster")
+	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", o.Namespace, "If present, the namespace scope for this CLI request")
 	cmd.Flags().StringVarP(&o.Selector, "selector", "l", o.Selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	cmd.Flags().BoolVarP(&o.AllNamespaces, "all-namespaces", "A", o.AllNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
 	cmd.Flags().BoolVar(&o.DescriberSettings.ShowEvents, "show-events", o.DescriberSettings.ShowEvents, "If true, display events related to the described object.")
@@ -127,10 +128,15 @@ func (o *CommandDescribeOptions) Complete(karmadaConfig KarmadaConfig, args []st
 
 	f := getFactory(o.Cluster, clusterInfo, "")
 
-	o.Namespace, o.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
+	namespace, enforceNamespace, err := f.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return err
 	}
+
+	if o.Namespace == "" {
+		o.Namespace = namespace
+	}
+	o.EnforceNamespace = enforceNamespace
 
 	if o.AllNamespaces {
 		o.EnforceNamespace = false


### PR DESCRIPTION
Signed-off-by: TheStylite <848099532@qq.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

```
(⎈ |karmada:default)➜  karmada git:(fix-karmadactl-describe) karmadactl describe po -C ocp micro-dao-2048-74d69cb547-vjqtr -n demo
Error: unknown shorthand flag: 'n' in -n
(⎈ |karmada:default)➜  karmada git:(fix-karmadactl-describe) kubens demo
Context "karmada" modified.
Active namespace is "demo".
(⎈ |karmada:demo)➜  karmada git:(fix-karmadactl-describe) karmadactl describe po -C ocp micro-dao-2048-74d69cb547-vjqtr
Name:           micro-dao-2048-74d69cb547-vjqtr
Namespace:      demo
Priority:       0
Node:           nodedsp07.ocp.ats.io/10.23.105.11
Start Time:     Thu, 30 Jun 2022 16:13:57 +0800
Labels:         dce.daocloud.io/app=micro-dao-2048
                dce.daocloud.io/component=micro-dao-2048
                pod-template-hash=3082576103
Annotations:    openshift.io/scc: restricted
Status:         Running
IP:             172.13.13.213
IPs:            <none>
Controlled By:  ReplicaSet/micro-dao-2048-74d69cb547
...
(⎈ |karmada:demo)➜  karmada git:(fix-karmadactl-describe) go run cmd/karmadactl/karmadactl.go describe po -C ocp micro-dao-2048-74d69cb547-vjqtr -n demo
Name:           micro-dao-2048-74d69cb547-vjqtr
Namespace:      demo
Priority:       0
Node:           nodedsp07.ocp.ats.io/10.23.105.11
Start Time:     Thu, 30 Jun 2022 16:13:57 +0800
Labels:         dce.daocloud.io/app=micro-dao-2048
                dce.daocloud.io/component=micro-dao-2048
                pod-template-hash=3082576103
...
 
(⎈ |karmada:demo)➜  karmada git:(fix-karmadactl-describe) kubens -
Context "karmada" modified.
Active namespace is "default".
(⎈ |karmada:default)➜  karmada git:(fix-karmadactl-describe) go run cmd/karmadactl/karmadactl.go describe po -C ocp micro-dao-2048-74d69cb547-vjqtr -n demo
Name:           micro-dao-2048-74d69cb547-vjqtr
Namespace:      demo
Priority:       0
Node:           nodedsp07.ocp.ats.io/10.23.105.11
Start Time:     Thu, 30 Jun 2022 16:13:57 +0800
Labels:         dce.daocloud.io/app=micro-dao-2048
                dce.daocloud.io/component=micro-dao-2048
                pod-template-hash=3082576103
Annotations:    openshift.io/scc: restricted
Status:         Running
IP:             172.13.13.213
IPs:            <none>
Controlled By:  ReplicaSet/micro-dao-2048-74d69cb547
...

```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmadactl describe support the --namespace flag
```

