### PR TITLE
avoid joining the same cluster repeatedly

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -120,6 +120,7 @@ func run(ctx context.Context, karmadaConfig karmadactl.KarmadaConfig, opts *opti
 	}
 	clusterKubeClient := kubeclientset.NewForConfigOrDie(clusterConfig)
 	controlPlaneKubeClient := kubeclientset.NewForConfigOrDie(controlPlaneRestConfig)
+	karmadaClient := karmadaclientset.NewForConfigOrDie(controlPlaneRestConfig)
 
 	registerOption := util.ClusterRegisterOption{
 		ClusterNamespace:   opts.ClusterNamespace,
@@ -138,6 +139,16 @@ func run(ctx context.Context, karmadaConfig karmadactl.KarmadaConfig, opts *opti
 	if err != nil {
 		return err
 	}
+
+	ok, name, err := util.IsClusterIdentifyUnique(karmadaClient, id)
+	if err != nil {
+		return err
+	}
+
+	if !ok {
+		return fmt.Errorf("the same cluster has been registered with name %s", name)
+	}
+
 	registerOption.ClusterID = id
 
 	clusterSecret, impersonatorSecret, err := util.ObtainCredentialsFromMemberCluster(clusterKubeClient, registerOption)

--- a/pkg/util/cluster.go
+++ b/pkg/util/cluster.go
@@ -130,6 +130,7 @@ func CreateOrUpdateClusterObject(controlPlaneClient karmadaclientset.Interface, 
 	}
 
 	mutate(clusterObj)
+
 	if cluster, err = createCluster(controlPlaneClient, clusterObj); err != nil {
 		klog.Warningf("failed to create cluster(%s). error: %v", clusterObj.Name, err)
 		return nil, err
@@ -179,4 +180,19 @@ func ObtainClusterID(clusterKubeClient *kubernetes.Clientset) (string, error) {
 		return "", err
 	}
 	return string(ns.UID), nil
+}
+
+// IsClusterIdentifyUnique checks whether the ClusterID exists in the karmada control plane.
+func IsClusterIdentifyUnique(controlPlaneClient karmadaclientset.Interface, id string) (bool, string, error) {
+	clusterList, err := controlPlaneClient.ClusterV1alpha1().Clusters().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return false, "", err
+	}
+
+	for _, cluster := range clusterList.Items {
+		if cluster.Spec.ID == id {
+			return false, cluster.Name, nil
+		}
+	}
+	return true, "", nil
 }


### PR DESCRIPTION
Signed-off-by: yy158775 <1584616775@qq.com>

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
prevent the same cluster repeating to join karmada.

**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/karmada/issues/1351

**Special notes for your reviewer**:
```
The same cluster repeatedly join has two scenarios.
One is use karmadactl to join push mode cluster.

Before join,the cluster member1,member2,member3 has joined in karmada.
Now we use member4 as the cluster's name to join the member1's cluster to control plane.

karmadactl join member4 --cluster-kubeconfig=~/.kube/members.config --cluster-context=member1

Results:
error: failed to create cluster(member4) object. error: cluster(id:fc1c4701-34c9-4a4b-afc2-296ecefe0c2d) already exist

The other is use karmada-agent to join pull mode cluster.
Results:

│ E0812 09:31:16.363961       1 agent.go:375] Failed to create cluster(member6) object, error: cluster(id:fc1c4701-34c9-4a4b-afc2-296ecefe0c2d) already exist                       │
│ E0812 09:31:16.363991       1 run.go:74] "command failed" err="failed to register with karmada control plane: cluster(id:fc1c4701-34c9-4a4b-afc2-296ecefe0c2d) already exist"
Then the pod turns into crashed.
```
**Does this PR introduce a user-facing change?**:
karmada-agent and karmadactl: avoid the same cluster joining in the karmada.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->