### PR TITLE
Update comments for ResourceSelectors in PropagationPolicy to eliminate ambiguity

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15328,7 +15328,7 @@
           "type": "boolean"
         },
         "resourceSelectors": {
-          "description": "ResourceSelectors used to select resources.",
+          "description": "ResourceSelectors used to select resources. Nil or empty selector is not allowed and doesn't mean match all kinds of resources for security concerns that sensitive resources(like Secret) might be accidentally propagated.",
           "type": "array",
           "items": {
             "default": {},

--- a/charts/karmada/_crds/bases/policy.karmada.io_clusterpropagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy.karmada.io_clusterpropagationpolicies.yaml
@@ -437,7 +437,10 @@ spec:
                   scenario. \n Defaults to false."
                 type: boolean
               resourceSelectors:
-                description: ResourceSelectors used to select resources.
+                description: ResourceSelectors used to select resources. Nil or empty
+                  selector is not allowed and doesn't mean match all kinds of resources
+                  for security concerns that sensitive resources(like Secret) might
+                  be accidentally propagated.
                 items:
                   description: ResourceSelector the resources will be selected.
                   properties:
@@ -505,6 +508,7 @@ spec:
                   - apiVersion
                   - kind
                   type: object
+                minItems: 1
                 type: array
               schedulerName:
                 description: SchedulerName represents which scheduler to proceed the

--- a/charts/karmada/_crds/bases/policy.karmada.io_propagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy.karmada.io_propagationpolicies.yaml
@@ -433,7 +433,10 @@ spec:
                   scenario. \n Defaults to false."
                 type: boolean
               resourceSelectors:
-                description: ResourceSelectors used to select resources.
+                description: ResourceSelectors used to select resources. Nil or empty
+                  selector is not allowed and doesn't mean match all kinds of resources
+                  for security concerns that sensitive resources(like Secret) might
+                  be accidentally propagated.
                 items:
                   description: ResourceSelector the resources will be selected.
                   properties:
@@ -501,6 +504,7 @@ spec:
                   - apiVersion
                   - kind
                   type: object
+                minItems: 1
                 type: array
               schedulerName:
                 description: SchedulerName represents which scheduler to proceed the

--- a/pkg/apis/policy/v1alpha1/propagation_types.go
+++ b/pkg/apis/policy/v1alpha1/propagation_types.go
@@ -42,7 +42,11 @@ type PropagationPolicy struct {
 // PropagationSpec represents the desired behavior of PropagationPolicy.
 type PropagationSpec struct {
 	// ResourceSelectors used to select resources.
+	// Nil or empty selector is not allowed and doesn't mean match all kinds
+	// of resources for security concerns that sensitive resources(like Secret)
+	// might be accidentally propagated.
 	// +required
+	// +kubebuilder:validation:MinItems=1
 	ResourceSelectors []ResourceSelector `json:"resourceSelectors"`
 
 	// Association tells if relevant resources should be selected automatically.

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -2851,7 +2851,7 @@ func schema_pkg_apis_policy_v1alpha1_PropagationSpec(ref common.ReferenceCallbac
 				Properties: map[string]spec.Schema{
 					"resourceSelectors": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ResourceSelectors used to select resources.",
+							Description: "ResourceSelectors used to select resources. Nil or empty selector is not allowed and doesn't mean match all kinds of resources for security concerns that sensitive resources(like Secret) might be accidentally propagated.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
People might be confused about why the behavior of `ResourceSelectors` is different between `PropagationPolicy` and `OverridePolicy`.(see #2618)

This PR adds a clear comment on it to eliminate ambiguity according to [the discussion](https://github.com/karmada-io/karmada/pull/422#issuecomment-858222351).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

With this patch, when applying with an empty resource selector as follow:
```bash
-bash-4.2# cat samples/nginx/propagationpolicy.yaml 
apiVersion: policy.karmada.io/v1alpha1
kind: PropagationPolicy
metadata:
  name: nginx-propagation
spec:
  resourceSelectors: []
#    - apiVersion: apps/v1
#      kind: Deployment
#      name: nginx
...
```
An error would raise up:
```bash
The PropagationPolicy "nginx-propagation" is invalid: spec.resourceSelectors: Invalid value: 0: spec.resourceSelectors in body should have at least 1 items
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

