### PR TITLE
Automated cherry pick of #2515: Fix that the ServiceExport can't be reported to control plane

### DIFF
--- a/pkg/karmadactl/cmdinit/karmada/rbac.go
+++ b/pkg/karmadactl/cmdinit/karmada/rbac.go
@@ -61,7 +61,7 @@ func grantAccessPermissionToAgent(clientSet *kubernetes.Clientset) error {
 		{
 			APIGroups: []string{"work.karmada.io"},
 			Resources: []string{"works"},
-			Verbs:     []string{"get", "list", "watch", "update"},
+			Verbs:     []string{"create", "get", "list", "watch", "update"},
 		},
 		{
 			APIGroups: []string{"work.karmada.io"},


### PR DESCRIPTION
Cherry pick of #2515 on release-1.3.
#2515: Fix that the ServiceExport can't be reported to control plane
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-agent`: Fixed `ServiceExport` controller can not report `endpointSlices` issue(due to miss `create` permission)
```