### PR TITLE
scheduler & descheduler introduce scheduler-estimator-service-prefix flag

### DIFF
--- a/cmd/descheduler/app/options/options.go
+++ b/cmd/descheduler/app/options/options.go
@@ -42,6 +42,8 @@ type Options struct {
 
 	// SchedulerEstimatorTimeout specifies the timeout period of calling the accurate scheduler estimator service.
 	SchedulerEstimatorTimeout metav1.Duration
+	// SchedulerEstimatorServicePrefix presents the prefix of the accurate scheduler estimator service name.
+	SchedulerEstimatorServicePrefix string
 	// SchedulerEstimatorPort is the port that the accurate scheduler estimator server serves at.
 	SchedulerEstimatorPort int
 	// DeschedulingInterval specifies time interval for descheduler to run.
@@ -81,6 +83,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&o.KubeAPIBurst, "kube-api-burst", 60, "Burst to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")
 	fs.DurationVar(&o.SchedulerEstimatorTimeout.Duration, "scheduler-estimator-timeout", 3*time.Second, "Specifies the timeout period of calling the scheduler estimator service.")
 	fs.IntVar(&o.SchedulerEstimatorPort, "scheduler-estimator-port", defaultEstimatorPort, "The secure port on which to connect the accurate scheduler estimator.")
+	fs.StringVar(&o.SchedulerEstimatorServicePrefix, "scheduler-estimator-service-prefix", "karmada-scheduler-estimator", "The prefix of scheduler estimator service name")
 	fs.DurationVar(&o.DeschedulingInterval.Duration, "descheduling-interval", defaultDeschedulingInterval, "Time interval between two consecutive descheduler executions. Setting this value instructs the descheduler to run in a continuous loop at the interval specified.")
 	fs.DurationVar(&o.UnschedulableThreshold.Duration, "unschedulable-threshold", defaultUnschedulableThreshold, "The period of pod unschedulable condition. This value is considered as a classification standard of unschedulable replicas.")
 	o.ProfileOpts.AddFlags(fs)

--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -49,6 +49,8 @@ type Options struct {
 	DisableSchedulerEstimatorInPullMode bool
 	// SchedulerEstimatorTimeout specifies the timeout period of calling the accurate scheduler estimator service.
 	SchedulerEstimatorTimeout metav1.Duration
+	// SchedulerEstimatorServicePrefix presents the prefix of the accurate scheduler estimator service name.
+	SchedulerEstimatorServicePrefix string
 	// SchedulerEstimatorPort is the port that the accurate scheduler estimator server serves at.
 	SchedulerEstimatorPort int
 
@@ -95,6 +97,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.EnableSchedulerEstimator, "enable-scheduler-estimator", false, "Enable calling cluster scheduler estimator for adjusting replicas.")
 	fs.BoolVar(&o.DisableSchedulerEstimatorInPullMode, "disable-scheduler-estimator-in-pull-mode", false, "Disable the scheduler estimator for clusters in pull mode, which takes effect only when enable-scheduler-estimator is true.")
 	fs.DurationVar(&o.SchedulerEstimatorTimeout.Duration, "scheduler-estimator-timeout", 3*time.Second, "Specifies the timeout period of calling the scheduler estimator service.")
