### PR TITLE
Reduce the number of reconciliations on update in detector

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -320,6 +320,23 @@ func (d *ResourceDetector) OnAdd(obj interface{}) {
 
 // OnUpdate handles object update event and push the object to queue.
 func (d *ResourceDetector) OnUpdate(oldObj, newObj interface{}) {
+	unstructuredOldObj, err := helper.ToUnstructured(oldObj)
+	if err != nil {
+		klog.Errorf("Failed to transform oldObj, error: %v", err)
+		return
+	}
+
+	unstructuredNewObj, err := helper.ToUnstructured(newObj)
+	if err != nil {
+		klog.Errorf("Failed to transform newObj, error: %v", err)
+		return
+	}
+
+	if !SpecificationChanged(unstructuredOldObj, unstructuredNewObj) {
+		klog.V(4).Infof("Ignore update event of object (kind=%s, %s/%s) as specification no change", unstructuredOldObj.GetKind(), unstructuredOldObj.GetNamespace(), unstructuredOldObj.GetName())
+		return
+	}
+
 	d.OnAdd(newObj)
 }
 

--- a/pkg/detector/eventfilter.go
+++ b/pkg/detector/eventfilter.go
@@ -1,0 +1,23 @@
+package detector
+
+import (
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// SpecificationChanged check if the specification of the given object change or not
+func SpecificationChanged(oldObj, newObj *unstructured.Unstructured) bool {
+	oldBackup := oldObj.DeepCopy()
+	newBackup := newObj.DeepCopy()
+
+	// Remove the status and some system defined mutable fields in metadata, including managedFields and resourceVersion.
+	// Refer to https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/object-meta/#ObjectMeta for more details.
+	removedFields := [][]string{{"status"}, {"metadata", "managedFields"}, {"metadata", "resourceVersion"}}
+	for _, r := range removedFields {
+		unstructured.RemoveNestedField(oldBackup.Object, r...)
+		unstructured.RemoveNestedField(newBackup.Object, r...)
+	}
+
+	return !reflect.DeepEqual(oldBackup, newBackup)
+}

--- a/pkg/detector/eventfilter_test.go
+++ b/pkg/detector/eventfilter_test.go
@@ -1,0 +1,205 @@
+package detector
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
+
+	workloadv1alpha1 "github.com/karmada-io/karmada/examples/customresourceinterpreter/apis/workload/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/util/helper"
+)
+
+func TestSpecificationChanged(t *testing.T) {
+	tests := []struct {
+		name       string
+		oldObj     interface{}
+		newObj     interface{}
+		wantChange bool
+	}{
+		{
+			name: "Only user defined fields changed(Deployment)",
+			oldObj: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123456",
+					ManagedFields:   []metav1.ManagedFieldsEntry{},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "nginx_v1"},
+					},
+				},
+				Status: appsv1.DeploymentStatus{},
+			},
+			newObj: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123456",
+					ManagedFields:   []metav1.ManagedFieldsEntry{},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "nginx_v2"},
+					},
+				},
+				Status: appsv1.DeploymentStatus{},
+			},
+			wantChange: true,
+		},
+		{
+			name: "Only status fields changed(Deployment)",
+			oldObj: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123456",
+					ManagedFields:   []metav1.ManagedFieldsEntry{{}},
+				},
+				Spec:   appsv1.DeploymentSpec{},
+				Status: appsv1.DeploymentStatus{Replicas: 3, UpdatedReplicas: 3, ReadyReplicas: 0},
+			},
+			newObj: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123498",
+					ManagedFields:   []metav1.ManagedFieldsEntry{{}, {}},
+				},
+				Spec:   appsv1.DeploymentSpec{},
+				Status: appsv1.DeploymentStatus{Replicas: 3, UpdatedReplicas: 1, ReadyReplicas: 2},
+			},
+			wantChange: false,
+		},
+		{
+			name: "Both user defined fields and status fields changed(Deployment)",
+			oldObj: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123456",
+					ManagedFields:   []metav1.ManagedFieldsEntry{{}},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "nginx_v1"},
+					},
+				},
+				Status: appsv1.DeploymentStatus{Replicas: 3, UpdatedReplicas: 3, ReadyReplicas: 0},
+			},
+			newObj: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123498",
+					ManagedFields:   []metav1.ManagedFieldsEntry{{}, {}},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "nginx_v2"},
+					},
+				},
+				Status: appsv1.DeploymentStatus{Replicas: 3, UpdatedReplicas: 1, ReadyReplicas: 2},
+			},
+			wantChange: true,
+		},
+		{
+			name: "Only user defined fields changed(CRD_WorkLoad)",
+			oldObj: &workloadv1alpha1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123456",
+					ManagedFields:   []metav1.ManagedFieldsEntry{{}},
+				},
+				Spec: workloadv1alpha1.WorkloadSpec{
+					Replicas: pointer.Int32(3),
+					Template: v1.PodTemplateSpec{},
+					Paused:   false,
+				},
+				Status: workloadv1alpha1.WorkloadStatus{ReadyReplicas: 3},
+			},
+			newObj: &workloadv1alpha1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123456",
+					ManagedFields:   []metav1.ManagedFieldsEntry{{}},
+				},
+				Spec: workloadv1alpha1.WorkloadSpec{
+					Replicas: pointer.Int32(5),
+					Template: v1.PodTemplateSpec{},
+					Paused:   false,
+				},
+				Status: workloadv1alpha1.WorkloadStatus{ReadyReplicas: 3},
+			},
+			wantChange: true,
+		},
+		{
+			name: "Only status fields changed(CRD_WorkLoad)",
+			oldObj: &workloadv1alpha1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123456",
+					ManagedFields:   []metav1.ManagedFieldsEntry{{}},
+				},
+				Spec: workloadv1alpha1.WorkloadSpec{
+					Replicas: pointer.Int32(3),
+					Template: v1.PodTemplateSpec{},
+					Paused:   false,
+				},
+				Status: workloadv1alpha1.WorkloadStatus{ReadyReplicas: 1},
+			},
+			newObj: &workloadv1alpha1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123498",
+					ManagedFields:   []metav1.ManagedFieldsEntry{{}, {}},
+				},
+				Spec: workloadv1alpha1.WorkloadSpec{
+					Replicas: pointer.Int32(3),
+					Template: v1.PodTemplateSpec{},
+					Paused:   false,
+				},
+				Status: workloadv1alpha1.WorkloadStatus{ReadyReplicas: 3},
+			},
+			wantChange: false,
+		},
+		{
+			name: "Both user defined fields and status fields changed(CRD_WorkLoad)",
+			oldObj: &workloadv1alpha1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123456",
+					ManagedFields:   []metav1.ManagedFieldsEntry{{}},
+				},
+				Spec: workloadv1alpha1.WorkloadSpec{
+					Replicas: pointer.Int32(3),
+					Template: v1.PodTemplateSpec{},
+					Paused:   false,
+				},
+				Status: workloadv1alpha1.WorkloadStatus{ReadyReplicas: 1},
+			},
+			newObj: &workloadv1alpha1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123498",
+					ManagedFields:   []metav1.ManagedFieldsEntry{{}, {}},
+				},
+				Spec: workloadv1alpha1.WorkloadSpec{
+					Replicas: pointer.Int32(5),
+					Template: v1.PodTemplateSpec{},
+					Paused:   false,
+				},
+				Status: workloadv1alpha1.WorkloadStatus{ReadyReplicas: 3},
+			},
+			wantChange: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unstructuredOldObj, err := helper.ToUnstructured(tt.oldObj)
+			if err != nil {
+				klog.Errorf("Failed to transform oldObj, error: %v", err)
+				return
+			}
+
+			unstructuredNewObj, err := helper.ToUnstructured(tt.newObj)
+			if err != nil {
+				klog.Errorf("Failed to transform newObj, error: %v", err)
+				return
+			}
+
+			got := SpecificationChanged(unstructuredOldObj, unstructuredNewObj)
+			if tt.wantChange != got {
+				t.Fatalf("SpecificationChanged() got %v, want %v", got, tt.wantChange)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Reduce the number of reconciliations on update in detector

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Test detector using the deployment and propagationpolicy in {repo}/samples/nginx, and change the parmaters as the follow steps:
* create nginx-propagation with weightPreference member1:1, menber2:2
* create nginx-deployment with replicas 1
* change nginx-deployment replicas to 3
* change nginx-propagation weightPreference to member1:2, member2:1
* change nginx-deployment replicas to 5
* change nginx-propagation weightPreference to member1:2, member2:3
* delete nginx-deployment
* delete nginx-propagation

the count number of reconciliations and interceptiosn as follows: 

Before:
* Reconciling: 18

![image](https://user-images.githubusercontent.com/108505214/180106929-15db5101-a254-4a81-95a7-d46689cc1764.png)


Now:
* Reconciling: 4
* Intercept: 14

![image](https://user-images.githubusercontent.com/108505214/180106956-3407b616-72b0-4eb1-b0d4-cbe5bcc0e92e.png)
![image](https://user-images.githubusercontent.com/108505214/180107000-34806605-0893-4942-9b8a-7f2a302be5c4.png)

**Does this PR introduce a user-facing change?**:
None
