### PR TITLE
karmadactl: Fix karmada-data directory not inilization isssue

### DIFF
--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -170,11 +170,18 @@ func (i *CommandInitOption) Complete() error {
 		}
 	}
 
-	// Determine whether KarmadaDataPath exists, if so, delete it
-	if utils.IsExist(i.KarmadaDataPath) {
-		if err := os.RemoveAll(i.KarmadaDataPath); err != nil {
+	return initializeDirectory(i.KarmadaDataPath)
+}
+
+// initializeDirectory initializes a directory and makes sure it's empty.
+func initializeDirectory(path string) error {
+	if utils.IsExist(path) {
+		if err := os.RemoveAll(path); err != nil {
 			return err
 		}
+	}
+	if err := os.MkdirAll(path, os.FileMode(0755)); err != nil {
+		return fmt.Errorf("failed to create directory: %s, error: %v", path, err)
 	}
 
 	return nil

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
@@ -1,0 +1,41 @@
+package kubernetes
+
+import (
+	"os"
+	"testing"
+)
+
+func Test_initializeDirectory(t *testing.T) {
+	tests := []struct {
+		name                string
+		createPathInAdvance bool
+		wantErr             bool
+	}{
+		{
+			name:                "Test when there is no dir exists",
+			createPathInAdvance: false,
+			wantErr:             false,
+		},
+		{
+			name:                "Test when there is dir exists",
+			createPathInAdvance: true,
+			wantErr:             false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.createPathInAdvance {
+				if err := os.MkdirAll("tmp", os.FileMode(0755)); err != nil {
+					t.Errorf("create test directory failed in advance:%v", err)
+				}
+			}
+			if err := initializeDirectory("tmp"); (err != nil) != tt.wantErr {
+				t.Errorf("initializeDirectory() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err := os.RemoveAll("tmp"); err != nil {
+				t.Errorf("clean up test directory failed after ut case:%s, %v", tt.name, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: jwcesign <jiangwei115@huawei.com>

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
This PR cause following error: https://github.com/karmada-io/karmada/pull/2297
```
jw@ecs-3fa1 [02:58:20 PM] [~/workspace/git/karmada-diff/karmada] [release-1.3]
-> % kubectl karmada init  --karmada-data=/home/jw/workspace/karmada_data
I0920 14:58:26.229852 3193825 deploy.go:145] kubeconfig file: /home/jw/.kube/karmada.config, kubernetes: https://192.168.1.237:42213
I0920 14:58:26.244413 3193825 deploy.go:165] karmada apiserver ip: [172.18.0.6]
I0920 14:58:26.620751 3193825 cert.go:229] Generate ca certificate success.
I0920 14:58:26.845036 3193825 cert.go:229] Generate karmada certificate success.
I0920 14:58:27.031043 3193825 cert.go:229] Generate apiserver certificate success.
I0920 14:58:27.088533 3193825 cert.go:229] Generate front-proxy-ca certificate success.
I0920 14:58:27.435088 3193825 cert.go:229] Generate front-proxy-client certificate success.
I0920 14:58:27.610710 3193825 cert.go:229] Generate etcd-ca certificate success.
I0920 14:58:27.725861 3193825 cert.go:229] Generate etcd-server certificate success.
I0920 14:58:27.844586 3193825 cert.go:229] Generate etcd-client certificate success.
I0920 14:58:27.844724 3193825 deploy.go:251] download crds file name: /home/jw/workspace/karmada_data/crds.tar.gz
error: prepare karmada failed.open /home/jw/workspace/karmada_data/crds.tar.gz: no such file or directory
```

With `release-1.2` works

**Which issue(s) this PR fixes**:
Fixes bugs about dir lost

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: Fixed `--karmada-data` directory not initialization issue in `init` command.
```

