### PR TITLE
add health field in the binding and work api

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15568,6 +15568,10 @@
         "identifier"
       ],
       "properties": {
+        "health": {
+          "description": "Health represents the healthy state of the current resource. There maybe different rules for different resources to achieve health status.",
+          "type": "string"
+        },
         "identifier": {
           "description": "Identifier represents the identity of a resource linking to manifests in spec.",
           "default": {},
@@ -15766,6 +15770,10 @@
           "description": "ClusterName represents the member cluster name which the resource deployed on.",
           "type": "string",
           "default": ""
+        },
+        "health": {
+          "description": "Health represents the healthy state of the current resource. There maybe different rules for different resources to achieve health status.",
+          "type": "string"
         },
         "status": {
           "description": "Status reflects running status of current manifest.",

--- a/charts/karmada/_crds/bases/work.karmada.io_clusterresourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work.karmada.io_clusterresourcebindings.yaml
@@ -592,6 +592,15 @@ spec:
                       description: ClusterName represents the member cluster name
                         which the resource deployed on.
                       type: string
+                    health:
+                      description: Health represents the healthy state of the current
+                        resource. There maybe different rules for different resources
+                        to achieve health status.
+                      enum:
+                      - Healthy
+                      - Unhealthy
+                      - Unknown
+                      type: string
                     status:
                       description: Status reflects running status of current manifest.
                       type: object

--- a/charts/karmada/_crds/bases/work.karmada.io_resourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work.karmada.io_resourcebindings.yaml
@@ -592,6 +592,15 @@ spec:
                       description: ClusterName represents the member cluster name
                         which the resource deployed on.
                       type: string
+                    health:
+                      description: Health represents the healthy state of the current
+                        resource. There maybe different rules for different resources
+                        to achieve health status.
+                      enum:
+                      - Healthy
+                      - Unhealthy
+                      - Unknown
+                      type: string
                     status:
                       description: Status reflects running status of current manifest.
                       type: object

--- a/charts/karmada/_crds/bases/work.karmada.io_works.yaml
+++ b/charts/karmada/_crds/bases/work.karmada.io_works.yaml
@@ -145,6 +145,15 @@ spec:
                   description: ManifestStatus contains running status of a specific
                     manifest in spec.
                   properties:
+                    health:
+                      description: Health represents the healthy state of the current
+                        resource. There maybe different rules for different resources
+                        to achieve health status.
+                      enum:
+                      - Healthy
+                      - Unhealthy
+                      - Unknown
+                      type: string
                     identifier:
                       description: Identifier represents the identity of a resource
                         linking to manifests in spec.

--- a/pkg/apis/work/v1alpha1/binding_types_conversion.go
+++ b/pkg/apis/work/v1alpha1/binding_types_conversion.go
@@ -83,7 +83,12 @@ func ConvertBindingSpecToHub(src *ResourceBindingSpec, dst *workv1alpha2.Resourc
 func ConvertBindingStatusToHub(src *ResourceBindingStatus, dst *workv1alpha2.ResourceBindingStatus) {
 	dst.Conditions = src.Conditions
 	for i := range src.AggregatedStatus {
-		dst.AggregatedStatus = append(dst.AggregatedStatus, workv1alpha2.AggregatedStatusItem(src.AggregatedStatus[i]))
+		dst.AggregatedStatus = append(dst.AggregatedStatus, workv1alpha2.AggregatedStatusItem{
+			ClusterName:    src.AggregatedStatus[i].ClusterName,
+			Status:         src.AggregatedStatus[i].Status,
+			Applied:        src.AggregatedStatus[i].Applied,
+			AppliedMessage: src.AggregatedStatus[i].AppliedMessage,
+		})
 	}
 }
 
@@ -110,6 +115,11 @@ func ConvertBindingSpecFromHub(src *workv1alpha2.ResourceBindingSpec, dst *Resou
 func ConvertBindingStatusFromHub(src *workv1alpha2.ResourceBindingStatus, dst *ResourceBindingStatus) {
 	dst.Conditions = src.Conditions
 	for i := range src.AggregatedStatus {
-		dst.AggregatedStatus = append(dst.AggregatedStatus, AggregatedStatusItem(src.AggregatedStatus[i]))
+		dst.AggregatedStatus = append(dst.AggregatedStatus, AggregatedStatusItem{
+			ClusterName:    src.AggregatedStatus[i].ClusterName,
+			Status:         src.AggregatedStatus[i].Status,
+			Applied:        src.AggregatedStatus[i].Applied,
+			AppliedMessage: src.AggregatedStatus[i].AppliedMessage,
+		})
 	}
 }

--- a/pkg/apis/work/v1alpha1/work_types.go
+++ b/pkg/apis/work/v1alpha1/work_types.go
@@ -82,6 +82,12 @@ type ManifestStatus struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +optional
 	Status *runtime.RawExtension `json:"status,omitempty"`
+
+	// Health represents the healthy state of the current resource.
+	// There maybe different rules for different resources to achieve health status.
+	// +kubebuilder:validation:Enum=Healthy;Unhealthy;Unknown
+	// +optional
+	Health ResourceHealth `json:"health,omitempty"`
 }
 
 // ResourceIdentifier provides the identifiers needed to interact with any arbitrary object.
@@ -123,6 +129,21 @@ const (
 	// WorkDegraded represents that the current state of Work does not match
 	// the desired state for a certain period.
 	WorkDegraded string = "Degraded"
+)
+
+// ResourceHealth represents that the health status of the reference resource.
+type ResourceHealth string
+
+const (
+	// ResourceHealthy represents that the health status of the current resource
+	// that applied on the managed cluster is healthy.
+	ResourceHealthy ResourceHealth = "Healthy"
+	// ResourceUnhealthy represents that the health status of the current resource
+	// that applied on the managed cluster is unhealthy.
+	ResourceUnhealthy ResourceHealth = "Unhealthy"
+	// ResourceUnknown represents that the health status of the current resource
+	// that applied on the managed cluster is unknown.
+	ResourceUnknown ResourceHealth = "Unknown"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/work/v1alpha2/binding_types.go
+++ b/pkg/apis/work/v1alpha2/binding_types.go
@@ -251,6 +251,12 @@ type AggregatedStatusItem struct {
 	// This is usually holds the error message in case of apply failed.
 	// +optional
 	AppliedMessage string `json:"appliedMessage,omitempty"`
+
+	// Health represents the healthy state of the current resource.
+	// There maybe different rules for different resources to achieve health status.
+	// +kubebuilder:validation:Enum=Healthy;Unhealthy;Unknown
+	// +optional
+	Health ResourceHealth `json:"health,omitempty"`
 }
 
 // Conditions definition
@@ -273,6 +279,21 @@ type ResourceBindingList struct {
 	// Items is the list of ResourceBinding.
 	Items []ResourceBinding `json:"items"`
 }
+
+// ResourceHealth represents that the health status of the reference resource.
+type ResourceHealth string
+
+const (
+	// ResourceHealthy represents that the health status of the current resource
+	// that applied on the managed cluster is healthy.
+	ResourceHealthy ResourceHealth = "Healthy"
+	// ResourceUnhealthy represents that the health status of the current resource
+	// that applied on the managed cluster is unhealthy.
+	ResourceUnhealthy ResourceHealth = "Unhealthy"
+	// ResourceUnknown represents that the health status of the current resource
+	// that applied on the managed cluster is unknown.
+	ResourceUnknown ResourceHealth = "Unknown"
+)
 
 // +genclient
 // +genclient:nonNamespaced

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -3501,6 +3501,13 @@ func schema_pkg_apis_work_v1alpha1_ManifestStatus(ref common.ReferenceCallback) 
 							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 						},
 					},
+					"health": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Health represents the healthy state of the current resource. There maybe different rules for different resources to achieve health status.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"identifier"},
 			},
@@ -4088,6 +4095,13 @@ func schema_pkg_apis_work_v1alpha2_AggregatedStatusItem(ref common.ReferenceCall
 					"appliedMessage": {
 						SchemaProps: spec.SchemaProps{
 							Description: "AppliedMessage is a human readable message indicating details about the applied status. This is usually holds the error message in case of apply failed.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"health": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Health represents the healthy state of the current resource. There maybe different rules for different resources to achieve health status.",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

We need to collect resource health status in the `Work` and `RsourceBinding/ClusterResourceBinding` objects to indicate the health of the resources that are applied to the member cluster, so I added the `health` field in the  `Work` and `RsourceBinding/ClusterResourceBinding`  API.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Add health field in the Work and RsourceBinding/ClusterResourceBinding API
```

