### PR TITLE
karmadactl exec support the namespace flag

### DIFF
--- a/pkg/karmadactl/exec.go
+++ b/pkg/karmadactl/exec.go
@@ -66,6 +66,7 @@ func NewCmdExec(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Comman
 	cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodExecTimeout)
 	cmdutil.AddJsonFilenameFlag(cmd.Flags(), &o.FilenameOptions.Filenames, "to use to exec into the resource")
 	cmd.Flags().StringVarP(&o.Cluster, "cluster", "C", "", "Specify a member cluster")
+	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", o.Namespace, "-n=namespace or -n namespace")
 	cmdutil.AddContainerVarFlags(cmd, &o.ContainerName, o.ContainerName)
 	cmd.Flags().BoolVarP(&o.Stdin, "stdin", "i", o.Stdin, "Pass stdin to the container")
 	cmd.Flags().BoolVarP(&o.TTY, "tty", "t", o.TTY, "Stdin is a TTY")
@@ -197,10 +198,15 @@ func (p *ExecOptions) Complete(karmadaConfig KarmadaConfig, argsIn []string, arg
 
 	f := getFactory(p.Cluster, clusterInfo)
 
-	p.Namespace, p.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
+	namespace, enforceNamespace, err := f.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return err
 	}
+
+	if p.Namespace == "" {
+		p.Namespace = namespace
+	}
+	p.EnforceNamespace = enforceNamespace
 
 	p.ExecutablePodFn = polymorphichelpers.AttachablePodForObjectFn
 


### PR DESCRIPTION
Signed-off-by: xin.li <xin.li@daocloud.io>

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:
karmadactl exec support the namespace flag
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
```shell
$ ./karmadactl -ndefault --kubeconfig=/etc/karmada/karmada-apiserver.config exec -it nginx-f89759699-cv4hl -C local  bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
root@nginx-f89759699-cv4hl:/#
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmadactl exec support the --namespace flag
```

