### PR TITLE
karmadactl register add args check

### DIFF
--- a/pkg/karmadactl/register/register.go
+++ b/pkg/karmadactl/register/register.go
@@ -151,6 +151,9 @@ func NewCmdRegister(parentCommand string) *cobra.Command {
 		Annotations: map[string]string{
 			cmdutil.TagCommandGroup: cmdutil.GroupClusterRegistration,
 		},
+
+		// We accept the control-plane location as an required positional argument karmada apiserver endpoint
+		Args: cobra.ExactArgs(1),
 	}
 	flags := cmd.Flags()
 
@@ -238,9 +241,6 @@ type CommandRegisterOption struct {
 // Complete ensures that options are valid and marshals them if necessary.
 func (o *CommandRegisterOption) Complete(args []string) error {
 	// Get karmada apiserver endpoint from the command args.
-	if len(args) == 0 {
-		return fmt.Errorf("karmada apiserver endpoint is required")
-	}
 	o.BootstrapToken.APIServerEndpoint = args[0]
 
 	restConfig, err := apiclient.RestConfig(o.Context, o.KubeConfig)


### PR DESCRIPTION
Signed-off-by: 宋文杰 <wenjie.song@daocloud.io>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

karmadactl register add args check:   karmada apiserver endpoint expects exactly one argument

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
karmada apiserver endpoint expects exactly one argument
```

