### PR TITLE
Automated cherry pick of #2401: fix: remove unexpected validate webhook in configuration #2258: fix: create cluster apiservice in post install job

### DIFF
--- a/charts/templates/_karmada_webhook_configuration.tpl
+++ b/charts/templates/_karmada_webhook_configuration.tpl
@@ -51,20 +51,6 @@ webhooks:
     sideEffects: None
     admissionReviewVersions: ["v1"]
     timeoutSeconds: 3
-  - name: clusteroverridepolicy.karmada.io
-    rules:
-      - operations: ["CREATE", "UPDATE"]
-        apiGroups: ["policy.karmada.io"]
-        apiVersions: ["*"]
-        resources: ["clusteroverridepolicies"]
-        scope: "Cluster"
-    clientConfig:
-      url: https://{{ $name }}.{{ $namespace }}.svc:443/validate-clusteroverridepolicy
-      {{- include "karmada.webhook.caBundle" . | nindent 6 }}
-    failurePolicy: Fail
-    sideEffects: None
-    admissionReviewVersions: ["v1"]
-    timeoutSeconds: 3
   - name: work.karmada.io
     rules:
       - operations: ["CREATE", "UPDATE"]
@@ -124,6 +110,20 @@ webhooks:
         scope: "Namespaced"
     clientConfig:
       url: https://{{ $name }}-webhook.{{ $namespace }}.svc:443/validate-overridepolicy
+      {{- include "karmada.webhook.caBundle" . | nindent 6 }}
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    timeoutSeconds: 3
+  - name: clusteroverridepolicy.karmada.io
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["policy.karmada.io"]
+        apiVersions: ["*"]
+        resources: ["clusteroverridepolicies"]
+        scope: "Cluster"
+    clientConfig:
+      url: https://{{ $name }}-webhook.{{ $namespace }}.svc:443/validate-clusteroverridepolicy
       {{- include "karmada.webhook.caBundle" . | nindent 6 }}
     failurePolicy: Fail
     sideEffects: None

--- a/charts/templates/post-install-job.yaml
+++ b/charts/templates/post-install-job.yaml
@@ -12,6 +12,8 @@ data:
     {{- include "karmada.webhook.configuration" . | nindent 4 }}
   {{- print "system-namespace.yaml: " | nindent 2 }} |-
     {{- include "karmada.systemNamespace" . | nindent 4 }}
+  {{- print "karmada-aggregated-apiserver-apiservice.yaml: " | nindent 6 }} |-
+    {{- include "karmada.apiservice" . | nindent 8 }}
   {{- print "cluster-proxy-admin-rbac.yaml: " | nindent 2 }} |-
     {{- include "karmada.proxyRbac" . | nindent 4 }}
 ---


### PR DESCRIPTION
Cherry pick of #2401 #2258 on release-1.2.
#2401: fix: remove unexpected validate webhook in configuration
#2258: fix: create cluster apiservice in post install job
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```release-note
`Helm Chart`: Fixed misconfigured `MutatingWebhookConfiguration`. 
`Helm Chart`: added missing `APIService` configuration for `karmada-aggregated-apiserver`.
```