### PR TITLE
Automated cherry pick of #2608: Modify the wrong noun for karmadactl

### DIFF
--- a/hack/post-run-e2e.sh
+++ b/hack/post-run-e2e.sh
@@ -33,7 +33,7 @@ kubectl apply -f - -n kube-system
 kubectl config use-context "${KARMADA_APISERVER}"
 kubectl delete ResourceInterpreterWebhookConfiguration examples
 
-# delete interpreter example workload CRD in karamada-apiserver and member clusters
+# delete interpreter example workload CRD in karmada-apiserver and member clusters
 kubectl delete -f "${REPO_ROOT}/examples/customresourceinterpreter/apis/workload.example.io_workloads.yaml"
 export KUBECONFIG="${MEMBER_CLUSTER_KUBECONFIG}"
 kubectl config use-context "${MEMBER_CLUSTER_1_NAME}"

--- a/hack/pre-run-e2e.sh
+++ b/hack/pre-run-e2e.sh
@@ -71,7 +71,7 @@ sed -i'' -e "s/{{karmada-interpreter-webhook-example-svc-address}}/${interpreter
 util::deploy_webhook_configuration "${ROOT_CA_FILE}" "${REPO_ROOT}/examples/customresourceinterpreter/webhook-configuration-temp.yaml"
 rm -rf "${REPO_ROOT}/examples/customresourceinterpreter/webhook-configuration-temp.yaml"
 
-# install interpreter example workload CRD in karamada-apiserver and member clusters
+# install interpreter example workload CRD in karmada-apiserver and member clusters
 kubectl apply -f "${REPO_ROOT}/examples/customresourceinterpreter/apis/workload.example.io_workloads.yaml"
 export KUBECONFIG="${MEMBER_CLUSTER_KUBECONFIG}"
 kubectl config use-context "${MEMBER_CLUSTER_1_NAME}"

--- a/pkg/karmadactl/join.go
+++ b/pkg/karmadactl/join.go
@@ -80,7 +80,7 @@ func NewCmdJoin(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Comman
 
 func joinExample(parentCommand string) string {
 	example := `
-# Join cluster into karamada control plane, if '--cluster-context' not specified, take the cluster name as the context` + "\n" +
+# Join cluster into karmada control plane, if '--cluster-context' not specified, take the cluster name as the context` + "\n" +
 		fmt.Sprintf("%s join CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG>", parentCommand)
 	return example
 }

--- a/pkg/karmadactl/unjoin.go
+++ b/pkg/karmadactl/unjoin.go
@@ -58,13 +58,13 @@ func NewCmdUnjoin(karmadaConfig KarmadaConfig, parentCommand string) *cobra.Comm
 
 func unjoinExample(parentCommand string) string {
 	example := `
-# Unjoin cluster from karamada control plane, but not to remove resources created by karmada in the unjoining cluster` + "\n" +
+# Unjoin cluster from karmada control plane, but not to remove resources created by karmada in the unjoining cluster` + "\n" +
 		fmt.Sprintf("%s unjoin CLUSTER_NAME", parentCommand) + `
 
-# Unjoin cluster from karamada control plane and attempt to remove resources created by karmada in the unjoining cluster` + "\n" +
+# Unjoin cluster from karmada control plane and attempt to remove resources created by karmada in the unjoining cluster` + "\n" +
 		fmt.Sprintf("%s unjoin CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG>", parentCommand) + `
 		
-# Unjoin cluster from karamada control plane with timeout` + "\n" +
+# Unjoin cluster from karmada control plane with timeout` + "\n" +
 		fmt.Sprintf("%s unjoin CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG> --wait 2m", parentCommand)
 	return example
 }


### PR DESCRIPTION
Cherry pick of #2608 on release-1.2.
#2608: Modify the wrong noun for karmadactl
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
NONE(fixed typo in CLI usage)
```