### PR TITLE
chore: simplify build scripts for kubectl apply when handling kustomization resources

### DIFF
--- a/charts/karmada/templates/post-install-job.yaml
+++ b/charts/karmada/templates/post-install-job.yaml
@@ -89,7 +89,7 @@ spec:
         - |
           bash <<'EOF'
           set -ex
-          kubectl kustomize /crds | kubectl apply --kubeconfig /etc/kubeconfig -f -
+          kubectl apply -k /crds --kubeconfig /etc/kubeconfig
           kubectl apply -f /static-resources --kubeconfig /etc/kubeconfig
           EOF
         volumeMounts:

--- a/docs/upgrading/README.md
+++ b/docs/upgrading/README.md
@@ -62,7 +62,7 @@ kubectl kustomize ./charts/karmada/_crds
 ```
 Or, you can apply to `karmada-apiserver` by:
 ```bash
-kubectl kustomize ./charts/karmada/_crds | kubectl apply -f -
+kubectl apply -k ./charts/karmada/_crds
 ```
 
 ### Upgrading Components

--- a/hack/deploy-karmada.sh
+++ b/hack/deploy-karmada.sh
@@ -109,7 +109,7 @@ function installCRDs() {
 
     kubectl apply -f "${REPO_ROOT}/artifacts/deploy/namespace.yaml"
 
-    kubectl kustomize "${crd_path}"/_crds | kubectl apply -f -
+    kubectl apply -k "${crd_path}"/_crds
 }
 
 # Use x.x.x.6 IP address, which is the same CIDR with the node address of the Kind cluster,


### PR DESCRIPTION
Simplify build scripts for kubectl apply when handling kustomization resources.
`kubectl apply -k` was direct commands to achieve the goals.
The edited script was used to install karmada.

**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:
There was a simply way to do it.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
`./hack/local-up-karmada.sh` tested successfully.

**Does this PR introduce a user-facing change?**:
None

```release-note
None
```

