### PR TITLE
allow to update the resourceSelector of PropagationPolicy/ClusterPropagationPolicy

### DIFF
--- a/pkg/util/helper/binding.go
+++ b/pkg/util/helper/binding.go
@@ -22,6 +22,7 @@ import (
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
+	"github.com/karmada-io/karmada/pkg/util/fedinformer/keys"
 	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/pkg/util/restmapper"
 )
@@ -245,4 +246,19 @@ func GenerateReplicaRequirements(podTemplate *corev1.PodTemplateSpec) *workv1alp
 	}
 
 	return nil
+}
+
+// ConstructClusterWideKey construct resource ClusterWideKey from binding's objectReference.
+func ConstructClusterWideKey(resource workv1alpha2.ObjectReference) (keys.ClusterWideKey, error) {
+	gv, err := schema.ParseGroupVersion(resource.APIVersion)
+	if err != nil {
+		return keys.ClusterWideKey{}, err
+	}
+	return keys.ClusterWideKey{
+		Group:     gv.Group,
+		Version:   gv.Version,
+		Kind:      resource.Kind,
+		Namespace: resource.Namespace,
+		Name:      resource.Name,
+	}, nil
 }

--- a/pkg/util/helper/policy.go
+++ b/pkg/util/helper/policy.go
@@ -15,9 +15,6 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
-// DenyReasonResourceSelectorsModify constructs a reason indicating that modify ResourceSelectors is not allowed.
-const DenyReasonResourceSelectorsModify = "modify ResourceSelectors is forbidden"
-
 // SetDefaultSpreadConstraints set default spread constraints if both 'SpreadByField' and 'SpreadByLabel' not set.
 func SetDefaultSpreadConstraints(spreadConstraints []policyv1alpha1.SpreadConstraint) {
 	for i := range spreadConstraints {

--- a/pkg/util/label.go
+++ b/pkg/util/label.go
@@ -15,12 +15,19 @@ func GetLabelValue(labels map[string]string, labelKey string) string {
 
 // MergeLabel adds label for the given object.
 func MergeLabel(obj *unstructured.Unstructured, labelKey string, labelValue string) {
-	workloadLabel := obj.GetLabels()
-	if workloadLabel == nil {
-		workloadLabel = make(map[string]string, 1)
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string, 1)
 	}
-	workloadLabel[labelKey] = labelValue
-	obj.SetLabels(workloadLabel)
+	labels[labelKey] = labelValue
+	obj.SetLabels(labels)
+}
+
+// RemoveLabel removes the label from the given object.
+func RemoveLabel(obj *unstructured.Unstructured, labelKey string) {
+	labels := obj.GetLabels()
+	delete(labels, labelKey)
+	obj.SetLabels(labels)
 }
 
 // DedupeAndMergeLabels merges the new labels into exist labels.

--- a/pkg/util/label_test.go
+++ b/pkg/util/label_test.go
@@ -208,3 +208,106 @@ func TestDedupeAndMergeLabels(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveLabel(t *testing.T) {
+	type args struct {
+		obj      *unstructured.Unstructured
+		labelKey string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected *unstructured.Unstructured
+	}{
+		{
+			name: "nil object labels",
+			args: args{
+				obj: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "apps/v1",
+						"kind":       "Deployment",
+						"metadata": map[string]interface{}{
+							"name": "demo-deployment",
+						},
+						"spec": map[string]interface{}{
+							"replicas": 2,
+						}}},
+				labelKey: "foo",
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "demo-deployment",
+					},
+					"spec": map[string]interface{}{
+						"replicas": 2,
+					}}},
+		},
+		{
+			name: "same labelKey",
+			args: args{
+				obj: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "apps/v1",
+						"kind":       "Deployment",
+						"metadata": map[string]interface{}{
+							"name":   "demo-deployment",
+							"labels": map[string]interface{}{"foo": "bar"},
+						},
+						"spec": map[string]interface{}{
+							"replicas": 2,
+						}}},
+				labelKey: "foo",
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":   "demo-deployment",
+						"labels": map[string]interface{}{},
+					},
+					"spec": map[string]interface{}{
+						"replicas": 2,
+					}}},
+		},
+		{
+			name: "different labelKey",
+			args: args{
+				obj: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "apps/v1",
+						"kind":       "Deployment",
+						"metadata": map[string]interface{}{
+							"name":   "demo-deployment",
+							"labels": map[string]interface{}{"foo": "bar"},
+						},
+						"spec": map[string]interface{}{
+							"replicas": 2,
+						}}},
+				labelKey: "foo1",
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":   "demo-deployment",
+						"labels": map[string]interface{}{"foo": "bar"},
+					},
+					"spec": map[string]interface{}{
+						"replicas": 2,
+					}}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RemoveLabel(tt.args.obj, tt.args.labelKey)
+			if !reflect.DeepEqual(tt.args.obj, tt.expected) {
+				t.Errorf("RemoveLabel() = %v, want %v", tt.args.obj, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/webhook/propagationpolicy/validating.go
+++ b/pkg/webhook/propagationpolicy/validating.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"net/http"
 
-	admissionv1 "k8s.io/api/admission/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -33,18 +31,6 @@ func (v *ValidatingAdmission) Handle(ctx context.Context, req admission.Request)
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 	klog.V(2).Infof("Validating PropagationPolicy(%s/%s) for request: %s", policy.Namespace, policy.Name, req.Operation)
-
-	if req.Operation == admissionv1.Update {
-		oldPolicy := &policyv1alpha1.PropagationPolicy{}
-		err := v.decoder.DecodeRaw(req.OldObject, oldPolicy)
-		if err != nil {
-			return admission.Errored(http.StatusBadRequest, err)
-		}
-		if !equality.Semantic.DeepEqual(policy.Spec.ResourceSelectors, oldPolicy.Spec.ResourceSelectors) {
-			klog.Info(helper.DenyReasonResourceSelectorsModify)
-			return admission.Denied(helper.DenyReasonResourceSelectorsModify)
-		}
-	}
 
 	if err := helper.ValidateSpreadConstraint(policy.Spec.Placement.SpreadConstraints); err != nil {
 		klog.Error(err)

--- a/test/e2e/clusterpropagationpolicy_test.go
+++ b/test/e2e/clusterpropagationpolicy_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/onsi/ginkgo/v2"
+	appsv1 "k8s.io/api/apps/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -13,7 +14,7 @@ import (
 	testhelper "github.com/karmada-io/karmada/test/helper"
 )
 
-var _ = ginkgo.Describe("[BasicClusterPropagation] basic cluster propagation testing", func() {
+var _ = ginkgo.Describe("[BasicClusterPropagation] propagation testing", func() {
 	ginkgo.Context("CustomResourceDefinition propagation testing", func() {
 		var crdGroup string
 		var randStr string
@@ -146,6 +147,174 @@ var _ = ginkgo.Describe("[BasicClusterPropagation] basic cluster propagation tes
 				func(binding *rbacv1.ClusterRoleBinding) bool {
 					return true
 				})
+		})
+	})
+})
+
+var _ = ginkgo.Describe("[AdvancedClusterPropagation] propagation testing", func() {
+	ginkgo.Context("Edit ClusterPropagationPolicy ResourceSelectors", func() {
+		ginkgo.When("propagate namespace scope resource", func() {
+			var policy *policyv1alpha1.ClusterPropagationPolicy
+			var deployment01, deployment02 *appsv1.Deployment
+			var targetMember string
+
+			ginkgo.BeforeEach(func() {
+				targetMember = framework.ClusterNames()[0]
+				policyName := deploymentNamePrefix + rand.String(RandomStrLength)
+
+				deployment01 = testhelper.NewDeployment(testNamespace, policyName+"01")
+				deployment02 = testhelper.NewDeployment(testNamespace, policyName+"02")
+
+				policy = testhelper.NewClusterPropagationPolicy(policyName, []policyv1alpha1.ResourceSelector{
+					{
+						APIVersion: deployment01.APIVersion,
+						Kind:       deployment01.Kind,
+						Name:       deployment01.Name,
+					}}, policyv1alpha1.Placement{
+					ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+						ClusterNames: []string{targetMember},
+					},
+				})
+			})
+
+			ginkgo.BeforeEach(func() {
+				framework.CreateClusterPropagationPolicy(karmadaClient, policy)
+				framework.CreateDeployment(kubeClient, deployment01)
+				framework.CreateDeployment(kubeClient, deployment02)
+				ginkgo.DeferCleanup(func() {
+					framework.RemoveClusterPropagationPolicy(karmadaClient, policy.Name)
+					framework.RemoveDeployment(kubeClient, deployment01.Namespace, deployment01.Name)
+					framework.RemoveDeployment(kubeClient, deployment02.Namespace, deployment02.Name)
+				})
+
+				framework.WaitDeploymentPresentOnClusterFitWith(targetMember, deployment01.Namespace, deployment01.Name,
+					func(deployment *appsv1.Deployment) bool { return true })
+			})
+
+			ginkgo.It("add resourceSelectors item", func() {
+				framework.UpdateClusterPropagationPolicy(karmadaClient, policy.Name, []policyv1alpha1.ResourceSelector{
+					{
+						APIVersion: deployment01.APIVersion,
+						Kind:       deployment01.Kind,
+						Name:       deployment01.Name,
+					},
+					{
+						APIVersion: deployment02.APIVersion,
+						Kind:       deployment02.Kind,
+						Name:       deployment02.Name,
+					},
+				})
+
+				framework.WaitDeploymentPresentOnClusterFitWith(targetMember, deployment02.Namespace, deployment02.Name,
+					func(deployment *appsv1.Deployment) bool { return true })
+			})
+
+			ginkgo.It("update resourceSelectors item", func() {
+				framework.UpdateClusterPropagationPolicy(karmadaClient, policy.Name, []policyv1alpha1.ResourceSelector{
+					{
+						APIVersion: deployment02.APIVersion,
+						Kind:       deployment02.Kind,
+						Name:       deployment02.Name,
+					},
+				})
+
+				framework.WaitDeploymentPresentOnClusterFitWith(targetMember, deployment02.Namespace, deployment02.Name,
+					func(deployment *appsv1.Deployment) bool { return true })
+				framework.WaitDeploymentGetByClientFitWith(kubeClient, deployment01.Namespace, deployment01.Name,
+					func(deployment *appsv1.Deployment) bool {
+						if deployment.Labels == nil {
+							return true
+						}
+
+						_, exist := deployment.Labels[policyv1alpha1.ClusterPropagationPolicyLabel]
+						return !exist
+					})
+			})
+		})
+
+		ginkgo.When("propagate cluster scope resource", func() {
+			var policy *policyv1alpha1.ClusterPropagationPolicy
+			var clusterRole01, clusterRole02 *rbacv1.ClusterRole
+			var targetMember string
+
+			ginkgo.BeforeEach(func() {
+				policyName := clusterRoleNamePrefix + rand.String(RandomStrLength)
+				targetMember = framework.ClusterNames()[0]
+
+				clusterRole01 = testhelper.NewClusterRole(fmt.Sprintf("system:test-%s-01", policyName), nil)
+				clusterRole02 = testhelper.NewClusterRole(fmt.Sprintf("system:test-%s-02", policyName), nil)
+				policy = testhelper.NewClusterPropagationPolicy(policyName, []policyv1alpha1.ResourceSelector{
+					{
+						APIVersion: clusterRole01.APIVersion,
+						Kind:       clusterRole01.Kind,
+						Name:       clusterRole01.Name,
+					},
+				}, policyv1alpha1.Placement{
+					ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+						ClusterNames: []string{targetMember},
+					},
+				})
+			})
+
+			ginkgo.BeforeEach(func() {
+				framework.CreateClusterPropagationPolicy(karmadaClient, policy)
+				framework.CreateClusterRole(kubeClient, clusterRole01)
+				framework.CreateClusterRole(kubeClient, clusterRole02)
+				ginkgo.DeferCleanup(func() {
+					framework.RemoveClusterPropagationPolicy(karmadaClient, policy.Name)
+					framework.RemoveClusterRole(kubeClient, clusterRole01.Name)
+					framework.RemoveClusterRole(kubeClient, clusterRole02.Name)
+				})
+
+				framework.WaitClusterRolePresentOnClusterFitWith(targetMember, clusterRole01.Name,
+					func(role *rbacv1.ClusterRole) bool {
+						return true
+					})
+			})
+
+			ginkgo.It("add resourceSelectors item", func() {
+				framework.UpdateClusterPropagationPolicy(karmadaClient, policy.Name, []policyv1alpha1.ResourceSelector{
+					{
+						APIVersion: clusterRole01.APIVersion,
+						Kind:       clusterRole01.Kind,
+						Name:       clusterRole01.Name,
+					},
+					{
+						APIVersion: clusterRole02.APIVersion,
+						Kind:       clusterRole02.Kind,
+						Name:       clusterRole02.Name,
+					},
+				})
+
+				framework.WaitClusterRolePresentOnClusterFitWith(targetMember, clusterRole02.Name,
+					func(role *rbacv1.ClusterRole) bool {
+						return true
+					})
+			})
+
+			ginkgo.It("update resourceSelectors item", func() {
+				framework.UpdateClusterPropagationPolicy(karmadaClient, policy.Name, []policyv1alpha1.ResourceSelector{
+					{
+						APIVersion: clusterRole02.APIVersion,
+						Kind:       clusterRole02.Kind,
+						Name:       clusterRole02.Name,
+					},
+				})
+
+				framework.WaitClusterRolePresentOnClusterFitWith(targetMember, clusterRole02.Name,
+					func(role *rbacv1.ClusterRole) bool {
+						return true
+					})
+				framework.WaitClusterRoleGetByClientFitWith(kubeClient, clusterRole01.Name,
+					func(clusterRole *rbacv1.ClusterRole) bool {
+						if clusterRole.Labels == nil {
+							return true
+						}
+
+						_, exist := clusterRole.Labels[policyv1alpha1.ClusterPropagationPolicyLabel]
+						return !exist
+					})
+			})
 		})
 	})
 })

