### PR TITLE
addons enable cluster flag usage description wrong

### DIFF
--- a/pkg/karmadactl/addons/init/global.go
+++ b/pkg/karmadactl/addons/init/global.go
@@ -43,7 +43,7 @@ func (o *GlobalCommandOptions) AddFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&o.Context, "context", "", "The name of the kubeconfig context to use.")
 	flags.StringVar(&o.KarmadaConfig, "karmada-kubeconfig", "/etc/karmada/karmada-apiserver.config", "Path to the karmada control plane kubeconfig file.")
 	flags.StringVar(&o.KarmadaContext, "karmada-context", "", "The name of the karmada control plane kubeconfig context to use.")
-	flags.StringVarP(&o.Cluster, "cluster", "C", "", "The name of member cluster to disable scheduler estimator")
+	flags.StringVarP(&o.Cluster, "cluster", "C", "", "Name of the member cluster that enables or disables the scheduler estimator.")
 }
 
 // Complete the conditions required to be able to run list.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This cluster is used on the enable and disable command lines, and the description here obviously does not match the actual description of the cluster
<img width="857" alt="image" src="https://user-images.githubusercontent.com/89956700/192102894-dc150238-1dc7-4bc2-ba06-498b7a6fe5d6.png">

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

