### PR TITLE
Automated cherry pick of #1691: fix karmada-apiserver pending when helm upgrade

### DIFF
--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -230,7 +230,16 @@ apiServer:
   ## @param apiServer.nodeSelector
   nodeSelector: { }
   ## @param apiServer.affinity
-  affinity: { }
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - karmada-apiserver
+          topologyKey: kubernetes.io/hostname
   ## @param apiServer.tolerations
   tolerations: [ ]
     # - key: node-role.kubernetes.io/master
@@ -244,6 +253,13 @@ apiServer:
   ## will take effect when 'apiServer.serviceType' is 'NodePort'.
   ## If no port is specified, the nodePort will be automatically assigned.
   nodePort: 0
+  maxRequestsInflight: 1500
+  maxMutatingRequestsInflight: 500
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
 
 ## karmada aggregated apiserver config
 aggregatedApiServer:


### PR DESCRIPTION
Cherry pick of #1691 on release-1.0.
#1691: fix karmada-apiserver pending when helm upgrade
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```release-note
`Helm Chart`: Fixed `karmada-apiserver` always in pending in case of upgrade issue.
```