### PR TITLE
remove overridepolicy trigger on cluster_resource_binding_controller

### DIFF
--- a/pkg/controllers/binding/cluster_resource_binding_controller.go
+++ b/pkg/controllers/binding/cluster_resource_binding_controller.go
@@ -218,7 +218,6 @@ func (c *ClusterResourceBindingController) SetupWithManager(mgr controllerruntim
 
 	return controllerruntime.NewControllerManagedBy(mgr).For(&workv1alpha2.ClusterResourceBinding{}).
 		Watches(&source.Kind{Type: &workv1alpha1.Work{}}, handler.EnqueueRequestsFromMapFunc(workFn), workPredicateFn).
-		Watches(&source.Kind{Type: &policyv1alpha1.OverridePolicy{}}, handler.EnqueueRequestsFromMapFunc(c.newOverridePolicyFunc())).
 		Watches(&source.Kind{Type: &policyv1alpha1.ClusterOverridePolicy{}}, handler.EnqueueRequestsFromMapFunc(c.newOverridePolicyFunc())).
 		WithOptions(controller.Options{
 			RateLimiter: ratelimiterflag.DefaultControllerRateLimiter(c.RateLimiterOptions),
@@ -231,8 +230,6 @@ func (c *ClusterResourceBindingController) newOverridePolicyFunc() handler.MapFu
 		var overrideRS []policyv1alpha1.ResourceSelector
 		switch t := a.(type) {
 		case *policyv1alpha1.ClusterOverridePolicy:
-			overrideRS = t.Spec.ResourceSelectors
-		case *policyv1alpha1.OverridePolicy:
 			overrideRS = t.Spec.ResourceSelectors
 		default:
 			return nil


### PR DESCRIPTION
Signed-off-by: wuyingjun <wuyingjun_yewu@cmss.chinamobile.com>

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind cleanup


-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Clean up before https://github.com/karmada-io/karmada/issues/2695

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
Overridepolicy will never work for cluster_resource_binding_controller
Reason :
```1:  cluster_resouce_binding will only be created for cluster-scoped resources in detector_controller```
```2:  overridepolicy will only work for namespace-scoped resources in override_manager```
```So cluster_resource_binding_controller do not need to watch the event for overridepolicy```
