### PR TITLE
fix: remove unexpected validate webhook in configuration

### DIFF
--- a/charts/karmada/templates/_karmada_webhook_configuration.tpl
+++ b/charts/karmada/templates/_karmada_webhook_configuration.tpl
@@ -51,20 +51,6 @@ webhooks:
     sideEffects: None
     admissionReviewVersions: ["v1"]
     timeoutSeconds: 3
-  - name: clusteroverridepolicy.karmada.io
-    rules:
-      - operations: ["CREATE", "UPDATE"]
-        apiGroups: ["policy.karmada.io"]
-        apiVersions: ["*"]
-        resources: ["clusteroverridepolicies"]
-        scope: "Cluster"
-    clientConfig:
-      url: https://{{ $name }}.{{ $namespace }}.svc:443/validate-clusteroverridepolicy
-      {{- include "karmada.webhook.caBundle" . | nindent 6 }}
-    failurePolicy: Fail
-    sideEffects: None
-    admissionReviewVersions: ["v1"]
-    timeoutSeconds: 3
   - name: work.karmada.io
     rules:
       - operations: ["CREATE", "UPDATE"]
@@ -124,6 +110,20 @@ webhooks:
         scope: "Namespaced"
     clientConfig:
       url: https://{{ $name }}-webhook.{{ $namespace }}.svc:443/validate-overridepolicy
+      {{- include "karmada.webhook.caBundle" . | nindent 6 }}
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    timeoutSeconds: 3
+  - name: clusteroverridepolicy.karmada.io
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["policy.karmada.io"]
+        apiVersions: ["*"]
+        resources: ["clusteroverridepolicies"]
+        scope: "Cluster"
+    clientConfig:
+      url: https://{{ $name }}-webhook.{{ $namespace }}.svc:443/validate-clusteroverridepolicy
       {{- include "karmada.webhook.caBundle" . | nindent 6 }}
     failurePolicy: Fail
     sideEffects: None


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
cleanup misconfigured validation webhook from the chart.

**Which issue(s) this PR fixes**:
Fixes #2254

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
