### PR TITLE
Automated cherry pick of #2858: fix setting resource selector default namespace for policy

### DIFF
--- a/pkg/webhook/overridepolicy/mutating.go
+++ b/pkg/webhook/overridepolicy/mutating.go
@@ -30,10 +30,13 @@ func (a *MutatingAdmission) Handle(ctx context.Context, req admission.Request) a
 	}
 
 	// Set default namespace for all resource selector if not set.
+	// We need to get the default namespace from the request because for kube-apiserver < v1.24,
+	// the namespace of the object with namespace unset in the mutating webook chain of a create request
+	// is not populated yet. See https://github.com/kubernetes/kubernetes/pull/94637 for more details.
 	for i := range policy.Spec.ResourceSelectors {
 		if len(policy.Spec.ResourceSelectors[i].Namespace) == 0 {
-			klog.Infof("Setting resource selector default namespace for policy: %s/%s", policy.Namespace, policy.Name)
-			policy.Spec.ResourceSelectors[i].Namespace = policy.Namespace
+			klog.Infof("Setting resource selector default namespace for policy: %s/%s", req.Namespace, policy.Name)
+			policy.Spec.ResourceSelectors[i].Namespace = req.Namespace
 		}
 	}
 

--- a/pkg/webhook/propagationpolicy/mutating.go
+++ b/pkg/webhook/propagationpolicy/mutating.go
@@ -31,13 +31,16 @@ func (a *MutatingAdmission) Handle(ctx context.Context, req admission.Request) a
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-	klog.V(2).Infof("Mutating PropagationPolicy(%s/%s) for request: %s", policy.Namespace, policy.Name, req.Operation)
+	klog.V(2).Infof("Mutating PropagationPolicy(%s/%s) for request: %s", req.Namespace, policy.Name, req.Operation)
 
 	// Set default namespace for all resource selector if not set.
+	// We need to get the default namespace from the request because for kube-apiserver < v1.24,
+	// the namespace of the object with namespace unset in the mutating webook chain of a create request
+	// is not populated yet. See https://github.com/kubernetes/kubernetes/pull/94637 for more details.
 	for i := range policy.Spec.ResourceSelectors {
 		if len(policy.Spec.ResourceSelectors[i].Namespace) == 0 {
-			klog.Infof("Setting resource selector default namespace for policy: %s/%s", policy.Namespace, policy.Name)
-			policy.Spec.ResourceSelectors[i].Namespace = policy.Namespace
+			klog.Infof("Setting resource selector default namespace for policy: %s/%s", req.Namespace, policy.Name)
+			policy.Spec.ResourceSelectors[i].Namespace = req.Namespace
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #2858 on release-1.1.
#2858: fix setting resource selector default namespace for policy
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-webhook`: Fixed failed to set resource selector default namespace if the relevant OverridePolicy and PropagationPolicy with namespace unset issue.
```