### PR TITLE
Fix Test Not Success in GoLand

### DIFF
--- a/pkg/search/proxy/controller_test.go
+++ b/pkg/search/proxy/controller_test.go
@@ -418,7 +418,6 @@ func TestController_Connect(t *testing.T) {
 			conn.ServeHTTP(recorder, req)
 
 			response := recorder.Result()
-			fmt.Printf("response: %v", response)
 
 			if (response.StatusCode != 200) != tt.wantErr {
 				t.Errorf("http request returned status code = %v, want error = %v",


### PR DESCRIPTION
Signed-off-by: raymondmiaochaoyue <raymondmiaochaoyue@didiglobal.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The original test used `fmt.Printf` without `\n` to print log, this will cause stdout be polluted. Polluted stdout will cause GoLand parse test result failure.

This is similar to this issue: <https://github.com/karmada-io/karmada/issues/2671>

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

