### PR TITLE
karmadactl exec uses factory to access member cluster

### DIFF
--- a/pkg/karmadactl/karmadactl.go
+++ b/pkg/karmadactl/karmadactl.go
@@ -88,7 +88,7 @@ func NewKarmadaCtlCommand(cmdUse, parentCommand string) *cobra.Command {
 			Message: "Troubleshooting and Debugging Commands:",
 			Commands: []*cobra.Command{
 				NewCmdLogs(f, parentCommand, ioStreams),
-				NewCmdExec(karmadaConfig, parentCommand, ioStreams),
+				NewCmdExec(f, parentCommand, ioStreams),
 				NewCmdDescribe(karmadaConfig, parentCommand, ioStreams),
 			},
 		},


### PR DESCRIPTION
Signed-off-by: carlory <baofa.fan@daocloud.io>

**What type of PR is this?**
/kind feature

**Which issue(s) this PR fixes**:
Part of #2349 

**Special notes for your reviewer**:

Test:

```shell
(⎈ |karmada:default)➜  karmada git:(karmadactl-exec) go run cmd/karmadactl/karmadactl.go exec -n kube-system -it -C ocp master-etcd-nodedsp01.ocp.ats.io ls /
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
bin   dev  exports  lib    media  opt	root  sbin  sys  usr
boot  etc  home     lib64  mnt	  proc	run   srv   tmp  var
(⎈ |karmada:default)➜  karmada git:(karmadactl-exec) go run cmd/karmadactl/karmadactl.go exec -it -C ocp logging-eventrouter-1-k6n87 ls
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
bin   dev  home  lib64	mnt  proc  run	 srv  tmp  var
boot  etc  lib	 media	opt  root  sbin  sys  usr
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

