### PR TITLE
Add memory request to karmada-apiserver and remove unused parameter in etcd

### DIFF
--- a/artifacts/deploy/karmada-apiserver.yaml
+++ b/artifacts/deploy/karmada-apiserver.yaml
@@ -87,6 +87,7 @@ spec:
           resources:
             requests:
               cpu: 250m
+              memory: 200Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/artifacts/deploy/karmada-etcd.yaml
+++ b/artifacts/deploy/karmada-etcd.yaml
@@ -60,7 +60,7 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 100Mi
+              memory: 150Mi
           command:
             - /usr/local/bin/etcd
             - --name
@@ -80,7 +80,6 @@ spec:
             - --key-file=/etc/kubernetes/pki/etcd/karmada.key
             - --trusted-ca-file=/etc/kubernetes/pki/etcd/server-ca.crt
             - --data-dir=/var/lib/etcd
-            - --snapshot-count=10000
       volumes:
         - hostPath:
             path: /var/lib/karmada-etcd


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind cleanup
/kind failing-test

**What this PR does / why we need it**:

Before we post a pr #2174 to fix the failing-test with `karmada-apiserver` accessing request.  After my own verification, it is found that the added etcd parameter `--snapshot-count` has no actual effect. The actual effect is that the resource request is added for etcd.

After multiple parameter adjustments, set appropriate resource requests for `etcd` and `karmada-apiserver`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

