### PR TITLE
Add placement for bindingSpec

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16651,6 +16651,10 @@
             "$ref": "#/definitions/com.github.karmada-io.karmada.pkg.apis.work.v1alpha2.GracefulEvictionTask"
           }
         },
+        "placement": {
+          "description": "Placement represents the rule for select clusters to propagate resources.",
+          "$ref": "#/definitions/com.github.karmada-io.karmada.pkg.apis.policy.v1alpha1.Placement"
+        },
         "propagateDeps": {
           "description": "PropagateDeps tells if relevant resources should be propagated automatically. It is inherited from PropagationPolicy or ClusterPropagationPolicy. default false.",
           "type": "boolean"

--- a/charts/karmada/_crds/bases/work.karmada.io_clusterresourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work.karmada.io_clusterresourcebindings.yaml
@@ -324,6 +324,372 @@ spec:
                   - reason
                   type: object
                 type: array
+              placement:
+                description: Placement represents the rule for select clusters to
+                  propagate resources.
+                properties:
+                  clusterAffinity:
+                    description: ClusterAffinity represents scheduling restrictions
+                      to a certain set of clusters. If not set, any cluster can be
+                      scheduling candidate.
+                    properties:
+                      clusterNames:
+                        description: ClusterNames is the list of clusters to be selected.
+                        items:
+                          type: string
+                        type: array
+                      exclude:
+                        description: ExcludedClusters is the list of clusters to be
+                          ignored.
+                        items:
+                          type: string
+                        type: array
+                      fieldSelector:
+                        description: FieldSelector is a filter to select member clusters
+                          by fields. If non-nil and non-empty, only the clusters match
+                          this filter will be selected.
+                        properties:
+                          matchExpressions:
+                            description: A list of field selector requirements.
+                            items:
+                              description: A node selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: The label key that the selector applies
+                                    to.
+                                  type: string
+                                operator:
+                                  description: Represents a key's relationship to
+                                    a set of values. Valid operators are In, NotIn,
+                                    Exists, DoesNotExist. Gt, and Lt.
+                                  type: string
+                                values:
+                                  description: An array of string values. If the operator
+                                    is In or NotIn, the values array must be non-empty.
+                                    If the operator is Exists or DoesNotExist, the
+                                    values array must be empty. If the operator is
+                                    Gt or Lt, the values array must have a single
+                                    element, which will be interpreted as an integer.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      labelSelector:
+                        description: LabelSelector is a filter to select member clusters
+                          by labels. If non-nil and non-empty, only the clusters match
+                          this filter will be selected.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                    type: object
+                  clusterTolerations:
+                    description: ClusterTolerations represents the tolerations.
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  replicaScheduling:
+                    description: ReplicaScheduling represents the scheduling policy
+                      on dealing with the number of replicas when propagating resources
+                      that have replicas in spec (e.g. deployments, statefulsets)
+                      to member clusters.
+                    properties:
+                      replicaDivisionPreference:
+                        description: ReplicaDivisionPreference determines how the
+                          replicas is divided when ReplicaSchedulingType is "Divided".
+                          Valid options are Aggregated and Weighted. "Aggregated"
+                          divides replicas into clusters as few as possible, while
+                          respecting clusters' resource availabilities during the
+                          division. "Weighted" divides replicas by weight according
+                          to WeightPreference.
+                        enum:
+                        - Aggregated
+                        - Weighted
+                        type: string
+                      replicaSchedulingType:
+                        default: Divided
+                        description: ReplicaSchedulingType determines how the replicas
+                          is scheduled when karmada propagating a resource. Valid
+                          options are Duplicated and Divided. "Duplicated" duplicates
+                          the same replicas to each candidate member cluster from
+                          resource. "Divided" divides replicas into parts according
+                          to number of valid candidate member clusters, and exact
+                          replicas for each cluster are determined by ReplicaDivisionPreference.
+                        enum:
+                        - Duplicated
+                        - Divided
+                        type: string
+                      weightPreference:
+                        description: WeightPreference describes weight for each cluster
+                          or for each group of cluster If ReplicaDivisionPreference
+                          is set to "Weighted", and WeightPreference is not set, scheduler
+                          will weight all clusters the same.
+                        properties:
+                          dynamicWeight:
+                            description: DynamicWeight specifies the factor to generates
+                              dynamic weight list. If specified, StaticWeightList
+                              will be ignored.
+                            enum:
+                            - AvailableReplicas
+                            type: string
+                          staticWeightList:
+                            description: StaticWeightList defines the static cluster
+                              weight.
+                            items:
+                              description: StaticClusterWeight defines the static
+                                cluster weight.
+                              properties:
+                                targetCluster:
+                                  description: TargetCluster describes the filter
+                                    to select clusters.
+                                  properties:
+                                    clusterNames:
+                                      description: ClusterNames is the list of clusters
+                                        to be selected.
+                                      items:
+                                        type: string
+                                      type: array
+                                    exclude:
+                                      description: ExcludedClusters is the list of
+                                        clusters to be ignored.
+                                      items:
+                                        type: string
+                                      type: array
+                                    fieldSelector:
+                                      description: FieldSelector is a filter to select
+                                        member clusters by fields. If non-nil and
+                                        non-empty, only the clusters match this filter
+                                        will be selected.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of field selector requirements.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    labelSelector:
+                                      description: LabelSelector is a filter to select
+                                        member clusters by labels. If non-nil and
+                                        non-empty, only the clusters match this filter
+                                        will be selected.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                  type: object
+                                weight:
+                                  description: Weight expressing the preference to
+                                    the cluster(s) specified by 'TargetCluster'.
+                                  format: int64
+                                  minimum: 1
+                                  type: integer
+                              required:
+                              - targetCluster
+                              - weight
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  spreadConstraints:
+                    description: SpreadConstraints represents a list of the scheduling
+                      constraints.
+                    items:
+                      description: SpreadConstraint represents the spread constraints
+                        on resources.
+                      properties:
+                        maxGroups:
+                          description: MaxGroups restricts the maximum number of cluster
+                            groups to be selected.
+                          type: integer
+                        minGroups:
+                          description: MinGroups restricts the minimum number of cluster
+                            groups to be selected. Defaults to 1.
+                          type: integer
+                        spreadByField:
+                          description: 'SpreadByField represents the fields on Karmada
+                            cluster API used for dynamically grouping member clusters
+                            into different groups. Resources will be spread among
+                            different cluster groups. Available fields for spreading
+                            are: cluster, region, zone, and provider. SpreadByField
+                            should not co-exist with SpreadByLabel. If both SpreadByField
+                            and SpreadByLabel are empty, SpreadByField will be set
+                            to "cluster" by system.'
+                          enum:
+                          - cluster
+                          - region
+                          - zone
+                          - provider
+                          type: string
+                        spreadByLabel:
+                          description: SpreadByLabel represents the label key used
+                            for grouping member clusters into different groups. Resources
+                            will be spread among different cluster groups. SpreadByLabel
+                            should not co-exist with SpreadByField.
+                          type: string
+                      type: object
+                    type: array
+                type: object
               propagateDeps:
                 description: PropagateDeps tells if relevant resources should be propagated
                   automatically. It is inherited from PropagationPolicy or ClusterPropagationPolicy.

--- a/charts/karmada/_crds/bases/work.karmada.io_resourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work.karmada.io_resourcebindings.yaml
@@ -324,6 +324,372 @@ spec:
                   - reason
                   type: object
                 type: array
+              placement:
+                description: Placement represents the rule for select clusters to
+                  propagate resources.
+                properties:
+                  clusterAffinity:
+                    description: ClusterAffinity represents scheduling restrictions
+                      to a certain set of clusters. If not set, any cluster can be
+                      scheduling candidate.
+                    properties:
+                      clusterNames:
+                        description: ClusterNames is the list of clusters to be selected.
+                        items:
+                          type: string
+                        type: array
+                      exclude:
+                        description: ExcludedClusters is the list of clusters to be
+                          ignored.
+                        items:
+                          type: string
+                        type: array
+                      fieldSelector:
+                        description: FieldSelector is a filter to select member clusters
+                          by fields. If non-nil and non-empty, only the clusters match
+                          this filter will be selected.
+                        properties:
+                          matchExpressions:
+                            description: A list of field selector requirements.
+                            items:
+                              description: A node selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: The label key that the selector applies
+                                    to.
+                                  type: string
+                                operator:
+                                  description: Represents a key's relationship to
+                                    a set of values. Valid operators are In, NotIn,
+                                    Exists, DoesNotExist. Gt, and Lt.
+                                  type: string
+                                values:
+                                  description: An array of string values. If the operator
+                                    is In or NotIn, the values array must be non-empty.
+                                    If the operator is Exists or DoesNotExist, the
+                                    values array must be empty. If the operator is
+                                    Gt or Lt, the values array must have a single
+                                    element, which will be interpreted as an integer.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      labelSelector:
+                        description: LabelSelector is a filter to select member clusters
+                          by labels. If non-nil and non-empty, only the clusters match
+                          this filter will be selected.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                    type: object
+                  clusterTolerations:
+                    description: ClusterTolerations represents the tolerations.
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  replicaScheduling:
+                    description: ReplicaScheduling represents the scheduling policy
+                      on dealing with the number of replicas when propagating resources
+                      that have replicas in spec (e.g. deployments, statefulsets)
+                      to member clusters.
+                    properties:
+                      replicaDivisionPreference:
+                        description: ReplicaDivisionPreference determines how the
+                          replicas is divided when ReplicaSchedulingType is "Divided".
+                          Valid options are Aggregated and Weighted. "Aggregated"
+                          divides replicas into clusters as few as possible, while
+                          respecting clusters' resource availabilities during the
+                          division. "Weighted" divides replicas by weight according
+                          to WeightPreference.
+                        enum:
+                        - Aggregated
+                        - Weighted
+                        type: string
+                      replicaSchedulingType:
+                        default: Divided
+                        description: ReplicaSchedulingType determines how the replicas
+                          is scheduled when karmada propagating a resource. Valid
+                          options are Duplicated and Divided. "Duplicated" duplicates
+                          the same replicas to each candidate member cluster from
+                          resource. "Divided" divides replicas into parts according
+                          to number of valid candidate member clusters, and exact
+                          replicas for each cluster are determined by ReplicaDivisionPreference.
+                        enum:
+                        - Duplicated
+                        - Divided
+                        type: string
+                      weightPreference:
+                        description: WeightPreference describes weight for each cluster
+                          or for each group of cluster If ReplicaDivisionPreference
+                          is set to "Weighted", and WeightPreference is not set, scheduler
+                          will weight all clusters the same.
+                        properties:
+                          dynamicWeight:
+                            description: DynamicWeight specifies the factor to generates
+                              dynamic weight list. If specified, StaticWeightList
+                              will be ignored.
+                            enum:
+                            - AvailableReplicas
+                            type: string
+                          staticWeightList:
+                            description: StaticWeightList defines the static cluster
+                              weight.
+                            items:
+                              description: StaticClusterWeight defines the static
+                                cluster weight.
+                              properties:
+                                targetCluster:
+                                  description: TargetCluster describes the filter
+                                    to select clusters.
+                                  properties:
+                                    clusterNames:
+                                      description: ClusterNames is the list of clusters
+                                        to be selected.
+                                      items:
+                                        type: string
+                                      type: array
+                                    exclude:
+                                      description: ExcludedClusters is the list of
+                                        clusters to be ignored.
+                                      items:
+                                        type: string
+                                      type: array
+                                    fieldSelector:
+                                      description: FieldSelector is a filter to select
+                                        member clusters by fields. If non-nil and
+                                        non-empty, only the clusters match this filter
+                                        will be selected.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of field selector requirements.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    labelSelector:
+                                      description: LabelSelector is a filter to select
+                                        member clusters by labels. If non-nil and
+                                        non-empty, only the clusters match this filter
+                                        will be selected.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                  type: object
+                                weight:
+                                  description: Weight expressing the preference to
+                                    the cluster(s) specified by 'TargetCluster'.
+                                  format: int64
+                                  minimum: 1
+                                  type: integer
+                              required:
+                              - targetCluster
+                              - weight
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  spreadConstraints:
+                    description: SpreadConstraints represents a list of the scheduling
+                      constraints.
+                    items:
+                      description: SpreadConstraint represents the spread constraints
+                        on resources.
+                      properties:
+                        maxGroups:
+                          description: MaxGroups restricts the maximum number of cluster
+                            groups to be selected.
+                          type: integer
+                        minGroups:
+                          description: MinGroups restricts the minimum number of cluster
+                            groups to be selected. Defaults to 1.
+                          type: integer
+                        spreadByField:
+                          description: 'SpreadByField represents the fields on Karmada
+                            cluster API used for dynamically grouping member clusters
+                            into different groups. Resources will be spread among
+                            different cluster groups. Available fields for spreading
+                            are: cluster, region, zone, and provider. SpreadByField
+                            should not co-exist with SpreadByLabel. If both SpreadByField
+                            and SpreadByLabel are empty, SpreadByField will be set
+                            to "cluster" by system.'
+                          enum:
+                          - cluster
+                          - region
+                          - zone
+                          - provider
+                          type: string
+                        spreadByLabel:
+                          description: SpreadByLabel represents the label key used
+                            for grouping member clusters into different groups. Resources
+                            will be spread among different cluster groups. SpreadByLabel
+                            should not co-exist with SpreadByField.
+                          type: string
+                      type: object
+                    type: array
+                type: object
               propagateDeps:
                 description: PropagateDeps tells if relevant resources should be propagated
                   automatically. It is inherited from PropagationPolicy or ClusterPropagationPolicy.

--- a/pkg/apis/work/v1alpha2/binding_types.go
+++ b/pkg/apis/work/v1alpha2/binding_types.go
@@ -5,6 +5,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 )
 
 const (
@@ -71,6 +73,10 @@ type ResourceBindingSpec struct {
 	// Clusters represents target member clusters where the resource to be deployed.
 	// +optional
 	Clusters []TargetCluster `json:"clusters,omitempty"`
+
+	// Placement represents the rule for select clusters to propagate resources.
+	// +optional
+	Placement *policyv1alpha1.Placement `json:"placement,omitempty"`
 
 	// GracefulEvictionTasks holds the eviction tasks that are expected to perform
 	// the eviction in a graceful way.

--- a/pkg/apis/work/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/work/v1alpha2/zz_generated.deepcopy.go
@@ -6,6 +6,7 @@
 package v1alpha2
 
 import (
+	v1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -289,6 +290,11 @@ func (in *ResourceBindingSpec) DeepCopyInto(out *ResourceBindingSpec) {
 		in, out := &in.Clusters, &out.Clusters
 		*out = make([]TargetCluster, len(*in))
 		copy(*out, *in)
+	}
+	if in.Placement != nil {
+		in, out := &in.Placement, &out.Placement
+		*out = new(v1alpha1.Placement)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.GracefulEvictionTasks != nil {
 		in, out := &in.GracefulEvictionTasks, &out.GracefulEvictionTasks

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -412,6 +412,7 @@ func (d *ResourceDetector) ApplyPolicy(object *unstructured.Unstructured, object
 			bindingCopy.Spec.Replicas = binding.Spec.Replicas
 			bindingCopy.Spec.PropagateDeps = binding.Spec.PropagateDeps
 			bindingCopy.Spec.SchedulerName = binding.Spec.SchedulerName
+			bindingCopy.Spec.Placement = binding.Spec.Placement
 			return nil
 		})
 		if err != nil {
@@ -486,6 +487,7 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 				bindingCopy.Spec.Replicas = binding.Spec.Replicas
 				bindingCopy.Spec.PropagateDeps = binding.Spec.PropagateDeps
 				bindingCopy.Spec.SchedulerName = binding.Spec.SchedulerName
+				bindingCopy.Spec.Placement = binding.Spec.Placement
 				return nil
 			})
 			if err != nil {
@@ -528,6 +530,7 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 			bindingCopy.Spec.ReplicaRequirements = binding.Spec.ReplicaRequirements
 			bindingCopy.Spec.Replicas = binding.Spec.Replicas
 			bindingCopy.Spec.SchedulerName = binding.Spec.SchedulerName
+			bindingCopy.Spec.Placement = binding.Spec.Placement
 			return nil
 		})
 		if err != nil {
@@ -625,6 +628,7 @@ func (d *ResourceDetector) BuildResourceBinding(object *unstructured.Unstructure
 		Spec: workv1alpha2.ResourceBindingSpec{
 			PropagateDeps: policySpec.PropagateDeps,
 			SchedulerName: policySpec.SchedulerName,
+			Placement:     &policySpec.Placement,
 			Resource: workv1alpha2.ObjectReference{
 				APIVersion:      object.GetAPIVersion(),
 				Kind:            object.GetKind(),
@@ -664,6 +668,7 @@ func (d *ResourceDetector) BuildClusterResourceBinding(object *unstructured.Unst
 		Spec: workv1alpha2.ResourceBindingSpec{
 			PropagateDeps: policySpec.PropagateDeps,
 			SchedulerName: policySpec.SchedulerName,
+			Placement:     &policySpec.Placement,
 			Resource: workv1alpha2.ObjectReference{
 				APIVersion:      object.GetAPIVersion(),
 				Kind:            object.GetKind(),

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -5209,6 +5209,12 @@ func schema_pkg_apis_work_v1alpha2_ResourceBindingSpec(ref common.ReferenceCallb
 							},
 						},
 					},
+					"placement": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Placement represents the rule for select clusters to propagate resources.",
+							Ref:         ref("github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1.Placement"),
+						},
+					},
 					"gracefulEvictionTasks": {
 						SchemaProps: spec.SchemaProps{
 							Description: "GracefulEvictionTasks holds the eviction tasks that are expected to perform the eviction in a graceful way. The intended workflow is: 1. Once the controller(such as 'taint-manager') decided to evict the resource that\n   is referenced by current ResourceBinding or ClusterResourceBinding from a target\n   cluster, it removes(or scale down the replicas) the target from Clusters(.spec.Clusters)\n   and builds a graceful eviction task.\n2. The scheduler may perform a re-scheduler and probably select a substitute cluster\n   to take over the evicting workload(resource).\n3. The graceful eviction controller takes care of the graceful eviction tasks and\n   performs the final removal after the workload(resource) is available on the substitute\n   cluster or exceed the grace termination period(defaults to 10 minutes).",
@@ -5249,7 +5255,7 @@ func schema_pkg_apis_work_v1alpha2_ResourceBindingSpec(ref common.ReferenceCallb
 			},
 		},
 		Dependencies: []string{
-			"github.com/karmada-io/karmada/pkg/apis/work/v1alpha2.BindingSnapshot", "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2.GracefulEvictionTask", "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2.ObjectReference", "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2.ReplicaRequirements", "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2.TargetCluster"},
+			"github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1.Placement", "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2.BindingSnapshot", "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2.GracefulEvictionTask", "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2.ObjectReference", "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2.ReplicaRequirements", "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2.TargetCluster"},
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
Add placement for BindingSpec can reduce the dependency of policy and make API more clear. Now the component above will check the placement of bindingSpec first and switch to get placement by label if placement of bindSpec is empty.

It can be smoothly upgraded from a lower version to a higher version. If karmada-controller-manager upgrades, spec.placement will occur according to the placement of policy.

Upgrade path: upgrade crd --> upgrade karmada-controller-manager --> upgrade karmada-scheduler.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

