### PR TITLE
Fixed pod can not be collected issue when building resource summary

### DIFF
--- a/pkg/util/fedinformer/transform.go
+++ b/pkg/util/fedinformer/transform.go
@@ -59,6 +59,10 @@ func PodTransformFunc(obj interface{}) (interface{}, error) {
 	}
 
 	aggregatedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+		},
 		Spec: corev1.PodSpec{
 			NodeName:       pod.Spec.NodeName,
 			InitContainers: pod.Spec.InitContainers,

--- a/pkg/util/fedinformer/transform_test.go
+++ b/pkg/util/fedinformer/transform_test.go
@@ -169,7 +169,7 @@ func TestPodTransformFunc(t *testing.T) {
 		want interface{}
 	}{
 		{
-			name: "transform pods without needed",
+			name: "transform pods without status",
 			obj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:   "foo",
@@ -183,10 +183,15 @@ func TestPodTransformFunc(t *testing.T) {
 					},
 				},
 			},
-			want: &corev1.Pod{},
+			want: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "bar",
+				},
+			},
 		},
 		{
-			name: "transform pods with needed",
+			name: "transform pods with status",
 			obj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "foo",
@@ -208,6 +213,10 @@ func TestPodTransformFunc(t *testing.T) {
 				},
 			},
 			want: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "bar",
+				},
 				Spec: corev1.PodSpec{
 					NodeName:       "test",
 					InitContainers: []corev1.Container{{Name: "test"}},


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When transformFunc ignores name and namespace of Pod，informer will only save one Pod.
Test Result After this PR:
```
nodeSummary:
    readyNum: 2
    totalNum: 2
....
 allocated:
      cpu: 1050m
      memory: 340Mi
      pods: "12"
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```
`karmada-controller-manager`/`karmada-agent`: Fixed pod information can not be collected issue when building resource summary.
```

