### PR TITLE
[E2E] replace gomeme.Eventually with wait when logic has assertions

### DIFF
--- a/test/e2e/failover_test.go
+++ b/test/e2e/failover_test.go
@@ -104,20 +104,17 @@ var _ = framework.SerialDescribe("failover testing", func() {
 			})
 
 			ginkgo.By("check whether deployment of failed cluster is rescheduled to other available cluster", func() {
-				err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+				gomega.Eventually(func() int {
 					targetClusterNames = framework.ExtractTargetClustersFrom(controlPlaneClient, deployment)
 					for _, targetClusterName := range targetClusterNames {
 						// the target cluster should be overwritten to another available cluster
 						if !testhelper.IsExclude(targetClusterName, disabledClusters) {
-							return false, nil
+							return 0
 						}
 					}
 
-					gomega.Expect(len(targetClusterNames)).Should(gomega.Equal(minGroups))
-					return true, nil
-				})
-
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+					return len(targetClusterNames)
+				}, pollTimeout, pollInterval).Should(gomega.Equal(minGroups))
 			})
 
 			ginkgo.By("recover not ready cluster", func() {

--- a/test/e2e/karmadactl_test.go
+++ b/test/e2e/karmadactl_test.go
@@ -14,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
@@ -130,13 +129,12 @@ var _ = ginkgo.Describe("Karmadactl promote testing", func() {
 			ginkgo.By(fmt.Sprintf("Waiting for deployment(%s)'s replicas is ready", deploymentName), func() {
 				wantedReplicas := *deployment.Spec.Replicas
 
-				err := wait.PollImmediate(pollInterval, pollTimeout, func() (done bool, err error) {
+				gomega.Eventually(func(g gomega.Gomega) (bool, error) {
 					currentDeployment, err := kubeClient.AppsV1().Deployments(deploymentNamespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
-					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+					g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 					return framework.CheckDeploymentReadyStatus(currentDeployment, wantedReplicas), nil
-				})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 			})
 		})
 	})

--- a/test/e2e/porting_workloads_test.go
+++ b/test/e2e/porting_workloads_test.go
@@ -8,7 +8,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
@@ -65,9 +64,9 @@ var _ = ginkgo.Describe("porting workloads testing", func() {
 				wantedReplicas := *deployment.Spec.Replicas * int32(len(framework.Clusters())-1)
 
 				klog.Infof("Waiting for deployment(%s/%s) collecting status", deploymentNamespace, deploymentName)
-				err := wait.PollImmediate(pollInterval, pollTimeout, func() (done bool, err error) {
+				gomega.Eventually(func(g gomega.Gomega) (bool, error) {
 					currentDeployment, err := kubeClient.AppsV1().Deployments(testNamespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
-					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+					g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 					klog.Infof("deployment(%s/%s) readyReplicas: %d, wanted replicas: %d", deploymentNamespace, deploymentName, currentDeployment.Status.ReadyReplicas, wantedReplicas)
 					if currentDeployment.Status.ReadyReplicas == wantedReplicas &&
@@ -78,8 +77,7 @@ var _ = ginkgo.Describe("porting workloads testing", func() {
 					}
 
 					return false, nil
-				})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 			})
 
 			klog.Infof(
@@ -93,9 +91,9 @@ var _ = ginkgo.Describe("porting workloads testing", func() {
 				wantedReplicas := *deployment.Spec.Replicas * int32(len(framework.Clusters()))
 
 				klog.Infof("Waiting for deployment(%s/%s) collecting status", deploymentNamespace, deploymentName)
-				err := wait.PollImmediate(pollInterval, pollTimeout, func() (done bool, err error) {
+				gomega.Eventually(func(g gomega.Gomega) (bool, error) {
 					currentDeployment, err := kubeClient.AppsV1().Deployments(testNamespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
-					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+					g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 					klog.Infof("deployment(%s/%s) readyReplicas: %d, wanted replicas: %d", deploymentNamespace, deploymentName, currentDeployment.Status.ReadyReplicas, wantedReplicas)
 					if currentDeployment.Status.ReadyReplicas == wantedReplicas &&
@@ -106,8 +104,7 @@ var _ = ginkgo.Describe("porting workloads testing", func() {
 					}
 
 					return false, nil
-				})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 			})
 		})
 	})

--- a/test/e2e/rescheduling_test.go
+++ b/test/e2e/rescheduling_test.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
@@ -137,12 +136,11 @@ var _ = ginkgo.Describe("[cluster unjoined] reschedule testing", func() {
 			})
 
 			ginkgo.By("check if the scheduled condition is true", func() {
-				err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+				gomega.Eventually(func(g gomega.Gomega) (bool, error) {
 					rb, err := getResourceBinding(deployment)
-					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+					g.Expect(err).ShouldNot(gomega.HaveOccurred())
 					return meta.IsStatusConditionTrue(rb.Status.Conditions, workv1alpha2.Scheduled), nil
-				})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 			})
 		})
 	})

--- a/test/e2e/resource_test.go
+++ b/test/e2e/resource_test.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
@@ -72,9 +71,9 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 				wantedReplicas := *deployment.Spec.Replicas * int32(len(framework.Clusters()))
 
 				klog.Infof("Waiting for deployment(%s/%s) collecting correctly status", deploymentNamespace, deploymentName)
-				err := wait.PollImmediate(pollInterval, pollTimeout, func() (done bool, err error) {
+				gomega.Eventually(func(g gomega.Gomega) (bool, error) {
 					currentDeployment, err := kubeClient.AppsV1().Deployments(testNamespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
-					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+					g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 					klog.Infof("deployment(%s/%s) readyReplicas: %d, wanted replicas: %d", deploymentNamespace, deploymentName, currentDeployment.Status.ReadyReplicas, wantedReplicas)
 					if currentDeployment.Status.ReadyReplicas == wantedReplicas &&
@@ -85,8 +84,7 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 					}
 
 					return false, nil
-				})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 			})
 
 			framework.UpdateDeploymentReplicas(kubeClient, deployment, updateDeploymentReplicas)
@@ -95,9 +93,9 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 				wantedReplicas := updateDeploymentReplicas * int32(len(framework.Clusters()))
 
 				klog.Infof("Waiting for deployment(%s/%s) collecting correctly status", deploymentNamespace, deploymentName)
-				err := wait.PollImmediate(pollInterval, pollTimeout, func() (done bool, err error) {
+				gomega.Eventually(func(g gomega.Gomega) (bool, error) {
 					currentDeployment, err := kubeClient.AppsV1().Deployments(testNamespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
-					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+					g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 					if currentDeployment.Status.ReadyReplicas == wantedReplicas &&
 						currentDeployment.Status.AvailableReplicas == wantedReplicas &&
@@ -107,8 +105,7 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 					}
 
 					return false, nil
-				})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 			})
 		})
 	})
