### PR TITLE
Add reflectStatusToWork and InterpretHealth event

### DIFF
--- a/pkg/apis/work/v1alpha1/events.go
+++ b/pkg/apis/work/v1alpha1/events.go
@@ -7,4 +7,16 @@ const (
 
 	// EventReasonSyncWorkSucceed indicates that Sync work succeed.
 	EventReasonSyncWorkSucceed = "SyncSucceed"
+
+	// EventReasonReflectStatusSucceed indicates that reflect status to work succeed.
+	EventReasonReflectStatusSucceed = "ReflectStatusSucceed"
+
+	// EventReasonReflectStatusFailed indicates that reflect status to work failed.
+	EventReasonReflectStatusFailed = "ReflectStatusFailed"
+
+	// EventReasonInterpretHealthSucceed indicates that interpret health succeed.
+	EventReasonInterpretHealthSucceed = "InterpretHealthSucceed"
+
+	// EventReasonInterpretHealthFailed indicates that interpret health failed.
+	EventReasonInterpretHealthFailed = "InterpretHealthFailed"
 )

--- a/pkg/controllers/status/workstatus_controller.go
+++ b/pkg/controllers/status/workstatus_controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -288,8 +289,10 @@ func (c *WorkStatusController) reflectStatus(work *workv1alpha1.Work, clusterObj
 	if err != nil {
 		klog.Errorf("Failed to reflect status for object(%s/%s/%s) with resourceInterpreter.",
 			clusterObj.GetKind(), clusterObj.GetNamespace(), clusterObj.GetName(), err)
+		c.EventRecorder.Eventf(work, corev1.EventTypeWarning, workv1alpha1.EventReasonReflectStatusFailed, "Reflect status for object(%s/%s/%s) failed, err: %s.", clusterObj.GetKind(), clusterObj.GetNamespace(), clusterObj.GetName(), err.Error())
 		return err
 	}
+	c.EventRecorder.Eventf(work, corev1.EventTypeNormal, workv1alpha1.EventReasonReflectStatusSucceed, "Reflect status for object(%s/%s/%s) succeed.", clusterObj.GetKind(), clusterObj.GetNamespace(), clusterObj.GetName())
 
 	if statusRaw == nil {
 		return nil
@@ -301,10 +304,13 @@ func (c *WorkStatusController) reflectStatus(work *workv1alpha1.Work, clusterObj
 	healthy, err := c.ResourceInterpreter.InterpretHealth(clusterObj)
 	if err != nil {
 		resourceHealth = workv1alpha1.ResourceUnknown
+		c.EventRecorder.Eventf(work, corev1.EventTypeWarning, workv1alpha1.EventReasonInterpretHealthFailed, "Interpret health of object(%s/%s/%s) failed, err: %s.", clusterObj.GetKind(), clusterObj.GetNamespace(), clusterObj.GetName(), err.Error())
 	} else if healthy {
 		resourceHealth = workv1alpha1.ResourceHealthy
+		c.EventRecorder.Eventf(work, corev1.EventTypeNormal, workv1alpha1.EventReasonInterpretHealthSucceed, "Interpret health of object(%s/%s/%s) as healthy.", clusterObj.GetKind(), clusterObj.GetNamespace(), clusterObj.GetName())
 	} else {
 		resourceHealth = workv1alpha1.ResourceUnhealthy
+		c.EventRecorder.Eventf(work, corev1.EventTypeNormal, workv1alpha1.EventReasonInterpretHealthSucceed, "Interpret health of object(%s/%s/%s) as unhealthy.", clusterObj.GetKind(), clusterObj.GetNamespace(), clusterObj.GetName())
 	}
 
 	identifier, err := c.buildStatusIdentifier(work, clusterObj)


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add reflectStatusToWork and InterpretHealth event to `work` object.
```
Events:
  Type    Reason                      Age                    From                    Message
  ----    ------                      ----                   ----                    -------
  Normal  SyncSucceed                 6m28s                  execution-controller    Sync work (nginx-687f7fb96f) to cluster(member1) successful.
  Normal  InterpretHealthSucceed      6m27s (x3 over 6m28s)  work-status-controller  Interpret health of object(Deployment/default/nginx) as unhealthy.
  Normal  ReflectStatusToWorkSucceed  6m21s (x6 over 6m28s)  work-status-controller  Reflect status for object(Deployment/default/nginx) succeed.
  Normal  InterpretHealthSucceed      6m21s (x3 over 6m27s)  work-status-controller  Interpret health of object(Deployment/default/nginx) as healthy.

```
**Which issue(s) this PR fixes**:
Part of #2472 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```
`Instrumentation`: Introduced the `ReflectStatusToWorkSucceed`, `ReflectStatusToWorkFailed`, `InterpretHealthSucceed` and `InterpretHealthFailed` events to `work` object.
```