--- a/test/e2e/framework/clusterpropagationpolicy.go
+++ b/test/e2e/framework/clusterpropagationpolicy.go
@@ -27,3 +27,15 @@ func RemoveClusterPropagationPolicy(client karmada.Interface, name string) {
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	})
 }
+
+// UpdateClusterPropagationPolicy update ClusterPropagationPolicy resourceSelectors with karmada client.
+func UpdateClusterPropagationPolicy(client karmada.Interface, name string, resourceSelectors []policyv1alpha1.ResourceSelector) {
+	ginkgo.By(fmt.Sprintf("Updating ClusterPropagationPolicy(%s)", name), func() {
+		newPolicy, err := client.PolicyV1alpha1().ClusterPropagationPolicies().Get(context.TODO(), name, metav1.GetOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+		newPolicy.Spec.ResourceSelectors = resourceSelectors
+		_, err = client.PolicyV1alpha1().ClusterPropagationPolicies().Update(context.TODO(), newPolicy, metav1.UpdateOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+}

--- a/test/e2e/framework/deployment.go
+++ b/test/e2e/framework/deployment.go
@@ -166,3 +166,16 @@ func CheckDeploymentReadyStatus(deployment *appsv1.Deployment, wantedReplicas in
 	}
 	return false
 }
+
+// WaitDeploymentGetByClientFitWith wait deployment get by client fit with func.
+func WaitDeploymentGetByClientFitWith(client kubernetes.Interface, namespace, name string, fit func(deployment *appsv1.Deployment) bool) {
+	ginkgo.By(fmt.Sprintf("Check deployment(%s/%s) labels fit with function", namespace, name), func() {
+		gomega.Eventually(func() bool {
+			dep, err := client.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			if err != nil {
+				return false
+			}
+			return fit(dep)
+		}, pollTimeout, pollInterval).Should(gomega.Equal(true))
+	})
+}

--- a/test/e2e/framework/propagationpolicy.go
+++ b/test/e2e/framework/propagationpolicy.go
@@ -40,3 +40,15 @@ func PatchPropagationPolicy(client karmada.Interface, namespace, name string, pa
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	})
 }
+
+// UpdatePropagationPolicy update PropagationPolicy resourceSelectors with karmada client.
+func UpdatePropagationPolicy(client karmada.Interface, namespace, name string, resourceSelectors []policyv1alpha1.ResourceSelector) {
+	ginkgo.By(fmt.Sprintf("Updating PropagationPolicy(%s/%s)", namespace, name), func() {
+		newPolicy, err := client.PolicyV1alpha1().PropagationPolicies(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+		newPolicy.Spec.ResourceSelectors = resourceSelectors
+		_, err = client.PolicyV1alpha1().PropagationPolicies(namespace).Update(context.TODO(), newPolicy, metav1.UpdateOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+}

--- a/test/e2e/framework/rbac.go
+++ b/test/e2e/framework/rbac.go
@@ -158,6 +158,19 @@ func WaitClusterRoleDisappearOnCluster(cluster, name string) {
 	}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 }
 
+// WaitClusterRoleGetByClientFitWith wait clusterRole get by client fit with func.
+func WaitClusterRoleGetByClientFitWith(client kubernetes.Interface, name string, fit func(clusterRole *rbacv1.ClusterRole) bool) {
+	ginkgo.By(fmt.Sprintf("Check clusterRole(%s) labels fit with function", name), func() {
+		gomega.Eventually(func() bool {
+			clusterRole, err := client.RbacV1().ClusterRoles().Get(context.TODO(), name, metav1.GetOptions{})
+			if err != nil {
+				return false
+			}
+			return fit(clusterRole)
+		}, pollTimeout, pollInterval).Should(gomega.Equal(true))
+	})
+}
+
 // CreateRoleBinding create roleBinding.
 func CreateRoleBinding(client kubernetes.Interface, roleBinding *rbacv1.RoleBinding) {
 	ginkgo.By(fmt.Sprintf("Creating RoleBinding(%s/%s)", roleBinding.Namespace, roleBinding.Name), func() {


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Allow users to update the `.spec.resourceSelectors` filed of `PropagationPolicy/ClusterPropagationPolicy`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-controller-manager: allow users to update the `.spec.resourceSelectors` filed of `PropagationPolicy/ClusterPropagationPolicy`.
```

