### PR TITLE
Automated cherry pick of #2469: add cache source annotation for objects returned by proxy
#2483: fix concurrent map writes panic while list via proxy
#2490: add wait for proxy ready
#2501: fix flaking test: search proxy get node report not found

### DIFF
--- a/pkg/search/proxy/cluster_proxy_test.go
+++ b/pkg/search/proxy/cluster_proxy_test.go
@@ -1,0 +1,144 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/search/proxy/store"
+)
+
+func TestModifyRequest(t *testing.T) {
+	newObjectFunc := func(annotations map[string]string, resourceVersion string) *unstructured.Unstructured {
+		obj := &unstructured.Unstructured{}
+		obj.SetAPIVersion("v1")
+		obj.SetKind("Pod")
+		obj.SetAnnotations(annotations)
+		obj.SetResourceVersion(resourceVersion)
+		return obj
+	}
+
+	type args struct {
+		body    interface{}
+		cluster string
+	}
+	type want struct {
+		body interface{}
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "Empty body",
+			args: args{
+				body: nil,
+			},
+			want: want{
+				body: nil,
+			},
+		},
+		{
+			name: "Body with nil annotations",
+			args: args{
+				body: newObjectFunc(nil, ""),
+			},
+			want: want{
+				body: newObjectFunc(nil, ""),
+			},
+		},
+		{
+			name: "Body with empty annotations",
+			args: args{
+				body: newObjectFunc(map[string]string{}, ""),
+			},
+			want: want{
+				body: newObjectFunc(map[string]string{}, ""),
+			},
+		},
+		{
+			name: "Body with cache source annotation",
+			args: args{
+				body: newObjectFunc(map[string]string{clusterv1alpha1.CacheSourceAnnotationKey: "bar"}, ""),
+			},
+			want: want{
+				body: newObjectFunc(map[string]string{}, ""),
+			},
+		},
+		{
+			name: "Body with single cluster resource version",
+			args: args{
+				body:    newObjectFunc(nil, "1234"),
+				cluster: "cluster1",
+			},
+			want: want{
+				body: newObjectFunc(nil, "1234"),
+			},
+		},
+		{
+			name: "Body with multi cluster resource version",
+			args: args{
+				body:    newObjectFunc(nil, store.BuildMultiClusterResourceVersion(map[string]string{"cluster1": "1234", "cluster2": "5678"})),
+				cluster: "cluster1",
+			},
+			want: want{
+				body: newObjectFunc(nil, "1234"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var body io.Reader
+			if tt.args.body != nil {
+				buf := bytes.NewBuffer(nil)
+				err := json.NewEncoder(buf).Encode(tt.args.body)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				body = buf
+			}
+			req, _ := http.NewRequest("PUT", "/api/v1/namespaces/default/pods/foo", body)
+			err := modifyRequest(req, tt.args.cluster)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			var get runtime.Object
+			if req.ContentLength != 0 {
+				data, err := ioutil.ReadAll(req.Body)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+
+				if int64(len(data)) != req.ContentLength {
+					t.Errorf("expect contentLength %v, but got %v", len(data), req.ContentLength)
+					return
+				}
+
+				get, _, err = unstructured.UnstructuredJSONScheme.Decode(data, nil, nil)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+			}
+
+			if !reflect.DeepEqual(tt.want.body, get) {
+				t.Errorf("get body diff: %v", cmp.Diff(tt.want.body, get))
+			}
+		})
+	}
+}

