### PR TITLE
Set open cluster-info to distribute root CA certificates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	k8s.io/apiserver v0.24.2
 	k8s.io/cli-runtime v0.24.2
 	k8s.io/client-go v0.24.2
+	k8s.io/cluster-bootstrap v0.24.2
 	k8s.io/code-generator v0.24.2
 	k8s.io/component-base v0.24.2
 	k8s.io/component-helpers v0.24.2
@@ -161,7 +162,6 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	k8s.io/cluster-bootstrap v0.24.2 // indirect
 	k8s.io/gengo v0.0.0-20211129171323-c02415ce4185 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect

--- a/pkg/karmadactl/cmdinit/bootstraptoken/clusterinfo/clusterinfo.go
+++ b/pkg/karmadactl/cmdinit/bootstraptoken/clusterinfo/clusterinfo.go
@@ -1,0 +1,99 @@
+package clusterinfo
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
+	"k8s.io/klog/v2"
+
+	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/utils"
+)
+
+const (
+	// BootstrapSignerClusterRoleName sets the name for the ClusterRole that allows access to ConfigMaps in the kube-public ns
+	BootstrapSignerClusterRoleName = "karmada:bootstrap-signer-clusterinfo"
+)
+
+// CreateBootstrapConfigMapIfNotExists creates the kube-public ConfigMap if it doesn't exist already
+func CreateBootstrapConfigMapIfNotExists(clientSet *kubernetes.Clientset, file string) error {
+	klog.V(1).Infoln("[bootstrap-token] loading karmada admin kubeconfig")
+	adminConfig, err := clientcmd.LoadFromFile(file)
+	if err != nil {
+		return fmt.Errorf("failed to load admin kubeconfig, %w", err)
+	}
+	if err = clientcmdapi.FlattenConfig(adminConfig); err != nil {
+		return err
+	}
+
+	adminCluster := adminConfig.Contexts[adminConfig.CurrentContext].Cluster
+	// Copy the cluster from admin.conf to the bootstrap kubeconfig, contains the CA cert and the server URL
+	klog.V(1).Infoln("[bootstrap-token] copying the cluster from admin.conf to the bootstrap kubeconfig")
+	bootstrapConfig := &clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"": adminConfig.Clusters[adminCluster],
+		},
+	}
+	bootstrapBytes, err := clientcmd.Write(*bootstrapConfig)
+	if err != nil {
+		return err
+	}
+
+	// Create or update the ConfigMap in the kube-public namespace
+	klog.V(1).Infoln("[bootstrap-token] creating/updating ConfigMap in kube-public namespace")
+	return utils.CreateOrUpdateConfigMap(clientSet, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bootstrapapi.ConfigMapClusterInfo,
+			Namespace: metav1.NamespacePublic,
+		},
+		Data: map[string]string{
+			bootstrapapi.KubeConfigKey: string(bootstrapBytes),
+		},
+	})
+}
+
+// CreateClusterInfoRBACRules creates the RBAC rules for exposing the cluster-info ConfigMap in the kube-public namespace to unauthenticated users
+func CreateClusterInfoRBACRules(clientSet *kubernetes.Clientset) error {
+	klog.V(1).Infoln("creating the RBAC rules for exposing the cluster-info ConfigMap in the kube-public namespace")
+	err := utils.CreateOrUpdateRole(clientSet, &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      BootstrapSignerClusterRoleName,
+			Namespace: metav1.NamespacePublic,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:         []string{"get"},
+				APIGroups:     []string{""},
+				Resources:     []string{"configmaps"},
+				ResourceNames: []string{bootstrapapi.ConfigMapClusterInfo},
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return utils.CreateOrUpdateRoleBinding(clientSet, &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      BootstrapSignerClusterRoleName,
+			Namespace: metav1.NamespacePublic,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     BootstrapSignerClusterRoleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: rbacv1.UserKind,
+				Name: user.Anonymous,
+			},
+		},
+	})
+}

--- a/pkg/karmadactl/cmdinit/utils/configmap.go
+++ b/pkg/karmadactl/cmdinit/utils/configmap.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+// CreateOrUpdateConfigMap creates a ConfigMap if the target resource doesn't exist. If the resource exists already, this function will update the resource instead.
+func CreateOrUpdateConfigMap(clientSet *kubernetes.Clientset, cm *corev1.ConfigMap) error {
+	if _, err := clientSet.CoreV1().ConfigMaps(cm.ObjectMeta.Namespace).Create(context.TODO(), cm, metav1.CreateOptions{}); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("unable to create ConfigMap: %v", err)
+		}
+
+		if _, err := clientSet.CoreV1().ConfigMaps(cm.ObjectMeta.Namespace).Update(context.TODO(), cm, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("unable to update ConfigMap: %v", err)
+		}
+	}
+	klog.Infof("ConfigMap %s/%s has been created or updated.", cm.ObjectMeta.Namespace, cm.ObjectMeta.Name)
+
+	return nil
+}

