### PR TITLE
Automated cherry pick of #2404: bump ci runner to ubuntu-20.04 as ubuntu-18.04 is deprecated.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
@@ -27,7 +27,7 @@ jobs:
         run: hack/verify-estimator-protobuf.sh
   codegen:
     name: codegen
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       GOPATH: ${{ github.workspace }}
     defaults:
@@ -49,7 +49,7 @@ jobs:
   build:
     name: compile
     needs: codegen # rely on codegen successful completion
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout code
         uses: actions/checkout@v2
@@ -66,7 +66,7 @@ jobs:
   test:
     name: unit test
     needs: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout code
         uses: actions/checkout@v2
@@ -79,7 +79,7 @@ jobs:
   e2e:
     name: e2e test
     needs: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARTIFACTS_PATH: ${{ github.workspace }}/karmada-e2e-logs/
     steps:

--- a/.github/workflows/dockerhub-released-image.yml
+++ b/.github/workflows/dockerhub-released-image.yml
@@ -16,7 +16,7 @@ jobs:
           - karmada-scheduler-estimator
           - karmada-interpreter-webhook-example
           - karmada-aggregated-apiserver
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   fossa:
     name: FOSSA
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -10,7 +10,7 @@ jobs:
     # 1. running on the forked repository would fail as missing necessary secret.
     # 2. running on the forked repository would use unnecessary GitHub Action time.
     if: ${{ github.repository == 'karmada-io/karmada' && github.ref == 'refs/heads/master' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ name: Build Release
 jobs:
   release-assests:
     name: release kubectl-karmada
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         include:
@@ -39,7 +39,7 @@ jobs:
   update-krew-index:
     needs: release-assests
     name: Update krew-index
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@master
     - name: Update new version in krew-index

--- a/.github/workflows/swr-released-image.yml
+++ b/.github/workflows/swr-released-image.yml
@@ -10,7 +10,7 @@ jobs:
     # 1. running on the forked repository would fail as missing necessary secret.
     # 2. running on the forked repository would use unnecessary GitHub Action time.
     if: ${{ github.repository == 'karmada-io/karmada' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Cherry pick of #2404 on release-1.1.
#2404: bump ci runner to ubuntu-20.04 as ubuntu-18.04 is deprecated.
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
NONE
```