### PR TITLE
karmadactl init: fix MutatingWebhookConfig and ValidateWebhookConfig aren't updated

### DIFF
--- a/pkg/karmadactl/cmdinit/bootstraptoken/agent/tlsbootstrap.go
+++ b/pkg/karmadactl/cmdinit/bootstraptoken/agent/tlsbootstrap.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/utils"
+	cmdutil "github.com/karmada-io/karmada/pkg/karmadactl/util"
 )
 
 const (
@@ -38,7 +39,7 @@ func AllowBootstrapTokensToPostCSRs(clientSet *kubernetes.Clientset) error {
 				Name: KarmadaAgentBootstrapTokenAuthGroup,
 			},
 		}, nil)
-	return utils.CreateIfNotExistClusterRoleBinding(clientSet, clusterRoleBinding)
+	return cmdutil.CreateOrUpdateClusterRoleBinding(clientSet, clusterRoleBinding)
 }
 
 // AutoApproveKarmadaAgentBootstrapTokens creates RBAC rules in a way that makes Karmada Agent Bootstrap Tokens' CSR auto-approved by the csrapprover controller
@@ -52,7 +53,7 @@ func AutoApproveKarmadaAgentBootstrapTokens(clientSet *kubernetes.Clientset) err
 				Name: KarmadaAgentBootstrapTokenAuthGroup,
 			},
 		}, nil)
-	return utils.CreateIfNotExistClusterRoleBinding(clientSet, clusterRoleBinding)
+	return cmdutil.CreateOrUpdateClusterRoleBinding(clientSet, clusterRoleBinding)
 }
 
 // AutoApproveAgentCertificateRotation creates RBAC rules in a way that makes Agent certificate rotation CSR auto-approved by the csrapprover controller
@@ -66,5 +67,5 @@ func AutoApproveAgentCertificateRotation(clientSet *kubernetes.Clientset) error 
 				Name: KarmadaAgentGroup,
 			},
 		}, nil)
-	return utils.CreateIfNotExistClusterRoleBinding(clientSet, clusterRoleBinding)
+	return cmdutil.CreateOrUpdateClusterRoleBinding(clientSet, clusterRoleBinding)
 }

--- a/pkg/karmadactl/cmdinit/bootstraptoken/clusterinfo/clusterinfo.go
+++ b/pkg/karmadactl/cmdinit/bootstraptoken/clusterinfo/clusterinfo.go
@@ -60,7 +60,7 @@ func CreateBootstrapConfigMapIfNotExists(clientSet *kubernetes.Clientset, file s
 
 // CreateClusterInfoRBACRules creates the RBAC rules for exposing the cluster-info ConfigMap in the kube-public namespace to unauthenticated users
 func CreateClusterInfoRBACRules(clientSet *kubernetes.Clientset) error {
-	klog.V(1).Infoln("creating the RBAC rules for exposing the cluster-info ConfigMap in the kube-public namespace")
+	klog.V(1).Info("creating the RBAC rules for exposing the cluster-info ConfigMap in the kube-public namespace")
 	err := cmdutil.CreateOrUpdateRole(clientSet, &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      BootstrapSignerClusterRoleName,

--- a/pkg/karmadactl/cmdinit/karmada/rbac.go
+++ b/pkg/karmadactl/cmdinit/karmada/rbac.go
@@ -3,8 +3,10 @@ package karmada
 import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/utils"
+	cmdutil "github.com/karmada-io/karmada/pkg/karmadactl/util"
 )
 
 const (
@@ -21,7 +23,7 @@ func grantProxyPermissionToAdmin(clientSet kubernetes.Interface) error {
 			Verbs:     []string{"*"},
 		},
 	}, nil)
-	err := utils.CreateIfNotExistClusterRole(clientSet, proxyAdminClusterRole)
+	err := cmdutil.CreateOrUpdateClusterRole(clientSet, proxyAdminClusterRole)
 	if err != nil {
 		return err
 	}
@@ -32,7 +34,9 @@ func grantProxyPermissionToAdmin(clientSet kubernetes.Interface) error {
 				Kind: "User",
 				Name: clusterProxyAdminUser,
 			}}, nil)
-	err = utils.CreateIfNotExistClusterRoleBinding(clientSet, proxyAdminClusterRoleBinding)
+
+	klog.V(1).Info("grant cluster proxy permission to 'system:admin'")
+	err = cmdutil.CreateOrUpdateClusterRoleBinding(clientSet, proxyAdminClusterRoleBinding)
 	if err != nil {
 		return err
 	}
