### PR TITLE
Automated cherry pick of #2608: Modify the wrong noun for karmadactl

### DIFF
--- a/hack/post-run-e2e.sh
+++ b/hack/post-run-e2e.sh
@@ -24,7 +24,7 @@ kubectl delete -f "${REPO_ROOT}"/examples/customresourceinterpreter/karmada-inte
 kubectl config use-context "${KARMADA_APISERVER}"
 kubectl delete ResourceInterpreterWebhookConfiguration examples
 
-# delete interpreter example workload CRD in karamada-apiserver and member clusters
+# delete interpreter example workload CRD in karmada-apiserver and member clusters
 kubectl delete -f "${REPO_ROOT}/examples/customresourceinterpreter/apis/workload.example.io_workloads.yaml"
 export KUBECONFIG="${MEMBER_CLUSTER_KUBECONFIG}"
 kubectl config use-context "${MEMBER_CLUSTER_1_NAME}"

--- a/hack/pre-run-e2e.sh
+++ b/hack/pre-run-e2e.sh
@@ -35,7 +35,7 @@ util::wait_pod_ready "${INTERPRETER_WEBHOOK_EXAMPLE_LABEL}" "${KARMADA_SYSTEM_NA
 kubectl config use-context "${KARMADA_APISERVER}"
 util::deploy_webhook_configuration "${ROOT_CA_FILE}" "${REPO_ROOT}/examples/customresourceinterpreter/webhook-configuration.yaml"
 
-# install interpreter example workload CRD in karamada-apiserver and member clusters
+# install interpreter example workload CRD in karmada-apiserver and member clusters
 kubectl apply -f "${REPO_ROOT}/examples/customresourceinterpreter/apis/workload.example.io_workloads.yaml"
 export KUBECONFIG="${MEMBER_CLUSTER_KUBECONFIG}"
 kubectl config use-context "${MEMBER_CLUSTER_1_NAME}"

--- a/pkg/karmadactl/join.go
+++ b/pkg/karmadactl/join.go
@@ -28,7 +28,7 @@ var (
 	joinShort   = `Register a cluster to control plane`
 	joinLong    = `Join registers a cluster to control plane.`
 	joinExample = `
-# Join cluster into karamada control plane
+# Join cluster into karmada control plane
 %s join CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG>
 `
 )

--- a/pkg/karmadactl/unjoin.go
+++ b/pkg/karmadactl/unjoin.go
@@ -26,10 +26,10 @@ var (
 	unjoinShort   = `Remove the registration of a cluster from control plane`
 	unjoinLong    = `Unjoin removes the registration of a cluster from control plane.`
 	unjoinExample = `
-# Unjoin cluster from karamada control plane
+# Unjoin cluster from karmada control plane
 %s unjoin CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG>
 
-# Unjoin cluster from karamada control plane with timeout
+# Unjoin cluster from karmada control plane with timeout
 %s unjoin CLUSTER_NAME --cluster-kubeconfig=<KUBECONFIG> --wait 2m
 `
 )


### PR DESCRIPTION
Cherry pick of #2608 on release-1.1.
#2608: Modify the wrong noun for karmadactl
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
NONE(fixed typo in CLI usage)
```