### PR TITLE
Fix deploy karmada-apiserver error by loadBalancer

### DIFF
--- a/hack/deploy-karmada.sh
+++ b/hack/deploy-karmada.sh
@@ -200,7 +200,7 @@ if [ "${HOST_CLUSTER_TYPE}" = "remote" ]; then
       KARMADA_APISERVER_IP=$(kubectl --context="${HOST_CLUSTER_NAME}" get pod -l app=karmada-apiserver -n "${KARMADA_SYSTEM_NAMESPACE}" -o=jsonpath='{.items[0].status.podIP}')
     ;;
     LoadBalancer)
-      if util::wait_service_external_ip "karmada-apiserver" "karmada-apiserver" "${KARMADA_SYSTEM_NAMESPACE}"; then
+      if util::wait_service_external_ip "${HOST_CLUSTER_NAME}" "karmada-apiserver" "${KARMADA_SYSTEM_NAMESPACE}"; then
         echo "Get service external IP: ${SERVICE_EXTERNAL_IP}, wait to check network connectivity"
         KARMADA_APISERVER_IP=$(util::get_load_balancer_ip) || KARMADA_APISERVER_IP=''
       else


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix deploy karmada-apiserver error by loadBalancer, there is two errors in scripts:
1. wait_service_external_ip should use "${HOST_CLUSTER_NAME}" context because context "karmada-apiserver" is available after append_client_kubeconfig.
2. When "{{range .status.loadBalancer.ingress}}{{.hostname}}" is empty, "external_ip" will be "<no value>".

Logs from "hack/deploy-karmada.sh":
```
Apply dynamic rendered apiserver service in /tmp/tmp.YDARfw2Jjk/karmada-apiserver.yaml.
deployment.apps/karmada-apiserver created
service/karmada-apiserver created
wait the karmada-apiserver ready...
pod/karmada-apiserver-547489884f-vdwcr condition met
Karmada API Server's IP is: 172.18.0.8, host cluster type is: remote
Cluster "karmada-apiserver" set.
User "karmada-apiserver" set.
Context "karmada-apiserver" modified.
deployment.apps/karmada-kube-controller-manager created
deployment.apps/karmada-aggregated-apiserver created
service/karmada-aggregated-apiserver created
wait the karmada-aggregated-apiserver ready...
pod/karmada-aggregated-apiserver-7d86576949-992hn condition met
pod/karmada-aggregated-apiserver-7d86576949-wl86w condition met
deployment.apps/karmada-search created
service/karmada-search created
```

**Which issue(s) this PR fixes**:
Fixes #2841 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

