### PR TITLE
Introduce graceful eviction feature gate and mark feature in alpha state

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -8,6 +8,11 @@ import (
 const (
 	// Failover indicates if scheduler should reschedule on cluster failure.
 	Failover featuregate.Feature = "Failover"
+
+	// GracefulEviction indicates if enable grace eviction.
+	// Takes effect only when the Failover feature is enabled.
+	GracefulEviction featuregate.Feature = "GracefulEviction"
+
 	// PropagateDeps indicates if relevant resources should be propagated automatically
 	PropagateDeps featuregate.Feature = "PropagateDeps"
 )
@@ -17,8 +22,9 @@ var (
 	FeatureGate featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
 
 	defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-		Failover:      {Default: false, PreRelease: featuregate.Alpha},
-		PropagateDeps: {Default: false, PreRelease: featuregate.Alpha},
+		Failover:         {Default: false, PreRelease: featuregate.Alpha},
+		GracefulEviction: {Default: false, PreRelease: featuregate.Alpha},
+		PropagateDeps:    {Default: false, PreRelease: featuregate.Alpha},
 	}
 )
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR introduced a feature gate and defaults in `alpha` state.

**Which issue(s) this PR fixes**:
Part of #2281

**Special notes for your reviewer**:
The new feature gate presents in the command line as expected:
```
      --feature-gates mapStringBool                                                                                                                                                                                              
                A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
                AllAlpha=true|false (ALPHA - default=false)
                AllBeta=true|false (BETA - default=false)
                Failover=true|false (ALPHA - default=false)
                GracefulEviction=true|false (ALPHA - default=false)
                PropagateDeps=true|false (ALPHA - default=false)
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE(Included in Graceful Eviction Feature)
```

