### PR TITLE
chart: support controller manager feature gate

### DIFF
--- a/charts/karmada/templates/_helpers.tpl
+++ b/charts/karmada/templates/_helpers.tpl
@@ -390,4 +390,18 @@ Return the proper karmada kubectl image name
 {{ include "common.images.image" (dict "imageRoot" .Values.kubectl.image "global" .Values.global) }}
 {{- end -}}
 
+{{- define "karmada.controllerManager.featureGates" -}}
+     {{- if (not (empty .Values.controllerManager.featureGates)) }}
+          {{- $featureGatesFlag := "" -}}
+          {{- range $key, $value := .Values.controllerManager.featureGates -}}
+               {{- if not (empty (toString $value)) }}
+                    {{- $featureGatesFlag = cat $featureGatesFlag $key "=" $value ","  -}}
+               {{- end -}}
+          {{- end -}}
 
+          {{- if gt (len $featureGatesFlag) 0 }}
+               {{- $featureGatesFlag := trimSuffix "," $featureGatesFlag  | nospace -}}
+               {{- printf "%s=%s" "--feature-gates" $featureGatesFlag -}}
+          {{- end -}}
+     {{- end -}}
+{{- end -}}

--- a/charts/karmada/templates/karmada-controller-manager.yaml
+++ b/charts/karmada/templates/karmada-controller-manager.yaml
@@ -54,6 +54,9 @@ spec:
             - --secure-port=10357
             - --leader-elect-resource-namespace={{ include "karmada.namespace" . }}
             - --v=2
+            {{- with (include "karmada.controllerManager.featureGates" .) }}
+            - {{ . }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -285,6 +285,10 @@ controllerManager:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 50%
+  ## @param featureGate to controllerManager
+  featureGates:
+    ## @param PropagateDeps is a feature gate for the controllerManager to allow propagate dependent respurce to workloads.
+    PropagateDeps: false
 
 ## karmada apiserver config
 apiServer:


### PR DESCRIPTION
Signed-off-by: calvin <wen.chen@daocloud.io>

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
we want to use the feature gate `Propagate dependent`, we have not a swith to open the feature.

<img width="984" alt="image" src="https://user-images.githubusercontent.com/45745657/194686798-f44970de-f617-4aeb-bcf9-180801ad2eda.png">


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
please correct me if not

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

