### PR TITLE
stop update status if Work object in terminating state

### DIFF
--- a/pkg/controllers/status/workstatus_controller.go
+++ b/pkg/controllers/status/workstatus_controller.go
@@ -194,6 +194,11 @@ func (c *WorkStatusController) syncWorkStatus(key util.QueueKey) error {
 		return err
 	}
 
+	// stop update status if Work object in terminating state.
+	if !workObject.DeletionTimestamp.IsZero() {
+		return nil
+	}
+
 	desiredObj, err := c.getRawManifest(workObject.Spec.Workload.Manifests, observedObj)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: yy158775 <1584616775@qq.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When the object's status changed,it will not collect status if the Work object being deleted. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
NONE
```release-note
NONE
```
Here are my tests:
Step 1:
kubectl apply -f samples/nginx/propagationpolicy.yaml
kubectl apply -f samples/nginx/deployment.yaml
Step 2:
Add finalizer to Work object in order to avoid being deleted.
![step-1](https://user-images.githubusercontent.com/70150334/182742324-34a2504d-75d7-48ae-a22a-5fb00c578644.png)
Step 3:
Add finalizer to Deployment object in order to avoid being deleted.
![step-3](https://user-images.githubusercontent.com/70150334/182742387-1e4f04b9-86d5-440f-84d9-a91147b145f1.png)
Step 4:
Delete Work.Because of finalizer Work and Deployment will not  be deleted.
Step 5:
In order to make status changed,we can delete Pod.Because Pod is in charge of ReplicaSet,the Pod will restart immediately.
Now we look up logs in controller-manager,we can find the log about update.
![代码](https://user-images.githubusercontent.com/70150334/182742755-68626357-3f27-4e71-a461-62a97907db16.png)
![result](https://user-images.githubusercontent.com/70150334/182742763-0061c9b9-224d-410f-bb02-b9170716fcce.png)

