### PR TITLE
support CRD category

### DIFF
--- a/charts/karmada/_crds/bases/networking.karmada.io_multiclusteringresses.yaml
+++ b/charts/karmada/_crds/bases/networking.karmada.io_multiclusteringresses.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: networking.karmada.io
   names:
+    categories:
+    - karmada-io
     kind: MultiClusterIngress
     listKind: MultiClusterIngressList
     plural: multiclusteringresses

--- a/charts/karmada/_crds/bases/policy.karmada.io_clusteroverridepolicies.yaml
+++ b/charts/karmada/_crds/bases/policy.karmada.io_clusteroverridepolicies.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: policy.karmada.io
   names:
+    categories:
+    - karmada-io
     kind: ClusterOverridePolicy
     listKind: ClusterOverridePolicyList
     plural: clusteroverridepolicies

--- a/charts/karmada/_crds/bases/policy.karmada.io_clusterpropagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy.karmada.io_clusterpropagationpolicies.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: policy.karmada.io
   names:
+    categories:
+    - karmada-io
     kind: ClusterPropagationPolicy
     listKind: ClusterPropagationPolicyList
     plural: clusterpropagationpolicies

--- a/charts/karmada/_crds/bases/policy.karmada.io_federatedresourcequotas.yaml
+++ b/charts/karmada/_crds/bases/policy.karmada.io_federatedresourcequotas.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: policy.karmada.io
   names:
+    categories:
+    - karmada-io
     kind: FederatedResourceQuota
     listKind: FederatedResourceQuotaList
     plural: federatedresourcequotas

--- a/charts/karmada/_crds/bases/policy.karmada.io_overridepolicies.yaml
+++ b/charts/karmada/_crds/bases/policy.karmada.io_overridepolicies.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: policy.karmada.io
   names:
+    categories:
+    - karmada-io
     kind: OverridePolicy
     listKind: OverridePolicyList
     plural: overridepolicies

--- a/charts/karmada/_crds/bases/policy.karmada.io_propagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy.karmada.io_propagationpolicies.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: policy.karmada.io
   names:
+    categories:
+    - karmada-io
     kind: PropagationPolicy
     listKind: PropagationPolicyList
     plural: propagationpolicies

--- a/charts/karmada/_crds/bases/work.karmada.io_clusterresourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work.karmada.io_clusterresourcebindings.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: work.karmada.io
   names:
+    categories:
+    - karmada-io
     kind: ClusterResourceBinding
     listKind: ClusterResourceBindingList
     plural: clusterresourcebindings

--- a/charts/karmada/_crds/bases/work.karmada.io_resourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work.karmada.io_resourcebindings.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: work.karmada.io
   names:
+    categories:
+    - karmada-io
     kind: ResourceBinding
     listKind: ResourceBindingList
     plural: resourcebindings

--- a/charts/karmada/_crds/bases/work.karmada.io_works.yaml
+++ b/charts/karmada/_crds/bases/work.karmada.io_works.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: work.karmada.io
   names:
+    categories:
+    - karmada-io
     kind: Work
     listKind: WorkList
     plural: works

--- a/pkg/apis/networking/v1alpha1/ingress_types.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types.go
@@ -19,7 +19,7 @@ const (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:shortName=mci
+// +kubebuilder:resource:shortName=mci,categories={karmada-io}
 
 // MultiClusterIngress is a collection of rules that allow inbound connections to reach the
 // endpoints defined by a backend. The structure of MultiClusterIngress is same as Ingress,

--- a/pkg/apis/policy/v1alpha1/federatedresourcequota_types.go
+++ b/pkg/apis/policy/v1alpha1/federatedresourcequota_types.go
@@ -18,6 +18,7 @@ const (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:categories={karmada-io}
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 

--- a/pkg/apis/policy/v1alpha1/override_types.go
+++ b/pkg/apis/policy/v1alpha1/override_types.go
@@ -27,7 +27,7 @@ const (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:shortName=op
+// +kubebuilder:resource:shortName=op,categories={karmada-io}
 
 // OverridePolicy represents the policy that overrides a group of resources to one or more clusters.
 type OverridePolicy struct {
@@ -223,7 +223,7 @@ type OverridePolicyList struct {
 
 // +genclient
 // +genclient:nonNamespaced
-// +kubebuilder:resource:scope="Cluster",shortName=cop
+// +kubebuilder:resource:scope="Cluster",shortName=cop,categories={karmada-io}
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ClusterOverridePolicy represents the cluster-wide policy that overrides a group of resources to one or more clusters.

--- a/pkg/apis/policy/v1alpha1/propagation_types.go
+++ b/pkg/apis/policy/v1alpha1/propagation_types.go
@@ -27,7 +27,7 @@ const (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:shortName=pp
+// +kubebuilder:resource:shortName=pp,categories={karmada-io}
 
 // PropagationPolicy represents the policy that propagates a group of resources to one or more clusters.
 type PropagationPolicy struct {
@@ -302,7 +302,7 @@ type PropagationPolicyList struct {
 
 // +genclient
 // +genclient:nonNamespaced
-// +kubebuilder:resource:scope="Cluster",shortName=cpp
+// +kubebuilder:resource:scope="Cluster",shortName=cpp,categories={karmada-io}
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ClusterPropagationPolicy represents the cluster-wide policy that propagates a group of resources to one or more clusters.

--- a/pkg/apis/work/v1alpha1/binding_types.go
+++ b/pkg/apis/work/v1alpha1/binding_types.go
@@ -9,7 +9,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:shortName=rb
+// +kubebuilder:resource:shortName=rb,categories={karmada-io}
 
 // ResourceBinding represents a binding of a kubernetes resource with a propagation policy.
 type ResourceBinding struct {
@@ -119,7 +119,7 @@ type ResourceBindingList struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope="Cluster",shortName=crb
+// +kubebuilder:resource:scope="Cluster",shortName=crb,categories={karmada-io}
 // +kubebuilder:subresource:status
 
 // ClusterResourceBinding represents a binding of a kubernetes resource with a ClusterPropagationPolicy.

--- a/pkg/apis/work/v1alpha1/work_types.go
+++ b/pkg/apis/work/v1alpha1/work_types.go
@@ -19,6 +19,7 @@ const (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:categories={karmada-io}
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Applied")].status`,name="Applied",type=string
 // +kubebuilder:printcolumn:JSONPath=`.metadata.creationTimestamp`,name="Age",type=date
 

--- a/pkg/apis/work/v1alpha2/binding_types.go
+++ b/pkg/apis/work/v1alpha2/binding_types.go
@@ -30,7 +30,7 @@ const (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:shortName=rb
+// +kubebuilder:resource:shortName=rb,categories={karmada-io}
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Scheduled")].status`,name="Scheduled",type=string
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="FullyApplied")].status`,name="FullyApplied",type=string
@@ -214,7 +214,7 @@ type ResourceBindingList struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope="Cluster",shortName=crb
+// +kubebuilder:resource:scope="Cluster",shortName=crb,categories={karmada-io}
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Scheduled")].status`,name="Scheduled",type=string


### PR DESCRIPTION
Signed-off-by: hejianpeng <hejianpeng2@huawei.com>

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature

**What this PR does / why we need it**:

with this PR allow user get all karamda CR via `kubectl get karmada-io`
also support list resources by `kubectl get policy-karmada-io`

more information can be found [here](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#categories)

cc @XiShanYongYe-Chang @RainbowMango 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Karmada APIs now are grouped by 'karmada-io' category. People can use `kubectl get karmada-io` command gets all Karmada resources.
```

