### PR TITLE
Karmadactl supports modifying existing clusters

### DIFF
--- a/pkg/util/cluster.go
+++ b/pkg/util/cluster.go
@@ -40,6 +40,7 @@ type ClusterRegisterOption struct {
 	ClusterRegion      string
 	ClusterZone        string
 	DryRun             bool
+	Overwrite          bool
 
 	ControlPlaneConfig *rest.Config
 	ClusterConfig      *rest.Config


### PR DESCRIPTION
Signed-off-by: chaunceyjiang <chaunceyjiang@gmail.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
For some reasons, our internal karmada must first create a `cluster` CR object, and then use karmadactl to join a cluster into karmada. At present, karmadactl can only use `util.CreateClusterObject()`, and then the error `cluster (dce-04) already exist`  will be reported. We hope to support `util.CreateOrUpdateClusterObject()` to update the existing `cluster` CR object


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl` supports --overwrite parameter
```

