### PR TITLE
Add user-specific cluster name support

### DIFF
--- a/hack/local-up-karmada.sh
+++ b/hack/local-up-karmada.sh
@@ -129,9 +129,9 @@ echo "cluster networks connected"
 
 #join push mode member clusters
 export KUBECONFIG="${MAIN_KUBECONFIG}"
-${KARMADACTL_BIN} join --karmada-context="${KARMADA_APISERVER_CLUSTER_NAME}" member1 --cluster-kubeconfig="${MEMBER_CLUSTER_KUBECONFIG}"
+${KARMADACTL_BIN} join --karmada-context="${KARMADA_APISERVER_CLUSTER_NAME}" ${MEMBER_CLUSTER_1_NAME} --cluster-kubeconfig="${MEMBER_CLUSTER_KUBECONFIG}"
 "${REPO_ROOT}"/hack/deploy-scheduler-estimator.sh "${MAIN_KUBECONFIG}" "${HOST_CLUSTER_NAME}" "${MEMBER_CLUSTER_KUBECONFIG}" "${MEMBER_CLUSTER_1_NAME}"
-${KARMADACTL_BIN} join --karmada-context="${KARMADA_APISERVER_CLUSTER_NAME}" member2 --cluster-kubeconfig="${MEMBER_CLUSTER_KUBECONFIG}"
+${KARMADACTL_BIN} join --karmada-context="${KARMADA_APISERVER_CLUSTER_NAME}" ${MEMBER_CLUSTER_2_NAME} --cluster-kubeconfig="${MEMBER_CLUSTER_KUBECONFIG}"
 "${REPO_ROOT}"/hack/deploy-scheduler-estimator.sh "${MAIN_KUBECONFIG}" "${HOST_CLUSTER_NAME}" "${MEMBER_CLUSTER_KUBECONFIG}" "${MEMBER_CLUSTER_2_NAME}"
 
 # wait until the pull mode cluster ready
@@ -151,10 +151,10 @@ function print_success() {
   echo "Local Karmada is running."
   echo -e "\nTo start using your karmada, run:"
   echo -e "  export KUBECONFIG=${MAIN_KUBECONFIG}"
-  echo "Please use 'kubectl config use-context karmada-host/karmada-apiserver' to switch the host and control plane cluster."
+  echo "Please use 'kubectl config use-context ${HOST_CLUSTER_NAME}/${KARMADA_APISERVER_CLUSTER_NAME}' to switch the host and control plane cluster."
   echo -e "\nTo manage your member clusters, run:"
   echo -e "  export KUBECONFIG=${MEMBER_CLUSTER_KUBECONFIG}"
-  echo "Please use 'kubectl config use-context member1/member2/member3' to switch to the different member cluster."
+  echo "Please use 'kubectl config use-context ${MEMBER_CLUSTER_1_NAME}/${MEMBER_CLUSTER_2_NAME}/${PULL_MODE_CLUSTER_NAME}' to switch to the different member cluster."
 }
 
 print_success


### PR DESCRIPTION
Signed-off-by: jwcesign <jiangwei115@huawei.com>

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind bug

**What this PR does / why we need it**:
If users want to set the cluster name by themselves like
```
xxx@ecs-3fa1 [03:13:06 PM] [~/workspace/git/karmada] [master *]
-> % tail ~/.zshrc
export PATH=$PATH:/home/jw/workspace/sf:/usr/local/go/bin/

# karmada env
export HOST_CLUSTER_NAME=jw-karmada-host
export MEMBER_CLUSTER_1_NAME=jw-member1-push
export MEMBER_CLUSTER_2_NAME=jw-member2-push
export PULL_MODE_CLUSTER_NAME=jw-member3-pull
export KIND_LOG_FILE=${HOME}/workspace/log/karmada
```
It will have errors:
![image](https://user-images.githubusercontent.com/19745536/190966663-19dae5ad-b031-4bf4-952d-409f53984ec1.png)


**Which issue(s) this PR fixes**:
Bugs in script to set clusters name by users

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
none
```

