### PR TITLE
chart: optimize pod startup order

### DIFF
--- a/charts/karmada/templates/karmada-controller-manager.yaml
+++ b/charts/karmada/templates/karmada-controller-manager.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: {{ include "karmada.namespace" . }}
   labels:
   {{- include "karmada.cm.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "2"
 spec:
   replicas: {{  .Values.controllerManager.replicaCount }}
   selector:


### PR DESCRIPTION
Signed-off-by: calvin <wen.chen@daocloud.io>

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
In our chart install workflow, use `post-job` to install all karmada crds. there is a problem, the karmada-controller-manager  is be installed before the job due to it always not running. becuase the karmada resource is not be `informer`:

<img width="1515" alt="wecom-temp-8ad6d41dcbe2b869cd65ae7833470986" src="https://user-images.githubusercontent.com/45745657/201308047-2e19be10-141d-4b04-b7a4-6d544e5780de.png">

so, we can install the karmada controller manager after the job have done.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
please correct me if not.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

