### PR TITLE
`karmada-controller-manager`: Fixed the panic when cluster ImpersonatorSecretRef is nil.

### DIFF
--- a/pkg/controllers/unifiedauth/unified_auth_controller.go
+++ b/pkg/controllers/unifiedauth/unified_auth_controller.go
@@ -63,6 +63,11 @@ func (c *Controller) Reconcile(ctx context.Context, req controllerruntime.Reques
 		return controllerruntime.Result{}, nil
 	}
 
+	if cluster.Spec.ImpersonatorSecretRef == nil {
+		klog.Infof("Aggregated API feature is disabled on cluster %s as it does not have an impersonator secret", cluster.Name)
+		return controllerruntime.Result{}, nil
+	}
+
 	err := c.syncImpersonationConfig(cluster)
 	if err != nil {
 		klog.Errorf("Failed to sync impersonation config for cluster %s. Error: %v.", cluster.Name, err)


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug

-->

**What this PR does / why we need it**:

Do nil check before using cluster ImpersonatorSecretRef

**Which issue(s) this PR fixes**:
Fixes #2674

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
- `karmada-controller-manager`: Fixed the panic when cluster ImpersonatorSecretRef is nil.
```

