### PR TITLE
[WIP]Adapt offline installation

### DIFF
--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -107,7 +107,7 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 	flags.StringVarP(&opts.EtcdStorageMode, "etcd-storage-mode", "", "hostPath",
 		fmt.Sprintf("etcd data storage mode(%s). value is PVC, specify --storage-classes-name", strings.Join(kubernetes.SupportedStorageMode(), ",")))
 	flags.StringVarP(&opts.EtcdImage, "etcd-image", "", "", "etcd image")
-	flags.StringVarP(&opts.EtcdInitImage, "etcd-init-image", "", "docker.io/alpine:3.15.1", "etcd init container image")
+	flags.StringVarP(&opts.EtcdInitImage, "etcd-init-image", "", "", "etcd init container image")
 	flags.Int32VarP(&opts.EtcdReplicas, "etcd-replicas", "", 1, "etcd replica set, cluster 3,5...singular")
 	flags.StringVarP(&opts.EtcdHostDataPath, "etcd-data", "", "/var/lib/karmada-etcd", "etcd data path,valid in hostPath mode.")
 	flags.StringVarP(&opts.EtcdNodeSelectorLabels, "etcd-node-selector-labels", "", "", "etcd pod select the labels of the node. valid in hostPath mode ( e.g. --etcd-node-selector-labels karmada.io/etcd=true)")

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -45,6 +45,8 @@ var (
 	defaultKubeConfig = filepath.Join(homeDir(), ".kube", "config")
 
 	defaultEtcdImage                  = "etcd:3.5.3-0"
+	defaultEtcdInitImage              = "alpine:3.15.1"
+	defaultDockerEtcdInitImage        = "docker.io/alpine:3.15.1"
 	defaultKubeAPIServerImage         = "kube-apiserver:v1.24.2"
 	defaultKubeControllerManagerImage = "kube-controller-manager:v1.24.2"
 )
@@ -529,6 +531,16 @@ func (i *CommandInitOption) etcdImage() string {
 		return i.EtcdImage
 	}
 	return i.kubeRegistry() + "/" + defaultEtcdImage
+}
+
+// get etcd init image
+func (i *CommandInitOption) etcdInitImage() string {
+	if i.EtcdInitImage != "" {
+		return i.EtcdInitImage
+	} else if i.KubeImageRegistry != "" {
+		return i.KubeImageRegistry + "/" + defaultEtcdInitImage
+	}
+	return defaultDockerEtcdInitImage
 }
 
 func homeDir() string {

--- a/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
@@ -136,7 +136,7 @@ peer-transport-security:
 initial-cluster-state: new
 initial-cluster-token: etcd-cluster
 initial-cluster: %s
-listen-peer-urls: http://${%s}:%v 
+listen-peer-urls: http://${%s}:%v
 listen-client-urls: https://${%s}:%v,http://127.0.0.1:%v
 initial-advertise-peer-urls: http://${%s}:%v
 advertise-client-urls: https://${%s}.%s.%s.svc.cluster.local:%v
@@ -288,7 +288,7 @@ func (i *CommandInitOption) makeETCDStatefulSet() *appsv1.StatefulSet {
 	podSpec.InitContainers = []corev1.Container{
 		{
 			Name:    "etcd-init-conf",
-			Image:   i.EtcdInitImage,
+			Image:   i.etcdInitImage(),
 			Command: i.etcdInitContainerCommand(),
 			VolumeMounts: []corev1.VolumeMount{
 				{


### PR DESCRIPTION
Signed-off-by: helen <helenfrank@protonmail.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When you cannot access the external network, you can simply install the karmada by specifying the KubeImageRegistry.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
When the KubeImageRegistry is specified, the EtcdInitImage will also be changed
```

