### PR TITLE
improve lua vm executing with pool

### DIFF
--- a/pkg/resourceinterpreter/configurableinterpreter/configurable.go
+++ b/pkg/resourceinterpreter/configurableinterpreter/configurable.go
@@ -17,6 +17,7 @@ import (
 type ConfigurableInterpreter struct {
 	// configManager caches all ResourceInterpreterCustomizations.
 	configManager configmanager.ConfigManager
+	luaVM         *luavm.VM
 }
 
 // NewConfigurableInterpreter builds a new interpreter by registering the
@@ -24,6 +25,8 @@ type ConfigurableInterpreter struct {
 func NewConfigurableInterpreter(informer genericmanager.SingleClusterInformerManager) *ConfigurableInterpreter {
 	return &ConfigurableInterpreter{
 		configManager: configmanager.NewInterpreterConfigManager(informer),
+		// TODO: set an appropriate pool size.
+		luaVM: luavm.New(false, 10),
 	}
 }
 
@@ -40,8 +43,7 @@ func (c *ConfigurableInterpreter) GetReplicas(object *unstructured.Unstructured)
 	if !enabled {
 		return
 	}
-	vm := luavm.VM{UseOpenLibs: false}
-	replicas, requires, err = vm.GetReplicas(object, luaScript)
+	replicas, requires, err = c.luaVM.GetReplicas(object, luaScript)
 	return
 }
 
@@ -52,8 +54,7 @@ func (c *ConfigurableInterpreter) ReviseReplica(object *unstructured.Unstructure
 	if !enabled {
 		return
 	}
-	vm := luavm.VM{UseOpenLibs: false}
-	revised, err = vm.ReviseReplica(object, replica, luaScript)
+	revised, err = c.luaVM.ReviseReplica(object, replica, luaScript)
 	return
 }
 
@@ -64,8 +65,7 @@ func (c *ConfigurableInterpreter) Retain(desired *unstructured.Unstructured, obs
 	if !enabled {
 		return
 	}
-	vm := luavm.VM{UseOpenLibs: false}
-	retained, err = vm.Retain(desired, observed, luaScript)
+	retained, err = c.luaVM.Retain(desired, observed, luaScript)
 	return
 }
 
@@ -76,8 +76,7 @@ func (c *ConfigurableInterpreter) AggregateStatus(object *unstructured.Unstructu
 	if !enabled {
 		return
 	}
-	vm := luavm.VM{UseOpenLibs: false}
-	status, err = vm.AggregateStatus(object, aggregatedStatusItems, luaScript)
+	status, err = c.luaVM.AggregateStatus(object, aggregatedStatusItems, luaScript)
 	return
 }
 
@@ -88,8 +87,7 @@ func (c *ConfigurableInterpreter) GetDependencies(object *unstructured.Unstructu
 	if !enabled {
 		return
 	}
-	vm := luavm.VM{UseOpenLibs: false}
-	dependencies, err = vm.GetDependencies(object, luaScript)
+	dependencies, err = c.luaVM.GetDependencies(object, luaScript)
 	return
 }
 
@@ -100,8 +98,7 @@ func (c *ConfigurableInterpreter) ReflectStatus(object *unstructured.Unstructure
 	if !enabled {
 		return
 	}
-	vm := luavm.VM{UseOpenLibs: false}
-	status, err = vm.ReflectStatus(object, luaScript)
+	status, err = c.luaVM.ReflectStatus(object, luaScript)
 	return
 }
 
@@ -112,8 +109,7 @@ func (c *ConfigurableInterpreter) InterpretHealth(object *unstructured.Unstructu
 	if !enabled {
 		return
 	}
-	vm := luavm.VM{UseOpenLibs: false}
-	health, err = vm.InterpretHealth(object, luaScript)
+	health, err = c.luaVM.InterpretHealth(object, luaScript)
 	return
 }
 

--- a/pkg/resourceinterpreter/configurableinterpreter/luavm/lua_test.go
+++ b/pkg/resourceinterpreter/configurableinterpreter/luavm/lua_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestGetReplicas(t *testing.T) {
 	var replicas int32 = 1
-	vm := VM{UseOpenLibs: false}
+	vm := New(false, 1)
 	tests := []struct {
 		name         string
 		deploy       *appsv1.Deployment
@@ -150,7 +150,7 @@ func TestReviseDeploymentReplica(t *testing.T) {
 						end`,
 		},
 	}
-	vm := VM{UseOpenLibs: false}
+	vm := New(false, 1)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -217,7 +217,7 @@ func TestAggregateDeploymentStatus(t *testing.T) {
 									end`,
 		},
 	}
-	vm := VM{UseOpenLibs: false}
+	vm := New(false, 1)
 
 	for _, tt := range tests {
 		actualObj, _ := vm.AggregateStatus(tt.curObj, tt.aggregatedStatusItems, tt.luaScript)
@@ -265,7 +265,7 @@ func TestHealthDeploymentStatus(t *testing.T) {
                         end `,
 		},
 	}
-	vm := VM{UseOpenLibs: false}
+	vm := New(false, 1)
 
 	for _, tt := range tests {
 		flag, err := vm.InterpretHealth(tt.curObj, tt.luaScript)
@@ -349,7 +349,7 @@ func TestRetainDeployment(t *testing.T) {
 						end`,
 		},
 	}
-	vm := VM{UseOpenLibs: false}
+	vm := New(false, 1)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -397,7 +397,7 @@ func TestStatusReflection(t *testing.T) {
 		},
 	}
 
-	vm := VM{UseOpenLibs: false}
+	vm := New(false, 1)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := vm.ReflectStatus(tt.args.object, tt.luaScript)
@@ -470,7 +470,7 @@ func TestGetDeployPodDependencies(t *testing.T) {
 		},
 	}
 
