### PR TITLE
karmadactl taint uses factory to access cluster

### DIFF
--- a/pkg/karmadactl/karmadactl.go
+++ b/pkg/karmadactl/karmadactl.go
@@ -81,7 +81,7 @@ func NewKarmadaCtlCommand(cmdUse, parentCommand string) *cobra.Command {
 			Commands: []*cobra.Command{
 				NewCmdCordon(f, parentCommand),
 				NewCmdUncordon(f, parentCommand),
-				NewCmdTaint(karmadaConfig, parentCommand),
+				NewCmdTaint(f, parentCommand),
 			},
 		},
 		{


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**Which issue(s) this PR fixes**:
Fixes #
Part of[#2349](https://github.com/karmada-io/karmada/issues/2349)
**Special notes for your reviewer**:
Test
```shell
go run ./cmd/karmadactl/karmadactl.go --kubeconfig /etc/karmada/karmada-apiserver.config taint clusters kind-multi-node1 bar:NoSchedule
cluster/kind-multi-node1 tainted

kubectl --kubeconfig /etc/karmada/karmada-apiserver.config get clusters kind-multi-node1 -oyaml | grep -C 5 taints                                         
    namespace: karmada-cluster
  secretRef:
    name: kind-multi-node1
    namespace: karmada-cluster
  syncMode: Push
  taints:
  - effect: NoSchedule
    key: bar
status:
  apiEnablements:
  - groupVersion: admissionregistration.k8s.io/v1

go run ./cmd/karmadactl/karmadactl.go --kubeconfig /etc/karmada/karmada-apiserver.config taint clusters kind-multi-node1 bar:NoSchedule-                                                       
cluster/kind-multi-node1 untainted
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

