### PR TITLE
Automated cherry pick of #2489: fix pod lister only list a pod

### DIFF
--- a/pkg/util/fedinformer/transform.go
+++ b/pkg/util/fedinformer/transform.go
@@ -59,6 +59,10 @@ func PodTransformFunc(obj interface{}) (interface{}, error) {
 	}
 
 	aggregatedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+		},
 		Spec: corev1.PodSpec{
 			NodeName:       pod.Spec.NodeName,
 			InitContainers: pod.Spec.InitContainers,

--- a/pkg/util/fedinformer/transform_test.go
+++ b/pkg/util/fedinformer/transform_test.go
@@ -169,7 +169,7 @@ func TestPodTransformFunc(t *testing.T) {
 		want interface{}
 	}{
 		{
-			name: "transform pods without needed",
+			name: "transform pods without status",
 			obj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:   "foo",
@@ -183,10 +183,15 @@ func TestPodTransformFunc(t *testing.T) {
 					},
 				},
 			},
-			want: &corev1.Pod{},
+			want: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "bar",
+				},
+			},
 		},
 		{
-			name: "transform pods with needed",
+			name: "transform pods with status",
 			obj: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "foo",
@@ -208,6 +213,10 @@ func TestPodTransformFunc(t *testing.T) {
 				},
 			},
 			want: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "bar",
+				},
 				Spec: corev1.PodSpec{
 					NodeName:       "test",
 					InitContainers: []corev1.Container{{Name: "test"}},


### PR DESCRIPTION
Cherry pick of #2489 on release-1.3.
#2489: fix pod lister only list a pod
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`/`karmada-agent`: Fixed pod information can not be collected issue when building resource summary.
```