### PR TITLE
Fixed misleading or outdate comments about --cluster-namespace flag

### DIFF
--- a/pkg/karmadactl/get.go
+++ b/pkg/karmadactl/get.go
@@ -105,7 +105,7 @@ type CommandGetOptions struct {
 	// global flags
 	options.GlobalCommandOptions
 
-	// ClusterNamespace holds the namespace name where the member cluster objects are stored.
+	// ClusterNamespace holds the namespace name where the member cluster secrets are stored.
 	ClusterNamespace string
 
 	Clusters []string
@@ -608,7 +608,7 @@ func (g *CommandGetOptions) watch(watchObjs []WatchObj) error {
 	return nil
 }
 
-//watchMultiClusterObj watch objects in multi clusters by goroutines
+// watchMultiClusterObj watch objects in multi clusters by goroutines
 func (g *CommandGetOptions) watchMultiClusterObj(watchObjs []WatchObj, mapping *meta.RESTMapping, outputObjects *bool, printer printers.ResourcePrinterFunc) {
 	var wg sync.WaitGroup
 

--- a/pkg/karmadactl/join.go
+++ b/pkg/karmadactl/join.go
@@ -64,7 +64,7 @@ func joinExample(parentCommand string) string {
 type CommandJoinOption struct {
 	options.GlobalCommandOptions
 
-	// ClusterNamespace holds the namespace name where the member cluster objects are stored.
+	// ClusterNamespace holds the namespace name where the member cluster secrets are stored.
 	ClusterNamespace string
 
 	// ClusterName is the cluster's name that we are going to join with.

--- a/pkg/karmadactl/options/global.go
+++ b/pkg/karmadactl/options/global.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-//DefaultKarmadaClusterNamespace defines the default namespace where the member cluster secrets are stored.
+// DefaultKarmadaClusterNamespace defines the default namespace where the member cluster secrets are stored.
 const DefaultKarmadaClusterNamespace = "karmada-cluster"
 
 // DefaultKarmadactlCommandDuration defines the default timeout for karmadactl execute

--- a/pkg/karmadactl/promote.go
+++ b/pkg/karmadactl/promote.go
@@ -95,7 +95,7 @@ type CommandPromoteOption struct {
 	// Cluster is the name of legacy cluster
 	Cluster string
 
-	// ClusterNamespace holds the namespace name where the member cluster objects are stored.
+	// ClusterNamespace holds the namespace name where the member cluster secrets are stored.
 	ClusterNamespace string
 
 	// Namespace is the namespace of legacy resource

--- a/pkg/karmadactl/unjoin.go
+++ b/pkg/karmadactl/unjoin.go
@@ -73,7 +73,7 @@ func unjoinExample(parentCommand string) string {
 type CommandUnjoinOption struct {
 	options.GlobalCommandOptions
 
-	// ClusterNamespace holds the namespace name where the member cluster objects are stored.
+	// ClusterNamespace holds namespace where the member cluster secrets are stored
 	ClusterNamespace string
 
 	// ClusterName is the cluster's name that we are going to join with.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR just fixed some misleading and/or outdated comments about `--cluster-namespace` flag.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Found this when I review the #1350.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

