### PR TITLE
validate cluster fields

### DIFF
--- a/pkg/apis/cluster/validation/validation.go
+++ b/pkg/apis/cluster/validation/validation.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"net/url"
+	"strings"
 
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -22,6 +23,7 @@ const clusterNameMaxLength int = 48
 // - Must be a valid label value as per RFC1123.
 //   * An alphanumeric (a-z, and 0-9) string, with a maximum length of 63 characters,
 //     with the '-' character allowed anywhere except the first or last character.
+//
 // - Length must be less than 48 characters.
 //   * Since cluster name used to generate execution namespace by adding a prefix, so reserve 15 characters for the prefix.
 func ValidateClusterName(name string) []string {
@@ -90,6 +92,8 @@ func ValidateClusterSpec(spec *api.ClusterSpec, fldPath *field.Path) field.Error
 		allErrs = append(allErrs, ValidateClusterProxyURL(fldPath.Child("proxyURL"), spec.ProxyURL)...)
 	}
 
+	allErrs = append(allErrs, validateClusterSpecForFieldSelector(spec, fldPath)...)
+
 	if len(spec.Taints) > 0 {
 		allErrs = append(allErrs, lifted.ValidateClusterTaints(spec.Taints, fldPath.Child("taints"))...)
 	}
@@ -140,6 +144,21 @@ func ValidateClusterProxyURL(fldPath *field.Path, proxyURL string) field.ErrorLi
 		default:
 			allErrs = append(allErrs, field.Invalid(fldPath, proxyURL, fmt.Sprintf("unsupported scheme %q, must be http, https, or socks5", u.Scheme)))
 		}
+	}
+	return allErrs
+}
+
+// validateClusterSpecForFieldSelector validates cluster's field value.
+func validateClusterSpecForFieldSelector(spec *api.ClusterSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if errs := kubevalidation.IsValidLabelValue(spec.Provider); len(errs) != 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("provider"), spec.Provider, strings.Join(errs, "; ")))
+	}
+	if errs := kubevalidation.IsValidLabelValue(spec.Region); len(errs) != 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("region"), spec.Region, strings.Join(errs, "; ")))
+	}
+	if errs := kubevalidation.IsValidLabelValue(spec.Zone); len(errs) != 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("zone"), spec.Zone, strings.Join(errs, "; ")))
 	}
 	return allErrs
 }

--- a/pkg/apis/cluster/validation/validation_test.go
+++ b/pkg/apis/cluster/validation/validation_test.go
@@ -53,6 +53,18 @@ func TestValidateCluster(t *testing.T) {
 			cluster:     api.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, Spec: api.ClusterSpec{SyncMode: api.Push, ProxyURL: "^Invalid"}},
 			expectError: true,
 		},
+		"invalid provider": {
+			cluster:     api.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, Spec: api.ClusterSpec{SyncMode: api.Push, Provider: "Invalid Provider"}},
+			expectError: true,
+		},
+		"invalid region": {
+			cluster:     api.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, Spec: api.ClusterSpec{SyncMode: api.Push, Region: "Invalid Region"}},
+			expectError: true,
+		},
+		"invalid zone": {
+			cluster:     api.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, Spec: api.ClusterSpec{SyncMode: api.Push, Provider: "Invalid Zone"}},
+			expectError: true,
+		},
 		"unsupported taint effect": {
 			cluster: api.Cluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},


### PR DESCRIPTION
Signed-off-by: carlory <baofa.fan@daocloud.io>

**What type of PR is this?**

/kind api-change
/kind feature

**What this PR does / why we need it**:

when we use the fieldSelector field of the clusterAffinity to select clusters, some cluster won't be selected and we will get this scheduler result that there're no fit clusters. 

for example, the provider of cluster contains chinese characters, the scheduler will not select this cluster. 

because the fieldSelector is converted to a labelSelector, the labelSelector will check the value.

FYI: 

- https://github.com/karmada-io/karmada/blob/master/pkg/util/selector.go#L110
- https://github.com/karmada-io/karmada/blob/23db2ac9d66b87033b855bd9f694defadc3d5b1c/vendor/k8s.io/apimachinery/pkg/labels/selector.go#L192

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
validate cluster fields: provider, region and zone.
```

