### PR TITLE
replace colon with point in the rbac resource name

### DIFF
--- a/pkg/util/names/names.go
+++ b/pkg/util/names/names.go
@@ -55,6 +55,17 @@ func GetClusterName(executionSpaceName string) (string, error) {
 
 // GenerateBindingName will generate binding name by kind and name
 func GenerateBindingName(kind, name string) string {
+	// The name of resources, like 'Role'/'ClusterRole'/'RoleBinding'/'ClusterRoleBinding',
+	// may contain symbols(like ':') that are not allowed by CRD resources which require the
+	// name can be used as a DNS subdomain name. So, we need to replace it.
+	// These resources may also allow for other characters(like '&','$') that are not allowed
+	// by CRD resources, we only handle the most common ones now for performance concerns.
+	// For more information about the DNS subdomain name, please refer to
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names.
+	if strings.Contains(name, ":") {
+		name = strings.ReplaceAll(name, ":", ".")
+	}
+
 	return strings.ToLower(name + "-" + kind)
 }
 
@@ -73,6 +84,17 @@ func GenerateBindingReferenceKey(namespace, name string) string {
 
 // GenerateWorkName will generate work name by its name and the hash of its namespace, kind and name.
 func GenerateWorkName(kind, name, namespace string) string {
+	// The name of resources, like 'Role'/'ClusterRole'/'RoleBinding'/'ClusterRoleBinding',
+	// may contain symbols(like ':') that are not allowed by CRD resources which require the
+	// name can be used as a DNS subdomain name. So, we need to replace it.
+	// These resources may also allow for other characters(like '&','$') that are not allowed
+	// by CRD resources, we only handle the most common ones now for performance concerns.
+	// For more information about the DNS subdomain name, please refer to
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names.
+	if strings.Contains(name, ":") {
+		name = strings.ReplaceAll(name, ":", ".")
+	}
+
 	var workName string
 	if len(namespace) == 0 {
 		workName = strings.ToLower(name + "-" + kind)

--- a/pkg/util/names/names_test.go
+++ b/pkg/util/names/names_test.go
@@ -140,6 +140,31 @@ func TestGenerateBindingName(t *testing.T) {
 			name:     "Pod",
 			expect:   "pod-pods",
 		},
+		// RBAC kind resource test with colon character in the name
+		{
+			testCase: "role kind resource",
+			kind:     "Role",
+			name:     "system:controller:tom",
+			expect:   "system.controller.tom-role",
+		},
+		{
+			testCase: "clusterRole kind resource",
+			kind:     "ClusterRole",
+			name:     "system::tom",
+			expect:   "system..tom-clusterrole",
+		},
+		{
+			testCase: "roleBinding kind resource",
+			kind:     "RoleBinding",
+			name:     "system::tt:tom",
+			expect:   "system..tt.tom-rolebinding",
+		},
+		{
+			testCase: "clusterRoleBinding kind resource",
+			kind:     "ClusterRoleBinding",
+			name:     "system:tt:tom",
+			expect:   "system.tt.tom-clusterrolebinding",
+		},
 	}
 	for _, test := range tests {
 		if result := GenerateBindingName(test.kind, test.name); result != test.expect {

--- a/test/e2e/clusterpropagationpolicy_test.go
+++ b/test/e2e/clusterpropagationpolicy_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/onsi/ginkgo/v2"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 
@@ -57,6 +58,94 @@ var _ = ginkgo.Describe("[BasicClusterPropagation] basic cluster propagation tes
 			framework.GetCRD(dynamicClient, crd.Name)
 			framework.WaitCRDPresentOnClusters(karmadaClient, framework.ClusterNames(),
 				fmt.Sprintf("%s/%s", crd.Spec.Group, "v1alpha1"), crd.Spec.Names.Kind)
+		})
+	})
+
+	ginkgo.Context("ClusterRole propagation testing", func() {
+		var (
+			clusterRoleName string
+			policyName      string
+			policy          *policyv1alpha1.ClusterPropagationPolicy
+			clusterRole     *rbacv1.ClusterRole
+		)
+
+		ginkgo.BeforeEach(func() {
+			policyName = clusterRoleNamePrefix + rand.String(RandomStrLength)
+			clusterRoleName = fmt.Sprintf("system:test-%s", policyName)
+
+			clusterRole = testhelper.NewClusterRole(clusterRoleName, nil)
+			policy = testhelper.NewClusterPropagationPolicy(policyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: clusterRole.APIVersion,
+					Kind:       clusterRole.Kind,
+					Name:       clusterRole.Name,
+				},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: framework.ClusterNames(),
+				},
+			})
+		})
+
+		ginkgo.BeforeEach(func() {
+			framework.CreateClusterPropagationPolicy(karmadaClient, policy)
+			framework.CreateClusterRole(kubeClient, clusterRole)
+			ginkgo.DeferCleanup(func() {
+				framework.RemoveClusterPropagationPolicy(karmadaClient, policy.Name)
+				framework.RemoveClusterRole(kubeClient, clusterRole.Name)
+				framework.WaitClusterRoleDisappearOnClusters(framework.ClusterNames(), clusterRole.Name)
+			})
+		})
+
+		ginkgo.It("clusterRole propagation testing", func() {
+			framework.WaitClusterRolePresentOnClustersFitWith(framework.ClusterNames(), clusterRole.Name,
+				func(role *rbacv1.ClusterRole) bool {
+					return true
+				})
+		})
+	})
+
+	ginkgo.Context("ClusterRoleBinding propagation testing", func() {
+		var (
+			clusterRoleBindingName string
+			policyName             string
+			policy                 *policyv1alpha1.ClusterPropagationPolicy
+			clusterRoleBinding     *rbacv1.ClusterRoleBinding
+		)
+
+		ginkgo.BeforeEach(func() {
+			policyName = clusterRoleBindingNamePrefix + rand.String(RandomStrLength)
+			clusterRoleBindingName = fmt.Sprintf("system:test.tt:%s", policyName)
+
+			clusterRoleBinding = testhelper.NewClusterRoleBinding(clusterRoleBindingName, clusterRoleBindingName, nil)
+			policy = testhelper.NewClusterPropagationPolicy(policyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: clusterRoleBinding.APIVersion,
+					Kind:       clusterRoleBinding.Kind,
+					Name:       clusterRoleBinding.Name,
+				},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: framework.ClusterNames(),
+				},
+			})
+		})
+
+		ginkgo.BeforeEach(func() {
+			framework.CreateClusterPropagationPolicy(karmadaClient, policy)
+			framework.CreateClusterRoleBinding(kubeClient, clusterRoleBinding)
+			ginkgo.DeferCleanup(func() {
+				framework.RemoveClusterPropagationPolicy(karmadaClient, policy.Name)
+				framework.RemoveClusterRoleBinding(kubeClient, clusterRoleBinding.Name)
+				framework.WaitClusterRoleBindingDisappearOnClusters(framework.ClusterNames(), clusterRoleBinding.Name)
+			})
+		})
+
+		ginkgo.It("clusterRoleBinding propagation testing", func() {
+			framework.WaitClusterRoleBindingPresentOnClustersFitWith(framework.ClusterNames(), clusterRoleBinding.Name,
+				func(binding *rbacv1.ClusterRoleBinding) bool {
+					return true
+				})
 		})
 	})
 })

