### PR TITLE
Add events for graceful eviction controller

### DIFF
--- a/pkg/controllers/gracefuleviction/evictiontask.go
+++ b/pkg/controllers/gracefuleviction/evictiontask.go
@@ -20,8 +20,9 @@ func assessEvictionTasks(bindingSpec workv1alpha2.ResourceBindingSpec,
 	observedStatus []workv1alpha2.AggregatedStatusItem,
 	timeout time.Duration,
 	now metav1.Time,
-) []workv1alpha2.GracefulEvictionTask {
+) ([]workv1alpha2.GracefulEvictionTask, []string) {
 	var keptTasks []workv1alpha2.GracefulEvictionTask
+	var evictedClusters []string
 
 	for _, task := range bindingSpec.GracefulEvictionTasks {
 		// set creation timestamp for new task
@@ -39,9 +40,11 @@ func assessEvictionTasks(bindingSpec workv1alpha2.ResourceBindingSpec,
 		})
 		if kt != nil {
 			keptTasks = append(keptTasks, *kt)
+		} else {
+			evictedClusters = append(evictedClusters, task.FromCluster)
 		}
 	}
-	return keptTasks
+	return keptTasks, evictedClusters
 }
 
 func assessSingleTask(task workv1alpha2.GracefulEvictionTask, opt assessmentOption) *workv1alpha2.GracefulEvictionTask {

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -64,6 +64,10 @@ const (
 	EventReasonDescheduleBindingFailed = "DescheduleBindingFailed"
 	// EventReasonDescheduleBindingSucceed indicates that deschedule binding succeed.
 	EventReasonDescheduleBindingSucceed = "DescheduleBindingSucceed"
+	// EventReasonEvictWorkloadFromClusterSucceed indicates that evict workload from cluster succeed.
+	EventReasonEvictWorkloadFromClusterSucceed = "EvictWorkloadFromClusterSucceed"
+	// EventReasonEvictWorkloadFromClusterFailed indicates that evict workload from cluster failed.
+	EventReasonEvictWorkloadFromClusterFailed = "EvictWorkloadFromClusterFailed"
 )
 
 // Define events for resource templates.


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add events for graceful eviction controller:
```
Events:
  Type    Reason                           Age                 From                                           Message
  ----    ------                           ----                ----                                           -------
  Normal  SyncWorkSucceed                  49s (x14 over 16m)  binding-controller                             Sync work of resourceBinding(default/nginx-deployment) successful.
  Normal  AggregateStatusSucceed           49s (x14 over 16m)  binding-controller                             Update resourceBinding(default/nginx-deployment) with AggregatedStatus successfully.
  Normal  EvictWorkloadFromClusterSucceed  49s                 resource-binding-graceful-eviction-controller  Evict from cluster member1 succeed.
  Normal  ScheduleBindingSucceed           47s (x37 over 17h)  karmada-scheduler                              Binding has been scheduled
```

**Which issue(s) this PR fixes**:
Part of #2472 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```
`Instrumentation`: Introduce `EvictWorkloadFromClusterSucceed`, `EvictWorkloadFromClusterFailed` to the `binding` object and its reference. Refactor the event name of `TaintManagerEviction`.
```