@@ -40,7 +44,7 @@ func grantProxyPermissionToAdmin(clientSet kubernetes.Interface) error {
 	return nil
 }
 
-// grantAccessPermissionToAgent grants the limited access permmission to 'karmada-agent'
+// grantAccessPermissionToAgent grants the limited access permission to 'karmada-agent'
 func grantAccessPermissionToAgent(clientSet kubernetes.Interface) error {
 	clusterRole := utils.ClusterRoleFromRules(karmadaAgentAccessClusterRole, []rbacv1.PolicyRule{
 		{
@@ -104,7 +108,7 @@ func grantAccessPermissionToAgent(clientSet kubernetes.Interface) error {
 			Verbs:     []string{"create", "patch", "update"},
 		},
 	}, nil)
-	err := utils.CreateIfNotExistClusterRole(clientSet, clusterRole)
+	err := cmdutil.CreateOrUpdateClusterRole(clientSet, clusterRole)
 	if err != nil {
 		return err
 	}
@@ -115,7 +119,9 @@ func grantAccessPermissionToAgent(clientSet kubernetes.Interface) error {
 				Kind: rbacv1.GroupKind,
 				Name: karmadaAgentGroup,
 			}}, nil)
-	err = utils.CreateIfNotExistClusterRoleBinding(clientSet, clusterRoleBinding)
+
+	klog.V(1).Info("grant the limited access permission to 'karmada-agent'")
+	err = cmdutil.CreateOrUpdateClusterRoleBinding(clientSet, clusterRoleBinding)
 	if err != nil {
 		return err
 	}

