### PR TITLE
fix descheduler estimator connection error

### DIFF
--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -61,17 +61,18 @@ type Descheduler struct {
 func NewDescheduler(karmadaClient karmadaclientset.Interface, kubeClient kubernetes.Interface, opts *options.Options) *Descheduler {
 	factory := informerfactory.NewSharedInformerFactory(karmadaClient, 0)
 	desched := &Descheduler{
-		KarmadaClient:           karmadaClient,
-		KubeClient:              kubeClient,
-		informerFactory:         factory,
-		bindingInformer:         factory.Work().V1alpha2().ResourceBindings().Informer(),
-		bindingLister:           factory.Work().V1alpha2().ResourceBindings().Lister(),
-		clusterInformer:         factory.Cluster().V1alpha1().Clusters().Informer(),
-		clusterLister:           factory.Cluster().V1alpha1().Clusters().Lister(),
-		schedulerEstimatorCache: estimatorclient.NewSchedulerEstimatorCache(),
-		schedulerEstimatorPort:  opts.SchedulerEstimatorPort,
-		unschedulableThreshold:  opts.UnschedulableThreshold.Duration,
-		deschedulingInterval:    opts.DeschedulingInterval.Duration,
+		KarmadaClient:                   karmadaClient,
+		KubeClient:                      kubeClient,
+		informerFactory:                 factory,
+		bindingInformer:                 factory.Work().V1alpha2().ResourceBindings().Informer(),
+		bindingLister:                   factory.Work().V1alpha2().ResourceBindings().Lister(),
+		clusterInformer:                 factory.Cluster().V1alpha1().Clusters().Informer(),
+		clusterLister:                   factory.Cluster().V1alpha1().Clusters().Lister(),
+		schedulerEstimatorCache:         estimatorclient.NewSchedulerEstimatorCache(),
+		schedulerEstimatorPort:          opts.SchedulerEstimatorPort,
+		schedulerEstimatorServicePrefix: opts.SchedulerEstimatorServicePrefix,
+		unschedulableThreshold:          opts.UnschedulableThreshold.Duration,
+		deschedulingInterval:            opts.DeschedulingInterval.Duration,
 	}
 	// ignore the error here because the informers haven't been started
 	_ = desched.bindingInformer.SetTransform(fedinformer.StripUnusedFields)


### PR DESCRIPTION
Signed-off-by: carlory <baofa.fan@daocloud.io>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

https://github.com/karmada-io/karmada/pull/2527

```
[root@dce-10-29-5-180 ~]# kubectl -n karmada-system logs karmada-descheduler-5b9f8ff755-kjxd5 --tail 10
}. Err: connection error: desc = "transport: Error while dialing dial tcp: lookup -member: no such host"
W1123 09:00:26.085826       1 logging.go:59] [core] [Channel #315 SubChannel #316] grpc: addrConn.createTransport failed to connect to {
  "Addr": "-member:10352",
  "ServerName": "-member:10352",
  "Attributes": null,
  "BalancerAttributes": null,
  "Type": 0,
  "Metadata": null
}. Err: connection error: desc = "transport: Error while dialing dial tcp: lookup -member: no such host"
E1123 09:00:28.773837       1 cache.go:97] Failed to dial cluster(member): dial -member:10352 error: context deadline exceeded
```

**Special notes for your reviewer**:

we need cherry-pick it to release-1.3

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
fix descheduler estimator connection error
```

