### PR TITLE
introduce kube-image-tag flag to karmadactl init

### DIFF
--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -97,6 +97,7 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 	// kube image registry
 	flags.StringVarP(&opts.KubeImageMirrorCountry, "kube-image-mirror-country", "", "", "Country code of the kube image registry to be used. For Chinese mainland users, set it to cn")
 	flags.StringVarP(&opts.KubeImageRegistry, "kube-image-registry", "", "", "Kube image registry. For Chinese mainland users, you may use local gcr.io mirrors such as registry.cn-hangzhou.aliyuncs.com/google_containers to override default kube image registry")
+	flags.StringVar(&opts.KubeImageTag, "kube-image-tag", "v1.25.2", "Choose a specific Kubernetes version for the control plane.")
 	// cert
 	flags.StringVar(&opts.ExternalIP, "cert-external-ip", "", "the external IP of Karmada certificate (e.g 192.168.1.2,172.16.1.2)")
 	flags.StringVar(&opts.ExternalDNS, "cert-external-dns", "", "the external DNS of Karmada certificate (e.g localhost,localhost.com)")

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -47,9 +47,7 @@ var (
 
 	karmadaRelease string
 
-	defaultEtcdImage                  = "etcd:3.5.3-0"
-	defaultKubeAPIServerImage         = "kube-apiserver:v1.25.2"
-	defaultKubeControllerManagerImage = "kube-controller-manager:v1.25.2"
+	defaultEtcdImage = "etcd:3.5.3-0"
 
 	// DefaultCrdURL Karmada crds resource
 	DefaultCrdURL string
@@ -92,6 +90,7 @@ type CommandInitOption struct {
 	ImageRegistry                      string
 	KubeImageRegistry                  string
 	KubeImageMirrorCountry             string
+	KubeImageTag                       string
 	EtcdImage                          string
 	EtcdReplicas                       int32
 	EtcdInitImage                      string
@@ -552,7 +551,8 @@ func (i *CommandInitOption) kubeAPIServerImage() string {
 	if i.KarmadaAPIServerImage != "" {
 		return i.KarmadaAPIServerImage
 	}
-	return i.kubeRegistry() + "/" + defaultKubeAPIServerImage
+
+	return i.kubeRegistry() + "/kube-apiserver:" + i.KubeImageTag
 }
 
 // get kube-controller-manager image
@@ -560,7 +560,8 @@ func (i *CommandInitOption) kubeControllerManagerImage() string {
 	if i.KubeControllerManagerImage != "" {
 		return i.KubeControllerManagerImage
 	}
-	return i.kubeRegistry() + "/" + defaultKubeControllerManagerImage
+
+	return i.kubeRegistry() + "/kube-controller-manager:" + i.KubeImageTag
 }
 
 // get etcd-init image


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Choose a specific Kubernetes version for the control plane.
**Which issue(s) this PR fixes**:
Fixes #
see https://github.com/karmada-io/karmada/pull/2541 https://github.com/karmada-io/karmada/pull/2655
**Special notes for your reviewer**:
TEST
```
./karmadactl init --private-image-registry=daocloud.io/atsctoo --kube-image-tag=v1.18.20 --crds=/root/karmada/crds.tar.gz
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: Introduced `--kube-image-tag` flag to the `init` command to specify the Kubernetes image version.
```