--- a/test/e2e/framework/rbac.go
+++ b/test/e2e/framework/rbac.go
@@ -14,18 +14,82 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// CreateClusterRole create clusterRole.
-func CreateClusterRole(client kubernetes.Interface, clusterRole *rbacv1.ClusterRole) {
-	ginkgo.By(fmt.Sprintf("Creating ClusterRole(%s)", clusterRole.Name), func() {
-		_, err := client.RbacV1().ClusterRoles().Create(context.TODO(), clusterRole, metav1.CreateOptions{})
+// CreateRole create role.
+func CreateRole(client kubernetes.Interface, role *rbacv1.Role) {
+	ginkgo.By(fmt.Sprintf("Creating Role(%s/%s)", role.Namespace, role.Name), func() {
+		_, err := client.RbacV1().Roles(role.Namespace).Create(context.TODO(), role, metav1.CreateOptions{})
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	})
 }
 
-// CreateClusterRoleBinding create clusterRoleBinding.
-func CreateClusterRoleBinding(client kubernetes.Interface, clusterRoleBinding *rbacv1.ClusterRoleBinding) {
-	ginkgo.By(fmt.Sprintf("Creating ClusterRoleBinding(%s)", clusterRoleBinding.Name), func() {
-		_, err := client.RbacV1().ClusterRoleBindings().Create(context.TODO(), clusterRoleBinding, metav1.CreateOptions{})
+// RemoveRole delete role.
+func RemoveRole(client kubernetes.Interface, namespace, name string) {
+	ginkgo.By(fmt.Sprintf("Remove Role(%s/%s)", namespace, name), func() {
+		err := client.RbacV1().Roles(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+		if apierrors.IsNotFound(err) {
+			return
+		}
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+}
+
+// WaitRolePresentOnClustersFitWith wait role present on clusters sync with fit func.
+func WaitRolePresentOnClustersFitWith(clusters []string, namespace, name string, fit func(role *rbacv1.Role) bool) {
+	ginkgo.By(fmt.Sprintf("Waiting for role(%s/%s) synced on member clusters", namespace, name), func() {
+		for _, clusterName := range clusters {
+			WaitRolePresentOnClusterFitWith(clusterName, namespace, name, fit)
+		}
+	})
+}
+
+// WaitRolePresentOnClusterFitWith wait role present on member cluster sync with fit func.
+func WaitRolePresentOnClusterFitWith(cluster, namespace, name string, fit func(role *rbacv1.Role) bool) {
+	clusterClient := GetClusterClient(cluster)
+	gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+
+	klog.Infof("Waiting for role(%s/%s) synced on cluster(%s)", namespace, name, cluster)
+	gomega.Eventually(func() bool {
+		role, err := clusterClient.RbacV1().Roles(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return fit(role)
+	}, pollTimeout, pollInterval).Should(gomega.Equal(true))
+}
+
+// WaitRoleDisappearOnClusters wait role disappear on member clusters until timeout.
+func WaitRoleDisappearOnClusters(clusters []string, namespace, name string) {
+	ginkgo.By(fmt.Sprintf("Check if role(%s/%s) disappear on member clusters", namespace, name), func() {
+		for _, clusterName := range clusters {
+			WaitRoleDisappearOnCluster(clusterName, namespace, name)
+		}
+	})
+}
+
+// WaitRoleDisappearOnCluster wait role disappear on cluster until timeout.
+func WaitRoleDisappearOnCluster(cluster, namespace, name string) {
+	clusterClient := GetClusterClient(cluster)
+	gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+
+	klog.Infof("Waiting for role(%s/%s) disappear on cluster(%s)", namespace, name, cluster)
+	gomega.Eventually(func() bool {
+		_, err := clusterClient.RbacV1().Roles(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err == nil {
+			return false
+		}
+		if apierrors.IsNotFound(err) {
+			return true
+		}
+
+		klog.Errorf("Failed to get role(%s/%s) on cluster(%s), err: %v", namespace, name, cluster, err)
+		return false
+	}, pollTimeout, pollInterval).Should(gomega.Equal(true))
+}
+
+// CreateClusterRole create clusterRole.
+func CreateClusterRole(client kubernetes.Interface, clusterRole *rbacv1.ClusterRole) {
+	ginkgo.By(fmt.Sprintf("Creating ClusterRole(%s)", clusterRole.Name), func() {
+		_, err := client.RbacV1().ClusterRoles().Create(context.TODO(), clusterRole, metav1.CreateOptions{})
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	})
 }
@@ -41,6 +105,139 @@ func RemoveClusterRole(client kubernetes.Interface, name string) {
 	})
 }
 
+// WaitClusterRolePresentOnClustersFitWith wait clusterRole present on clusters sync with fit func.
+func WaitClusterRolePresentOnClustersFitWith(clusters []string, name string, fit func(clusterRole *rbacv1.ClusterRole) bool) {
+	ginkgo.By(fmt.Sprintf("Waiting for clusterRole(%s) synced on member clusters", name), func() {
+		for _, clusterName := range clusters {
+			WaitClusterRolePresentOnClusterFitWith(clusterName, name, fit)
+		}
+	})
+}
+
+// WaitClusterRolePresentOnClusterFitWith wait clusterRole present on member cluster sync with fit func.
+func WaitClusterRolePresentOnClusterFitWith(cluster, name string, fit func(clusterRole *rbacv1.ClusterRole) bool) {
+	clusterClient := GetClusterClient(cluster)
+	gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+
+	klog.Infof("Waiting for clusterRole(%s) synced on cluster(%s)", name, cluster)
+	gomega.Eventually(func() bool {
+		clusterRole, err := clusterClient.RbacV1().ClusterRoles().Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return fit(clusterRole)
+	}, pollTimeout, pollInterval).Should(gomega.Equal(true))
+}
+
+// WaitClusterRoleDisappearOnClusters wait clusterRole disappear on member clusters until timeout.
+func WaitClusterRoleDisappearOnClusters(clusters []string, name string) {
+	ginkgo.By(fmt.Sprintf("Check if clusterRole(%s) disappear on member clusters", name), func() {
+		for _, clusterName := range clusters {
+			WaitClusterRoleDisappearOnCluster(clusterName, name)
+		}
+	})
+}
+
+// WaitClusterRoleDisappearOnCluster wait clusterRole disappear on cluster until timeout.
+func WaitClusterRoleDisappearOnCluster(cluster, name string) {
+	clusterClient := GetClusterClient(cluster)
+	gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+
+	klog.Infof("Waiting for clusterRole(%s) disappear on cluster(%s)", name, cluster)
+	gomega.Eventually(func() bool {
+		_, err := clusterClient.RbacV1().ClusterRoles().Get(context.TODO(), name, metav1.GetOptions{})
+		if err == nil {
+			return false
+		}
+		if apierrors.IsNotFound(err) {
+			return true
+		}
+
+		klog.Errorf("Failed to get clusterRole(%s) on cluster(%s), err: %v", name, cluster, err)
+		return false
+	}, pollTimeout, pollInterval).Should(gomega.Equal(true))
+}
+
+// CreateRoleBinding create roleBinding.
+func CreateRoleBinding(client kubernetes.Interface, roleBinding *rbacv1.RoleBinding) {
+	ginkgo.By(fmt.Sprintf("Creating RoleBinding(%s/%s)", roleBinding.Namespace, roleBinding.Name), func() {
+		_, err := client.RbacV1().RoleBindings(roleBinding.Namespace).Create(context.TODO(), roleBinding, metav1.CreateOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+}
+
+// RemoveRoleBinding delete roleBinding.
+func RemoveRoleBinding(client kubernetes.Interface, namespace, name string) {
+	ginkgo.By(fmt.Sprintf("Remove RoleBinding(%s/%s)", namespace, name), func() {
+		err := client.RbacV1().RoleBindings(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+		if apierrors.IsNotFound(err) {
+			return
+		}
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+}
+
+// WaitRoleBindingPresentOnClustersFitWith wait robeBinding present on clusters sync with fit func.
+func WaitRoleBindingPresentOnClustersFitWith(clusters []string, namespace, name string, fit func(roleBinding *rbacv1.RoleBinding) bool) {
+	ginkgo.By(fmt.Sprintf("Waiting for rolebinding(%s/%s) synced on member clusters", namespace, name), func() {
+		for _, clusterName := range clusters {
+			WaitRoleBindingPresentOnClusterFitWith(clusterName, namespace, name, fit)
+		}
+	})
+}
+
+// WaitRoleBindingPresentOnClusterFitWith wait roleBinding present on member cluster sync with fit func.
+func WaitRoleBindingPresentOnClusterFitWith(cluster, namespace, name string, fit func(roleBinding *rbacv1.RoleBinding) bool) {
+	clusterClient := GetClusterClient(cluster)
+	gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+
+	klog.Infof("Waiting for roleBinding(%s/%s) synced on cluster(%s)", namespace, name, cluster)
+	gomega.Eventually(func() bool {
+		roleBinding, err := clusterClient.RbacV1().RoleBindings(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return fit(roleBinding)
+	}, pollTimeout, pollInterval).Should(gomega.Equal(true))
+}
+
+// WaitRoleBindingDisappearOnClusters wait roleBinding disappear on member clusters until timeout.
+func WaitRoleBindingDisappearOnClusters(clusters []string, namespace, name string) {
+	ginkgo.By(fmt.Sprintf("Check if roleBinding(%s/%s) disappear on member clusters", namespace, name), func() {
+		for _, clusterName := range clusters {
+			WaitRoleBindingDisappearOnCluster(clusterName, namespace, name)
+		}
+	})
+}
+
+// WaitRoleBindingDisappearOnCluster wait roleBinding disappear on cluster until timeout.
+func WaitRoleBindingDisappearOnCluster(cluster, namespace, name string) {
+	clusterClient := GetClusterClient(cluster)
+	gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+
+	klog.Infof("Waiting for roleBinding(%s/%s) disappear on cluster(%s)", namespace, name, cluster)
+	gomega.Eventually(func() bool {
+		_, err := clusterClient.RbacV1().RoleBindings(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err == nil {
+			return false
+		}
+		if apierrors.IsNotFound(err) {
+			return true
+		}
+
+		klog.Errorf("Failed to get roleBinding(%s/%s) on cluster(%s), err: %v", namespace, name, cluster, err)
+		return false
+	}, pollTimeout, pollInterval).Should(gomega.Equal(true))
+}
+
+// CreateClusterRoleBinding create clusterRoleBinding.
+func CreateClusterRoleBinding(client kubernetes.Interface, clusterRoleBinding *rbacv1.ClusterRoleBinding) {
+	ginkgo.By(fmt.Sprintf("Creating ClusterRoleBinding(%s)", clusterRoleBinding.Name), func() {
+		_, err := client.RbacV1().ClusterRoleBindings().Create(context.TODO(), clusterRoleBinding, metav1.CreateOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+}
+
 // RemoveClusterRoleBinding delete clusterRoleBinding.
 func RemoveClusterRoleBinding(client kubernetes.Interface, name string) {
 	ginkgo.By(fmt.Sprintf("Remove ClusterRoleBinding(%s)", name), func() {
@@ -50,6 +247,59 @@ func RemoveClusterRoleBinding(client kubernetes.Interface, name string) {
 		}
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	})
+}
+
+// WaitClusterRoleBindingPresentOnClustersFitWith wait clusterRoleBinding present on clusters sync with fit func.
+func WaitClusterRoleBindingPresentOnClustersFitWith(clusters []string, name string, fit func(clusterRoleBinding *rbacv1.ClusterRoleBinding) bool) {
+	ginkgo.By(fmt.Sprintf("Waiting for clusterRolebinding(%s) synced on member clusters", name), func() {
+		for _, clusterName := range clusters {
+			WaitClusterRoleBindingPresentOnClusterFitWith(clusterName, name, fit)
+		}
+	})
+}
+
+// WaitClusterRoleBindingPresentOnClusterFitWith wait clusterRoleBinding present on member cluster sync with fit func.
+func WaitClusterRoleBindingPresentOnClusterFitWith(cluster, name string, fit func(clusterRoleBinding *rbacv1.ClusterRoleBinding) bool) {
+	clusterClient := GetClusterClient(cluster)
+	gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+
+	klog.Infof("Waiting for clusterRolebinding(%s) synced on cluster(%s)", name, cluster)
+	gomega.Eventually(func() bool {
+		clusterRoleBinding, err := clusterClient.RbacV1().ClusterRoleBindings().Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return fit(clusterRoleBinding)
+	}, pollTimeout, pollInterval).Should(gomega.Equal(true))
+}
+
+// WaitClusterRoleBindingDisappearOnClusters wait clusterRoleBinding disappear on member clusters until timeout.
+func WaitClusterRoleBindingDisappearOnClusters(clusters []string, name string) {
+	ginkgo.By(fmt.Sprintf("Check if clusterRoleBinding(%s) disappear on member clusters", name), func() {
+		for _, clusterName := range clusters {
+			WaitClusterRoleBindingDisappearOnCluster(clusterName, name)
+		}
+	})
+}
+
+// WaitClusterRoleBindingDisappearOnCluster wait clusterRoleBinding disappear on cluster until timeout.
+func WaitClusterRoleBindingDisappearOnCluster(cluster, name string) {
+	clusterClient := GetClusterClient(cluster)
+	gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+
+	klog.Infof("Waiting for clusterRoleBinding(%s) disappear on cluster(%s)", name, cluster)
+	gomega.Eventually(func() bool {
+		_, err := clusterClient.RbacV1().ClusterRoleBindings().Get(context.TODO(), name, metav1.GetOptions{})
+		if err == nil {
+			return false
+		}
+		if apierrors.IsNotFound(err) {
+			return true
+		}
+
+		klog.Errorf("Failed to get clusterRoleBinding(%s) on cluster(%s), err: %v", name, cluster, err)
+		return false
+	}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 }
 
 // CreateServiceAccount create serviceaccount.

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -51,6 +51,10 @@ const (
 	ingressNamePrefix            = "ingress-"
 	daemonSetNamePrefix          = "daemonset-"
 	statefulSetNamePrefix        = "statefulset-"
+	roleNamePrefix               = "role-"
+	clusterRoleNamePrefix        = "clusterrole-"
+	roleBindingNamePrefix        = "rolebinding-"
+	clusterRoleBindingNamePrefix = "clusterrolebinding-"
 
 	updateDeploymentReplicas  = 6
 	updateStatefulSetReplicas = 6

--- a/test/helper/resource.go
+++ b/test/helper/resource.go
@@ -642,9 +642,42 @@ func NewServiceaccount(namespace, name string) *corev1.ServiceAccount {
 	}
 }
 
+// NewRole will build a new role object.
+func NewRole(namespace, name string, rules []rbacv1.PolicyRule) *rbacv1.Role {
+	return &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "Role",
+		},
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Rules:      rules,
+	}
+}
+
+// NewRoleBinding will build a new roleBinding object.
+func NewRoleBinding(namespace, name, roleRefName string, subject []rbacv1.Subject) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "RoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Subjects:   subject,
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     roleRefName,
+		},
+	}
+}
+
 // NewClusterRole will build a new clusterRole object.
 func NewClusterRole(name string, rules []rbacv1.PolicyRule) *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "ClusterRole",
+		},
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Rules:      rules,
 	}
@@ -653,6 +686,10 @@ func NewClusterRole(name string, rules []rbacv1.PolicyRule) *rbacv1.ClusterRole 
 // NewClusterRoleBinding will build a new clusterRoleBinding object.
 func NewClusterRoleBinding(name, roleRefName string, subject []rbacv1.Subject) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "ClusterRoleBinding",
+		},
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Subjects:   subject,
 		RoleRef: rbacv1.RoleRef{


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind bug
/kind feature

**What this PR does / why we need it**:

As talked about in #2392, when we propagate RBAC resources, whose names contain colon characters, it will report err.

The reason is that colons are allowed in names in validations for these resources, but this is different from name validations for CRD resources:

https://github.com/kubernetes/kubernetes/blob/f0823c0f59d6ea8e2ad0dc4e3fe0f2b396c9185f/pkg/apis/rbac/validation/validation.go#L124

https://github.com/kubernetes/kubernetes/blob/f0823c0f59d6ea8e2ad0dc4e3fe0f2b396c9185f/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/validator.go#L60

**Which issue(s) this PR fixes**:
Fixes #2392 

**Special notes for your reviewer**:

Replace colon with point in the RBAC resource name.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-controller-manager: fix the error of resources whose name contains colons failing to be created.
```

