### PR TITLE
Cleanup ClusterClientSetFunc field in execution-controller

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -262,14 +262,13 @@ func startClusterStatusController(ctx controllerscontext.Context) (bool, error) 
 
 func startExecutionController(ctx controllerscontext.Context) (bool, error) {
 	executionController := &execution.Controller{
-		Client:               ctx.Mgr.GetClient(),
-		EventRecorder:        ctx.Mgr.GetEventRecorderFor(execution.ControllerName),
-		RESTMapper:           ctx.Mgr.GetRESTMapper(),
-		ObjectWatcher:        ctx.ObjectWatcher,
-		PredicateFunc:        helper.NewExecutionPredicateOnAgent(),
-		InformerManager:      informermanager.GetInstance(),
-		ClusterClientSetFunc: util.NewClusterDynamicClientSetForAgent,
-		RatelimiterOptions:   ctx.Opts.RateLimiterOptions,
+		Client:             ctx.Mgr.GetClient(),
+		EventRecorder:      ctx.Mgr.GetEventRecorderFor(execution.ControllerName),
+		RESTMapper:         ctx.Mgr.GetRESTMapper(),
+		ObjectWatcher:      ctx.ObjectWatcher,
+		PredicateFunc:      helper.NewExecutionPredicateOnAgent(),
+		InformerManager:    informermanager.GetInstance(),
+		RatelimiterOptions: ctx.Opts.RateLimiterOptions,
 	}
 	if err := executionController.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -320,14 +320,13 @@ func startBindingController(ctx controllerscontext.Context) (enabled bool, err e
 
 func startExecutionController(ctx controllerscontext.Context) (enabled bool, err error) {
 	executionController := &execution.Controller{
-		Client:               ctx.Mgr.GetClient(),
-		EventRecorder:        ctx.Mgr.GetEventRecorderFor(execution.ControllerName),
-		RESTMapper:           ctx.Mgr.GetRESTMapper(),
-		ObjectWatcher:        ctx.ObjectWatcher,
-		PredicateFunc:        helper.NewExecutionPredicate(ctx.Mgr),
-		InformerManager:      informermanager.GetInstance(),
-		ClusterClientSetFunc: util.NewClusterDynamicClientSet,
-		RatelimiterOptions:   ctx.Opts.RateLimiterOptions,
+		Client:             ctx.Mgr.GetClient(),
+		EventRecorder:      ctx.Mgr.GetEventRecorderFor(execution.ControllerName),
+		RESTMapper:         ctx.Mgr.GetRESTMapper(),
+		ObjectWatcher:      ctx.ObjectWatcher,
+		PredicateFunc:      helper.NewExecutionPredicate(ctx.Mgr),
+		InformerManager:    informermanager.GetInstance(),
+		RatelimiterOptions: ctx.Opts.RateLimiterOptions,
 	}
 	if err := executionController.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err

--- a/pkg/controllers/execution/execution_controller.go
+++ b/pkg/controllers/execution/execution_controller.go
@@ -37,14 +37,13 @@ const (
 
 // Controller is to sync Work.
 type Controller struct {
-	client.Client        // used to operate Work resources.
-	EventRecorder        record.EventRecorder
-	RESTMapper           meta.RESTMapper
-	ObjectWatcher        objectwatcher.ObjectWatcher
-	PredicateFunc        predicate.Predicate
-	InformerManager      informermanager.MultiClusterInformerManager
-	ClusterClientSetFunc func(clusterName string, client client.Client) (*util.DynamicClusterClient, error)
-	RatelimiterOptions   ratelimiterflag.Options
+	client.Client      // used to operate Work resources.
+	EventRecorder      record.EventRecorder
+	RESTMapper         meta.RESTMapper
+	ObjectWatcher      objectwatcher.ObjectWatcher
+	PredicateFunc      predicate.Predicate
+	InformerManager    informermanager.MultiClusterInformerManager
+	RatelimiterOptions ratelimiterflag.Options
 }
 
 // Reconcile performs a full reconciliation for the object referred to by the Request.


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Since `ClusterClientSetFunc` is no more used by execution-controller, cleanup this field.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
None

