### PR TITLE
karmadactl:print long describe by templates like kubectl

### DIFF
--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -12,12 +12,9 @@ import (
 	"github.com/karmada-io/karmada/pkg/version"
 )
 
-const (
-	initShort = `Install karmada in kubernetes`
-	initLong  = `Install karmada in kubernetes.`
-)
-
 var (
+	initLong = templates.LongDesc(`
+		Install karmada in kubernetes.`)
 	initExamples = templates.Examples(`
 		# Install Karmada in Kubernetes cluster
 		# The karmada-apiserver binds the master node's IP by default
@@ -59,7 +56,7 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 	opts := kubernetes.CommandInitOption{}
 	cmd := &cobra.Command{
 		Use:          "init",
-		Short:        initShort,
+		Short:        "Install karmada in kubernetes",
 		Long:         initLong,
 		Example:      initExample(parentCommand),
 		SilenceUsage: true,

--- a/pkg/karmadactl/cordon.go
+++ b/pkg/karmadactl/cordon.go
@@ -19,12 +19,10 @@ import (
 )
 
 var (
-	cordonShort = `Mark cluster as unschedulable`
-	cordonLong  = `Mark cluster as unschedulable.`
-
-	uncordonShort = `Mark cluster as schedulable`
-	uncordonLong  = `Mark cluster as schedulable.`
-
+	cordonLong = templates.LongDesc(`
+		Mark cluster as unschedulable.`)
+	uncordonLong = templates.LongDesc(`
+		Mark cluster as schedulable.`)
 	cordonExample = templates.Examples(`
 		# Mark cluster "foo" as unschedulable.
 		%[1]s cordon foo`)
@@ -46,7 +44,7 @@ func NewCmdCordon(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Comm
 	opts := CommandCordonOption{}
 	cmd := &cobra.Command{
 		Use:          "cordon CLUSTER",
-		Short:        cordonShort,
+		Short:        "Mark cluster as unschedulable",
 		Long:         cordonLong,
 		Example:      fmt.Sprintf(cordonExample, parentCommand),
 		SilenceUsage: true,
@@ -74,7 +72,7 @@ func NewCmdUncordon(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Co
 	opts := CommandCordonOption{}
 	cmd := &cobra.Command{
 		Use:          "uncordon CLUSTER",
-		Short:        uncordonShort,
+		Short:        "Mark cluster as schedulable",
 		Long:         uncordonLong,
 		Example:      fmt.Sprintf(uncordonExample, parentCommand),
 		SilenceUsage: true,

--- a/pkg/karmadactl/deinit.go
+++ b/pkg/karmadactl/deinit.go
@@ -21,6 +21,8 @@ const (
 )
 
 var (
+	deinitLong = templates.LongDesc(`
+		Removes Karmada from Kubernetes.`)
 	deInitExample = templates.Examples(`
 		# Remove Karmada from the Kubernetes cluster.
 		%[1]s deinit`)
@@ -46,7 +48,7 @@ func NewCmdDeInit(parentCommand string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "deinit",
 		Short:        "Removes Karmada from Kubernetes",
-		Long:         "Removes Karmada from Kubernetes",
+		Long:         deinitLong,
 		Example:      fmt.Sprintf(deInitExample, parentCommand),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/karmadactl/describe.go
+++ b/pkg/karmadactl/describe.go
@@ -19,6 +19,8 @@ import (
 )
 
 var (
+	describeLong = templates.LongDesc(`
+		Show details of a specific resource or group of resources in a cluster.`)
 	describeExample = templates.Examples(`
 		# Describe a pod in cluster(member1)
 		%[1]s describe pods/nginx -C=member1
@@ -55,6 +57,7 @@ func NewCmdDescribe(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Co
 	cmd := &cobra.Command{
 		Use:          "describe (-f FILENAME | TYPE [NAME_PREFIX | -l label] | TYPE/NAME) (-C CLUSTER)",
 		Short:        "Show details of a specific resource or group of resources in a cluster",
+		Long:         describeLong,
 		SilenceUsage: true,
 		Example:      fmt.Sprintf(describeExample, parentCommand),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/karmadactl/exec.go
+++ b/pkg/karmadactl/exec.go
@@ -18,6 +18,8 @@ const (
 )
 
 var (
+	execLong = templates.LongDesc(`
+		Execute a command in a container in a cluster.`)
 	execExample = templates.Examples(`
 		# Get output from running the 'date' command from pod mypod, using the first container by default in cluster(member1)
 		%[1]s exec mypod -C=member1 -- date
@@ -54,7 +56,7 @@ func NewCmdExec(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:     "exec (POD | TYPE/NAME) [-c CONTAINER] [flags] (-C CLUSTER) -- COMMAND [args...]",
 		Short:   "Execute a command in a container in a cluster",
-		Long:    "Execute a command in a container in a cluster",
+		Long:    execLong,
 		Example: fmt.Sprintf(execExample, parentCommand),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			argsLenAtDash := cmd.ArgsLenAtDash()

--- a/pkg/karmadactl/get.go
+++ b/pkg/karmadactl/get.go
@@ -59,8 +59,8 @@ var (
 	}
 	eventColumn = metav1.TableColumnDefinition{Name: "EVENT", Type: "string", Format: "", Priority: 0}
 
-	getShort = `Display one or many resources`
-
+	getLong = templates.LongDesc(`
+		Display one or many resources.`)
 	getExample = templates.Examples(`
 		# List all pods in ps output format
 		%[1]s get pods
@@ -93,7 +93,8 @@ func NewCmdGet(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Command
 	o := NewCommandGetOptions(ioStreams)
 	cmd := &cobra.Command{
 		Use:          "get [NAME | -l label | -n namespace]  [flags]",
-		Short:        getShort,
+		Short:        `Display one or many resources`,
+		Long:         getLong,
 		SilenceUsage: true,
 		Example:      fmt.Sprintf(getExample, parentCommand),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/karmadactl/join.go
+++ b/pkg/karmadactl/join.go
@@ -20,9 +20,8 @@ import (
 )
 
 var (
-	joinShort = `Register a cluster to control plane`
-	joinLong  = `Join registers a cluster to control plane.`
-
+	joinLong = templates.LongDesc(`
+		Join registers a cluster to control plane.`)
 	joinExample = templates.Examples(`
 		# Join cluster into karamada control plane, if '--cluster-context' not specified, take the cluster name as the context
 		%[1]s join CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG>`)
@@ -34,7 +33,7 @@ func NewCmdJoin(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Comman
 
 	cmd := &cobra.Command{
 		Use:          "join CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG>",
-		Short:        joinShort,
+		Short:        "Register a cluster to control plane",
 		Long:         joinLong,
 		Example:      fmt.Sprintf(joinExample, parentCommand),
 		SilenceUsage: true,
@@ -124,7 +123,7 @@ func (j *CommandJoinOption) AddFlags(flags *pflag.FlagSet) {
 		"Path of the cluster's kubeconfig.")
 	flags.StringVar(&j.ClusterProvider, "cluster-provider", "", "Provider of the joining cluster. The Karmada scheduler can use this information to spread workloads across providers for higher availability.")
 	flags.StringVar(&j.ClusterRegion, "cluster-region", "", "The region of the joining cluster. The Karmada scheduler can use this information to spread workloads across regions for higher availability.")
-	flags.StringVar(&j.ClusterZone, "cluster-zone", "", "The zone of the joining cluster")
+	flags.StringVar(&j.ClusterZone, "cluster-zone", "", "The zone of the joining cluster.")
 	flags.BoolVar(&j.DryRun, "dry-run", false, "Run the command in dry-run mode, without making any server requests.")
 }
 

--- a/pkg/karmadactl/logs.go
+++ b/pkg/karmadactl/logs.go
@@ -23,7 +23,9 @@ const (
 
 var (
 	logsUsageErrStr = fmt.Sprintf("expected '%s'.\nPOD or TYPE/NAME is a required argument for the logs command", logsUsageStr)
-	logsExample     = templates.Examples(`
+	logsLong        = templates.LongDesc(`
+		Print the logs for a container in a pod in a cluster.`)
+	logsExample = templates.Examples(`
 		# Return snapshot logs from pod nginx with only one container in cluster(member1)
 		%[1]s logs nginx -C=member1
 	
@@ -59,6 +61,7 @@ func NewCmdLogs(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:          logsUsageStr,
 		Short:        "Print the logs for a container in a pod in a cluster",
+		Long:         logsLong,
 		SilenceUsage: true,
 		Example:      fmt.Sprintf(logsExample, parentCommand),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/karmadactl/promote.go
+++ b/pkg/karmadactl/promote.go
@@ -31,8 +31,8 @@ import (
 )
 
 var (
-	promoteShort   = `Promote resources from legacy clusters to karmada control plane`
-	promoteLong    = `Promote resources from legacy clusters to karmada control plane. Requires the cluster be joined or registered.`
+	promoteLong = templates.LongDesc(`
+		Promote resources from legacy clusters to karmada control plane. Requires the cluster be joined or registered.`)
 	promoteExample = templates.Examples(`
 		# Promote deployment(default/nginx) from cluster1 to Karmada
 		%[1]s promote deployment nginx -n default -C cluster1
@@ -60,7 +60,7 @@ func NewCmdPromote(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Com
 
 	cmd := &cobra.Command{
 		Use:          "promote <RESOURCE_TYPE> <RESOURCE_NAME> -n <NAME_SPACE> -C <CLUSTER_NAME>",
-		Short:        promoteShort,
+		Short:        "Promote resources from legacy clusters to karmada control plane",
 		Long:         promoteLong,
 		Example:      fmt.Sprintf(promoteExample, parentCommand),
 		SilenceUsage: true,

--- a/pkg/karmadactl/taint.go
+++ b/pkg/karmadactl/taint.go
@@ -34,8 +34,8 @@ const (
 )
 
 var (
-	taintShort   = `Update the taints on one or more clusters`
-	taintLong    = `Update the taints on one or more clusters.`
+	taintLong = templates.LongDesc(`
+		Update the taints on one or more clusters.`)
 	taintExample = templates.Examples(`
 		# Update cluster 'foo' with a taint with key 'dedicated' and value 'special-user' and effect 'NoSchedule'
 		# If a taint with that key and effect already exists, its value is replaced as specified
@@ -57,7 +57,7 @@ func NewCmdTaint(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Comma
 
 	cmd := &cobra.Command{
 		Use:          "taint CLUSTER NAME KEY_1=VAL_1:TAINT_EFFECT_1 ... KEY_N=VAL_N:TAINT_EFFECT_N",
-		Short:        taintShort,
+		Short:        "Update the taints on one or more clusters",
 		Long:         taintLong,
 		Example:      fmt.Sprintf(taintExample, parentCommand),
 		SilenceUsage: true,

--- a/pkg/karmadactl/unjoin.go
+++ b/pkg/karmadactl/unjoin.go
@@ -23,8 +23,8 @@ import (
 )
 
 var (
-	unjoinShort   = `Remove the registration of a cluster from control plane`
-	unjoinLong    = `Unjoin removes the registration of a cluster from control plane.`
+	unjoinLong = templates.LongDesc(`
+		Unjoin removes the registration of a cluster from control plane.`)
 	unjoinExample = templates.Examples(`
 		# Unjoin cluster from karamada control plane, but not to remove resources created by karmada in the unjoining cluster
 		%[1]s unjoin CLUSTER_NAME
@@ -42,7 +42,7 @@ func NewCmdUnjoin(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Comm
 
 	cmd := &cobra.Command{
 		Use:          "unjoin CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG>",
-		Short:        unjoinShort,
+		Short:        "Remove the registration of a cluster from control plane",
 		Long:         unjoinLong,
 		Example:      fmt.Sprintf(unjoinExample, parentCommand),
 		SilenceUsage: true,


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
The existing uses of short and long, include const, string, var, without uniform formatting rules, the code is hard to read,now fix it

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

