### PR TITLE
update cfssl version to v1.6.2

### DIFF
--- a/hack/deploy-karmada.sh
+++ b/hack/deploy-karmada.sh
@@ -16,7 +16,7 @@ KARMADA_APISERVER_SECURE_PORT=${KARMADA_APISERVER_SECURE_PORT:-5443}
 HOST_CLUSTER_NAME=${HOST_CLUSTER_NAME:-"karmada-host"}
 ROOT_CA_FILE=${CERT_DIR}/ca.crt
 ROOT_CA_KEY=${CERT_DIR}/ca.key
-CFSSL_VERSION="v1.5.0"
+CFSSL_VERSION="v1.6.2"
 LOAD_BALANCER=${LOAD_BALANCER:-false} # whether create a 'LoadBalancer' type service for karmada apiserver
 source "${REPO_ROOT}"/hack/util.sh
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The cffsl_vserion is updated to v1.6.2. Because the previous version has runtime error in go 1.19. And v1.6.2 can run correctly in go1.18 and 1.19.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
[edit by @RainbowMango]
This PR address the discussion at https://github.com/karmada-io/karmada/issues/2405#issuecomment-1223495053.
And we asked the newest release by https://github.com/cloudflare/cfssl/issues/1242.

cc @liys87x @jingxiaolu 


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

