### PR TITLE
[karmada-scheduler] don't consider the older cluster when filtering with taint_toleration

### DIFF
--- a/artifacts/deploy/karmada-controller-manager.yaml
+++ b/artifacts/deploy/karmada-controller-manager.yaml
@@ -30,6 +30,7 @@ spec:
             - --cluster-status-update-frequency=10s
             - --secure-port=10357
             - --feature-gates=PropagateDeps=true,Failover=true,GracefulEviction=true,CustomizedClusterResourceModeling=true
+            - --failover-eviction-timeout=30s
             - --v=4
           livenessProbe:
             httpGet:

--- a/artifacts/deploy/karmada-webhook.yaml
+++ b/artifacts/deploy/karmada-webhook.yaml
@@ -27,6 +27,8 @@ spec:
             - /bin/karmada-webhook
             - --kubeconfig=/etc/kubeconfig
             - --bind-address=0.0.0.0
+            - --default-not-ready-toleration-seconds=30
+            - --default-unreachable-toleration-seconds=30
             - --secure-port=8443
             - --cert-dir=/var/serving-cert
             - --v=4

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -24,7 +24,7 @@ type Framework interface {
 
 	// RunFilterPlugins runs the set of configured Filter plugins for resources on
 	// the given cluster.
-	RunFilterPlugins(ctx context.Context, placement *policyv1alpha1.Placement, resource *workv1alpha2.ObjectReference, clusterv1alpha1 *clusterv1alpha1.Cluster) *Result
+	RunFilterPlugins(ctx context.Context, placement *policyv1alpha1.Placement, bindingSpec *workv1alpha2.ResourceBindingSpec, clusterv1alpha1 *clusterv1alpha1.Cluster) *Result
 
 	// RunScorePlugins runs the set of configured Score plugins, it returns a map of plugin name to cores
 	RunScorePlugins(ctx context.Context, placement *policyv1alpha1.Placement, spec *workv1alpha2.ResourceBindingSpec, clusters []*clusterv1alpha1.Cluster) (PluginToClusterScores, error)
@@ -40,7 +40,7 @@ type Plugin interface {
 type FilterPlugin interface {
 	Plugin
 	// Filter is called by the scheduling framework.
-	Filter(ctx context.Context, placement *policyv1alpha1.Placement, resource *workv1alpha2.ObjectReference, clusterv1alpha1 *clusterv1alpha1.Cluster) *Result
+	Filter(ctx context.Context, placement *policyv1alpha1.Placement, bindingSpec *workv1alpha2.ResourceBindingSpec, clusterv1alpha1 *clusterv1alpha1.Cluster) *Result
 }
 
 // Result indicates the result of running a plugin. It consists of a code, a

--- a/pkg/scheduler/framework/plugins/apienablement/api_enablement.go
+++ b/pkg/scheduler/framework/plugins/apienablement/api_enablement.go
@@ -33,9 +33,10 @@ func (p *APIEnablement) Name() string {
 }
 
 // Filter checks if the API(CRD) of the resource is enabled or installed in the target cluster.
-func (p *APIEnablement) Filter(ctx context.Context, placement *policyv1alpha1.Placement, resource *workv1alpha2.ObjectReference, cluster *clusterv1alpha1.Cluster) *framework.Result {
-	if !helper.IsAPIEnabled(cluster.Status.APIEnablements, resource.APIVersion, resource.Kind) {
-		klog.V(2).Infof("Cluster(%s) not fit as missing API(%s, kind=%s)", cluster.Name, resource.APIVersion, resource.Kind)
+func (p *APIEnablement) Filter(ctx context.Context, placement *policyv1alpha1.Placement,
+	bindingSpec *workv1alpha2.ResourceBindingSpec, cluster *clusterv1alpha1.Cluster) *framework.Result {
+	if !helper.IsAPIEnabled(cluster.Status.APIEnablements, bindingSpec.Resource.APIVersion, bindingSpec.Resource.Kind) {
+		klog.V(2).Infof("Cluster(%s) not fit as missing API(%s, kind=%s)", cluster.Name, bindingSpec.Resource.APIVersion, bindingSpec.Resource.Kind)
 		return framework.NewResult(framework.Unschedulable, "no such API resource")
 	}
 

--- a/pkg/scheduler/framework/plugins/clusteraffinity/cluster_affinity.go
+++ b/pkg/scheduler/framework/plugins/clusteraffinity/cluster_affinity.go
@@ -32,7 +32,8 @@ func (p *ClusterAffinity) Name() string {
 }
 
 // Filter checks if the cluster matched the placement cluster affinity constraint.
-func (p *ClusterAffinity) Filter(ctx context.Context, placement *policyv1alpha1.Placement, resource *workv1alpha2.ObjectReference, cluster *clusterv1alpha1.Cluster) *framework.Result {
+func (p *ClusterAffinity) Filter(ctx context.Context, placement *policyv1alpha1.Placement,
+	bindingSpec *workv1alpha2.ResourceBindingSpec, cluster *clusterv1alpha1.Cluster) *framework.Result {
 	affinity := placement.ClusterAffinity
 	if affinity != nil {
 		if util.ClusterMatches(cluster, *affinity) {

--- a/pkg/scheduler/framework/plugins/spreadconstraint/spread_constraint.go
+++ b/pkg/scheduler/framework/plugins/spreadconstraint/spread_constraint.go
@@ -30,7 +30,8 @@ func (p *SpreadConstraint) Name() string {
 }
 
 // Filter checks if the cluster Provider/Zone/Region spread is null.
-func (p *SpreadConstraint) Filter(ctx context.Context, placement *policyv1alpha1.Placement, resource *workv1alpha2.ObjectReference, cluster *clusterv1alpha1.Cluster) *framework.Result {
+func (p *SpreadConstraint) Filter(ctx context.Context, placement *policyv1alpha1.Placement,
+	bindingSpec *workv1alpha2.ResourceBindingSpec, cluster *clusterv1alpha1.Cluster) *framework.Result {
 	for _, spreadConstraint := range placement.SpreadConstraints {
 		if spreadConstraint.SpreadByField == policyv1alpha1.SpreadByFieldProvider && cluster.Spec.Provider == "" {
 			return framework.NewResult(framework.Unschedulable, "No Provider Property in the Cluster.Spec")

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -44,9 +44,9 @@ func NewFramework(r Registry) (framework.Framework, error) {
 
 // RunFilterPlugins runs the set of configured Filter plugins for resources on the cluster.
 // If any of the result is not success, the cluster is not suited for the resource.
-func (frw *frameworkImpl) RunFilterPlugins(ctx context.Context, placement *policyv1alpha1.Placement, resource *workv1alpha2.ObjectReference, cluster *clusterv1alpha1.Cluster) *framework.Result {
+func (frw *frameworkImpl) RunFilterPlugins(ctx context.Context, placement *policyv1alpha1.Placement, bindingSpec *workv1alpha2.ResourceBindingSpec, cluster *clusterv1alpha1.Cluster) *framework.Result {
 	for _, p := range frw.filterPlugins {
-		if result := p.Filter(ctx, placement, resource, cluster); !result.IsSuccess() {
+		if result := p.Filter(ctx, placement, bindingSpec, cluster); !result.IsSuccess() {
 			return result
 		}
 	}

--- a/test/e2e/rescheduling_test.go
+++ b/test/e2e/rescheduling_test.go
@@ -69,7 +69,6 @@ var _ = ginkgo.Describe("[cluster unjoined] reschedule testing", func() {
 			deployment = testhelper.NewDeployment(deploymentNamespace, deploymentName)
 			deployment.Spec.Replicas = pointer.Int32Ptr(10)
 
-			// set MaxGroups=MinGroups=1, label is sync-mode=Push.
 			policy = testhelper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
 				{
 					APIVersion: deployment.APIVersion,


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

When we use `taint_toleration` plug-in in the scheduler to filter clusters, we should ignore those clusters that have been scheduled and leave them to the `taint-manager` for processing.  This way, the cluster failover eviction will be performed only in the `taint-manager`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-scheduler: don't consider the older cluster when filtering with taint_toleration
```

