### PR TITLE
Fix "namespace \"karmada-cluster"\ not found" when cluster is being registered with "pull" mode

### DIFF
--- a/pkg/karmadactl/cmdinit/karmada/deploy.go
+++ b/pkg/karmadactl/cmdinit/karmada/deploy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	options2 "github.com/karmada-io/karmada/pkg/karmadactl/options"
 	"io/ioutil"
 	"path"
 	"path/filepath"
@@ -47,6 +48,15 @@ func InitKarmadaResources(dir, caBase64, systemNamespace string) error {
 	if _, err := clientSet.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: systemNamespace,
+		},
+	}, metav1.CreateOptions{}); err != nil {
+		klog.Exitln(err)
+	}
+
+	// create karmada-cluster namespace
+	if _, err := clientSet.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: options2.DefaultKarmadaClusterNamespace,
 		},
 	}, metav1.CreateOptions{}); err != nil {
 		klog.Exitln(err)


### PR DESCRIPTION
Fix "namespace \"karmada-cluster"\ not found" when cluster is being registered with "pull" mode

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
After installed karmada through "kubectl karmada init", and then registering the member cluster with ‘pull’ mode, the agent log reports an error ”namespace \"karmada-cluster"\ not found“，so the ”karmada-cluster“ namespace needs to be created by default when the karmada control plane is initialized.
![45dac71f0e9384104fc36a03aa080b8](https://user-images.githubusercontent.com/37976659/182801806-dfaffc34-7e7c-4437-9d07-59dc31f4d5b9.png)
![b7e01e82d3b5a93c2c62b932c9b6eaa](https://user-images.githubusercontent.com/37976659/182801910-7ef13547-225c-4c00-9983-aaf3b8bcfc81.jpg)


**Which issue(s) this PR fixes**:
Fixes #
After installed karmada through "kubectl karmada init", and then registering the member cluster with ‘pull’ mode, the agent log reports an error ”namespace \"karmada-cluster"\ not found“，so the ”karmada-cluster“ namespace needs to be created by default when the karmada control plane is initialized.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

