### PR TITLE
Add metrics for resource

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -213,6 +213,7 @@ func run(ctx context.Context, opts *options.Options) error {
 	}
 
 	crtlmetrics.Registry.MustRegister(metrics.ClusterCollectors()...)
+	crtlmetrics.Registry.MustRegister(metrics.ResourceCollectorsForAgent()...)
 
 	if err = setupControllers(controllerManager, opts, ctx.Done()); err != nil {
 		return err

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -157,6 +157,7 @@ func Run(ctx context.Context, opts *options.Options) error {
 	}
 
 	crtlmetrics.Registry.MustRegister(metrics.ClusterCollectors()...)
+	crtlmetrics.Registry.MustRegister(metrics.ResourceCollectors()...)
 
 	setupControllers(controllerManager, opts, ctx.Done())
 

--- a/pkg/controllers/binding/binding_controller.go
+++ b/pkg/controllers/binding/binding_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -29,6 +30,7 @@ import (
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/events"
+	"github.com/karmada-io/karmada/pkg/metrics"
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter"
 	"github.com/karmada-io/karmada/pkg/sharedcli/ratelimiterflag"
 	"github.com/karmada-io/karmada/pkg/util"
@@ -114,7 +116,9 @@ func (c *ResourceBindingController) syncBinding(binding *workv1alpha2.ResourceBi
 		return controllerruntime.Result{Requeue: true}, err
 	}
 	var errs []error
+	start := time.Now()
 	err = ensureWork(c.Client, c.ResourceInterpreter, workload, c.OverrideManager, binding, apiextensionsv1.NamespaceScoped)
+	metrics.ObserveSyncWorkLatency(binding.ObjectMeta, err, start)
 	if err != nil {
 		klog.Errorf("Failed to transform resourceBinding(%s/%s) to works. Error: %v.",
 			binding.GetNamespace(), binding.GetName(), err)

--- a/pkg/controllers/execution/execution_controller.go
+++ b/pkg/controllers/execution/execution_controller.go
@@ -3,6 +3,7 @@ package execution
 import (
 	"context"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,6 +23,7 @@ import (
 
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/events"
+	"github.com/karmada-io/karmada/pkg/metrics"
 	"github.com/karmada-io/karmada/pkg/sharedcli/ratelimiterflag"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
@@ -110,7 +112,9 @@ func (c *Controller) SetupWithManager(mgr controllerruntime.Manager) error {
 }
 
 func (c *Controller) syncWork(clusterName string, work *workv1alpha1.Work) (controllerruntime.Result, error) {
+	start := time.Now()
 	err := c.syncToClusters(clusterName, work)
+	metrics.ObserveSyncWorkloadLatency(work.ObjectMeta, err, start)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to sync work(%s) to cluster(%s): %v", work.Name, clusterName, err)
 		klog.Errorf(msg)

--- a/pkg/detector/policy.go
+++ b/pkg/detector/policy.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"context"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -15,6 +16,7 @@ import (
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/events"
+	"github.com/karmada-io/karmada/pkg/metrics"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/keys"
 	"github.com/karmada-io/karmada/pkg/util/helper"
@@ -38,6 +40,7 @@ func (d *ResourceDetector) propagateResource(object *unstructured.Unstructured, 
 	}
 
 	// 3. attempt to match policy in its namespace.
+	start := time.Now()
 	propagationPolicy, err := d.LookForMatchedPolicy(object, objectKey)
 	if err != nil {
 		klog.Errorf("Failed to retrieve policy for object: %s, error: %v", objectKey.String(), err)
@@ -50,6 +53,7 @@ func (d *ResourceDetector) propagateResource(object *unstructured.Unstructured, 
 			return fmt.Errorf("waiting for dependent overrides")
 		}
 		d.RemoveWaiting(objectKey)
+		metrics.ObserveFindMatchedPolicyLatency(object, start)
 		return d.ApplyPolicy(object, objectKey, propagationPolicy)
 	}
 
@@ -66,6 +70,7 @@ func (d *ResourceDetector) propagateResource(object *unstructured.Unstructured, 
 			return fmt.Errorf("waiting for dependent overrides")
 		}
 		d.RemoveWaiting(objectKey)
+		metrics.ObserveFindMatchedPolicyLatency(object, start)
 		return d.ApplyClusterPolicy(object, objectKey, clusterPolicy)
 	}
 

--- a/pkg/metrics/resource.go
+++ b/pkg/metrics/resource.go
@@ -1,0 +1,89 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	utilmetrics "github.com/karmada-io/karmada/pkg/util/metrics"
+)
+
+const (
+	resourceMatchPolicyDurationMetricsName = "resource_match_policy_duration_seconds"
+	resourceApplyPolicyDurationMetricsName = "resource_apply_policy_duration_seconds"
+	policyApplyAttemptsMetricsName         = "policy_apply_attempts_total"
+	syncWorkDurationMetricsName            = "binding_sync_work_duration_seconds"
+	syncWorkloadDurationMetricsName        = "work_sync_workload_duration_seconds"
+)
+
+var (
+	findMatchedPolicyDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    resourceMatchPolicyDurationMetricsName,
+		Help:    "Duration in seconds to find a matched propagation policy for the resource template.",
+		Buckets: prometheus.ExponentialBuckets(0.001, 2, 12),
+	}, []string{"apiVersion", "kind", "name", "namespace"})
+
+	applyPolicyDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    resourceApplyPolicyDurationMetricsName,
+		Help:    "Duration in seconds to apply a propagation policy for the resource template. By the result, 'error' means a resource template failed to apply the policy. Otherwise 'success'.",
+		Buckets: prometheus.ExponentialBuckets(0.001, 2, 12),
+	}, []string{"apiVersion", "kind", "name", "namespace", "result"})
+
+	policyApplyAttempts = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: policyApplyAttemptsMetricsName,
+		Help: "Number of attempts to be applied for a propagation policy. By the result, 'error' means a resource template failed to apply the policy. Otherwise 'success'.",
+	}, []string{"namespace", "name", "result"})
+
+	syncWorkDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    syncWorkDurationMetricsName,
+		Help:    "Duration in seconds to sync works for a binding object. By the result, 'error' means a binding failed to sync works. Otherwise 'success'.",
+		Buckets: prometheus.ExponentialBuckets(0.001, 2, 12),
+	}, []string{"namespace", "name", "result"})
+
+	syncWorkloadDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    syncWorkloadDurationMetricsName,
+		Help:    "Duration in seconds to sync the workload to a target cluster. By the result, 'error' means a work failed to sync workloads. Otherwise 'success'.",
+		Buckets: prometheus.ExponentialBuckets(0.001, 2, 12),
+	}, []string{"namespace", "name", "result"})
+)
+
+// ObserveFindMatchedPolicyLatency records the duration for the resource finding a matched policy.
+func ObserveFindMatchedPolicyLatency(object *unstructured.Unstructured, start time.Time) {
+	findMatchedPolicyDurationHistogram.WithLabelValues(object.GetAPIVersion(), object.GetKind(), object.GetName(), object.GetNamespace()).Observe(utilmetrics.DurationInSeconds(start))
+}
+
+// ObserveApplyPolicyAttemptAndLatency records the duration for the resource applying a policy and a applying attempt for the policy.
+func ObserveApplyPolicyAttemptAndLatency(object *unstructured.Unstructured, policyMetaData metav1.ObjectMeta, err error, start time.Time) {
+	applyPolicyDurationHistogram.WithLabelValues(object.GetAPIVersion(), object.GetKind(), object.GetName(), object.GetNamespace(), utilmetrics.GetResultByError(err)).Observe(utilmetrics.DurationInSeconds(start))
+	policyApplyAttempts.WithLabelValues(policyMetaData.Namespace, policyMetaData.Name, utilmetrics.GetResultByError(err)).Inc()
+}
+
+// ObserveSyncWorkLatency records the duration to sync works for a binding object.
+func ObserveSyncWorkLatency(bindingMetaData metav1.ObjectMeta, err error, start time.Time) {
+	syncWorkDurationHistogram.WithLabelValues(bindingMetaData.Namespace, bindingMetaData.Name, utilmetrics.GetResultByError(err)).Observe(utilmetrics.DurationInSeconds(start))
+}
+
+// ObserveSyncWorkloadLatency records the duration to sync the workload to a target cluster.
+func ObserveSyncWorkloadLatency(workMetadata metav1.ObjectMeta, err error, start time.Time) {
+	syncWorkloadDurationHistogram.WithLabelValues(workMetadata.Namespace, workMetadata.Name, utilmetrics.GetResultByError(err)).Observe(utilmetrics.DurationInSeconds(start))
+}
+
+// ResourceCollectors returns the collectors about resources.
+func ResourceCollectors() []prometheus.Collector {
+	return []prometheus.Collector{
+		applyPolicyDurationHistogram,
+		findMatchedPolicyDurationHistogram,
+		policyApplyAttempts,
+		syncWorkDurationHistogram,
+		syncWorkloadDurationHistogram,
+	}
+}
+
+// ResourceCollectorsForAgent returns the collectors about resources for karmada-agent.
+func ResourceCollectorsForAgent() []prometheus.Collector {
+	return []prometheus.Collector{
+		syncWorkloadDurationHistogram,
+	}
+}


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
As we consider the resource distribution latency as one of the important metrics to measure the multi-cluster system, we might need some metrics to some detailed steps.

