### PR TITLE
docs: add clearer documentation for multiple cluster ingress

### DIFF
--- a/pkg/resourceinterpreter/defaultinterpreter/aggregatestatus.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/aggregatestatus.go
@@ -51,6 +51,7 @@ func aggregateDeploymentStatus(object *unstructured.Unstructured, aggregatedStat
 		}
 		klog.V(3).Infof("Grab deployment(%s/%s) status from cluster(%s), replicas: %d, ready: %d, updated: %d, available: %d, unavailable: %d",
 			deploy.Namespace, deploy.Name, item.ClusterName, temp.Replicas, temp.ReadyReplicas, temp.UpdatedReplicas, temp.AvailableReplicas, temp.UnavailableReplicas)
+		newStatus.ObservedGeneration = deploy.Generation
 		newStatus.Replicas += temp.Replicas
 		newStatus.ReadyReplicas += temp.ReadyReplicas
 		newStatus.UpdatedReplicas += temp.UpdatedReplicas
@@ -58,7 +59,8 @@ func aggregateDeploymentStatus(object *unstructured.Unstructured, aggregatedStat
 		newStatus.UnavailableReplicas += temp.UnavailableReplicas
 	}
 
-	if oldStatus.Replicas == newStatus.Replicas &&
+	if oldStatus.ObservedGeneration == newStatus.ObservedGeneration &&
+		oldStatus.Replicas == newStatus.Replicas &&
 		oldStatus.ReadyReplicas == newStatus.ReadyReplicas &&
 		oldStatus.UpdatedReplicas == newStatus.UpdatedReplicas &&
 		oldStatus.AvailableReplicas == newStatus.AvailableReplicas &&
@@ -67,6 +69,7 @@ func aggregateDeploymentStatus(object *unstructured.Unstructured, aggregatedStat
 		return object, nil
 	}
 
+	oldStatus.ObservedGeneration = newStatus.ObservedGeneration
 	oldStatus.Replicas = newStatus.Replicas
 	oldStatus.ReadyReplicas = newStatus.ReadyReplicas
 	oldStatus.UpdatedReplicas = newStatus.UpdatedReplicas


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

After verifying and testing the multi-cluster ingress, incomplete commands were found in the document and the operation process was tedious. The PR optimized the problems found and simplified some steps

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

