### PR TITLE
Apply cachedRESTMapper for other Karmada components

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -39,6 +39,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/informermanager"
 	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/pkg/util/objectwatcher"
+	"github.com/karmada-io/karmada/pkg/util/restmapper"
 	"github.com/karmada-io/karmada/pkg/version"
 	"github.com/karmada-io/karmada/pkg/version/sharedcommand"
 )
@@ -161,6 +162,7 @@ func run(ctx context.Context, karmadaConfig karmadactl.KarmadaConfig, opts *opti
 		HealthProbeBindAddress:     net.JoinHostPort(opts.BindAddress, strconv.Itoa(opts.SecurePort)),
 		LivenessEndpointName:       "/healthz",
 		MetricsBindAddress:         opts.MetricsBindAddress,
+		MapperProvider:             restmapper.MapperProvider,
 		Controller: v1alpha1.ControllerConfigurationSpec{
 			GroupKindConcurrency: map[string]int{
 				workv1alpha1.SchemeGroupVersion.WithKind("Work").GroupKind().String():       opts.ConcurrentWorkSyncs,

--- a/pkg/karmadactl/promote.go
+++ b/pkg/karmadactl/promote.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
@@ -220,7 +219,7 @@ func RunPromote(karmadaConfig KarmadaConfig, opts CommandPromoteOption, args []s
 
 	opts.gvk = obj.GetObjectKind().GroupVersionKind()
 
-	mapper, err := apiutil.NewDynamicRESTMapper(controlPlaneRestConfig)
+	mapper, err := restmapper.MapperProvider(controlPlaneRestConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create restmapper: %v", err)
 	}

--- a/pkg/search/controller.go
+++ b/pkg/search/controller.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	clusterV1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
@@ -61,7 +60,7 @@ func NewController(restConfig *rest.Config) (*Controller, error) {
 	karmadaClient := karmadaclientset.NewForConfigOrDie(restConfig)
 	factory := informerfactory.NewSharedInformerFactory(karmadaClient, 0)
 	clusterLister := factory.Cluster().V1alpha1().Clusters().Lister()
-	restMapper, err := apiutil.NewDynamicRESTMapper(restConfig)
+	restMapper, err := restmapper.MapperProvider(restConfig)
 	if err != nil {
 		klog.Errorf("Failed to create REST mapper: %v", err)
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
As is talked in #2187，we add a new type cachedRESTMapper for performance improvement in controller-manager，we should apply it to other Karmada components.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @yy158775 @RainbowMango 
