### PR TITLE
fix karmada-agent can not ensure default namespace issue

### DIFF
--- a/pkg/karmadactl/join.go
+++ b/pkg/karmadactl/join.go
@@ -160,11 +160,6 @@ func JoinCluster(controlPlaneRestConfig, clusterConfig *rest.Config, opts Comman
 
 	klog.V(1).Infof("joining cluster config. endpoint: %s", clusterConfig.Host)
 
-	// ensure namespace where the cluster object be stored exists in control plane.
-	if _, err = util.EnsureNamespaceExist(controlPlaneKubeClient, opts.ClusterNamespace, opts.DryRun); err != nil {
-		return err
-	}
-
 	registerOption := util.ClusterRegisterOption{
 		ClusterNamespace:   opts.ClusterNamespace,
 		ClusterName:        opts.ClusterName,

--- a/pkg/util/credential.go
+++ b/pkg/util/credential.go
@@ -98,6 +98,11 @@ func ObtainCredentialsFromMemberCluster(clusterKubeClient kubeclient.Interface, 
 
 // RegisterClusterInControllerPlane represents register cluster in controller plane
 func RegisterClusterInControllerPlane(opts ClusterRegisterOption, controlPlaneKubeClient kubeclient.Interface, generateClusterInControllerPlane generateClusterInControllerPlaneFunc) error {
+	// ensure namespace where the cluster object be stored exists in control plane.
+	if _, err := EnsureNamespaceExist(controlPlaneKubeClient, opts.ClusterNamespace, opts.DryRun); err != nil {
+		return err
+	}
+
 	impersonatorSecret := &corev1.Secret{}
 	secret := &corev1.Secret{}
 	var err error


### PR DESCRIPTION
Fix "namespace "karmada-cluster" not found" when cluster is being registered with "pull" mode

Signed-off-by: wuzhongjian <wuzhongjian_yewu@cmss.chinamobile.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
After installed karmada through "kubectl karmada init", and then registering the member cluster with ‘pull’ mode, the agent log reports an error ”namespace \"karmada-cluster"\ not found“，so the ”karmada-cluster“ namespace needs to be created by default when the karmada control plane is initialized.
![45dac71f0e9384104fc36a03aa080b8](https://user-images.githubusercontent.com/37976659/182801806-dfaffc34-7e7c-4437-9d07-59dc31f4d5b9.png)
![b7e01e82d3b5a93c2c62b932c9b6eaa](https://user-images.githubusercontent.com/37976659/182801910-7ef13547-225c-4c00-9983-aaf3b8bcfc81.jpg)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```