### PR TITLE
Fix a problem with the API interface for creating a propagationpolicy when neither the namespace of the propagationpolicy nor the resourceselectors is set

### DIFF
--- a/pkg/webhook/propagationpolicy/mutating.go
+++ b/pkg/webhook/propagationpolicy/mutating.go
@@ -38,8 +38,13 @@ func (a *MutatingAdmission) Handle(ctx context.Context, req admission.Request) a
 	// Set default namespace for all resource selector if not set.
 	for i := range policy.Spec.ResourceSelectors {
 		if len(policy.Spec.ResourceSelectors[i].Namespace) == 0 {
-			klog.Infof("Setting resource selector default namespace for policy: %s/%s", policy.Namespace, policy.Name)
-			policy.Spec.ResourceSelectors[i].Namespace = policy.Namespace
+			if len(policy.Namespace) == 0 {
+				klog.Infof("Setting resource selector default namespace for policy: %s/%s", policy.Namespace, policy.Name)
+				policy.Spec.ResourceSelectors[i].Namespace = defaultNameSpace
+			} else {
+				klog.Infof("Setting resource selector default namespace for policy: %s/%s", policy.Namespace, policy.Name)
+				policy.Spec.ResourceSelectors[i].Namespace = policy.Namespace
+			}
 		}
 	}
 

--- a/pkg/webhook/propagationpolicy/mutating.go
+++ b/pkg/webhook/propagationpolicy/mutating.go
@@ -19,6 +19,8 @@ type MutatingAdmission struct {
 	decoder *admission.Decoder
 }
 
+const defaultNameSpace = "default"
+
 // Check if our MutatingAdmission implements necessary interface
 var _ admission.Handler = &MutatingAdmission{}
 var _ admission.DecoderInjector = &MutatingAdmission{}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When the API interface is called to create a PropagationPolicy, and the namespaces of both the PropagationPolicy and resourceSelectors are not set, we automatically set the namespace in resourceSelectors to default. You can based on https://github.com/karmada-io/karmada/issues/2597
**Which issue(s) this PR fixes**:
Fixes #2597

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

