### PR TITLE
cmdinit prohibit passing in additional parameters

### DIFF
--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -22,34 +22,34 @@ var (
 		# Install Karmada in Kubernetes cluster
 		# The karmada-apiserver binds the master node's IP by default
 		%[1]s init
-		
+
 		# China mainland registry mirror can be specified by using kube-image-mirror-country
 		%[1]s init --kube-image-mirror-country=cn
-		
+
 		# Kube registry can be specified by using kube-image-registry
 		%[1]s init --kube-image-registry=registry.cn-hangzhou.aliyuncs.com/google_containers
-		
+
 		# Specify the URL to download CRD tarball
 		%[1]s init --crds https://github.com/karmada-io/karmada/releases/download/%[2]s/crds.tar.gz
-		
+
 		# Specify the local CRD tarball
 		%[1]s init --crds /root/crds.tar.gz
-		
+
 		# Use PVC to persistent storage etcd data
 		%[1]s init --etcd-storage-mode PVC --storage-classes-name {StorageClassesName}
-		
+
 		# Use hostPath to persistent storage etcd data. For data security, only 1 etcd pod can run in hostPath mode
 		%[1]s init --etcd-storage-mode hostPath  --etcd-replicas 1
-		
+
 		# Use hostPath to persistent storage etcd data but select nodes by labels
 		%[1]s init --etcd-storage-mode hostPath --etcd-node-selector-labels karmada.io/etcd=true
-		
+
 		# Private registry can be specified for all images
 		%[1]s init --etcd-image local.registry.com/library/etcd:3.5.3-0
-		
+
 		# Deploy highly available(HA) karmada
 		%[1]s init --karmada-apiserver-replicas 3 --etcd-replicas 3 --etcd-storage-mode PVC --storage-classes-name {StorageClassesName}
-				
+
 		# Specify external IPs(load balancer or HA IP) which used to sign the certificate
 		%[1]s init --cert-external-ip 10.235.1.2 --cert-external-dns www.karmada.io`)
 )
@@ -73,6 +73,14 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 			}
 			if err := opts.RunInit(parentCommand); err != nil {
 				return err
+			}
+			return nil
+		},
+		Args: func(cmd *cobra.Command, args []string) error {
+			for _, arg := range args {
+				if len(arg) > 0 {
+					return fmt.Errorf("%q does not take any arguments, got %q", cmd.CommandPath(), args)
+				}
 			}
 			return nil
 		},

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -180,7 +180,7 @@ func (i *CommandInitOption) Complete() error {
 	return nil
 }
 
-//  genCerts create ca etcd karmada cert
+// genCerts create ca etcd karmada cert
 func (i *CommandInitOption) genCerts() error {
 	notAfter := time.Now().Add(cert.Duration365d).UTC()
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
When I need to specify the related version of k8s, I mistakenly write flag as args, which causes the specified version to fail without any error and install the default v1.24.2 kube-controller-manager.
I have browsed the source code of relevant parts of init, and I think args can be disabled to ensure correct input.

for example:
```shell
karmadactl init --kubeconfig ./kind-multi-node2/config --karmada-apiserver-image=k8s.gcr.io/kube-apiserver:v1.18.20 karmada-kube-controller-manager-image=k8s.gcr.io/kube-controller-manager:v1.18.20
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmadactl prohibit input extra arguments for 'init' command.
```

