### PR TITLE
add implicit priority for OP and COP

### DIFF
--- a/pkg/util/overridemanager/overridemanager_test.go
+++ b/pkg/util/overridemanager/overridemanager_test.go
@@ -48,6 +48,7 @@ func TestGetMatchingOverridePolicies(t *testing.T) {
 			},
 		},
 	}
+	// high implicit priority
 	overridePolicy1 := &policyv1alpha1.OverridePolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: metav1.NamespaceDefault,
@@ -77,6 +78,7 @@ func TestGetMatchingOverridePolicies(t *testing.T) {
 			},
 		},
 	}
+	// low implicit priority
 	overridePolicy2 := &policyv1alpha1.OverridePolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: metav1.NamespaceDefault,
@@ -138,14 +140,14 @@ func TestGetMatchingOverridePolicies(t *testing.T) {
 			cluster:  cluster1,
 			wantedOverriders: []policyOverriders{
 				{
-					name:       overridePolicy1.Name,
-					namespace:  overridePolicy1.Namespace,
-					overriders: overriders1,
-				},
-				{
 					name:       overridePolicy2.Name,
 					namespace:  overridePolicy2.Namespace,
 					overriders: overriders3,
+				},
+				{
+					name:       overridePolicy1.Name,
+					namespace:  overridePolicy1.Namespace,
+					overriders: overriders1,
 				},
 			},
 		},
@@ -156,6 +158,11 @@ func TestGetMatchingOverridePolicies(t *testing.T) {
 			cluster:  cluster2,
 			wantedOverriders: []policyOverriders{
 				{
+					name:       overridePolicy2.Name,
+					namespace:  overridePolicy2.Namespace,
+					overriders: overriders3,
+				},
+				{
 					name:       overridePolicy1.Name,
 					namespace:  overridePolicy1.Namespace,
 					overriders: overriders1,
@@ -164,11 +171,6 @@ func TestGetMatchingOverridePolicies(t *testing.T) {
 					name:       overridePolicy1.Name,
 					namespace:  overridePolicy1.Namespace,
 					overriders: overriders2,
-				},
-				{
-					name:       overridePolicy2.Name,
-					namespace:  overridePolicy2.Namespace,
-					overriders: overriders3,
 				},
 			},
 		},


### PR DESCRIPTION
Signed-off-by: chaunceyjiang <chaunceyjiang@gmail.com>

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

add implicit priority for OP and COP


**Which issue(s) this PR fixes**:

like https://github.com/karmada-io/karmada/pull/2267

**Special notes for your reviewer**:

1. get the list of PP(or OP) that matches the workload.
2. sort the list by priority (I assume the list won't be so long, so performance won't be a concern here.)
3. for PP, we just pick the first item from the list, for OP, we apply the whole list by order.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Now the `OverridePolicy` and `ClusterOverridePolicy` will be applied by implicit priority order. The one with lower priority will be applied before the one with higher priority.
```

