### PR TITLE
Fix "namespace \"karmada-cluster"\ not found" when cluster is being registered with "pull" mode

### DIFF
--- a/docs/userguide/aggregated-api-endpoint.md
+++ b/docs/userguide/aggregated-api-endpoint.md
@@ -12,10 +12,10 @@ To quickly experience this feature, we experimented with karmada-apiserver certi
 
 ### Step1: Obtain the karmada-apiserver Certificate
 
-For Karmada deployed using `hack/local-up-karmada.sh`, you can directly copy it from the `/root/.kube/` directory.
+For Karmada deployed using `hack/local-up-karmada.sh`, you can directly copy it from the `$HOME/.kube/` directory.
 
 ```shell
-cp /root/.kube/karmada.config karmada-apiserver.config
+cp $HOME/.kube/karmada.config karmada-apiserver.config
 ```
 
 ### Step2: Grant permission to user `system:admin`
@@ -63,7 +63,7 @@ subjects:
 </details>
 
 ```shell
-kubectl --kubeconfig /root/.kube/karmada.config --context karmada-apiserver apply -f cluster-proxy-rbac.yaml
+kubectl --kubeconfig $HOME/.kube/karmada.config --context karmada-apiserver apply -f cluster-proxy-rbac.yaml
 ```
 
 ### Step3: Access member clusters
@@ -95,13 +95,13 @@ If the serviceaccount has been created in your environment, you can skip this st
 Create a serviceaccount that does not have any permission:
 
 ```shell
-kubectl --kubeconfig /root/.kube/members.config --context member1 create serviceaccount tom
+kubectl --kubeconfig $HOME/.kube/members.config --context member1 create serviceaccount tom
 ```
 
 ### Step2: Create ServiceAccount in Karmada control plane
 
 ```shell
-kubectl --kubeconfig /root/.kube/karmada.config --context karmada-apiserver create serviceaccount tom
+kubectl --kubeconfig $HOME/.kube/karmada.config --context karmada-apiserver create serviceaccount tom
 ```
 
 In order to grant serviceaccount the `clusters/proxy` permission, apply the following rbac yaml file:
@@ -149,7 +149,7 @@ subjects:
 </details>
 
 ```shell
-kubectl --kubeconfig /root/.kube/karmada.config --context karmada-apiserver apply -f cluster-proxy-rbac.yaml
+kubectl --kubeconfig $HOME/.kube/karmada.config --context karmada-apiserver apply -f cluster-proxy-rbac.yaml
 ```
 
 ### Step3: Access member1 cluster
@@ -167,7 +167,7 @@ apiVersion: v1
 clusters:
 - cluster:
     insecure-skip-tls-verify: true
-    server: {karmada-apiserver-address} # Replace {karmada-apiserver-address} with karmada-apiserver-address. You can find it in /root/.kube/karmada.config file.
+    server: {karmada-apiserver-address} # Replace {karmada-apiserver-address} with karmada-apiserver-address. You can find it in $HOME/.kube/karmada.config file.
   name: tom
 contexts:
 - context:
@@ -236,7 +236,7 @@ subjects:
 </details>
 
 ```shell
-kubectl --kubeconfig /root/.kube/members.config --context member1 apply -f member1-rbac.yaml
+kubectl --kubeconfig $HOME/.kube/members.config --context member1 apply -f member1-rbac.yaml
 ```
 
 Run the command that failed in the previous step again:

--- a/hack/.import-aliases
+++ b/hack/.import-aliases
@@ -11,6 +11,7 @@
     "k8s.io/api/authorization/v1": "authorizationv1",
     "k8s.io/api/authorization/v1beta1": "authorizationv1beta1",
     "k8s.io/api/autoscaling/v1": "autoscalingv1",
+    "k8s.io/api/autoscaling/v2": "autoscalingv2",
     "k8s.io/api/batch/v1": "batchv1",
     "k8s.io/api/batch/v1beta1": "batchv1beta1",
     "k8s.io/api/certificates/v1beta1": "certificatesv1beta1",
@@ -52,6 +53,9 @@
 
     "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1": "clusterv1alpha1",
     "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1": "configv1alpha1",
+    "github.com/karmada-io/karmada/pkg/apis/networking/v1alpha1": "networkingv1alpha1",
     "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1": "policyv1alpha1",
-    "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1": "workv1alpha1"
+    "github.com/karmada-io/karmada/pkg/apis/search/v1alpha1": "searchv1alpha1",
+    "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1": "workv1alpha1",
+    "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2": "workv1alpha2"
 }

--- a/pkg/controllers/mcs/endpointslice_controller.go
+++ b/pkg/controllers/mcs/endpointslice_controller.go
@@ -91,7 +91,8 @@ func (c *EndpointSliceController) collectEndpointSliceFromWork(work *workv1alpha
 			return controllerruntime.Result{Requeue: true}, err
 		}
 
