### PR TITLE
Automated cherry pick of #2811: mark test case  as serial

### DIFF
--- a/test/e2e/clusteroverridepolicy_test.go
+++ b/test/e2e/clusteroverridepolicy_test.go
@@ -10,7 +10,7 @@ import (
 	testhelper "github.com/karmada-io/karmada/test/helper"
 )
 
-var _ = ginkgo.Describe("Test clusterOverridePolicy with nil resourceSelectors", func() {
+var _ = framework.SerialDescribe("Test clusterOverridePolicy with nil resourceSelectors", func() {
 	var deploymentNamespace, deploymentName string
 	var propagationPolicyNamespace, propagationPolicyName string
 	var clusterOverridePolicyName string

--- a/test/e2e/overridepolicy_test.go
+++ b/test/e2e/overridepolicy_test.go
@@ -232,7 +232,7 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 	})
 })
 
-var _ = ginkgo.Describe("OverridePolicy with nil resourceSelectors", func() {
+var _ = framework.SerialDescribe("OverridePolicy with nil resourceSelectors", func() {
 	ginkgo.Context("Deployment override testing", func() {
 		deploymentNamespace := testNamespace
 		deploymentName := deploymentNamePrefix + rand.String(RandomStrLength)
@@ -528,7 +528,7 @@ var _ = ginkgo.Describe("[OverrideRules] apply overriders testing", func() {
 	})
 })
 
-var _ = ginkgo.Describe("OverrideRules with nil resourceSelectors", func() {
+var _ = framework.SerialDescribe("OverrideRules with nil resourceSelectors", func() {
 	var deploymentNamespace, deploymentName string
 	var propagationPolicyNamespace, propagationPolicyName string
 	var overridePolicyNamespace, overridePolicyName string


### PR DESCRIPTION
Cherry pick of #2811 on release-1.1.
#2811: mark test case  as serial
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
NONE
```