-	vm := VM{UseOpenLibs: false}
+	vm := New(false, 1)
 
 	for _, tt := range tests {
 		res, err := vm.GetDependencies(tt.curObj, tt.luaScript)

--- a/pkg/util/fixedpool/fixedpool.go
+++ b/pkg/util/fixedpool/fixedpool.go
@@ -1,0 +1,72 @@
+package fixedpool
+
+import (
+	"sync"
+)
+
+// A FixedPool like sync.Pool. But it's limited capacity.
+// When pool is full, Put will abandon and call destroyFunc to destroy the object.
+type FixedPool struct {
+	lock     sync.Mutex
+	pool     []any
+	capacity int
+
+	newFunc     func() (any, error)
+	destroyFunc func(any)
+}
+
+// New return a FixedPool
+func New(newFunc func() (any, error), destroyFunc func(any), capacity int) *FixedPool {
+	return &FixedPool{
+		pool:        make([]any, 0, capacity),
+		capacity:    capacity,
+		newFunc:     newFunc,
+		destroyFunc: destroyFunc,
+	}
+}
+
+// Get selects an arbitrary item from the pool, removes it from the
+// pool, and returns it to the caller.
+// Get may choose to ignore the pool and treat it as empty.
+// Callers should not assume any relation between values passed to Put and
+// the values returned by Get.
+//
+// If pool is empty, Get returns the result of calling newFunc.
+func (p *FixedPool) Get() (any, error) {
+	o, ok := p.pop()
+	if ok {
+		return o, nil
+	}
+
+	return p.newFunc()
+}
+
+// Put adds x to the pool. If pool is full, x will be abandoned,
+// and it's destroy function will be called.
+func (p *FixedPool) Put(x any) {
+	if p.push(x) {
+		return
+	}
+	p.destroyFunc(x)
+}
+
+func (p *FixedPool) pop() (any, bool) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	if s := len(p.pool); s > 0 {
+		o := p.pool[s-1]
+		p.pool = p.pool[:s-1]
+		return o, true
+	}
+	return nil, false
+}
+
+func (p *FixedPool) push(o any) bool {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	if s := len(p.pool); s < p.capacity {
+		p.pool = append(p.pool, o)
+		return true
+	}
+	return false
+}

