### PR TITLE
support ClusterOverridePolicy in namespaces_sync_controller

### DIFF
--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -367,6 +367,7 @@ func startNamespaceController(ctx controllerscontext.Context) (enabled bool, err
 		Client:                       ctx.Mgr.GetClient(),
 		EventRecorder:                ctx.Mgr.GetEventRecorderFor(namespace.ControllerName),
 		SkippedPropagatingNamespaces: skippedPropagatingNamespaces,
+		OverrideManager:              ctx.OverrideManager,
 	}
 	if err := namespaceSyncController.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err

--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -125,7 +125,7 @@ func ensureWork(
 		workLabel := mergeLabel(clonedWorkload, workNamespace, binding, scope)
 
 		annotations := mergeAnnotations(clonedWorkload, binding, scope)
-		annotations, err = recordAppliedOverrides(cops, ops, annotations)
+		annotations, err = RecordAppliedOverrides(cops, ops, annotations)
 		if err != nil {
 			klog.Errorf("failed to record appliedOverrides, Error: %v", err)
 			return err
@@ -209,7 +209,8 @@ func mergeAnnotations(workload *unstructured.Unstructured, binding metav1.Object
 	return annotations
 }
 
-func recordAppliedOverrides(cops *overridemanager.AppliedOverrides, ops *overridemanager.AppliedOverrides,
+// RecordAppliedOverrides record applied (cluster) overrides to annotations
+func RecordAppliedOverrides(cops *overridemanager.AppliedOverrides, ops *overridemanager.AppliedOverrides,
 	annotations map[string]string) (map[string]string, error) {
 	if annotations == nil {
 		annotations = make(map[string]string)

--- a/test/e2e/clusteroverridepolicy_test.go
+++ b/test/e2e/clusteroverridepolicy_test.go
@@ -1,0 +1,99 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/klog/v2"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	"github.com/karmada-io/karmada/test/e2e/framework"
+	testhelper "github.com/karmada-io/karmada/test/helper"
+)
+
+var _ = ginkgo.Describe("[BasicClusterOverridePolicy] basic cluster override policy testing", func() {
+	ginkgo.Context("Namespace propagation testing", func() {
+		var (
+			randNamespace string
+			ns            *corev1.Namespace
+			namespaceCop  *policyv1alpha1.ClusterOverridePolicy
+
+			customLabelKey          = "hello"
+			customLabelVal          = "world"
+			plaintextOverriderValue = fmt.Sprintf("{ \"%s\": \"%s\"}", customLabelKey, customLabelVal)
+		)
+
+		ginkgo.BeforeEach(func() {
+			randNamespace = "cop-test-ns-" + rand.String(RandomStrLength)
+			ns = testhelper.NewNamespace(randNamespace)
+			namespaceCop = testhelper.NewClusterOverridePolicyByOverrideRules(ns.Name,
+				[]policyv1alpha1.ResourceSelector{
+					{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+						Name:       ns.Name,
+					},
+				},
+				[]policyv1alpha1.RuleWithCluster{
+					{
+						TargetCluster: &policyv1alpha1.ClusterAffinity{
+							ClusterNames: framework.ClusterNames(),
+						},
+						Overriders: policyv1alpha1.Overriders{
+							Plaintext: []policyv1alpha1.PlaintextOverrider{
+								{
+									Path:     "/metadata/labels",
+									Operator: policyv1alpha1.OverriderOpAdd,
+									Value:    apiextensionsv1.JSON{Raw: []byte(plaintextOverriderValue)},
+								},
+							},
+						},
+					},
+				})
+		})
+
+		ginkgo.BeforeEach(func() {
+			framework.CreateClusterOverridePolicy(karmadaClient, namespaceCop)
+			framework.CreateNamespace(kubeClient, ns)
+			ginkgo.DeferCleanup(func() {
+				framework.RemoveClusterOverridePolicy(karmadaClient, namespaceCop.Name)
+				framework.RemoveNamespace(kubeClient, ns.Name)
+				framework.WaitNamespaceDisappearOnClusters(framework.ClusterNames(), ns.Name)
+			})
+		})
+
+		ginkgo.It("Namespace testing", func() {
+			ginkgo.By(fmt.Sprintf("Check if namespace(%s) present on member clusters", ns.Name), func() {
+				for _, clusterName := range framework.ClusterNames() {
+					clusterClient := framework.GetClusterClient(clusterName)
+					gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+
+					klog.Infof("Waiting for namespace present on cluster(%s)", clusterName)
+					gomega.Eventually(func(g gomega.Gomega) (bool, error) {
+						clusterNs, err := clusterClient.CoreV1().Namespaces().Get(context.TODO(), ns.Name, metav1.GetOptions{})
+						if err != nil {
+							if apierrors.IsNotFound(err) {
+								return false, nil
+							}
+
+							return false, err
+						}
+
+						v, ok := clusterNs.Labels[customLabelKey]
+						if ok && v == customLabelVal {
+							return true, nil
+						}
+						return false, nil
+					}, pollTimeout, pollInterval).Should(gomega.Equal(true))
+				}
+			})
+		})
+	})
+})

--- a/test/e2e/framework/clusteroverridepolicy.go
+++ b/test/e2e/framework/clusteroverridepolicy.go
@@ -1,0 +1,29 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	karmada "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
+)
+
+// CreateClusterOverridePolicy create ClusterOverridePolicy with karmada client.
+func CreateClusterOverridePolicy(client karmada.Interface, policy *policyv1alpha1.ClusterOverridePolicy) {
+	ginkgo.By(fmt.Sprintf("Creating ClusterOverridePolicy(%s)", policy.Name), func() {
+		_, err := client.PolicyV1alpha1().ClusterOverridePolicies().Create(context.TODO(), policy, metav1.CreateOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+}
+
+// RemoveClusterOverridePolicy delete ClusterOverridePolicy with karmada client.
+func RemoveClusterOverridePolicy(client karmada.Interface, name string) {
+	ginkgo.By(fmt.Sprintf("Removing ClusterOverridePolicy(%s)", name), func() {
+		err := client.PolicyV1alpha1().ClusterOverridePolicies().Delete(context.TODO(), name, metav1.DeleteOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+}

--- a/test/helper/policy.go
+++ b/test/helper/policy.go
@@ -64,6 +64,19 @@ func NewOverridePolicyByOverrideRules(namespace, policyName string, rsSelectors 
 	}
 }
 
+// NewClusterOverridePolicyByOverrideRules will build a ClusterOverridePolicy object by OverrideRules
+func NewClusterOverridePolicyByOverrideRules(policyName string, rsSelectors []policyv1alpha1.ResourceSelector, overrideRules []policyv1alpha1.RuleWithCluster) *policyv1alpha1.ClusterOverridePolicy {
+	return &policyv1alpha1.ClusterOverridePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: policyName,
+		},
+		Spec: policyv1alpha1.OverrideSpec{
+			ResourceSelectors: rsSelectors,
+			OverrideRules:     overrideRules,
+		},
+	}
+}
+
 // NewFederatedResourceQuota will build a demo FederatedResourceQuota object.
 func NewFederatedResourceQuota(ns, name string) *policyv1alpha1.FederatedResourceQuota {
 	return &policyv1alpha1.FederatedResourceQuota{


### PR DESCRIPTION
Signed-off-by: hejianpeng <hejianpeng2@huawei.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #2236

**Special notes for your reviewer**:
support ClusterOverridePolicy in namespaces_sync_controller

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: `namespace` controller starts to apply `ClusterOverridePolicy` during propagation namespaces.
```

