### PR TITLE
remove unused flag for karmadactl promote

### DIFF
--- a/pkg/karmadactl/promote.go
+++ b/pkg/karmadactl/promote.go
@@ -95,9 +95,6 @@ type CommandPromoteOption struct {
 	// Cluster is the name of legacy cluster
 	Cluster string
 
-	// ClusterNamespace holds the namespace name where the member cluster secrets are stored.
-	ClusterNamespace string
-
 	// Namespace is the namespace of legacy resource
 	Namespace string
 
@@ -129,7 +126,6 @@ func (o *CommandPromoteOption) AddFlags(flags *pflag.FlagSet) {
 
 	flags.StringVarP(&o.Namespace, "namespace", "n", "default", "-n=namespace or -n namespace")
 	flags.StringVarP(&o.Cluster, "cluster", "C", "", "the name of legacy cluster (eg -C=member1)")
-	flags.StringVar(&o.ClusterNamespace, "cluster-namespace", options.DefaultKarmadaClusterNamespace, "Namespace in the control plane where member cluster secrets are stored.")
 	flags.StringVar(&o.ClusterContext, "cluster-context", "",
 		"Context name of legacy cluster in kubeconfig. Only works when there are multiple contexts in the kubeconfig.")
 	flags.StringVar(&o.ClusterKubeConfig, "cluster-kubeconfig", "",

--- a/test/e2e/karmadactl_test.go
+++ b/test/e2e/karmadactl_test.go
@@ -84,8 +84,7 @@ var _ = ginkgo.Describe("Karmadactl promote testing", func() {
 			// Step 2, promote namespace used by the deployment from member1 to karmada
 			ginkgo.By(fmt.Sprintf("Promoting namespace %s from member: %s to karmada control plane", deploymentNamespace, member1), func() {
 				namespaceOpts = karmadactl.CommandPromoteOption{
-					Cluster:          member1,
-					ClusterNamespace: options.DefaultKarmadaClusterNamespace,
+					Cluster: member1,
 				}
 				args := []string{"namespace", deploymentNamespace}
 				// init args: place namespace name to CommandPromoteOption.name
@@ -102,9 +101,8 @@ var _ = ginkgo.Describe("Karmadactl promote testing", func() {
 			// Step 3,  promote deployment from cluster member1 to karmada
 			ginkgo.By(fmt.Sprintf("Promoting deployment %s from member: %s to karmada", deploymentName, member1), func() {
 				deploymentOpts = karmadactl.CommandPromoteOption{
-					Namespace:        deploymentNamespace,
-					Cluster:          member1,
-					ClusterNamespace: options.DefaultKarmadaClusterNamespace,
+					Namespace: deploymentNamespace,
+					Cluster:   member1,
 				}
 				args := []string{"deployment", deploymentName}
 				// init args: place deployment name to CommandPromoteOption.name
@@ -192,8 +190,7 @@ var _ = ginkgo.Describe("Karmadactl promote testing", func() {
 			// Step2, promote clusterrole and clusterrolebinding from member1
 			ginkgo.By(fmt.Sprintf("Promoting clusterrole %s and clusterrolebindings %s from member to karmada", clusterRoleName, clusterRoleBindingName), func() {
 				clusterRoleOpts = karmadactl.CommandPromoteOption{
-					Cluster:          member1,
-					ClusterNamespace: options.DefaultKarmadaClusterNamespace,
+					Cluster: member1,
 				}
 
 				args := []string{"clusterrole", clusterRoleName}
@@ -206,8 +203,7 @@ var _ = ginkgo.Describe("Karmadactl promote testing", func() {
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 				clusterRoleBindingOpts = karmadactl.CommandPromoteOption{
-					Cluster:          member1,
-					ClusterNamespace: options.DefaultKarmadaClusterNamespace,
+					Cluster: member1,
 				}
 
 				args = []string{"clusterrolebinding", clusterRoleBindingName}
@@ -259,8 +255,7 @@ var _ = ginkgo.Describe("Karmadactl promote testing", func() {
 
 			ginkgo.By(fmt.Sprintf("Promoting namespace %s from member: %s to karmada control plane", serviceNamespace, member1), func() {
 				opts := karmadactl.CommandPromoteOption{
-					Cluster:          member1,
-					ClusterNamespace: options.DefaultKarmadaClusterNamespace,
+					Cluster: member1,
 				}
 				args := []string{"namespace", serviceNamespace}
 				err := opts.Complete(args)
@@ -274,9 +269,8 @@ var _ = ginkgo.Describe("Karmadactl promote testing", func() {
 
 			ginkgo.By(fmt.Sprintf("Promoting service %s from member: %s to karmada control plane", serviceName, member1), func() {
 				opts := karmadactl.CommandPromoteOption{
-					Namespace:        serviceNamespace,
-					Cluster:          member1,
-					ClusterNamespace: options.DefaultKarmadaClusterNamespace,
+					Namespace: serviceNamespace,
+					Cluster:   member1,
 				}
 				args := []string{"service", serviceName}
 				err := opts.Complete(args)


### PR DESCRIPTION
Signed-off-by: carlory <baofa.fan@daocloud.io>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

After #1795 is merged, the --cluster-namespace flag should be removed.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: removed the `--cluster-namespace` flag for `promote` command.
```