--- a/pkg/util/fixedpool/fixedpool_test.go
+++ b/pkg/util/fixedpool/fixedpool_test.go
@@ -1,0 +1,141 @@
+package fixedpool
+
+import (
+	"testing"
+)
+
+func TestFixedPool_Get(t *testing.T) {
+	type fields struct {
+		pool     []any
+		capacity int
+	}
+	type want struct {
+		len int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   want
+	}{
+		{
+			name: "poll is empty",
+			fields: fields{
+				pool:     []any{},
+				capacity: 3,
+			},
+			want: want{
+				len: 0,
+			},
+		},
+		{
+			name: "poll is not empty",
+			fields: fields{
+				pool:     []any{1},
+				capacity: 3,
+			},
+			want: want{
+				len: 0,
+			},
+		},
+		{
+			name: "poll is full",
+			fields: fields{
+				pool:     []any{1, 2, 3},
+				capacity: 3,
+			},
+			want: want{
+				len: 2,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &FixedPool{
+				pool:        tt.fields.pool,
+				capacity:    tt.fields.capacity,
+				newFunc:     func() (any, error) { return &struct{}{}, nil },
+				destroyFunc: func(a any) {},
+			}
+			g, err := p.Get()
+			if err != nil {
+				t.Errorf("Get() returns error: %v", err)
+				return
+			}
+			if g == nil {
+				t.Errorf("Get() returns nil")
+				return
+			}
+			if got := len(p.pool); got != tt.want.len {
+				t.Errorf("Get() got = %v, want %v", got, tt.want.len)
+			}
+		})
+	}
+}
+
+func TestFixedPool_Put(t *testing.T) {
+	type fields struct {
+		pool     []any
+		capacity int
+	}
+	type want struct {
+		len       int
+		destroyed bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   want
+	}{
+		{
+			name: "pool is empty",
+			fields: fields{
+				pool:     nil,
+				capacity: 3,
+			},
+			want: want{
+				len:       1,
+				destroyed: false,
+			},
+		},
+		{
+			name: "pool is not empty",
+			fields: fields{
+				pool:     []any{1},
+				capacity: 3,
+			},
+			want: want{
+				len:       2,
+				destroyed: false,
+			},
+		},
+		{
+			name: "pool is not full",
+			fields: fields{
+				pool:     []any{1, 2, 3},
+				capacity: 3,
+			},
+			want: want{
+				len:       3,
+				destroyed: true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			destroyed := false
+			p := &FixedPool{
+				pool:        tt.fields.pool,
+				capacity:    tt.fields.capacity,
+				newFunc:     func() (any, error) { return &struct{}{}, nil },
+				destroyFunc: func(a any) { destroyed = true },
+			}
+			p.Put(&struct{}{})
+			if got := len(p.pool); got != tt.want.len {
+				t.Errorf("pool len got %v, want %v", got, tt.want)
+			}
+			if destroyed != tt.want.destroyed {
+				t.Errorf("destroyed got %v, want %v", destroyed, tt.want.destroyed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: yingjinhui <yingjinhui@didiglobal.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
At present, we create a new Lua vm to run script for every calling. This pr create vm once, before running script, get vm from pool, reducing the cost of vm creating.

I test it with a demo, calling the script every 10ms:
```
const script = `
function GetReplicas(obj)
	return 0, {}
end`

func main() {
	vm := luavm.New(false, 10)
	for range time.Tick(time.Millisecond * 10) {
		_, _, err := vm.GetReplicas(&unstructured.Unstructured{}, script)
		if err != nil {
			fmt.Println(err)
			os.Exit(1)
		}
	}
}
```

and implements `GetReplicas` in two ways:
- without pool : run in `luavm1` pod
- with pool:  run in `luavm2` pod

<img width="1081" alt="image" src="https://user-images.githubusercontent.com/17907604/203726764-46c24d1e-484b-4671-8fad-10ef73fd21a3.png">

Even in `luavm2` cost little more memory(48M v.s. 36M), but has much less in CPU (0.03 v.s. 0.1)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

