### PR TITLE
Check file path before Initialize crd

### DIFF
--- a/pkg/karmadactl/cmdinit/karmada/deploy.go
+++ b/pkg/karmadactl/cmdinit/karmada/deploy.go
@@ -64,26 +64,8 @@ func InitKarmadaResources(dir, caBase64, systemNamespace string) error {
 	}
 
 	// Initialize crd
-	basesCRDsFiles := utils.ListFiles(dir + "/crds/bases")
-	klog.Infof("Initialize karmada bases crd resource `%s/crds/bases`", dir)
-	for _, v := range basesCRDsFiles {
-		if path.Ext(v) != ".yaml" {
-			continue
-		}
-		if err := createCRDs(crdClient, v); err != nil {
-			return err
-		}
-	}
-
-	patchesCRDsFiles := utils.ListFiles(dir + "/crds/patches")
-	klog.Infof("Initialize karmada patches crd resource `%s/crds/patches`", dir)
-	for _, v := range patchesCRDsFiles {
-		if path.Ext(v) != ".yaml" {
-			continue
-		}
-		if err := patchCRDs(crdClient, caBase64, v); err != nil {
-			return err
-		}
+	if err = crdInitialize(crdClient, dir, caBase64); err != nil {
+		klog.Exitln(err)
 	}
 
 	// create webhook configuration
@@ -175,6 +157,38 @@ func createExtralResources(clientSet *kubernetes.Clientset, dir string) error {
 		return err
 	}
 
+	return nil
+}
+
+// crdInitialize initialize crd
+func crdInitialize(crdClient *clientset.Clientset, dir, caBase64 string) error {
+	if err := utils.PathExist(dir + "/crds/bases"); err != nil {
+		return err
+	}
+	basesCRDsFiles := utils.ListFiles(dir + "/crds/bases")
+	klog.Infof("Initialize karmada bases crd resource `%s/crds/bases`", dir)
+	for _, v := range basesCRDsFiles {
+		if path.Ext(v) != ".yaml" {
+			continue
+		}
+		if err := createCRDs(crdClient, v); err != nil {
+			return err
+		}
+	}
+
+	if err := utils.PathExist(dir + "/crds/patches"); err != nil {
+		return err
+	}
+	patchesCRDsFiles := utils.ListFiles(dir + "/crds/patches")
+	klog.Infof("Initialize karmada patches crd resource `%s/crds/patches`", dir)
+	for _, v := range patchesCRDsFiles {
+		if path.Ext(v) != ".yaml" {
+			continue
+		}
+		if err := patchCRDs(crdClient, caBase64, v); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/karmadactl/cmdinit/utils/util.go
+++ b/pkg/karmadactl/cmdinit/utils/util.go
@@ -126,6 +126,15 @@ func ioCopyN(outFile *os.File, tr *tar.Reader) error {
 	return nil
 }
 
+// PathExists check if the file path exists
+func PathExist(path string) error {
+	_, err := os.Stat(path)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+	return nil
+}
+
 // ListFiles traverse directory files
 func ListFiles(path string) []string {
 	var files []string


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
1.When  we run `karmadactl init --kube-image-registry=registry.cn-hangzhou.aliyuncs.com/google_containers --crds /root/crds.tar.gz`
2.If the crds dir do not has patches or bases, like
```
$ ls crds
crd.yaml  net.yaml
```
3. The output:
<img width="1042" alt="image" src="https://user-images.githubusercontent.com/76980726/179384910-657cd6bc-195d-41ca-9296-3aaba061ac28.png">

4. What do we expect:
Command output file does not exist, and exit


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The test result:
<img width="901" alt="image" src="https://user-images.githubusercontent.com/76980726/179385284-f840420c-928c-4f2f-92ce-0bab07bbda50.png">

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Check if the file path exists before Initialize crd.
```

