### PR TITLE
[e2e] mark test case `Test clusterOverridePolicy with nil resourceSelectors` as serial

### DIFF
--- a/test/e2e/clusteroverridepolicy_test.go
+++ b/test/e2e/clusteroverridepolicy_test.go
@@ -99,7 +99,7 @@ var _ = ginkgo.Describe("[BasicClusterOverridePolicy] basic cluster override pol
 	})
 })
 
-var _ = ginkgo.Describe("Test clusterOverridePolicy with nil resourceSelectors", func() {
+var _ = framework.SerialDescribe("Test clusterOverridePolicy with nil resourceSelectors", func() {
 	var deploymentNamespace, deploymentName string
 	var propagationPolicyNamespace, propagationPolicyName string
 	var clusterOverridePolicyName string

--- a/test/e2e/overridepolicy_test.go
+++ b/test/e2e/overridepolicy_test.go
@@ -411,7 +411,7 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 	})
 })
 
-var _ = ginkgo.Describe("OverridePolicy with nil resourceSelectors", func() {
+var _ = framework.SerialDescribe("OverridePolicy with nil resourceSelectors", func() {
 	var deploymentNamespace, deploymentName string
 	var propagationPolicyNamespace, propagationPolicyName string
 	var overridePolicyNamespace, overridePolicyName string
@@ -720,7 +720,7 @@ var _ = ginkgo.Describe("[OverrideRules] apply overriders testing", func() {
 	})
 })
 
-var _ = ginkgo.Describe("OverrideRules with nil resourceSelectors", func() {
+var _ = framework.SerialDescribe("OverrideRules with nil resourceSelectors", func() {
 	var deploymentNamespace, deploymentName string
 	var propagationPolicyNamespace, propagationPolicyName string
 	var overridePolicyNamespace, overridePolicyName string


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

https://github.com/karmada-io/karmada/issues/2804#issuecomment-1316519640

**Which issue(s) this PR fixes**:
Fixes #2804

**Special notes for your reviewer**:

This patch maybe needs to rebase to the previous release.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

