### PR TITLE
fix dirty is not added in docker image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,12 @@
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
-LDFLAGS='$(shell hack/version.sh)'
+VERSION ?= '$(shell hack/version.sh)'
 
 # Images management
 REGISTRY?="docker.io/karmada"
 REGISTRY_USER_NAME?=""
 REGISTRY_PASSWORD?=""
 REGISTRY_SERVER_ADDRESS?=""
-
-# Set your version by env or using latest tags from git
-VERSION?=""
-ifeq ($(VERSION), "")
-    LATEST_TAG=$(shell git describe --tags)
-    ifeq ($(LATEST_TAG),)
-        # Forked repo may not sync tags from upstream, so give it a default tag to make CI happy.
-        VERSION="unknown"
-    else
-        VERSION=$(LATEST_TAG)
-    endif
-endif
 
 TARGETS := karmada-aggregated-apiserver \
 			karmada-controller-manager \
@@ -50,7 +38,7 @@ all: $(CMD_TARGET)
 
 .PHONY: $(CMD_TARGET)
 $(CMD_TARGET):
-	LDFLAGS=$(LDFLAGS) BUILD_PLATFORMS=$(GOOS)/$(GOARCH) hack/build.sh $@
+	BUILD_PLATFORMS=$(GOOS)/$(GOARCH) hack/build.sh $@
 
 # Build image.
 #

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -23,6 +23,8 @@ set -o pipefail
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${REPO_ROOT}/hack/util.sh"
 
+LDFLAGS="$(util::version_ldflags) ${LDFLAGS:-}"
+
 function build_binary() {
   local -r target=$1
 

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -622,9 +622,13 @@ function util::get_macos_ipaddress() {
   fi
 }
 
-function util::get_GO_LDFLAGS() {
+function util::get_version() {
+  git describe --tags --dirty
+}
+
+function util::version_ldflags() {
   # Git information
-  GIT_VERSION=$(git describe --tags --dirty)
+  GIT_VERSION=$(util::get_version)
   GIT_COMMIT_HASH=$(git rev-parse HEAD)
   if git_status=$(git status --porcelain 2>/dev/null) && [[ -z ${git_status} ]]; then
     GIT_TREESTATE="clean"

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -7,4 +7,4 @@ set -o pipefail
 KARMADA_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 source "${KARMADA_ROOT}/hack/util.sh"
 
-util::get_GO_LDFLAGS
+util::get_version


### PR DESCRIPTION
Signed-off-by: yingjinhui <yingjinhui@didiglobal.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
```bash
$ echo >> README.md

$ make image-karmada-controller-manager
Building image for linux/amd64: docker.io/karmada/karmada-controller-manager:v1.3.0-452-g63a67d7c
...
```

Expect image: `docker.io/karmada/karmada-controller-manager:v1.3.0-452-g63a67d7c-dirty`


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
fix dirty is not added in docker image tag
```

