### PR TITLE
Add getDependencies and syncScheduleResultToDependencies event

### DIFF
--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -545,6 +545,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 			InformerManager:     controlPlaneInformerManager,
 			ResourceInterpreter: resourceInterpreter,
 			RESTMapper:          mgr.GetRESTMapper(),
+			EventRecorder:       mgr.GetEventRecorderFor("dependencies-distributor"),
 		}
 		if err := mgr.Add(dependenciesDistributor); err != nil {
 			klog.Fatalf("Failed to setup dependencies distributor: %v", err)

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -44,6 +44,10 @@ const (
 const (
 	// EventReasonCleanupWorkFailed indicates that Cleanup work failed.
 	EventReasonCleanupWorkFailed = "CleanupWorkFailed"
+	// EventReasonSyncScheduleResultToDependenciesSucceed indicates sync schedule result to attached bindings succeed.
+	EventReasonSyncScheduleResultToDependenciesSucceed = "SyncScheduleResultToDependenciesSucceed"
+	// EventReasonSyncScheduleResultToDependenciesFailed indicates sync schedule result to attached bindings failed.
+	EventReasonSyncScheduleResultToDependenciesFailed = "SyncScheduleResultToDependenciesFailed"
 )
 
 // Define events for ResourceBinding, ClusterResourceBinding objects and their associated resources.
@@ -76,4 +80,8 @@ const (
 	EventReasonApplyOverridePolicyFailed = "ApplyOverridePolicyFailed"
 	// EventReasonApplyOverridePolicySucceed indicates that apply override policy succeed.
 	EventReasonApplyOverridePolicySucceed = "ApplyOverridePolicySucceed"
+	// EventReasonGetDependenciesSucceed indicates get dependencies of resource template succeed.
+	EventReasonGetDependenciesSucceed = "GetDependenciesSucceed"
+	// EventReasonGetDependenciesFailed indicates get dependencies of resource template failed.
+	EventReasonGetDependenciesFailed = "GetDependenciesFailed"
 )


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add getDependencies to resource template
```
Events:
  Type     Reason                  Age                 From                      Message
  ----     ------                  ----                ----                      -------
  Warning  ApplyPolicyFailed       28s                 resource-detector         No policy match for resource
  Normal   ApplyPolicySucceed      22s                 resource-detector         Apply policy(default/my-nginx-propagation) succeed
  Normal   SyncWorkSucceed         22s (x7 over 22s)   binding-controller        Sync work of resourceBinding(default/my-nginx-deployment) successful.
  Normal   AggregateStatusSucceed  22s (x7 over 22s)   binding-controller        Update resourceBinding(default/my-nginx-deployment) with AggregatedStatus successfully.
  Normal   ScheduleBindingSucceed  22s (x10 over 22s)  karmada-scheduler         Binding has been scheduled
  Normal   GetDependenciesSucceed  22s                 dependencies-distributor  Get dependencies([{APIVersion:v1 Kind:ConfigMap Namespace:default Name:my-nginx-config}]) succeed.
  Normal   SyncSucceed             22s                 execution-controller      Successfully applied resource(default/my-nginx) to cluster member2
  Normal   SyncSucceed             22s                 execution-controller      Successfully applied resource(default/my-nginx) to cluster member1
```

Add syncScheduleResultToDependencies to `resourceBinding` object
```
Events:
  Type    Reason                                   Age                     From                      Message
  ----    ------                                   ----                    ----                      -------
  Normal  SyncScheduleResultToDependenciesSucceed  7m35s (x2 over 7m35s)   dependencies-distributor  Sync schedule results to dependencies succeed.
  Normal  SyncWorkSucceed                          7m29s (x10 over 7m35s)  binding-controller        Sync work of resourceBinding(default/my-nginx-deployment) successful.
  Normal  AggregateStatusSucceed                   7m29s (x10 over 7m35s)  binding-controller        Update resourceBinding(default/my-nginx-deployment) with AggregatedStatus successfully.
  Normal  ScheduleBindingSucceed                   7m29s (x11 over 7m35s)  karmada-scheduler         Binding has been scheduled
```

**Which issue(s) this PR fixes**:
Part of #2472 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```
`Instrumentation`: Introduced the `GetDependenciesSucceed` and `GetDependenciesFailed` to the resource template. Introduced the `SyncScheduleResultToDependenciesSucceed` and `SyncScheduleResultToDependenciesFailed` to `resourceBinding` object
```

