### PR TITLE
disabled search APIService chart resource by default

### DIFF
--- a/charts/karmada/templates/_karmada_apiservice.tpl
+++ b/charts/karmada/templates/_karmada_apiservice.tpl
@@ -26,7 +26,8 @@ metadata:
 spec:
   type: ExternalName
   externalName: {{ $name }}-aggregated-apiserver.{{ include "karmada.namespace" . }}.svc.{{ .Values.clusterDomain }}
----
+
+{{- if and (eq .Values.installMode "component") (has "search" .Values.components) }}
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
@@ -52,4 +53,5 @@ metadata:
 spec:
   type: ExternalName
   externalName: {{ $name }}-search.{{ include "karmada.namespace" . }}.svc.{{ .Values.clusterDomain }}
+{{- end }}
 {{- end -}}


### PR DESCRIPTION
Signed-off-by: calvin0327 <wen.chen@daocloud.io>

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When use the helm cmd install karmada without any component,  but the search `APIService` is be deployed togother. 
if we want to delete a namespace in karmada cluster, the following error message will be report:

<img width="1897" alt="image" src="https://user-images.githubusercontent.com/45745657/181915484-f3b31a27-4989-4ded-8aee-e5af009d6c56.png">

Because when we delete namespace, the k8s will delete all of the resource with delete verb in the namespace, incloude of  AA resource. But the search conponent is not be installed by default,  the apiserver not find the server of search.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Please correct me if not.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

