### PR TITLE
when estimator and schedular not in a same namespace and calls betwee…

### DIFF
--- a/cmd/descheduler/app/options/options.go
+++ b/cmd/descheduler/app/options/options.go
@@ -42,6 +42,8 @@ type Options struct {
 
 	// SchedulerEstimatorTimeout specifies the timeout period of calling the accurate scheduler estimator service.
 	SchedulerEstimatorTimeout metav1.Duration
+	// SchedulerEstimatorNamespace is the namespace that the accurate scheduler estimator server serves at.
+	SchedulerEstimatorNamespace string
 	// SchedulerEstimatorPort is the port that the accurate scheduler estimator server serves at.
 	SchedulerEstimatorPort int
 	// DeschedulingInterval specifies time interval for descheduler to run.
@@ -80,6 +82,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.Float32Var(&o.KubeAPIQPS, "kube-api-qps", 40.0, "QPS to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")
 	fs.IntVar(&o.KubeAPIBurst, "kube-api-burst", 60, "Burst to use while talking with karmada-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")
 	fs.DurationVar(&o.SchedulerEstimatorTimeout.Duration, "scheduler-estimator-timeout", 3*time.Second, "Specifies the timeout period of calling the scheduler estimator service.")
+	fs.StringVar(&o.SchedulerEstimatorNamespace, "scheduler-estimator-namespace", util.NamespaceKarmadaSystem, "The namespace of accurate scheduler estimator.")
 	fs.IntVar(&o.SchedulerEstimatorPort, "scheduler-estimator-port", defaultEstimatorPort, "The secure port on which to connect the accurate scheduler estimator.")
 	fs.DurationVar(&o.DeschedulingInterval.Duration, "descheduling-interval", defaultDeschedulingInterval, "Time interval between two consecutive descheduler executions. Setting this value instructs the descheduler to run in a continuous loop at the interval specified.")
 	fs.DurationVar(&o.UnschedulableThreshold.Duration, "unschedulable-threshold", defaultUnschedulableThreshold, "The period of pod unschedulable condition. This value is considered as a classification standard of unschedulable replicas.")

--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -49,6 +49,8 @@ type Options struct {
 	DisableSchedulerEstimatorInPullMode bool
 	// SchedulerEstimatorTimeout specifies the timeout period of calling the accurate scheduler estimator service.
 	SchedulerEstimatorTimeout metav1.Duration
+	// SchedulerEstimatorNamespace is the namespace that the accurate scheduler estimator server serves at.
+	SchedulerEstimatorNamespace string
 	// SchedulerEstimatorPort is the port that the accurate scheduler estimator server serves at.
 	SchedulerEstimatorPort int
 
@@ -95,6 +97,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.EnableSchedulerEstimator, "enable-scheduler-estimator", false, "Enable calling cluster scheduler estimator for adjusting replicas.")
 	fs.BoolVar(&o.DisableSchedulerEstimatorInPullMode, "disable-scheduler-estimator-in-pull-mode", false, "Disable the scheduler estimator for clusters in pull mode, which takes effect only when enable-scheduler-estimator is true.")
 	fs.DurationVar(&o.SchedulerEstimatorTimeout.Duration, "scheduler-estimator-timeout", 3*time.Second, "Specifies the timeout period of calling the scheduler estimator service.")
+	fs.StringVar(&o.SchedulerEstimatorNamespace, "scheduler-estimator-namespace", util.NamespaceKarmadaSystem, "The namespace of accurate scheduler estimator.")
 	fs.IntVar(&o.SchedulerEstimatorPort, "scheduler-estimator-port", defaultEstimatorPort, "The secure port on which to connect the accurate scheduler estimator.")
 	fs.BoolVar(&o.EnableEmptyWorkloadPropagation, "enable-empty-workload-propagation", false, "Enable workload with replicas 0 to be propagated to member clusters.")
 	fs.StringSliceVar(&o.Plugins, "plugins", []string{"*"},

--- a/cmd/scheduler/app/scheduler.go
+++ b/cmd/scheduler/app/scheduler.go
@@ -136,6 +136,7 @@ func run(opts *options.Options, stopChan <-chan struct{}, registryOptions ...Opt
 		scheduler.WithOutOfTreeRegistry(outOfTreeRegistry),
 		scheduler.WithEnableSchedulerEstimator(opts.EnableSchedulerEstimator),
 		scheduler.WithDisableSchedulerEstimatorInPullMode(opts.DisableSchedulerEstimatorInPullMode),
+		scheduler.WithSchedulerEstimatorNamespace(opts.SchedulerEstimatorNamespace),
 		scheduler.WithSchedulerEstimatorPort(opts.SchedulerEstimatorPort),
 		scheduler.WithSchedulerEstimatorTimeout(opts.SchedulerEstimatorTimeout),
 		scheduler.WithEnableEmptyWorkloadPropagation(opts.EnableEmptyWorkloadPropagation),

--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -46,9 +46,10 @@ type Descheduler struct {
 
 	eventRecorder record.EventRecorder
 
-	schedulerEstimatorCache  *estimatorclient.SchedulerEstimatorCache
-	schedulerEstimatorPort   int
-	schedulerEstimatorWorker util.AsyncWorker
+	schedulerEstimatorCache     *estimatorclient.SchedulerEstimatorCache
+	schedulerEstimatorNamespace string
+	schedulerEstimatorPort      int
+	schedulerEstimatorWorker    util.AsyncWorker
 
 	unschedulableThreshold time.Duration
 	deschedulingInterval   time.Duration
@@ -59,17 +60,18 @@ type Descheduler struct {
 func NewDescheduler(karmadaClient karmadaclientset.Interface, kubeClient kubernetes.Interface, opts *options.Options) *Descheduler {
 	factory := informerfactory.NewSharedInformerFactory(karmadaClient, 0)
 	desched := &Descheduler{
-		KarmadaClient:           karmadaClient,
-		KubeClient:              kubeClient,
-		informerFactory:         factory,
-		bindingInformer:         factory.Work().V1alpha2().ResourceBindings().Informer(),
-		bindingLister:           factory.Work().V1alpha2().ResourceBindings().Lister(),
-		clusterInformer:         factory.Cluster().V1alpha1().Clusters().Informer(),
-		clusterLister:           factory.Cluster().V1alpha1().Clusters().Lister(),
-		schedulerEstimatorCache: estimatorclient.NewSchedulerEstimatorCache(),
-		schedulerEstimatorPort:  opts.SchedulerEstimatorPort,
-		unschedulableThreshold:  opts.UnschedulableThreshold.Duration,
-		deschedulingInterval:    opts.DeschedulingInterval.Duration,
+		KarmadaClient:               karmadaClient,
+		KubeClient:                  kubeClient,
+		informerFactory:             factory,
+		bindingInformer:             factory.Work().V1alpha2().ResourceBindings().Informer(),
+		bindingLister:               factory.Work().V1alpha2().ResourceBindings().Lister(),
+		clusterInformer:             factory.Cluster().V1alpha1().Clusters().Informer(),
+		clusterLister:               factory.Cluster().V1alpha1().Clusters().Lister(),
+		schedulerEstimatorCache:     estimatorclient.NewSchedulerEstimatorCache(),
+		schedulerEstimatorNamespace: opts.SchedulerEstimatorNamespace,
+		schedulerEstimatorPort:      opts.SchedulerEstimatorPort,
+		unschedulableThreshold:      opts.UnschedulableThreshold.Duration,
+		deschedulingInterval:        opts.DeschedulingInterval.Duration,
 	}
 	// ignore the error here because the informers haven't been started
 	_ = desched.bindingInformer.SetTransform(fedinformer.StripUnusedFields)
@@ -250,7 +252,7 @@ func (d *Descheduler) establishEstimatorConnections() {
 		return
 	}
 	for i := range clusterList.Items {
-		if err = estimatorclient.EstablishConnection(d.KubeClient, clusterList.Items[i].Name, d.schedulerEstimatorCache, d.schedulerEstimatorPort); err != nil {
+		if err = estimatorclient.EstablishConnection(d.KubeClient, clusterList.Items[i].Name, d.schedulerEstimatorNamespace, d.schedulerEstimatorCache, d.schedulerEstimatorPort); err != nil {
 			klog.Error(err)
 		}
 	}
@@ -270,7 +272,7 @@ func (d *Descheduler) reconcileEstimatorConnection(key util.QueueKey) error {
 		}
 		return err
 	}
-	return estimatorclient.EstablishConnection(d.KubeClient, name, d.schedulerEstimatorCache, d.schedulerEstimatorPort)
+	return estimatorclient.EstablishConnection(d.KubeClient, name, d.schedulerEstimatorNamespace, d.schedulerEstimatorCache, d.schedulerEstimatorPort)
 }
 
 func (d *Descheduler) recordDescheduleResultEventForResourceBinding(rb *workv1alpha2.ResourceBinding, message string, err error) {

--- a/pkg/estimator/client/cache.go
+++ b/pkg/estimator/client/cache.go
@@ -80,12 +80,12 @@ func (c *SchedulerEstimatorCache) GetClient(name string) (estimatorservice.Estim
 }
 
 // EstablishConnection establishes a new gRPC connection with the specified cluster scheduler estimator.
-func EstablishConnection(kubeClient kubernetes.Interface, name string, estimatorCache *SchedulerEstimatorCache, port int) error {
+func EstablishConnection(kubeClient kubernetes.Interface, name, namespace string, estimatorCache *SchedulerEstimatorCache, port int) error {
 	if estimatorCache.IsEstimatorExist(name) {
 		return nil
 	}
 
-	serverAddr, err := resolveCluster(kubeClient, util.NamespaceKarmadaSystem,
+	serverAddr, err := resolveCluster(kubeClient, namespace,
 		names.GenerateEstimatorServiceName(name), int32(port))
 	if err != nil {
 		return err

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -80,6 +80,7 @@ type Scheduler struct {
 	enableSchedulerEstimator            bool
 	disableSchedulerEstimatorInPullMode bool
 	schedulerEstimatorCache             *estimatorclient.SchedulerEstimatorCache
+	schedulerEstimatorNamespace         string
 	schedulerEstimatorPort              int
 	schedulerEstimatorWorker            util.AsyncWorker
 
@@ -93,6 +94,8 @@ type schedulerOptions struct {
 	disableSchedulerEstimatorInPullMode bool
 	// schedulerEstimatorTimeout specifies the timeout period of calling the accurate scheduler estimator service.
 	schedulerEstimatorTimeout metav1.Duration
+	// schedulerEstimatorNamespace is the namespace that the accurate scheduler estimator server serves at.
+	schedulerEstimatorNamespace string
 	// schedulerEstimatorPort is the port that the accurate scheduler estimator server serves at.
 	schedulerEstimatorPort int
 	//enableEmptyWorkloadPropagation represents whether allow workload with replicas 0 propagated to member clusters should be enabled
@@ -124,6 +127,13 @@ func WithDisableSchedulerEstimatorInPullMode(disableSchedulerEstimatorInPullMode
 func WithSchedulerEstimatorTimeout(schedulerEstimatorTimeout metav1.Duration) Option {
 	return func(o *schedulerOptions) {
 		o.schedulerEstimatorTimeout = schedulerEstimatorTimeout
+	}
+}
+
+// WithSchedulerEstimatorNamespace sets the schedulerEstimatorNamespace for scheduler
+func WithSchedulerEstimatorNamespace(schedulerEstimatorNamespace string) Option {
+	return func(o *schedulerOptions) {
+		o.schedulerEstimatorNamespace = schedulerEstimatorNamespace
 	}
 }
 
@@ -577,7 +587,7 @@ func (s *Scheduler) reconcileEstimatorConnection(key util.QueueKey) error {
 		return nil
 	}
 
-	return estimatorclient.EstablishConnection(s.KubeClient, name, s.schedulerEstimatorCache, s.schedulerEstimatorPort)
+	return estimatorclient.EstablishConnection(s.KubeClient, name, s.schedulerEstimatorNamespace, s.schedulerEstimatorCache, s.schedulerEstimatorPort)
 }
 
 func (s *Scheduler) establishEstimatorConnections() {
@@ -590,7 +600,7 @@ func (s *Scheduler) establishEstimatorConnections() {
 		if clusterList.Items[i].Spec.SyncMode == clusterv1alpha1.Pull && s.disableSchedulerEstimatorInPullMode {
 			continue
 		}
-		if err = estimatorclient.EstablishConnection(s.KubeClient, clusterList.Items[i].Name, s.schedulerEstimatorCache, s.schedulerEstimatorPort); err != nil {
+		if err = estimatorclient.EstablishConnection(s.KubeClient, s.schedulerEstimatorNamespace, clusterList.Items[i].Name, s.schedulerEstimatorCache, s.schedulerEstimatorPort); err != nil {
 			klog.Error(err)
 		}
 	}


### PR DESCRIPTION
…n them time out

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

Since the deployment process of estimator and scheduler is separated, there will be an operation scenario. I deployed them in different namespaces. At this time, the scheduler cannot establish a connection with the estimator.
<img width="737" alt="image" src="https://user-images.githubusercontent.com/89956700/192100874-8bb55647-6e4f-4a30-87b0-23eed78bb0df.png">

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

