### PR TITLE
fix karmada chart kube-controller cluster-signing config error

### DIFF
--- a/charts/karmada/templates/kube-controller-manager.yaml
+++ b/charts/karmada/templates/kube-controller-manager.yaml
@@ -57,8 +57,8 @@ spec:
             - --client-ca-file=/etc/karmada/pki/server-ca.crt
             - --cluster-cidr=10.244.0.0/16
             - --cluster-name=karmada
-            - --cluster-signing-cert-file=/etc/karmada/pki/karmada.crt
-            - --cluster-signing-key-file=/etc/karmada/pki/karmada.key
+            - --cluster-signing-cert-file=/etc/karmada/pki/server-ca.crt
+            - --cluster-signing-key-file=/etc/karmada/pki/server-ca.key
             - --controllers=namespace,garbagecollector,serviceaccount-token
             - --kubeconfig=/etc/kubeconfig
             - --leader-elect=true

--- a/charts/karmada/templates/pre-install-job.yaml
+++ b/charts/karmada/templates/pre-install-job.yaml
@@ -20,6 +20,8 @@ data:
     data:
       server-ca.crt: |-
         {{ print "{{ ca_crt }}" }}
+      server-ca.key: |-
+        {{ print "{{ ca_key }}" }}
       karmada.crt: |-
         {{ print "{{ crt }}" }}
       karmada.key: |-
@@ -166,12 +168,14 @@ spec:
           echo '{"signing":{"default":{"expiry":{{ printf `"%s"` .Values.certs.auto.expiry }},"usages":["signing","key encipherment","client auth","server auth"]}}}' > "/opt/certs/front-proxy-ca-config.json"
           echo '{"CN":"front-proxy-client","hosts":{{ tpl (toJson .Values.certs.auto.hosts) . }},"names":[{"O":"system:masters"}],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -ca=/opt/certs/front-proxy-ca.crt -ca-key=/opt/certs/front-proxy-ca.key -config=/opt/certs/front-proxy-ca-config.json - | cfssljson -bare /opt/certs/front-proxy-client
           karmada_ca=$(base64 /opt/certs/server-ca.crt | tr -d '\r\n')
+          karmada_ca_key=$(base64 /opt/certs/server-ca.key | tr -d '\r\n')
           karmada_crt=$(base64 /opt/certs/karmada.pem | tr -d '\r\n')
           karmada_key=$(base64 /opt/certs/karmada-key.pem | tr -d '\r\n')
           front_proxy_ca=$(base64 /opt/certs/front-proxy-ca.crt | tr -d '\r\n')
           front_proxy_client_crt=$(base64 /opt/certs/front-proxy-client.pem | tr -d '\r\n')
           front_proxy_client_key=$(base64 /opt/certs/front-proxy-client-key.pem | tr -d '\r\n')
           sed -i'' -e "s/{{ print "{{ ca_crt }}" }}/${karmada_ca}/g" /opt/configs/cert.yaml
+          sed -i'' -e "s/{{ print "{{ ca_key }}" }}/${karmada_ca_key}/g" /opt/configs/cert.yaml
           sed -i'' -e "s/{{ print "{{ crt }}" }}/${karmada_crt}/g" /opt/configs/cert.yaml
           sed -i'' -e "s/{{ print "{{ key }}" }}/${karmada_key}/g" /opt/configs/cert.yaml
           sed -i'' -e "s/{{ print "{{ front_proxy_ca_crt }}" }}/${front_proxy_ca}/g" /opt/configs/cert.yaml


### PR DESCRIPTION
Signed-off-by: ndx-robot <xiao.zhang@daocloud.io>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

At present, in the karmada charts, the kube-controller configuration is incorrect, which causes the certificate to not work properly after it is issued.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

