### PR TITLE
karmadactl describe uses factory to access member cluster

### DIFF
--- a/pkg/karmadactl/describe.go
+++ b/pkg/karmadactl/describe.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/kubectl/pkg/describe"
 	"k8s.io/kubectl/pkg/util/templates"
 
-	"github.com/karmada-io/karmada/pkg/karmadactl/options"
+	"github.com/karmada-io/karmada/pkg/karmadactl/util"
 )
 
 var (
@@ -34,7 +34,7 @@ var (
 )
 
 // NewCmdDescribe new describe command.
-func NewCmdDescribe(karmadaConfig KarmadaConfig, parentCommand string, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdDescribe(f util.Factory, parentCommand string, streams genericclioptions.IOStreams) *cobra.Command {
 	o := &DescribeOptions{
 		KubectlDescribeOptions: &kubectldescribe.DescribeOptions{
 			FilenameOptions: &resource.FilenameOptions{},
@@ -53,7 +53,7 @@ func NewCmdDescribe(karmadaConfig KarmadaConfig, parentCommand string, streams g
 		SilenceUsage: true,
 		Example:      fmt.Sprintf(describeExample, parentCommand),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := o.Complete(karmadaConfig, cmd, args); err != nil {
+			if err := o.Complete(f, cmd, args); err != nil {
 				return err
 			}
 			if err := o.Run(); err != nil {
@@ -63,47 +63,40 @@ func NewCmdDescribe(karmadaConfig KarmadaConfig, parentCommand string, streams g
 		},
 	}
 
-	o.GlobalCommandOptions.AddFlags(cmd.Flags())
+	flags := cmd.Flags()
 
 	usage := "containing the resource to describe"
 	cmdutil.AddFilenameOptionFlags(cmd, o.KubectlDescribeOptions.FilenameOptions, usage)
-	cmd.Flags().StringVarP(&o.Cluster, "cluster", "C", "", "Specify a member cluster")
-	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", o.Namespace, "If present, the namespace scope for this CLI request")
-	cmd.Flags().StringVarP(&o.KubectlDescribeOptions.Selector, "selector", "l", o.KubectlDescribeOptions.Selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
-	cmd.Flags().BoolVarP(&o.KubectlDescribeOptions.AllNamespaces, "all-namespaces", "A", o.KubectlDescribeOptions.AllNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
-	cmd.Flags().BoolVar(&o.KubectlDescribeOptions.DescriberSettings.ShowEvents, "show-events", o.KubectlDescribeOptions.DescriberSettings.ShowEvents, "If true, display events related to the described object.")
+	flags.StringVarP(&o.KubectlDescribeOptions.Selector, "selector", "l", o.KubectlDescribeOptions.Selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
+	flags.BoolVarP(&o.KubectlDescribeOptions.AllNamespaces, "all-namespaces", "A", o.KubectlDescribeOptions.AllNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
+	flags.BoolVar(&o.KubectlDescribeOptions.DescriberSettings.ShowEvents, "show-events", o.KubectlDescribeOptions.DescriberSettings.ShowEvents, "If true, display events related to the described object.")
 	cmdutil.AddChunkSizeFlag(cmd, &o.KubectlDescribeOptions.DescriberSettings.ChunkSize)
+	flags.StringVarP(&o.Cluster, "cluster", "C", "", "Specify a member cluster")
+	flags.StringVar(defaultConfigFlags.KubeConfig, "kubeconfig", *defaultConfigFlags.KubeConfig, "Path to the kubeconfig file to use for CLI requests.")
+	flags.StringVar(defaultConfigFlags.Context, "karmada-context", *defaultConfigFlags.Context, "The name of the kubeconfig context to use")
+	flags.StringVarP(defaultConfigFlags.Namespace, "namespace", "n", *defaultConfigFlags.Namespace, "If present, the namespace scope for this CLI request")
 
 	return cmd
 }
 
 // DescribeOptions contains the input to the describe command.
 type DescribeOptions struct {
-	// global flags
-	options.GlobalCommandOptions
 	// flags specific to describe
 	KubectlDescribeOptions *kubectldescribe.DescribeOptions
-	Namespace              string
 	Cluster                string
 }
 
 // Complete ensures that options are valid and marshals them if necessary
-func (o *DescribeOptions) Complete(karmadaConfig KarmadaConfig, cmd *cobra.Command, args []string) error {
+func (o *DescribeOptions) Complete(f util.Factory, cmd *cobra.Command, args []string) error {
 	if len(o.Cluster) == 0 {
 		return fmt.Errorf("must specify a cluster")
 	}
 
-	karmadaRestConfig, err := karmadaConfig.GetRestConfig(o.KarmadaContext, o.KubeConfig)
-	if err != nil {
-		return fmt.Errorf("failed to get control plane rest config. context: %s, kube-config: %s, error: %v",
-			o.KarmadaContext, o.KubeConfig, err)
-	}
-	clusterInfo, err := getClusterInfo(karmadaRestConfig, o.Cluster, o.KubeConfig, o.KarmadaContext)
+	memberFactory, err := f.FactoryForMemberCluster(o.Cluster)
 	if err != nil {
 		return err
 	}
-	f := getFactory(o.Cluster, clusterInfo, o.Namespace)
-	return o.KubectlDescribeOptions.Complete(f, cmd, args)
+	return o.KubectlDescribeOptions.Complete(memberFactory, cmd, args)
 }
 
 // Run describe information of resources

--- a/pkg/karmadactl/karmadactl.go
+++ b/pkg/karmadactl/karmadactl.go
@@ -89,7 +89,7 @@ func NewKarmadaCtlCommand(cmdUse, parentCommand string) *cobra.Command {
 			Commands: []*cobra.Command{
 				NewCmdLogs(f, parentCommand, ioStreams),
 				NewCmdExec(f, parentCommand, ioStreams),
-				NewCmdDescribe(karmadaConfig, parentCommand, ioStreams),
+				NewCmdDescribe(f, parentCommand, ioStreams),
 			},
 		},
 		{

--- a/pkg/karmadactl/logs.go
+++ b/pkg/karmadactl/logs.go
@@ -1,19 +1,14 @@
 package karmadactl
 
 import (
-	"context"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/rest"
 	kubectllogs "k8s.io/kubectl/pkg/cmd/logs"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/templates"
 
-	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
 	"github.com/karmada-io/karmada/pkg/karmadactl/util"
 )
 
@@ -127,33 +122,4 @@ func (o *LogsOptions) Validate() error {
 // Run retrieves a pod log
 func (o *LogsOptions) Run() error {
 	return o.KubectlLogsOptions.RunLogs()
-}
-
-// getClusterInfo get information of cluster
-// TODO(@carlory): remove it when all sub command accepts factory as input parameter.
-func getClusterInfo(karmadaRestConfig *rest.Config, clusterName, kubeConfig, karmadaContext string) (map[string]*ClusterInfo, error) {
-	clusterClient := karmadaclientset.NewForConfigOrDie(karmadaRestConfig).ClusterV1alpha1().Clusters()
-
-	// check if the cluster exist in karmada control plane
-	_, err := clusterClient.Get(context.TODO(), clusterName, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	clusterInfos := make(map[string]*ClusterInfo)
-	clusterInfos[clusterName] = &ClusterInfo{}
-
-	clusterInfos[clusterName].APIEndpoint = karmadaRestConfig.Host + fmt.Sprintf(proxyURL, clusterName)
-	clusterInfos[clusterName].KubeConfig = kubeConfig
-	clusterInfos[clusterName].Context = karmadaContext
-	if clusterInfos[clusterName].KubeConfig == "" {
-		env := os.Getenv("KUBECONFIG")
-		if env != "" {
-			clusterInfos[clusterName].KubeConfig = env
-		} else {
-			clusterInfos[clusterName].KubeConfig = defaultKubeConfig
-		}
-	}
-
-	return clusterInfos, nil
 }


### PR DESCRIPTION
Signed-off-by: carlory <baofa.fan@daocloud.io>

**What type of PR is this?**

/kind feature

**Which issue(s) this PR fixes**:
Part of#2349

**Special notes for your reviewer**:

Test:

```shell
(⎈ |karmada:default)➜  karmada git:(karmadactl-describe) go run cmd/karmadactl/karmadactl.go describe -C ocp po logging-eventrouter-1-k6n87
Name:           logging-eventrouter-1-k6n87
Namespace:      default
Priority:       0
Node:           nodedsp06.ocp.ats.io/10.23.105.10
Start Time:     Sat, 23 Jul 2022 09:41:47 +0800
Labels:         component=eventrouter
                deployment=logging-eventrouter-1
                deploymentconfig=logging-eventrouter
                logging-infra=eventrouter
                provider=openshift
Annotations:    openshift.io/deployment-config.latest-version: 1
                openshift.io/deployment-config.name: logging-eventrouter
                openshift.io/deployment.name: logging-eventrouter-1
                openshift.io/scc: restricted
Status:         Running
IP:             172.13.5.60
IPs:            <none>
Controlled By:  ReplicationController/logging-eventrouter-1
Containers:
  kube-eventrouter:
    Container ID:   docker://c43207e709e0263b3f0c1214aecf3075c186bf279e24e8107bd37040b70a5879
    Image:          harbor.ocp.dsp.local/openshift3/ose-logging-eventrouter:v3.11.82
    Image ID:       docker-pullable://harbor.ocp.dsp.local/openshift3/ose-logging-eventrouter@sha256:9197908884536866f2f076283e0780a214980baded8e9e3ab14fe479198caefd
    Port:           <none>
    Host Port:      <none>
    State:          Running
      Started:      Fri, 02 Sep 2022 09:58:20 +0800
    Last State:     Terminated
      Reason:       Error
      Exit Code:    255
      Started:      Sat, 23 Jul 2022 09:42:00 +0800
      Finished:     Fri, 02 Sep 2022 09:56:44 +0800
    Ready:          True
    Restart Count:  1
    Limits:
      memory:  128Mi
    Requests:
      cpu:        100m
      memory:     128Mi
    Environment:  <none>
    Mounts:
      /etc/eventrouter from config-volume (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from aggregated-logging-eventrouter-token-h9b6k (ro)
Conditions:
  Type              Status
  Initialized       True
  Ready             True
  ContainersReady   True
  PodScheduled      True
Volumes:
  config-volume:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      logging-eventrouter
    Optional:  false
  aggregated-logging-eventrouter-token-h9b6k:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  aggregated-logging-eventrouter-token-h9b6k
    Optional:    false
QoS Class:       Burstable
Node-Selectors:  region=infra
Tolerations:     node.kubernetes.io/memory-pressure:NoSchedule op=Exists
Events:          <none>
(⎈ |karmada:default)➜  karmada git:(karmadactl-describe) go run cmd/karmadactl/karmadactl.go describe -n kube-system -C ocp po master-etcd-nodedsp01.ocp.ats.io
Name:                 master-etcd-nodedsp01.ocp.ats.io
Namespace:            kube-system
Priority:             2000001000
Priority Class Name:  system-node-critical
Node:                 nodedsp01.ocp.ats.io/10.23.105.5
Start Time:           Sat, 18 Jun 2022 19:24:50 +0800
Labels:               openshift.io/component=etcd
                      openshift.io/control-plane=true
Annotations:          kubernetes.io/config.hash: 4d8438b87a4cdd9130ac90be5efab948
                      kubernetes.io/config.mirror: 4d8438b87a4cdd9130ac90be5efab948
                      kubernetes.io/config.seen: 2022-03-10T10:11:00.434161859+08:00
                      kubernetes.io/config.source: file
                      scheduler.alpha.kubernetes.io/critical-pod:
Status:               Running
IP:                   10.23.105.5
IPs:                  <none>
Containers:
  etcd:
    Container ID:  docker://fdc33b9abba63b33503e3e2c7e77d824e00c41ed210e7a47efd1892145ed7325
    Image:         harbor.ocp.dsp.local/rhel7/etcd:3.2.22
    Image ID:      docker-pullable://harbor.ocp.dsp.local/rhel7/etcd@sha256:5cfb741e9359cec241de67e404ba459b58193ebd47723bb6d499a179b734dc90
    Port:          <none>
    Host Port:     <none>
    Command:
      /bin/sh
      -c
    Args:
      #!/bin/sh
      set -o allexport
      source /etc/etcd/etcd.conf
      exec etcd

    State:          Running
      Started:      Fri, 02 Sep 2022 23:01:14 +0800
    Last State:     Terminated
      Reason:       Completed
      Exit Code:    0
      Started:      Fri, 02 Sep 2022 19:00:52 +0800
      Finished:     Fri, 02 Sep 2022 23:00:57 +0800
    Ready:          True
    Restart Count:  191
    Liveness:       exec [etcdctl --cert-file /etc/etcd/peer.crt --key-file /etc/etcd/peer.key --ca-file /etc/etcd/ca.crt --endpoints https://10.23.105.5:2379 cluster-health] delay=45s timeout=1s period=10s #success=1 #failure=3
    Environment:    <none>
    Mounts:
      /etc/etcd/ from master-config (ro)
      /etc/localtime from host-localtime (rw)
      /var/lib/etcd/ from master-data (rw)
Conditions:
  Type              Status
  Initialized       True
  Ready             True
  ContainersReady   True
  PodScheduled      True
Volumes:
  master-config:
    Type:          HostPath (bare host directory volume)
    Path:          /etc/etcd/
    HostPathType:
  master-data:
    Type:          HostPath (bare host directory volume)
    Path:          /var/lib/etcd
    HostPathType:
  host-localtime:
    Type:          HostPath (bare host directory volume)
    Path:          /etc/localtime
    HostPathType:
QoS Class:         BestEffort
Node-Selectors:    <none>
Tolerations:       :NoExecute op=Exists
Events:            <none>
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

