### PR TITLE
add execute mod for interpret command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,10 +22,12 @@ require (
 	github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64
 	go.uber.org/atomic v1.7.0
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
+	golang.org/x/text v0.3.7
 	golang.org/x/time v0.0.0-20220609170525-579cf78fd858
 	golang.org/x/tools v0.1.12
 	gomodules.xyz/jsonpatch/v2 v2.2.0
 	google.golang.org/grpc v1.47.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.25.4
 	k8s.io/apiextensions-apiserver v0.25.4
 	k8s.io/apimachinery v0.25.4
@@ -159,7 +161,6 @@ require (
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
-	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220502173005-c8bf987b8c21 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
@@ -168,7 +169,6 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.2.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/gengo v0.0.0-20211129171323-c02415ce4185 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.33 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect

--- a/pkg/karmadactl/interpret/execute.go
+++ b/pkg/karmadactl/interpret/execute.go
@@ -1,16 +1,156 @@
 package interpret
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"strings"
 
-	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/kubectl/pkg/cmd/util"
+
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/karmadactl/util/genericresource"
+	"github.com/karmada-io/karmada/pkg/resourceinterpreter/configurableinterpreter"
 )
 
-func (o *Options) completeExecute(_ util.Factory, _ *cobra.Command, _ []string) []error {
-	return nil
+func (o *Options) completeExecute(f util.Factory) []error {
+	var errs []error
+	if o.DesiredFile != "" {
+		o.DesiredResult = f.NewBuilder().
+			Unstructured().
+			FilenameParam(false, &resource.FilenameOptions{Filenames: []string{o.DesiredFile}}).
+			RequireObject(true).
+			Local().
+			Do()
+		errs = append(errs, o.DesiredResult.Err())
+	}
+
+	if o.ObservedFile != "" {
+		o.ObservedResult = f.NewBuilder().
+			Unstructured().
+			FilenameParam(false, &resource.FilenameOptions{Filenames: []string{o.ObservedFile}}).
+			RequireObject(true).
+			Local().
+			Do()
+		errs = append(errs, o.ObservedResult.Err())
+	}
+
+	if len(o.StatusFile) > 0 {
+		o.StatusResult = genericresource.NewBuilder().
+			Constructor(func() interface{} { return &workv1alpha2.AggregatedStatusItem{} }).
+			Filename(false, o.StatusFile).
+			Do()
+		errs = append(errs, o.StatusResult.Err())
+	}
+	return errs
 }
 
 func (o *Options) runExecute() error {
-	return fmt.Errorf("not implement")
+	if o.Operation == "" {
+		return fmt.Errorf("operation is not set for executing")
+	}
+
+	customizations, err := o.getCustomizationObject()
+	if err != nil {
+		return fmt.Errorf("fail to get customization object: %v", err)
+	}
+
+	desired, err := getUnstructuredObjectFromResult(o.DesiredResult)
+	if err != nil {
+		return fmt.Errorf("fail to get desired object: %v", err)
+	}
+
+	observed, err := getUnstructuredObjectFromResult(o.ObservedResult)
+	if err != nil {
+		return fmt.Errorf("fail to get observed object: %v", err)
+	}
+
+	status, err := o.getAggregatedStatusItems()
+	if err != nil {
+		return fmt.Errorf("fail to get status items: %v", err)
+	}
+
+	args := ruleArgs{
+		Desired:  desired,
+		Observed: observed,
+		Status:   status,
+		Replica:  int64(o.DesiredReplica),
+	}
+
+	interpreter := configurableinterpreter.NewConfigurableInterpreter(nil)
+	interpreter.LoadConfig(customizations)
+
+	r := o.Rules.GetByOperation(o.Operation)
+	if r == nil {
+		// Shall never occur, because we validate it before.
+		return fmt.Errorf("operation %s is not supported. Use one of: %s", o.Operation, strings.Join(o.Rules.Names(), ", "))
+	}
+	result := r.Run(interpreter, args)
+	printExecuteResult(o.Out, o.ErrOut, r.Name(), result)
+	return nil
+}
+
+func printExecuteResult(w, errOut io.Writer, name string, result *ruleResult) {
+	if result.Err != nil {
+		fmt.Fprintf(errOut, "Execute %s error: %v\n", name, result.Err)
+		return
+	}
+
+	for i, res := range result.Results {
+		func() {
+			fmt.Fprintln(w, "---")
+			fmt.Fprintf(w, "# [%v/%v] %s:\n", i+1, len(result.Results), res.Name)
+			if err := printObjectYaml(w, res.Value); err != nil {
+				fmt.Fprintf(errOut, "ERROR: %v\n", err)
+			}
+		}()
+	}
+}
+
+// MarshalJSON doesn't work for yaml encoder, so unstructured.Unstructured and runtime.RawExtension objects
+// will be encoded into unexpected data.
+// Example1:
+//
+//	  &unstructured.Unstructured{
+//	  	Object: map[string]interface{}{
+//				"foo": "bar"
+//	  	},
+//	  }
+//
+// will be encoded into:
+//
+//	Object:
+//	  foo: bar
+//
+// Example2:
+//
+//	&runtime.RawExtension{
+//		Raw: []byte("{}"),
+//	}
+//
+// will be encoded into:
+//
+//	raw:
+//	  - 123
+//	  - 125
+//
+// Inspired from https://github.com/kubernetes/kubernetes/blob/8fb423bfabe0d53934cc94c154c7da2dc3ce1332/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go#L781-L786
+// we convert it to map[string]interface{} by json, then encode the converted object to yaml.
+func printObjectYaml(w io.Writer, obj interface{}) error {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+
+	var converted interface{}
+	err = json.Unmarshal(data, &converted)
+	if err != nil {
+		return err
+	}
+
+	encoder := yaml.NewEncoder(w)
+	defer encoder.Close()
+	return encoder.Encode(converted)
 }

--- a/pkg/karmadactl/util/genericresource/builder.go
+++ b/pkg/karmadactl/util/genericresource/builder.go
@@ -1,0 +1,167 @@
+package genericresource
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/cli-runtime/pkg/resource"
+)
+
+const defaultHTTPGetAttempts int = 3
+
+var defaultNewFunc = func() interface{} {
+	return map[string]interface{}{}
+}
+
+var errMissingResource = fmt.Errorf(`you must provide one or more resources`)
+
+// Builder provides convenience functions for taking arguments and parameters
+// from the command line and converting them to a list of resources to iterate
+// over using the Visitor interface.
+type Builder struct {
+	errs       []error
+	paths      []Visitor
+	stdinInUse bool
+	mapper     *mapper
+	schema     resource.ContentValidator
+}
+
+// NewBuilder returns a Builder.
+func NewBuilder() *Builder {
+	return &Builder{
+		mapper: &mapper{
+			newFunc: defaultNewFunc,
+		},
+	}
+}
+
+// Schema set the schema to validate data in files.
+func (b *Builder) Schema(schema resource.ContentValidator) *Builder {
+	b.schema = schema
+	return b
+}
+
+// Constructor tells wanted type of object.
+func (b *Builder) Constructor(newFunc func() interface{}) *Builder {
+	b.mapper.newFunc = newFunc
+	return b
+}
+
+// Filename groups input in two categories: URLs and files (files, directories, STDIN)
+func (b *Builder) Filename(recursive bool, filenames ...string) *Builder {
+	for _, s := range filenames {
+		switch {
+		case s == "-":
+			b.Stdin()
+		case strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://"):
+			u, err := url.Parse(s)
+			if err != nil {
+				b.errs = append(b.errs, fmt.Errorf("the URL passed to filename %q is not valid: %v", s, err))
+				continue
+			}
+			b.URL(defaultHTTPGetAttempts, u)
+		default:
+			matches, err := expandIfFilePattern(s)
+			if err != nil {
+				b.errs = append(b.errs, err)
+				continue
+			}
+			b.Path(recursive, matches...)
+		}
+	}
+	return b
+}
+
+// Stdin will read objects from the standard input.
+func (b *Builder) Stdin() *Builder {
+	if b.stdinInUse {
+		b.errs = append(b.errs, resource.StdinMultiUseError)
+	}
+	b.stdinInUse = true
+	b.paths = append(b.paths, FileVisitorForSTDIN(b.mapper, b.schema))
+	return b
+}
+
+// URL accepts a number of URLs directly.
+func (b *Builder) URL(httpAttemptCount int, urls ...*url.URL) *Builder {
+	for _, u := range urls {
+		b.paths = append(b.paths, NewURLVisitor(b.mapper, httpAttemptCount, u, b.schema))
+	}
+	return b
+}
+
+// Path accepts a set of paths that may be files, directories (all can contain
+// one or more resources). Creates a FileVisitor for each file and then each
+// FileVisitor is streaming the content to a StreamVisitor.
+func (b *Builder) Path(recursive bool, paths ...string) *Builder {
+	for _, p := range paths {
+		_, err := os.Stat(p)
+		if os.IsNotExist(err) {
+			b.errs = append(b.errs, fmt.Errorf("the path %q does not exist", p))
+			continue
+		}
+		if err != nil {
+			b.errs = append(b.errs, fmt.Errorf("the path %q cannot be accessed: %v", p, err))
+			continue
+		}
+
+		visitors, err := ExpandPathsToFileVisitors(b.mapper, p, recursive, resource.FileExtensions, b.schema)
+		if err != nil {
+			b.errs = append(b.errs, fmt.Errorf("error reading %q: %v", p, err))
+		}
+
+		b.paths = append(b.paths, visitors...)
+	}
+	if len(b.paths) == 0 && len(b.errs) == 0 {
+		b.errs = append(b.errs, fmt.Errorf("error reading %v: recognized file extensions are %v", paths, resource.FileExtensions))
+	}
+	return b
+}
+
+// Do returns a Result object with a Visitor for the resources identified by the Builder. Note that stream
+// inputs are consumed by the first execution - use Infos() or Objects() on the Result to capture a list
+// for further iteration.
+func (b *Builder) Do() *Result {
+	r := b.visitorResult()
+	return r
+}
+
+func (b *Builder) visitorResult() *Result {
+	if len(b.errs) > 0 {
+		return &Result{err: utilerrors.NewAggregate(b.errs)}
+	}
+
+	// visit items specified by paths
+	if len(b.paths) != 0 {
+		return b.visitByPaths()
+	}
+	return &Result{err: errMissingResource}
+}
+
+func (b *Builder) visitByPaths() *Result {
+	result := &Result{}
+
+	result.visitor = VisitorList(b.paths)
+	return result
+}
+
+// expandIfFilePattern returns all the filenames that match the input pattern
+// or the filename if it is a specific filename and not a pattern.
+// If the input is a pattern and it yields no result it will result in an error.
+func expandIfFilePattern(pattern string) ([]string, error) {
+	if _, err := os.Stat(pattern); os.IsNotExist(err) {
+		matches, err := filepath.Glob(pattern)
+		if err == nil && len(matches) == 0 {
+			return nil, fmt.Errorf("the path %q does not exist", pattern)
+		}
+		if err == filepath.ErrBadPattern {
+			return nil, fmt.Errorf("pattern %q is not valid: %v", pattern, err)
+		}
+		return matches, err
+	}
+	return []string{pattern}, nil
+}

--- a/pkg/karmadactl/util/genericresource/doc.go
+++ b/pkg/karmadactl/util/genericresource/doc.go
@@ -1,0 +1,3 @@
+// Package genericresource is modified from "k8s.io/cli-runtime/pkg/resource".
+// It can fetch any object (not only runtime.object) from file, http, and stdin.
+package genericresource

--- a/pkg/karmadactl/util/genericresource/interface.go
+++ b/pkg/karmadactl/util/genericresource/interface.go
@@ -1,0 +1,13 @@
+package genericresource
+
+// Visitor lets clients walk a list of resources.
+type Visitor interface {
+	Visit(VisitorFunc) error
+}
+
+// VisitorFunc implements the Visitor interface for a matching function.
+// If there was a problem walking a list of resources, the incoming error
+// will describe the problem and the function can decide how to handle that error.
+// A nil returned indicates to accept an error to continue loops even when errors happen.
+// This is useful for ignoring certain kinds of errors or aggregating errors in some way.
+type VisitorFunc func(*Info, error) error

--- a/pkg/karmadactl/util/genericresource/result.go
+++ b/pkg/karmadactl/util/genericresource/result.go
@@ -1,0 +1,74 @@
+package genericresource
+
+import (
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+// Result contains helper methods for dealing with the outcome of a Builder.
+type Result struct {
+	err     error
+	visitor Visitor
+
+	// populated by a call to Infos
+	info []*Info
+
+	ignoreErrors []utilerrors.Matcher
+}
+
+// Err returns one or more errors (via a util.ErrorList) that occurred prior
+// to visiting the elements in the visitor. To see all errors including those
+// that occur during visitation, invoke Infos().
+func (r *Result) Err() error {
+	return r.err
+}
+
+// Objects returns the list of objects of all found resources.
+func (r *Result) Objects() ([]interface{}, error) {
+	infos, err := r.Infos()
+	if err != nil {
+		return nil, err
+	}
+
+	objects := make([]interface{}, len(infos))
+	for i, info := range infos {
+		objects[i] = info.Object
+	}
+	return objects, err
+}
+
+// Infos returns an array of all of the resource infos retrieved via traversal.
+// Will attempt to traverse the entire set of visitors only once, and will return
+// a cached list on subsequent calls.
+func (r *Result) Infos() ([]*Info, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.info != nil {
+		return r.info, nil
+	}
+
+	var infos []*Info
+	err := r.visitor.Visit(func(info *Info, err error) error {
+		if err != nil {
+			return err
+		}
+		infos = append(infos, info)
+		return nil
+	})
+	err = utilerrors.FilterOut(err, r.ignoreErrors...)
+
+	r.info, r.err = infos, err
+	return infos, err
+}
+
+// Visit implements the Visitor interface on the items described in the Builder.
+// Note that some visitor sources are not traversable more than once, or may
+// return different results.  If you wish to operate on the same set of resources
+// multiple times, use the Infos() method.
+func (r *Result) Visit(fn VisitorFunc) error {
+	if r.err != nil {
+		return r.err
+	}
+	err := r.visitor.Visit(fn)
+	return utilerrors.FilterOut(err, r.ignoreErrors...)
+}

--- a/pkg/karmadactl/util/genericresource/visitor.go
+++ b/pkg/karmadactl/util/genericresource/visitor.go
@@ -1,0 +1,294 @@
+package genericresource
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/cli-runtime/pkg/resource"
+)
+
+const (
+	constSTDINstr = "STDIN"
+)
+
+// VisitorList implements Visit for the sub visitors it contains. The first error
+// returned from a child Visitor will terminate iteration.
+type VisitorList []Visitor
+
+// Visit implements Visitor
+func (l VisitorList) Visit(fn VisitorFunc) error {
+	for i := range l {
+		if err := l[i].Visit(fn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// URLVisitor downloads the contents of a URL, and if successful, returns
+// an info object representing the downloaded object.
+type URLVisitor struct {
+	URL *url.URL
+	*StreamVisitor
+	HTTPAttemptCount int
+}
+
+// NewURLVisitor returns a visitor to download from given url. It will max retry "httpAttemptCount" when failed.
+func NewURLVisitor(mapper *mapper, httpAttemptCount int, u *url.URL, schema resource.ContentValidator) *URLVisitor {
+	return &URLVisitor{
+		URL:              u,
+		StreamVisitor:    NewStreamVisitor(nil, mapper, u.String(), schema),
+		HTTPAttemptCount: httpAttemptCount,
+	}
+}
+
+// Visit down object from url.
+func (v *URLVisitor) Visit(fn VisitorFunc) error {
+	body, err := readHTTPWithRetries(httpgetImpl, time.Second, v.URL.String(), v.HTTPAttemptCount)
+	if err != nil {
+		return err
+	}
+	defer body.Close()
+	v.StreamVisitor.Reader = body
+	return v.StreamVisitor.Visit(fn)
+}
+
+func ignoreFile(path string, extensions []string) bool {
+	if len(extensions) == 0 {
+		return false
+	}
+	ext := filepath.Ext(path)
+	for _, s := range extensions {
+		if s == ext {
+			return false
+		}
+	}
+	return true
+}
+
+// FileVisitorForSTDIN return a special FileVisitor just for STDIN
+func FileVisitorForSTDIN(mapper *mapper, schema resource.ContentValidator) Visitor {
+	return &FileVisitor{
+		Path:          constSTDINstr,
+		StreamVisitor: NewStreamVisitor(nil, mapper, constSTDINstr, schema),
+	}
+}
+
+// ExpandPathsToFileVisitors will return a slice of FileVisitors that will handle files from the provided path.
+// After FileVisitors open the files, they will pass an io.Reader to a StreamVisitor to do the reading. (stdin
+// is also taken care of). Paths argument also accepts a single file, and will return a single visitor
+func ExpandPathsToFileVisitors(mapper *mapper, paths string, recursive bool, extensions []string, schema resource.ContentValidator) ([]Visitor, error) {
+	var visitors []Visitor
+	err := filepath.Walk(paths, func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if fi.IsDir() {
+			if path != paths && !recursive {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		// Don't check extension if the filepath was passed explicitly
+		if path != paths && ignoreFile(path, extensions) {
+			return nil
+		}
+
+		visitor := &FileVisitor{
+			Path:          path,
+			StreamVisitor: NewStreamVisitor(nil, mapper, path, schema),
+		}
+
+		visitors = append(visitors, visitor)
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return visitors, nil
+}
+
+// FileVisitor is wrapping around a StreamVisitor, to handle open/close files
+type FileVisitor struct {
+	Path string
+	*StreamVisitor
+}
+
+// Visit in a FileVisitor is just taking care of opening/closing files
+func (v *FileVisitor) Visit(fn VisitorFunc) error {
+	var f *os.File
+	if v.Path == constSTDINstr {
+		f = os.Stdin
+	} else {
+		var err error
+		f, err = os.Open(v.Path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+	}
+
+	// TODO: Consider adding a flag to force to UTF16, apparently some
+	// Windows tools don't write the BOM
+	utf16bom := unicode.BOMOverride(unicode.UTF8.NewDecoder())
+	v.StreamVisitor.Reader = transform.NewReader(f, utf16bom)
+
+	return v.StreamVisitor.Visit(fn)
+}
+
+// StreamVisitor reads objects from an io.Reader and walks them. A stream visitor can only be
+// visited once.
+// Unmarshal stream to object by json.
+type StreamVisitor struct {
+	io.Reader
+	*mapper
+
+	Source string
+	Schema resource.ContentValidator
+}
+
+// NewStreamVisitor is a helper function that is useful when we want to change the fields of the struct but keep calls the same.
+func NewStreamVisitor(r io.Reader, mapper *mapper, source string, schema resource.ContentValidator) *StreamVisitor {
+	return &StreamVisitor{
+		Reader: r,
+		mapper: mapper,
+		Source: source,
+		Schema: schema,
+	}
+}
+
+// Visit implements Visitor over a stream. StreamVisitor is able to distinct multiple resources in one stream.
+func (v *StreamVisitor) Visit(fn VisitorFunc) error {
+	d := yaml.NewYAMLOrJSONDecoder(v.Reader, 4096)
+	for {
+		ext := runtime.RawExtension{}
+		if err := d.Decode(&ext); err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return fmt.Errorf("error parsing %s: %v", v.Source, err)
+		}
+		// TODO: This needs to be able to handle object in other encodings and schemas.
+		ext.Raw = bytes.TrimSpace(ext.Raw)
+		if len(ext.Raw) == 0 || bytes.Equal(ext.Raw, []byte("null")) {
+			continue
+		}
+		if err := resource.ValidateSchema(ext.Raw, v.Schema); err != nil {
+			return fmt.Errorf("error validating %q: %v", v.Source, err)
+		}
+		info, err := v.infoForData(ext.Raw, v.Source)
+		if err != nil {
+			if fnErr := fn(info, err); fnErr != nil {
+				return fnErr
+			}
+			continue
+		}
+		if err = fn(info, nil); err != nil {
+			return err
+		}
+	}
+}
+
+type mapper struct {
+	newFunc func() interface{}
+}
+
+func (m *mapper) infoForData(data []byte, source string) (*Info, error) {
+	info := &Info{
+		Source: source,
+		Data:   data,
+		Object: m.newFunc(),
+	}
+
+	err := json.Unmarshal(data, info.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	return info, nil
+}
+
+// httpget Defines function to retrieve a url and return the results.  Exists for unit test stubbing.
+type httpget func(url string) (int, string, io.ReadCloser, error)
+
+// httpgetImpl Implements a function to retrieve a url and return the results.
+func httpgetImpl(url string) (int, string, io.ReadCloser, error) {
+	// nolint:gosec
+	resp, err := http.Get(url)
+	if err != nil {
+		return 0, "", nil, err
+	}
+	return resp.StatusCode, resp.Status, resp.Body, nil
+}
+
+// readHTTPWithRetries tries to http.Get the v.URL retries times before giving up.
+func readHTTPWithRetries(get httpget, duration time.Duration, u string, attempts int) (io.ReadCloser, error) {
+	var err error
+	if attempts <= 0 {
+		return nil, fmt.Errorf("http attempts must be greater than 0, was %d", attempts)
+	}
+	for i := 0; i < attempts; i++ {
+		var (
+			statusCode int
+			status     string
+			body       io.ReadCloser
+		)
+		if i > 0 {
+			time.Sleep(duration)
+		}
+
+		// Try to get the URL
+		statusCode, status, body, err = get(u)
+
+		// Retry Errors
+		if err != nil {
+			continue
+		}
+
+		if statusCode == http.StatusOK {
+			return body, nil
+		}
+		body.Close()
+		// Error - Set the error condition from the StatusCode
+		err = fmt.Errorf("unable to read URL %q, server reported %s, status code=%d", u, status, statusCode)
+
+		if statusCode >= 500 && statusCode < 600 {
+			// Retry 500's
+			continue
+		} else {
+			// Don't retry other StatusCodes
+			break
+		}
+	}
+	return nil, err
+}
+
+// Info contains temporary info to execute a REST call, or show the results
+// of an already completed REST call.
+type Info struct {
+	// Optional, Source is the filename or URL to template file (.json or .yaml),
+	// or stdin to use to handle the resource
+	Source string
+	// Optional, this is the most recent value returned by the server if available. It will
+	// typically be in unstructured or internal forms, depending on how the Builder was
+	// defined. If retrieved from the server, the Builder expects the mapping client to
+	// decide the final form. Use the AsVersioned, AsUnstructured, and AsInternal helpers
+	// to alter the object versions.
+	// If Subresource is specified, this will be the object for the subresource.
+	Data []byte
+
+	Object interface{}
+}

--- a/pkg/resourceinterpreter/configurableinterpreter/configurable.go
+++ b/pkg/resourceinterpreter/configurableinterpreter/configurable.go
@@ -145,3 +145,8 @@ func (c *ConfigurableInterpreter) getInterpreter(kind schema.GroupVersionKind, o
 	}
 	return script, len(script) > 0
 }
+
+// LoadConfig loads and stores rules from customizations
+func (c *ConfigurableInterpreter) LoadConfig(customizations []*configv1alpha1.ResourceInterpreterCustomization) {
+	c.configManager.LoadConfig(customizations)
+}


### PR DESCRIPTION
Signed-off-by: yingjinhui <yingjinhui@didiglobal.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
add skeleton of interpreter command.

**Which issue(s) this PR fixes**:
part of #2371

**Special notes for your reviewer**:

### Testing

Prepare a `get-replica.yml`

<details>

```yaml
apiVersion: config.karmada.io/v1alpha1
kind: ResourceInterpreterCustomization
metadata:
  name: get-replica
spec:
  target:
    apiVersion: apps/v1
    kind: Deployment
  customizations:
    retention:
    replicaResource:
      luaScript: >
        function GetReplicas(obj)
          replica = obj.spec.replicas + 1
          requirement = {}
          return replica, requirement
        end
```
</details>

and `deploy-nginx.yml`

<details>

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
spec:
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - image: nginx:alpine
        name: nginx
```
</details>


```bash
karmadactl interpret -f get-replica.yml --observed-file deploy-nginx.yml --operation=replicaResource
```

Output:
```
# replicaResource RESULTS:
---
# REPLICA
4
---
# REQUIRES
nodeclaim: null
resourcerequest: {}
```


**Does this PR introduce a user-facing change?**:
```release-note
`karmadactl`: add execute mod for interpret command.
```

