### PR TITLE
Automated cherry pick of #2771: fix overridepolicy with nil resource selector could not work

### DIFF
--- a/pkg/controllers/binding/binding_controller.go
+++ b/pkg/controllers/binding/binding_controller.go
@@ -175,11 +175,13 @@ func (c *ResourceBindingController) SetupWithManager(mgr controllerruntime.Manag
 func (c *ResourceBindingController) newOverridePolicyFunc() handler.MapFunc {
 	return func(a client.Object) []reconcile.Request {
 		var overrideRS []policyv1alpha1.ResourceSelector
+		var namespace string
 		switch t := a.(type) {
 		case *policyv1alpha1.ClusterOverridePolicy:
 			overrideRS = t.Spec.ResourceSelectors
 		case *policyv1alpha1.OverridePolicy:
 			overrideRS = t.Spec.ResourceSelectors
+			namespace = t.Namespace
 		default:
 			return nil
 		}
@@ -192,6 +194,18 @@ func (c *ResourceBindingController) newOverridePolicyFunc() handler.MapFunc {
 
 		var requests []reconcile.Request
 		for _, binding := range bindingList.Items {
+			// Skip resourceBinding with different namespace of current overridePolicy.
+			if len(namespace) != 0 && namespace != binding.Namespace {
+				continue
+			}
+
+			// Nil resourceSelectors means matching all resources.
+			if len(overrideRS) == 0 {
+				klog.V(2).Infof("Enqueue ResourceBinding(%s/%s) as override policy(%s/%s) changes.", binding.Namespace, binding.Name, a.GetNamespace(), a.GetName())
+				requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: binding.Namespace, Name: binding.Name}})
+				continue
+			}
+
 			workload, err := helper.FetchWorkload(c.DynamicClient, c.InformerManager, c.RESTMapper, binding.Spec.Resource)
 			if err != nil {
 				klog.Errorf("Failed to fetch workload for resourceBinding(%s/%s). Error: %v.", binding.Namespace, binding.Name, err)

--- a/pkg/controllers/binding/cluster_resource_binding_controller.go
+++ b/pkg/controllers/binding/cluster_resource_binding_controller.go
@@ -181,6 +181,13 @@ func (c *ClusterResourceBindingController) newOverridePolicyFunc() handler.MapFu
 
 		var requests []reconcile.Request
 		for _, binding := range bindingList.Items {
+			// Nil resourceSelectors means matching all resources.
+			if len(overrideRS) == 0 {
+				klog.V(2).Infof("Enqueue ClusterResourceBinding(%s) as cluster override policy(%s) changes.", binding.Name, a.GetName())
+				requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: binding.Name}})
+				continue
+			}
+
 			workload, err := helper.FetchWorkload(c.DynamicClient, c.InformerManager, c.RESTMapper, binding.Spec.Resource)
 			if err != nil {
 				klog.Errorf("Failed to fetch workload for clusterResourceBinding(%s). Error: %v.", binding.Name, err)
@@ -189,7 +196,7 @@ func (c *ClusterResourceBindingController) newOverridePolicyFunc() handler.MapFu
 
 			for _, rs := range overrideRS {
 				if util.ResourceMatches(workload, rs) {
-					klog.V(2).Infof("Enqueue ClusterResourceBinding(%s) as override policy(%s/%s) changes.", binding.Name, a.GetNamespace(), a.GetName())
+					klog.V(2).Infof("Enqueue ClusterResourceBinding(%s) as cluster override policy(%s) changes.", binding.Name, a.GetName())
 					requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: binding.Name}})
 					break
 				}

