### PR TITLE
Automated cherry pick of #2277: fix kube controller manager restart all the time

### DIFF
--- a/artifacts/deploy/kube-controller-manager.yaml
+++ b/artifacts/deploy/kube-controller-manager.yaml
@@ -56,7 +56,6 @@ spec:
           livenessProbe:
             failureThreshold: 8
             httpGet:
-              host: 127.0.0.1
               path: /healthz
               port: 10257
               scheme: HTTPS

--- a/charts/karmada/templates/kube-controller-manager.yaml
+++ b/charts/karmada/templates/kube-controller-manager.yaml
@@ -72,7 +72,6 @@ spec:
           livenessProbe:
             failureThreshold: 8
             httpGet:
-              host: 127.0.0.1
               path: /healthz
               port: 10257
               scheme: HTTPS


### PR DESCRIPTION
Cherry pick of #2277 on release-1.3.
#2277: fix kube controller manager restart all the time
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`kube-controller-manager`:  Fixed liveness probe misconfiguration which caused kube-controller-manager to always `CrashLoopBackup`.
```