### PR TITLE
Add default path prompt for deinit to delete etcd data

### DIFF
--- a/pkg/karmadactl/deinit.go
+++ b/pkg/karmadactl/deinit.go
@@ -297,6 +297,7 @@ func (o *CommandDeInitOption) Run() error {
 	}
 
 	fmt.Println("remove Karmada from Kubernetes successfully.\n" +
-		"\ndeinit will not delete etcd data, if the etcd data is persistent, please delete it yourself.")
+		"\ndeinit will not delete etcd data, if the etcd data is persistent, please delete it yourself." +
+		"\nthe default persistence path for etcd data is '/var/lib/karmada-etcd'")
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: wuzhongjian <wuzhongjian_yewu@cmss.chinamobile.com>

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Prompt the user to delete the default path of etcd data to deinit karmada

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

