### PR TITLE
Make it support external kubeconfig for undeploy agent script

### DIFF
--- a/hack/undeploy-karmada-agent.sh
+++ b/hack/undeploy-karmada-agent.sh
@@ -52,13 +52,16 @@ MEMBER_CLUSTER_NAME=$4
 
 source "${REPO_ROOT}"/hack/util.sh
 
-# remove the member cluster from karmada control plane
-kubectl delete cluster ${MEMBER_CLUSTER_NAME}
-
-# remove agent from the member cluster
 if [ -n "${KUBECONFIG+x}" ];then
   CURR_KUBECONFIG=$KUBECONFIG # backup current kubeconfig
 fi
+
+# remove the member cluster from karmada control plane
+export KUBECONFIG="${KARMADA_APISERVER_KUBECONFIG}"
+kubectl config use-context "${KARMADA_APISERVER_CONTEXT_NAME}"
+kubectl delete cluster ${MEMBER_CLUSTER_NAME}
+
+# remove agent from the member cluster
 export KUBECONFIG="${MEMBER_CLUSTER_KUBECONFIG}" # switch to member cluster
 kubectl config use-context "${MEMBER_CLUSTER_NAME}"
 


### PR DESCRIPTION
Signed-off-by: lonelyCZ <531187475@qq.com>

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When using other `kubeconfig` not `~/.kube/config`, it will occur a error.

```
[root@master67 karmada]# hack/undeploy-karmada-agent.sh /etc/karmada/karmada-apiserver.config karmada-apiserver ~/.kube/members.config member68
error: the server doesn't have a resource type "cluster"
```
It still called `~/.kube/config`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

