### PR TITLE
Automated cherry pick of #2428: fix error of reflectStatus failed when call

### DIFF
--- a/pkg/controllers/status/workstatus_controller.go
+++ b/pkg/controllers/status/workstatus_controller.go
@@ -281,6 +281,7 @@ func (c *WorkStatusController) reflectStatus(work *workv1alpha1.Work, clusterObj
 	if err != nil {
 		klog.Errorf("Failed to reflect status for object(%s/%s/%s) with resourceInterpreter.",
 			clusterObj.GetKind(), clusterObj.GetNamespace(), clusterObj.GetName(), err)
+		return err
 	}
 
 	if statusRaw == nil {


### PR DESCRIPTION
Cherry pick of #2428 on release-1.2.
#2428: fix error of reflectStatus failed when call
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```release-note
`karmada-controller-manager`/`karmada-agent`: Fixed an resource status can not be collected issue in case of Resource Interpreter returns an error.
```