### PR TITLE
Add helm variables to choose controllers of karmada and kubernetes ma…

### DIFF
--- a/charts/karmada/templates/karmada-controller-manager.yaml
+++ b/charts/karmada/templates/karmada-controller-manager.yaml
@@ -50,6 +50,9 @@ spec:
             - /bin/karmada-controller-manager
             - --kubeconfig=/etc/kubeconfig
             - --bind-address=0.0.0.0
+            {{- if .Values.controllerManager.config.controllers }}
+            - --controllers={{ .Values.controllerManager.config.controllers }}
+            {{- end }}
             - --cluster-status-update-frequency=10s
             - --secure-port=10357
             - --leader-elect-resource-namespace={{ include "karmada.namespace" . }}

--- a/charts/karmada/templates/kube-controller-manager.yaml
+++ b/charts/karmada/templates/kube-controller-manager.yaml
@@ -53,7 +53,7 @@ spec:
             - --cluster-name=karmada
             - --cluster-signing-cert-file=/etc/karmada/pki/server-ca.crt
             - --cluster-signing-key-file=/etc/karmada/pki/server-ca.key
-            - --controllers=namespace,garbagecollector,serviceaccount-token,ttl-after-finished,bootstrapsigner,csrapproving,csrcleaner,csrsigning
+            - --controllers={{ .Values.kubeControllerManager.config.controllers }}
             - --kubeconfig=/etc/kubeconfig
             - --leader-elect=true
             - --node-cidr-mask-size=24

--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -261,6 +261,9 @@ controllerManager:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
+  ## @param controllerManager.config.controllers the controllers launched by the manager.
+  config:
+    controllers: ""
   ## @param controllerManager.resources resource quota of the karmada-controller-manager
   resources: {}
     # If you do want to specify resources, uncomment the following
@@ -458,6 +461,9 @@ kubeControllerManager:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
+  ## @param kubeControllerManager.config.controllers the controllers launched by the kubernetes manager.
+  config:
+    controllers: namespace,garbagecollector,serviceaccount-token,ttl-after-finished,bootstrapsigner,csrapproving,csrcleaner,csrsigning
   ## @param kubeControllerManager.resources resource quota of the kube-controller-manager
   resources:
     # If you do want to specify resources, uncomment the following


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Allow to choose controllers executed by karmada and kubernetes manager of control plane when deploying with the Helm chart.

**Which issue(s) this PR fixes**:
Fixes #2512 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Add variables `controllerManager.config.controllers` and `kubeControllerManager.config.controllers` to choose controllers executed by karmada and kubernetes managers
```

