### PR TITLE
fix karmada init help crd version

### DIFF
--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -87,6 +87,11 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 }
 
 func initExample(parentCommand string) string {
+	releaseVer, err := version.ParseGitVersion(version.Get().GitVersion)
+	if err != nil {
+		klog.Infof("No default release version found. build version: %s", version.Get().String())
+		releaseVer = &version.ReleaseVersion{}
+	}
 	example := `
 # Install Karmada in Kubernetes cluster
 # The karmada-apiserver binds the master node's IP by default` + "\n" +
@@ -99,7 +104,7 @@ func initExample(parentCommand string) string {
 		fmt.Sprintf("%s init --kube-image-registry=registry.cn-hangzhou.aliyuncs.com/google_containers", parentCommand) + `
 
 # Specify the URL to download CRD tarball` + "\n" +
-		fmt.Sprintf("%s init --crds https://github.com/karmada-io/karmada/releases/download/v1.1.0/crds.tar.gz", parentCommand) + `
+		fmt.Sprintf("%s init --crds https://github.com/karmada-io/karmada/releases/download/%s/crds.tar.gz", parentCommand, releaseVer.FirstMinorRelease()) + `
 
 # Specify the local CRD tarball` + "\n" +
 		fmt.Sprintf("%s init --crds /root/crds.tar.gz", parentCommand) + `


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
```shell
$ karmadactl version
karmadactl version: version.Info{GitVersion:"v1.2.0-311-gdb983ed", GitCommit:"db983ed7fc1244a5d20c17932663a86e866c65a6", GitTreeState:"clean", BuildDate:"2022-07-15T02:06:25Z", GoVersion:"go1.17.7", Compiler:"gc", Platform:"linux/amd64"}
```
The crds version example output is stable, Will not change with karmadactl version, maybe we can optimize this place

<img width="853" alt="image" src="https://user-images.githubusercontent.com/76980726/179770290-f43739a9-e1c1-404c-893d-97f52bd13f89.png">


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Test result:
<img width="978" alt="image" src="https://user-images.githubusercontent.com/76980726/179770755-c1287d5d-55fc-4691-8fb6-3fa13162275b.png">

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

