### PR TITLE
Fix karmadactl register failed to read kubeconfig file

### DIFF
--- a/pkg/karmadactl/register/register.go
+++ b/pkg/karmadactl/register/register.go
@@ -249,6 +249,8 @@ func (o *CommandRegisterOption) Complete(args []string) error {
 	}
 
 	if len(o.ClusterName) == 0 {
+		o.KubeConfig = apiclient.KubeConfigPath(o.KubeConfig)
+
 		configBytes, err := os.ReadFile(o.KubeConfig)
 		if err != nil {
 			return fmt.Errorf("failed to read kubeconfig file %s, err: %w", o.KubeConfig, err)

--- a/pkg/karmadactl/util/apiclient/apiclient.go
+++ b/pkg/karmadactl/util/apiclient/apiclient.go
@@ -24,6 +24,23 @@ var (
 `)
 )
 
+// KubeConfigPath is to return kubeconfig file path in the following order:
+// 1. Via the command-line flag --kubeconfig
+// 2. Via the KUBECONFIG environment variable
+// 3. In your home directory as ~/.kube/config
+func KubeConfigPath(kubeconfigPath string) string {
+	if kubeconfigPath == "" {
+		env := os.Getenv("KUBECONFIG")
+		if env != "" {
+			kubeconfigPath = env
+		} else {
+			kubeconfigPath = defaultKubeConfig
+		}
+	}
+
+	return kubeconfigPath
+}
+
 // RestConfig is to create a rest config from the context and kubeconfig passed as arguments.
 func RestConfig(context, kubeconfigPath string) (*rest.Config, error) {
 	if kubeconfigPath == "" {
@@ -34,7 +51,6 @@ func RestConfig(context, kubeconfigPath string) (*rest.Config, error) {
 			kubeconfigPath = defaultKubeConfig
 		}
 	}
-
 	if !Exists(kubeconfigPath) {
 		return nil, ErrEmptyConfig
 	}


### PR DESCRIPTION
Signed-off-by: lonelyCZ <chengzhe@zju.edu.cn>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
```
[root@master67 karmada]# ./karmadactl register 10.10.103.67:32443 --token w1s6h8.6s2w87vbhs6rjphp --discovery-token-ca-cert-hash sha256:e40e2e42128b7fbd9df76ed1f829e0b3dcfd06c21b2a50a1d50de5c49e44b983 -v=6
I1124 14:36:16.076443   22896 loader.go:372] Config loaded from file:  /root/.kube/config
error: failed to read kubeconfig file , err: open : no such file or directory
```

It was introduced at #2752 

https://github.com/karmada-io/karmada/blob/63a67d7cbdb255297d9b889d5c3752e9b75a931b/pkg/karmadactl/register/register.go#L251-L255

It need to extract member cluster name from kubeconfig file if the name wasn't set, but the `o.KubeConfig` is nil, so this error occured.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
It doesn't need cherry-pick.

/cc @RainbowMango 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

