### PR TITLE
Reflect health status for recording the healthy state of the current resource

### DIFF
--- a/pkg/resourceinterpreter/defaultinterpreter/default.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/default.go
@@ -63,7 +63,9 @@ func (e *DefaultInterpreter) HookEnabled(kind schema.GroupVersionKind, operation
 	case configv1alpha1.InterpreterOperationInterpretStatus:
 		return true
 	case configv1alpha1.InterpreterOperationInterpretHealth:
-		return true
+		if _, exist := e.healthHandlers[kind]; exist {
+			return true
+		}
 		// TODO(RainbowMango): more cases should be added here
 	}
 

--- a/pkg/util/helper/workstatus.go
+++ b/pkg/util/helper/workstatus.go
@@ -167,6 +167,7 @@ func assembleWorkStatus(works []workv1alpha1.Work, workload *unstructured.Unstru
 				ClusterName:    clusterName,
 				Applied:        applied,
 				AppliedMessage: appliedMsg,
+				Health:         workv1alpha2.ResourceUnknown,
 			}
 			statuses = append(statuses, aggregatedStatus)
 			continue
@@ -176,6 +177,7 @@ func assembleWorkStatus(works []workv1alpha1.Work, workload *unstructured.Unstru
 		aggregatedStatus := workv1alpha2.AggregatedStatusItem{
 			ClusterName: clusterName,
 			Applied:     applied,
+			Health:      workv1alpha2.ResourceUnknown,
 		}
 
 		for _, manifestStatus := range work.Status.ManifestStatuses {
@@ -185,6 +187,7 @@ func assembleWorkStatus(works []workv1alpha1.Work, workload *unstructured.Unstru
 			}
 			if equal {
 				aggregatedStatus.Status = manifestStatus.Status
+				aggregatedStatus.Health = workv1alpha2.ResourceHealth(manifestStatus.Health)
 				break
 			}
 		}


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

As we import health field with Work API in #2351, we plan to:
- Reflect `Work` health status for recording the healthy state of the current resource.
- Assemble `ResourceBinding/ClusterResourceBinding` health item status for recording the healthy state of the current resource running in the member cluster.

Preparing for subsequent graceful evictions #2281 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE(include in graceful eviction feature)
```

