### PR TITLE
Add the CreateExecutionSpaceSucceed and RemoveExecutionSpaceSucceed event

### DIFF
--- a/pkg/apis/cluster/v1alpha1/events.go
+++ b/pkg/apis/cluster/v1alpha1/events.go
@@ -1,11 +1,15 @@
 package v1alpha1
 
-// Define events for execute space objects.
+// Define events for cluster objects.
 const (
 	// EventReasonCreateExecutionSpaceFailed indicates that create execution space failed.
 	EventReasonCreateExecutionSpaceFailed = "CreateExecutionSpaceFailed"
+	// EventReasonCreateExecutionSpaceSucceed indicates that create execution space succeed.
+	EventReasonCreateExecutionSpaceSucceed = "CreateExecutionSpaceSucceed"
 	// EventReasonRemoveExecutionSpaceFailed indicates that remove execution space failed.
 	EventReasonRemoveExecutionSpaceFailed = "RemoveExecutionSpaceFailed"
+	// EventReasonRemoveExecutionSpaceSucceed indicates that remove execution space succeed.
+	EventReasonRemoveExecutionSpaceSucceed = "RemoveExecutionSpaceSucceed"
 	// EventReasonTaintClusterByConditionFailed indicates that taint cluster by condition failed.
 	EventReasonTaintClusterByConditionFailed = "TaintClusterByConditionFailed"
 	// EventReasonRemoveTargetClusterFailed indicates that failed to remove target cluster from binding.

--- a/pkg/controllers/cluster/cluster_controller.go
+++ b/pkg/controllers/cluster/cluster_controller.go
@@ -243,6 +243,8 @@ func (c *Controller) removeCluster(ctx context.Context, cluster *clusterv1alpha1
 		c.EventRecorder.Event(cluster, corev1.EventTypeWarning, clusterv1alpha1.EventReasonRemoveExecutionSpaceFailed, err.Error())
 		return controllerruntime.Result{Requeue: true}, err
 	}
+	msg := fmt.Sprintf("Removed execution space for cluster(%s).", cluster.Name)
+	c.EventRecorder.Event(cluster, corev1.EventTypeNormal, clusterv1alpha1.EventReasonRemoveExecutionSpaceSucceed, msg)
 
 	if exist, err := c.ExecutionSpaceExistForCluster(cluster.Name); err != nil {
 		klog.Errorf("Failed to check weather the execution space exist in the given member cluster or not, error is: %v", err)
@@ -392,7 +394,9 @@ func (c *Controller) createExecutionSpace(cluster *clusterv1alpha1.Cluster) erro
 			klog.Errorf("Failed to create execution space for cluster(%s): %v", cluster.Name, err)
 			return err
 		}
-		klog.V(2).Infof("Created execution space(%s) for cluster(%s).", executionSpaceName, cluster.Name)
+		msg := fmt.Sprintf("Created execution space(%s) for cluster(%s).", executionSpaceName, cluster.Name)
+		klog.V(2).Info(msg)
+		c.EventRecorder.Event(cluster, corev1.EventTypeNormal, clusterv1alpha1.EventReasonCreateExecutionSpaceSucceed, msg)
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add the CreateExecutionSpaceSucceed and RemoveExecutionSpaceSucceed event.

```
Events:
  Type    Reason                       Age   From                Message
  ----    ------                       ----  ----                -------
  Normal  CreateExecutionSpaceSucceed  8s    cluster-controller  Created execution space(karmada-es-member1) for cluster(member1).
  Normal  TaintClusterByStatusSucceed  8s    cluster-controller  Taint cluster by status succeed: add([{cluster.karmada.io/not-ready  NoSchedule <nil>}]), remove([]).
  Normal  TaintClusterByStatusSucceed  8s    cluster-controller  Taint cluster by status succeed: add([]), remove([{cluster.karmada.io/not-ready  NoSchedule <nil>}]).
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```
`Instrumentation`: Introduced the `CreateExecutionSpaceSucceed` and `RemoveExecutionSpaceSucceed` events to `Cluster` object.
```