@@ -363,9 +360,9 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 				wantedSucceedPods := int32(len(framework.Clusters()))
 
 				klog.Infof("Waiting for job(%s/%s) collecting correctly status", jobNamespace, jobName)
-				err := wait.PollImmediate(pollInterval, pollTimeout, func() (done bool, err error) {
+				gomega.Eventually(func(g gomega.Gomega) (bool, error) {
 					currentJob, err := kubeClient.BatchV1().Jobs(jobNamespace).Get(context.TODO(), jobName, metav1.GetOptions{})
-					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+					g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 					klog.Infof("job(%s/%s) succeedPods: %d, wanted succeedPods: %d", jobNamespace, jobName, currentJob.Status.Succeeded, wantedSucceedPods)
 					if currentJob.Status.Succeeded == wantedSucceedPods {
@@ -373,8 +370,7 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 					}
 
 					return false, nil
-				})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 			})
 		})
 	})
@@ -424,9 +420,9 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 				wantedReplicas := int32(len(framework.Clusters()))
 
 				klog.Infof("Waiting for daemonSet(%s/%s) collecting correctly status", daemonSetNamespace, daemonSetName)
-				err := wait.PollImmediate(pollInterval, pollTimeout, func() (done bool, err error) {
+				gomega.Eventually(func(g gomega.Gomega) (bool, error) {
 					currentDaemonSet, err := kubeClient.AppsV1().DaemonSets(daemonSetNamespace).Get(context.TODO(), daemonSetName, metav1.GetOptions{})
-					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+					g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 					klog.Infof("daemonSet(%s/%s) replicas: %d, wanted replicas: %d", daemonSetNamespace, daemonSetName, currentDaemonSet.Status.NumberReady, wantedReplicas)
 					if currentDaemonSet.Status.NumberReady == wantedReplicas &&
@@ -438,8 +434,7 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 					}
 
 					return false, nil
-				})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 			})
 
 			framework.PatchPropagationPolicy(karmadaClient, policy.Namespace, policyName, patch, types.JSONPatchType)
@@ -448,9 +443,9 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 				wantedReplicas := int32(len(framework.Clusters()) - 1)
 
 				klog.Infof("Waiting for daemonSet(%s/%s) collecting correctly status", daemonSetNamespace, daemonSetName)
-				err := wait.PollImmediate(pollInterval, pollTimeout, func() (done bool, err error) {
+				gomega.Eventually(func(g gomega.Gomega) (bool, error) {
 					currentDaemonSet, err := kubeClient.AppsV1().DaemonSets(daemonSetNamespace).Get(context.TODO(), daemonSetName, metav1.GetOptions{})
-					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+					g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 					if currentDaemonSet.Status.NumberReady == wantedReplicas &&
 						currentDaemonSet.Status.CurrentNumberScheduled == wantedReplicas &&
@@ -461,8 +456,7 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 					}
 
 					return false, nil
-				})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 			})
 		})
 	})
