### PR TITLE
add implicit priority for PP

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -373,9 +373,16 @@ func (d *ResourceDetector) LookForMatchedPolicy(object *unstructured.Unstructure
 		policyList = append(policyList, policy)
 	}
 
-	var matchedPolicy *policyv1alpha1.PropagationPolicy
+	var (
+		matchedPolicy         *policyv1alpha1.PropagationPolicy
+		matchedPolicyPriority = util.PriorityMisMatch
+	)
+
 	for _, policy := range policyList {
-		if util.ResourceMatchSelectors(object, policy.Spec.ResourceSelectors...) {
+		if p := util.ResourceMatchSelectorsPriority(object, policy.Spec.ResourceSelectors...); p > matchedPolicyPriority {
+			matchedPolicy = policy
+			matchedPolicyPriority = p
+		} else if p > util.PriorityMisMatch && p == matchedPolicyPriority {
 			matchedPolicy = GetHigherPriorityPropagationPolicy(matchedPolicy, policy)
 		}
 	}
@@ -411,9 +418,16 @@ func (d *ResourceDetector) LookForMatchedClusterPolicy(object *unstructured.Unst
 		policyList = append(policyList, policy)
 	}
 
-	var matchedClusterPolicy *policyv1alpha1.ClusterPropagationPolicy
+	var (
+		matchedClusterPolicy         *policyv1alpha1.ClusterPropagationPolicy
+		matchedClusterPolicyPriority = util.PriorityMisMatch
+	)
+
 	for _, policy := range policyList {
-		if util.ResourceMatchSelectors(object, policy.Spec.ResourceSelectors...) {
+		if p := util.ResourceMatchSelectorsPriority(object, policy.Spec.ResourceSelectors...); p > matchedClusterPolicyPriority {
+			matchedClusterPolicy = policy
+			matchedClusterPolicyPriority = p
+		} else if p > util.PriorityMisMatch && p == matchedClusterPolicyPriority {
 			matchedClusterPolicy = GetHigherPriorityClusterPropagationPolicy(matchedClusterPolicy, policy)
 		}
 	}

--- a/pkg/util/selector.go
+++ b/pkg/util/selector.go
@@ -10,12 +10,29 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/lifted"
 )
 
+const (
+	// PriorityMisMatch means the ResourceSelector does not match the resource.
+	PriorityMisMatch = iota
+	// PriorityMatchAll means the ResourceSelector whose Name and LabelSelector is empty
+	// matches the resource.
+	PriorityMatchAll
+	// PriorityMatchLabelSelector means the LabelSelector of ResourceSelector matches the resource.
+	PriorityMatchLabelSelector
+	// PriorityMatchName means the Name of ResourceSelector matches the resource.
+	PriorityMatchName
+)
+
 // ResourceMatches tells if the specific resource matches the selector.
 func ResourceMatches(resource *unstructured.Unstructured, rs policyv1alpha1.ResourceSelector) bool {
+	return ResourceSelectorPriority(resource, rs) > PriorityMisMatch
+}
+
+// ResourceSelectorPriority tells the priority between the specific resource and the selector.
+func ResourceSelectorPriority(resource *unstructured.Unstructured, rs policyv1alpha1.ResourceSelector) int {
 	if resource.GetAPIVersion() != rs.APIVersion ||
 		resource.GetKind() != rs.Kind ||
 		(len(rs.Namespace) > 0 && resource.GetNamespace() != rs.Namespace) {
-		return false
+		return PriorityMisMatch
 	}
 
 	// match rules:
@@ -27,12 +44,15 @@ func ResourceMatches(resource *unstructured.Unstructured, rs policyv1alpha1.Reso
 
 	// case 1, 2: name not empty, don't need to consult selector.
 	if len(rs.Name) > 0 {
-		return rs.Name == resource.GetName()
+		if rs.Name == resource.GetName() {
+			return PriorityMatchName
+		}
+		return PriorityMisMatch
 	}
 
 	// case 4: short path, both name and selector empty, matches all
 	if rs.LabelSelector == nil {
-		return true
+		return PriorityMatchAll
 	}
 
 	// case 3: matches with selector
@@ -40,10 +60,13 @@ func ResourceMatches(resource *unstructured.Unstructured, rs policyv1alpha1.Reso
 	var err error
 	if s, err = metav1.LabelSelectorAsSelector(rs.LabelSelector); err != nil {
 		// should not happen because all resource selector should be fully validated by webhook.
-		return false
+		return PriorityMisMatch
 	}
 
-	return s.Matches(labels.Set(resource.GetLabels()))
+	if s.Matches(labels.Set(resource.GetLabels())) {
+		return PriorityMatchLabelSelector
+	}
+	return PriorityMisMatch
 }
 
 // ClusterMatches tells if specific cluster matches the affinity.
@@ -114,6 +137,17 @@ func ResourceMatchSelectors(resource *unstructured.Unstructured, selectors ...po
 		}
 	}
 	return false
+}
+
+// ResourceMatchSelectorsPriority returns the highest priority between specific resource and the selectors.
+func ResourceMatchSelectorsPriority(resource *unstructured.Unstructured, selectors ...policyv1alpha1.ResourceSelector) int {
+	var priority int
+	for _, rs := range selectors {
+		if p := ResourceSelectorPriority(resource, rs); p > priority {
+			priority = p
+		}
+	}
+	return priority
 }
 
 func extractClusterFields(cluster *clusterv1alpha1.Cluster) labels.Set {

--- a/pkg/util/selector.go
+++ b/pkg/util/selector.go
@@ -10,9 +10,13 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/lifted"
 )
 
+// ImplicitPriority describes the extent to which a ResourceSelector or a set of
+// ResourceSelectors match resources.
+type ImplicitPriority int
+
 const (
 	// PriorityMisMatch means the ResourceSelector does not match the resource.
-	PriorityMisMatch = iota
+	PriorityMisMatch ImplicitPriority = iota
 	// PriorityMatchAll means the ResourceSelector whose Name and LabelSelector is empty
 	// matches the resource.
 	PriorityMatchAll
@@ -28,7 +32,7 @@ func ResourceMatches(resource *unstructured.Unstructured, rs policyv1alpha1.Reso
 }
 
 // ResourceSelectorPriority tells the priority between the specific resource and the selector.
-func ResourceSelectorPriority(resource *unstructured.Unstructured, rs policyv1alpha1.ResourceSelector) int {
+func ResourceSelectorPriority(resource *unstructured.Unstructured, rs policyv1alpha1.ResourceSelector) ImplicitPriority {
 	if resource.GetAPIVersion() != rs.APIVersion ||
 		resource.GetKind() != rs.Kind ||
 		(len(rs.Namespace) > 0 && resource.GetNamespace() != rs.Namespace) {
@@ -140,8 +144,8 @@ func ResourceMatchSelectors(resource *unstructured.Unstructured, selectors ...po
 }
 
 // ResourceMatchSelectorsPriority returns the highest priority between specific resource and the selectors.
-func ResourceMatchSelectorsPriority(resource *unstructured.Unstructured, selectors ...policyv1alpha1.ResourceSelector) int {
-	var priority int
+func ResourceMatchSelectorsPriority(resource *unstructured.Unstructured, selectors ...policyv1alpha1.ResourceSelector) ImplicitPriority {
+	var priority ImplicitPriority
 	for _, rs := range selectors {
 		if p := ResourceSelectorPriority(resource, rs); p > priority {
 			priority = p


### PR DESCRIPTION
Signed-off-by: Garrybest <garrybest@foxmail.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
If more than one PP matches the object, we shuold choose the most suitable one. However, now we select PP by alphabetical order, it does not make any sense.

There are 4 types of implicit priority here, ordered by descend.
1. Name: ResourceSelector contains object Name and matches the object.
2. LabelSelector: ResourceSelector contains a LabelSelector and matches the object.
3. All: ResourceSelector has no Name or LabelSelector, which selects all target objects in the namespace.
4. MisMatch: ResourceSelector does not match the object.

For example:

```yaml
apiVersion: policy.karmada.io/v1alpha1
kind: PropagationPolicy
metadata:
  name: nginx-propagation-1
spec:
  resourceSelectors:
    - apiVersion: apps/v1
      kind: Deployment
      name: nginx
```

```yaml
apiVersion: policy.karmada.io/v1alpha1
kind: PropagationPolicy
metadata:
  name: nginx-propagation-2
spec:
  resourceSelectors:
    - apiVersion: apps/v1
      kind: Deployment
```

In this case, `nginx-propagation-1` should be privileged compared to `nginx-propagation-2` because it's more precise.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
add implicit priority for PropagationPolicy
```

