### PR TITLE
Resource Aggregation Proxy: make multi cluster ResourceVersion string stable

### DIFF
--- a/pkg/search/proxy/store/util_test.go
+++ b/pkg/search/proxy/store/util_test.go
@@ -201,7 +201,7 @@ func Test_newMultiClusterResourceVersionFromString(t *testing.T) {
 			},
 		},
 		{
-			name: "success",
+			name: "success - normal",
 			args: args{
 				s: base64.RawURLEncoding.EncodeToString([]byte(`{"cluster1":"1","cluster2":"2"}`)),
 			},
@@ -209,6 +209,30 @@ func Test_newMultiClusterResourceVersionFromString(t *testing.T) {
 				rvs: map[string]string{
 					"cluster1": "1",
 					"cluster2": "2",
+				},
+			},
+		},
+		{
+			name: "success - empty cluster name",
+			args: args{
+				s: base64.RawURLEncoding.EncodeToString([]byte(`{"":"1","cluster2":"2"}`)),
+			},
+			want: &multiClusterResourceVersion{
+				rvs: map[string]string{
+					"":         "1",
+					"cluster2": "2",
+				},
+			},
+		},
+		{
+			name: "success - empty ResourceVersion",
+			args: args{
+				s: base64.RawURLEncoding.EncodeToString([]byte(`{"cluster1":"","cluster2":""}`)),
+			},
+			want: &multiClusterResourceVersion{
+				rvs: map[string]string{
+					"cluster1": "",
+					"cluster2": "",
 				},
 			},
 		},
@@ -310,7 +334,7 @@ func Test_multiClusterResourceVersion_String(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "get success",
+			name: "get success - normal",
 			fields: fields{
 				rvs: map[string]string{
 					"cluster1": "1",
@@ -318,6 +342,26 @@ func Test_multiClusterResourceVersion_String(t *testing.T) {
 				},
 			},
 			want: base64.RawURLEncoding.EncodeToString([]byte(`{"cluster1":"1","cluster2":"2"}`)),
+		},
+		{
+			name: "get success - empty cluster name",
+			fields: fields{
+				rvs: map[string]string{
+					"":         "1",
+					"cluster2": "2",
+				},
+			},
+			want: base64.RawURLEncoding.EncodeToString([]byte(`{"":"1","cluster2":"2"}`)),
+		},
+		{
+			name: "get success - empty ResourceVersion",
+			fields: fields{
+				rvs: map[string]string{
+					"cluster1": "",
+					"cluster2": "",
+				},
+			},
+			want: base64.RawURLEncoding.EncodeToString([]byte(`{"cluster1":"","cluster2":""}`)),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Signed-off-by: raymondmiaochaoyue <raymondmiaochaoyue@didiglobal.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

"Resource Aggregation Proxy" uses json to merge multiple cluster ResourceVersions. Original it's serialized directly from `map[string]string`, the result string is like following without base64 encoding:

```
{"cluster1":"1","cluster2":"2"}
```

We must make sure the returned json string is stable, because client might use this string for equality comparison. But hash map's key iteration order is not determined. So instead we convert the map to a slice, and the slice must be sorted by `Cluster` field before encoding.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
karmada-search: Fixed ResourceVersion returned by proxy is not stable.
```