### PR TITLE
fix karmadactl get -C cluster error

### DIFF
--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -89,7 +89,18 @@ type Options struct {
 	MetricsBindAddress string
 
 	RateLimiterOpts ratelimiterflag.Options
-	ProfileOpts     profileflag.Options
+
+	ProfileOpts profileflag.Options
+
+	// ReportSecrets specifies the secrets that are allowed to be reported to the Karmada control plane
+	// during registering.
+	// Valid values are:
+	// - "None": Don't report any secrets.
+	// - "KubeCredentials": Report the secret that contains mandatory credentials to access the member cluster.
+	// - "KubeImpersonator": Report the secret that contains the token of impersonator.
+	// - "KubeCredentials,KubeImpersonator": Report both KubeCredentials and KubeImpersonator.
+	// Defaults to "KubeCredentials,KubeImpersonator".
+	ReportSecrets []string
 }
 
 // NewOptions builds an default scheduler options.
@@ -153,6 +164,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, allControllers []string) {
 	fs.DurationVar(&o.ResyncPeriod.Duration, "resync-period", 0, "Base frequency the informers are resynced.")
 	fs.IntVar(&o.ConcurrentClusterSyncs, "concurrent-cluster-syncs", 5, "The number of Clusters that are allowed to sync concurrently.")
 	fs.IntVar(&o.ConcurrentWorkSyncs, "concurrent-work-syncs", 5, "The number of Works that are allowed to sync concurrently.")
+	fs.StringSliceVar(&o.ReportSecrets, "report-secrets", []string{"KubeCredentials", "KubeImpersonator"}, "The secrets that are allowed to be reported to the Karmada control plane during registering. Valid values are 'KubeCredentials', 'KubeImpersonator' and 'None'. e.g 'KubeCredentials,KubeImpersonator' or 'None'.")
 	fs.StringVar(&o.MetricsBindAddress, "metrics-bind-address", ":8080", "The TCP address that the controller should bind to for serving prometheus metrics(e.g. 127.0.0.1:8088, :8088)")
 	o.RateLimiterOpts.AddFlags(fs)
 	o.ProfileOpts.AddFlags(fs)

--- a/pkg/karmadactl/get.go
+++ b/pkg/karmadactl/get.go
@@ -35,6 +35,7 @@ import (
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
 	"github.com/karmada-io/karmada/pkg/karmadactl/options"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	"github.com/karmada-io/karmada/pkg/util/helper"
@@ -263,7 +264,10 @@ func (g *CommandGetOptions) Run(karmadaConfig KarmadaConfig, cmd *cobra.Command,
 
 	wg.Add(len(g.Clusters))
 	for idx := range g.Clusters {
-		g.setClusterProxyInfo(karmadaRestConfig, g.Clusters[idx], clusterInfos)
+		err = g.setClusterProxyInfo(karmadaRestConfig, g.Clusters[idx], clusterInfos)
+		if err != nil {
+			return err
+		}
 		f := getFactory(g.Clusters[idx], clusterInfos)
 		go g.getObjInfo(&wg, &mux, f, g.Clusters[idx], &objs, &watchObjs, &allErrs, args)
 	}
@@ -936,7 +940,15 @@ func (g *CommandGetOptions) getRBInKarmada(namespace string, config *rest.Config
 }
 
 // setClusterProxyInfo set proxy information of cluster
-func (g *CommandGetOptions) setClusterProxyInfo(karmadaRestConfig *rest.Config, name string, clusterInfos map[string]*ClusterInfo) {
+func (g *CommandGetOptions) setClusterProxyInfo(karmadaRestConfig *rest.Config, name string, clusterInfos map[string]*ClusterInfo) error {
+	clusterClient := karmadaclientset.NewForConfigOrDie(karmadaRestConfig).ClusterV1alpha1().Clusters()
+
+	// check if the cluster exist in karmada control plane
+	_, err := clusterClient.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
 	clusterInfos[name].APIEndpoint = karmadaRestConfig.Host + fmt.Sprintf(proxyURL, name)
 	clusterInfos[name].KubeConfig = g.KubeConfig
 	clusterInfos[name].Context = g.KarmadaContext
@@ -948,6 +960,7 @@ func (g *CommandGetOptions) setClusterProxyInfo(karmadaRestConfig *rest.Config, 
 			clusterInfos[name].KubeConfig = defaultKubeConfig
 		}
 	}
+	return nil
 }
 
 // getClusterInKarmada get cluster info in karmada cluster

--- a/pkg/karmadactl/join.go
+++ b/pkg/karmadactl/join.go
@@ -7,10 +7,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -20,33 +16,12 @@ import (
 	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
 	"github.com/karmada-io/karmada/pkg/karmadactl/options"
 	"github.com/karmada-io/karmada/pkg/util"
-	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 var (
 	joinShort = `Register a cluster to control plane`
 	joinLong  = `Join registers a cluster to control plane.`
 )
-
-var (
-	// Policy rules allowing full access to resources in the cluster or namespace.
-	namespacedPolicyRules = []rbacv1.PolicyRule{
-		{
-			Verbs:     []string{rbacv1.VerbAll},
-			APIGroups: []string{rbacv1.APIGroupAll},
-			Resources: []string{rbacv1.ResourceAll},
-		},
-	}
-	clusterPolicyRules = []rbacv1.PolicyRule{
-		namespacedPolicyRules[0],
-		{
-			NonResourceURLs: []string{rbacv1.NonResourceAll},
-			Verbs:           []string{"get"},
-		},
-	}
-)
-
-var clusterResourceKind = clusterv1alpha1.SchemeGroupVersion.WithKind("Cluster")
 
 // NewCmdJoin defines the `join` command that registers a cluster.
 func NewCmdJoin(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Command {
@@ -188,7 +163,19 @@ func JoinCluster(controlPlaneRestConfig, clusterConfig *rest.Config, opts Comman
 		return err
 	}
 
-	clusterSecret, impersonatorSecret, err := obtainCredentialsFromMemberCluster(clusterKubeClient, opts.ClusterNamespace, opts.ClusterName, opts.DryRun)
+	registerOption := util.ClusterRegisterOption{
+		ClusterNamespace:   opts.ClusterNamespace,
+		ClusterName:        opts.ClusterName,
+		ReportSecrets:      []string{util.KubeCredentials, util.KubeImpersonator},
+		ClusterProvider:    opts.ClusterProvider,
+		ClusterRegion:      opts.ClusterRegion,
+		ClusterZone:        opts.ClusterZone,
+		DryRun:             opts.DryRun,
+		ControlPlaneConfig: controlPlaneRestConfig,
+		ClusterConfig:      clusterConfig,
+	}
+
+	clusterSecret, impersonatorSecret, err := util.ObtainCredentialsFromMemberCluster(clusterKubeClient, registerOption)
 	if err != nil {
 		return err
 	}
@@ -196,8 +183,9 @@ func JoinCluster(controlPlaneRestConfig, clusterConfig *rest.Config, opts Comman
 	if opts.DryRun {
 		return nil
 	}
-
-	err = registerClusterInControllerPlane(opts, controlPlaneRestConfig, clusterConfig, controlPlaneKubeClient, clusterSecret, impersonatorSecret)
+	registerOption.Secret = *clusterSecret
+	registerOption.ImpersonatorSecret = *impersonatorSecret
+	err = util.RegisterClusterInControllerPlane(registerOption, controlPlaneKubeClient, generateClusterInControllerPlane)
 	if err != nil {
 		return err
 	}
@@ -206,137 +194,18 @@ func JoinCluster(controlPlaneRestConfig, clusterConfig *rest.Config, opts Comman
 	return nil
 }
 
-func obtainCredentialsFromMemberCluster(clusterKubeClient kubeclient.Interface, clusterNamespace, clusterName string, dryRun bool) (*corev1.Secret, *corev1.Secret, error) {
-	var err error
-
-	// ensure namespace where the karmada control plane credential be stored exists in cluster.
-	if _, err = util.EnsureNamespaceExist(clusterKubeClient, clusterNamespace, dryRun); err != nil {
-		return nil, nil, err
-	}
-
-	// create a ServiceAccount in cluster.
-	serviceAccountObj := &corev1.ServiceAccount{}
-	serviceAccountObj.Namespace = clusterNamespace
-	serviceAccountObj.Name = names.GenerateServiceAccountName(clusterName)
-	if serviceAccountObj, err = util.EnsureServiceAccountExist(clusterKubeClient, serviceAccountObj, dryRun); err != nil {
-		return nil, nil, err
-	}
-
-	// create a ServiceAccount for impersonation in cluster.
-	impersonationSA := &corev1.ServiceAccount{}
-	impersonationSA.Namespace = clusterNamespace
-	impersonationSA.Name = names.GenerateServiceAccountName("impersonator")
-	if impersonationSA, err = util.EnsureServiceAccountExist(clusterKubeClient, impersonationSA, dryRun); err != nil {
-		return nil, nil, err
-	}
-
-	// create a ClusterRole in cluster.
-	clusterRole := &rbacv1.ClusterRole{}
-	clusterRole.Name = names.GenerateRoleName(serviceAccountObj.Name)
-	clusterRole.Rules = clusterPolicyRules
-	if _, err = ensureClusterRoleExist(clusterKubeClient, clusterRole, dryRun); err != nil {
-		return nil, nil, err
-	}
-
-	// create a ClusterRoleBinding in cluster.
-	clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
-	clusterRoleBinding.Name = clusterRole.Name
-	clusterRoleBinding.Subjects = buildRoleBindingSubjects(serviceAccountObj.Name, serviceAccountObj.Namespace)
-	clusterRoleBinding.RoleRef = buildClusterRoleReference(clusterRole.Name)
-	if _, err = ensureClusterRoleBindingExist(clusterKubeClient, clusterRoleBinding, dryRun); err != nil {
-		return nil, nil, err
-	}
-
-	if dryRun {
-		return nil, nil, nil
-	}
-
-	clusterSecret, err := util.WaitForServiceAccountSecretCreation(clusterKubeClient, serviceAccountObj)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get serviceAccount secret from cluster(%s), error: %v", clusterName, err)
-	}
-
-	impersonatorSecret, err := util.WaitForServiceAccountSecretCreation(clusterKubeClient, impersonationSA)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get serviceAccount secret for impersonation from cluster(%s), error: %v", clusterName, err)
-	}
-
-	return clusterSecret, impersonatorSecret, nil
-}
-
-func registerClusterInControllerPlane(opts CommandJoinOption, controlPlaneRestConfig, clusterConfig *rest.Config, controlPlaneKubeClient kubeclient.Interface, clusterSecret, clusterImpersonatorSecret *corev1.Secret) error {
-	// create secret in control plane
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: opts.ClusterNamespace,
-			Name:      opts.ClusterName,
-		},
-		Data: map[string][]byte{
-			clusterv1alpha1.SecretCADataKey: clusterSecret.Data["ca.crt"],
-			clusterv1alpha1.SecretTokenKey:  clusterSecret.Data[clusterv1alpha1.SecretTokenKey],
-		},
-	}
-
-	secret, err := util.CreateSecret(controlPlaneKubeClient, secret)
-	if err != nil {
-		return fmt.Errorf("failed to create secret in control plane. error: %v", err)
-	}
-
-	// create secret to store impersonation info in control plane
-	impersonatorSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: opts.ClusterNamespace,
-			Name:      names.GenerateImpersonationSecretName(opts.ClusterName),
-		},
-		Data: map[string][]byte{
-			clusterv1alpha1.SecretTokenKey: clusterImpersonatorSecret.Data[clusterv1alpha1.SecretTokenKey],
-		},
-	}
-
-	impersonatorSecret, err = util.CreateSecret(controlPlaneKubeClient, impersonatorSecret)
-	if err != nil {
-		return fmt.Errorf("failed to create impersonator secret in control plane. error: %v", err)
-	}
-
-	cluster, err := generateClusterInControllerPlane(controlPlaneRestConfig, clusterConfig, opts, *secret, *impersonatorSecret)
-	if err != nil {
-		return err
-	}
-
-	// add OwnerReference for secrets.
-	patchSecretBody := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(cluster, clusterResourceKind),
-			},
-		},
-	}
-
-	err = util.PatchSecret(controlPlaneKubeClient, secret.Namespace, secret.Name, types.MergePatchType, patchSecretBody)
-	if err != nil {
-		return fmt.Errorf("failed to patch secret %s/%s, error: %v", secret.Namespace, secret.Name, err)
-	}
-
-	err = util.PatchSecret(controlPlaneKubeClient, impersonatorSecret.Namespace, impersonatorSecret.Name, types.MergePatchType, patchSecretBody)
-	if err != nil {
-		return fmt.Errorf("failed to patch impersonator secret %s/%s, error: %v", impersonatorSecret.Namespace, impersonatorSecret.Name, err)
-	}
-
-	return nil
-}
-
-func generateClusterInControllerPlane(controlPlaneConfig, clusterConfig *rest.Config, opts CommandJoinOption, secret, impersonatorSecret corev1.Secret) (*clusterv1alpha1.Cluster, error) {
+func generateClusterInControllerPlane(opts util.ClusterRegisterOption) (*clusterv1alpha1.Cluster, error) {
 	clusterObj := &clusterv1alpha1.Cluster{}
 	clusterObj.Name = opts.ClusterName
 	clusterObj.Spec.SyncMode = clusterv1alpha1.Push
-	clusterObj.Spec.APIEndpoint = clusterConfig.Host
+	clusterObj.Spec.APIEndpoint = opts.ClusterConfig.Host
 	clusterObj.Spec.SecretRef = &clusterv1alpha1.LocalSecretReference{
-		Namespace: secret.Namespace,
-		Name:      secret.Name,
+		Namespace: opts.Secret.Namespace,
+		Name:      opts.Secret.Name,
 	}
 	clusterObj.Spec.ImpersonatorSecretRef = &clusterv1alpha1.LocalSecretReference{
-		Namespace: impersonatorSecret.Namespace,
-		Name:      impersonatorSecret.Name,
+		Namespace: opts.ImpersonatorSecret.Namespace,
+		Name:      opts.ImpersonatorSecret.Name,
 	}
 
 	if opts.ClusterProvider != "" {
@@ -351,92 +220,23 @@ func generateClusterInControllerPlane(controlPlaneConfig, clusterConfig *rest.Co
 		clusterObj.Spec.Region = opts.ClusterRegion
 	}
 
-	if clusterConfig.TLSClientConfig.Insecure {
+	if opts.ClusterConfig.TLSClientConfig.Insecure {
 		clusterObj.Spec.InsecureSkipTLSVerification = true
 	}
 
-	if clusterConfig.Proxy != nil {
-		url, err := clusterConfig.Proxy(nil)
+	if opts.ClusterConfig.Proxy != nil {
+		url, err := opts.ClusterConfig.Proxy(nil)
 		if err != nil {
 			return nil, fmt.Errorf("clusterConfig.Proxy error, %v", err)
 		}
 		clusterObj.Spec.ProxyURL = url.String()
 	}
 
-	controlPlaneKarmadaClient := karmadaclientset.NewForConfigOrDie(controlPlaneConfig)
+	controlPlaneKarmadaClient := karmadaclientset.NewForConfigOrDie(opts.ControlPlaneConfig)
 	cluster, err := util.CreateClusterObject(controlPlaneKarmadaClient, clusterObj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cluster(%s) object. error: %v", opts.ClusterName, err)
 	}
 
 	return cluster, nil
-}
-
-// ensureClusterRoleExist makes sure that the specific cluster role exist in cluster.
-// If cluster role not exit, just create it.
-func ensureClusterRoleExist(client kubeclient.Interface, clusterRole *rbacv1.ClusterRole, dryRun bool) (*rbacv1.ClusterRole, error) {
-	if dryRun {
-		return clusterRole, nil
-	}
-
-	exist, err := util.IsClusterRoleExist(client, clusterRole.Name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to check if ClusterRole exist. ClusterRole: %s, error: %v", clusterRole.Name, err)
-	}
-	if exist {
-		klog.V(1).Infof("ensure ClusterRole succeed as already exist. ClusterRole: %s", clusterRole.Name)
-		return clusterRole, nil
-	}
-
-	createdObj, err := util.CreateClusterRole(client, clusterRole)
-	if err != nil {
-		return nil, fmt.Errorf("ensure ClusterRole failed due to create failed. ClusterRole: %s, error: %v", clusterRole.Name, err)
-	}
-
-	return createdObj, nil
-}
-
-// ensureClusterRoleBindingExist makes sure that the specific ClusterRoleBinding exist in cluster.
-// If ClusterRoleBinding not exit, just create it.
-func ensureClusterRoleBindingExist(client kubeclient.Interface, clusterRoleBinding *rbacv1.ClusterRoleBinding, dryRun bool) (*rbacv1.ClusterRoleBinding, error) {
-	if dryRun {
-		return clusterRoleBinding, nil
-	}
-
-	exist, err := util.IsClusterRoleBindingExist(client, clusterRoleBinding.Name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to check if ClusterRole exist. ClusterRole: %s, error: %v", clusterRoleBinding.Name, err)
-	}
-	if exist {
-		klog.V(1).Infof("ensure ClusterRole succeed as already exist. ClusterRole: %s", clusterRoleBinding.Name)
-		return clusterRoleBinding, nil
-	}
-
-	createdObj, err := util.CreateClusterRoleBinding(client, clusterRoleBinding)
-	if err != nil {
-		return nil, fmt.Errorf("ensure ClusterRole failed due to create failed. ClusterRole: %s, error: %v", clusterRoleBinding.Name, err)
-	}
-
-	return createdObj, nil
-}
-
-// buildRoleBindingSubjects will generate a subject as per service account.
-// The subject used by RoleBinding or ClusterRoleBinding.
-func buildRoleBindingSubjects(serviceAccountName, serviceAccountNamespace string) []rbacv1.Subject {
-	return []rbacv1.Subject{
-		{
-			Kind:      rbacv1.ServiceAccountKind,
-			Name:      serviceAccountName,
-			Namespace: serviceAccountNamespace,
-		},
-	}
-}
-
-// buildClusterRoleReference will generate a ClusterRole reference.
-func buildClusterRoleReference(roleName string) rbacv1.RoleRef {
-	return rbacv1.RoleRef{
-		APIGroup: rbacv1.GroupName,
-		Kind:     "ClusterRole",
-		Name:     roleName,
-	}
 }

--- a/pkg/util/cluster.go
+++ b/pkg/util/cluster.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"reflect"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -19,7 +21,57 @@ import (
 const (
 	// NamespaceClusterLease is the namespace which cluster lease are stored.
 	NamespaceClusterLease = "karmada-cluster"
+	// KubeCredentials is the secret that contains mandatory credentials whether reported when registering cluster
+	KubeCredentials = "KubeCredentials"
+	// KubeImpersonator is the secret that contains the token of impersonator whether reported when registering cluster
+	KubeImpersonator = "KubeImpersonator"
+	// None is means don't report any secrets.
+	None = "None"
 )
+
+// ClusterRegisterOption represents the option for RegistryCluster.
+type ClusterRegisterOption struct {
+	ClusterNamespace   string
+	ClusterName        string
+	ReportSecrets      []string
+	ClusterAPIEndpoint string
+	ProxyServerAddress string
+	ClusterProvider    string
+	ClusterRegion      string
+	ClusterZone        string
+	DryRun             bool
+
+	ControlPlaneConfig *rest.Config
+	ClusterConfig      *rest.Config
+	Secret             corev1.Secret
+	ImpersonatorSecret corev1.Secret
+}
+
+// IsKubeCredentialsEnabled represents whether report secret
+func (r ClusterRegisterOption) IsKubeCredentialsEnabled() bool {
+	if len(r.ReportSecrets) == 1 && r.ReportSecrets[0] == None {
+		return false
+	}
+	for _, sct := range r.ReportSecrets {
+		if sct == KubeCredentials {
+			return true
+		}
+	}
+	return false
+}
+
+// IsKubeImpersonatorEnabled represents whether report impersonator secret
+func (r ClusterRegisterOption) IsKubeImpersonatorEnabled() bool {
+	if len(r.ReportSecrets) == 1 && r.ReportSecrets[0] == None {
+		return false
+	}
+	for _, sct := range r.ReportSecrets {
+		if sct == KubeImpersonator {
+			return true
+		}
+	}
+	return false
+}
 
 // IsClusterReady tells whether the cluster status in 'Ready' condition.
 func IsClusterReady(clusterStatus *clusterv1alpha1.ClusterStatus) bool {
@@ -36,7 +88,7 @@ func GetCluster(hostClient client.Client, clusterName string) (*clusterv1alpha1.
 }
 
 // CreateClusterObject create cluster object in karmada control plane
-func CreateClusterObject(controlPlaneClient *karmadaclientset.Clientset, clusterObj *clusterv1alpha1.Cluster) (*clusterv1alpha1.Cluster, error) {
+func CreateClusterObject(controlPlaneClient karmadaclientset.Interface, clusterObj *clusterv1alpha1.Cluster) (*clusterv1alpha1.Cluster, error) {
 	cluster, exist, err := GetClusterWithKarmadaClient(controlPlaneClient, clusterObj.Name)
 	if err != nil {
 		return nil, err
@@ -56,12 +108,11 @@ func CreateClusterObject(controlPlaneClient *karmadaclientset.Clientset, cluster
 
 // CreateOrUpdateClusterObject create cluster object in karmada control plane,
 // if cluster object has been existed and different from input clusterObj, update it.
-func CreateOrUpdateClusterObject(controlPlaneClient *karmadaclientset.Clientset, clusterObj *clusterv1alpha1.Cluster, mutate func(*clusterv1alpha1.Cluster)) (*clusterv1alpha1.Cluster, error) {
+func CreateOrUpdateClusterObject(controlPlaneClient karmadaclientset.Interface, clusterObj *clusterv1alpha1.Cluster, mutate func(*clusterv1alpha1.Cluster)) (*clusterv1alpha1.Cluster, error) {
 	cluster, exist, err := GetClusterWithKarmadaClient(controlPlaneClient, clusterObj.Name)
 	if err != nil {
 		return nil, err
 	}
-
 	if exist {
 		if reflect.DeepEqual(cluster.Spec, clusterObj.Spec) {
 			klog.Warningf("cluster(%s) already exist and newest", clusterObj.Name)
@@ -81,7 +132,6 @@ func CreateOrUpdateClusterObject(controlPlaneClient *karmadaclientset.Clientset,
 		klog.Warningf("failed to create cluster(%s). error: %v", clusterObj.Name, err)
 		return nil, err
 	}
-
 	return cluster, nil
 }
 

--- a/pkg/util/cluster_test.go
+++ b/pkg/util/cluster_test.go
@@ -1,0 +1,101 @@
+package util
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
+	karmadaclientsetfake "github.com/karmada-io/karmada/pkg/generated/clientset/versioned/fake"
+)
+
+func newCluster(name string) *clusterv1alpha1.Cluster {
+	return &clusterv1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec:   clusterv1alpha1.ClusterSpec{},
+		Status: clusterv1alpha1.ClusterStatus{},
+	}
+}
+
+func withAPIEndPoint(cluster *clusterv1alpha1.Cluster, apiEndPoint string) *clusterv1alpha1.Cluster {
+	cluster.Spec.APIEndpoint = apiEndPoint
+	return cluster
+}
+
+func withSyncMode(cluster *clusterv1alpha1.Cluster, syncMode clusterv1alpha1.ClusterSyncMode) *clusterv1alpha1.Cluster {
+	cluster.Spec.SyncMode = syncMode
+	return cluster
+}
+
+func TestCreateOrUpdateClusterObject(t *testing.T) {
+	fakeClient := karmadaclientsetfake.NewSimpleClientset()
+	type args struct {
+		controlPlaneClient karmadaclientset.Interface
+		clusterObj         *clusterv1alpha1.Cluster
+		mutate             func(*clusterv1alpha1.Cluster)
+		aop                func() func()
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *clusterv1alpha1.Cluster
+		wantErr bool
+	}{
+		{
+			name: "cluster exist, and update cluster",
+			args: args{
+				controlPlaneClient: fakeClient,
+				clusterObj:         newCluster(ClusterMember1),
+				mutate: func(cluster *clusterv1alpha1.Cluster) {
+					cluster.Spec.SyncMode = clusterv1alpha1.Pull
+				},
+				aop: func() func() {
+					cluster := withAPIEndPoint(newCluster(ClusterMember1), "https://127.0.0.1:6443")
+					_, _ = fakeClient.ClusterV1alpha1().Clusters().Create(context.TODO(), cluster, metav1.CreateOptions{})
+					return func() {
+						_ = fakeClient.ClusterV1alpha1().Clusters().Delete(context.TODO(), cluster.Name, metav1.DeleteOptions{})
+					}
+				},
+			},
+			want: withSyncMode(withAPIEndPoint(newCluster(ClusterMember1), "https://127.0.0.1:6443"), clusterv1alpha1.Pull),
+		},
+		{
+			name: "cluster not exist, and create cluster",
+			args: args{
+				controlPlaneClient: fakeClient,
+				clusterObj:         newCluster(ClusterMember1),
+				mutate: func(cluster *clusterv1alpha1.Cluster) {
+					cluster.Spec.SyncMode = clusterv1alpha1.Pull
+				},
+				aop: func() func() {
+					cluster := withSyncMode(newCluster(ClusterMember1), clusterv1alpha1.Pull)
+					return func() {
+						_ = fakeClient.ClusterV1alpha1().Clusters().Delete(context.TODO(), cluster.Name, metav1.DeleteOptions{})
+					}
+				},
+			},
+			want: withSyncMode(newCluster(ClusterMember1), clusterv1alpha1.Pull),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.args.aop != nil {
+				cancel := tt.args.aop()
+				defer cancel()
+			}
+			got, err := CreateOrUpdateClusterObject(tt.args.controlPlaneClient, tt.args.clusterObj, tt.args.mutate)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateOrUpdateClusterObject() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateOrUpdateClusterObject() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/util/clusterrole.go
+++ b/pkg/util/clusterrole.go
@@ -1,0 +1,78 @@
+package util
+
+import (
+	"fmt"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	kubeclient "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+// EnsureClusterRoleExist makes sure that the specific cluster role exist in cluster.
+// If cluster role not exit, just create it.
+func EnsureClusterRoleExist(client kubeclient.Interface, clusterRole *rbacv1.ClusterRole, dryRun bool) (*rbacv1.ClusterRole, error) {
+	if dryRun {
+		return clusterRole, nil
+	}
+
+	exist, err := IsClusterRoleExist(client, clusterRole.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if ClusterRole exist. ClusterRole: %s, error: %v", clusterRole.Name, err)
+	}
+	if exist {
+		klog.V(1).Infof("ensure ClusterRole succeed as already exist. ClusterRole: %s", clusterRole.Name)
+		return clusterRole, nil
+	}
+
+	createdObj, err := CreateClusterRole(client, clusterRole)
+	if err != nil {
+		return nil, fmt.Errorf("ensure ClusterRole failed due to create failed. ClusterRole: %s, error: %v", clusterRole.Name, err)
+	}
+
+	return createdObj, nil
+}
+
+// EnsureClusterRoleBindingExist makes sure that the specific ClusterRoleBinding exist in cluster.
+// If ClusterRoleBinding not exit, just create it.
+func EnsureClusterRoleBindingExist(client kubeclient.Interface, clusterRoleBinding *rbacv1.ClusterRoleBinding, dryRun bool) (*rbacv1.ClusterRoleBinding, error) {
+	if dryRun {
+		return clusterRoleBinding, nil
+	}
+
+	exist, err := IsClusterRoleBindingExist(client, clusterRoleBinding.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if ClusterRole exist. ClusterRole: %s, error: %v", clusterRoleBinding.Name, err)
+	}
+	if exist {
+		klog.V(1).Infof("ensure ClusterRole succeed as already exist. ClusterRole: %s", clusterRoleBinding.Name)
+		return clusterRoleBinding, nil
+	}
+
+	createdObj, err := CreateClusterRoleBinding(client, clusterRoleBinding)
+	if err != nil {
+		return nil, fmt.Errorf("ensure ClusterRole failed due to create failed. ClusterRole: %s, error: %v", clusterRoleBinding.Name, err)
+	}
+
+	return createdObj, nil
+}
+
+// BuildRoleBindingSubjects will generate a subject as per service account.
+// The subject used by RoleBinding or ClusterRoleBinding.
+func BuildRoleBindingSubjects(serviceAccountName, serviceAccountNamespace string) []rbacv1.Subject {
+	return []rbacv1.Subject{
+		{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      serviceAccountName,
+			Namespace: serviceAccountNamespace,
+		},
+	}
+}
+
+// BuildClusterRoleReference will generate a ClusterRole reference.
+func BuildClusterRoleReference(roleName string) rbacv1.RoleRef {
+	return rbacv1.RoleRef{
+		APIGroup: rbacv1.GroupName,
+		Kind:     "ClusterRole",
+		Name:     roleName,
+	}
+}

--- a/pkg/util/credential.go
+++ b/pkg/util/credential.go
@@ -1,0 +1,166 @@
+package util
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	kubeclient "k8s.io/client-go/kubernetes"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/util/names"
+)
+
+var (
+	clusterResourceKind = clusterv1alpha1.SchemeGroupVersion.WithKind("Cluster")
+
+	// Policy rules allowing full access to resources in the cluster or namespace.
+	namespacedPolicyRules = []rbacv1.PolicyRule{
+		{
+			Verbs:     []string{rbacv1.VerbAll},
+			APIGroups: []string{rbacv1.APIGroupAll},
+			Resources: []string{rbacv1.ResourceAll},
+		},
+	}
+	// ClusterPolicyRules represents cluster policy rules
+	ClusterPolicyRules = []rbacv1.PolicyRule{
+		namespacedPolicyRules[0],
+		{
+			NonResourceURLs: []string{rbacv1.NonResourceAll},
+			Verbs:           []string{"get"},
+		},
+	}
+)
+
+type generateClusterInControllerPlaneFunc func(opts ClusterRegisterOption) (*clusterv1alpha1.Cluster, error)
+
+// ObtainCredentialsFromMemberCluster obtain credentials for member cluster
+func ObtainCredentialsFromMemberCluster(clusterKubeClient kubeclient.Interface, opts ClusterRegisterOption) (*corev1.Secret, *corev1.Secret, error) {
+	var impersonatorSecret *corev1.Secret
+	var clusterSecret *corev1.Secret
+	var err error
+	// ensure namespace where the karmada control plane credential be stored exists in cluster.
+	if _, err = EnsureNamespaceExist(clusterKubeClient, opts.ClusterNamespace, opts.DryRun); err != nil {
+		return nil, nil, err
+	}
+
+	if opts.IsKubeImpersonatorEnabled() {
+		// create a ServiceAccount for impersonation in cluster.
+		impersonationSA := &corev1.ServiceAccount{}
+		impersonationSA.Namespace = opts.ClusterNamespace
+		impersonationSA.Name = names.GenerateServiceAccountName("impersonator")
+		if impersonationSA, err = EnsureServiceAccountExist(clusterKubeClient, impersonationSA, opts.DryRun); err != nil {
+			return nil, nil, err
+		}
+
+		impersonatorSecret, err = WaitForServiceAccountSecretCreation(clusterKubeClient, impersonationSA)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get serviceAccount secret for impersonation from cluster(%s), error: %v", opts.ClusterName, err)
+		}
+	}
+	if opts.IsKubeCredentialsEnabled() {
+		// create a ServiceAccount in cluster.
+		serviceAccountObj := &corev1.ServiceAccount{}
+		serviceAccountObj.Namespace = opts.ClusterNamespace
+		serviceAccountObj.Name = names.GenerateServiceAccountName(opts.ClusterName)
+		if serviceAccountObj, err = EnsureServiceAccountExist(clusterKubeClient, serviceAccountObj, opts.DryRun); err != nil {
+			return nil, nil, err
+		}
+
+		// create a ClusterRole in cluster.
+		clusterRole := &rbacv1.ClusterRole{}
+		clusterRole.Name = names.GenerateRoleName(serviceAccountObj.Name)
+		clusterRole.Rules = ClusterPolicyRules
+		if _, err = EnsureClusterRoleExist(clusterKubeClient, clusterRole, opts.DryRun); err != nil {
+			return nil, nil, err
+		}
+
+		// create a ClusterRoleBinding in cluster.
+		clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
+		clusterRoleBinding.Name = clusterRole.Name
+		clusterRoleBinding.Subjects = BuildRoleBindingSubjects(serviceAccountObj.Name, serviceAccountObj.Namespace)
+		clusterRoleBinding.RoleRef = BuildClusterRoleReference(clusterRole.Name)
+		if _, err = EnsureClusterRoleBindingExist(clusterKubeClient, clusterRoleBinding, opts.DryRun); err != nil {
+			return nil, nil, err
+		}
+		clusterSecret, err = WaitForServiceAccountSecretCreation(clusterKubeClient, serviceAccountObj)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get serviceAccount secret from cluster(%s), error: %v", opts.ClusterName, err)
+		}
+	}
+	if opts.DryRun {
+		return nil, nil, nil
+	}
+	return clusterSecret, impersonatorSecret, nil
+}
+
+// RegisterClusterInControllerPlane represents register cluster in controller plane
+func RegisterClusterInControllerPlane(opts ClusterRegisterOption, controlPlaneKubeClient kubeclient.Interface, generateClusterInControllerPlane generateClusterInControllerPlaneFunc) error {
+	impersonatorSecret := &corev1.Secret{}
+	secret := &corev1.Secret{}
+	var err error
+
+	if opts.IsKubeImpersonatorEnabled() {
+		// create secret to store impersonation info in control plane
+		impersonatorSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: opts.ClusterNamespace,
+				Name:      names.GenerateImpersonationSecretName(opts.ClusterName),
+			},
+			Data: map[string][]byte{
+				clusterv1alpha1.SecretTokenKey: opts.ImpersonatorSecret.Data[clusterv1alpha1.SecretTokenKey],
+			},
+		}
+		impersonatorSecret, err = CreateSecret(controlPlaneKubeClient, impersonatorSecret)
+		if err != nil {
+			return fmt.Errorf("failed to create impersonator secret in control plane. error: %v", err)
+		}
+		opts.ImpersonatorSecret = *impersonatorSecret
+	}
+
+	if opts.IsKubeCredentialsEnabled() {
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: opts.ClusterNamespace,
+				Name:      opts.ClusterName,
+			},
+			Data: map[string][]byte{
+				clusterv1alpha1.SecretCADataKey: opts.Secret.Data["ca.crt"],
+				clusterv1alpha1.SecretTokenKey:  opts.Secret.Data[clusterv1alpha1.SecretTokenKey],
+			},
+		}
+
+		secret, err = CreateSecret(controlPlaneKubeClient, secret)
+		if err != nil {
+			return fmt.Errorf("failed to create secret in control plane. error: %v", err)
+		}
+		opts.Secret = *secret
+	}
+	cluster, err := generateClusterInControllerPlane(opts)
+	if err != nil {
+		return err
+	}
+	patchSecretBody := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(cluster, clusterResourceKind),
+			},
+		},
+	}
+	if opts.IsKubeImpersonatorEnabled() {
+		err = PatchSecret(controlPlaneKubeClient, impersonatorSecret.Namespace, impersonatorSecret.Name, types.MergePatchType, patchSecretBody)
+		if err != nil {
+			return fmt.Errorf("failed to patch impersonator secret %s/%s, error: %v", impersonatorSecret.Namespace, impersonatorSecret.Name, err)
+		}
+	}
+
+	if opts.IsKubeCredentialsEnabled() {
+		err = PatchSecret(controlPlaneKubeClient, secret.Namespace, secret.Name, types.MergePatchType, patchSecretBody)
+		if err != nil {
+			return fmt.Errorf("failed to patch secret %s/%s, error: %v", secret.Namespace, secret.Name, err)
+		}
+	}
+	return nil
+}

--- a/pkg/util/credential_test.go
+++ b/pkg/util/credential_test.go
@@ -1,0 +1,256 @@
+package util
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/util/names"
+)
+
+func TestObtainCredentialsFromMemberCluster(t *testing.T) {
+	type args struct {
+		clusterKubeClient kubernetes.Interface
+		opts              ClusterRegisterOption
+		aop               func(t *testing.T, clusterKubeClient kubernetes.Interface) func()
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *corev1.Secret
+		want1   *corev1.Secret
+		wantErr bool
+	}{
+		{
+			name: "disable report secret",
+			args: args{
+				opts: ClusterRegisterOption{
+					ClusterNamespace: "karmada-cluster",
+					ClusterName:      "member1",
+					ReportSecrets:    []string{KubeImpersonator},
+					DryRun:           false,
+				},
+				aop: func(t *testing.T, clusterKubeClient kubernetes.Interface) func() {
+					stopChan := make(chan struct{})
+					go func(clusterKubeClient kubernetes.Interface) {
+						_ = wait.PollUntil(1*time.Second, func() (done bool, err error) {
+							impersonationSA, err := clusterKubeClient.CoreV1().ServiceAccounts("karmada-cluster").Get(context.TODO(), names.GenerateServiceAccountName("impersonator"), metav1.GetOptions{})
+							if err != nil {
+								t.Logf("get sa failed, err: %v", err)
+								return false, nil
+							}
+							impersonatorSecret := &corev1.Secret{
+								ObjectMeta: metav1.ObjectMeta{Namespace: "karmada-cluster", Name: impersonationSA.Name},
+								Type:       corev1.SecretTypeServiceAccountToken,
+								Data: map[string][]byte{
+									"token": []byte(`impersonatorSecret-token-value`),
+								},
+							}
+							impersonationSA.Secrets = []corev1.ObjectReference{{Kind: "Secret", Namespace: impersonatorSecret.Namespace, Name: impersonatorSecret.Name}}
+							_, _ = clusterKubeClient.CoreV1().ServiceAccounts(impersonationSA.Namespace).Update(context.TODO(), impersonationSA, metav1.UpdateOptions{})
+							_, err = clusterKubeClient.CoreV1().Secrets(impersonatorSecret.Namespace).Create(context.TODO(), impersonatorSecret, metav1.CreateOptions{})
+							if err != nil && apierrors.IsAlreadyExists(err) {
+								_, _ = clusterKubeClient.CoreV1().Secrets(impersonatorSecret.Namespace).Update(context.TODO(), impersonatorSecret, metav1.UpdateOptions{})
+								t.Logf("secret exists and update it")
+							}
+							t.Log("create secret successfully")
+							return true, nil
+						}, stopChan)
+					}(clusterKubeClient)
+					return func() {
+						close(stopChan)
+					}
+				},
+			},
+			want:  nil,
+			want1: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "karmada-cluster", Name: names.GenerateServiceAccountName("impersonator")}, Type: corev1.SecretTypeServiceAccountToken, Data: map[string][]byte{"token": []byte(`impersonatorSecret-token-value`)}},
+		},
+		{
+			name: "report secret enabled",
+			args: args{
+				opts: ClusterRegisterOption{
+					ClusterNamespace: "karmada-cluster",
+					ClusterName:      "member1",
+					ReportSecrets:    []string{KubeImpersonator, KubeCredentials},
+					DryRun:           false,
+				},
+				aop: func(t *testing.T, clusterKubeClient kubernetes.Interface) func() {
+					stopChan := make(chan struct{})
+					go func(clusterKubeClient kubernetes.Interface) {
+						_ = wait.PollUntil(1*time.Second, func() (done bool, err error) {
+							impersonationSA, err := clusterKubeClient.CoreV1().ServiceAccounts("karmada-cluster").Get(context.TODO(), names.GenerateServiceAccountName("impersonator"), metav1.GetOptions{})
+							if err != nil {
+								t.Logf("create impersonationSA failed, err:%v", err)
+								return false, nil
+							}
+							impersonatorSecret := &corev1.Secret{
+								ObjectMeta: metav1.ObjectMeta{Namespace: "karmada-cluster", Name: impersonationSA.Name},
+								Type:       corev1.SecretTypeServiceAccountToken,
+								Data: map[string][]byte{
+									"token": []byte(`impersonatorSecret-token-value`),
+								},
+							}
+							impersonationSA.Secrets = []corev1.ObjectReference{{Kind: "Secret", Namespace: impersonatorSecret.Namespace, Name: impersonatorSecret.Name}}
+							_, _ = clusterKubeClient.CoreV1().ServiceAccounts(impersonationSA.Namespace).Update(context.TODO(), impersonationSA, metav1.UpdateOptions{})
+							_, err = clusterKubeClient.CoreV1().Secrets(impersonatorSecret.Namespace).Create(context.TODO(), impersonatorSecret, metav1.CreateOptions{})
+							if err != nil && apierrors.IsAlreadyExists(err) {
+								_, _ = clusterKubeClient.CoreV1().Secrets(impersonatorSecret.Namespace).Update(context.TODO(), impersonatorSecret, metav1.UpdateOptions{})
+								t.Log("impersonatorSecret exists and update it")
+							}
+							t.Log("create impersonatorSecret successfully")
+
+							serviceAccountObj, err := clusterKubeClient.CoreV1().ServiceAccounts("karmada-cluster").Get(context.TODO(), names.GenerateServiceAccountName("member1"), metav1.GetOptions{})
+							if err != nil {
+								t.Logf("get sa failed, err:%v", err)
+								return false, nil
+							}
+							clusterSecret := &corev1.Secret{
+								ObjectMeta: metav1.ObjectMeta{Namespace: "karmada-cluster", Name: serviceAccountObj.Name},
+								Type:       corev1.SecretTypeServiceAccountToken,
+								Data: map[string][]byte{
+									"token": []byte(`clusterSecret-token-value`),
+								},
+							}
+							serviceAccountObj.Secrets = []corev1.ObjectReference{{Kind: "Secret", Namespace: clusterSecret.Namespace, Name: clusterSecret.Name}}
+							_, _ = clusterKubeClient.CoreV1().ServiceAccounts(serviceAccountObj.Namespace).Update(context.TODO(), serviceAccountObj, metav1.UpdateOptions{})
+							_, err = clusterKubeClient.CoreV1().Secrets(clusterSecret.Namespace).Create(context.TODO(), clusterSecret, metav1.CreateOptions{})
+							if err != nil && apierrors.IsAlreadyExists(err) {
+								_, _ = clusterKubeClient.CoreV1().Secrets(clusterSecret.Namespace).Update(context.TODO(), clusterSecret, metav1.UpdateOptions{})
+								t.Log("secret exist and update it")
+							}
+							t.Log("create clusterSecret successfully")
+							return true, nil
+						}, stopChan)
+					}(clusterKubeClient)
+					return func() {
+						close(stopChan)
+					}
+				},
+			},
+			want: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "karmada-cluster", Name: names.GenerateServiceAccountName("member1")}, Type: corev1.SecretTypeServiceAccountToken, Data: map[string][]byte{
+				"token": []byte(`clusterSecret-token-value`),
+			}},
+			want1: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "karmada-cluster", Name: names.GenerateServiceAccountName("impersonator")}, Type: corev1.SecretTypeServiceAccountToken, Data: map[string][]byte{
+				"token": []byte(`impersonatorSecret-token-value`),
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.args.clusterKubeClient = fake.NewSimpleClientset()
+			if tt.args.aop != nil {
+				cancel := tt.args.aop(t, tt.args.clusterKubeClient)
+				defer cancel()
+			}
+			got, got1, err := ObtainCredentialsFromMemberCluster(tt.args.clusterKubeClient, tt.args.opts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ObtainCredentialsFromMemberCluster() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ObtainCredentialsFromMemberCluster() got = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(got1, tt.want1) {
+				t.Errorf("ObtainCredentialsFromMemberCluster() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+func TestRegisterClusterInControllerPlane(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	type args struct {
+		opts                             ClusterRegisterOption
+		controlPlaneKubeClient           kubernetes.Interface
+		generateClusterInControllerPlane generateClusterInControllerPlaneFunc
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "report secret not enabled",
+			args: args{
+				opts: ClusterRegisterOption{
+					ClusterNamespace:   "karmada-cluster",
+					ClusterName:        "member1",
+					ReportSecrets:      []string{"KubeImpersonator"},
+					DryRun:             false,
+					ControlPlaneConfig: &rest.Config{},
+					ClusterConfig:      &rest.Config{},
+					ImpersonatorSecret: corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "karmada-cluster", Name: names.GenerateImpersonationSecretName("member1")},
+						Data:       map[string][]byte{clusterv1alpha1.SecretTokenKey: []byte("impersonator-secret-token-value")},
+					},
+				},
+				controlPlaneKubeClient: fakeClient,
+				generateClusterInControllerPlane: func(opts ClusterRegisterOption) (*clusterv1alpha1.Cluster, error) {
+					clusterObj := &clusterv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: opts.ClusterName}}
+					clusterObj.Spec.SyncMode = clusterv1alpha1.Pull
+					clusterObj.Spec.APIEndpoint = opts.ClusterAPIEndpoint
+					clusterObj.Spec.ProxyURL = opts.ProxyServerAddress
+					clusterObj.Spec.ImpersonatorSecretRef = &clusterv1alpha1.LocalSecretReference{
+						Namespace: opts.ImpersonatorSecret.Namespace,
+						Name:      opts.ImpersonatorSecret.Name,
+					}
+					return clusterObj, nil
+				},
+			},
+		},
+		{
+			name: "enable report secret",
+			args: args{
+				opts: ClusterRegisterOption{
+					ClusterNamespace:   "karmada-cluster",
+					ClusterName:        "member1",
+					ReportSecrets:      []string{"KubeImpersonator", "KubeCredentials"},
+					DryRun:             false,
+					ControlPlaneConfig: &rest.Config{},
+					ClusterConfig:      &rest.Config{},
+					Secret: corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "karmada-cluster", Name: "member1"},
+						Data:       map[string][]byte{"ca.crt": []byte("ca.crt-values"), clusterv1alpha1.SecretTokenKey: []byte(`secret-token-value`)},
+					},
+					ImpersonatorSecret: corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "karmada-cluster", Name: names.GenerateImpersonationSecretName("member1")},
+						Data:       map[string][]byte{clusterv1alpha1.SecretTokenKey: []byte(`impersonator-secret-token-value`)},
+					},
+				},
+				controlPlaneKubeClient: fakeClient,
+				generateClusterInControllerPlane: func(opts ClusterRegisterOption) (*clusterv1alpha1.Cluster, error) {
+					clusterObj := &clusterv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: opts.ClusterName}}
+					clusterObj.Spec.SyncMode = clusterv1alpha1.Push
+					clusterObj.Spec.APIEndpoint = opts.ClusterAPIEndpoint
+					clusterObj.Spec.ProxyURL = opts.ProxyServerAddress
+					clusterObj.Spec.ImpersonatorSecretRef = &clusterv1alpha1.LocalSecretReference{
+						Namespace: opts.ImpersonatorSecret.Namespace,
+						Name:      opts.ImpersonatorSecret.Name,
+					}
+					clusterObj.Spec.SecretRef = &clusterv1alpha1.LocalSecretReference{
+						Namespace: opts.Secret.Namespace,
+						Name:      opts.Secret.Name,
+					}
+					return clusterObj, nil
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := RegisterClusterInControllerPlane(tt.args.opts, tt.args.controlPlaneKubeClient, tt.args.generateClusterInControllerPlane); (err != nil) != tt.wantErr {
+				t.Errorf("RegisterClusterInControllerPlane() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/util/secret.go
+++ b/pkg/util/secret.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
@@ -15,6 +16,9 @@ import (
 
 // GetTargetSecret will get secrets(type=targetType, namespace=targetNamespace) from a list of secret references.
 func GetTargetSecret(client kubeclient.Interface, secretReferences []corev1.ObjectReference, targetType corev1.SecretType, targetNamespace string) (*corev1.Secret, error) {
+	if len(secretReferences) == 0 {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "secret"}, "")
+	}
 	var errNotFound error
 	for _, objectReference := range secretReferences {
 		klog.V(2).Infof("checking secret: %s/%s", targetNamespace, objectReference.Name)


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
When using karmadactl get to specify a clustername that does not exist in the kubeconfig file, an error is reported:
```shell
$ karmadactl --kubeconfig=/etc/karmada/karmada-apiserver.config get po -C local1
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x1951352]

goroutine 1 [running]:
github.com/karmada-io/karmada/pkg/karmadactl.(*CommandGetOptions).setClusterProxyInfo(0xc000521540, 0xc0000da900, {0xc0001335f0, 0x6}, 0x5)
	/root/karmada/pkg/karmadactl/get.go:940 +0xd2
github.com/karmada-io/karmada/pkg/karmadactl.(*CommandGetOptions).Run(0xc000521540, {0x2092268, 0xc0001420b0}, 0xc0000ebc30, {0xc000642400, 0x1, 0x4})
	/root/karmada/pkg/karmadactl/get.go:266 +0x316
github.com/karmada-io/karmada/pkg/karmadactl.NewCmdGet.func1(0xc0007ac280, {0xc000642400, 0x1, 0x4})
	/root/karmada/pkg/karmadactl/get.go:80 +0x96
github.com/spf13/cobra.(*Command).execute(0xc0007ac280, {0xc0006423c0, 0x4, 0x4})
	/root/karmada/vendor/github.com/spf13/cobra/command.go:856 +0x60e
github.com/spf13/cobra.(*Command).ExecuteC(0xc0003e4a00)
	/root/karmada/vendor/github.com/spf13/cobra/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
	/root/karmada/vendor/github.com/spf13/cobra/command.go:902
k8s.io/component-base/cli.run(0xc0003e4a00)
	/root/karmada/vendor/k8s.io/component-base/cli/run.go:146 +0x325
k8s.io/component-base/cli.Run(0x1dec2c4)
	/root/karmada/vendor/k8s.io/component-base/cli/run.go:46 +0x1d
main.main()
	/root/karmada/cmd/karmadactl/karmadactl.go:14 +0x30
````
What we expect, like karmadactl describe 
```shell
$ karmadactl --kubeconfig=/etc/karmada/karmada-apiserver.config describe po nginx-f89759699-prdrj -C local1
E0709 19:08:27.508430 2438456 run.go:74] "command failed" err="clusters.cluster.karmada.io \"local1\" not found"
```

**Special notes for your reviewer**:
Adjusted  output
```shell
$ go run cmd/karmadactl/karmadactl.go --kubeconfig=/etc/karmada/karmada-apiserver.config get po -C local1
E0709 19:11:19.324463 2446618 run.go:74] "command failed" err="clusters.cluster.karmada.io \"local1\" not found"
exit status 1
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