A complete distribution contains: looking for a matched policy -> apply policy -> sync work -> sync workload to target cluster.

```
# HELP resource_find_matched_policy_duration_seconds Duration in seconds to find a matched propagation policy for the resource template.
# TYPE resource_find_matched_policy_duration_seconds histogram
resource_find_matched_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",le="0.001"} 1
resource_find_matched_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",le="0.002"} 1
resource_find_matched_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",le="0.004"} 1
resource_find_matched_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",le="0.008"} 1
resource_find_matched_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",le="0.016"} 1
resource_find_matched_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",le="0.032"} 1
resource_find_matched_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",le="0.064"} 1
resource_find_matched_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",le="0.128"} 1
resource_find_matched_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",le="0.256"} 1
resource_find_matched_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",le="0.512"} 1
resource_find_matched_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",le="1.024"} 1
resource_find_matched_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",le="2.048"} 1
resource_find_matched_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",le="+Inf"} 1
resource_find_matched_policy_duration_seconds_sum{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default"} 0.000183851
resource_find_matched_policy_duration_seconds_count{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default"} 1
# HELP resource_apply_policy_duration_seconds Duration in seconds to apply a propagation policy for the resource template. By the result, 'error' means a resource template failed to apply the policy. Otherwise 'success'.
# TYPE resource_apply_policy_duration_seconds histogram
resource_apply_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",result="success",le="0.001"} 0
resource_apply_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",result="success",le="0.002"} 0
resource_apply_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",result="success",le="0.004"} 0
resource_apply_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",result="success",le="0.008"} 0
resource_apply_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",result="success",le="0.016"} 1
resource_apply_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",result="success",le="0.032"} 1
resource_apply_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",result="success",le="0.064"} 2
resource_apply_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",result="success",le="0.128"} 2
resource_apply_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",result="success",le="0.256"} 2
resource_apply_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",result="success",le="0.512"} 2
resource_apply_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",result="success",le="1.024"} 2
resource_apply_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",result="success",le="2.048"} 2
resource_apply_policy_duration_seconds_bucket{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",result="success",le="+Inf"} 2
resource_apply_policy_duration_seconds_sum{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",result="success"} 0.052528434
resource_apply_policy_duration_seconds_count{apiVersion="apps/v1",kind="Deployment",name="nginx",namespace="default",result="success"} 2
# HELP policy_apply_attempts_total Number of attempts to be applied for a propagation policy. By the result, 'error' means a resource template failed to apply the policy. Otherwise 'success'.
# TYPE policy_apply_attempts_total counter
policy_apply_attempts_total{name="nginx-propagation",namespace="default",result="success"} 2
# HELP binding_sync_work_duration_seconds Duration in seconds to sync works for a binding object. By the result, 'error' means a binding failed to sync works. Otherwise 'success'.
# TYPE binding_sync_work_duration_seconds histogram
binding_sync_work_duration_seconds_bucket{name="nginx-deployment",namespace="default",result="success",le="0.001"} 2
binding_sync_work_duration_seconds_bucket{name="nginx-deployment",namespace="default",result="success",le="0.002"} 2
binding_sync_work_duration_seconds_bucket{name="nginx-deployment",namespace="default",result="success",le="0.004"} 2
binding_sync_work_duration_seconds_bucket{name="nginx-deployment",namespace="default",result="success",le="0.008"} 2
binding_sync_work_duration_seconds_bucket{name="nginx-deployment",namespace="default",result="success",le="0.016"} 2
binding_sync_work_duration_seconds_bucket{name="nginx-deployment",namespace="default",result="success",le="0.032"} 5
binding_sync_work_duration_seconds_bucket{name="nginx-deployment",namespace="default",result="success",le="0.064"} 9
binding_sync_work_duration_seconds_bucket{name="nginx-deployment",namespace="default",result="success",le="0.128"} 10
binding_sync_work_duration_seconds_bucket{name="nginx-deployment",namespace="default",result="success",le="0.256"} 10
binding_sync_work_duration_seconds_bucket{name="nginx-deployment",namespace="default",result="success",le="0.512"} 10
binding_sync_work_duration_seconds_bucket{name="nginx-deployment",namespace="default",result="success",le="1.024"} 10
binding_sync_work_duration_seconds_bucket{name="nginx-deployment",namespace="default",result="success",le="2.048"} 10
binding_sync_work_duration_seconds_bucket{name="nginx-deployment",namespace="default",result="success",le="+Inf"} 10
binding_sync_work_duration_seconds_sum{name="nginx-deployment",namespace="default",result="success"} 0.3456216
binding_sync_work_duration_seconds_count{name="nginx-deployment",namespace="default",result="success"} 10
# HELP work_sync_workload_duration_seconds Duration in seconds to sync the workload to a target cluster. By the result, 'error' means a work failed to sync workloads. Otherwise 'success'.
# TYPE work_sync_workload_duration_seconds histogram
work_sync_workload_duration_seconds_bucket{name="karmada-impersonator-7cbb6bd5c9",namespace="karmada-es-member1",result="error",le="0.001"} 0
work_sync_workload_duration_seconds_bucket{name="karmada-impersonator-7cbb6bd5c9",namespace="karmada-es-member1",result="error",le="0.002"} 0
work_sync_workload_duration_seconds_bucket{name="karmada-impersonator-7cbb6bd5c9",namespace="karmada-es-member1",result="error",le="0.004"} 0
work_sync_workload_duration_seconds_bucket{name="karmada-impersonator-7cbb6bd5c9",namespace="karmada-es-member1",result="error",le="0.008"} 0
work_sync_workload_duration_seconds_bucket{name="karmada-impersonator-7cbb6bd5c9",namespace="karmada-es-member1",result="error",le="0.016"} 0
work_sync_workload_duration_seconds_bucket{name="karmada-impersonator-7cbb6bd5c9",namespace="karmada-es-member1",result="error",le="0.032"} 1
work_sync_workload_duration_seconds_bucket{name="karmada-impersonator-7cbb6bd5c9",namespace="karmada-es-member1",result="error",le="0.064"} 1
work_sync_workload_duration_seconds_bucket{name="karmada-impersonator-7cbb6bd5c9",namespace="karmada-es-member1",result="error",le="0.128"} 1
work_sync_workload_duration_seconds_bucket{name="karmada-impersonator-7cbb6bd5c9",namespace="karmada-es-member1",result="error",le="0.256"} 1
work_sync_workload_duration_seconds_bucket{name="karmada-impersonator-7cbb6bd5c9",namespace="karmada-es-member1",result="error",le="0.512"} 1
work_sync_workload_duration_seconds_bucket{name="karmada-impersonator-7cbb6bd5c9",namespace="karmada-es-member1",result="error",le="1.024"} 1
work_sync_workload_duration_seconds_bucket{name="karmada-impersonator-7cbb6bd5c9",namespace="karmada-es-member1",result="error",le="2.048"} 1
work_sync_workload_duration_seconds_bucket{name="karmada-impersonator-7cbb6bd5c9",namespace="karmada-es-member1",result="error",le="+Inf"} 1
work_sync_workload_duration_seconds_sum{name="karmada-impersonator-7cbb6bd5c9",namespace="karmada-es-member1",result="error"} 0.02985906
work_sync_workload_duration_seconds_count{name="karmada-impersonator-7cbb6bd5c9",namespace="karmada-es-member1",result="error"} 1
```

**Which issue(s) this PR fixes**:
Part of #2472 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```
`Instrumentation`: Introduced the `resource_find_matched_policy_duration_seconds`, `resource_apply_policy_duration_seconds`, `policy_apply_attempts_total`, `binding_sync_work_duration_seconds`, `work_sync_workload_duration_seconds` metrics.
```