-		endpointSlice, err := helper.ConvertToEndpointSlice(unstructObj)
+		endpointSlice := &discoveryv1.EndpointSlice{}
+		err = helper.ConvertToTypedObject(unstructObj, endpointSlice)
 		if err != nil {
 			klog.Errorf("failed to convert unstructured to typed object: %v", err)
 			return controllerruntime.Result{Requeue: true}, err

--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -14,7 +14,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -469,8 +468,8 @@ func getResourceSummary(nodes []*corev1.Node, pods []*corev1.Pod) *clusterv1alph
 func convertObjectsToNodes(nodeList []runtime.Object) ([]*corev1.Node, error) {
 	nodes := make([]*corev1.Node, 0, len(nodeList))
 	for _, obj := range nodeList {
-		node, err := helper.ConvertToNode(obj.(*unstructured.Unstructured))
-		if err != nil {
+		node := &corev1.Node{}
+		if err := helper.ConvertToTypedObject(obj, node); err != nil {
 			return nil, fmt.Errorf("failed to convert unstructured to typed object: %v", err)
 		}
 		nodes = append(nodes, node)
@@ -481,8 +480,8 @@ func convertObjectsToNodes(nodeList []runtime.Object) ([]*corev1.Node, error) {
 func convertObjectsToPods(podList []runtime.Object) ([]*corev1.Pod, error) {
 	pods := make([]*corev1.Pod, 0, len(podList))
 	for _, obj := range podList {
-		pod, err := helper.ConvertToPod(obj.(*unstructured.Unstructured))
-		if err != nil {
+		pod := &corev1.Pod{}
+		if err := helper.ConvertToTypedObject(obj, pod); err != nil {
 			return nil, fmt.Errorf("failed to convert unstructured to typed object: %v", err)
 		}
 		pods = append(pods, pod)

--- a/pkg/controllers/status/workstatus_controller.go
+++ b/pkg/controllers/status/workstatus_controller.go
@@ -194,6 +194,11 @@ func (c *WorkStatusController) syncWorkStatus(key util.QueueKey) error {
 		return err
 	}
 
+	// stop update status if Work object in terminating state.
+	if !workObject.DeletionTimestamp.IsZero() {
+		return nil
+	}
+
 	desiredObj, err := c.getRawManifest(workObject.Spec.Workload.Manifests, observedObj)
 	if err != nil {
 		return err

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -364,8 +364,8 @@ func (d *ResourceDetector) LookForMatchedPolicy(object *unstructured.Unstructure
 
 	policyList := make([]*policyv1alpha1.PropagationPolicy, 0)
 	for index := range policyObjects {
-		policy, err := helper.ConvertToPropagationPolicy(policyObjects[index].(*unstructured.Unstructured))
-		if err != nil {
+		policy := &policyv1alpha1.PropagationPolicy{}
+		if err = helper.ConvertToTypedObject(policyObjects[index], policy); err != nil {
 			klog.Errorf("Failed to convert PropagationPolicy from unstructured object: %v", err)
 			return nil, err
 		}
@@ -402,8 +402,8 @@ func (d *ResourceDetector) LookForMatchedClusterPolicy(object *unstructured.Unst
 
 	policyList := make([]*policyv1alpha1.ClusterPropagationPolicy, 0)
 	for index := range policyObjects {
-		policy, err := helper.ConvertToClusterPropagationPolicy(policyObjects[index].(*unstructured.Unstructured))
-		if err != nil {
+		policy := &policyv1alpha1.ClusterPropagationPolicy{}
+		if err = helper.ConvertToTypedObject(policyObjects[index], policy); err != nil {
 			klog.Errorf("Failed to convert ClusterPropagationPolicy from unstructured object: %v", err)
 			return nil, err
 		}
@@ -830,8 +830,8 @@ func (d *ResourceDetector) ReconcilePropagationPolicy(key util.QueueKey) error {
 	}
 
 	klog.Infof("PropagationPolicy(%s) has been added.", ckey.NamespaceKey())
-	propagationObject, err := helper.ConvertToPropagationPolicy(unstructuredObj.(*unstructured.Unstructured))
-	if err != nil {
+	propagationObject := &policyv1alpha1.PropagationPolicy{}
+	if err = helper.ConvertToTypedObject(unstructuredObj, propagationObject); err != nil {
 		klog.Errorf("Failed to convert PropagationPolicy(%s) from unstructured object: %v", ckey.NamespaceKey(), err)
 		return err
 	}
@@ -889,8 +889,8 @@ func (d *ResourceDetector) ReconcileClusterPropagationPolicy(key util.QueueKey) 
 	}
 
 	klog.Infof("Policy(%s) has been added", ckey.NamespaceKey())
-	propagationObject, err := helper.ConvertToClusterPropagationPolicy(unstructuredObj.(*unstructured.Unstructured))
-	if err != nil {
+	propagationObject := &policyv1alpha1.ClusterPropagationPolicy{}
+	if err = helper.ConvertToTypedObject(unstructuredObj, propagationObject); err != nil {
 		klog.Errorf("Failed to convert ClusterPropagationPolicy(%s) from unstructured object: %v", ckey.NamespaceKey(), err)
 		return err
 	}

--- a/pkg/estimator/server/replica/replica.go
+++ b/pkg/estimator/server/replica/replica.go
@@ -44,8 +44,8 @@ func GetUnschedulablePodsOfWorkload(unstructObj *unstructured.Unstructured, thre
 	// and the other is which owns Pod directly.
 	switch unstructObj.GetKind() {
 	case util.DeploymentKind:
-		deployment, err := helper.ConvertToDeployment(unstructObj)
-		if err != nil {
+		deployment := &appsv1.Deployment{}
+		if err := helper.ConvertToTypedObject(unstructObj, deployment); err != nil {
 			return 0, fmt.Errorf("failed to convert ReplicaSet from unstructured object: %v", err)
 		}
 		pods, err := listDeploymentPods(deployment, listers)

--- a/pkg/karmadactl/cmdinit/karmada/deploy.go
+++ b/pkg/karmadactl/cmdinit/karmada/deploy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	options2 "github.com/karmada-io/karmada/pkg/karmadactl/options"
 	"io/ioutil"
 	"path"
 	"path/filepath"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/utils"
+	options2 "github.com/karmada-io/karmada/pkg/karmadactl/options"
 )
 
 const (
@@ -47,6 +49,15 @@ func InitKarmadaResources(dir, caBase64, systemNamespace string) error {
 	if _, err := clientSet.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: systemNamespace,
+		},
+	}, metav1.CreateOptions{}); err != nil {
+		klog.Exitln(err)
+	}
+
+	// create karmada-cluster namespace
+	if _, err := clientSet.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: options2.DefaultKarmadaClusterNamespace,
 		},
 	}, metav1.CreateOptions{}); err != nil {
 		klog.Exitln(err)

--- a/pkg/resourceinterpreter/customizedinterpreter/configmanager/manager.go
+++ b/pkg/resourceinterpreter/customizedinterpreter/configmanager/manager.go
@@ -93,7 +93,8 @@ func (m *interpreterConfigManager) updateConfiguration() {
 			return
 		}
 
-		config, err := helper.ConvertToResourceExploringWebhookConfiguration(unstructuredConfig)
+		config := &configv1alpha1.ResourceInterpreterWebhookConfiguration{}
+		err = helper.ConvertToTypedObject(unstructuredConfig, config)
 		if err != nil {
 			gvk := unstructuredConfig.GroupVersionKind().String()
 			klog.Errorf("Failed to convert object(%s), err: %v", gvk, err)

--- a/pkg/resourceinterpreter/defaultinterpreter/aggregatestatus.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/aggregatestatus.go
@@ -34,7 +34,8 @@ func getAllDefaultAggregateStatusInterpreter() map[schema.GroupVersionKind]aggre
 }
 
 func aggregateDeploymentStatus(object *unstructured.Unstructured, aggregatedStatusItems []workv1alpha2.AggregatedStatusItem) (*unstructured.Unstructured, error) {
-	deploy, err := helper.ConvertToDeployment(object)
+	deploy := &appsv1.Deployment{}
+	err := helper.ConvertToTypedObject(object, deploy)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +86,8 @@ func aggregateDeploymentStatus(object *unstructured.Unstructured, aggregatedStat
 }
 
 func aggregateServiceStatus(object *unstructured.Unstructured, aggregatedStatusItems []workv1alpha2.AggregatedStatusItem) (*unstructured.Unstructured, error) {
-	service, err := helper.ConvertToService(object)
+	service := &corev1.Service{}
+	err := helper.ConvertToTypedObject(object, service)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +130,8 @@ func aggregateServiceStatus(object *unstructured.Unstructured, aggregatedStatusI
 }
 
 func aggregateIngressStatus(object *unstructured.Unstructured, aggregatedStatusItems []workv1alpha2.AggregatedStatusItem) (*unstructured.Unstructured, error) {
-	ingress, err := helper.ConvertToIngress(object)
+	ingress := &networkingv1.Ingress{}
+	err := helper.ConvertToTypedObject(object, ingress)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +169,8 @@ func aggregateIngressStatus(object *unstructured.Unstructured, aggregatedStatusI
 }
 
 func aggregateJobStatus(object *unstructured.Unstructured, aggregatedStatusItems []workv1alpha2.AggregatedStatusItem) (*unstructured.Unstructured, error) {
-	job, err := helper.ConvertToJob(object)
+	job := &batchv1.Job{}
+	err := helper.ConvertToTypedObject(object, job)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +195,8 @@ func aggregateJobStatus(object *unstructured.Unstructured, aggregatedStatusItems
 }
 
 func aggregateDaemonSetStatus(object *unstructured.Unstructured, aggregatedStatusItems []workv1alpha2.AggregatedStatusItem) (*unstructured.Unstructured, error) {
-	daemonSet, err := helper.ConvertToDaemonSet(object)
+	daemonSet := &appsv1.DaemonSet{}
+	err := helper.ConvertToTypedObject(object, daemonSet)
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +253,8 @@ func aggregateDaemonSetStatus(object *unstructured.Unstructured, aggregatedStatu
 }
 
 func aggregateStatefulSetStatus(object *unstructured.Unstructured, aggregatedStatusItems []workv1alpha2.AggregatedStatusItem) (*unstructured.Unstructured, error) {
-	statefulSet, err := helper.ConvertToStatefulSet(object)
+	statefulSet := &appsv1.StatefulSet{}
+	err := helper.ConvertToTypedObject(object, statefulSet)
 	if err != nil {
 		return nil, err
 	}
@@ -298,7 +304,8 @@ func aggregateStatefulSetStatus(object *unstructured.Unstructured, aggregatedSta
 }
 
 func aggregatePodStatus(object *unstructured.Unstructured, aggregatedStatusItems []workv1alpha2.AggregatedStatusItem) (*unstructured.Unstructured, error) {
-	pod, err := helper.ConvertToPod(object)
+	pod := &corev1.Pod{}
+	err := helper.ConvertToTypedObject(object, pod)
 	if err != nil {
 		return nil, err
 	}
@@ -358,7 +365,8 @@ func aggregatePodStatus(object *unstructured.Unstructured, aggregatedStatusItems
 }
 
 func aggregatePersistentVolumeClaimStatus(object *unstructured.Unstructured, aggregatedStatusItems []workv1alpha2.AggregatedStatusItem) (*unstructured.Unstructured, error) {
-	pvc, err := helper.ConvertToPersistentVolumeClaim(object)
+	pvc := &corev1.PersistentVolumeClaim{}
+	err := helper.ConvertToTypedObject(object, pvc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resourceinterpreter/defaultinterpreter/aggregatestatus_test.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/aggregatestatus_test.go
@@ -338,7 +338,8 @@ func TestAggregateStatefulSetStatus(t *testing.T) {
 }
 
 func cleanUnstructuredJobConditionTime(object *unstructured.Unstructured) *unstructured.Unstructured {
-	job, _ := helper.ConvertToJob(object)
+	job := &batchv1.Job{}
+	_ = helper.ConvertToTypedObject(object, job)
 	for i := range job.Status.Conditions {
 		cond := &job.Status.Conditions[i]
 		cond.LastProbeTime = metav1.Time{}

--- a/pkg/resourceinterpreter/defaultinterpreter/dependencies.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/dependencies.go
@@ -30,8 +30,8 @@ func getAllDefaultDependenciesInterpreter() map[schema.GroupVersionKind]dependen
 }
 
 func getDeploymentDependencies(object *unstructured.Unstructured) ([]configv1alpha1.DependentObjectReference, error) {
-	deploymentObj, err := helper.ConvertToDeployment(object)
-	if err != nil {
+	deploymentObj := &appsv1.Deployment{}
+	if err := helper.ConvertToTypedObject(object, deploymentObj); err != nil {
 		return nil, fmt.Errorf("failed to convert Deployment from unstructured object: %v", err)
 	}
 
@@ -44,7 +44,8 @@ func getDeploymentDependencies(object *unstructured.Unstructured) ([]configv1alp
 }
 
 func getJobDependencies(object *unstructured.Unstructured) ([]configv1alpha1.DependentObjectReference, error) {
-	jobObj, err := helper.ConvertToJob(object)
+	jobObj := &batchv1.Job{}
+	err := helper.ConvertToTypedObject(object, jobObj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert Job from unstructured object: %v", err)
 	}
@@ -58,7 +59,8 @@ func getJobDependencies(object *unstructured.Unstructured) ([]configv1alpha1.Dep
 }
 
 func getCronJobDependencies(object *unstructured.Unstructured) ([]configv1alpha1.DependentObjectReference, error) {
-	cronjobObj, err := helper.ConvertToCronJob(object)
+	cronjobObj := &batchv1.CronJob{}
+	err := helper.ConvertToTypedObject(object, cronjobObj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert CronJob from unstructured object: %v", err)
 	}
@@ -72,7 +74,8 @@ func getCronJobDependencies(object *unstructured.Unstructured) ([]configv1alpha1
 }
 
 func getPodDependencies(object *unstructured.Unstructured) ([]configv1alpha1.DependentObjectReference, error) {
-	podObj, err := helper.ConvertToPod(object)
+	podObj := &corev1.Pod{}
+	err := helper.ConvertToTypedObject(object, podObj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert Pod from unstructured object: %v", err)
 	}
@@ -81,7 +84,8 @@ func getPodDependencies(object *unstructured.Unstructured) ([]configv1alpha1.Dep
 }
 
 func getDaemonSetDependencies(object *unstructured.Unstructured) ([]configv1alpha1.DependentObjectReference, error) {
-	daemonSetObj, err := helper.ConvertToDaemonSet(object)
+	daemonSetObj := &appsv1.DaemonSet{}
+	err := helper.ConvertToTypedObject(object, daemonSetObj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert DaemonSet from unstructured object: %v", err)
 	}
@@ -95,7 +99,8 @@ func getDaemonSetDependencies(object *unstructured.Unstructured) ([]configv1alph
 }
 
 func getStatefulSetDependencies(object *unstructured.Unstructured) ([]configv1alpha1.DependentObjectReference, error) {
-	statefulSetObj, err := helper.ConvertToStatefulSet(object)
+	statefulSetObj := &appsv1.StatefulSet{}
+	err := helper.ConvertToTypedObject(object, statefulSetObj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert StatefulSet from unstructured object: %v", err)
 	}

--- a/pkg/resourceinterpreter/defaultinterpreter/prune/prune.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/prune/prune.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -57,7 +58,8 @@ func RemoveIrrelevantField(workload *unstructured.Unstructured) error {
 	}
 
 	if workload.GetKind() == util.JobKind {
-		job, err := helper.ConvertToJob(workload)
+		job := &batchv1.Job{}
+		err := helper.ConvertToTypedObject(workload, job)
 		if err != nil {
 			return err
 		}

--- a/pkg/resourceinterpreter/defaultinterpreter/reflectstatus.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/reflectstatus.go
@@ -42,8 +42,8 @@ func reflectDeploymentStatus(object *unstructured.Unstructured) (*runtime.RawExt
 		return nil, nil
 	}
 
-	deploymentStatus, err := helper.ConvertToDeploymentStatus(statusMap)
-	if err != nil {
+	deploymentStatus := &appsv1.DeploymentStatus{}
+	if err = helper.ConvertToTypedObject(statusMap, deploymentStatus); err != nil {
 		return nil, fmt.Errorf("failed to convert DeploymentStatus from map[string]interface{}: %v", err)
 	}
 
@@ -83,7 +83,8 @@ func reflectServiceStatus(object *unstructured.Unstructured) (*runtime.RawExtens
 		return nil, nil
 	}
 
-	serviceStatus, err := helper.ConvertToServiceStatus(statusMap)
+	serviceStatus := &corev1.ServiceStatus{}
+	err = helper.ConvertToTypedObject(statusMap, serviceStatus)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert ServiceStatus from map[string]interface{}: %v", err)
 	}
@@ -111,7 +112,8 @@ func reflectJobStatus(object *unstructured.Unstructured) (*runtime.RawExtension,
 		return nil, nil
 	}
 
-	jobStatus, err := helper.ConvertToJobStatus(statusMap)
+	jobStatus := &batchv1.JobStatus{}
+	err = helper.ConvertToTypedObject(statusMap, jobStatus)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert JobStatus from map[string]interface{}: %v", err)
 	}
@@ -140,7 +142,8 @@ func reflectDaemonSetStatus(object *unstructured.Unstructured) (*runtime.RawExte
 		return nil, nil
 	}
 
-	daemonSetStatus, err := helper.ConvertToDaemonSetStatus(statusMap)
+	daemonSetStatus := &appsv1.DaemonSetStatus{}
+	err = helper.ConvertToTypedObject(statusMap, daemonSetStatus)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert DaemonSetStatus from map[string]interface{}: %v", err)
 	}
@@ -170,7 +173,8 @@ func reflectStatefulSetStatus(object *unstructured.Unstructured) (*runtime.RawEx
 		return nil, nil
 	}
 
-	statefulSetStatus, err := helper.ConvertToStatefulSetStatus(statusMap)
+	statefulSetStatus := &appsv1.StatefulSetStatus{}
+	err = helper.ConvertToTypedObject(statusMap, statefulSetStatus)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert StatefulSetStatus from map[string]interface{}: %v", err)
 	}

--- a/pkg/resourceinterpreter/defaultinterpreter/replica.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/replica.go
@@ -23,8 +23,8 @@ func getAllDefaultReplicaInterpreter() map[schema.GroupVersionKind]replicaInterp
 }
 
 func deployReplica(object *unstructured.Unstructured) (int32, *workv1alpha2.ReplicaRequirements, error) {
-	deploy, err := helper.ConvertToDeployment(object)
-	if err != nil {
+	deploy := &appsv1.Deployment{}
+	if err := helper.ConvertToTypedObject(object, deploy); err != nil {
 		klog.Errorf("Failed to convert object(%s), err", object.GroupVersionKind().String(), err)
 		return 0, nil, err
 	}
@@ -39,7 +39,8 @@ func deployReplica(object *unstructured.Unstructured) (int32, *workv1alpha2.Repl
 }
 
 func jobReplica(object *unstructured.Unstructured) (int32, *workv1alpha2.ReplicaRequirements, error) {
-	job, err := helper.ConvertToJob(object)
+	job := &batchv1.Job{}
+	err := helper.ConvertToTypedObject(object, job)
 	if err != nil {
 		klog.Errorf("Failed to convert object(%s), err", object.GroupVersionKind().String(), err)
 		return 0, nil, err

--- a/pkg/resourceinterpreter/defaultinterpreter/retain.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/retain.go
@@ -27,12 +27,14 @@ func getAllDefaultRetentionInterpreter() map[schema.GroupVersionKind]retentionIn
 }
 
 func retainPodFields(desired, observed *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-	desiredPod, err := helper.ConvertToPod(desired)
+	desiredPod := &corev1.Pod{}
+	err := helper.ConvertToTypedObject(desired, desiredPod)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert desiredPod from unstructured object: %v", err)
 	}
 
-	clusterPod, err := helper.ConvertToPod(observed)
+	clusterPod := &corev1.Pod{}
+	err = helper.ConvertToTypedObject(observed, clusterPod)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert clusterPod from unstructured object: %v", err)
 	}

--- a/pkg/search/backendstore/opensearch.go
+++ b/pkg/search/backendstore/opensearch.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/klog/v2"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
-	"github.com/karmada-io/karmada/pkg/apis/search/v1alpha1"
+	searchv1alpha1 "github.com/karmada-io/karmada/pkg/apis/search/v1alpha1"
 )
 
 var defaultPrefix = "kubernetes"
@@ -104,7 +104,7 @@ type OpenSearch struct {
 }
 
 // NewOpenSearch returns a new OpenSearch
-func NewOpenSearch(cluster string, cfg *v1alpha1.BackendStoreConfig) (*OpenSearch, error) {
+func NewOpenSearch(cluster string, cfg *searchv1alpha1.BackendStoreConfig) (*OpenSearch, error) {
 	klog.Infof("create openserch backend store: %s", cluster)
 	os := &OpenSearch{
 		cluster: cluster,
@@ -258,7 +258,7 @@ func (os *OpenSearch) indexName(us *unstructured.Unstructured) (string, error) {
 	return name, nil
 }
 
-func (os *OpenSearch) initClient(bsc *v1alpha1.BackendStoreConfig) error {
+func (os *OpenSearch) initClient(bsc *searchv1alpha1.BackendStoreConfig) error {
 	if bsc == nil || bsc.OpenSearch == nil {
 		return errors.New("opensearch config is nil")
 	}

--- a/pkg/search/backendstore/store.go
+++ b/pkg/search/backendstore/store.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
-	"github.com/karmada-io/karmada/pkg/apis/search/v1alpha1"
+	searchv1alpha1 "github.com/karmada-io/karmada/pkg/apis/search/v1alpha1"
 )
 
 // BackendStore define BackendStore interface
@@ -31,7 +31,7 @@ func Init(cs *kubernetes.Clientset) {
 }
 
 // AddBackend add backend store
-func AddBackend(cluster string, cfg *v1alpha1.BackendStoreConfig) {
+func AddBackend(cluster string, cfg *searchv1alpha1.BackendStoreConfig) {
 	backendLock.Lock()
 	defer backendLock.Unlock()
 

--- a/pkg/search/controller.go
+++ b/pkg/search/controller.go
@@ -20,7 +20,7 @@ import (
 
 	clusterV1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
-	"github.com/karmada-io/karmada/pkg/apis/search/v1alpha1"
+	searchv1alpha1 "github.com/karmada-io/karmada/pkg/apis/search/v1alpha1"
 	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
 	informerfactory "github.com/karmada-io/karmada/pkg/generated/informers/externalversions"
 	clusterlister "github.com/karmada-io/karmada/pkg/generated/listers/cluster/v1alpha1"
@@ -231,7 +231,7 @@ func (c *Controller) doCacheCluster(cluster string) error {
 
 // addResourceRegistry parse the resourceRegistry object and add Cluster to the queue
 func (c *Controller) addResourceRegistry(obj interface{}) {
-	rr := obj.(*v1alpha1.ResourceRegistry)
+	rr := obj.(*searchv1alpha1.ResourceRegistry)
 	resources := c.getResources(rr.Spec.ResourceSelectors)
 
 	for _, cluster := range c.getClusters(rr.Spec.TargetCluster) {
@@ -260,8 +260,8 @@ func (c *Controller) addResourceRegistry(obj interface{}) {
 
 // updateResourceRegistry parse the resourceRegistry object and add (added/deleted) Cluster to the queue
 func (c *Controller) updateResourceRegistry(oldObj, newObj interface{}) {
-	oldRR := oldObj.(*v1alpha1.ResourceRegistry)
-	newRR := newObj.(*v1alpha1.ResourceRegistry)
+	oldRR := oldObj.(*searchv1alpha1.ResourceRegistry)
+	newRR := newObj.(*searchv1alpha1.ResourceRegistry)
 
 	if reflect.DeepEqual(oldRR.Spec, newRR.Spec) {
 		klog.V(4).Infof("Ignore ResourceRegistry(%s) update event as spec not changed", newRR.Name)
@@ -324,7 +324,7 @@ func (c *Controller) updateResourceRegistry(oldObj, newObj interface{}) {
 
 // deleteResourceRegistry parse the resourceRegistry object and add deleted Cluster to the queue
 func (c *Controller) deleteResourceRegistry(obj interface{}) {
-	rr := obj.(*v1alpha1.ResourceRegistry)
+	rr := obj.(*searchv1alpha1.ResourceRegistry)
 	for _, cluster := range c.getClusters(rr.Spec.TargetCluster) {
 		v, ok := c.clusterRegistry.Load(cluster)
 		if !ok {
@@ -420,7 +420,7 @@ func (c *Controller) getClusters(affinity policyv1alpha1.ClusterAffinity) []stri
 }
 
 // getClusterAndResource returns the cluster and resources from the resourceRegistry object
-func (c *Controller) getResources(selectors []v1alpha1.ResourceSelector) []schema.GroupVersionResource {
+func (c *Controller) getResources(selectors []searchv1alpha1.ResourceSelector) []schema.GroupVersionResource {
 	resources := make([]schema.GroupVersionResource, 0)
 	for _, rs := range selectors {
 		gvr, err := restmapper.GetGroupVersionResource(

--- a/pkg/util/gclient/gclient.go
+++ b/pkg/util/gclient/gclient.go
@@ -11,7 +11,7 @@ import (
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	configv1alpha1 "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1"
-	networkv1alpha1 "github.com/karmada-io/karmada/pkg/apis/networking/v1alpha1"
+	networkingv1alpha1 "github.com/karmada-io/karmada/pkg/apis/networking/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	searchv1alpha1 "github.com/karmada-io/karmada/pkg/apis/search/v1alpha1"
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
@@ -25,7 +25,7 @@ func init() {
 	var _ = scheme.AddToScheme(aggregatedScheme)             // add Kubernetes schemes
 	var _ = clusterv1alpha1.AddToScheme(aggregatedScheme)    // add cluster schemes
 	var _ = configv1alpha1.AddToScheme(aggregatedScheme)     // add config v1alpha1 schemes
-	var _ = networkv1alpha1.AddToScheme(aggregatedScheme)    // add network v1alpha1 schemes
+	var _ = networkingv1alpha1.AddToScheme(aggregatedScheme) // add network v1alpha1 schemes
 	var _ = policyv1alpha1.AddToScheme(aggregatedScheme)     // add propagation schemes
 	var _ = workv1alpha1.AddToScheme(aggregatedScheme)       // add work v1alpha1 schemes
 	var _ = workv1alpha2.AddToScheme(aggregatedScheme)       // add work v1alpha2 schemes

--- a/pkg/util/helper/unstructured.go
+++ b/pkg/util/helper/unstructured.go
@@ -1,228 +1,28 @@
 package helper
 
 import (
-	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
-	discoveryv1 "k8s.io/api/discovery/v1"
-	networkingv1 "k8s.io/api/networking/v1"
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	configv1alpha1 "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1"
-	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
-	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/util"
 )
 
-// ConvertToPropagationPolicy converts a PropagationPolicy object from unstructured to typed.
-func ConvertToPropagationPolicy(obj *unstructured.Unstructured) (*policyv1alpha1.PropagationPolicy, error) {
-	typedObj := &policyv1alpha1.PropagationPolicy{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
-		return nil, err
+// ConvertToTypedObject converts an unstructured object to typed.
+func ConvertToTypedObject(in, out interface{}) error {
+	if in == nil || out == nil {
+		return fmt.Errorf("convert objects should not be nil")
 	}
 
-	return typedObj, nil
-}
-
-// ConvertToClusterPropagationPolicy converts a ClusterPropagationPolicy object from unstructured to typed.
-func ConvertToClusterPropagationPolicy(obj *unstructured.Unstructured) (*policyv1alpha1.ClusterPropagationPolicy, error) {
-	typedObj := &policyv1alpha1.ClusterPropagationPolicy{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
-		return nil, err
+	switch v := in.(type) {
+	case *unstructured.Unstructured:
+		return runtime.DefaultUnstructuredConverter.FromUnstructured(v.UnstructuredContent(), out)
+	case map[string]interface{}:
+		return runtime.DefaultUnstructuredConverter.FromUnstructured(v, out)
+	default:
+		return fmt.Errorf("convert object must be pointer of unstructured or map[string]interface{}")
 	}
-
-	return typedObj, nil
-}
-
-// ConvertToResourceBinding converts a ResourceBinding object from unstructured to typed.
-func ConvertToResourceBinding(obj *unstructured.Unstructured) (*workv1alpha2.ResourceBinding, error) {
-	typedObj := &workv1alpha2.ResourceBinding{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
-		return nil, err
-	}
-
-	return typedObj, nil
-}
-
-// ConvertToPod converts a Pod object from unstructured to typed.
-func ConvertToPod(obj *unstructured.Unstructured) (*corev1.Pod, error) {
-	typedObj := &corev1.Pod{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
-		return nil, err
-	}
-
-	return typedObj, nil
-}
-
-// ConvertToPersistentVolumeClaim converts a pvc object from unstructured to typed.
-func ConvertToPersistentVolumeClaim(obj *unstructured.Unstructured) (*corev1.PersistentVolumeClaim, error) {
-	typedObj := &corev1.PersistentVolumeClaim{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
-		return nil, err
-	}
-
-	return typedObj, nil
-}
-
-// ConvertToNode converts a Node object from unstructured to typed.
-func ConvertToNode(obj *unstructured.Unstructured) (*corev1.Node, error) {
-	typedObj := &corev1.Node{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
-		return nil, err
-	}
-
-	return typedObj, nil
-}
-
-// ConvertToReplicaSet converts a ReplicaSet object from unstructured to typed.
-func ConvertToReplicaSet(obj *unstructured.Unstructured) (*appsv1.ReplicaSet, error) {
-	typedObj := &appsv1.ReplicaSet{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
-		return nil, err
-	}
-
-	return typedObj, nil
-}
-
-// ConvertToDeployment converts a Deployment object from unstructured to typed.
-func ConvertToDeployment(obj *unstructured.Unstructured) (*appsv1.Deployment, error) {
-	typedObj := &appsv1.Deployment{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
-		return nil, err
-	}
-
-	return typedObj, nil
-}
-
-// ConvertToDeploymentStatus converts a DeploymentStatus object from unstructured to typed.
-func ConvertToDeploymentStatus(obj map[string]interface{}) (*appsv1.DeploymentStatus, error) {
-	typedObj := &appsv1.DeploymentStatus{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj, typedObj); err != nil {
-		return nil, err
-	}
-
-	return typedObj, nil
-}
-
-// ConvertToDaemonSet converts a DaemonSet object from unstructured to typed.
-func ConvertToDaemonSet(obj *unstructured.Unstructured) (*appsv1.DaemonSet, error) {
-	typedObj := &appsv1.DaemonSet{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
-		return nil, err
-	}
-
-	return typedObj, nil
-}
-
-// ConvertToDaemonSetStatus converts a DaemonSetStatus object from unstructured to typed.
-func ConvertToDaemonSetStatus(obj map[string]interface{}) (*appsv1.DaemonSetStatus, error) {
-	typedObj := &appsv1.DaemonSetStatus{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj, typedObj); err != nil {
-		return nil, err
-	}
-
-	return typedObj, nil
-}
-
-// ConvertToStatefulSet converts a StatefulSet object from unstructured to typed.
-func ConvertToStatefulSet(obj *unstructured.Unstructured) (*appsv1.StatefulSet, error) {
-	typedObj := &appsv1.StatefulSet{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
-		return nil, err
-	}
-
-	return typedObj, nil
-}
-
-// ConvertToStatefulSetStatus converts a StatefulSetStatus object from unstructured to typed.
-func ConvertToStatefulSetStatus(obj map[string]interface{}) (*appsv1.StatefulSetStatus, error) {
-	typedObj := &appsv1.StatefulSetStatus{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj, typedObj); err != nil {
-		return nil, err
-	}
-
-	return typedObj, nil
-}
-
-// ConvertToJob converts a Job object from unstructured to typed.
-func ConvertToJob(obj *unstructured.Unstructured) (*batchv1.Job, error) {
-	typedObj := &batchv1.Job{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
-		return nil, err
-	}
-
-	return typedObj, nil
-}
-
-// ConvertToCronJob converts a CronJob object from unstructured to typed.
-func ConvertToCronJob(obj *unstructured.Unstructured) (*batchv1.CronJob, error) {
-	typedObj := &batchv1.CronJob{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
-		return nil, err
-	}
-
-	return typedObj, nil
-}
-
-// ConvertToJobStatus converts a JobStatus from unstructured to typed.
-func ConvertToJobStatus(obj map[string]interface{}) (*batchv1.JobStatus, error) {
-	typedObj := &batchv1.JobStatus{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj, typedObj); err != nil {
-		return nil, err
-	}
-
-	return typedObj, nil
-}
-
-// ConvertToEndpointSlice converts a EndpointSlice object from unstructured to typed.
-func ConvertToEndpointSlice(obj *unstructured.Unstructured) (*discoveryv1.EndpointSlice, error) {
-	typedObj := &discoveryv1.EndpointSlice{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
-		return nil, err
-	}
-
-	return typedObj, nil
-}
-
-// ConvertToResourceExploringWebhookConfiguration converts a ResourceInterpreterWebhookConfiguration object from unstructured to typed.
-func ConvertToResourceExploringWebhookConfiguration(obj *unstructured.Unstructured) (*configv1alpha1.ResourceInterpreterWebhookConfiguration, error) {
-	typedObj := &configv1alpha1.ResourceInterpreterWebhookConfiguration{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
-		return nil, err
-	}
-
-	return typedObj, nil
-}
-
-// ConvertToService converts a Service object from unstructured to typed.
-func ConvertToService(obj *unstructured.Unstructured) (*corev1.Service, error) {
-	typedObj := &corev1.Service{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
-		return nil, err
-	}
-
-	return typedObj, nil
-}
-
-// ConvertToServiceStatus converts a ServiceStatus object from unstructured to typed.
-func ConvertToServiceStatus(obj map[string]interface{}) (*corev1.ServiceStatus, error) {
-	typedObj := &corev1.ServiceStatus{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj, typedObj); err != nil {
-		return nil, err
-	}
-
-	return typedObj, nil
-}
-
-// ConvertToIngress converts an Ingress object from unstructured to typed.
-func ConvertToIngress(obj *unstructured.Unstructured) (*networkingv1.Ingress, error) {
-	typedObj := &networkingv1.Ingress{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObj); err != nil {
-		return nil, err
-	}
-
-	return typedObj, nil
 }
 
 // ApplyReplica applies the Replica value for the specific field.

--- a/pkg/util/overridemanager/imageoverride.go
+++ b/pkg/util/overridemanager/imageoverride.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -32,38 +34,38 @@ func buildPatches(rawObj *unstructured.Unstructured, imageOverrider *policyv1alp
 func buildPatchesWithEmptyPredicate(rawObj *unstructured.Unstructured, imageOverrider *policyv1alpha1.ImageOverrider) ([]overrideOption, error) {
 	switch rawObj.GetKind() {
 	case util.PodKind:
-		podObj, err := helper.ConvertToPod(rawObj)
-		if err != nil {
+		podObj := &corev1.Pod{}
+		if err := helper.ConvertToTypedObject(rawObj, podObj); err != nil {
 			return nil, fmt.Errorf("failed to convert Pod from unstructured object: %v", err)
 		}
 		return extractPatchesBy(podObj.Spec, podSpecPrefix, imageOverrider)
 	case util.ReplicaSetKind:
-		replicaSetObj, err := helper.ConvertToReplicaSet(rawObj)
-		if err != nil {
+		replicaSetObj := &appsv1.ReplicaSet{}
+		if err := helper.ConvertToTypedObject(rawObj, replicaSetObj); err != nil {
 			return nil, fmt.Errorf("failed to convert ReplicaSet from unstructured object: %v", err)
 		}
 		return extractPatchesBy(replicaSetObj.Spec.Template.Spec, podTemplatePrefix, imageOverrider)
 	case util.DeploymentKind:
-		deploymentObj, err := helper.ConvertToDeployment(rawObj)
-		if err != nil {
+		deploymentObj := &appsv1.Deployment{}
+		if err := helper.ConvertToTypedObject(rawObj, deploymentObj); err != nil {
 			return nil, fmt.Errorf("failed to convert Deployment from unstructured object: %v", err)
 		}
 		return extractPatchesBy(deploymentObj.Spec.Template.Spec, podTemplatePrefix, imageOverrider)
 	case util.DaemonSetKind:
-		daemonSetObj, err := helper.ConvertToDaemonSet(rawObj)
-		if err != nil {
+		daemonSetObj := &appsv1.DaemonSet{}
+		if err := helper.ConvertToTypedObject(rawObj, daemonSetObj); err != nil {
 			return nil, fmt.Errorf("failed to convert DaemonSet from unstructured object: %v", err)
 		}
 		return extractPatchesBy(daemonSetObj.Spec.Template.Spec, podTemplatePrefix, imageOverrider)
 	case util.StatefulSetKind:
-		statefulSetObj, err := helper.ConvertToStatefulSet(rawObj)
-		if err != nil {
+		statefulSetObj := &appsv1.StatefulSet{}
+		if err := helper.ConvertToTypedObject(rawObj, statefulSetObj); err != nil {
 			return nil, fmt.Errorf("failed to convert StatefulSet from unstructured object: %v", err)
 		}
 		return extractPatchesBy(statefulSetObj.Spec.Template.Spec, podTemplatePrefix, imageOverrider)
 	case util.JobKind:
-		jobObj, err := helper.ConvertToJob(rawObj)
-		if err != nil {
+		jobObj := &batchv1.Job{}
+		if err := helper.ConvertToTypedObject(rawObj, jobObj); err != nil {
 			return nil, fmt.Errorf("failed to convert Job from unstructured object: %v", err)
 		}
 		return extractPatchesBy(jobObj.Spec.Template.Spec, podTemplatePrefix, imageOverrider)


### PR DESCRIPTION
Fix "namespace \"karmada-cluster"\ not found" when cluster is being registered with "pull" mode

Signed-off-by: wuzhongjian <wuzhongjian_yewu@cmss.chinamobile.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
After installed karmada through "kubectl karmada init", and then registering the member cluster with ‘pull’ mode, the agent log reports an error ”namespace \"karmada-cluster"\ not found“，so the ”karmada-cluster“ namespace needs to be created by default when the karmada control plane is initialized.
![45dac71f0e9384104fc36a03aa080b8](https://user-images.githubusercontent.com/37976659/182801806-dfaffc34-7e7c-4437-9d07-59dc31f4d5b9.png)
![b7e01e82d3b5a93c2c62b932c9b6eaa](https://user-images.githubusercontent.com/37976659/182801910-7ef13547-225c-4c00-9983-aaf3b8bcfc81.jpg)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

