### PR TITLE
Automated cherry pick of #2450: fix karmadactl init pending when k8s is in ipv6 mode

### DIFF
--- a/pkg/karmadactl/cmdinit/utils/ip.go
+++ b/pkg/karmadactl/cmdinit/utils/ip.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"fmt"
+	"net"
+)
+
+//ParseIP parse an ip address and return whether it is a v4 or v6 ip address
+func ParseIP(s string) (net.IP, int, error) {
+	ip := net.ParseIP(s)
+	if ip == nil {
+		return nil, 0, fmt.Errorf("%s is not a valid ip address", s)
+	}
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '.':
+			return ip, 4, nil
+		case ':':
+			return ip, 6, nil
+		}
+	}
+	return nil, 0, fmt.Errorf("%s is not a valid ip address", s)
+}

--- a/pkg/karmadactl/cmdinit/utils/ip_test.go
+++ b/pkg/karmadactl/cmdinit/utils/ip_test.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestParseIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		IP       string
+		expected int
+	}{
+		{"v4", "127.0.0.1", 4},
+		{"v6", "1030::C9B4:FF12:48AA:1A2B", 6},
+		{"v4-error", "333.0.0.0", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, IPType, _ := ParseIP(tt.IP)
+			if IPType != tt.expected {
+				t.Errorf("parse ip %d, want %d", IPType, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cherry pick of #2450 on release-1.3.
#2450: fix karmadactl init pending when k8s is in ipv6 mode
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmadactl`: Fixed `init` can not honor IPV6 address issue when generating kubeconfig file.
```