### PR TITLE
Build release-1.1 with go1.17.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.17.13
       - name: vendor
         run: hack/verify-vendor.sh
       - name: lint
@@ -41,7 +41,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.17.13
       - name: verify codegen
         run: hack/verify-codegen.sh
       - name: verify crdgen
@@ -60,7 +60,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.17.13
       - name: compile
         run: make all
   test:
@@ -73,7 +73,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.17.13
       - name: make test
         run: make test
   e2e:
@@ -88,7 +88,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.17.13
       - name: setup e2e test environment
         run: hack/local-up-karmada.sh
       - name: run e2e

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -22,7 +22,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.17.13
       - name: build images
         env:
           REGISTRY: ${{secrets.SWR_REGISTRY}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.x
+        go-version: 1.17.13
     - name: Making kubectl-karmada
       run: make kubectl-karmada
       env:

--- a/.github/workflows/swr-released-image.yml
+++ b/.github/workflows/swr-released-image.yml
@@ -19,7 +19,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.17.13
       - name: build images
         env:
           REGISTRY: ${{secrets.SWR_REGISTRY}}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR updates the default Go version for CI and releases bots to v1.17.13.

The reason why we don't use 1.17.x is we need to know the Go version for each release so that we can track and figure out if it is affected by a security issue.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Karmada(v1.1) is now built with Go1.17.13.
```

