### PR TITLE
improve karmadactl command line description

### DIFF
--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	initShort = `Install karmada in kubernetes.`
+	initShort = `Install karmada in kubernetes`
 	initLong  = `Install karmada in kubernetes.`
 )
 

--- a/pkg/karmadactl/promote.go
+++ b/pkg/karmadactl/promote.go
@@ -31,7 +31,7 @@ import (
 )
 
 var (
-	promoteShort = `Promote resources from legacy clusters to karmada control plane.`
+	promoteShort = `Promote resources from legacy clusters to karmada control plane`
 	promoteLong  = `Promote resources from legacy clusters to karmada control plane. Requires the cluster be joined or registered.`
 )
 

--- a/pkg/karmadactl/taint.go
+++ b/pkg/karmadactl/taint.go
@@ -33,7 +33,7 @@ const (
 )
 
 var (
-	taintShort = `Update the taints on one or more clusters.`
+	taintShort = `Update the taints on one or more clusters`
 	taintLong  = `Update the taints on one or more clusters.`
 )
 

--- a/pkg/version/sharedcommand/sharedcommand.go
+++ b/pkg/version/sharedcommand/sharedcommand.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	versionShort   = `Print the version information.`
+	versionShort   = `Print the version information`
 	versionLong    = `Print the version information.`
 	versionExample = `  # Print %s command version
   %s version`


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Unify the style of command line descriptions
```
➜  ~ kubectl karmada -h     
karmadactl controls a Kubernetes Cluster Federation.

Usage:
  karmadactl [flags]
  karmadactl [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  cordon      Mark cluster as unschedulable
  deinit      Removes Karmada from Kubernetes
  describe    Show details of a specific resource or group of resources in a cluster
  exec        Execute a command in a container in a cluster
  get         Display one or many resources
  help        Help about any command
  init        Install karmada in kubernetes.
  join        Register a cluster to control plane
  logs        Print the logs for a container in a pod in a cluster
  promote     Promote resources from legacy clusters to karmada control plane.
  taint       Update the taints on one or more clusters.
  uncordon    Mark cluster as schedulable
  unjoin      Remove the registration of a cluster from control plane
  version     Print the version information.
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

