### PR TITLE
fix chart lint failure

### DIFF
--- a/.github/workflows/lint-chart.yaml
+++ b/.github/workflows/lint-chart.yaml
@@ -65,4 +65,4 @@ jobs:
           kubectl_version: ${{ env.K8S_VERSION }}
 
       - name: Run chart-testing (install)
-        run: ct install --debug --helm-extra-args "--timeout 400s"
+        run: ct install --debug --helm-extra-args "--timeout 800s"

--- a/charts/karmada/templates/karmada-apiserver.yaml
+++ b/charts/karmada/templates/karmada-apiserver.yaml
@@ -94,7 +94,8 @@ spec:
               path: /readyz
               port: 5443
               scheme: HTTPS
-            periodSeconds: 1
+            initialDelaySeconds: 10
+            periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 15
           resources:


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Recently chart-lint sometimes failed, such as https://github.com/karmada-io/karmada/actions/runs/3350829274/jobs/5551890843.

There are mainly two reasons:
1. Timeout. The installation of the release could not be completed within the given time(400s).
2. Post-install job failed. This is mainly because karmada-apiserver is always not ready due to readinessProbe. The job will install the crd but it cannot visit karmada-apiserver. After backoffLimit, it will fail in the end.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

