### PR TITLE
karmada controller-plane supports the ability to issue certificates via csr

### DIFF
--- a/artifacts/deploy/kube-controller-manager.yaml
+++ b/artifacts/deploy/kube-controller-manager.yaml
@@ -42,7 +42,7 @@ spec:
             - --cluster-name=karmada
             - --cluster-signing-cert-file=/etc/karmada/pki/ca.crt
             - --cluster-signing-key-file=/etc/karmada/pki/ca.key
-            - --controllers=namespace,garbagecollector,serviceaccount-token,ttl-after-finished
+            - --controllers=namespace,garbagecollector,serviceaccount-token,ttl-after-finished,bootstrapsigner,csrapproving,csrcleaner,csrsigning
             - --kubeconfig=/etc/kubeconfig
             - --leader-elect=true
             - --node-cidr-mask-size=24

--- a/charts/karmada/templates/kube-controller-manager.yaml
+++ b/charts/karmada/templates/kube-controller-manager.yaml
@@ -59,7 +59,7 @@ spec:
             - --cluster-name=karmada
             - --cluster-signing-cert-file=/etc/karmada/pki/server-ca.crt
             - --cluster-signing-key-file=/etc/karmada/pki/server-ca.key
-            - --controllers=namespace,garbagecollector,serviceaccount-token
+            - --controllers=namespace,garbagecollector,serviceaccount-token,ttl-after-finished,bootstrapsigner,csrapproving,csrcleaner,csrsigning
             - --kubeconfig=/etc/kubeconfig
             - --leader-elect=true
             - --node-cidr-mask-size=24


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

At present, karmada controller-plane does not support the ability to issue certificates through csr, but we can access karmada controller-plane by issuing certificates with different permissions through csr, which is very meaningful

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