@@ -502,9 +496,9 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 			ginkgo.By("check whether the statefulSet status can be correctly collected", func() {
 				wantedReplicas := *statefulSet.Spec.Replicas * int32(len(framework.Clusters()))
 				klog.Infof("Waiting for statefulSet(%s/%s) collecting correctly status", statefulSetNamespace, statefulSetName)
-				err := wait.PollImmediate(pollInterval, pollTimeout, func() (done bool, err error) {
+				gomega.Eventually(func(g gomega.Gomega) (bool, error) {
 					currentStatefulSet, err := kubeClient.AppsV1().StatefulSets(statefulSetNamespace).Get(context.TODO(), statefulSetName, metav1.GetOptions{})
-					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+					g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 					klog.Infof("statefulSet(%s/%s) replicas: %d, wanted replicas: %d", statefulSetNamespace, statefulSetName, currentStatefulSet.Status.Replicas, wantedReplicas)
 					if currentStatefulSet.Status.Replicas == wantedReplicas &&
@@ -515,8 +509,7 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 					}
 
 					return false, nil
-				})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 			})
 
 			framework.UpdateStatefulSetReplicas(kubeClient, statefulSet, updateStatefulSetReplicas)
@@ -525,9 +518,9 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 				wantedReplicas := updateStatefulSetReplicas * int32(len(framework.Clusters()))
 
 				klog.Infof("Waiting for statefulSet(%s/%s) collecting correctly status", statefulSetNamespace, statefulSetName)
-				err := wait.PollImmediate(pollInterval, pollTimeout, func() (done bool, err error) {
+				gomega.Eventually(func(g gomega.Gomega) (bool, error) {
 					currentStatefulSet, err := kubeClient.AppsV1().StatefulSets(statefulSetNamespace).Get(context.TODO(), statefulSetName, metav1.GetOptions{})
-					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+					g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 					if currentStatefulSet.Status.Replicas == wantedReplicas &&
 						currentStatefulSet.Status.ReadyReplicas == wantedReplicas &&
@@ -537,8 +530,7 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 					}
 
 					return false, nil
-				})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 			})
 		})
 	})

--- a/test/e2e/scheduling_test.go
+++ b/test/e2e/scheduling_test.go
@@ -90,12 +90,11 @@ var _ = ginkgo.Describe("propagation with label and group constraints testing", 
 			})
 
 			ginkgo.By("check if the scheduled condition is true", func() {
-				err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+				gomega.Eventually(func(g gomega.Gomega) (bool, error) {
 					rb, err := getResourceBinding(deployment)
-					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+					g.Expect(err).ShouldNot(gomega.HaveOccurred())
 					return meta.IsStatusConditionTrue(rb.Status.Conditions, workv1alpha2.Scheduled), nil
-				})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 			})
 
 			ginkgo.By("check if deployment present on right clusters", func() {
@@ -199,12 +198,11 @@ var _ = ginkgo.Describe("propagation with label and group constraints testing", 
 			})
 
 			ginkgo.By("check if the scheduled condition is true", func() {
-				err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+				gomega.Eventually(func(g gomega.Gomega) (bool, error) {
 					crb, err := getClusterResourceBinding(crd)
-					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+					g.Expect(err).ShouldNot(gomega.HaveOccurred())
 					return meta.IsStatusConditionTrue(crb.Status.Conditions, workv1alpha2.Scheduled), nil
-				})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 			})
 
 			ginkgo.By("check if crd present on right clusters", func() {
@@ -306,12 +304,11 @@ var _ = ginkgo.Describe("propagation with label and group constraints testing", 
 			})
 
 			ginkgo.By("check if the scheduled condition is true", func() {
-				err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+				gomega.Eventually(func(g gomega.Gomega) (bool, error) {
 					rb, err := getResourceBinding(job)
-					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+					g.Expect(err).ShouldNot(gomega.HaveOccurred())
 					return meta.IsStatusConditionTrue(rb.Status.Conditions, workv1alpha2.Scheduled), nil
-				})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 			})
 
 			ginkgo.By("check if job present on right clusters", func() {


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind failing-test
/kind cleanup

**What this PR does / why we need it**:

Using assertions in `wait.PollImmediate` breaks the cyclic waiting process, resulting in failure.

Meanwhile, as the error message suggests:

```
      When you, or your assertion library, calls Ginkgo's Fail(),
      Ginkgo panics to prevent subsequent assertions from running.

      Normally Ginkgo rescues this panic so you shouldn't see it.

      However, if you make an assertion in a goroutine, Ginkgo can't capture the
      panic.
      To circumvent this, you should call

      	defer GinkgoRecover()

      at the top of the goroutine that caused this panic.

      Alternatively, you may have made an assertion outside of a Ginkgo
      leaf node (e.g. in a container node or some out-of-band function) - please
      move your assertion to
      an appropriate Ginkgo node (e.g. a BeforeSuite, BeforeEach, It, etc...).
```

Error info has printed the panic, as a result, we can see the normal error info, so I use `gomega.Eventually` to replace `wait.PollImmediate`.

**Which issue(s) this PR fixes**:
Fixes #

https://github.com/karmada-io/karmada/actions/runs/3088395768/jobs/4994950606

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

