### PR TITLE
Automated cherry pick of #2451: fix bug of #2447: when replicaDivisionPreference is Weighted

### DIFF
--- a/pkg/scheduler/core/spreadconstraint/group_clusters.go
+++ b/pkg/scheduler/core/spreadconstraint/group_clusters.go
@@ -245,7 +245,8 @@ func isTopologyIgnored(placement *policyv1alpha1.Placement) bool {
 	// If the replica division preference is 'static weighted', ignore the declaration specified by spread constraints.
 	if strategy != nil && strategy.ReplicaSchedulingType == policyv1alpha1.ReplicaSchedulingTypeDivided &&
 		strategy.ReplicaDivisionPreference == policyv1alpha1.ReplicaDivisionPreferenceWeighted &&
-		(len(strategy.WeightPreference.StaticWeightList) != 0 && strategy.WeightPreference.DynamicWeight == "") {
+		(strategy.WeightPreference == nil ||
+			len(strategy.WeightPreference.StaticWeightList) != 0 && strategy.WeightPreference.DynamicWeight == "") {
 		return true
 	}
 


### PR DESCRIPTION
Cherry pick of #2451 on release-1.2.
#2451: fix bug of #2447: when replicaDivisionPreference is Weighted
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```release-note
`karmada-sechduler`: Fixed a panic issue when `replicaDivisionPreference` is `Weighted` and `WeightPreference` is nil.
```