### PR TITLE
add scheduling diagnosis

### DIFF
--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -126,6 +126,11 @@ func (s *Result) AsError() error {
 	return errors.New(strings.Join(s.reasons, ", "))
 }
 
+// Reasons returns reasons of the Result.
+func (s *Result) Reasons() []string {
+	return s.reasons
+}
+
 // ScorePlugin is an interface that must be implemented by "Score" plugins to rank
 // clusters that passed the filtering phase.
 type ScorePlugin interface {

--- a/pkg/scheduler/framework/plugins/apienablement/api_enablement.go
+++ b/pkg/scheduler/framework/plugins/apienablement/api_enablement.go
@@ -37,7 +37,7 @@ func (p *APIEnablement) Filter(ctx context.Context, placement *policyv1alpha1.Pl
 	bindingSpec *workv1alpha2.ResourceBindingSpec, cluster *clusterv1alpha1.Cluster) *framework.Result {
 	if !helper.IsAPIEnabled(cluster.Status.APIEnablements, bindingSpec.Resource.APIVersion, bindingSpec.Resource.Kind) {
 		klog.V(2).Infof("Cluster(%s) not fit as missing API(%s, kind=%s)", cluster.Name, bindingSpec.Resource.APIVersion, bindingSpec.Resource.Kind)
-		return framework.NewResult(framework.Unschedulable, "no such API resource")
+		return framework.NewResult(framework.Unschedulable, "cluster(s) didn't have the API resource")
 	}
 
 	return framework.NewResult(framework.Success)

--- a/pkg/scheduler/framework/plugins/clusteraffinity/cluster_affinity.go
+++ b/pkg/scheduler/framework/plugins/clusteraffinity/cluster_affinity.go
@@ -39,7 +39,7 @@ func (p *ClusterAffinity) Filter(ctx context.Context, placement *policyv1alpha1.
 		if util.ClusterMatches(cluster, *affinity) {
 			return framework.NewResult(framework.Success)
 		}
-		return framework.NewResult(framework.Unschedulable, "cluster is not matched the placement cluster affinity constraint")
+		return framework.NewResult(framework.Unschedulable, "cluster(s) didn't match the placement cluster affinity constraint")
 	}
 
 	// If no clusters specified and it is not excluded, mark it matched

--- a/pkg/scheduler/framework/plugins/spreadconstraint/spread_constraint.go
+++ b/pkg/scheduler/framework/plugins/spreadconstraint/spread_constraint.go
@@ -34,11 +34,11 @@ func (p *SpreadConstraint) Filter(ctx context.Context, placement *policyv1alpha1
 	bindingSpec *workv1alpha2.ResourceBindingSpec, cluster *clusterv1alpha1.Cluster) *framework.Result {
 	for _, spreadConstraint := range placement.SpreadConstraints {
 		if spreadConstraint.SpreadByField == policyv1alpha1.SpreadByFieldProvider && cluster.Spec.Provider == "" {
-			return framework.NewResult(framework.Unschedulable, "No Provider Property in the Cluster.Spec")
+			return framework.NewResult(framework.Unschedulable, "cluster(s) didn't have provider property")
 		} else if spreadConstraint.SpreadByField == policyv1alpha1.SpreadByFieldRegion && cluster.Spec.Region == "" {
-			return framework.NewResult(framework.Unschedulable, "No Region Property in the Cluster.Spec")
+			return framework.NewResult(framework.Unschedulable, "cluster(s) didn't have region property")
 		} else if spreadConstraint.SpreadByField == policyv1alpha1.SpreadByFieldZone && cluster.Spec.Zone == "" {
-			return framework.NewResult(framework.Unschedulable, "No Zone Property in the Cluster.Spec")
+			return framework.NewResult(framework.Unschedulable, "cluster(s) didn't have zone property")
 		}
 	}
 

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -52,6 +52,5 @@ func (p *TaintToleration) Filter(ctx context.Context, placement *policyv1alpha1.
 		return framework.NewResult(framework.Success)
 	}
 
-	return framework.NewResult(framework.Unschedulable, fmt.Sprintf("cluster had taint {%s: %s}, that the propagation policy didn't tolerate",
-		taint.Key, taint.Value))
+	return framework.NewResult(framework.Unschedulable, fmt.Sprintf("cluster(s) had untolerated taint {%s: %s}", taint.Key, taint.Value))
 }

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -1,8 +1,20 @@
 package framework
 
 import (
+	"fmt"
+	"sort"
+	"strings"
+
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 )
+
+const (
+	// NoClusterAvailableMsg is used to format message when no clusters available.
+	NoClusterAvailableMsg = "0/%v clusters are available"
+)
+
+// ClusterToResultMap declares map from cluster name to its Result.
+type ClusterToResultMap map[string]*Result
 
 // ClusterInfo is cluster level aggregated information.
 type ClusterInfo struct {
@@ -23,4 +35,36 @@ func (n *ClusterInfo) Cluster() *clusterv1alpha1.Cluster {
 		return nil
 	}
 	return n.cluster
+}
+
+// Diagnosis records the details to diagnose a scheduling failure.
+type Diagnosis struct {
+	ClusterToResultMap ClusterToResultMap
+}
+
+// FitError describes a fit error of a object.
+type FitError struct {
+	NumAllClusters int
+	Diagnosis      Diagnosis
+}
+
+// Error returns detailed information of why the object failed to fit on each cluster
+func (f *FitError) Error() string {
+	reasons := make(map[string]int)
+	for _, result := range f.Diagnosis.ClusterToResultMap {
+		for _, reason := range result.Reasons() {
+			reasons[reason]++
+		}
+	}
+
+	sortReasonsHistogram := func() []string {
+		var reasonStrings []string
+		for k, v := range reasons {
+			reasonStrings = append(reasonStrings, fmt.Sprintf("%v %v", v, k))
+		}
+		sort.Strings(reasonStrings)
+		return reasonStrings
+	}
+	reasonMsg := fmt.Sprintf(NoClusterAvailableMsg+": %v.", f.NumAllClusters, strings.Join(sortReasonsHistogram(), ", "))
+	return reasonMsg
 }


### PR DESCRIPTION
Signed-off-by: Garrybest <garrybest@foxmail.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Add scheduling diagnosis when no clusters fit. Here is the example.

Warning  ScheduleBindingFailed   2s (x10 over 4s)  karmada-scheduler  0/3 clusters are available: 1 cluster(s) had untolerated taint {dedicated: special-user}, 2 cluster(s) didn't have the API resource.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
add scheduling diagnosis
```

