### PR TITLE
Automated cherry pick of #2540: deinit help fix

### DIFF
--- a/pkg/karmadactl/deinit.go
+++ b/pkg/karmadactl/deinit.go
@@ -60,7 +60,7 @@ func NewCmdDeInit(parentCommand string) *cobra.Command {
 		},
 	}
 
-	flags := cmd.PersistentFlags()
+	flags := cmd.Flags()
 	flags.StringVarP(&opts.Namespace, "namespace", "n", "karmada-system", "namespace where Karmada components are installed.")
 	flags.StringVar(&opts.KubeConfig, "kubeconfig", "", "Path to the host cluster kubeconfig file.")
 	flags.StringVar(&opts.Context, "context", "", "The name of the kubeconfig context to use")


### PR DESCRIPTION
Cherry pick of #2540 on release-1.3.
#2540: deinit help fix
For details on the cherry pick process, see the [cherry pick requests](https://github.com/karmada-io/karmada/blob/master/docs/contributors/devel/cherry-picks.md) page.
```release-note
`karmadactl`: Fixed options of `deinit` can not be shown issue.
```