### PR TITLE
evolute PropagateDeps FeatureGate to Beta  and enable it by default

### DIFF
--- a/artifacts/deploy/karmada-controller-manager.yaml
+++ b/artifacts/deploy/karmada-controller-manager.yaml
@@ -29,7 +29,7 @@ spec:
             - --bind-address=0.0.0.0
             - --cluster-status-update-frequency=10s
             - --secure-port=10357
-            - --feature-gates=PropagateDeps=true,Failover=true,GracefulEviction=true,CustomizedClusterResourceModeling=true
+            - --feature-gates=Failover=true,GracefulEviction=true,CustomizedClusterResourceModeling=true
             - --failover-eviction-timeout=30s
             - --v=4
           livenessProbe:

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -28,7 +28,7 @@ var (
 	DefaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 		Failover:                          {Default: false, PreRelease: featuregate.Alpha},
 		GracefulEviction:                  {Default: false, PreRelease: featuregate.Alpha},
-		PropagateDeps:                     {Default: false, PreRelease: featuregate.Alpha},
+		PropagateDeps:                     {Default: true, PreRelease: featuregate.Beta},
 		CustomizedClusterResourceModeling: {Default: false, PreRelease: featuregate.Alpha},
 	}
 )


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind api-change

**What this PR does / why we need it**:

The `PropagateDeps` feautre hes been stably supported n multiple versions (since version v1.1). It is planned to enable the `PropagateDeps FeatureGate` by default and evolute it to beta.

This is a global gate. Users need to set the `.spec.propagateDeps` of the `PropagationPolicy/ClusterPropagationPolicy` to true to enable the releavant resources be propagated automatically.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-controller-manager: evolute PropagateDeps FeatureGate to Beta  and enable it by default
```

