### PR TITLE
[bugfix] when replicaDivisionPreference is Weighted and WeightPreference is nil

### DIFF
--- a/pkg/scheduler/core/spreadconstraint/group_clusters.go
+++ b/pkg/scheduler/core/spreadconstraint/group_clusters.go
@@ -245,7 +245,8 @@ func isTopologyIgnored(placement *policyv1alpha1.Placement) bool {
 	// If the replica division preference is 'static weighted', ignore the declaration specified by spread constraints.
 	if strategy != nil && strategy.ReplicaSchedulingType == policyv1alpha1.ReplicaSchedulingTypeDivided &&
 		strategy.ReplicaDivisionPreference == policyv1alpha1.ReplicaDivisionPreferenceWeighted &&
-		(len(strategy.WeightPreference.StaticWeightList) != 0 && strategy.WeightPreference.DynamicWeight == "") {
+		(strategy.WeightPreference == nil ||
+			len(strategy.WeightPreference.StaticWeightList) != 0 && strategy.WeightPreference.DynamicWeight == "") {
 		return true
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fix bug of panic when `replicaDivisionPreference` is `Weighted` and `WeightPreference` is nil at the same time:

```yaml
replicaScheduling:
      replicaSchedulingType: Divided 
      replicaDivisionPreference: Weighted
```

**Which issue(s) this PR fixes**:
Fixes #2447 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-sechduler: Fix panic when `replicaDivisionPreference` is `Weighted` and `WeightPreference` is nil.
```

