### PR TITLE
Add override policy apply event

### DIFF
--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -499,7 +499,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 	dynamicClientSet := dynamic.NewForConfigOrDie(restConfig)
 	discoverClientSet := discovery.NewDiscoveryClientForConfigOrDie(restConfig)
 
-	overrideManager := overridemanager.New(mgr.GetClient())
+	overrideManager := overridemanager.New(mgr.GetClient(), mgr.GetEventRecorderFor(overridemanager.OverrideManagerName))
 	skippedResourceConfig := util.NewSkippedResourceConfig()
 	if err := skippedResourceConfig.Parse(opts.SkippedPropagatingAPIs); err != nil {
 		// The program will never go here because the parameters have been checked

--- a/pkg/apis/work/v1alpha2/events.go
+++ b/pkg/apis/work/v1alpha2/events.go
@@ -16,6 +16,10 @@ const (
 	EventReasonApplyPolicyFailed = "ApplyPolicyFailed"
 	// EventReasonApplyPolicySucceed indicates that apply policy for resource succeed.
 	EventReasonApplyPolicySucceed = "ApplyPolicySucceed"
+	// EventReasonApplyOverridePolicyFailed indicates that apply override policy failed.
+	EventReasonApplyOverridePolicyFailed = "ApplyOverridePolicyFailed"
+	// EventReasonApplyOverridePolicySucceed indicates that apply override policy succeed.
+	EventReasonApplyOverridePolicySucceed = "ApplyOverridePolicySucceed"
 	// EventReasonScheduleBindingFailed indicates that schedule binding failed.
 	EventReasonScheduleBindingFailed = "ScheduleBindingFailed"
 	// EventReasonScheduleBindingSucceed indicates that schedule binding succeed.

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -435,7 +435,7 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 		if err != nil {
 			d.EventRecorder.Eventf(object, corev1.EventTypeWarning, workv1alpha2.EventReasonApplyPolicyFailed, "Apply cluster policy(%s) failed: %v", policy.Name, err)
 		} else if operationResult != controllerutil.OperationResultNone {
-			d.EventRecorder.Eventf(object, corev1.EventTypeNormal, workv1alpha2.EventReasonApplyPolicySucceed, "Apply policy(%s/%s) succeed", policy.Name)
+			d.EventRecorder.Eventf(object, corev1.EventTypeNormal, workv1alpha2.EventReasonApplyPolicySucceed, "Apply cluster policy(%s/%s) succeed", policy.Name)
 		}
 	}()
 


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add override policy apply event. Now users can get events from workloads to know whether override policy is applied succeessfully.
```
Events:
  Type     Reason                      Age                    From                  Message
  ----     ------                      ----                   ----                  -------
  Normal   SyncWorkSucceed             3m57s                  binding-controller    Sync work of resourceBinding(default/nginx-deployment) successful.
  Normal   AggregateStatusSucceed      3m57s                  binding-controller    Update resourceBinding(default/nginx-deployment) with AggregatedStatus successfully.
  Warning  SyncFailed                  3m35s                  execution-controller  Failed to update resource(default/nginx) in member cluster(member1): the informer of cluster(member1) has not been initialized
  Normal   ApplyPolicySucceed          3m35s                  resource-detector     Apply policy(default/nginx-propagation) succeed
  Warning  SyncFailed                  3m35s (x3 over 3m35s)  execution-controller  Failed to create resource(default/nginx) in member cluster(member1): the informer of cluster(member1) has not been initialized
  Normal   ScheduleBindingSucceed      86s (x18 over 15h)     karmada-scheduler     Binding has been scheduled
  Normal   SyncWorkSucceed             86s (x10 over 3m35s)   binding-controller    Sync work of resourceBinding(default/nginx-deployment) successful.
  Normal   AggregateStatusSucceed      86s (x10 over 3m35s)   binding-controller    Update resourceBinding(default/nginx-deployment) with AggregatedStatus successfully.
  Normal   SyncSucceed                 86s (x2 over 3m35s)    execution-controller  Successfully applied resource(default/nginx) to cluster member1
  Normal   ApplyOverridePolicySucceed  86s (x5 over 86s)      override-manager      Apply override policy(default/nginx-op) for cluster(member1) succeed.

```
**Which issue(s) this PR fixes**:
Part of #2472 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```
`Instrumentation`: Introduced the `ApplyOverridePolicySucceed` and `ApplyOverridePolicyFailed` events to workload.
```

