### PR TITLE
introduce karmada-apiserver-advertise-address

### DIFF
--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -47,6 +47,9 @@ var (
 		# Private registry can be specified for all images
 		%[1]s init --etcd-image local.registry.com/library/etcd:3.5.3-0
 
+		# Specify Karmada API Server IP address. If not set, the address on the master node will be used.
+		%[1]s init --karmada-apiserver-advertise-address 192.168.1.2
+
 		# Deploy highly available(HA) karmada
 		%[1]s init --karmada-apiserver-replicas 3 --etcd-replicas 3 --etcd-storage-mode PVC --storage-classes-name {StorageClassesName}
 
@@ -115,6 +118,7 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 	// karmada
 	crdURL := fmt.Sprintf("https://github.com/karmada-io/karmada/releases/download/%s/crds.tar.gz", releaseVer.FirstMinorRelease())
 	flags.StringVar(&opts.CRDs, "crds", crdURL, "Karmada crds resource.(local file e.g. --crds /root/crds.tar.gz)")
+	flags.StringVarP(&opts.KarmadaAPIServerAdvertiseAddress, "karmada-apiserver-advertise-address", "", "", "The IP address the Karmada API Server will advertise it's listening on. If not set, the address on the master node will be used.")
 	flags.Int32VarP(&opts.KarmadaAPIServerNodePort, "port", "p", 32443, "Karmada apiserver service node port")
 	flags.StringVarP(&opts.KarmadaDataPath, "karmada-data", "d", "/etc/karmada", "Karmada data path. kubeconfig cert and crds files")
 	flags.StringVarP(&opts.KarmadaPkiPath, "karmada-pki", "", "/etc/karmada/pki", "Karmada pki path. Karmada cert files")

--- a/pkg/karmadactl/cmdinit/kubernetes/node.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/node.go
@@ -19,7 +19,12 @@ var (
 	etcdSelectorLabels map[string]string
 )
 
-func (i *CommandInitOption) getKubeMasterIP() error {
+func (i *CommandInitOption) getKarmadaAPIServerIP() error {
+	if i.KarmadaAPIServerAdvertiseAddress != "" {
+		i.KarmadaAPIServerIP = append(i.KarmadaAPIServerIP, utils.StringToNetIP(i.KarmadaAPIServerAdvertiseAddress))
+		return nil
+	}
+
 	nodeClient := i.KubeClientSet.CoreV1().Nodes()
 	masterNodes, err := nodeClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/master"})
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: wuyingjun <wuyingjun_yewu@cmss.chinamobile.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/karmada/issues/2537

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: Introduced `--karmada-apiserver-advertise-address` flag to specify Karmada APIserver's address to the `init` sub-command.
```

