### PR TITLE
disable flags in use line

### DIFF
--- a/pkg/karmadactl/addons/disable.go
+++ b/pkg/karmadactl/addons/disable.go
@@ -38,11 +38,12 @@ var (
 func NewCmdAddonsDisable(parentCommand string) *cobra.Command {
 	opts := addoninit.CommandAddonsDisableOption{}
 	cmd := &cobra.Command{
-		Use:          "disable",
-		Short:        "Disable karmada addons from Kubernetes",
-		Long:         "Disable Karmada addons from Kubernetes",
-		Example:      fmt.Sprintf(disableExample, parentCommand),
-		SilenceUsage: true,
+		Use:                   "disable",
+		Short:                 "Disable karmada addons from Kubernetes",
+		Long:                  "Disable Karmada addons from Kubernetes",
+		Example:               fmt.Sprintf(disableExample, parentCommand),
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Complete(); err != nil {
 				return err

--- a/pkg/karmadactl/addons/enable.go
+++ b/pkg/karmadactl/addons/enable.go
@@ -43,11 +43,12 @@ var (
 func NewCmdAddonsEnable(parentCommand string) *cobra.Command {
 	opts := addoninit.CommandAddonsEnableOption{}
 	cmd := &cobra.Command{
-		Use:          "enable",
-		Short:        "Enable Karmada addons from Kubernetes",
-		Long:         "Enable Karmada addons from Kubernetes",
-		Example:      fmt.Sprintf(enableExample, parentCommand),
-		SilenceUsage: true,
+		Use:                   "enable",
+		Short:                 "Enable Karmada addons from Kubernetes",
+		Long:                  "Enable Karmada addons from Kubernetes",
+		Example:               fmt.Sprintf(enableExample, parentCommand),
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Complete(); err != nil {
 				return err

--- a/pkg/karmadactl/addons/list.go
+++ b/pkg/karmadactl/addons/list.go
@@ -32,11 +32,12 @@ var (
 func NewCmdAddonsList(parentCommand string) *cobra.Command {
 	opts := addoninit.CommandAddonsListOption{}
 	cmd := &cobra.Command{
-		Use:          "list",
-		Short:        "List karmada addons from Kubernetes",
-		Long:         "List Karmada addons from Kubernetes",
-		Example:      fmt.Sprintf(listExample, parentCommand),
-		SilenceUsage: true,
+		Use:                   "list",
+		Short:                 "List karmada addons from Kubernetes",
+		Long:                  "List Karmada addons from Kubernetes",
+		Example:               fmt.Sprintf(listExample, parentCommand),
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Complete(); err != nil {
 				return err

--- a/pkg/karmadactl/apply.go
+++ b/pkg/karmadactl/apply.go
@@ -73,10 +73,12 @@ func NewCmdApply(karmadaConfig KarmadaConfig, parentCommand string, streams gene
 		KubectlApplyFlags: kubectlapply.NewApplyFlags(nil, streams),
 	}
 	cmd := &cobra.Command{
-		Use:     "apply (-f FILENAME | -k DIRECTORY)",
-		Short:   "Apply a configuration to a resource by file name or stdin and propagate them into member clusters",
-		Long:    applyLong,
-		Example: fmt.Sprintf(applyExample, parentCommand),
+		Use:                   "apply (-f FILENAME | -k DIRECTORY)",
+		Short:                 "Apply a configuration to a resource by file name or stdin and propagate them into member clusters",
+		Long:                  applyLong,
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
+		Example:               fmt.Sprintf(applyExample, parentCommand),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(karmadaConfig, cmd, parentCommand, args); err != nil {
 				return err

--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -58,11 +58,12 @@ var (
 func NewCmdInit(parentCommand string) *cobra.Command {
 	opts := kubernetes.CommandInitOption{}
 	cmd := &cobra.Command{
-		Use:          "init",
-		Short:        initShort,
-		Long:         initLong,
-		Example:      initExample(parentCommand),
-		SilenceUsage: true,
+		Use:                   "init",
+		Short:                 initShort,
+		Long:                  initLong,
+		Example:               initExample(parentCommand),
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(parentCommand); err != nil {
 				return err

--- a/pkg/karmadactl/cordon.go
+++ b/pkg/karmadactl/cordon.go
@@ -45,11 +45,12 @@ const (
 func NewCmdCordon(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Command {
 	opts := CommandCordonOption{}
 	cmd := &cobra.Command{
-		Use:          "cordon CLUSTER",
-		Short:        cordonShort,
-		Long:         cordonLong,
-		Example:      fmt.Sprintf(cordonExample, parentCommand),
-		SilenceUsage: true,
+		Use:                   "cordon CLUSTER",
+		Short:                 cordonShort,
+		Long:                  cordonLong,
+		Example:               fmt.Sprintf(cordonExample, parentCommand),
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Complete(args); err != nil {
 				return err
@@ -73,11 +74,12 @@ func NewCmdCordon(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Comm
 func NewCmdUncordon(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Command {
 	opts := CommandCordonOption{}
 	cmd := &cobra.Command{
-		Use:          "uncordon CLUSTER",
-		Short:        uncordonShort,
-		Long:         uncordonLong,
-		Example:      fmt.Sprintf(uncordonExample, parentCommand),
-		SilenceUsage: true,
+		Use:                   "uncordon CLUSTER",
+		Short:                 uncordonShort,
+		Long:                  uncordonLong,
+		Example:               fmt.Sprintf(uncordonExample, parentCommand),
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Complete(args); err != nil {
 				return err

--- a/pkg/karmadactl/deinit.go
+++ b/pkg/karmadactl/deinit.go
@@ -44,11 +44,12 @@ type CommandDeInitOption struct {
 func NewCmdDeInit(parentCommand string) *cobra.Command {
 	opts := CommandDeInitOption{}
 	cmd := &cobra.Command{
-		Use:          "deinit",
-		Short:        "Removes Karmada from Kubernetes",
-		Long:         "Removes Karmada from Kubernetes",
-		Example:      fmt.Sprintf(deInitExample, parentCommand),
-		SilenceUsage: true,
+		Use:                   "deinit",
+		Short:                 "Removes Karmada from Kubernetes",
+		Long:                  "Removes Karmada from Kubernetes",
+		Example:               fmt.Sprintf(deInitExample, parentCommand),
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Complete(); err != nil {
 				return err

--- a/pkg/karmadactl/describe.go
+++ b/pkg/karmadactl/describe.go
@@ -48,10 +48,11 @@ func NewCmdDescribe(karmadaConfig KarmadaConfig, parentCommand string, streams g
 	}
 
 	cmd := &cobra.Command{
-		Use:          "describe (-f FILENAME | TYPE [NAME_PREFIX | -l label] | TYPE/NAME) (-C CLUSTER)",
-		Short:        "Show details of a specific resource or group of resources in a cluster",
-		SilenceUsage: true,
-		Example:      fmt.Sprintf(describeExample, parentCommand),
+		Use:                   "describe (-f FILENAME | TYPE [NAME_PREFIX | -l label] | TYPE/NAME) (-C CLUSTER)",
+		Short:                 "Show details of a specific resource or group of resources in a cluster",
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
+		Example:               fmt.Sprintf(describeExample, parentCommand),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(karmadaConfig, cmd, args); err != nil {
 				return err

--- a/pkg/karmadactl/exec.go
+++ b/pkg/karmadactl/exec.go
@@ -51,10 +51,12 @@ func NewCmdExec(karmadaConfig KarmadaConfig, parentCommand string, streams gener
 	}
 
 	cmd := &cobra.Command{
-		Use:     "exec (POD | TYPE/NAME) [-c CONTAINER] [flags] (-C CLUSTER) -- COMMAND [args...]",
-		Short:   "Execute a command in a container in a cluster",
-		Long:    "Execute a command in a container in a cluster",
-		Example: fmt.Sprintf(execExample, parentCommand),
+		Use:                   "exec (POD | TYPE/NAME) [-c CONTAINER] (-C CLUSTER) -- COMMAND [args...]",
+		Short:                 "Execute a command in a container in a cluster",
+		Long:                  "Execute a command in a container in a cluster",
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
+		Example:               fmt.Sprintf(execExample, parentCommand),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			argsLenAtDash := cmd.ArgsLenAtDash()
 			if err := o.Complete(karmadaConfig, cmd, args, argsLenAtDash); err != nil {

--- a/pkg/karmadactl/get.go
+++ b/pkg/karmadactl/get.go
@@ -87,10 +87,11 @@ var (
 func NewCmdGet(karmadaConfig KarmadaConfig, parentCommand string, streams genericclioptions.IOStreams) *cobra.Command {
 	o := NewCommandGetOptions(streams)
 	cmd := &cobra.Command{
-		Use:          "get [NAME | -l label | -n namespace]  [flags]",
-		Short:        getShort,
-		SilenceUsage: true,
-		Example:      fmt.Sprintf(getExample, parentCommand),
+		Use:                   "get [NAME | -l label | -n namespace]",
+		Short:                 getShort,
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
+		Example:               fmt.Sprintf(getExample, parentCommand),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(karmadaConfig); err != nil {
 				return err

--- a/pkg/karmadactl/join.go
+++ b/pkg/karmadactl/join.go
@@ -32,11 +32,12 @@ func NewCmdJoin(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Comman
 	opts := CommandJoinOption{}
 
 	cmd := &cobra.Command{
-		Use:          "join CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG>",
-		Short:        joinShort,
-		Long:         joinLong,
-		Example:      fmt.Sprintf(joinExample, parentCommand),
-		SilenceUsage: true,
+		Use:                   "join CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG>",
+		Short:                 joinShort,
+		Long:                  joinLong,
+		Example:               fmt.Sprintf(joinExample, parentCommand),
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Complete(args); err != nil {
 				return err

--- a/pkg/karmadactl/logs.go
+++ b/pkg/karmadactl/logs.go
@@ -56,10 +56,11 @@ func NewCmdLogs(f util.Factory, parentCommand string, streams genericclioptions.
 	}
 
 	cmd := &cobra.Command{
-		Use:          logsUsageStr,
-		Short:        "Print the logs for a container in a pod in a cluster",
-		SilenceUsage: true,
-		Example:      fmt.Sprintf(logsExample, parentCommand),
+		Use:                   logsUsageStr,
+		Short:                 "Print the logs for a container in a pod in a cluster",
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
+		Example:               fmt.Sprintf(logsExample, parentCommand),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(cmd, args, f); err != nil {
 				return err

--- a/pkg/karmadactl/promote.go
+++ b/pkg/karmadactl/promote.go
@@ -59,11 +59,12 @@ func NewCmdPromote(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Com
 	opts.JSONYamlPrintFlags = genericclioptions.NewJSONYamlPrintFlags()
 
 	cmd := &cobra.Command{
-		Use:          "promote <RESOURCE_TYPE> <RESOURCE_NAME> -n <NAME_SPACE> -C <CLUSTER_NAME>",
-		Short:        promoteShort,
-		Long:         promoteLong,
-		Example:      fmt.Sprintf(promoteExample, parentCommand),
-		SilenceUsage: true,
+		Use:                   "promote <RESOURCE_TYPE> <RESOURCE_NAME> -n <NAME_SPACE> -C <CLUSTER_NAME>",
+		Short:                 promoteShort,
+		Long:                  promoteLong,
+		Example:               fmt.Sprintf(promoteExample, parentCommand),
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Complete(args); err != nil {
 				return err

--- a/pkg/karmadactl/register.go
+++ b/pkg/karmadactl/register.go
@@ -129,11 +129,12 @@ func NewCmdRegister(parentCommand string) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:          "register [karmada-apiserver-endpoint]",
-		Short:        registerShort,
-		Long:         registerLong,
-		Example:      fmt.Sprintf(registerExample, parentCommand),
-		SilenceUsage: true,
+		Use:                   "register [karmada-apiserver-endpoint]",
+		Short:                 registerShort,
+		Long:                  registerLong,
+		Example:               fmt.Sprintf(registerExample, parentCommand),
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Complete(args); err != nil {
 				return err

--- a/pkg/karmadactl/taint.go
+++ b/pkg/karmadactl/taint.go
@@ -56,11 +56,12 @@ func NewCmdTaint(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Comma
 	opts := CommandTaintOption{}
 
 	cmd := &cobra.Command{
-		Use:          "taint CLUSTER NAME KEY_1=VAL_1:TAINT_EFFECT_1 ... KEY_N=VAL_N:TAINT_EFFECT_N",
-		Short:        taintShort,
-		Long:         taintLong,
-		Example:      fmt.Sprintf(taintExample, parentCommand),
-		SilenceUsage: true,
+		Use:                   "taint CLUSTER NAME KEY_1=VAL_1:TAINT_EFFECT_1 ... KEY_N=VAL_N:TAINT_EFFECT_N",
+		Short:                 taintShort,
+		Long:                  taintLong,
+		Example:               fmt.Sprintf(taintExample, parentCommand),
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Complete(args); err != nil {
 				return err

--- a/pkg/karmadactl/token.go
+++ b/pkg/karmadactl/token.go
@@ -90,15 +90,16 @@ type CommandTokenOptions struct {
 // NewCmdTokenCreate returns cobra.Command to create token
 func NewCmdTokenCreate(karmadaConfig KarmadaConfig, out io.Writer, tokenOpts *CommandTokenOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "create",
-		DisableFlagsInUseLine: true,
-		Short:                 "Create bootstrap tokens on the server",
+		Use:   "create",
+		Short: "Create bootstrap tokens on the server",
 		Long: templates.LongDesc(`
 			This command will create a bootstrap token for you.
 			You can specify the usages for this token, the "time to live" and an optional human friendly description.
 
 			This should be a securely generated random token of the form "[a-z0-9]{6}.[a-z0-9]{16}".
 		`),
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
 		RunE: func(Cmd *cobra.Command, args []string) error {
 			// Get control plane kube-apiserver client
 			client, err := tokenOpts.getClientSet(karmadaConfig)

--- a/pkg/karmadactl/unjoin.go
+++ b/pkg/karmadactl/unjoin.go
@@ -40,11 +40,12 @@ func NewCmdUnjoin(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Comm
 	opts := CommandUnjoinOption{}
 
 	cmd := &cobra.Command{
-		Use:          "unjoin CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG>",
-		Short:        unjoinShort,
-		Long:         unjoinLong,
-		Example:      fmt.Sprintf(unjoinExample, parentCommand),
-		SilenceUsage: true,
+		Use:                   "unjoin CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG>",
+		Short:                 unjoinShort,
+		Long:                  unjoinLong,
+		Example:               fmt.Sprintf(unjoinExample, parentCommand),
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Complete(args); err != nil {
 				return err


### PR DESCRIPTION
Signed-off-by: carlory <baofa.fan@daocloud.io>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

After #2283 is merged, Flags are renamed to options. We should disable flags in useline for karmada sub command.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

