### PR TITLE
Optimize `karmadactl init` to output example

### DIFF
--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -471,12 +471,18 @@ func (i *CommandInitOption) RunInit(parentCommand string) error {
 		return err
 	}
 
+	// Create bootstarp token in karmada
+	registerCommand, err := karmada.InitKarmadaBootstrapToken(i.KarmadaDataPath)
+	if err != nil {
+		return err
+	}
+
 	// install karmada Component
 	if err := i.initKarmadaComponent(); err != nil {
 		return err
 	}
 
-	utils.GenExamples(i.KarmadaDataPath, parentCommand)
+	utils.GenExamples(i.KarmadaDataPath, parentCommand, registerCommand)
 	return nil
 }
 

--- a/pkg/karmadactl/cmdinit/utils/examples_test.go
+++ b/pkg/karmadactl/cmdinit/utils/examples_test.go
@@ -3,5 +3,5 @@ package utils
 import "testing"
 
 func TestGenExamples(t *testing.T) {
-	GenExamples("/tmp", "kubectl karmada")
+	GenExamples("/tmp", "kubectl karmada", " register")
 }


### PR DESCRIPTION
Signed-off-by: lonelyCZ <531187475@qq.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Print the new cluster register way after finishing karmadactl init.

```
------------------------------------------------------------------------------------------------------
 █████   ████   █████████   ███████████   ██████   ██████   █████████   ██████████     █████████
░░███   ███░   ███░░░░░███ ░░███░░░░░███ ░░██████ ██████   ███░░░░░███ ░░███░░░░███   ███░░░░░███
 ░███  ███    ░███    ░███  ░███    ░███  ░███░█████░███  ░███    ░███  ░███   ░░███ ░███    ░███
 ░███████     ░███████████  ░██████████   ░███░░███ ░███  ░███████████  ░███    ░███ ░███████████
 ░███░░███    ░███░░░░░███  ░███░░░░░███  ░███ ░░░  ░███  ░███░░░░░███  ░███    ░███ ░███░░░░░███
 ░███ ░░███   ░███    ░███  ░███    ░███  ░███      ░███  ░███    ░███  ░███    ███  ░███    ░███
 █████ ░░████ █████   █████ █████   █████ █████     █████ █████   █████ ██████████   █████   █████
░░░░░   ░░░░ ░░░░░   ░░░░░ ░░░░░   ░░░░░ ░░░░░     ░░░░░ ░░░░░   ░░░░░ ░░░░░░░░░░   ░░░░░   ░░░░░
------------------------------------------------------------------------------------------------------
Karmada is installed successfully.

Register Kubernetes cluster to Karmada control plane.

Register cluster with 'Push' mode
                                                                                                                                                                     
Step 1: Use "karmadactl join" command to register the cluster to Karmada control plane. --cluster-kubeconfig is kubeconfig of the member cluster.
(In karmada)~# MEMBER_CLUSTER_NAME="cat ~/.kube/config  | grep current-context | sed 's/: /\n/g'| sed '1d'"
(In karmada)~# karmadactl --kubeconfig /etc/karmada/karmada-apiserver.config  join ${MEMBER_CLUSTER_NAME} --cluster-kubeconfig=$HOME/.kube/config

Step 2: Show members of karmada
(In karmada)~# kubectl  --kubeconfig /etc/karmada/karmada-apiserver.config get clusters


Register cluster with 'Pull' mode

Step 1: Use "karmadactl register" command to register the cluster to Karmada control plane. "--cluster-name" is set to cluster of current-context by default.
(In member cluster)~# karmadactl register 10.10.103.67:32443 --token n22coq.e27ei7g5kj4zt7f6 --discovery-token-ca-cert-hash sha256:fe79b399c093283ae37a8e02b1d143055200afad6229c1ecfd7f05e4956648a7

Step 2: Show members of karmada                                                                                                                                      
(In karmada)~# kubectl  --kubeconfig /etc/karmada/karmada-apiserver.config get clusters


```

**Which issue(s) this PR fixes**:
Part of #2282 

**Special notes for your reviewer**:
/cc @RainbowMango @prodanlabs 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