--- a/pkg/karmadactl/cmdinit/karmada/webhook_configuration_test.go
+++ b/pkg/karmadactl/cmdinit/karmada/webhook_configuration_test.go
@@ -7,24 +7,24 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func Test_createValidatingWebhookConfiguration(t *testing.T) {
+func Test_createOrUpdateValidatingWebhookConfiguration(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	cfg := validatingConfig(base64.StdEncoding.EncodeToString([]byte("foo")), "bar")
 	if cfg == "" {
 		t.Errorf("validatingConfig() return = %v, want yaml config", cfg)
 	}
-	if err := createValidatingWebhookConfiguration(client, cfg); err != nil {
-		t.Errorf("createValidatingWebhookConfiguration() return = %v, want no error", err)
+	if err := createOrUpdateValidatingWebhookConfiguration(client, cfg); err != nil {
+		t.Errorf("createOrUpdateValidatingWebhookConfiguration() return = %v, want no error", err)
 	}
 }
 
-func Test_createMutatingWebhookConfiguration(t *testing.T) {
+func Test_createOrUpdateMutatingWebhookConfiguration(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	cfg := mutatingConfig(base64.StdEncoding.EncodeToString([]byte("foo")), "bar")
 	if cfg == "" {
 		t.Errorf("mutatingConfig() return = %v, want yaml config", cfg)
 	}
-	if err := createMutatingWebhookConfiguration(client, cfg); err != nil {
-		t.Errorf("createMutatingWebhookConfiguration() return = %v, want no error", err)
+	if err := createOrUpdateMutatingWebhookConfiguration(client, cfg); err != nil {
+		t.Errorf("createOrUpdateMutatingWebhookConfiguration() return = %v, want no error", err)
 	}
 }

--- a/pkg/karmadactl/cmdinit/utils/rbac.go
+++ b/pkg/karmadactl/cmdinit/utils/rbac.go
@@ -1,14 +1,8 @@
 package utils
 
 import (
-	"context"
-	"fmt"
-
 	rbacv1 "k8s.io/api/rbac/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 )
 
 // ClusterRoleFromRules ClusterRole Rules
@@ -44,46 +38,4 @@ func ClusterRoleBindingFromSubjects(clusterRoleBindingName, clusterRoleName stri
 		},
 		Subjects: sub,
 	}
-}
-
-// CreateIfNotExistClusterRole  create ClusterRole when it doesn't exist
-func CreateIfNotExistClusterRole(clientSet kubernetes.Interface, role *rbacv1.ClusterRole) error {
-	clusterRoleClient := clientSet.RbacV1().ClusterRoles()
-	_, err := clusterRoleClient.Get(context.TODO(), role.Name, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			_, err = clusterRoleClient.Create(context.TODO(), role, metav1.CreateOptions{})
-			if err != nil {
-				return fmt.Errorf("create ClusterRole %s failed: %v", role.Name, err)
-			}
-
-			klog.Infof("CreateClusterRole %s success.", role.Name)
-			return nil
-		}
-		return fmt.Errorf("get ClusterRole %s failed: %v", role.Name, err)
-	}
-	klog.Infof("CreateClusterRole %s already exists.", role.Name)
-
-	return nil
-}
-
-// CreateIfNotExistClusterRoleBinding create ClusterRoleBinding when it doesn't exist
-func CreateIfNotExistClusterRoleBinding(clientSet kubernetes.Interface, binding *rbacv1.ClusterRoleBinding) error {
-	crbClient := clientSet.RbacV1().ClusterRoleBindings()
-	_, err := crbClient.Get(context.TODO(), binding.Name, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			_, err = crbClient.Create(context.TODO(), binding, metav1.CreateOptions{})
-			if err != nil {
-				return fmt.Errorf("create ClusterRoleBinding %s failed: %v", binding.Name, err)
-			}
-
-			klog.Infof("CreateClusterRoleBinding %s success.", binding.Name)
-			return nil
-		}
-		return fmt.Errorf("get ClusterRoleBinding %s failed: %v", binding.Name, err)
-	}
-	klog.Infof("CreateClusterRoleBinding %s already exists.", binding.Name)
-
-	return nil
 }


### PR DESCRIPTION
Signed-off-by: lonelyCZ <chengzhe@zju.edu.cn>

**What type of PR is this?**
/kind bug
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When deploy karmada by `karmadactl init`, if `/var/lib/karmada-etcd` wasn't removed, the MutatingWebhookConfig and ValidateWebhookConfig will be not updated, lead to bad certificate.

```
I1118 17:55:47.030069   27650 deploy.go:91] Create MutatingWebhookConfiguration mutating-config.
I1118 17:55:47.042878   27650 webhook_configuration.go:195] MutatingWebhookConfiguration mutating-config already exists, skipping.
I1118 17:55:47.042937   27650 deploy.go:96] Create ValidatingWebhookConfiguration validating-config.
I1118 17:55:47.054390   27650 webhook_configuration.go:175] ValidatingWebhookConfiguration validating-config already exists, skipping.
```

It will lead that the webhook works bad.
```
[root@master67 yaml]# kapi apply -f deploy_propagationpolicy.yaml
Error from server (InternalError): error when creating "deploy_propagationpolicy.yaml": Internal error occurred: failed calling webhook "propagationpolicy.karmada.io": failed to call webhook: Post "https://karmada-webhook.karmada-system.svc:443/mutate-propagationpolicy?timeout=3s": x509: certificate signed by unknown authority (possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate "karmada")
```

```
[root@master67 yaml]# kubectl logs -n karmada-system   karmada-webhook-769c4886c-xkgpk
I1117 06:18:46.639617       1 webhook.go:82] karmada-webhook version: version.Info{GitVersion:"v1.3.0", GitCommit:"12e8f01d01571932e6fe45cb7f0d1bffd2e40fd9", GitTreeState:"clean", BuildDate:"2022-08-31T13:10:02Z", GoVersion:"go1.18.3", Compiler:"gc", Platform:"linux/amd64"}
I1117 06:18:46.701693       1 webhook.go:112] registering webhooks to the webhook server
I1117 06:18:46.705433       1 internal.go:362] "Starting server" kind="health probe" addr="[::]:8000"
I1117 06:18:46.705579       1 internal.go:362] "Starting server" path="/metrics" kind="metrics" addr="[::]:8080"
I1117 06:18:46.705835       1 shared_informer.go:285] caches populated
I1117 13:33:02.994127       1 log.go:195] http: TLS handshake error from 10.244.0.225:51454: remote error: tls: bad certificate
I1117 13:33:02.997083       1 log.go:195] http: TLS handshake error from 10.244.0.225:51450: remote error: tls: bad certificate
I1117 13:33:03.020559       1 log.go:195] http: TLS handshake error from 10.244.0.225:51458: remote error: tls: bad certificate
I1117 13:33:03.062823       1 log.go:195] http: TLS handshake error from 10.244.0.225:51460: remote error: tls: bad certificate
```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This PR doesn't need cherry-pick.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

