### PR TITLE
[bugfix] fix error of reflectStatus failed when call resourceInterpreter

### DIFF
--- a/pkg/controllers/status/workstatus_controller.go
+++ b/pkg/controllers/status/workstatus_controller.go
@@ -288,6 +288,7 @@ func (c *WorkStatusController) reflectStatus(work *workv1alpha1.Work, clusterObj
 	if err != nil {
 		klog.Errorf("Failed to reflect status for object(%s/%s/%s) with resourceInterpreter.",
 			clusterObj.GetKind(), clusterObj.GetNamespace(), clusterObj.GetName(), err)
+		return err
 	}
 
 	if statusRaw == nil {


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind failing-test
/kind bug

**What this PR does / why we need it**:

In the pr #2425 we encountered a CI error https://github.com/karmada-io/karmada/runs/8028253698?check_suite_focus=true and the component `karmada-controller-manager` error log shows as below:

```log
2022-08-26T01:43:46.835385736Z stderr F W0826 01:43:46.835129       1 customized.go:148] Failed calling webhook examples/workloads.example.com: failed calling webhook "examples/workloads.example.com": failed to call webhook: Post "https://172.18.0.6:443/interpreter-workload?timeout=3s": context deadline exceeded
2022-08-26T01:43:46.835568337Z stderr F E0826 01:43:46.835487       1 workstatus_controller.go:289] Failed to reflect status for object(Workload/karmadatest-nhq/workload-wh8) with resourceInterpreter.%!(EXTRA *errors.StatusError=Internal error occurred: failed calling webhook "examples/workloads.example.com": failed to call webhook: Post "https://172.18.0.6:443/interpreter-workload?timeout=3s": context deadline exceeded)
```

When we call `ResourceInterpreter` to reflect workload status failed, we didn't return err, so that work can not sync status again. So we need to return err immediately.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`/`karmada-agent`: Fixed an resource status can not be collected issue in case of Resource Interpreter returns an error.
```

