### PR TITLE
Apply ClusterClientOption to controllers

### DIFF
--- a/cmd/karmada-search/app/karmada-search.go
+++ b/cmd/karmada-search/app/karmada-search.go
@@ -32,6 +32,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/sharedcli"
 	"github.com/karmada-io/karmada/pkg/sharedcli/klogflag"
 	"github.com/karmada-io/karmada/pkg/sharedcli/profileflag"
+	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/lifted"
 	"github.com/karmada-io/karmada/pkg/version"
 	"github.com/karmada-io/karmada/pkg/version/sharedcommand"
@@ -171,7 +172,7 @@ func config(o *options.Options, outOfTreeRegistryOptions ...Option) (*search.Con
 
 	var ctl *search.Controller
 	if !o.DisableSearch {
-		ctl, err = search.NewController(serverConfig.ClientConfig, factory, restMapper)
+		ctl, err = search.NewController(serverConfig.ClientConfig, factory, restMapper, util.NewClientOption(o.ClusterAPIQPS, o.ClusterAPIBurst))
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/karmada-search/app/options/options.go
+++ b/cmd/karmada-search/app/options/options.go
@@ -23,6 +23,10 @@ type Options struct {
 	KubeAPIQPS float32
 	// KubeAPIBurst is the burst to allow while talking with karmada-search.
 	KubeAPIBurst int
+	// ClusterAPIQPS is the QPS to use while talking with cluster kube-apiserver.
+	ClusterAPIQPS float32
+	// ClusterAPIBurst is the burst to allow while talking with cluster kube-apiserver.
+	ClusterAPIBurst int
 
 	ProfileOpts profileflag.Options
 
@@ -52,7 +56,8 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 	flags.IntVar(&o.KubeAPIBurst, "kube-api-burst", 60, "Burst to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")
 	flags.BoolVar(&o.DisableSearch, "disable-search", false, "Disable search feature that would save memory usage significantly.")
 	flags.BoolVar(&o.DisableProxy, "disable-proxy", false, "Disable proxy feature that would save memory usage significantly.")
-
+	flags.Float32Var(&o.ClusterAPIQPS, "cluster-api-qps", 40.0, "QPS to use while talking with cluster kube-apiserver.")
+	flags.IntVar(&o.ClusterAPIBurst, "cluster-api-burst", 60, "Burst to use while talking with cluster kube-apiserver.")
 	utilfeature.DefaultMutableFeatureGate.AddFlag(flags)
 	o.ProfileOpts.AddFlags(flags)
 }

--- a/pkg/controllers/mcs/service_export_controller.go
+++ b/pkg/controllers/mcs/service_export_controller.go
@@ -47,7 +47,7 @@ type ServiceExportController struct {
 	InformerManager             genericmanager.MultiClusterInformerManager
 	WorkerNumber                int                 // WorkerNumber is the number of worker goroutines
 	PredicateFunc               predicate.Predicate // PredicateFunc is the function that filters events before enqueuing the keys.
-	ClusterDynamicClientSetFunc func(clusterName string, client client.Client) (*util.DynamicClusterClient, error)
+	ClusterDynamicClientSetFunc func(clusterName string, client client.Client, clientOption *util.ClientOption) (*util.DynamicClusterClient, error)
 	// eventHandlers holds the handlers which used to handle events reported from member clusters.
 	// Each handler takes the cluster name as key and takes the handler function as the value, e.g.
 	// "member1": instance of ResourceEventHandler
@@ -55,6 +55,7 @@ type ServiceExportController struct {
 	worker        util.AsyncWorker // worker process resources periodic from rateLimitingQueue.
 
 	ClusterCacheSyncTimeout metav1.Duration
+	ClusterClientOption     *util.ClientOption
 }
 
 var (
@@ -181,7 +182,7 @@ func (c *ServiceExportController) buildResourceInformers(cluster *clusterv1alpha
 func (c *ServiceExportController) registerInformersAndStart(cluster *clusterv1alpha1.Cluster) error {
 	singleClusterInformerManager := c.InformerManager.GetSingleClusterManager(cluster.Name)
 	if singleClusterInformerManager == nil {
-		dynamicClusterClient, err := c.ClusterDynamicClientSetFunc(cluster.Name, c.Client)
+		dynamicClusterClient, err := c.ClusterDynamicClientSetFunc(cluster.Name, c.Client, c.ClusterClientOption)
 		if err != nil {
 			klog.Errorf("Failed to build dynamic cluster client for cluster %s.", cluster.Name)
 			return err

--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -68,7 +68,7 @@ type ClusterStatusController struct {
 	GenericInformerManager      genericmanager.MultiClusterInformerManager
 	StopChan                    <-chan struct{}
 	ClusterClientSetFunc        func(string, client.Client, *util.ClientOption) (*util.ClusterClient, error)
-	ClusterDynamicClientSetFunc func(clusterName string, client client.Client) (*util.DynamicClusterClient, error)
+	ClusterDynamicClientSetFunc func(clusterName string, client client.Client, clientOption *util.ClientOption) (*util.DynamicClusterClient, error)
 	// ClusterClientOption holds the attributes that should be injected to a Kubernetes client.
 	ClusterClientOption *util.ClientOption
 
@@ -293,7 +293,7 @@ func (c *ClusterStatusController) initializeGenericInformerManagerForCluster(clu
 		return
 	}
 
-	dynamicClient, err := c.ClusterDynamicClientSetFunc(clusterClient.ClusterName, c.Client)
+	dynamicClient, err := c.ClusterDynamicClientSetFunc(clusterClient.ClusterName, c.Client, c.ClusterClientOption)
 	if err != nil {
 		klog.Errorf("Failed to build dynamic cluster client for cluster %s.", clusterClient.ClusterName)
 		return

--- a/pkg/controllers/status/workstatus_controller.go
+++ b/pkg/controllers/status/workstatus_controller.go
@@ -52,10 +52,11 @@ type WorkStatusController struct {
 	ConcurrentWorkStatusSyncs   int
 	ObjectWatcher               objectwatcher.ObjectWatcher
 	PredicateFunc               predicate.Predicate
-	ClusterDynamicClientSetFunc func(clusterName string, client client.Client) (*util.DynamicClusterClient, error)
+	ClusterDynamicClientSetFunc func(clusterName string, client client.Client, clientOption *util.ClientOption) (*util.DynamicClusterClient, error)
 	ClusterCacheSyncTimeout     metav1.Duration
 	RateLimiterOptions          ratelimiterflag.Options
 	ResourceInterpreter         resourceinterpreter.ResourceInterpreter
+	ClusterClientOption         *util.ClientOption
 }
 
 // Reconcile performs a full reconciliation for the object referred to by the Request.
@@ -466,7 +467,7 @@ func (c *WorkStatusController) getSingleClusterManager(cluster *clusterv1alpha1.
 	//  the cache in informer manager should be updated.
 	singleClusterInformerManager := c.InformerManager.GetSingleClusterManager(cluster.Name)
 	if singleClusterInformerManager == nil {
-		dynamicClusterClient, err := c.ClusterDynamicClientSetFunc(cluster.Name, c.Client)
+		dynamicClusterClient, err := c.ClusterDynamicClientSetFunc(cluster.Name, c.Client, c.ClusterClientOption)
 		if err != nil {
 			klog.Errorf("Failed to build dynamic cluster client for cluster %s.", cluster.Name)
 			return nil, err

--- a/pkg/util/membercluster_client_test.go
+++ b/pkg/util/membercluster_client_test.go
@@ -433,7 +433,7 @@ func TestNewClusterDynamicClientSet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewClusterDynamicClientSet(tt.args.clusterName, tt.args.client)
+			got, err := NewClusterDynamicClientSet(tt.args.clusterName, tt.args.client, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewClusterClientSet() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -489,7 +489,7 @@ func TestNewClusterDynamicClientSet_ClientWorks(t *testing.T) {
 			},
 		}).Build()
 
-	clusterClient, err := NewClusterDynamicClientSet(clusterName, hostClient)
+	clusterClient, err := NewClusterDynamicClientSet(clusterName, hostClient, nil)
 	if err != nil {
 		t.Error(err)
 		return

--- a/test/e2e/framework/cluster.go
+++ b/test/e2e/framework/cluster.go
@@ -181,7 +181,7 @@ func newClusterClientSet(controlPlaneClient client.Client, c *clusterv1alpha1.Cl
 		if err != nil {
 			return nil, nil, err
 		}
-		clusterDynamicClient, err := util.NewClusterDynamicClientSet(c.Name, controlPlaneClient)
+		clusterDynamicClient, err := util.NewClusterDynamicClientSet(c.Name, controlPlaneClient, nil)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Now ClusterAPIQPS and ClusterAPIBurst are not fully applied to controllers which need to connect with kube-apiservers in member clusters.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
karmada-search introduces `cluster-api-qps` to indicate qps to use while talking with cluster kube-apiserver and `cluster-api-burst` to indicate burst to use while talking with cluster kube-apiserver.
`cluster-api-qps` and `cluster-api-burst` in karmada-controller-manager and karmada-agent now are valid for all controllers.
```