### PR TITLE
karmadactl pretty-print the error and exit with an error

### DIFF
--- a/cmd/karmadactl/karmadactl.go
+++ b/cmd/karmadactl/karmadactl.go
@@ -1,16 +1,15 @@
 package main
 
 import (
-	"os"
-
 	"k8s.io/component-base/cli"
-	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
+	"k8s.io/kubectl/pkg/cmd/util"
 
 	"github.com/karmada-io/karmada/pkg/karmadactl"
 )
 
 func main() {
 	cmd := karmadactl.NewKarmadaCtlCommand("karmadactl", "karmadactl")
-	code := cli.Run(cmd)
-	os.Exit(code)
+	if err := cli.RunNoErrOutput(cmd); err != nil {
+		util.CheckErr(err)
+	}
 }

--- a/cmd/kubectl-karmada/kubectl-karmada.go
+++ b/cmd/kubectl-karmada/kubectl-karmada.go
@@ -1,16 +1,15 @@
 package main
 
 import (
-	"os"
-
 	"k8s.io/component-base/cli"
-	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
+	"k8s.io/kubectl/pkg/cmd/util"
 
 	"github.com/karmada-io/karmada/pkg/karmadactl"
 )
 
 func main() {
-	cmd := karmadactl.NewKarmadaCtlCommand("karmadactl", "karmadactl")
-	code := cli.Run(cmd)
-	os.Exit(code)
+	cmd := karmadactl.NewKarmadaCtlCommand("karmada", "kubectl karmada")
+	if err := cli.RunNoErrOutput(cmd); err != nil {
+		util.CheckErr(err)
+	}
 }


### PR DESCRIPTION
Signed-off-by: lonelyCZ <531187475@qq.com>

**What type of PR is this?**
/kind  feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
We have introduced `k8s.io/component-base/cli` at #2049, but for `karmadactl`, we need to preety-print the error refering https://github.com/kubernetes/kubernetes/blob/01f80aefeb4c1e85b29bdc006f3d407c6ed43fd8/cmd/kubectl/kubectl.go#L28-L34

```
[root@master67 karmada]# karmadactl get p
E0710 17:03:14.590436   32212 run.go:74] "command failed" err="[cluster(member2): the server doesn't have a resource type \"p\", cluster(member1): the server doesn't have a resource type \"p\"]"
```

change to
```
[root@master67 karmada]# ./karmadactl get p
cluster(member1): the server doesn't have a resource type "p"
cluster(member2): the server doesn't have a resource type "p"
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @RainbowMango @wuyingjun-lucky 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

