### PR TITLE
Automated cherry pick of #2765: Add limitReader to io.ReadAll

### DIFF
--- a/pkg/karmadactl/cmdinit/utils/format.go
+++ b/pkg/karmadactl/cmdinit/utils/format.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -19,6 +19,8 @@ const (
 	// A split symbol that receives multiple values from a command flag
 	separator      = ","
 	labelSeparator = "="
+	// MaxRespBodyLength is the max length of http response body
+	MaxRespBodyLength = 1 << 20 // 1 MiB
 )
 
 // IsExist Determine whether the path exists
@@ -60,7 +62,7 @@ func InternetIP() (net.IP, error) {
 
 	defer resp.Body.Close()
 
-	content, err := ioutil.ReadAll(resp.Body)
+	content, err := io.ReadAll(io.LimitReader(resp.Body, MaxRespBodyLength))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/webhook/interpreter/http.go
+++ b/pkg/webhook/interpreter/http.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -13,6 +12,11 @@ import (
 	"k8s.io/klog/v2"
 
 	configv1alpha1 "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1"
+)
+
+const (
+	// MaxRespBodyLength is the max length of http response body
+	MaxRespBodyLength = 1 << 20 // 1 MiB
 )
 
 var admissionScheme = runtime.NewScheme()
@@ -34,7 +38,7 @@ func (wh *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	defer r.Body.Close()
-	if body, err = ioutil.ReadAll(r.Body); err != nil {
+	if body, err = io.ReadAll(io.LimitReader(r.Body, MaxRespBodyLength)); err != nil {
 		klog.Errorf("unable to read the body from the incoming request: %w", err)
 		res = Errored(http.StatusBadRequest, err)
 		wh.writeResponse(w, res)


### PR DESCRIPTION
Cherry pick of #2765 on release-1.2.
#2765: Add limitReader to io.ReadAll
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`Security`: Add limitReader to `io.ReadAll` which could limit the memory request and avoid DoS attacks.
```