### PR TITLE
enable addition of [flags] to the usage line 

### DIFF
--- a/pkg/karmadactl/describe.go
+++ b/pkg/karmadactl/describe.go
@@ -33,11 +33,10 @@ func NewCmdDescribe(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Co
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "describe (-f FILENAME | TYPE [NAME_PREFIX | -l label] | TYPE/NAME) (-C CLUSTER)",
-		DisableFlagsInUseLine: true,
-		Short:                 "Show details of a specific resource or group of resources in a cluster",
-		SilenceUsage:          true,
-		Example:               describeExample(parentCommand),
+		Use:          "describe (-f FILENAME | TYPE [NAME_PREFIX | -l label] | TYPE/NAME) (-C CLUSTER)",
+		Short:        "Show details of a specific resource or group of resources in a cluster",
+		SilenceUsage: true,
+		Example:      describeExample(parentCommand),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(karmadaConfig, args); err != nil {
 				return err

--- a/pkg/karmadactl/exec.go
+++ b/pkg/karmadactl/exec.go
@@ -29,11 +29,10 @@ func NewCmdExec(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Comman
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "exec (POD | TYPE/NAME) [-c CONTAINER] [flags] (-C CLUSTER) -- COMMAND [args...]",
-		DisableFlagsInUseLine: true,
-		Short:                 "Execute a command in a container in a cluster",
-		Long:                  "Execute a command in a container in a cluster",
-		Example:               execExample(parentCommand),
+		Use:     "exec (POD | TYPE/NAME) [-c CONTAINER] [flags] (-C CLUSTER) -- COMMAND [args...]",
+		Short:   "Execute a command in a container in a cluster",
+		Long:    "Execute a command in a container in a cluster",
+		Example: execExample(parentCommand),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			argsLenAtDash := cmd.ArgsLenAtDash()
 			if err := o.Complete(karmadaConfig, cmd, args, argsLenAtDash); err != nil {

--- a/pkg/karmadactl/get.go
+++ b/pkg/karmadactl/get.go
@@ -66,11 +66,10 @@ func NewCmdGet(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Command
 	ioStreams := genericclioptions.IOStreams{In: getIn, Out: getOut, ErrOut: getErr}
 	o := NewCommandGetOptions("karmadactl", ioStreams)
 	cmd := &cobra.Command{
-		Use:                   "get [NAME | -l label | -n namespace]  [flags]",
-		DisableFlagsInUseLine: true,
-		Short:                 getShort,
-		SilenceUsage:          true,
-		Example:               getExample(parentCommand),
+		Use:          "get [NAME | -l label | -n namespace]  [flags]",
+		Short:        getShort,
+		SilenceUsage: true,
+		Example:      getExample(parentCommand),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(karmadaConfig); err != nil {
 				return err


### PR DESCRIPTION
Signed-off-by: carlory <baofa.fan@daocloud.io>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

```
(⎈ |karmada:default)➜  karmada git:(master) go run cmd/karmadactl/karmadactl.go describe -h
Show details of a specific resource or group of resources in a cluster

Usage:
  karmadactl describe (-f FILENAME | TYPE [NAME_PREFIX | -l label] | TYPE/NAME) (-C CLUSTER)

Examples:
...

(⎈ |karmada:default)➜  karmada git:(remove-DisableFlagsInUseLine) go run cmd/karmadactl/karmadactl.go describe -h
Show details of a specific resource or group of resources in a cluster

Usage:
  karmadactl describe (-f FILENAME | TYPE [NAME_PREFIX | -l label] | TYPE/NAME) (-C CLUSTER) [flags]

Examples:
...
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