--- a/pkg/karmadactl/cmdinit/utils/rbac.go
+++ b/pkg/karmadactl/cmdinit/utils/rbac.go
@@ -87,3 +87,35 @@ func CreateIfNotExistClusterRoleBinding(clientSet *kubernetes.Clientset, binding
 
 	return nil
 }
+
+// CreateOrUpdateRole creates a Role if the target resource doesn't exist. If the resource exists already, this function will update the resource instead.
+func CreateOrUpdateRole(clientSet *kubernetes.Clientset, role *rbacv1.Role) error {
+	if _, err := clientSet.RbacV1().Roles(role.ObjectMeta.Namespace).Create(context.TODO(), role, metav1.CreateOptions{}); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("unable to create RBAC role: %v", err)
+		}
+
+		if _, err := clientSet.RbacV1().Roles(role.ObjectMeta.Namespace).Update(context.TODO(), role, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("unable to update RBAC role: %v", err)
+		}
+	}
+	klog.Infof("Role %s%s has been created or updated.", role.ObjectMeta.Namespace, role.ObjectMeta.Name)
+
+	return nil
+}
+
+// CreateOrUpdateRoleBinding creates a RoleBinding if the target resource doesn't exist. If the resource exists already, this function will update the resource instead.
+func CreateOrUpdateRoleBinding(clientSet *kubernetes.Clientset, roleBinding *rbacv1.RoleBinding) error {
+	if _, err := clientSet.RbacV1().RoleBindings(roleBinding.ObjectMeta.Namespace).Create(context.TODO(), roleBinding, metav1.CreateOptions{}); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("unable to create RBAC rolebinding: %v", err)
+		}
+
+		if _, err := clientSet.RbacV1().RoleBindings(roleBinding.ObjectMeta.Namespace).Update(context.TODO(), roleBinding, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("unable to update RBAC rolebinding: %v", err)
+		}
+	}
+	klog.Infof("RoleBinding %s/%s has been created or updated.", roleBinding.ObjectMeta.Namespace, roleBinding.ObjectMeta.Name)
+
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: lonelyCZ <531187475@qq.com>

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of #2282 

**Special notes for your reviewer**:
```
[root@master67 karmada]# kubectl get configmap -n kube-public cluster-info -o yaml --kubeconfig /etc/karmada/karmada-apiserver.config
apiVersion: v1
data:
  kubeconfig: |
    apiVersion: v1
    clusters:
    - cluster:
        certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURDakNDQWZLZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFmTVJBd0RnWURWUVFLRXdkcllYSnQKWVdSaE1Rc3dDUVlEVlFRREV3SmpZVEFlRncweU1qQTRNREl3T0RVMk5EZGFGdzB6TWpBM016QXdPRFUyTkRkYQpNQjh4RURBT0JnTlZCQW9UQjJ0aGNtMWhaR0V4Q3pBSkJnTlZCQU1UQW1OaE1JSUJJakFOQmdrcWhraUc5dzBCCkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXRkUzF2eEIwQkd0RElBS1kzTDlueHRvVEpJMm5VeDhFRzhoWDd3eFkKVGJRTDNNSGJVUmlieFlTRllzREJXeWJVZ0xwRm5idkwwbDRIcVlQcms0R0VmSUNmSU5Sc3VUd2ErSmFPeUpLeQoraDlZa3dKTEpzYWlYOWtNcTZScU44SjZyQ0IzRVo2SzFkdzYwQVFpRnpxWTRFTUVNV0xEYktpeTFaM1lURmVlClY5b3pVT04ycW9VQzJNbzF0TmduNnNhV2ZMN21xT1RDanNPZFhobmdXUGFwaE9ab29CZHVhT3p2dm9nQzdjYSsKOU5FRmRKWEhHSUhqalJXYjJ5TkwzdFhZK2FFblpUMVdrekg3MjRmWGQxaUdUNE9zSkViYnNpb3dBOStPcUppZgpxUzRJeFl0S0xxT2lsYnEySFVPeUR3WjYyQy9WVTV4cXpQOTducVhlaytCc0dRSURBUUFCbzFFd1R6QU9CZ05WCkhROEJBZjhFQkFNQ0FxUXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVVMeS9SOGxsU3AvWXoKSHlnNHhTeVB6QXFBRUlVd0RRWURWUjBSQkFZd0JJSUNZMkV3RFFZSktvWklodmNOQVFFTEJRQURnZ0VCQUIxdAp5c0lmQlhJQWxnNFJ6SVRLNjFxb3o3L2xMdklZVEg5M0RiM1pZTzZYMmc0T200T01CNUlIUmxTTU1MQldnakg1CnVDd1AzWThnYmhZaDFNdmFLMHpPUC9neXlSbVpRdU1mYWFyaTU4R0Qzd2xYdC96MFloNUxyNEpBdVdKa3pVZU0KeWRJV0dNbWFpdWcxSk40RUowSmx4SWhwbEJGL2tBbUhqdURQNm4zQnFWZ1dlcGY1TWIxRUR5YWYyeHdMa3pyYgo1dkg1alE5bVArU3pSY0gwM3p4R3ZvK1pzUElJMHYyanRNRmo2cWJ3TDNSaTRseG1hSVVOYmtyRTZ1cDlIOWFVCkYveUJoZTIxRlZTMlZPUjF1RUlaYmxjb1BGSHFxZWRQUmNZMUY4Sm5RMjZESjM3VjV3WDlIWjQybEJQSnNmdzUKZTFtK1VFSzVUKzlpMkQ5WnIxND0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
        server: https://10.10.103.67:32443
      name: ""
    contexts: null
    current-context: ""
    kind: Config
    preferences: {}
    users: null
kind: ConfigMap
metadata:
  creationTimestamp: "2022-08-02T08:57:36Z"
  name: cluster-info
  namespace: kube-public
  resourceVersion: "255"
  uid: 7b15f4bf-84a4-4ae4-b6fa-311db4c80788
```

