### PR TITLE
Stop update krew for release 1.1.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,3 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         files: ./kubectl-karmada-${{ matrix.goos }}-${{ matrix.goarch }}.tgz
-  update-krew-index:
-    needs: release-assests
-    name: Update krew-index
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@master
-    - name: Update new version in krew-index
-      uses: rajatjindal/krew-release-bot@v0.0.40


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Since [krew ](https://github.com/kubernetes-sigs/krew)only caches the latest release, so we don't need to update it for v1.1.x releases. Otherwise, it will open an invalid PR, like https://github.com/kubernetes-sigs/krew-index/pull/2657.

**Which issue(s) this PR fixes**:
Fixes #2743

**Special notes for your reviewer**:


