### PR TITLE
bump ci runner to ubuntu-20.04 as ubuntu-18.04 is deprecated.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout code
         uses: actions/checkout@v2
@@ -23,7 +23,7 @@ jobs:
         run: hack/verify-import-aliases.sh
   codegen:
     name: codegen
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       GOPATH: ${{ github.workspace }}
     defaults:
@@ -53,7 +53,7 @@ jobs:
   build:
     name: compile
     needs: codegen # rely on codegen successful completion
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout code
         uses: actions/checkout@v2
@@ -70,7 +70,7 @@ jobs:
   test:
     name: unit test
     needs: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout code
         uses: actions/checkout@v2
@@ -83,7 +83,7 @@ jobs:
   e2e:
     name: e2e test
     needs: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         k8s: [ v1.21.10, v1.22.7, v1.23.4, v1.24.2 ]

--- a/.github/workflows/dockerhub-latest-image.yml
+++ b/.github/workflows/dockerhub-latest-image.yml
@@ -22,7 +22,7 @@ jobs:
           - karmada-interpreter-webhook-example
           - karmada-aggregated-apiserver
           - karmada-search
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/dockerhub-released-image.yml
+++ b/.github/workflows/dockerhub-released-image.yml
@@ -18,7 +18,7 @@ jobs:
           - karmada-interpreter-webhook-example
           - karmada-aggregated-apiserver
           - karmada-search
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -8,7 +8,7 @@ jobs:
     # 1. running on the forked repository would fail as missing necessary secret.
     # 2. running on the forked repository would use unnecessary GitHub Action time.
     if: ${{ github.repository == 'karmada-io/karmada' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ name: Build Release
 jobs:
   release-assests:
     name: release kubectl-karmada
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         target:
@@ -39,7 +39,7 @@ jobs:
   update-krew-index:
     needs: release-assests
     name: Update krew-index
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@master
     - name: Update new version in krew-index

--- a/.github/workflows/swr-latest-image.yml
+++ b/.github/workflows/swr-latest-image.yml
@@ -10,7 +10,7 @@ jobs:
     # 1. running on the forked repository would fail as missing necessary secret.
     # 2. running on the forked repository would use unnecessary GitHub Action time.
     if: ${{ github.repository == 'karmada-io/karmada' && github.ref == 'refs/heads/master' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/swr-released-image.yml
+++ b/.github/workflows/swr-released-image.yml
@@ -10,7 +10,7 @@ jobs:
     # 1. running on the forked repository would fail as missing necessary secret.
     # 2. running on the forked repository would use unnecessary GitHub Action time.
     if: ${{ github.repository == 'karmada-io/karmada' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
The Ubuntu-18.04 environment is deprecated and will be removed on December 1st, 2022. For more details, see https://github.com/actions/runner-images/issues/6002

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Our CI jobs are affected by the brownout periods :):
https://github.com/karmada-io/karmada/actions/runs/2903700379

The reason why I didn't choose the newer `ubuntu-22.04` is that it's not the stable(GA) one by now.
Just echo from the [Label Schema](https://github.com/actions/runner-images#label-scheme):
> In general the -latest label is used for the latest OS image version that is GA

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

