### PR TITLE
Add SyncImpersonationConfig event

### DIFF
--- a/pkg/controllers/unifiedauth/unified_auth_controller.go
+++ b/pkg/controllers/unifiedauth/unified_auth_controller.go
@@ -3,6 +3,7 @@ package unifiedauth
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,6 +23,7 @@ import (
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/events"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/helper"
 	"github.com/karmada-io/karmada/pkg/util/names"
@@ -71,8 +73,10 @@ func (c *Controller) Reconcile(ctx context.Context, req controllerruntime.Reques
 	err := c.syncImpersonationConfig(cluster)
 	if err != nil {
 		klog.Errorf("Failed to sync impersonation config for cluster %s. Error: %v.", cluster.Name, err)
+		c.EventRecorder.Eventf(cluster, corev1.EventTypeWarning, events.EventReasonSyncImpersonationConfigFailed, err.Error())
 		return controllerruntime.Result{Requeue: true}, err
 	}
+	c.EventRecorder.Eventf(cluster, corev1.EventTypeNormal, events.EventReasonSyncImpersonationConfigSucceed, "Sync impersonation config succeed.")
 
 	return controllerruntime.Result{}, nil
 }

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -14,6 +14,10 @@ const (
 	EventReasonTaintClusterByConditionFailed = "TaintClusterByConditionFailed"
 	// EventReasonRemoveTargetClusterFailed indicates that failed to remove target cluster from binding.
 	EventReasonRemoveTargetClusterFailed = "RemoveTargetClusterFailed"
+	// EventReasonSyncImpersonationConfigSucceed indicates that sync impersonation config succeed.
+	EventReasonSyncImpersonationConfigSucceed = "SyncImpersonationConfigSucceed"
+	// EventReasonSyncImpersonationConfigFailed indicates that sync impersonation config failed.
+	EventReasonSyncImpersonationConfigFailed = "SyncImpersonationConfigFailed"
 )
 
 // Define events for work objects.


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add SyncImpersonationConfig event
```
Events:
  Type    Reason                          Age                    From                     Message
  ----    ------                          ----                   ----                     -------
  Normal  SyncImpersonationConfigSucceed  4m45s (x2 over 4m45s)  unified-auth-controller  Sync impersonation config succeed.

```

**Which issue(s) this PR fixes**:
Part of #2472 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```
`Instrumentation`: Introduced the `SyncImpersonationConfigSucceed` and `SyncImpersonationConfigFailed` to the `cluster` object. 
```
