### PR TITLE
fix a gramma that is not accepted by GNU `sed` command

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -681,7 +681,7 @@ function util::set_mirror_registry_for_china_mainland() {
     "cluster/images/buildx.Dockerfile"
   )
   for dockerfile in "${dockerfile_list[@]}"; do
-    grep 'mirrors.ustc.edu.cn' ${repo_root}/${dockerfile} > /dev/null || sed -i '' -e "1a\\
+    grep 'mirrors.ustc.edu.cn' ${repo_root}/${dockerfile} > /dev/null || sed -i'' -e "1a\\
 RUN echo -e http://mirrors.ustc.edu.cn/alpine/v3.15/main/ > /etc/apk/repositories" ${repo_root}/${dockerfile}
   done
 }


### PR DESCRIPTION

Signed-off-by: mrningyang <mrningyangning@didiglobal.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix bug of hack/util.sh, which will lead to failure when run hack/local-up-karmada.sh with environment CHINA_MAINLAND=true

**Which issue(s) this PR fixes**:
Fixes #2521

**Special notes for your reviewer**:
Just see #2521

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```NONE

```

