### PR TITLE
introduce factory interface for karmadactl

### DIFF
--- a/pkg/karmadactl/karmadactl.go
+++ b/pkg/karmadactl/karmadactl.go
@@ -16,12 +16,16 @@ import (
 	"github.com/karmada-io/karmada/pkg/karmadactl/addons"
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit"
 	"github.com/karmada-io/karmada/pkg/karmadactl/options"
+	"github.com/karmada-io/karmada/pkg/karmadactl/util"
 	"github.com/karmada-io/karmada/pkg/version/sharedcommand"
 )
 
 var (
 	rootCmdShort = "%s controls a Kubernetes Cluster Federation."
 	rootCmdLong  = "%s controls a Kubernetes Cluster Federation."
+
+	// It composes the set of values necessary for obtaining a REST client config with default values set.
+	defaultConfigFlags = genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag().WithDiscoveryBurst(300).WithDiscoveryQPS(50.0)
 )
 
 // NewKarmadaCtlCommand creates the `karmadactl` command.
@@ -51,6 +55,7 @@ func NewKarmadaCtlCommand(cmdUse, parentCommand string) *cobra.Command {
 	_ = flag.CommandLine.Parse(nil)
 
 	karmadaConfig := NewKarmadaConfig(clientcmd.NewDefaultPathOptions())
+	f := util.NewFactory(defaultConfigFlags)
 	ioStreams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
 	groups := templates.CommandGroups{
 		{
@@ -82,7 +87,7 @@ func NewKarmadaCtlCommand(cmdUse, parentCommand string) *cobra.Command {
 		{
 			Message: "Troubleshooting and Debugging Commands:",
 			Commands: []*cobra.Command{
-				NewCmdLogs(karmadaConfig, parentCommand, ioStreams),
+				NewCmdLogs(f, parentCommand, ioStreams),
 				NewCmdExec(karmadaConfig, parentCommand, ioStreams),
 				NewCmdDescribe(karmadaConfig, parentCommand, ioStreams),
 			},

--- a/pkg/karmadactl/util/factory.go
+++ b/pkg/karmadactl/util/factory.go
@@ -1,0 +1,104 @@
+package util
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
+)
+
+const proxyURL = "/apis/cluster.karmada.io/v1alpha1/clusters/%s/proxy/"
+
+// The Factory interface provides 2 major features compared to the cmdutil.Factory:
+// 1. provides a method to get a karmada clientset
+// 2. provides a method to get a cmdutil.Factory for the member cluster
+type Factory interface {
+	cmdutil.Factory
+
+	// KarmadaClientSet returns a karmada clientset
+	KarmadaClientSet() (karmadaclientset.Interface, error)
+
+	// FacotryForMemberCluster returns a cmdutil.Factory for the member cluster
+	FactoryForMemberCluster(clusterName string) (cmdutil.Factory, error)
+}
+
+var _ Factory = &factoryImpl{}
+
+// factoryImpl is the implementation of Factory
+type factoryImpl struct {
+	cmdutil.Factory
+
+	// kubeConfigFlags holds all the flags specificed by user.
+	// These flags will be inherited by the member cluster's client.
+	kubeConfigFlags *genericclioptions.ConfigFlags
+}
+
+// NewFactory returns a new factory
+func NewFactory(kubeConfigFlags *genericclioptions.ConfigFlags) Factory {
+	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
+	f := &factoryImpl{
+		kubeConfigFlags: kubeConfigFlags,
+		Factory:         cmdutil.NewFactory(matchVersionKubeConfigFlags),
+	}
+	return f
+}
+
+// KarmadaClientSet returns a karmada clientset
+func (f *factoryImpl) KarmadaClientSet() (karmadaclientset.Interface, error) {
+	clientConfig, err := f.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+	return karmadaclientset.NewForConfig(clientConfig)
+}
+
+// FacotryForMemberCluster returns a cmdutil.Factory for the member cluster
+func (f *factoryImpl) FactoryForMemberCluster(clusterName string) (cmdutil.Factory, error) {
+	// Get client config of the karmada, and use it to create a cmdutil.Factory for the member cluster later.
+	clientConfig, err := f.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+	karmadaAPIServer := clientConfig.Host
+
+	// Check if the given cluster is joined to karmada
+	client, err := karmadaclientset.NewForConfig(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+	_, err = client.ClusterV1alpha1().Clusters().Get(context.TODO(), clusterName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	// Inherit all properties from the original flags specified by user except for the kube-apiserver address.
+	kubeConfigFlags := &genericclioptions.ConfigFlags{
+		CacheDir:         f.kubeConfigFlags.CacheDir,
+		KubeConfig:       f.kubeConfigFlags.KubeConfig,
+		ClusterName:      f.kubeConfigFlags.ClusterName,
+		AuthInfoName:     f.kubeConfigFlags.AuthInfoName,
+		Context:          f.kubeConfigFlags.Context,
+		Namespace:        f.kubeConfigFlags.Namespace,
+		Insecure:         f.kubeConfigFlags.Insecure,
+		CertFile:         f.kubeConfigFlags.CertFile,
+		KeyFile:          f.kubeConfigFlags.KeyFile,
+		CAFile:           f.kubeConfigFlags.CAFile,
+		BearerToken:      f.kubeConfigFlags.BearerToken,
+		Impersonate:      f.kubeConfigFlags.Impersonate,
+		ImpersonateUID:   f.kubeConfigFlags.ImpersonateUID,
+		ImpersonateGroup: f.kubeConfigFlags.ImpersonateGroup,
+		Username:         f.kubeConfigFlags.Username,
+		Password:         f.kubeConfigFlags.Password,
+		Timeout:          f.kubeConfigFlags.Timeout,
+		WrapConfigFn:     f.kubeConfigFlags.WrapConfigFn,
+	}
+	// Override the kube-apiserver address.
+	memberAPIserver := karmadaAPIServer + fmt.Sprintf(proxyURL, clusterName)
+	kubeConfigFlags.APIServer = &memberAPIserver
+	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
+	return cmdutil.NewFactory(matchVersionKubeConfigFlags), nil
+}

--- a/pkg/karmadactl/util/factory.go
+++ b/pkg/karmadactl/util/factory.go
@@ -22,7 +22,7 @@ type Factory interface {
 	// KarmadaClientSet returns a karmada clientset
 	KarmadaClientSet() (karmadaclientset.Interface, error)
 
-	// FacotryForMemberCluster returns a cmdutil.Factory for the member cluster
+	// FactoryForMemberCluster returns a cmdutil.Factory for the member cluster
 	FactoryForMemberCluster(clusterName string) (cmdutil.Factory, error)
 }
 
@@ -56,7 +56,7 @@ func (f *factoryImpl) KarmadaClientSet() (karmadaclientset.Interface, error) {
 	return karmadaclientset.NewForConfig(clientConfig)
 }
 
-// FacotryForMemberCluster returns a cmdutil.Factory for the member cluster
+// FactoryForMemberCluster returns a cmdutil.Factory for the member cluster
 func (f *factoryImpl) FactoryForMemberCluster(clusterName string) (cmdutil.Factory, error) {
 	// Get client config of the karmada, and use it to create a cmdutil.Factory for the member cluster later.
 	clientConfig, err := f.ToRESTConfig()


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

At present, there are many places in karmadactl, which are building clients and factories repeatedly, such as init, get, log, exec, etc.

The purpose of this PR is to provide a unified place to get clients accessing the cluster and factories needed to access sub-clusters.

With this change, after a little refactoring, the following files can be removed in the future:

- https://github.com/karmada-io/karmada/blob/master/pkg/karmadactl/get_flags.go
- https://github.com/karmada-io/karmada/blob/master/pkg/karmadactl/config.go
- https://github.com/karmada-io/karmada/blob/master/pkg/karmadactl/options/global.go

An example of the alpha command is provided to make it easier for reviewers to understand the usage. It will be removed after feedback is collected.

```shell
(⎈ |karmada:default)➜  karmada git:(karmadactl-factory) go run cmd/karmadactl/karmadactl.go alpha
karmada: Kubernetes v1.21.7
ik8s: Kubernetes v1.21.5
ocp: Kubernetes v1.11.0+d4cacc0

(⎈ |karmada:default)➜  karmada git:(karmadactl-factory) go run cmd/karmadactl/karmadactl.go alpha -v6
I0716 15:29:22.371611   75493 loader.go:372] Config loaded from file:  /Users/kiki/.kube/config
I0716 15:29:22.414523   75493 round_trippers.go:553] GET https://10.29.0.221:5443/version 200 OK in 41 milliseconds
karmada: Kubernetes v1.21.7
I0716 15:29:22.440589   75493 round_trippers.go:553] GET https://10.29.0.221:5443/apis/cluster.karmada.io/v1alpha1/clusters 200 OK in 25 milliseconds
ik8s: I0716 15:29:22.798588   75493 round_trippers.go:553] GET https://10.29.0.221:5443/apis/cluster.karmada.io/v1alpha1/clusters/ik8s 200 OK in 24 milliseconds
I0716 15:29:22.828802   75493 loader.go:372] Config loaded from file:  /Users/kiki/.kube/config
I0716 15:29:22.887672   75493 round_trippers.go:553] GET https://10.29.0.221:5443/apis/cluster.karmada.io/v1alpha1/clusters/ik8s/proxy/version 200 OK in 57 milliseconds
Kubernetes v1.21.5
ocp: I0716 15:29:22.909929   75493 round_trippers.go:553] GET https://10.29.0.221:5443/apis/cluster.karmada.io/v1alpha1/clusters/ocp 200 OK in 21 milliseconds
I0716 15:29:22.935370   75493 loader.go:372] Config loaded from file:  /Users/kiki/.kube/config
I0716 15:29:23.024844   75493 round_trippers.go:553] GET https://10.29.0.221:5443/apis/cluster.karmada.io/v1alpha1/clusters/ocp/proxy/version 200 OK in 88 milliseconds
Kubernetes v1.11.0+d4cacc0
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

