### PR TITLE
Adjust the order of kubeconfig loadingRules

### DIFF
--- a/pkg/karmadactl/cmdinit/utils/kubeclient.go
+++ b/pkg/karmadactl/cmdinit/utils/kubeclient.go
@@ -13,8 +13,8 @@ func RestConfig(context, kubeconfigPath string) (*rest.Config, error) {
 	pathOptions := clientcmd.NewDefaultPathOptions()
 
 	loadingRules := *pathOptions.LoadingRules
-	loadingRules.Precedence = pathOptions.GetLoadingPrecedence()
 	loadingRules.ExplicitPath = kubeconfigPath
+	loadingRules.Precedence = pathOptions.GetLoadingPrecedence()
 	overrides := &clientcmd.ConfigOverrides{
 		CurrentContext: context,
 	}

--- a/pkg/karmadactl/config.go
+++ b/pkg/karmadactl/config.go
@@ -44,8 +44,8 @@ func (a *karmadaConfig) GetRestConfig(context, kubeconfigPath string) (*rest.Con
 // context and kubeconfig passed as arguments.
 func (a *karmadaConfig) GetClientConfig(context, kubeconfigPath string) clientcmd.ClientConfig {
 	loadingRules := *a.pathOptions.LoadingRules
-	loadingRules.Precedence = a.pathOptions.GetLoadingPrecedence()
 	loadingRules.ExplicitPath = kubeconfigPath
+	loadingRules.Precedence = a.pathOptions.GetLoadingPrecedence()
 	overrides := &clientcmd.ConfigOverrides{
 		CurrentContext: context,
 	}


### PR DESCRIPTION

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

If we use the same `karmadaConfig` object, and call method `GetClientConfig` more than once. The first time it would set the `ExplicitPath` and `Precedence` successfully. But the second time it would set `Precedence` with the value of `ExplicitPath` the first time set.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

