### PR TITLE
docs: changed the way to get the kubeconfig path in aggregation api

### DIFF
--- a/docs/userguide/aggregated-api-endpoint.md
+++ b/docs/userguide/aggregated-api-endpoint.md
@@ -12,10 +12,10 @@ To quickly experience this feature, we experimented with karmada-apiserver certi
 
 ### Step1: Obtain the karmada-apiserver Certificate
 
-For Karmada deployed using `hack/local-up-karmada.sh`, you can directly copy it from the `/root/.kube/` directory.
+For Karmada deployed using `hack/local-up-karmada.sh`, you can directly copy it from the `$HOME/.kube/` directory.
 
 ```shell
-cp /root/.kube/karmada.config karmada-apiserver.config
+cp $HOME/.kube/karmada.config karmada-apiserver.config
 ```
 
 ### Step2: Grant permission to user `system:admin`
@@ -63,7 +63,7 @@ subjects:
 </details>
 
 ```shell
-kubectl --kubeconfig /root/.kube/karmada.config --context karmada-apiserver apply -f cluster-proxy-rbac.yaml
+kubectl --kubeconfig $HOME/.kube/karmada.config --context karmada-apiserver apply -f cluster-proxy-rbac.yaml
 ```
 
 ### Step3: Access member clusters
@@ -95,13 +95,13 @@ If the serviceaccount has been created in your environment, you can skip this st
 Create a serviceaccount that does not have any permission:
 
 ```shell
-kubectl --kubeconfig /root/.kube/members.config --context member1 create serviceaccount tom
+kubectl --kubeconfig $HOME/.kube/members.config --context member1 create serviceaccount tom
 ```
 
 ### Step2: Create ServiceAccount in Karmada control plane
 
 ```shell
-kubectl --kubeconfig /root/.kube/karmada.config --context karmada-apiserver create serviceaccount tom
+kubectl --kubeconfig $HOME/.kube/karmada.config --context karmada-apiserver create serviceaccount tom
 ```
 
 In order to grant serviceaccount the `clusters/proxy` permission, apply the following rbac yaml file:
@@ -149,7 +149,7 @@ subjects:
 </details>
 
 ```shell
-kubectl --kubeconfig /root/.kube/karmada.config --context karmada-apiserver apply -f cluster-proxy-rbac.yaml
+kubectl --kubeconfig $HOME/.kube/karmada.config --context karmada-apiserver apply -f cluster-proxy-rbac.yaml
 ```
 
 ### Step3: Access member1 cluster
@@ -167,7 +167,7 @@ apiVersion: v1
 clusters:
 - cluster:
     insecure-skip-tls-verify: true
-    server: {karmada-apiserver-address} # Replace {karmada-apiserver-address} with karmada-apiserver-address. You can find it in /root/.kube/karmada.config file.
+    server: {karmada-apiserver-address} # Replace {karmada-apiserver-address} with karmada-apiserver-address. You can find it in $HOME/.kube/karmada.config file.
   name: tom
 contexts:
 - context:
@@ -236,7 +236,7 @@ subjects:
 </details>
 
 ```shell
-kubectl --kubeconfig /root/.kube/members.config --context member1 apply -f member1-rbac.yaml
+kubectl --kubeconfig $HOME/.kube/members.config --context member1 apply -f member1-rbac.yaml
 ```
 
 Run the command that failed in the previous step again:


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

When we install Karmada using `hack/local-up-karmada.sh`, the kubeconfig file is stored under `${HOME}/.kube`, so `$HOME` is not necessarily set to `/root`, and can be seen in `local-up-karmada.sh` as follows
```shell
# variable define
KUBECONFIG_PATH=${KUBECONFIG_PATH:-"${HOME}/.kube"}
MAIN_KUBECONFIG=${MAIN_KUBECONFIG:-"${KUBECONFIG_PATH}/karmada.config"}
HOST_CLUSTER_NAME=${HOST_CLUSTER_NAME:-"karmada-host"}
KARMADA_APISERVER_CLUSTER_NAME=${KARMADA_APISERVER_CLUSTER_NAME:-"karmada-apiserver"}
MEMBER_CLUSTER_KUBECONFIG=${MEMBER_CLUSTER_KUBECONFIG:-"${KUBECONFIG_PATH}/members.config"}
MEMBER_CLUSTER_1_NAME=${MEMBER_CLUSTER_1_NAME:-"member1"}
MEMBER_CLUSTER_2_NAME=${MEMBER_CLUSTER_2_NAME:-"member2"}
PULL_MODE_CLUSTER_NAME=${PULL_MODE_CLUSTER_NAME:-"member3"}
HOST_IPADDRESS=${1:-}
```
For example, on MASOS, the kubeconfig file is stored
```shell
➜  .kube pwd
/Users/york/.kube
➜  .kube ll
total 88
-rw-------     1 york  staff   9.9K  8  1 11:07 karmada.config
-rw-------     1 york  staff    16K  8  1 11:07 members.config
```
When I execute `cp /root/.kube/karmada.config karmada-apiserver.config`
```shell
➜  aggregated cp /root/.kube/karmada.config karmada-apiserver.config
cp: /root/.kube/karmada.config: No such file or directory
```
This pr fixes the error

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

