### PR TITLE
add ID the unique identifier for push and pull mode's cluster

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -132,6 +132,13 @@ func run(ctx context.Context, karmadaConfig karmadactl.KarmadaConfig, opts *opti
 		ControlPlaneConfig: controlPlaneRestConfig,
 		ClusterConfig:      clusterConfig,
 	}
+
+	id, err := util.ObtainClusterID(clusterKubeClient)
+	if err != nil {
+		return err
+	}
+	registerOption.ClusterID = id
+
 	clusterSecret, impersonatorSecret, err := util.ObtainCredentialsFromMemberCluster(clusterKubeClient, registerOption)
 	if err != nil {
 		return err
@@ -323,6 +330,7 @@ func generateClusterInControllerPlane(opts util.ClusterRegisterOption) (*cluster
 		cluster.Spec.SyncMode = clusterv1alpha1.Pull
 		cluster.Spec.APIEndpoint = opts.ClusterAPIEndpoint
 		cluster.Spec.ProxyURL = opts.ProxyServerAddress
+		cluster.Spec.ID = opts.ClusterID
 		if opts.ClusterProvider != "" {
 			cluster.Spec.Provider = opts.ClusterProvider
 		}

--- a/pkg/karmadactl/join.go
+++ b/pkg/karmadactl/join.go
@@ -177,6 +177,12 @@ func JoinCluster(controlPlaneRestConfig, clusterConfig *rest.Config, opts Comman
 		ClusterConfig:      clusterConfig,
 	}
 
+	id, err := util.ObtainClusterID(clusterKubeClient)
+	if err != nil {
+		return err
+	}
+	registerOption.ClusterID = id
+
 	clusterSecret, impersonatorSecret, err := util.ObtainCredentialsFromMemberCluster(clusterKubeClient, registerOption)
 	if err != nil {
 		return err
@@ -201,6 +207,7 @@ func generateClusterInControllerPlane(opts util.ClusterRegisterOption) (*cluster
 	clusterObj.Name = opts.ClusterName
 	clusterObj.Spec.SyncMode = clusterv1alpha1.Push
 	clusterObj.Spec.APIEndpoint = opts.ClusterConfig.Host
+	clusterObj.Spec.ID = opts.ClusterID
 	clusterObj.Spec.SecretRef = &clusterv1alpha1.LocalSecretReference{
 		Namespace: opts.Secret.Namespace,
 		Name:      opts.Secret.Name,

--- a/pkg/util/cluster.go
+++ b/pkg/util/cluster.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,6 +46,7 @@ type ClusterRegisterOption struct {
 	ClusterConfig      *rest.Config
 	Secret             corev1.Secret
 	ImpersonatorSecret corev1.Secret
+	ClusterID          string
 }
 
 // IsKubeCredentialsEnabled represents whether report secret
@@ -168,4 +170,13 @@ func updateCluster(controlPlaneClient karmadaclientset.Interface, cluster *clust
 	}
 
 	return newCluster, nil
+}
+
+// ObtainClusterID returns the cluster ID property with clusterKubeClient
+func ObtainClusterID(clusterKubeClient *kubernetes.Clientset) (string, error) {
+	ns, err := clusterKubeClient.CoreV1().Namespaces().Get(context.TODO(), metav1.NamespaceSystem, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	return string(ns.UID), nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
To add spec.id in karmada control plane's Cluster object.
refer to #2017

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Collect cluster's kube-system namespace uuid into Cluster object.
```

Here are Verification Results,
When use hack/local-up-karmada to start,you can find the result:
1.push mode
![1](https://user-images.githubusercontent.com/70150334/182559208-ee42b4a8-2de8-473d-884d-0acc0aa85058.png)
the same as kube-system's Namespace in Cluster. 
![2](https://user-images.githubusercontent.com/70150334/182559708-a80a50c6-bbe7-4b44-9655-14a309ecf70b.png)

2.pull mode
The result is the same as above.

When upgrading,the existed Cluster objects will have spec.id field.
 
![3](https://user-images.githubusercontent.com/70150334/182560177-cfaeb942-8dcf-4dba-bcde-14981f5c2e7f.png)

Push and Pull mode both have the same result.
