### PR TITLE
Update golangci-lint from 1.46.2 to 1.49.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,15 +32,12 @@ linters:
   - goimports
   - govet
   # linters default enabled by golangci-lint .
-  - deadcode
   - errcheck
   - gosimple
   - ineffassign
   - staticcheck
-  - structcheck
   - typecheck
   - unused
-  - varcheck
   # other linters supported by golangci-lint.
   - gci
   - gocyclo

--- a/hack/verify-staticcheck.sh
+++ b/hack/verify-staticcheck.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 GOLANGCI_LINT_PKG="github.com/golangci/golangci-lint/cmd/golangci-lint"
-GOLANGCI_LINT_VER="v1.46.2"
+GOLANGCI_LINT_VER="v1.49.0"
 
 cd "${REPO_ROOT}"
 source "hack/util.sh"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR updates golangci-lint, and deprecates some linters:
```
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Following warnings raised that should be solved or ignored before this PR.
```
pkg/sharedcli/profileflag/profileflag.go:42:14: G114: Use of net/http serve function that has no support for setting timeouts (gosec)
			if err := http.ListenAndServe(opts.ProfilingBindAddress, mux); err != nil {
			          ^
cmd/scheduler-estimator/app/scheduler-estimator.go:101:13: G114: Use of net/http serve function that has no support for setting timeouts (gosec)
	klog.Fatal(http.ListenAndServe(address, mux))
	           ^
cmd/descheduler/app/descheduler.go:156:13: G114: Use of net/http serve function that has no support for setting timeouts (gosec)
	klog.Fatal(http.ListenAndServe(address, mux))
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

