### PR TITLE
Automated cherry pick of #2855: fix deschedulerestimator connection error

### DIFF
--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -58,17 +58,18 @@ type Descheduler struct {
 func NewDescheduler(karmadaClient karmadaclientset.Interface, kubeClient kubernetes.Interface, opts *options.Options) *Descheduler {
 	factory := informerfactory.NewSharedInformerFactory(karmadaClient, 0)
 	desched := &Descheduler{
-		KarmadaClient:           karmadaClient,
-		KubeClient:              kubeClient,
-		informerFactory:         factory,
-		bindingInformer:         factory.Work().V1alpha2().ResourceBindings().Informer(),
-		bindingLister:           factory.Work().V1alpha2().ResourceBindings().Lister(),
-		clusterInformer:         factory.Cluster().V1alpha1().Clusters().Informer(),
-		clusterLister:           factory.Cluster().V1alpha1().Clusters().Lister(),
-		schedulerEstimatorCache: estimatorclient.NewSchedulerEstimatorCache(),
-		schedulerEstimatorPort:  opts.SchedulerEstimatorPort,
-		unschedulableThreshold:  opts.UnschedulableThreshold.Duration,
-		deschedulingInterval:    opts.DeschedulingInterval.Duration,
+		KarmadaClient:                   karmadaClient,
+		KubeClient:                      kubeClient,
+		informerFactory:                 factory,
+		bindingInformer:                 factory.Work().V1alpha2().ResourceBindings().Informer(),
+		bindingLister:                   factory.Work().V1alpha2().ResourceBindings().Lister(),
+		clusterInformer:                 factory.Cluster().V1alpha1().Clusters().Informer(),
+		clusterLister:                   factory.Cluster().V1alpha1().Clusters().Lister(),
+		schedulerEstimatorCache:         estimatorclient.NewSchedulerEstimatorCache(),
+		schedulerEstimatorPort:          opts.SchedulerEstimatorPort,
+		schedulerEstimatorServicePrefix: opts.SchedulerEstimatorServicePrefix,
+		unschedulableThreshold:          opts.UnschedulableThreshold.Duration,
+		deschedulingInterval:            opts.DeschedulingInterval.Duration,
 	}
 	schedulerEstimatorWorkerOptions := util.Options{
 		Name:          "scheduler-estimator",


### PR DESCRIPTION
Cherry pick of #2855 on release-1.3.
#2855: fix deschedulerestimator connection error
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
```