### PR TITLE
Fix that the ServiceExport can't be reported to control plane by karmada-agent

### DIFF
--- a/pkg/karmadactl/cmdinit/karmada/rbac.go
+++ b/pkg/karmadactl/cmdinit/karmada/rbac.go
@@ -61,7 +61,7 @@ func grantAccessPermissionToAgent(clientSet *kubernetes.Clientset) error {
 		{
 			APIGroups: []string{"work.karmada.io"},
 			Resources: []string{"works"},
-			Verbs:     []string{"get", "list", "watch", "update"},
+			Verbs:     []string{"create", "get", "list", "watch", "update"},
 		},
 		{
 			APIGroups: []string{"work.karmada.io"},


### PR DESCRIPTION
Signed-off-by: lonelyCZ <531187475@qq.com>

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

I just found that `service_export_controller` is used by `karmada-agent`, it need to create work to collect `endpointSlices`, so the `karmada-agent` need to permission to create `Works`.

```
I0914 08:35:33.330001       1 service_export_controller.go:150] Begin to sync EndpointSlice default/dc-demo-ff75r.
E0914 08:35:33.411613       1 work.go:64] Failed to create/update work karmada-es-member140/dc-demo-ff75r-78db6c96f5. Error: works.work.karmada.io is forbidden: User "system:node:member140" cannot create resource "works" in API group "work.karmada.io" in the namespace "karmada-es-member140"
E0914 08:35:33.411669       1 service_export_controller.go:325] Failed to handle endpointSlice(default/dc-demo-ff75r) event, Error: works.work.karmada.io is forbidden: User "system:node:member140" cannot create resource "works" in API group "work.karmada.io" in the namespace "karmada-es-member140"
E0914 08:35:33.411713       1 service_export_controller.go:161] Failed to handle endpointSlice(default/dc-demo-ff75r) event, Error: works.work.karmada.io is forbidden: User "system:node:member140" cannot create resource "works" in API group "work.karmada.io" in the namespace "karmada-es-member140"
I0914 08:35:33.411744       1 worker.go:127] Dropping resource "cluster=member140, discovery.k8s.io/v1, kind=EndpointSlice, default/dc-demo-ff75r" out of the queue: works.work.karmada.io is forbidden: User "system:node:member140" cannot create resource "works" in API group "work.karmada.io" in the namespace "karmada-es-member140"
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-agent`: Fixed `ServiceExport` controller can not report `endpointSlices` issue(due to miss `create` permission)
```

