### PR TITLE
karmadactl are compatible with v1.24 master node label

### DIFF
--- a/pkg/karmadactl/cmdinit/kubernetes/node.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/node.go
@@ -31,6 +31,12 @@ func (i *CommandInitOption) getKarmadaAPIServerIP() error {
 	if err != nil {
 		return err
 	}
+	if len(masterNodes.Items) == 0 {
+		masterNodes, err = nodeClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/control-plane"})
+		if err != nil {
+			return err
+		}
+	}
 
 	if len(masterNodes.Items) == 0 {
 		klog.Warning("the kubernetes cluster does not have a Master role.")


### PR DESCRIPTION
Signed-off-by: calvin0327 <wen.chen@daocloud.io>

**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

if the k8s cluster is v1.24, we can not use the previous label to select  master node.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
please correct me if not.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

