### PR TITLE
Automated cherry pick of #2450: fix karmadactl init pending when k8s is in ipv6 mode

### DIFF
--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -398,15 +398,12 @@ func (i *CommandInitOption) RunInit(_ io.Writer, parentCommand string) error {
 	}
 
 	// Create karmada kubeconfig
-	serverURL := fmt.Sprintf("https://%s:%v", i.KarmadaAPIServerIP[0].String(), i.KarmadaAPIServerNodePort)
-	if err := utils.WriteKubeConfigFromSpec(serverURL, options.UserName, options.ClusterName, i.KarmadaDataPath, options.KarmadaKubeConfigName,
-		i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.CaCertAndKeyName)], i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaCertAndKeyName)],
-		i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaCertAndKeyName)]); err != nil {
-		return fmt.Errorf("failed to create karmada kubeconfig file. %v", err)
+	err := i.createKarmadaConfig()
+	if err != nil {
+		return fmt.Errorf("create karmada kubeconfig failed.%v", err)
 	}
-	klog.Info("Create karmada kubeconfig success.")
 
-	// create ns
+	// Create ns
 	if err := i.CreateNamespace(); err != nil {
 		return fmt.Errorf("create namespace %s failed: %v", i.Namespace, err)
 	}
@@ -446,9 +443,78 @@ func (i *CommandInitOption) RunInit(_ io.Writer, parentCommand string) error {
 	return nil
 }
 
+func (i *CommandInitOption) createKarmadaConfig() error {
+	serverIP := i.KarmadaAPIServerIP[0].String()
+	serverURL, err := generateServerURL(serverIP, i.KarmadaAPIServerNodePort)
+	if err != nil {
+		return err
+	}
+	if err := utils.WriteKubeConfigFromSpec(serverURL, options.UserName, options.ClusterName, i.KarmadaDataPath, options.KarmadaKubeConfigName,
+		i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.CaCertAndKeyName)], i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaCertAndKeyName)],
+		i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaCertAndKeyName)]); err != nil {
+		return fmt.Errorf("failed to create karmada kubeconfig file. %v", err)
+	}
+	klog.Info("Create karmada kubeconfig success.")
+	return err
+}
+
+// get kube components registry
+func (i *CommandInitOption) kubeRegistry() string {
+	registry := i.KubeImageRegistry
+	mirrorCountry := strings.ToLower(i.KubeImageMirrorCountry)
+
+	if registry != "" {
+		return registry
+	}
+
+	if mirrorCountry != "" {
+		value, ok := imageRepositories[mirrorCountry]
+		if ok {
+			return value
+		}
+	}
+
+	return imageRepositories["global"]
+}
+
+// get kube-apiserver image
+func (i *CommandInitOption) kubeAPIServerImage() string {
+	if i.KarmadaAPIServerImage != "" {
+		return i.KarmadaAPIServerImage
+	}
+	return i.kubeRegistry() + "/" + defaultKubeAPIServerImage
+}
+
+// get kube-controller-manager image
+func (i *CommandInitOption) kubeControllerManagerImage() string {
+	if i.KubeControllerManagerImage != "" {
+		return i.KubeControllerManagerImage
+	}
+	return i.kubeRegistry() + "/" + defaultKubeControllerManagerImage
+}
+
+// get etcd image
+func (i *CommandInitOption) etcdImage() string {
+	if i.EtcdImage != "" {
+		return i.EtcdImage
+	}
+	return i.kubeRegistry() + "/" + defaultEtcdImage
+}
+
 func homeDir() string {
 	if h := os.Getenv("HOME"); h != "" {
 		return h
 	}
 	return os.Getenv("USERPROFILE") // windows
+}
+
+func generateServerURL(serverIP string, nodePort int32) (string, error) {
+	_, ipType, err := utils.ParseIP(serverIP)
+	if err != nil {
+		return "", err
+	}
+	if ipType == 4 {
+		return fmt.Sprintf("https://%s:%v", serverIP, nodePort), nil
+	}
+	return fmt.Sprintf("https://[%s]:%v", serverIP, nodePort), nil
 }

--- a/pkg/karmadactl/cmdinit/utils/ip.go
+++ b/pkg/karmadactl/cmdinit/utils/ip.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"fmt"
+	"net"
+)
+
+//ParseIP parse an ip address and return whether it is a v4 or v6 ip address
+func ParseIP(s string) (net.IP, int, error) {
+	ip := net.ParseIP(s)
+	if ip == nil {
+		return nil, 0, fmt.Errorf("%s is not a valid ip address", s)
+	}
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '.':
+			return ip, 4, nil
+		case ':':
+			return ip, 6, nil
+		}
+	}
+	return nil, 0, fmt.Errorf("%s is not a valid ip address", s)
+}

--- a/pkg/karmadactl/cmdinit/utils/ip_test.go
+++ b/pkg/karmadactl/cmdinit/utils/ip_test.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestParseIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		IP       string
+		expected int
+	}{
+		{"v4", "127.0.0.1", 4},
+		{"v6", "1030::C9B4:FF12:48AA:1A2B", 6},
+		{"v4-error", "333.0.0.0", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, IPType, _ := ParseIP(tt.IP)
+			if IPType != tt.expected {
+				t.Errorf("parse ip %d, want %d", IPType, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cherry pick of #2450 on release-1.1.
#2450: fix karmadactl init pending when k8s is in ipv6 mode
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
```