### PR TITLE
do not propagate finalizers to member cluster

### DIFF
--- a/pkg/resourceinterpreter/defaultinterpreter/prune/prune.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/prune/prune.go
@@ -46,6 +46,8 @@ func RemoveIrrelevantField(workload *unstructured.Unstructured, extraHooks ...fu
 
 	unstructured.RemoveNestedField(workload.Object, "metadata", "ownerReferences")
 
+	unstructured.RemoveNestedField(workload.Object, "metadata", "finalizers")
+
 	unstructured.RemoveNestedField(workload.Object, "status")
 
 	if workload.GetKind() == util.ServiceKind {


### PR DESCRIPTION
What type of PR is this?

/kind bug

What this PR does / why we need it:
Object watcher retains finalizers on member cluster when updating. Finalizers shouldn't be propagated to member cluster from control plane.

Which issue(s) this PR fixes:
Fixes #2810

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

Finalizers will not be propagated to member cluster