### PR TITLE
fix MEMBER_CLUSTER_NAME command usage

### DIFF
--- a/pkg/karmadactl/cmdinit/utils/examples.go
+++ b/pkg/karmadactl/cmdinit/utils/examples.go
@@ -178,9 +178,9 @@ Karmada is installed successfully.
 Register Kubernetes cluster to Karmada control plane.
 
 Register cluster with 'Push' mode
-                                                                                                                                                                             
+
 Step 1: Use "%[2]s join" command to register the cluster to Karmada control plane. --cluster-kubeconfig is kubeconfig of the member cluster.
-(In karmada)~# MEMBER_CLUSTER_NAME="cat ~/.kube/config  | grep current-context | sed 's/: /\n/g'| sed '1d'"
+(In karmada)~# MEMBER_CLUSTER_NAME=$(cat ~/.kube/config  | grep current-context | sed 's/: /\n/g'| sed '1d')
 (In karmada)~# %[2]s --kubeconfig %[1]s/karmada-apiserver.config  join ${MEMBER_CLUSTER_NAME} --cluster-kubeconfig=$HOME/.kube/config
 
 Step 2: Show members of karmada


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

modify the MEMBER_CLUSTER_NAME command acquisition when registering cluster.

what happened：

```text
Karmada is installed successfully.

Register Kubernetes cluster to Karmada control plane.

Register cluster with 'Push' mode

Step 1: Use "karmadactl join" command to register the cluster to Karmada control plane. --cluster-kubeconfig is kubeconfig of the member cluster.
(In karmada)~# MEMBER_CLUSTER_NAME="cat ~/.kube/config  | grep current-context | sed 's/: /\n/g'| sed '1d'"
(In karmada)~# karmadactl --kubeconfig /etc/karmada/karmada-apiserver.config  join ${MEMBER_CLUSTER_NAME} --cluster-kubeconfig=$HOME/.kube/config

Step 2: Show members of karmada
(In karmada)~# kubectl  --kubeconfig /etc/karmada/karmada-apiserver.config get clusters


Register cluster with 'Pull' mode

Step 1: Use "karmadactl register" command to register the cluster to Karmada control plane. "--cluster-name" is set to cluster of current-context by default.
(In member cluster)~# karmadactl register 172.18.0.6:32443 --token tudh6i.pka7ohsiz2sidpxt --discovery-token-ca-cert-hash sha256:34487923ae4de3504a7697c37214489a596f4434c6e8fea59eba9a273eb70f9d

Step 2: Show members of karmada
(In karmada)~# kubectl  --kubeconfig /etc/karmada/karmada-apiserver.config get clusters

# MEMBER_CLUSTER_NAME="cat ~/.kube/config  | grep current-context | sed 's/: /\n/g'| sed '1d'"                                                                                              
# echo $MEMBER_CLUSTER_NAME                                                                                                                                                                 
cat ~/.kube/config | grep current-context | sed 's/: /\n/g'| sed '1d'

```

with this change：

```text
# echo $MEMBER_CLUSTER_NAME      
kubernetes-admin@kubernetes
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

