### PR TITLE
Automated cherry-pick: Merge pull request #2171 :Fix karmadactl get -C error

### DIFF
--- a/pkg/karmadactl/get.go
+++ b/pkg/karmadactl/get.go
@@ -35,6 +35,7 @@ import (
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
 	"github.com/karmada-io/karmada/pkg/karmadactl/options"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	"github.com/karmada-io/karmada/pkg/util/helper"
@@ -263,7 +264,10 @@ func (g *CommandGetOptions) Run(karmadaConfig KarmadaConfig, cmd *cobra.Command,
 
 	wg.Add(len(g.Clusters))
 	for idx := range g.Clusters {
-		g.setClusterProxyInfo(karmadaRestConfig, g.Clusters[idx], clusterInfos)
+		err = g.setClusterProxyInfo(karmadaRestConfig, g.Clusters[idx], clusterInfos)
+		if err != nil {
+			return err
+		}
 		f := getFactory(g.Clusters[idx], clusterInfos)
 		go g.getObjInfo(&wg, &mux, f, g.Clusters[idx], &objs, &watchObjs, &allErrs, args)
 	}
@@ -936,7 +940,15 @@ func (g *CommandGetOptions) getRBInKarmada(namespace string, config *rest.Config
 }
 
 // setClusterProxyInfo set proxy information of cluster
-func (g *CommandGetOptions) setClusterProxyInfo(karmadaRestConfig *rest.Config, name string, clusterInfos map[string]*ClusterInfo) {
+func (g *CommandGetOptions) setClusterProxyInfo(karmadaRestConfig *rest.Config, name string, clusterInfos map[string]*ClusterInfo) error {
+	clusterClient := karmadaclientset.NewForConfigOrDie(karmadaRestConfig).ClusterV1alpha1().Clusters()
+
+	// check if the cluster exists in the Karmada control plane
+	_, err := clusterClient.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
 	clusterInfos[name].APIEndpoint = karmadaRestConfig.Host + fmt.Sprintf(proxyURL, name)
 	clusterInfos[name].KubeConfig = g.KubeConfig
 	clusterInfos[name].Context = g.KarmadaContext
@@ -948,6 +960,7 @@ func (g *CommandGetOptions) setClusterProxyInfo(karmadaRestConfig *rest.Config, 
 			clusterInfos[name].KubeConfig = defaultKubeConfig
 		}
 	}
+	return nil
 }
 
 // getClusterInKarmada get cluster info in karmada cluster


### PR DESCRIPTION
Cherry pick of https://github.com/karmada-io/karmada/pull/2171 on release-1.2.
#2171 :Fix karmadactl get -C error
/kind bug

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: Fixed a panic issue when retrieving resources from an unknown cluster(`karmadactl get xxx --cluster=not-exist`).
```