### PR TITLE
Update work status when a cluster becomes (not) ready

### DIFF
--- a/charts/karmada/_crds/bases/work.karmada.io_works.yaml
+++ b/charts/karmada/_crds/bases/work.karmada.io_works.yaml
@@ -21,6 +21,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Applied")].status
       name: Applied
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/pkg/apis/work/v1alpha1/work_types.go
+++ b/pkg/apis/work/v1alpha1/work_types.go
@@ -21,6 +21,7 @@ const (
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:categories={karmada-io}
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Applied")].status`,name="Applied",type=string
+// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Available")].status`,name="Available",type=string
 // +kubebuilder:printcolumn:JSONPath=`.metadata.creationTimestamp`,name="Age",type=date
 
 // Work defines a list of resources to be deployed on the member cluster.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Now when a cluster goes down, the status of resources will stay the same as before, instead of being correctly reflected in the control plane
This pr tries making use of [WorkAvailable](https://github.com/karmada-io/karmada/blob/v1.3.0/pkg/apis/work/v1alpha1/work_types.go#L128) to solve the problem

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Test in my env:
1. A deploy is running on member1
```
[root@test karmada]# kubectl get cluster --context karmada-apiserver
NAME      VERSION   MODE   READY   AGE
member1   v1.24.0   Push   True    3h56m

[root@test karmada]# kubectl get deploy --context karmada-apiserver
NAME    READY   UP-TO-DATE   AVAILABLE   AGE
nginx   1/1     1            1           2m11s
```

2. Then member1 becomes not ready, the deploy status will be correctly reflected in the control plane
```
[root@test karmada]# kubectl get cluster --context karmada-apiserver
NAME      VERSION   MODE   READY   AGE
member1   v1.24.0   Push   False   4h3m

[root@test karmada]# kubectl get deploy --context karmada-apiserver
NAME    READY   UP-TO-DATE   AVAILABLE   AGE
nginx   0/1     0            0           9m34s

[root@test karmada]# kubectl get work -A --context karmada-apiserver
NAMESPACE            NAME               APPLIED   AVAILABLE   AGE
karmada-es-member1   nginx-687f7fb96f   True      Unknown     9m33s
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

