### PR TITLE
Automated cherry pick of #2252: Fixed Argo CD can not assess StatefulSet and DaemonSet health

### DIFF
--- a/pkg/resourceinterpreter/defaultinterpreter/aggregatestatus.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/aggregatestatus.go
@@ -48,6 +48,11 @@ func aggregateDeploymentStatus(object *unstructured.Unstructured, aggregatedStat
 		}
 		klog.V(3).Infof("Grab deployment(%s/%s) status from cluster(%s), replicas: %d, ready: %d, updated: %d, available: %d, unavailable: %d",
 			deploy.Namespace, deploy.Name, item.ClusterName, temp.Replicas, temp.ReadyReplicas, temp.UpdatedReplicas, temp.AvailableReplicas, temp.UnavailableReplicas)
+
+		// always set 'observedGeneration' with current generation(.metadata.generation)
+		// which is the generation Karmada 'observed'.
+		// The 'observedGeneration' is mainly used by GitOps tools(like 'Argo CD') to assess the health status.
+		// For more details, please refer to https://argo-cd.readthedocs.io/en/stable/operator-manual/health/.
 		newStatus.ObservedGeneration = deploy.Generation
 		newStatus.Replicas += temp.Replicas
 		newStatus.ReadyReplicas += temp.ReadyReplicas
@@ -200,6 +205,12 @@ func aggregateDaemonSetStatus(object *unstructured.Unstructured, aggregatedStatu
 		}
 		klog.V(3).Infof("Grab daemonSet(%s/%s) status from cluster(%s), currentNumberScheduled: %d, desiredNumberScheduled: %d, numberAvailable: %d, numberMisscheduled: %d, numberReady: %d, updatedNumberScheduled: %d, numberUnavailable: %d",
 			daemonSet.Namespace, daemonSet.Name, item.ClusterName, temp.CurrentNumberScheduled, temp.DesiredNumberScheduled, temp.NumberAvailable, temp.NumberMisscheduled, temp.NumberReady, temp.UpdatedNumberScheduled, temp.NumberUnavailable)
+
+		// always set 'observedGeneration' with current generation(.metadata.generation)
+		// which is the generation Karmada 'observed'.
+		// The 'observedGeneration' is mainly used by GitOps tools(like 'Argo CD') to assess the health status.
+		// For more details, please refer to https://argo-cd.readthedocs.io/en/stable/operator-manual/health/.
+		newStatus.ObservedGeneration = daemonSet.Generation
 		newStatus.CurrentNumberScheduled += temp.CurrentNumberScheduled
 		newStatus.DesiredNumberScheduled += temp.DesiredNumberScheduled
 		newStatus.NumberAvailable += temp.NumberAvailable
@@ -209,7 +220,8 @@ func aggregateDaemonSetStatus(object *unstructured.Unstructured, aggregatedStatu
 		newStatus.NumberUnavailable += temp.NumberUnavailable
 	}
 
-	if oldStatus.CurrentNumberScheduled == newStatus.CurrentNumberScheduled &&
+	if oldStatus.ObservedGeneration == newStatus.ObservedGeneration &&
+		oldStatus.CurrentNumberScheduled == newStatus.CurrentNumberScheduled &&
 		oldStatus.DesiredNumberScheduled == newStatus.DesiredNumberScheduled &&
 		oldStatus.NumberAvailable == newStatus.NumberAvailable &&
 		oldStatus.NumberMisscheduled == newStatus.NumberMisscheduled &&
@@ -220,6 +232,7 @@ func aggregateDaemonSetStatus(object *unstructured.Unstructured, aggregatedStatu
 		return object, nil
 	}
 
+	oldStatus.ObservedGeneration = newStatus.ObservedGeneration
 	oldStatus.CurrentNumberScheduled = newStatus.CurrentNumberScheduled
 	oldStatus.DesiredNumberScheduled = newStatus.DesiredNumberScheduled
 	oldStatus.NumberAvailable = newStatus.NumberAvailable
@@ -248,6 +261,12 @@ func aggregateStatefulSetStatus(object *unstructured.Unstructured, aggregatedSta
 		}
 		klog.V(3).Infof("Grab statefulSet(%s/%s) status from cluster(%s), availableReplicas: %d, currentReplicas: %d, readyReplicas: %d, replicas: %d, updatedReplicas: %d",
 			statefulSet.Namespace, statefulSet.Name, item.ClusterName, temp.AvailableReplicas, temp.CurrentReplicas, temp.ReadyReplicas, temp.Replicas, temp.UpdatedReplicas)
+
+		// always set 'observedGeneration' with current generation(.metadata.generation)
+		// which is the generation Karmada 'observed'.
+		// The 'observedGeneration' is mainly used by GitOps tools(like 'Argo CD') to assess the health status.
+		// For more details, please refer to https://argo-cd.readthedocs.io/en/stable/operator-manual/health/.
+		newStatus.ObservedGeneration = statefulSet.Generation
 		newStatus.AvailableReplicas += temp.AvailableReplicas
 		newStatus.CurrentReplicas += temp.CurrentReplicas
 		newStatus.ReadyReplicas += temp.ReadyReplicas
@@ -255,7 +274,8 @@ func aggregateStatefulSetStatus(object *unstructured.Unstructured, aggregatedSta
 		newStatus.UpdatedReplicas += temp.UpdatedReplicas
 	}
 
-	if oldStatus.AvailableReplicas == newStatus.AvailableReplicas &&
+	if oldStatus.ObservedGeneration == newStatus.ObservedGeneration &&
+		oldStatus.AvailableReplicas == newStatus.AvailableReplicas &&
 		oldStatus.CurrentReplicas == newStatus.CurrentReplicas &&
 		oldStatus.ReadyReplicas == newStatus.ReadyReplicas &&
 		oldStatus.Replicas == newStatus.Replicas &&
@@ -264,6 +284,7 @@ func aggregateStatefulSetStatus(object *unstructured.Unstructured, aggregatedSta
 		return object, nil
 	}
 
+	oldStatus.ObservedGeneration = newStatus.ObservedGeneration
 	oldStatus.AvailableReplicas = newStatus.AvailableReplicas
 	oldStatus.CurrentReplicas = newStatus.CurrentReplicas
 	oldStatus.ReadyReplicas = newStatus.ReadyReplicas


### PR DESCRIPTION
Cherry pick of #2252 on release-1.2.
#2252: Fixed Argo CD can not assess StatefulSet and DaemonSet health
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```release-note
`karmada-controller-manager`: Fixed Argo CD can not assess StatefulSet/DaemonSet health status issue.
```