### PR TITLE
remove TargetCluster when cluster is terminating

### DIFF
--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -184,12 +184,14 @@ func startClusterController(ctx controllerscontext.Context) (enabled bool, err e
 	opts := ctx.Opts
 
 	clusterController := &cluster.Controller{
-		Client:                    mgr.GetClient(),
-		EventRecorder:             mgr.GetEventRecorderFor(cluster.ControllerName),
-		ClusterMonitorPeriod:      opts.ClusterMonitorPeriod.Duration,
-		ClusterMonitorGracePeriod: opts.ClusterMonitorGracePeriod.Duration,
-		ClusterStartupGracePeriod: opts.ClusterStartupGracePeriod.Duration,
-		FailoverEvictionTimeout:   opts.FailoverEvictionTimeout.Duration,
+		Client:                             mgr.GetClient(),
+		EventRecorder:                      mgr.GetEventRecorderFor(cluster.ControllerName),
+		ClusterMonitorPeriod:               opts.ClusterMonitorPeriod.Duration,
+		ClusterMonitorGracePeriod:          opts.ClusterMonitorGracePeriod.Duration,
+		ClusterStartupGracePeriod:          opts.ClusterStartupGracePeriod.Duration,
+		FailoverEvictionTimeout:            opts.FailoverEvictionTimeout.Duration,
+		EnableTaintManager:                 ctx.Opts.EnableTaintManager,
+		ClusterTaintEvictionRetryFrequency: 10 * time.Second,
 	}
 	if err := clusterController.SetupWithManager(mgr); err != nil {
 		return false, err
@@ -199,7 +201,6 @@ func startClusterController(ctx controllerscontext.Context) (enabled bool, err e
 		if err := cluster.IndexField(mgr); err != nil {
 			return false, err
 		}
-
 		taintManager := &cluster.NoExecuteTaintManager{
 			Client:                             mgr.GetClient(),
 			EventRecorder:                      mgr.GetEventRecorderFor(cluster.TaintManagerName),

--- a/pkg/apis/cluster/v1alpha1/events.go
+++ b/pkg/apis/cluster/v1alpha1/events.go
@@ -8,4 +8,6 @@ const (
 	EventReasonRemoveExecutionSpaceFailed = "RemoveExecutionSpaceFailed"
 	// EventReasonTaintClusterByConditionFailed indicates that taint cluster by condition
 	EventReasonTaintClusterByConditionFailed = "TaintClusterByCondition"
+	// EventReasonRemoveTargetClusterFailed indicates that failed to remove target cluster from binding.
+	EventReasonRemoveTargetClusterFailed = "RemoveTargetClusterFailed"
 )

--- a/pkg/apis/cluster/v1alpha1/well_known_constants.go
+++ b/pkg/apis/cluster/v1alpha1/well_known_constants.go
@@ -11,6 +11,8 @@ const (
 	// (corresponding to ClusterConditionReady status ConditionUnknown)
 	// and removed when cluster becomes reachable (ClusterConditionReady status ConditionTrue).
 	TaintClusterUnreachable = "cluster.karmada.io/unreachable"
+	// TaintClusterTerminating will be added when cluster is terminating.
+	TaintClusterTerminating = "cluster.karmada.io/terminating"
 
 	// CacheSourceAnnotationKey is the annotation that added to a resource to
 	// represent which cluster it cached from.


### PR DESCRIPTION
Signed-off-by: Garrybest <garrybest@foxmail.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Remove cluster scheduling result in spec.clusters when the cluster is terminating.

**Which issue(s) this PR fixes**:
part of #1762
Fixes #1995

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

