### PR TITLE
Fix karmadactl get -C error

### DIFF
--- a/pkg/karmadactl/get.go
+++ b/pkg/karmadactl/get.go
@@ -35,6 +35,7 @@ import (
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
 	"github.com/karmada-io/karmada/pkg/karmadactl/options"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	"github.com/karmada-io/karmada/pkg/util/helper"
@@ -263,7 +264,10 @@ func (g *CommandGetOptions) Run(karmadaConfig KarmadaConfig, cmd *cobra.Command,
 
 	wg.Add(len(g.Clusters))
 	for idx := range g.Clusters {
-		g.setClusterProxyInfo(karmadaRestConfig, g.Clusters[idx], clusterInfos)
+		err = g.setClusterProxyInfo(karmadaRestConfig, g.Clusters[idx], clusterInfos)
+		if err != nil {
+			return err
+		}
 		f := getFactory(g.Clusters[idx], clusterInfos, "")
 		go g.getObjInfo(&wg, &mux, f, g.Clusters[idx], &objs, &watchObjs, &allErrs, args)
 	}
@@ -940,7 +944,15 @@ func (g *CommandGetOptions) getRBInKarmada(namespace string, config *rest.Config
 }
 
 // setClusterProxyInfo set proxy information of cluster
-func (g *CommandGetOptions) setClusterProxyInfo(karmadaRestConfig *rest.Config, name string, clusterInfos map[string]*ClusterInfo) {
+func (g *CommandGetOptions) setClusterProxyInfo(karmadaRestConfig *rest.Config, name string, clusterInfos map[string]*ClusterInfo) error {
+	clusterClient := karmadaclientset.NewForConfigOrDie(karmadaRestConfig).ClusterV1alpha1().Clusters()
+
+	// check if the cluster exists in the Karmada control plane
+	_, err := clusterClient.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
 	clusterInfos[name].APIEndpoint = karmadaRestConfig.Host + fmt.Sprintf(proxyURL, name)
 	clusterInfos[name].KubeConfig = g.KubeConfig
 	clusterInfos[name].Context = g.KarmadaContext
@@ -952,6 +964,7 @@ func (g *CommandGetOptions) setClusterProxyInfo(karmadaRestConfig *rest.Config, 
 			clusterInfos[name].KubeConfig = defaultKubeConfig
 		}
 	}
+	return nil
 }
 
 // getClusterInKarmada get cluster info in karmada cluster


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:


When using karmadactl get to specify a clustername that does not exist in the kubeconfig file, an error is reported:
```shell
$ karmadactl --kubeconfig=/etc/karmada/karmada-apiserver.config get po -C local1
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x1951352]

goroutine 1 [running]:
github.com/karmada-io/karmada/pkg/karmadactl.(*CommandGetOptions).setClusterProxyInfo(0xc000521540, 0xc0000da900, {0xc0001335f0, 0x6}, 0x5)
	/root/karmada/pkg/karmadactl/get.go:940 +0xd2
github.com/karmada-io/karmada/pkg/karmadactl.(*CommandGetOptions).Run(0xc000521540, {0x2092268, 0xc0001420b0}, 0xc0000ebc30, {0xc000642400, 0x1, 0x4})
	/root/karmada/pkg/karmadactl/get.go:266 +0x316
github.com/karmada-io/karmada/pkg/karmadactl.NewCmdGet.func1(0xc0007ac280, {0xc000642400, 0x1, 0x4})
	/root/karmada/pkg/karmadactl/get.go:80 +0x96
github.com/spf13/cobra.(*Command).execute(0xc0007ac280, {0xc0006423c0, 0x4, 0x4})
	/root/karmada/vendor/github.com/spf13/cobra/command.go:856 +0x60e
github.com/spf13/cobra.(*Command).ExecuteC(0xc0003e4a00)
	/root/karmada/vendor/github.com/spf13/cobra/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
	/root/karmada/vendor/github.com/spf13/cobra/command.go:902
k8s.io/component-base/cli.run(0xc0003e4a00)
	/root/karmada/vendor/k8s.io/component-base/cli/run.go:146 +0x325
k8s.io/component-base/cli.Run(0x1dec2c4)
	/root/karmada/vendor/k8s.io/component-base/cli/run.go:46 +0x1d
main.main()
	/root/karmada/cmd/karmadactl/karmadactl.go:14 +0x30
````

What we expect, like karmadactl describe 
```shell
$ karmadactl --kubeconfig=/etc/karmada/karmada-apiserver.config describe po nginx-f89759699-prdrj -C local1
E0709 19:08:27.508430 2438456 run.go:74] "command failed" err="clusters.cluster.karmada.io \"local1\" not found"
```

**Special notes for your reviewer**:

Adjusted  output
```shell
$ go run cmd/karmadactl/karmadactl.go --kubeconfig=/etc/karmada/karmada-apiserver.config get po -C local1
E0711 20:04:00.595057 2081423 run.go:74] "command failed" err="clusters.cluster.karmada.io \"local1\" not found"
exit status 1
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE(as the bug in the master branch which hasn't been released.)
```

associated pr: https://github.com/karmada-io/karmada/pull/2160