### PR TITLE
update chart feature gates of components

### DIFF
--- a/charts/karmada/templates/_helpers.tpl
+++ b/charts/karmada/templates/_helpers.tpl
@@ -390,10 +390,14 @@ Return the proper karmada kubectl image name
 {{ include "common.images.image" (dict "imageRoot" .Values.kubectl.image "global" .Values.global) }}
 {{- end -}}
 
-{{- define "karmada.controllerManager.featureGates" -}}
-     {{- if (not (empty .Values.controllerManager.featureGates)) }}
+{{/*
+Return the proper featureGates
+{{ include "karmada.common.featureGates" ( dict "featureGates" .Values.path.to.the.featureGates $) }}
+*/}}
+{{- define "karmada.common.featureGates" -}}
+     {{- if (not (empty .featureGates)) }}
           {{- $featureGatesFlag := "" -}}
-          {{- range $key, $value := .Values.controllerManager.featureGates -}}
+          {{- range $key, $value := .featureGates -}}
                {{- if not (empty (toString $value)) }}
                     {{- $featureGatesFlag = cat $featureGatesFlag $key "=" $value ","  -}}
                {{- end -}}

--- a/charts/karmada/templates/karmada-aggregated-apiserver.yaml
+++ b/charts/karmada/templates/karmada-aggregated-apiserver.yaml
@@ -62,9 +62,11 @@ spec:
             - --tls-cert-file=/etc/kubernetes/pki/karmada.crt
             - --tls-private-key-file=/etc/kubernetes/pki/karmada.key
             - --audit-log-path=-
-            - --feature-gates=APIPriorityAndFairness=false
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
+            {{- with (include "karmada.common.featureGates" (dict "featureGates" .Values.aggregatedApiServer.featureGates)) }}
+            - {{ . }}
+            {{- end }}
           resources:
             {{- toYaml .Values.aggregatedApiServer.resources | nindent 12 }}
           readinessProbe:

--- a/charts/karmada/templates/karmada-controller-manager.yaml
+++ b/charts/karmada/templates/karmada-controller-manager.yaml
@@ -57,7 +57,7 @@ spec:
             - --secure-port=10357
             - --leader-elect-resource-namespace={{ include "karmada.namespace" . }}
             - --v=2
-            {{- with (include "karmada.controllerManager.featureGates" .) }}
+            {{- with (include "karmada.common.featureGates" (dict "featureGates" .Values.controllerManager.featureGates)) }}
             - {{ . }}
             {{- end }}
           livenessProbe:

--- a/charts/karmada/templates/karmada-scheduler.yaml
+++ b/charts/karmada/templates/karmada-scheduler.yaml
@@ -50,8 +50,10 @@ spec:
             - --kubeconfig=/etc/kubeconfig
             - --bind-address=0.0.0.0
             - --secure-port=10351
-            - --feature-gates=Failover=true
             - --leader-elect-resource-namespace={{ include "karmada.namespace" . }}
+            {{- with (include "karmada.common.featureGates" (dict "featureGates" .Values.scheduler.featureGates)) }}
+            - {{ . }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -176,6 +176,10 @@ scheduler:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 50%
+  ## @param featureGate to scheduler
+  featureGates:
+    ## @param CustomizedClusterResourceModeling indicates if enable cluster resource custom modeling.
+    CustomizedClusterResourceModeling: true
 
 ## webhook config
 webhook:
@@ -293,7 +297,13 @@ controllerManager:
   ## @param featureGate to controllerManager
   featureGates:
     ## @param PropagateDeps is a feature gate for the controllerManager to allow propagate dependent respurce to workloads.
-    PropagateDeps: false
+    PropagateDeps: ture
+    ## @param Failover indicates if scheduler should reschedule on cluster failure.
+    Failover: true
+    ## @param GracefulEviction indicates if enable grace eviction. Takes effect only when the Failover feature is enabled.
+    GracefulEviction: true
+    ## @param CustomizedClusterResourceModeling indicates if enable cluster resource custom modeling.
+    CustomizedClusterResourceModeling: true
 
 ## karmada apiserver config
 apiServer:
@@ -434,6 +444,12 @@ aggregatedApiServer:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 50%
+  ## @param featureGate to aggregatedApiServer
+  featureGates:
+    ## @param Enables managing request concurrency with prioritization and fairness at each server.
+    APIPriorityAndFairness: false
+    ## @param CustomizedClusterResourceModeling indicates if enable cluster resource custom modeling.
+    CustomizedClusterResourceModeling: true
 
 ## kubernetes controller manager config
 kubeControllerManager:


### PR DESCRIPTION
Signed-off-by: calvin0327 <wen.chen@daocloud.io>

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
The featureGates  of  deploy files `airfacts/deploy` is out of sync with the chart template `charts/karmada/templates`.

Exec :

```shell
helm template charts/karmada | grep feature-gates  -C 3
```

the test results:
```shell
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /Users/chenwen/.kube/config
            - --audit-log-path=-
            - --audit-log-maxage=0
            - --audit-log-maxbackup=0
            - --feature-gates=APIPriorityAndFairness=false,CustomizedClusterResourceModeling=true
          resources:
            requests:
              cpu: 100m
--
            - --bind-address=0.0.0.0
            - --secure-port=10351
            - --leader-elect-resource-namespace=default
            - --feature-gates=CustomizedClusterResourceModeling=true
          livenessProbe:
            httpGet:
              path: /healthz
--
            - --secure-port=10357
            - --leader-elect-resource-namespace=default
            - --v=2
            - --feature-gates=CustomizedClusterResourceModeling=true,Failover=true,GracefulEviction=true,PropagateDeps=ture
          livenessProbe:
            httpGet:
              path: /healthz
```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
please correct me if not.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