--- a/test/e2e/aggregatedapi_test.go
+++ b/test/e2e/aggregatedapi_test.go
@@ -119,9 +119,9 @@ var _ = ginkgo.Describe("Aggregated Kubernetes API Endpoint testing", func() {
 
 			ginkgo.It("tom access the member cluster", func() {
 				ginkgo.By("access the cluster `/api` path with right", func() {
-					gomega.Eventually(func() (int, error) {
+					gomega.Eventually(func(g gomega.Gomega) (int, error) {
 						code, err := helper.DoRequest(fmt.Sprintf(karmadaHost+clusterProxy+"api", member1), tomToken)
-						gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+						g.Expect(err).ShouldNot(gomega.HaveOccurred())
 						return code, nil
 					}, pollTimeout, pollInterval).Should(gomega.Equal(http.StatusOK))
 				})
@@ -138,9 +138,9 @@ var _ = ginkgo.Describe("Aggregated Kubernetes API Endpoint testing", func() {
 				})
 
 				ginkgo.By("access the member1 /api/v1/nodes path with right", func() {
-					gomega.Eventually(func() (int, error) {
+					gomega.Eventually(func(g gomega.Gomega) (int, error) {
 						code, err := helper.DoRequest(fmt.Sprintf(karmadaHost+clusterProxy+"api/v1/nodes", member1), tomToken)
-						gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+						g.Expect(err).ShouldNot(gomega.HaveOccurred())
 						return code, nil
 					}, pollTimeout, pollInterval).Should(gomega.Equal(http.StatusOK))
 				})

--- a/test/e2e/framework/workload.go
+++ b/test/e2e/framework/workload.go
@@ -81,15 +81,15 @@ func WaitWorkloadPresentOnClusterFitWith(cluster, namespace, name string, fit fu
 	gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
 
 	klog.Infof("Waiting for Workload(%s/%s) synced on cluster(%s)", namespace, name, cluster)
-	gomega.Eventually(func() bool {
+	gomega.Eventually(func(g gomega.Gomega) (bool, error) {
 		workload, err := clusterClient.Resource(workloadGVR).Namespace(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
-			return false
+			return false, nil
 		}
 		typedObj := &workloadv1alpha1.Workload{}
 		err = runtime.DefaultUnstructuredConverter.FromUnstructured(workload.UnstructuredContent(), typedObj)
-		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-		return fit(typedObj)
+		g.Expect(err).ShouldNot(gomega.HaveOccurred())
+		return fit(typedObj), nil
 	}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 }
 

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -54,12 +54,12 @@ var _ = ginkgo.Describe("[karmada-search] karmada search testing", ginkgo.Ordere
 
 	// var pollTimeout = 30 * time.Second
 	var searchObject = func(path, target string, exists bool) {
-		gomega.Eventually(func() bool {
+		gomega.Eventually(func(g gomega.Gomega) (bool, error) {
 			res := karmadaClient.SearchV1alpha1().RESTClient().Get().AbsPath(path).Do(context.TODO())
-			gomega.Expect(res.Error()).ShouldNot(gomega.HaveOccurred())
+			g.Expect(res.Error()).ShouldNot(gomega.HaveOccurred())
 			raw, err := res.Raw()
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			return strings.Contains(string(raw), target)
+			g.Expect(err).ShouldNot(gomega.HaveOccurred())
+			return strings.Contains(string(raw), target), nil
 		}, pollTimeout, pollInterval).Should(gomega.Equal(exists))
 	}
 
@@ -557,7 +557,7 @@ var _ = ginkgo.Describe("[karmada-search] karmada search testing", ginkgo.Ordere
 					gomega.Eventually(func(g gomega.Gomega) {
 						var err error
 						get, err = proxyClient.CoreV1().Nodes().Get(context.TODO(), testObject.GetName(), metav1.GetOptions{})
-						gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+						g.Expect(err).ShouldNot(gomega.HaveOccurred())
 					}, pollTimeout, pollInterval).Should(gomega.Succeed())
 
 					gomega.Expect(get.Annotations[clusterv1alpha1.CacheSourceAnnotationKey]).Should(gomega.Equal(member1))
@@ -574,7 +574,7 @@ var _ = ginkgo.Describe("[karmada-search] karmada search testing", ginkgo.Ordere
 					gomega.Eventually(func(g gomega.Gomega) {
 						var err error
 						proxyList, err = proxyClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
-						gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+						g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 						fromProxy := sets.NewString()
 						for _, item := range proxyList.Items {


### PR DESCRIPTION
Cherry pick of #2469 #2483 #2490 #2501 on release-1.3.
#2469: add cache source annotation for objects returned by proxy
#2483: fix concurrent map writes panic while list via proxy
#2490: add wait for proxy ready
#2501: fix flaking test: search proxy get node report not found
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-search`: fix concurrent map writes panic while list via proxy; And add cache source annotation to returned objects.
```