+	fs.StringVar(&o.SchedulerEstimatorServicePrefix, "scheduler-estimator-service-prefix", "karmada-scheduler-estimator", "The prefix of scheduler estimator service name")
 	fs.IntVar(&o.SchedulerEstimatorPort, "scheduler-estimator-port", defaultEstimatorPort, "The secure port on which to connect the accurate scheduler estimator.")
 	fs.BoolVar(&o.EnableEmptyWorkloadPropagation, "enable-empty-workload-propagation", false, "Enable workload with replicas 0 to be propagated to member clusters.")
 	fs.StringSliceVar(&o.Plugins, "plugins", []string{"*"},

--- a/cmd/scheduler/app/scheduler.go
+++ b/cmd/scheduler/app/scheduler.go
@@ -136,6 +136,7 @@ func run(opts *options.Options, stopChan <-chan struct{}, registryOptions ...Opt
 		scheduler.WithOutOfTreeRegistry(outOfTreeRegistry),
 		scheduler.WithEnableSchedulerEstimator(opts.EnableSchedulerEstimator),
 		scheduler.WithDisableSchedulerEstimatorInPullMode(opts.DisableSchedulerEstimatorInPullMode),
+		scheduler.WithSchedulerEstimatorServicePrefix(opts.SchedulerEstimatorServicePrefix),
 		scheduler.WithSchedulerEstimatorPort(opts.SchedulerEstimatorPort),
 		scheduler.WithSchedulerEstimatorTimeout(opts.SchedulerEstimatorTimeout),
 		scheduler.WithEnableEmptyWorkloadPropagation(opts.EnableEmptyWorkloadPropagation),

--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -46,9 +46,10 @@ type Descheduler struct {
 
 	eventRecorder record.EventRecorder
 
-	schedulerEstimatorCache  *estimatorclient.SchedulerEstimatorCache
-	schedulerEstimatorPort   int
-	schedulerEstimatorWorker util.AsyncWorker
+	schedulerEstimatorCache         *estimatorclient.SchedulerEstimatorCache
+	schedulerEstimatorServicePrefix string
+	schedulerEstimatorPort          int
+	schedulerEstimatorWorker        util.AsyncWorker
 
 	unschedulableThreshold time.Duration
 	deschedulingInterval   time.Duration
@@ -250,7 +251,7 @@ func (d *Descheduler) establishEstimatorConnections() {
 		return
 	}
 	for i := range clusterList.Items {
-		if err = estimatorclient.EstablishConnection(d.KubeClient, clusterList.Items[i].Name, d.schedulerEstimatorCache, d.schedulerEstimatorPort); err != nil {
+		if err = estimatorclient.EstablishConnection(d.KubeClient, clusterList.Items[i].Name, d.schedulerEstimatorCache, d.schedulerEstimatorServicePrefix, d.schedulerEstimatorPort); err != nil {
 			klog.Error(err)
 		}
 	}
@@ -270,7 +271,7 @@ func (d *Descheduler) reconcileEstimatorConnection(key util.QueueKey) error {
 		}
 		return err
 	}
-	return estimatorclient.EstablishConnection(d.KubeClient, name, d.schedulerEstimatorCache, d.schedulerEstimatorPort)
+	return estimatorclient.EstablishConnection(d.KubeClient, name, d.schedulerEstimatorCache, d.schedulerEstimatorServicePrefix, d.schedulerEstimatorPort)
 }
 
 func (d *Descheduler) recordDescheduleResultEventForResourceBinding(rb *workv1alpha2.ResourceBinding, message string, err error) {

--- a/pkg/estimator/client/cache.go
+++ b/pkg/estimator/client/cache.go
@@ -80,13 +80,13 @@ func (c *SchedulerEstimatorCache) GetClient(name string) (estimatorservice.Estim
 }
 
 // EstablishConnection establishes a new gRPC connection with the specified cluster scheduler estimator.
-func EstablishConnection(kubeClient kubernetes.Interface, name string, estimatorCache *SchedulerEstimatorCache, port int) error {
+func EstablishConnection(kubeClient kubernetes.Interface, name string, estimatorCache *SchedulerEstimatorCache, estimatorServicePrefix string, port int) error {
 	if estimatorCache.IsEstimatorExist(name) {
 		return nil
 	}
 
 	serverAddr, err := resolveCluster(kubeClient, util.NamespaceKarmadaSystem,
-		names.GenerateEstimatorServiceName(name), int32(port))
+		names.GenerateEstimatorServiceName(estimatorServicePrefix, name), int32(port))
 	if err != nil {
 		return err
 	}

--- a/pkg/util/names/names.go
+++ b/pkg/util/names/names.go
@@ -127,7 +127,7 @@ func GenerateDerivedServiceName(serviceName string) string {
 }
 
 // GenerateEstimatorServiceName generates the gRPC scheduler estimator service name which belongs to a cluster.
-func GenerateEstimatorServiceName(clusterName string) string {
+func GenerateEstimatorServiceName(estimatorServicePrefix, clusterName string) string {
 	return fmt.Sprintf("%s-%s", estimatorServicePrefix, clusterName)
 }
 

--- a/pkg/util/names/names_test.go
+++ b/pkg/util/names/names_test.go
@@ -312,18 +312,26 @@ func TestGenerateEstimatorDeploymentName(t *testing.T) {
 
 func TestGenerateEstimatorServiceName(t *testing.T) {
 	tests := []struct {
-		name        string
-		clusterName string
-		expected    string
+		name                   string
+		clusterName            string
+		estimatorServicePrefix string
+		expected               string
 	}{
 		{
-			name:        "",
-			clusterName: "cluster",
-			expected:    "karmada-scheduler-estimator-cluster",
+			name:                   "",
+			clusterName:            "cluster",
+			estimatorServicePrefix: "karmada-scheduler-estimator",
+			expected:               "karmada-scheduler-estimator-cluster",
+		},
+		{
+			name:                   "",
+			clusterName:            "cluster",
+			estimatorServicePrefix: "demo-karmada-scheduler-estimator",
+			expected:               "demo-karmada-scheduler-estimator-cluster",
 		},
 	}
 	for _, test := range tests {
-		got := GenerateEstimatorServiceName(test.clusterName)
+		got := GenerateEstimatorServiceName(test.estimatorServicePrefix, test.clusterName)
 		if got != test.expected {
 			t.Errorf("Test %s failed: expected %v, but got %v", test.name, test.expected, got)
 		}


### PR DESCRIPTION
Signed-off-by: carlory <baofa.fan@daocloud.io>

**What type of PR is this?**

/kind feature

**Which issue(s) this PR fixes**:
Part of #2526 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-scheduler`/`karmada-scheduler-descheduler`: Introduced `--scheduler-estimator-service-prefix` flag for discovery estimators.
```

