### PR TITLE
take iostreams as a func parameter 

### DIFF
--- a/pkg/karmadactl/apply.go
+++ b/pkg/karmadactl/apply.go
@@ -54,18 +54,11 @@ var (
 		%[1]s apply -f dir/ --all-clusters`)
 )
 
-// NewCommandApplyOptions returns an initialized CommandApplyOptions instance
-func NewCommandApplyOptions() *CommandApplyOptions {
-	streams := genericclioptions.IOStreams{In: getIn, Out: getOut, ErrOut: getErr}
-	flags := kubectlapply.NewApplyFlags(nil, streams)
-	return &CommandApplyOptions{
-		KubectlApplyFlags: flags,
-	}
-}
-
 // NewCmdApply creates the `apply` command
-func NewCmdApply(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Command {
-	o := NewCommandApplyOptions()
+func NewCmdApply(karmadaConfig KarmadaConfig, parentCommand string, streams genericclioptions.IOStreams) *cobra.Command {
+	o := &CommandApplyOptions{
+		KubectlApplyFlags: kubectlapply.NewApplyFlags(nil, streams),
+	}
 	cmd := &cobra.Command{
 		Use:     "apply (-f FILENAME | -k DIRECTORY)",
 		Short:   "Apply a configuration to a resource by file name or stdin and propagate them into member clusters",

--- a/pkg/karmadactl/describe.go
+++ b/pkg/karmadactl/describe.go
@@ -18,8 +18,7 @@ import (
 )
 
 // NewCmdDescribe new describe command.
-func NewCmdDescribe(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Command {
-	ioStreams := genericclioptions.IOStreams{In: getIn, Out: getOut, ErrOut: getErr}
+func NewCmdDescribe(karmadaConfig KarmadaConfig, parentCommand string, streams genericclioptions.IOStreams) *cobra.Command {
 	o := &CommandDescribeOptions{
 		FilenameOptions: &resource.FilenameOptions{},
 		DescriberSettings: &describe.DescriberSettings{
@@ -29,7 +28,7 @@ func NewCmdDescribe(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Co
 
 		CmdParent: parentCommand,
 
-		IOStreams: ioStreams,
+		IOStreams: streams,
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/karmadactl/exec.go
+++ b/pkg/karmadactl/exec.go
@@ -17,8 +17,7 @@ const (
 )
 
 // NewCmdExec new exec command.
-func NewCmdExec(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Command {
-	streams := genericclioptions.IOStreams{In: getIn, Out: getOut, ErrOut: getErr}
+func NewCmdExec(karmadaConfig KarmadaConfig, parentCommand string, streams genericclioptions.IOStreams) *cobra.Command {
 	o := &ExecOptions{
 		KubectlExecOptions: &kubectlexec.ExecOptions{
 			StreamOptions: kubectlexec.StreamOptions{

--- a/pkg/karmadactl/get.go
+++ b/pkg/karmadactl/get.go
@@ -48,10 +48,6 @@ const (
 )
 
 var (
-	getIn  = os.Stdin
-	getOut = os.Stdout
-	getErr = os.Stderr
-
 	podColumns = []metav1.TableColumnDefinition{
 		{Name: "CLUSTER", Type: "string", Format: "", Priority: 0},
 		{Name: "ADOPTION", Type: "string", Format: "", Priority: 0},
@@ -62,9 +58,8 @@ var (
 )
 
 // NewCmdGet New get command
-func NewCmdGet(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Command {
-	ioStreams := genericclioptions.IOStreams{In: getIn, Out: getOut, ErrOut: getErr}
-	o := NewCommandGetOptions(ioStreams)
+func NewCmdGet(karmadaConfig KarmadaConfig, parentCommand string, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewCommandGetOptions(streams)
 	cmd := &cobra.Command{
 		Use:          "get [NAME | -l label | -n namespace]  [flags]",
 		Short:        getShort,

--- a/pkg/karmadactl/karmadactl.go
+++ b/pkg/karmadactl/karmadactl.go
@@ -3,9 +3,11 @@ package karmadactl
 import (
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 	apiserverflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2"
@@ -47,12 +49,12 @@ func NewKarmadaCtlCommand(cmdUse, parentCommand string) *cobra.Command {
 	_ = flag.CommandLine.Parse(nil)
 
 	karmadaConfig := NewKarmadaConfig(clientcmd.NewDefaultPathOptions())
-
+	ioStreams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
 	groups := templates.CommandGroups{
 		{
 			Message: "Basic Commands:",
 			Commands: []*cobra.Command{
-				NewCmdGet(karmadaConfig, parentCommand),
+				NewCmdGet(karmadaConfig, parentCommand, ioStreams),
 			},
 		},
 		{
@@ -75,15 +77,15 @@ func NewKarmadaCtlCommand(cmdUse, parentCommand string) *cobra.Command {
 		{
 			Message: "Troubleshooting and Debugging Commands:",
 			Commands: []*cobra.Command{
-				NewCmdLogs(karmadaConfig, parentCommand),
-				NewCmdExec(karmadaConfig, parentCommand),
-				NewCmdDescribe(karmadaConfig, parentCommand),
+				NewCmdLogs(karmadaConfig, parentCommand, ioStreams),
+				NewCmdExec(karmadaConfig, parentCommand, ioStreams),
+				NewCmdDescribe(karmadaConfig, parentCommand, ioStreams),
 			},
 		},
 		{
 			Message: "Advanced Commands:",
 			Commands: []*cobra.Command{
-				NewCmdApply(karmadaConfig, parentCommand),
+				NewCmdApply(karmadaConfig, parentCommand, ioStreams),
 				NewCmdPromote(karmadaConfig, parentCommand),
 			},
 		},

--- a/pkg/karmadactl/logs.go
+++ b/pkg/karmadactl/logs.go
@@ -25,8 +25,7 @@ var (
 )
 
 // NewCmdLogs new logs command.
-func NewCmdLogs(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Command {
-	streams := genericclioptions.IOStreams{In: getIn, Out: getOut, ErrOut: getErr}
+func NewCmdLogs(karmadaConfig KarmadaConfig, parentCommand string, streams genericclioptions.IOStreams) *cobra.Command {
 	o := &LogsOptions{
 		KubectlLogsOptions: kubectllogs.NewLogsOptions(streams, false),
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

take iostreams as a func parameter that can be used by logs, get, describe and exec.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

