### PR TITLE
Extend the timeout period of webhook to 10s

### DIFF
--- a/artifacts/deploy/webhook-configuration.yaml
+++ b/artifacts/deploy/webhook-configuration.yaml
@@ -18,7 +18,7 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     admissionReviewVersions: ["v1"]
-    timeoutSeconds: 3
+    timeoutSeconds: 10
   - name: clusterpropagationpolicy.karmada.io
     rules:
       - operations: ["CREATE", "UPDATE"]
@@ -32,7 +32,7 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     admissionReviewVersions: ["v1"]
-    timeoutSeconds: 3
+    timeoutSeconds: 10
   - name: overridepolicy.karmada.io
     rules:
       - operations: ["CREATE", "UPDATE"]
@@ -46,7 +46,7 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     admissionReviewVersions: ["v1"]
-    timeoutSeconds: 3
+    timeoutSeconds: 10
   - name: work.karmada.io
     rules:
       - operations: ["CREATE", "UPDATE"]
@@ -60,7 +60,7 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     admissionReviewVersions: ["v1"]
-    timeoutSeconds: 3
+    timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -82,7 +82,7 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     admissionReviewVersions: ["v1"]
-    timeoutSeconds: 3
+    timeoutSeconds: 10
   - name: clusterpropagationpolicy.karmada.io
     rules:
       - operations: ["CREATE", "UPDATE"]
@@ -96,7 +96,7 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     admissionReviewVersions: ["v1"]
-    timeoutSeconds: 3
+    timeoutSeconds: 10
   - name: overridepolicy.karmada.io
     rules:
       - operations: ["CREATE", "UPDATE"]
@@ -110,7 +110,7 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     admissionReviewVersions: ["v1"]
-    timeoutSeconds: 3
+    timeoutSeconds: 10
   - name: clusteroverridepolicy.karmada.io
     rules:
       - operations: ["CREATE", "UPDATE"]
@@ -124,7 +124,7 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     admissionReviewVersions: ["v1"]
-    timeoutSeconds: 3
+    timeoutSeconds: 10
   - name: config.karmada.io
     rules:
       - operations: ["CREATE", "UPDATE"]
@@ -138,7 +138,7 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     admissionReviewVersions: ["v1"]
-    timeoutSeconds: 3
+    timeoutSeconds: 10
   - name: federatedresourcequota.karmada.io
     rules:
       - operations: ["CREATE", "UPDATE"]
@@ -152,4 +152,4 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     admissionReviewVersions: [ "v1" ]
-    timeoutSeconds: 3
+    timeoutSeconds: 10


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

/kind failing-test

**What this PR does / why we need it**:

The original webhook call timeout is 3s, with this time, our CI always has a timeout error, so I extend the timeout period of webhook to 10s.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