--- a/test/e2e/clusteroverridepolicy_test.go
+++ b/test/e2e/clusteroverridepolicy_test.go
@@ -1,0 +1,93 @@
+package e2e
+
+import (
+	"github.com/onsi/ginkgo"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	"github.com/karmada-io/karmada/test/e2e/framework"
+	testhelper "github.com/karmada-io/karmada/test/helper"
+)
+
+var _ = ginkgo.Describe("Test clusterOverridePolicy with nil resourceSelectors", func() {
+	var deploymentNamespace, deploymentName string
+	var propagationPolicyNamespace, propagationPolicyName string
+	var clusterOverridePolicyName string
+	var deployment *appsv1.Deployment
+	var propagationPolicy *policyv1alpha1.PropagationPolicy
+	var clusterOverridePolicy *policyv1alpha1.ClusterOverridePolicy
+
+	ginkgo.BeforeEach(func() {
+		deploymentNamespace = testNamespace
+		deploymentName = deploymentNamePrefix + rand.String(RandomStrLength)
+		propagationPolicyNamespace = testNamespace
+		propagationPolicyName = deploymentName
+		clusterOverridePolicyName = deploymentName
+
+		deployment = testhelper.NewDeployment(deploymentNamespace, deploymentName)
+		propagationPolicy = testhelper.NewPropagationPolicy(propagationPolicyNamespace, propagationPolicyName, []policyv1alpha1.ResourceSelector{
+			{
+				APIVersion: deployment.APIVersion,
+				Kind:       deployment.Kind,
+				Name:       deployment.Name,
+			},
+		}, policyv1alpha1.Placement{
+			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+				ClusterNames: framework.ClusterNames(),
+			},
+		})
+
+		clusterOverridePolicy = testhelper.NewClusterOverridePolicyByOverrideRules(clusterOverridePolicyName, nil, []policyv1alpha1.RuleWithCluster{
+			{
+				TargetCluster: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: framework.ClusterNames(),
+				},
+				Overriders: policyv1alpha1.Overriders{
+					ImageOverrider: []policyv1alpha1.ImageOverrider{
+						{
+							Predicate: &policyv1alpha1.ImagePredicate{
+								Path: "/spec/template/spec/containers/0/image",
+							},
+							Component: "Registry",
+							Operator:  "replace",
+							Value:     "fictional.registry.us",
+						},
+					},
+				},
+			},
+		})
+	})
+
+	ginkgo.Context("Deployment override testing", func() {
+		ginkgo.BeforeEach(func() {
+			framework.CreatePropagationPolicy(karmadaClient, propagationPolicy)
+			framework.CreateDeployment(kubeClient, deployment)
+		})
+
+		ginkgo.AfterEach(func() {
+			framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
+			framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
+		})
+
+		ginkgo.It("deployment imageOverride testing", func() {
+			ginkgo.By("Check if deployment have presented on member clusters", func() {
+				framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
+					func(deployment *appsv1.Deployment) bool {
+						return true
+					})
+			})
+
+			framework.CreateClusterOverridePolicy(karmadaClient, clusterOverridePolicy)
+
+			ginkgo.By("Check if deployment presented on member clusters have correct image value", func() {
+				framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
+					func(deployment *appsv1.Deployment) bool {
+						return deployment.Spec.Template.Spec.Containers[0].Image == "fictional.registry.us/nginx:1.19.0"
+					})
+			})
+
+			framework.RemoveClusterOverridePolicy(karmadaClient, clusterOverridePolicy.Name)
+		})
+	})
+})

--- a/test/e2e/framework/clusteroverridepolicy.go
+++ b/test/e2e/framework/clusteroverridepolicy.go
@@ -1,0 +1,29 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	karmada "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
+)
+
+// CreateClusterOverridePolicy create ClusterOverridePolicy with karmada client.
+func CreateClusterOverridePolicy(client karmada.Interface, policy *policyv1alpha1.ClusterOverridePolicy) {
+	ginkgo.By(fmt.Sprintf("Creating ClusterOverridePolicy(%s)", policy.Name), func() {
+		_, err := client.PolicyV1alpha1().ClusterOverridePolicies().Create(context.TODO(), policy, metav1.CreateOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+}
+
+// RemoveClusterOverridePolicy delete ClusterOverridePolicy with karmada client.
+func RemoveClusterOverridePolicy(client karmada.Interface, name string) {
+	ginkgo.By(fmt.Sprintf("Removing ClusterOverridePolicy(%s)", name), func() {
+		err := client.PolicyV1alpha1().ClusterOverridePolicies().Delete(context.TODO(), name, metav1.DeleteOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+}

--- a/test/helper/policy.go
+++ b/test/helper/policy.go
@@ -61,3 +61,16 @@ func NewOverridePolicyByOverrideRules(namespace, policyName string, rsSelectors 
 		},
 	}
 }
+
+// NewClusterOverridePolicyByOverrideRules will build a ClusterOverridePolicy object by OverrideRules
+func NewClusterOverridePolicyByOverrideRules(policyName string, rsSelectors []policyv1alpha1.ResourceSelector, overrideRules []policyv1alpha1.RuleWithCluster) *policyv1alpha1.ClusterOverridePolicy {
+	return &policyv1alpha1.ClusterOverridePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: policyName,
+		},
+		Spec: policyv1alpha1.OverrideSpec{
+			ResourceSelectors: rsSelectors,
+			OverrideRules:     overrideRules,
+		},
+	}
+}


### PR DESCRIPTION
Cherry pick of #2771 on release-1.1.
#2771: fix overridepolicy with nil resource selector could not work
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`: Fix clusterOverridePolicy and overridePolicy with nil resource selector could not work
```