### PR TITLE
karmadactl: modify the wrong noun for karmadactl

### DIFF
--- a/hack/post-run-e2e.sh
+++ b/hack/post-run-e2e.sh
@@ -29,7 +29,7 @@ kubectl --context="${HOST_CLUSTER_NAME}" apply -f - -n kube-system
 # delete interpreter workload webhook configuration
 kubectl --context="${KARMADA_APISERVER}" delete ResourceInterpreterWebhookConfiguration examples
 
-# delete interpreter example workload CRD in karamada-apiserver and member clusters
+# delete interpreter example workload CRD in karmada-apiserver and member clusters
 kubectl --context="${KARMADA_APISERVER}" delete -f "${REPO_ROOT}/examples/customresourceinterpreter/apis/workload.example.io_workloads.yaml"
 export KUBECONFIG="${MEMBER_CLUSTER_KUBECONFIG}"
 kubectl --context="${MEMBER_CLUSTER_1_NAME}" delete -f "${REPO_ROOT}/examples/customresourceinterpreter/apis/workload.example.io_workloads.yaml"

--- a/hack/pre-run-e2e.sh
+++ b/hack/pre-run-e2e.sh
@@ -75,7 +75,7 @@ sed -i'' -e "s/{{karmada-interpreter-webhook-example-svc-address}}/${interpreter
 util::deploy_webhook_configuration "${KARMADA_APISERVER}" "${ROOT_CA_FILE}" "${REPO_ROOT}/examples/customresourceinterpreter/webhook-configuration-temp.yaml"
 rm -rf "${REPO_ROOT}/examples/customresourceinterpreter/webhook-configuration-temp.yaml"
 
-# install interpreter example workload CRD in karamada-apiserver and member clusters
+# install interpreter example workload CRD in karmada-apiserver and member clusters
 kubectl --context="${KARMADA_APISERVER}" apply -f "${REPO_ROOT}/examples/customresourceinterpreter/apis/workload.example.io_workloads.yaml"
 export KUBECONFIG="${MEMBER_CLUSTER_KUBECONFIG}"
 kubectl --context="${MEMBER_CLUSTER_1_NAME}" apply -f "${REPO_ROOT}/examples/customresourceinterpreter/apis/workload.example.io_workloads.yaml"

--- a/pkg/karmadactl/join.go
+++ b/pkg/karmadactl/join.go
@@ -23,7 +23,7 @@ var (
 	joinLong  = `Join registers a cluster to control plane.`
 
 	joinExample = templates.Examples(`
-		# Join cluster into karamada control plane, if '--cluster-context' not specified, take the cluster name as the context
+		# Join cluster into karmada control plane, if '--cluster-context' not specified, take the cluster name as the context
 		%[1]s join CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG>`)
 )
 

--- a/pkg/karmadactl/register.go
+++ b/pkg/karmadactl/register.go
@@ -49,7 +49,7 @@ var (
 	registerLong  = `Register a cluster to Karmada control plane with PULL mode.`
 
 	registerExample = templates.Examples(`
-		# Register cluster into karamada control plane with PULL mode.
+		# Register cluster into karmada control plane with PULL mode.
 		# If '--cluster-name' isn't specified, the cluster of current-context will be used by default.
 		%[1]s register [karmada-apiserver-endpoint] --cluster-name=<CLUSTER_NAME> --token=<TOKEN>  --discovery-token-ca-cert-hash=<CA-CERT-HASH>
 		

--- a/pkg/karmadactl/unjoin.go
+++ b/pkg/karmadactl/unjoin.go
@@ -25,13 +25,13 @@ var (
 	unjoinShort   = `Remove the registration of a cluster from control plane`
 	unjoinLong    = `Unjoin removes the registration of a cluster from control plane.`
 	unjoinExample = templates.Examples(`
-		# Unjoin cluster from karamada control plane, but not to remove resources created by karmada in the unjoining cluster
+		# Unjoin cluster from karmada control plane, but not to remove resources created by karmada in the unjoining cluster
 		%[1]s unjoin CLUSTER_NAME
 	
-		# Unjoin cluster from karamada control plane and attempt to remove resources created by karmada in the unjoining cluster
+		# Unjoin cluster from karmada control plane and attempt to remove resources created by karmada in the unjoining cluster
 		%[1]s unjoin CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG>
 			
-		# Unjoin cluster from karamada control plane with timeout
+		# Unjoin cluster from karmada control plane with timeout
 		%[1]s unjoin CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG> --wait 2m`)
 )
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
When we have the following command in mind, we will have the following printed help information. The printed prompt has `karamada` in it, but it should be `karmada`, and this pr corrects all positions involved in that misspelling.
`karmadactl join -h` or `karmadactl unjoin -h` or `karmadactl register -h`
```shell
$ karmadactl join -h
Join registers a cluster to control plane.

Examples:
  # Join cluster into karamada control plane, if '--cluster-context' not
specified, take the cluster name as the context
  karmadactl join CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG>
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

