### PR TITLE
helm chart support configuration for ca key

### DIFF
--- a/charts/karmada/templates/karmada-cert.yaml
+++ b/charts/karmada/templates/karmada-cert.yaml
@@ -8,6 +8,8 @@ type: Opaque
 data:
   server-ca.crt: |
     {{ b64enc .Values.certs.custom.caCrt }}
+  server-ca.key: |
+    {{ b64enc .Values.certs.custom.caKey }}
   karmada.crt: |
     {{ b64enc .Values.certs.custom.crt }}
   karmada.key: |

--- a/charts/karmada/templates/post-install-job.yaml
+++ b/charts/karmada/templates/post-install-job.yaml
@@ -12,8 +12,8 @@ data:
     {{- include "karmada.webhook.configuration" . | nindent 4 }}
   {{- print "system-namespace.yaml: " | nindent 2 }} |-
     {{- include "karmada.systemNamespace" . | nindent 4 }}
-  {{- print "karmada-aggregated-apiserver-apiservice.yaml: " | nindent 6 }} |-
-    {{- include "karmada.apiservice" . | nindent 8 }}
+  {{- print "karmada-aggregated-apiserver-apiservice.yaml: " | nindent 2 }} |-
+    {{- include "karmada.apiservice" . | nindent 4 }}
   {{- print "cluster-proxy-admin-rbac.yaml: " | nindent 2 }} |-
     {{- include "karmada.proxyRbac" . | nindent 4 }}
 ---

--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -89,6 +89,11 @@ certs:
       -----BEGIN CERTIFICATE-----
       XXXXXXXXXXXXXXXXXXXXXXXXXXX
       -----END CERTIFICATE-----
+    ## @param certs.custom.caKey key of the ca
+    caKey: |
+      -----BEGIN RSA PRIVATE KEY-----
+      XXXXXXXXXXXXXXXXXXXXXXXXXXX
+      -----END RSA PRIVATE KEY-----
     ## @param certs.custom.crt crt of the certificate
     crt: |
       -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
fix use custom certs lead to post-install-job failed and kube-controller-manager crash by missing /etc/karmada/pki/server-ca.key

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
helm install 使用自定义证书
- post-install-job 运行失败，`kubectl apply -f /static-resources --kubeconfig /etc/kubeconfig` 因为yaml格式问题运行不了,导致安装失败
- kube-controller-manager 运行时报错no such file缺失`/etc/karmada/pki/server-ca.key `，custom模式没有传入，auto是有的



**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/karmada/issues/2628#issuecomment-1277002908  提到的问题

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

