### PR TITLE
Increase codecov successful uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,15 @@ jobs:
       - name: make test
         run: make test
       - name: Upload coverage to Codecov
+        # Prevent running from the forked repository that doesn't need to upload coverage.
+        # In addition, running on the forked repository would fail as missing the necessary secret.
+        if: ${{ github.repository == 'karmada-io/karmada' }}
         uses: codecov/codecov-action@v3
         with:
+          # Even though token upload token is not required for public repos,
+          # but adding a token might increase successful uploads as per:
+          # https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954
+          token: ${{secrets.CODECOV_UPLOAD_TOKEN}}
           files: ./_output/coverage/coverage_pkg.txt,./_output/coverage/coverage_cmd.txt,./_output/coverage/coverage_examples.txt
           flags: unittests
           fail_ci_if_error: true


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

There is an open issue on `CodeCov` that would fail when uploading coverage reports.
As per https://github.com/codecov/codecov-action/issues/598#issuecomment-1302610539, we can improve it by providing an upload token.

This PR does:
1. Prevent code coverage upload from the forked repo
2. Introduce upload token to increase successful uploads

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

According to the test result, the upload coverage step could be skipped, see:
https://github.com/RainbowMango/karmada/actions/runs/3390765450/jobs/5635308741

![image](https://user-images.githubusercontent.com/8268873/199873439-4729cd64-8983-4d0c-bb21-58af862578eb.png)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

