### PR TITLE
Refactor the func and event of taint cluster

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -10,10 +10,10 @@ const (
 	EventReasonRemoveExecutionSpaceFailed = "RemoveExecutionSpaceFailed"
 	// EventReasonRemoveExecutionSpaceSucceed indicates that remove execution space succeed.
 	EventReasonRemoveExecutionSpaceSucceed = "RemoveExecutionSpaceSucceed"
-	// EventReasonTaintClusterByConditionFailed indicates that taint cluster by condition failed.
-	EventReasonTaintClusterByConditionFailed = "TaintClusterByConditionFailed"
-	// EventReasonRemoveTargetClusterFailed indicates that failed to remove target cluster from binding.
-	EventReasonRemoveTargetClusterFailed = "RemoveTargetClusterFailed"
+	// EventReasonTaintClusterFailed indicates that taint cluster failed.
+	EventReasonTaintClusterFailed = "TaintClusterFailed"
+	// EventReasonTaintClusterSucceed indicates that taint cluster succeed.
+	EventReasonTaintClusterSucceed = "TaintClusterSucceed"
 	// EventReasonSyncImpersonationConfigSucceed indicates that sync impersonation config succeed.
 	EventReasonSyncImpersonationConfigSucceed = "SyncImpersonationConfigSucceed"
 	// EventReasonSyncImpersonationConfigFailed indicates that sync impersonation config failed.

--- a/test/e2e/failover_test.go
+++ b/test/e2e/failover_test.go
@@ -558,7 +558,8 @@ func recoverTaintedCluster(c client.Client, clusterName string, taint corev1.Tai
 			}
 			return false, err
 		}
-		if err := helper.UpdateClusterControllerTaint(context.TODO(), c, nil, []*corev1.Taint{&taint}, clusterObj); err != nil {
+		clusterObj.Spec.Taints = helper.SetCurrentClusterTaints(nil, []*corev1.Taint{&taint}, clusterObj)
+		if err := c.Update(context.TODO(), clusterObj); err != nil {
 			if apierrors.IsConflict(err) {
 				return false, nil
 			}


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Refactor:
1. Now the former `UpdateClusterControllerTaint` is an unclear naming. Changed to `UpdateClusterTaints`.
2. `UpdateClusterControllerTaint` do two things. The first is generate the updated taints based on the taintsAdd and taintsRemove. The Second is update the cluster taints which is generated above. Splitting functions makes responsibilities more single.
3. `updateClusterTaints` should be a method of the cluster-controller by its responsibility. This is also good for joining events.
4. `RemoveTargetClusterFailed` is triggered by updating the termating taint failure. It should be merged into `TaintClusterFailed`.

```
Events:
  Type    Reason                          Age   From                     Message
  ----    ------                          ----  ----                     -------
  Normal  CreateExecutionSpaceSucceed     32s   cluster-controller       Created execution space(karmada-es-member1) for cluster(member1).
  Normal  TaintClusterSucceed             32s   cluster-controller       Taint cluster succeed: cluster now has taints([{Key:cluster.karmada.io/not-ready,Effect:NoSchedule}]).
  Normal  SyncImpersonationConfigSucceed  32s   unified-auth-controller  Sync impersonation config succeed.
  Normal  TaintClusterSucceed             32s   cluster-controller       Taint cluster succeed: cluster now does not have taints.
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```
`Instrumentation`: Introduced the `TaintClusterSucceed` event to `Cluster` object and merged `TaintClusterByConditionFailed` and `RemoveTargetClusterFailed` to `TaintClusterFailed`.
```