```
[root@master67 karmada]# curl https://10.10.103.67:32443/api/v1/namespaces/kube-public/configmaps/cluster-info -k
{
  "kind": "ConfigMap",
  "apiVersion": "v1",
  "metadata": {
    "name": "cluster-info",
    "namespace": "kube-public",
    "uid": "7b15f4bf-84a4-4ae4-b6fa-311db4c80788",
    "resourceVersion": "255",
    "creationTimestamp": "2022-08-02T08:57:36Z",
    "managedFields": [
      {
        "manager": "karmadactl",
        "operation": "Update",
        "apiVersion": "v1",
        "time": "2022-08-02T08:57:36Z",
        "fieldsType": "FieldsV1",
        "fieldsV1": {
          "f:data": {
            ".": {},
            "f:kubeconfig": {}
          }
        }
      }
    ]
  },
  "data": {
    "kubeconfig": "apiVersion: v1\nclusters:\n- cluster:\n    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURDakNDQWZLZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFmTVJBd0RnWURWUVFLRXdkcllYSnQKWVdSaE1Rc3dDUVlEVlFRREV3SmpZVEFlRncweU1qQTRNREl3T0RVMk5EZGFGdzB6TWpBM016QXdPRFUyTkRkYQpNQjh4RURBT0JnTlZCQW9UQjJ0aGNtMWhaR0V4Q3pBSkJnTlZCQU1UQW1OaE1JSUJJakFOQmdrcWhraUc5dzBCCkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXRkUzF2eEIwQkd0RElBS1kzTDlueHRvVEpJMm5VeDhFRzhoWDd3eFkKVGJRTDNNSGJVUmlieFlTRllzREJXeWJVZ0xwRm5idkwwbDRIcVlQcms0R0VmSUNmSU5Sc3VUd2ErSmFPeUpLeQoraDlZa3dKTEpzYWlYOWtNcTZScU44SjZyQ0IzRVo2SzFkdzYwQVFpRnpxWTRFTUVNV0xEYktpeTFaM1lURmVlClY5b3pVT04ycW9VQzJNbzF0TmduNnNhV2ZMN21xT1RDanNPZFhobmdXUGFwaE9ab29CZHVhT3p2dm9nQzdjYSsKOU5FRmRKWEhHSUhqalJXYjJ5TkwzdFhZK2FFblpUMVdrekg3MjRmWGQxaUdUNE9zSkViYnNpb3dBOStPcUppZgpxUzRJeFl0S0xxT2lsYnEySFVPeUR3WjYyQy9WVTV4cXpQOTducVhlaytCc0dRSURBUUFCbzFFd1R6QU9CZ05WCkhROEJBZjhFQkFNQ0FxUXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVVMeS9SOGxsU3AvWXoKSHlnNHhTeVB6QXFBRUlVd0RRWURWUjBSQkFZd0JJSUNZMkV3RFFZSktvWklodmNOQVFFTEJRQURnZ0VCQUIxdAp5c0lmQlhJQWxnNFJ6SVRLNjFxb3o3L2xMdklZVEg5M0RiM1pZTzZYMmc0T200T01CNUlIUmxTTU1MQldnakg1CnVDd1AzWThnYmhZaDFNdmFLMHpPUC9neXlSbVpRdU1mYWFyaTU4R0Qzd2xYdC96MFloNUxyNEpBdVdKa3pVZU0KeWRJV0dNbWFpdWcxSk40RUowSmx4SWhwbEJGL2tBbUhqdURQNm4zQnFWZ1dlcGY1TWIxRUR5YWYyeHdMa3pyYgo1dkg1alE5bVArU3pSY0gwM3p4R3ZvK1pzUElJMHYyanRNRmo2cWJ3TDNSaTRseG1hSVVOYmtyRTZ1cDlIOWFVCkYveUJoZTIxRlZTMlZPUjF1RUlaYmxjb1BGSHFxZWRQUmNZMUY4Sm5RMjZESjM3VjV3WDlIWjQybEJQSnNmdzUKZTFtK1VFSzVUKzlpMkQ5WnIxND0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=\n    server: https://10.10.103.67:32443\n  name: \"\"\ncontexts: null\ncurrent-context: \"\"\nkind: Config\npreferences: {}\nusers: null\n"
  }
}
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

