### PR TITLE
[E2E] fix flaking test: search proxy get node report not found

### DIFF
--- a/test/e2e/aggregatedapi_test.go
+++ b/test/e2e/aggregatedapi_test.go
@@ -119,9 +119,9 @@ var _ = ginkgo.Describe("Aggregated Kubernetes API Endpoint testing", func() {
 
 			ginkgo.It("tom access the member cluster", func() {
 				ginkgo.By("access the cluster `/api` path with right", func() {
-					gomega.Eventually(func() (int, error) {
+					gomega.Eventually(func(g gomega.Gomega) (int, error) {
 						code, err := helper.DoRequest(fmt.Sprintf(karmadaHost+clusterProxy+"api", member1), tomToken)
-						gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+						g.Expect(err).ShouldNot(gomega.HaveOccurred())
 						return code, nil
 					}, pollTimeout, pollInterval).Should(gomega.Equal(http.StatusOK))
 				})
@@ -138,9 +138,9 @@ var _ = ginkgo.Describe("Aggregated Kubernetes API Endpoint testing", func() {
 				})
 
 				ginkgo.By("access the member1 /api/v1/nodes path with right", func() {
-					gomega.Eventually(func() (int, error) {
+					gomega.Eventually(func(g gomega.Gomega) (int, error) {
 						code, err := helper.DoRequest(fmt.Sprintf(karmadaHost+clusterProxy+"api/v1/nodes", member1), tomToken)
-						gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+						g.Expect(err).ShouldNot(gomega.HaveOccurred())
 						return code, nil
 					}, pollTimeout, pollInterval).Should(gomega.Equal(http.StatusOK))
 				})

--- a/test/e2e/framework/workload.go
+++ b/test/e2e/framework/workload.go
@@ -81,15 +81,15 @@ func WaitWorkloadPresentOnClusterFitWith(cluster, namespace, name string, fit fu
 	gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
 
 	klog.Infof("Waiting for Workload(%s/%s) synced on cluster(%s)", namespace, name, cluster)
-	gomega.Eventually(func() bool {
+	gomega.Eventually(func(g gomega.Gomega) (bool, error) {
 		workload, err := clusterClient.Resource(workloadGVR).Namespace(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
-			return false
+			return false, nil
 		}
 		typedObj := &workloadv1alpha1.Workload{}
 		err = runtime.DefaultUnstructuredConverter.FromUnstructured(workload.UnstructuredContent(), typedObj)
-		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-		return fit(typedObj)
+		g.Expect(err).ShouldNot(gomega.HaveOccurred())
+		return fit(typedObj), nil
 	}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 }
 

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -54,12 +54,12 @@ var _ = ginkgo.Describe("[karmada-search] karmada search testing", ginkgo.Ordere
 
 	// var pollTimeout = 30 * time.Second
 	var searchObject = func(path, target string, exists bool) {
-		gomega.Eventually(func() bool {
+		gomega.Eventually(func(g gomega.Gomega) (bool, error) {
 			res := karmadaClient.SearchV1alpha1().RESTClient().Get().AbsPath(path).Do(context.TODO())
-			gomega.Expect(res.Error()).ShouldNot(gomega.HaveOccurred())
+			g.Expect(res.Error()).ShouldNot(gomega.HaveOccurred())
 			raw, err := res.Raw()
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			return strings.Contains(string(raw), target)
+			g.Expect(err).ShouldNot(gomega.HaveOccurred())
+			return strings.Contains(string(raw), target), nil
 		}, pollTimeout, pollInterval).Should(gomega.Equal(exists))
 	}
 
@@ -557,7 +557,7 @@ var _ = ginkgo.Describe("[karmada-search] karmada search testing", ginkgo.Ordere
 					gomega.Eventually(func(g gomega.Gomega) {
 						var err error
 						get, err = proxyClient.CoreV1().Nodes().Get(context.TODO(), testObject.GetName(), metav1.GetOptions{})
-						gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+						g.Expect(err).ShouldNot(gomega.HaveOccurred())
 					}, pollTimeout, pollInterval).Should(gomega.Succeed())
 
 					gomega.Expect(get.Annotations[clusterv1alpha1.CacheSourceAnnotationKey]).Should(gomega.Equal(member1))
@@ -574,7 +574,7 @@ var _ = ginkgo.Describe("[karmada-search] karmada search testing", ginkgo.Ordere
 					gomega.Eventually(func(g gomega.Gomega) {
 						var err error
 						proxyList, err = proxyClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
-						gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+						g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 						fromProxy := sets.NewString()
 						for _, item := range proxyList.Items {


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

I found a new flaking test in master branch:

https://github.com/karmada-io/karmada/runs/8267105862?check_suite_focus=true

It still report:

```log
"nodes \"member1-control-plane\" not found",
```

We need to use `g` for assert in `gomega.Eventually(func(g gomega.Gomega) {}` block.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

/cc @ikaven1024 @RainbowMango Can you help review it?

