### PR TITLE
Automated cherry pick of #2650: add feature gate for search and proxy

### DIFF
--- a/pkg/search/controller.go
+++ b/pkg/search/controller.go
@@ -21,7 +21,6 @@ import (
 	clusterV1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	searchv1alpha1 "github.com/karmada-io/karmada/pkg/apis/search/v1alpha1"
-	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
 	informerfactory "github.com/karmada-io/karmada/pkg/generated/informers/externalversions"
 	clusterlister "github.com/karmada-io/karmada/pkg/generated/listers/cluster/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/search/backendstore"
@@ -56,16 +55,8 @@ type Controller struct {
 }
 
 // NewController returns a new ResourceRegistry controller
-func NewController(restConfig *rest.Config) (*Controller, error) {
-	karmadaClient := karmadaclientset.NewForConfigOrDie(restConfig)
-	factory := informerfactory.NewSharedInformerFactory(karmadaClient, 0)
+func NewController(restConfig *rest.Config, factory informerfactory.SharedInformerFactory, restMapper meta.RESTMapper) (*Controller, error) {
 	clusterLister := factory.Cluster().V1alpha1().Clusters().Lister()
-	restMapper, err := restmapper.MapperProvider(restConfig)
-	if err != nil {
-		klog.Errorf("Failed to create REST mapper: %v", err)
-		return nil, err
-	}
-
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 
 	c := &Controller{
@@ -111,7 +102,6 @@ func (c *Controller) Start(stopCh <-chan struct{}) {
 
 	defer runtime.HandleCrash()
 
-	c.informerFactory.Start(stopCh)
 	c.informerFactory.WaitForCacheSync(stopCh)
 
 	go wait.Until(c.worker, time.Second, stopCh)


### PR DESCRIPTION
Cherry pick of #2650 on release-1.3.
#2650: add feature gate for search and proxy
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-search`: users now can use `--disable-search` and `--disable-proxy` options to disable search and proxy feature (default both are enabled).
```