### PR TITLE
reorder `make verify`

### DIFF
--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -6,10 +6,16 @@ set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
-bash "$REPO_ROOT/hack/verify-codegen.sh"
-bash "$REPO_ROOT/hack/verify-crdgen.sh"
-bash "$REPO_ROOT/hack/verify-staticcheck.sh"
+# Show progress
+set -x
+
+# Orders are determined by two factors:
+# (1) Less Execution time item should be executed first.
+# (2) More likely to fail item should be executed first.
+bash "$REPO_ROOT/hack/verify-lifted.sh"
 bash "$REPO_ROOT/hack/verify-import-aliases.sh"
+bash "$REPO_ROOT/hack/verify-staticcheck.sh"
 bash "$REPO_ROOT/hack/verify-vendor.sh"
 bash "$REPO_ROOT/hack/verify-swagger-docs.sh"
-bash "$REPO_ROOT/hack/verify-lifted.sh"
+bash "$REPO_ROOT/hack/verify-crdgen.sh"
+bash "$REPO_ROOT/hack/verify-codegen.sh"


### PR DESCRIPTION
Signed-off-by: raymondmiaochaoyue <raymondmiaochaoyue@didiglobal.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

(1) When run `make verify` in command line, there is no indication what verify script is running.

(2) The current running sequence is not optimized. 

I often spend 3 minutes running`verify-codegen.sh`, only find `verify-staticcheck.sh` or `verify-import-aliases.sh` fail. `verify-staticcheck.sh` only needs 5 seconds to execute. `verify-import-aliases.sh` only needs 1.5 seconds to execute.

I reorder them based on two factors:
1. Less Execution time item should be executed first.
2. More likely to fail item should be executed first.

Every script execution time measured by `time` command:


| script                   | time      |
| ------------------------ | --------- |
| verify-codegen.sh        | 3m2.208s  |
| verify-crdgen.sh         | 0m3.484s  |
| verify-staticcheck.sh    | 0m4.786s  |
| verify-import-aliases.sh | 0m1.452s  |
| verify-vendor.sh         | 0m11.224s |
| verify-swagger-docs.sh   | 0m8.982s  |
| verify-lifted.sh         | 0m0.701s  |


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

