### PR TITLE
Automated cherry pick of #2548: Fix bugs about karmada-data dir lost

### DIFF
--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -170,11 +170,18 @@ func (i *CommandInitOption) Complete() error {
 		}
 	}
 
-	// Determine whether KarmadaDataPath exists, if so, delete it
-	if utils.IsExist(i.KarmadaDataPath) {
-		if err := os.RemoveAll(i.KarmadaDataPath); err != nil {
+	return initializeDirectory(i.KarmadaDataPath)
+}
+
+// initializeDirectory initializes a directory and makes sure it's empty.
+func initializeDirectory(path string) error {
+	if utils.IsExist(path) {
+		if err := os.RemoveAll(path); err != nil {
 			return err
 		}
+	}
+	if err := os.MkdirAll(path, os.FileMode(0755)); err != nil {
+		return fmt.Errorf("failed to create directory: %s, error: %v", path, err)
 	}
 
 	return nil

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
@@ -1,0 +1,41 @@
+package kubernetes
+
+import (
+	"os"
+	"testing"
+)
+
+func Test_initializeDirectory(t *testing.T) {
+	tests := []struct {
+		name                string
+		createPathInAdvance bool
+		wantErr             bool
+	}{
+		{
+			name:                "Test when there is no dir exists",
+			createPathInAdvance: false,
+			wantErr:             false,
+		},
+		{
+			name:                "Test when there is dir exists",
+			createPathInAdvance: true,
+			wantErr:             false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.createPathInAdvance {
+				if err := os.MkdirAll("tmp", os.FileMode(0755)); err != nil {
+					t.Errorf("create test directory failed in advance:%v", err)
+				}
+			}
+			if err := initializeDirectory("tmp"); (err != nil) != tt.wantErr {
+				t.Errorf("initializeDirectory() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err := os.RemoveAll("tmp"); err != nil {
+				t.Errorf("clean up test directory failed after ut case:%s, %v", tt.name, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cherry pick of #2548 on release-1.3.
#2548: Fix bugs about karmada-data dir lost
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmadactl`: Fixed `--karmada-data` directory not initialization issue in `init` command.
```