### PR TITLE
fix wrong GO_LDFLAGS when the git tree status is dirty

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -612,10 +612,10 @@ function util::get_GO_LDFLAGS() {
   # Git information
   GIT_VERSION=$(git describe --tags --dirty)
   GIT_COMMIT_HASH=$(git rev-parse HEAD)
-  GIT_TREESTATE="clean"
-  GIT_DIFF=$(git diff --quiet >/dev/null 2>&1; if [[ $$ = 1 ]]; then echo "1"; fi)
-  if [[ "${GIT_DIFF}" == "1" ]];then
-      GIT_TREESTATE="dirty"
+  if git_status=$(git status --porcelain 2>/dev/null) && [[ -z ${git_status} ]]; then
+    GIT_TREESTATE="clean"
+  else
+    GIT_TREESTATE="dirty"
   fi
   BUILDDATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
   LDFLAGS="-X github.com/karmada-io/karmada/pkg/version.gitVersion=${GIT_VERSION} \


### PR DESCRIPTION
Signed-off-by: carlory <baofa.fan@daocloud.io>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`git diff` does not normally reflect whether the current git repository has been modified, for example, adding a new file into repo.

FYI https://github.com/kubernetes/kubernetes/blob/master/hack/lib/version.sh#L61

```sh
(⎈ |ik8s01:karmada-system)➜  karmada git:(fix-hack-utils) make karmadactl
LDFLAGS='-X github.com/karmada-io/karmada/pkg/version.gitVersion=v1.2.0-310-g156e329f -X github.com/karmada-io/karmada/pkg/version.gitCommit=156e329f447bf60426b64c4a3441ff194319b288 -X github.com/karmada-io/karmada/pkg/version.gitTreeState=clean -X github.com/karmada-io/karmada/pkg/version.buildDate=2022-07-20T14:26:37Z' BUILD_PLATFORMS=darwin/arm64 hack/build.sh karmadactl
!!! Building karmadactl for darwin/arm64:
+ CGO_ENABLED=0
+ GOOS=darwin
+ GOARCH=arm64
+ go build -ldflags '-X github.com/karmada-io/karmada/pkg/version.gitVersion=v1.2.0-310-g156e329f -X github.com/karmada-io/karmada/pkg/version.gitCommit=156e329f447bf60426b64c4a3441ff194319b288 -X github.com/karmada-io/karmada/pkg/version.gitTreeState=clean -X github.com/karmada-io/karmada/pkg/version.buildDate=2022-07-20T14:26:37Z' -o _output/bin/darwin/arm64/karmadactl github.com/karmada-io/karmada/cmd/karmadactl
+ set +x

(⎈ |ik8s01:karmada-system)➜  karmada git:(fix-hack-utils) touch dirty
(⎈ |ik8s01:karmada-system)➜  karmada git:(fix-hack-utils) ✗ make karmadactl
LDFLAGS='-X github.com/karmada-io/karmada/pkg/version.gitVersion=v1.2.0-310-g156e329f -X github.com/karmada-io/karmada/pkg/version.gitCommit=156e329f447bf60426b64c4a3441ff194319b288 -X github.com/karmada-io/karmada/pkg/version.gitTreeState=dirty -X github.com/karmada-io/karmada/pkg/version.buildDate=2022-07-20T14:27:06Z' BUILD_PLATFORMS=darwin/arm64 hack/build.sh karmadactl
!!! Building karmadactl for darwin/arm64:
+ CGO_ENABLED=0
+ GOOS=darwin
+ GOARCH=arm64
+ go build -ldflags '-X github.com/karmada-io/karmada/pkg/version.gitVersion=v1.2.0-310-g156e329f -X github.com/karmada-io/karmada/pkg/version.gitCommit=156e329f447bf60426b64c4a3441ff194319b288 -X github.com/karmada-io/karmada/pkg/version.gitTreeState=dirty -X github.com/karmada-io/karmada/pkg/version.buildDate=2022-07-20T14:27:06Z' -o _output/bin/darwin/arm64/karmadactl github.com/karmada-io/karmada/cmd/karmadactl
+ set +x

(⎈ |ik8s01:karmada-system)➜  karmada git:(fix-hack-utils) ✗ git add .
(⎈ |ik8s01:karmada-system)➜  karmada git:(fix-hack-utils) ✗ make karmadactl
LDFLAGS='-X github.com/karmada-io/karmada/pkg/version.gitVersion=v1.2.0-310-g156e329f-dirty -X github.com/karmada-io/karmada/pkg/version.gitCommit=156e329f447bf60426b64c4a3441ff194319b288 -X github.com/karmada-io/karmada/pkg/version.gitTreeState=dirty -X github.com/karmada-io/karmada/pkg/version.buildDate=2022-07-20T14:28:06Z' BUILD_PLATFORMS=darwin/arm64 hack/build.sh karmadactl
!!! Building karmadactl for darwin/arm64:
+ CGO_ENABLED=0
+ GOOS=darwin
+ GOARCH=arm64
+ go build -ldflags '-X github.com/karmada-io/karmada/pkg/version.gitVersion=v1.2.0-310-g156e329f-dirty -X github.com/karmada-io/karmada/pkg/version.gitCommit=156e329f447bf60426b64c4a3441ff194319b288 -X github.com/karmada-io/karmada/pkg/version.gitTreeState=dirty -X github.com/karmada-io/karmada/pkg/version.buildDate=2022-07-20T14:28:06Z' -o _output/bin/darwin/arm64/karmadactl github.com/karmada-io/karmada/cmd/karmadactl
+ set +x

(⎈ |ik8s01:karmada-system)➜  karmada git:(fix-hack-utils) make karmadactl
LDFLAGS='-X github.com/karmada-io/karmada/pkg/version.gitVersion=v1.2.0-311-g5d01a002 -X github.com/karmada-io/karmada/pkg/version.gitCommit=5d01a00281f9e519b196b824003b4d1ed8480b00 -X github.com/karmada-io/karmada/pkg/version.gitTreeState=clean -X github.com/karmada-io/karmada/pkg/version.buildDate=2022-07-20T14:28:45Z' BUILD_PLATFORMS=darwin/arm64 hack/build.sh karmadactl
!!! Building karmadactl for darwin/arm64:
+ CGO_ENABLED=0
+ GOOS=darwin
+ GOARCH=arm64
+ go build -ldflags '-X github.com/karmada-io/karmada/pkg/version.gitVersion=v1.2.0-311-g5d01a002 -X github.com/karmada-io/karmada/pkg/version.gitCommit=5d01a00281f9e519b196b824003b4d1ed8480b00 -X github.com/karmada-io/karmada/pkg/version.gitTreeState=clean -X github.com/karmada-io/karmada/pkg/version.buildDate=2022-07-20T14:28:45Z' -o _output/bin/darwin/arm64/karmadactl github.com/karmada-io/karmada/cmd/karmadactl
+ set +x

(⎈ |ik8s01:karmada-system)➜  karmada git:(fix-hack-utils) echo "hello" > dirty
(⎈ |ik8s01:karmada-system)➜  karmada git:(fix-hack-utils) ✗ make karmadactl
LDFLAGS='-X github.com/karmada-io/karmada/pkg/version.gitVersion=v1.2.0-311-g5d01a002-dirty -X github.com/karmada-io/karmada/pkg/version.gitCommit=5d01a00281f9e519b196b824003b4d1ed8480b00 -X github.com/karmada-io/karmada/pkg/version.gitTreeState=dirty -X github.com/karmada-io/karmada/pkg/version.buildDate=2022-07-20T14:29:38Z' BUILD_PLATFORMS=darwin/arm64 hack/build.sh karmadactl
!!! Building karmadactl for darwin/arm64:
+ CGO_ENABLED=0
+ GOOS=darwin
+ GOARCH=arm64
+ go build -ldflags '-X github.com/karmada-io/karmada/pkg/version.gitVersion=v1.2.0-311-g5d01a002-dirty -X github.com/karmada-io/karmada/pkg/version.gitCommit=5d01a00281f9e519b196b824003b4d1ed8480b00 -X github.com/karmada-io/karmada/pkg/version.gitTreeState=dirty -X github.com/karmada-io/karmada/pkg/version.buildDate=2022-07-20T14:29:38Z' -o _output/bin/darwin/arm64/karmadactl github.com/karmada-io/karmada/cmd/karmadactl
+ set +x

(⎈ |ik8s01:karmada-system)➜  karmada git:(fix-hack-utils) ✗ rm dirty
(⎈ |ik8s01:karmada-system)➜  karmada git:(fix-hack-utils) ✗ make karmadactl
LDFLAGS='-X github.com/karmada-io/karmada/pkg/version.gitVersion=v1.2.0-311-g5d01a002-dirty -X github.com/karmada-io/karmada/pkg/version.gitCommit=5d01a00281f9e519b196b824003b4d1ed8480b00 -X github.com/karmada-io/karmada/pkg/version.gitTreeState=dirty -X github.com/karmada-io/karmada/pkg/version.buildDate=2022-07-20T14:30:09Z' BUILD_PLATFORMS=darwin/arm64 hack/build.sh karmadactl
!!! Building karmadactl for darwin/arm64:
+ CGO_ENABLED=0
+ GOOS=darwin
+ GOARCH=arm64
+ go build -ldflags '-X github.com/karmada-io/karmada/pkg/version.gitVersion=v1.2.0-311-g5d01a002-dirty -X github.com/karmada-io/karmada/pkg/version.gitCommit=5d01a00281f9e519b196b824003b4d1ed8480b00 -X github.com/karmada-io/karmada/pkg/version.gitTreeState=dirty -X github.com/karmada-io/karmada/pkg/version.buildDate=2022-07-20T14:30:09Z' -o _output/bin/darwin/arm64/karmadactl github.com/karmada-io/karmada/cmd/karmadactl
+ set +x
```

**Which issue(s) this PR fixes**:

Fixes #2155

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

