### PR TITLE
Perceiving the health status of cluster scheduling results in graceful evictions

### DIFF
--- a/pkg/controllers/gracefuleviction/crb_graceful_eviction_controller.go
+++ b/pkg/controllers/gracefuleviction/crb_graceful_eviction_controller.go
@@ -83,17 +83,12 @@ func (c *CRBGracefulEvictionController) SetupWithManager(mgr controllerruntime.M
 		CreateFunc: func(createEvent event.CreateEvent) bool { return false },
 		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
 			newObj := updateEvent.ObjectNew.(*workv1alpha2.ClusterResourceBinding)
-			oldObj := updateEvent.ObjectOld.(*workv1alpha2.ClusterResourceBinding)
 
 			if len(newObj.Spec.GracefulEvictionTasks) == 0 {
 				return false
 			}
 
-			if newObj.Status.SchedulerObservedGeneration != newObj.Generation {
-				return false
-			}
-
-			return !reflect.DeepEqual(newObj.Spec.GracefulEvictionTasks, oldObj.Spec.GracefulEvictionTasks)
+			return newObj.Status.SchedulerObservedGeneration == newObj.Generation
 		},
 		DeleteFunc:  func(deleteEvent event.DeleteEvent) bool { return false },
 		GenericFunc: func(genericEvent event.GenericEvent) bool { return false },

--- a/pkg/controllers/gracefuleviction/rb_graceful_eviction_controller.go
+++ b/pkg/controllers/gracefuleviction/rb_graceful_eviction_controller.go
@@ -83,17 +83,12 @@ func (c *RBGracefulEvictionController) SetupWithManager(mgr controllerruntime.Ma
 		CreateFunc: func(createEvent event.CreateEvent) bool { return false },
 		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
 			newObj := updateEvent.ObjectNew.(*workv1alpha2.ResourceBinding)
-			oldObj := updateEvent.ObjectOld.(*workv1alpha2.ResourceBinding)
 
 			if len(newObj.Spec.GracefulEvictionTasks) == 0 {
 				return false
 			}
 
-			if newObj.Status.SchedulerObservedGeneration != newObj.Generation {
-				return false
-			}
-
-			return !reflect.DeepEqual(newObj.Spec.GracefulEvictionTasks, oldObj.Spec.GracefulEvictionTasks)
+			return newObj.Status.SchedulerObservedGeneration == newObj.Generation
 		},
 		DeleteFunc:  func(deleteEvent event.DeleteEvent) bool { return false },
 		GenericFunc: func(genericEvent event.GenericEvent) bool { return false },


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

When we evict workload replicas from the failover cluster in the `ResourceBinding/ClusterResourceBinding`, we need to perceive the health status of the current scheduling result of the binding to make the eviction more graceful. If the status is healthy, we can evict workload replicas directly. Otherwise, wait for the timeout period.

**Which issue(s) this PR fixes**:
Part of #2281 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE(include in graceful eviction feature)
```

