### PR TITLE
Fix ut failure

### DIFF
--- a/pkg/resourceinterpreter/configurableinterpreter/luavm/lua_test.go
+++ b/pkg/resourceinterpreter/configurableinterpreter/luavm/lua_test.go
@@ -623,13 +623,11 @@ func Test_decodeValue(t *testing.T) {
 			args: args{
 				value: map[string]interface{}{
 					"foo": "foo1",
-					"bar": "bar1",
 				},
 			},
 			want: func() lua.LValue {
-				v := L.CreateTable(0, 2)
+				v := L.CreateTable(0, 1)
 				v.RawSetString("foo", lua.LString("foo1"))
-				v.RawSetString("bar", lua.LString("bar1"))
 				return v
 			}(),
 		},


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Map is unordered in memory. There are probabilities of unequal situations.
```
    lua_test.go:645: decodeValue() got = table: 0xc000095860, want table: 0xc000095620
--- FAIL: Test_decodeValue (0.00s)
    --- PASS: Test_decodeValue/nil (0.00s)
    --- PASS: Test_decodeValue/nil_pointer (0.00s)
    --- PASS: Test_decodeValue/int_pointer (0.00s)
    --- PASS: Test_decodeValue/int (0.00s)
    --- PASS: Test_decodeValue/uint (0.00s)
    --- PASS: Test_decodeValue/float (0.00s)
    --- PASS: Test_decodeValue/bool (0.00s)
    --- PASS: Test_decodeValue/string (0.00s)
    --- PASS: Test_decodeValue/json_number (0.00s)
    --- PASS: Test_decodeValue/slice (0.00s)
    --- PASS: Test_decodeValue/slice_pointer (0.00s)
    --- PASS: Test_decodeValue/struct (0.00s)
    --- PASS: Test_decodeValue/struct_pointer (0.00s)
    --- PASS: Test_decodeValue/[]interface{} (0.00s)
    --- FAIL: Test_decodeValue/map[string]interface{} (0.00s)
FAIL
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

