### PR TITLE
Automated cherry pick of #2675: check if cluster ImpersonatorSecretRef is nil before using it

### DIFF
--- a/pkg/controllers/unifiedauth/unified_auth_controller.go
+++ b/pkg/controllers/unifiedauth/unified_auth_controller.go
@@ -63,6 +63,11 @@ func (c *Controller) Reconcile(ctx context.Context, req controllerruntime.Reques
 		return controllerruntime.Result{}, nil
 	}
 
+	if cluster.Spec.ImpersonatorSecretRef == nil {
+		klog.Infof("Aggregated API feature is disabled on cluster %s as it does not have an impersonator secret", cluster.Name)
+		return controllerruntime.Result{}, nil
+	}
+
 	err := c.syncImpersonationConfig(cluster)
 	if err != nil {
 		klog.Errorf("Failed to sync impersonation config for cluster %s. Error: %v.", cluster.Name, err)


### PR DESCRIPTION
Cherry pick of #2675 on release-1.3.
#2675: check if cluster ImpersonatorSecretRef is nil before using it
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`: Fixed the panic when cluster ImpersonatorSecretRef is nil.
```