### PR TITLE
Use Cluster secret ref namespace in unified-auth-controller when generate ClusterRoleBinding

### DIFF
--- a/pkg/util/rbac.go
+++ b/pkg/util/rbac.go
@@ -86,8 +86,8 @@ func DeleteClusterRoleBinding(client kubeclient.Interface, name string) error {
 }
 
 // PolicyRuleAPIGroupMatches determines if the given policy rule is applied for requested group.
-func PolicyRuleAPIGroupMatches(rules *rbacv1.PolicyRule, requestedGroup string) bool {
-	for _, ruleGroup := range rules.APIGroups {
+func PolicyRuleAPIGroupMatches(rule *rbacv1.PolicyRule, requestedGroup string) bool {
+	for _, ruleGroup := range rule.APIGroups {
 		if ruleGroup == rbacv1.APIGroupAll {
 			return true
 		}
@@ -100,8 +100,8 @@ func PolicyRuleAPIGroupMatches(rules *rbacv1.PolicyRule, requestedGroup string) 
 }
 
 // PolicyRuleResourceMatches determines if the given policy rule is applied for requested resource.
-func PolicyRuleResourceMatches(rules *rbacv1.PolicyRule, requestedResource string) bool {
-	for _, ruleResource := range rules.Resources {
+func PolicyRuleResourceMatches(rule *rbacv1.PolicyRule, requestedResource string) bool {
+	for _, ruleResource := range rule.Resources {
 		if ruleResource == rbacv1.ResourceAll {
 			return true
 		}
@@ -119,8 +119,8 @@ func PolicyRuleResourceNameMatches(rule *rbacv1.PolicyRule, requestedName string
 		return true
 	}
 
-	for _, ruleName := range rule.ResourceNames {
-		if ruleName == requestedName {
+	for _, resourceName := range rule.ResourceNames {
+		if resourceName == requestedName {
 			return true
 		}
 	}

--- a/test/e2e/aggregatedapi_test.go
+++ b/test/e2e/aggregatedapi_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -11,8 +12,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 
+	"github.com/karmada-io/karmada/pkg/karmadactl"
+	"github.com/karmada-io/karmada/pkg/karmadactl/options"
 	"github.com/karmada-io/karmada/test/e2e/framework"
 	"github.com/karmada-io/karmada/test/helper"
 )
@@ -21,7 +25,7 @@ const (
 	clusterProxy = "/apis/cluster.karmada.io/v1alpha1/clusters/%s/proxy/"
 )
 
-var _ = ginkgo.Describe("Aggregated Kubernetes API Endpoint testing", func() {
+var _ = framework.SerialDescribe("Aggregated Kubernetes API Endpoint testing", func() {
 	var member1, member2 string
 	var saName, saNamespace string
 	var tomServiceAccount *corev1.ServiceAccount
@@ -30,6 +34,78 @@ var _ = ginkgo.Describe("Aggregated Kubernetes API Endpoint testing", func() {
 	var tomClusterRoleBinding *rbacv1.ClusterRoleBinding
 	var tomClusterRoleOnMember *rbacv1.ClusterRole
 	var tomClusterRoleBindingOnMember *rbacv1.ClusterRoleBinding
+
+	var (
+		clusterName    string
+		homeDir        string
+		kubeConfigPath string
+		clusterContext string
+		controlPlane   string
+		karmadaConfig  karmadactl.KarmadaConfig
+
+		secretStoreNamespace string
+	)
+
+	ginkgo.BeforeEach(func() {
+		clusterName = "member-e2e-" + rand.String(RandomStrLength)
+		homeDir = os.Getenv("HOME")
+		kubeConfigPath = fmt.Sprintf("%s/.kube/%s.config", homeDir, clusterName)
+		clusterContext = fmt.Sprintf("kind-%s", clusterName)
+		controlPlane = fmt.Sprintf("%s-control-plane", clusterName)
+		karmadaConfig = karmadactl.NewKarmadaConfig(clientcmd.NewDefaultPathOptions())
+
+		secretStoreNamespace = "test-" + rand.String(RandomStrLength)
+	})
+
+	ginkgo.BeforeEach(func() {
+		ginkgo.By(fmt.Sprintf("Create cluster: %s", clusterName), func() {
+			err := createCluster(clusterName, kubeConfigPath, controlPlane, clusterContext)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		})
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By(fmt.Sprintf("Deleting clusters: %s", clusterName), func() {
+				err := deleteCluster(clusterName, kubeConfigPath)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				_ = os.Remove(kubeConfigPath)
+			})
+		})
+	})
+
+	ginkgo.BeforeEach(func() {
+		ginkgo.By(fmt.Sprintf("Joinning cluster: %s", clusterName), func() {
+			opts := karmadactl.CommandJoinOption{
+				GlobalCommandOptions: options.GlobalCommandOptions{
+					KarmadaContext: karmadaContext,
+				},
+				DryRun:            false,
+				ClusterNamespace:  secretStoreNamespace,
+				ClusterName:       clusterName,
+				ClusterContext:    clusterContext,
+				ClusterKubeConfig: kubeConfigPath,
+			}
+			err := karmadactl.RunJoin(karmadaConfig, opts)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		})
+	})
+
+	ginkgo.AfterEach(func() {
+		ginkgo.By(fmt.Sprintf("Unjoinning cluster: %s", clusterName), func() {
+			karmadaConfig := karmadactl.NewKarmadaConfig(clientcmd.NewDefaultPathOptions())
+			opts := karmadactl.CommandUnjoinOption{
+				GlobalCommandOptions: options.GlobalCommandOptions{
+					KarmadaContext: karmadaContext,
+				},
+				DryRun:            false,
+				ClusterNamespace:  secretStoreNamespace,
+				ClusterName:       clusterName,
+				ClusterContext:    clusterContext,
+				ClusterKubeConfig: kubeConfigPath,
+				Wait:              5 * options.DefaultKarmadactlCommandDuration,
+			}
+			err := karmadactl.RunUnjoin(karmadaConfig, opts)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		})
+	})
 
 	ginkgo.BeforeEach(func() {
 		member1, member2 = "member1", "member2"
@@ -52,7 +128,7 @@ var _ = ginkgo.Describe("Aggregated Kubernetes API Endpoint testing", func() {
 				APIGroups:     []string{"cluster.karmada.io"},
 				Verbs:         []string{"*"},
 				Resources:     []string{"clusters/proxy"},
-				ResourceNames: []string{member1},
+				ResourceNames: []string{member1, clusterName},
 			},
 		})
 		tomClusterRoleBinding = helper.NewClusterRoleBinding(tomServiceAccount.Name, tomClusterRole.Name, []rbacv1.Subject{
@@ -153,6 +229,62 @@ var _ = ginkgo.Describe("Aggregated Kubernetes API Endpoint testing", func() {
 					code, err := helper.DoRequest(fmt.Sprintf(karmadaHost+clusterProxy, member2), tomToken)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 					gomega.Expect(code).Should(gomega.Equal(http.StatusForbidden))
+				})
+			})
+		})
+
+		ginkgo.When(fmt.Sprintf("Serviceaccount(tom) access the %s cluster", clusterName), func() {
+			var clusterClient kubernetes.Interface
+
+			ginkgo.BeforeEach(func() {
+				clusterConfig, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				clusterClient = kubernetes.NewForConfigOrDie(clusterConfig)
+			})
+
+			ginkgo.BeforeEach(func() {
+				klog.Infof("Waiting for namespace present on cluster(%s)", clusterName)
+				framework.WaitNamespacePresentOnClusterByClient(clusterClient, tomServiceAccount.Namespace)
+
+				klog.Infof("Create ServiceAccount(%s) in the cluster(%s)", klog.KObj(tomServiceAccount).String(), clusterName)
+				framework.CreateServiceAccount(clusterClient, tomServiceAccount)
+				ginkgo.DeferCleanup(func() {
+					klog.Infof("Delete ServiceAccount(%s) in the cluster(%s)", klog.KObj(tomServiceAccount).String(), clusterName)
+					framework.RemoveServiceAccount(clusterClient, tomServiceAccount.Namespace, tomServiceAccount.Name)
+				})
+			})
+
+			ginkgo.AfterEach(func() {
+				framework.RemoveClusterRole(clusterClient, tomClusterRoleOnMember.Name)
+				framework.RemoveClusterRoleBinding(clusterClient, tomClusterRoleBindingOnMember.Name)
+			})
+
+			ginkgo.It("tom access the member cluster", func() {
+				ginkgo.By("access the cluster `/api` path with right", func() {
+					gomega.Eventually(func(g gomega.Gomega) (int, error) {
+						code, err := helper.DoRequest(fmt.Sprintf(karmadaHost+clusterProxy+"api", clusterName), tomToken)
+						g.Expect(err).ShouldNot(gomega.HaveOccurred())
+						return code, nil
+					}, pollTimeout, pollInterval).Should(gomega.Equal(http.StatusOK))
+				})
+
+				ginkgo.By("access the cluster /api/v1/nodes path without right", func() {
+					code, err := helper.DoRequest(fmt.Sprintf(karmadaHost+clusterProxy+"api/v1/nodes", clusterName), tomToken)
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+					gomega.Expect(code).Should(gomega.Equal(http.StatusForbidden))
+				})
+
+				ginkgo.By(fmt.Sprintf("create rbac in the %s cluster", clusterName), func() {
+					framework.CreateClusterRole(clusterClient, tomClusterRoleOnMember)
+					framework.CreateClusterRoleBinding(clusterClient, tomClusterRoleBindingOnMember)
+				})
+
+				ginkgo.By(fmt.Sprintf("access the %s /api/v1/nodes path with right", clusterName), func() {
+					gomega.Eventually(func(g gomega.Gomega) (int, error) {
+						code, err := helper.DoRequest(fmt.Sprintf(karmadaHost+clusterProxy+"api/v1/nodes", clusterName), tomToken)
+						g.Expect(err).ShouldNot(gomega.HaveOccurred())
+						return code, nil
+					}, pollTimeout, pollInterval).Should(gomega.Equal(http.StatusOK))
 				})
 			})
 		})


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

As talked in https://github.com/karmada-io/karmada/issues/2480#issuecomment-1240372168 and #2495, we need to use cluster impersonate secret ref in `unified-auth-controller` when generating ClusterRoleBinding. As a result, we can access subCluster resources through the `aggregate-apiserver`  when the cluster uses different namespaces to store secrets.

**Which issue(s) this PR fixes**:
Fixes #2495 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-controller-manager: use cluster secret ref namespace in unified-auth-controller when generate ClusterRoleBinding
```

