### PR TITLE
Add label "namespace.karmada.io/skip-auto-propagation" to control whether to propagate ns to member clusters

### DIFF
--- a/pkg/apis/policy/v1alpha1/well_known_constants.go
+++ b/pkg/apis/policy/v1alpha1/well_known_constants.go
@@ -9,4 +9,14 @@ const (
 
 	// ClusterPropagationPolicyLabel is added to objects to specify associated ClusterPropagationPolicy.
 	ClusterPropagationPolicyLabel = "clusterpropagationpolicy.karmada.io/name"
+
+	// NamespaceSkipAutoPropagationLabel is added to namespace objects to indicate if
+	// the namespace should be skipped from propagating by the namespace controller.
+	// For example, a namespace with the following label will be skipped:
+	//   labels:
+	//     namespace.karmada.io/skip-auto-propagation: "true"
+	//
+	// NOTE: If create a ns without this label, then patch it with this label, the ns will not be
+	// synced to new member clusters, but old member clusters still have it.
+	NamespaceSkipAutoPropagationLabel = "namespace.karmada.io/skip-auto-propagation"
 )


### PR DESCRIPTION
Signed-off-by: jwcesign <jiangwei115@huawei.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Referring to: https://github.com/karmada-io/karmada/issues/2525
Customers may not want to sync some specific namespace

**Which issue(s) this PR fixes**:
Fixes  #https://github.com/karmada-io/karmada/issues/2525


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Introduced resource label `namespace.karmada.io/skip-auto-propagation: "true"` which can label the namespaces that should be skipped from auto propagation.
```

