### PR TITLE
e2e: wait till the informer's cache is synced in karmada-controller

### DIFF
--- a/test/e2e/clusterpropagationpolicy_test.go
+++ b/test/e2e/clusterpropagationpolicy_test.go
@@ -331,8 +331,6 @@ var _ = ginkgo.Describe("[ExplicitPriority] propagation testing", func() {
 		var deploymentNamespace, deploymentName string
 		var deployment *appsv1.Deployment
 		var policyHigherPriorityLabelSelector, policyLowerPriorityMatchName, policyImplicitPriorityMatchName *policyv1alpha1.ClusterPropagationPolicy
-		var priorityLabelKey = "priority"
-		var priorityLabelValue = "priority"
 
 		ginkgo.BeforeEach(func() {
 			higherPriorityLabelSelector = deploymentNamePrefix + "higherprioritylabelselector" + rand.String(RandomStrLength)
@@ -340,6 +338,8 @@ var _ = ginkgo.Describe("[ExplicitPriority] propagation testing", func() {
 			implicitPriorityMatchName = deploymentNamePrefix + "implicitprioritymatchname" + rand.String(RandomStrLength)
 			deploymentNamespace = testNamespace
 			deploymentName = deploymentNamePrefix + rand.String(RandomStrLength)
+			var priorityLabelKey = "priority"
+			var priorityLabelValue = "priority" + rand.String(RandomStrLength)
 
 			deployment = testhelper.NewDeployment(deploymentNamespace, deploymentName)
 			deployment.SetLabels(map[string]string{priorityLabelKey: priorityLabelValue})
@@ -383,8 +383,9 @@ var _ = ginkgo.Describe("[ExplicitPriority] propagation testing", func() {
 			framework.CreateClusterPropagationPolicy(karmadaClient, policyLowerPriorityMatchName)
 			framework.CreateClusterPropagationPolicy(karmadaClient, policyImplicitPriorityMatchName)
 
-			// Wait policy present in cache
-			time.Sleep(time.Second)
+			// Wait till the informer's cache is synced in karmada-controller.
+			// Note: We tested and find that it takes about 1s before cache synced.
+			time.Sleep(time.Second * 5)
 
 			framework.CreateDeployment(kubeClient, deployment)
 			ginkgo.DeferCleanup(func() {
@@ -413,14 +414,14 @@ var _ = ginkgo.Describe("[ExplicitPriority] propagation testing", func() {
 		var deploymentNamespace, deploymentName string
 		var deployment *appsv1.Deployment
 		var policyExplicitPriorityLabelSelector, policyExplicitPriorityMatchName *policyv1alpha1.ClusterPropagationPolicy
-		var priorityLabelKey = "priority"
-		var priorityLabelValue = "priority"
 
 		ginkgo.BeforeEach(func() {
 			explicitPriorityLabelSelector = deploymentNamePrefix + "explicitprioritylabelselector" + rand.String(RandomStrLength)
 			explicitPriorityMatchName = deploymentNamePrefix + "explicitprioritymatchname" + rand.String(RandomStrLength)
 			deploymentNamespace = testNamespace
 			deploymentName = deploymentNamePrefix + rand.String(RandomStrLength)
+			var priorityLabelKey = "priority"
+			var priorityLabelValue = "priority" + rand.String(RandomStrLength)
 
 			deployment = testhelper.NewDeployment(deploymentNamespace, deploymentName)
 			deployment.SetLabels(map[string]string{priorityLabelKey: priorityLabelValue})
@@ -452,8 +453,9 @@ var _ = ginkgo.Describe("[ExplicitPriority] propagation testing", func() {
 			framework.CreateClusterPropagationPolicy(karmadaClient, policyExplicitPriorityLabelSelector)
 			framework.CreateClusterPropagationPolicy(karmadaClient, policyExplicitPriorityMatchName)
 
-			// Wait policy present in cache
-			time.Sleep(time.Second)
+			// Wait till the informer's cache is synced in karmada-controller.
+			// Note: We tested and find that it takes about 1s before cache synced.
+			time.Sleep(time.Second * 5)
 
 			framework.CreateDeployment(kubeClient, deployment)
 			ginkgo.DeferCleanup(func() {

--- a/test/e2e/propagationpolicy_test.go
+++ b/test/e2e/propagationpolicy_test.go
@@ -700,8 +700,6 @@ var _ = ginkgo.Describe("[ExplicitPriority] propagation testing", func() {
 		var deploymentNamespace, deploymentName string
 		var deployment *appsv1.Deployment
 		var policyHigherPriorityLabelSelector, policyLowerPriorityMatchMatchName, policyImplicitPriorityMatchMatchName *policyv1alpha1.PropagationPolicy
-		var priorityLabelKey = "priority"
-		var priorityLabelValue = "priority"
 
 		ginkgo.BeforeEach(func() {
 			policyNamespace = testNamespace
@@ -710,6 +708,8 @@ var _ = ginkgo.Describe("[ExplicitPriority] propagation testing", func() {
 			implicitPriorityMatchName = deploymentNamePrefix + "implicitprioritymatchname" + rand.String(RandomStrLength)
 			deploymentNamespace = testNamespace
 			deploymentName = deploymentNamePrefix + rand.String(RandomStrLength)
+			var priorityLabelKey = "priority"
+			var priorityLabelValue = "priority" + rand.String(RandomStrLength)
 
 			deployment = testhelper.NewDeployment(deploymentNamespace, deploymentName)
 			deployment.SetLabels(map[string]string{priorityLabelKey: priorityLabelValue})
@@ -753,8 +753,9 @@ var _ = ginkgo.Describe("[ExplicitPriority] propagation testing", func() {
 			framework.CreatePropagationPolicy(karmadaClient, policyLowerPriorityMatchMatchName)
 			framework.CreatePropagationPolicy(karmadaClient, policyImplicitPriorityMatchMatchName)
 
-			// Wait policy present in cache
-			time.Sleep(time.Second)
+			// Wait till the informer's cache is synced in karmada-controller.
+			// Note: We tested and find that it takes about 1s before cache synced.
+			time.Sleep(time.Second * 5)
 
 			framework.CreateDeployment(kubeClient, deployment)
 			ginkgo.DeferCleanup(func() {
@@ -784,8 +785,6 @@ var _ = ginkgo.Describe("[ExplicitPriority] propagation testing", func() {
 		var deploymentNamespace, deploymentName string
 		var deployment *appsv1.Deployment
 		var policyExplicitPriorityLabelSelector, policyExplicitPriorityMatchName *policyv1alpha1.PropagationPolicy
-		var priorityLabelKey = "priority"
-		var priorityLabelValue = "priority"
 
 		ginkgo.BeforeEach(func() {
 			policyNamespace = testNamespace
@@ -793,6 +792,8 @@ var _ = ginkgo.Describe("[ExplicitPriority] propagation testing", func() {
 			explicitPriorityMatchName = deploymentNamePrefix + "explicitprioritymatchname" + rand.String(RandomStrLength)
 			deploymentNamespace = testNamespace
 			deploymentName = deploymentNamePrefix + rand.String(RandomStrLength)
+			var priorityLabelKey = "priority"
+			var priorityLabelValue = "priority" + rand.String(RandomStrLength)
 
 			deployment = testhelper.NewDeployment(deploymentNamespace, deploymentName)
 			deployment.SetLabels(map[string]string{priorityLabelKey: priorityLabelValue})
@@ -824,8 +825,9 @@ var _ = ginkgo.Describe("[ExplicitPriority] propagation testing", func() {
 			framework.CreatePropagationPolicy(karmadaClient, policyExplicitPriorityLabelSelector)
 			framework.CreatePropagationPolicy(karmadaClient, policyExplicitPriorityMatchName)
 
-			// Wait policy present in cache
-			time.Sleep(time.Second)
+			// Wait till the informer's cache is synced in karmada-controller.
+			// Note: We tested and find that it takes about 1s before cache synced.
+			time.Sleep(time.Second * 5)
 
 			framework.CreateDeployment(kubeClient, deployment)
 			ginkgo.DeferCleanup(func() {


### PR DESCRIPTION
Signed-off-by: jwcesign <jiangwei115@huawei.com>

**What type of PR is this?**
/kind flake

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
e2e will occasionally fail because it takes about 1s to sync cache in karmada-controller(get this from log). So we must increase the waiting time.

**Which issue(s) this PR fixes**:
Fixes #none

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
none
```

