### PR TITLE
Add limitReader to io.ReadAll

### DIFF
--- a/pkg/karmadactl/cmdinit/utils/format.go
+++ b/pkg/karmadactl/cmdinit/utils/format.go
@@ -19,6 +19,8 @@ const (
 	// A split symbol that receives multiple values from a command flag
 	separator      = ","
 	labelSeparator = "="
+	// MaxRespBodyLength is the max length of http response body
+	MaxRespBodyLength = 1 << 20 // 1 MiB
 )
 
 // IsExist Determine whether the path exists
@@ -60,7 +62,7 @@ func InternetIP() (net.IP, error) {
 
 	defer resp.Body.Close()
 
-	content, err := io.ReadAll(resp.Body)
+	content, err := io.ReadAll(io.LimitReader(resp.Body, MaxRespBodyLength))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`io.ReadAll` has no restrictions on memory request, which can easily lead to DoS attacks. Add limitReader can limit the memory.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```
`Security`: Add limitReader to `io.ReadAll` which could limit the memory request and avoid DoS attacks.
```

