### PR TITLE
[e2e] add e2e for cluster status

### DIFF
--- a/test/e2e/framework/cluster.go
+++ b/test/e2e/framework/cluster.go
@@ -146,8 +146,8 @@ func fetchClusters(client karmada.Interface) ([]*clusterv1alpha1.Cluster, error)
 	return clusters, nil
 }
 
-// fetchCluster will fetch member cluster by name.
-func fetchCluster(client karmada.Interface, clusterName string) (*clusterv1alpha1.Cluster, error) {
+// FetchCluster will fetch member cluster by name.
+func FetchCluster(client karmada.Interface, clusterName string) (*clusterv1alpha1.Cluster, error) {
 	cluster, err := client.ClusterV1alpha1().Clusters().Get(context.TODO(), clusterName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err

--- a/test/e2e/framework/customresourcedefine.go
+++ b/test/e2e/framework/customresourcedefine.go
@@ -55,7 +55,7 @@ func WaitCRDPresentOnClusters(client karmada.Interface, clusters []string, crdAP
 		for _, clusterName := range clusters {
 			klog.Infof("Waiting for crd present on cluster(%s)", clusterName)
 			gomega.Eventually(func(g gomega.Gomega) (bool, error) {
-				cluster, err := fetchCluster(client, clusterName)
+				cluster, err := FetchCluster(client, clusterName)
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				return helper.IsAPIEnabled(cluster.Status.APIEnablements, crdAPIVersion, crdKind), nil
 			}, pollTimeout, pollInterval).Should(gomega.Equal(true))


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
add e2e for collecting cluster status after #2397 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @XiShanYongYe-Chang 

**Does this PR introduce a user-facing change?**:
None

