### PR TITLE
fix setting resource selector default namespace for policy

### DIFF
--- a/pkg/webhook/overridepolicy/mutating.go
+++ b/pkg/webhook/overridepolicy/mutating.go
@@ -30,10 +30,13 @@ func (a *MutatingAdmission) Handle(ctx context.Context, req admission.Request) a
 	}
 
 	// Set default namespace for all resource selector if not set.
+	// We need to get the default namespace from the request because for kube-apiserver < v1.24,
+	// the namespace of the object with namespace unset in the mutating webook chain of a create request
+	// is not populated yet. See https://github.com/kubernetes/kubernetes/pull/94637 for more details.
 	for i := range policy.Spec.ResourceSelectors {
 		if len(policy.Spec.ResourceSelectors[i].Namespace) == 0 {
-			klog.Infof("Setting resource selector default namespace for policy: %s/%s", policy.Namespace, policy.Name)
-			policy.Spec.ResourceSelectors[i].Namespace = policy.Namespace
+			klog.Infof("Setting resource selector default namespace for policy: %s/%s", req.Namespace, policy.Name)
+			policy.Spec.ResourceSelectors[i].Namespace = req.Namespace
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes #2598
Fixes #2597

karmada-webhook log:

```
I1123 12:06:11.103068       1 mutating.go:45] Mutating PropagationPolicy(/demo33-propagation-3fpnly) for request: CREATE
I1123 12:06:11.103098       1 mutating.go:50] Setting resource selector default namespace for policy: /demo33-propagation-3fpnly
I1123 12:06:11.106849       1 validating.go:35] Validating PropagationPolicy(kaihua-karmada-pair/demo33-propagation-3fpnly) for request: CREATE
I1123 12:06:11.120063       1 mutating.go:35] Setting resource selector default namespace for policy: /demo33-deployment-override
I1123 12:06:11.123010       1 validating.go:32] Validating OverridePolicy(kaihua-karmada-pair/demo33-deployment-override) for request: CREATE
```

Although the creation is successful, it will cause the related policy update to fail.

```
# kubectl --kubeconfig kmd32403.config -n kaihua-karmada-pair label pp demo33-propagation-3fpnly a=b
Error from server (modify ResourceSelectors is forbidden): admission webhook "propagationpolicy.karmada.io" denied the request: modify ResourceSelectors is forbidden
```

the root cause is that the mutating Webhooks cannot get correct namespace if the namespace of the policy's request body is empty.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-webhook`: Fixed failed to set resource selector default namespace if the relevant OverridePolicy and PropagationPolicy with namespace unset issue.
```

