### PR TITLE
Fix cherry pick script to skip verify certificate

### DIFF
--- a/hack/cherry_pick_pull.sh
+++ b/hack/cherry_pick_pull.sh
@@ -162,7 +162,7 @@ gitamcleanup=true
 for pull in "${PULLS[@]}"; do
   echo "+++ Downloading patch to /tmp/${pull}.patch (in case you need to do this again)"
 
-  curl -o "/tmp/${pull}.patch" -sSL "https://github.com/${MAIN_REPO_ORG}/${MAIN_REPO_NAME}/pull/${pull}.patch"
+  curl -o "/tmp/${pull}.patch" -sSL "https://github.com/${MAIN_REPO_ORG}/${MAIN_REPO_NAME}/pull/${pull}.patch" -k
   echo
   echo "+++ About to attempt cherry pick of PR. To reattempt:"
   echo "  $ git am -3 /tmp/${pull}.patch"


### PR DESCRIPTION
Signed-off-by: jwcesign <jiangwei115@huawei.com>

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
can't cherry pick:
```sh
xxx@xxx MINGW64 /d/git/karmada-diff/karmada (fix-dir-lost)
$ bash hack/cherry_pick_pull.sh upstream/release-1.3 2548
github.com
  ✓ Logged in to github.com as jwcesign (oauth_token)
  ✓ Git operations for github.com configured to use ssh protocol.
  ✓ Token: *******************

+++ Updating remotes...
Fetching upstream
Fetching origin
+++ Creating local branch automated-cherry-pick-of-#2548-upstream-release-1.3-1663837616
Switched to a new branch 'automated-cherry-pick-of-#2548-upstream-release-1.3-1663837616'
Branch 'automated-cherry-pick-of-#2548-upstream-release-1.3-1663837616' set up to track remote branch 'release-1.3' from 'upstream'.
+++ Downloading patch to /tmp/2548.patch (in case you need to do this again)
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.

+++ Aborting in-progress git am.

+++ Returning you to the fix-dir-lost branch and cleaning up.
```

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
none
```

