### PR TITLE
raise an error when there is no healthy nodes for etcd installation

### DIFF
--- a/pkg/karmadactl/cmdinit/kubernetes/node.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/node.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -106,6 +107,10 @@ func (i *CommandInitOption) AddNodeSelectorLabels() error {
 			etcdSelectorLabels = v.Labels
 			break
 		}
+	}
+
+	if etcdSelectorLabels == nil {
+		return errors.New("failed to find a healthy node for karmada-etcd")
 	}
 
 	etcdSelectorLabels["karmada.io/etcd"] = ""


### PR DESCRIPTION


Signed-off-by: Lan Liang <gcslyp@gmail.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Now, it just panic when can not found that can be scheduled for AddNodeSelectorLabels. Add  return error and talk user what happen.

```
[root@watchdog karmadactl]# go run karmadactl.go  --kubeconfig config5621 init --kube-image-registry=lank8s.cn
I1004 02:29:11.960379    4001 deploy.go:154] kubeconfig file: config5621, kubernetes: https://192.168.56.21:6443
panic: assignment to entry in nil map
```

After PR :

```
[root@watchdog karmadactl]# go run karmadactl.go  --kubeconfig config5621 init --kube-image-registry=lank8s.cn
I1004 03:05:15.460215    5110 deploy.go:154] kubeconfig file: config5621, kubernetes: https://192.168.56.21:6443
error: have no node can be scheduled.
exit status 1
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

