### PR TITLE
optimize error message for collectClusterID

### DIFF
--- a/pkg/controllers/cluster/cluster_controller.go
+++ b/pkg/controllers/cluster/cluster_controller.go
@@ -654,20 +654,20 @@ func (c *Controller) collectIDForClusterObjectIfNeeded(ctx context.Context) (err
 
 		clusterClient, err := util.NewClusterClientSet(cluster.Name, c.Client, nil)
 		if err != nil {
-			errs = append(errs, err)
+			errs = append(errs, fmt.Errorf("%s: %s", cluster.Name, err.Error()))
 			continue
 		}
 
 		id, err := util.ObtainClusterID(clusterClient.KubeClient)
 		if err != nil {
-			errs = append(errs, err)
+			errs = append(errs, fmt.Errorf("%s: %s", cluster.Name, err.Error()))
 			continue
 		}
 		cluster.Spec.ID = id
 
 		err = c.Client.Update(ctx, cluster)
 		if err != nil {
-			errs = append(errs, err)
+			errs = append(errs, fmt.Errorf("%s: %s", cluster.Name, err.Error()))
 			continue
 		}
 	}


### PR DESCRIPTION
Signed-off-by: calvin <wen.chen@daocloud.io>

**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
optimize error message for `collectIDForClusterObjectIfNeeded`, It's clear to konw which cluster failed to update cluster ID.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

