### PR TITLE
`karmadactl`: Fixed options of `deinit` can not be shown issue.

### DIFF
--- a/pkg/karmadactl/deinit.go
+++ b/pkg/karmadactl/deinit.go
@@ -61,7 +61,7 @@ func NewCmdDeInit(parentCommand string) *cobra.Command {
 		},
 	}
 
-	flags := cmd.PersistentFlags()
+	flags := cmd.Flags()
 	flags.StringVarP(&opts.Namespace, "namespace", "n", "karmada-system", "namespace where Karmada components are installed.")
 	flags.StringVar(&opts.KubeConfig, "kubeconfig", "", "Path to the host cluster kubeconfig file.")
 	flags.StringVar(&opts.Context, "context", "", "The name of the kubeconfig context to use")


### PR DESCRIPTION
Signed-off-by: helen <helenfrank@protonmail.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
`deinit -h` need print options
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
A novice who has just come into contact with karmada thinks it is very important for `deinit -h` to have options.
it`s me ^-^
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: Fixed options of `deinit` can not be shown issue.
```

