### PR TITLE
Evolute Failover/GracefulEviction FeatureGate  to beta version and  enable it by default

### DIFF
--- a/artifacts/deploy/karmada-controller-manager.yaml
+++ b/artifacts/deploy/karmada-controller-manager.yaml
@@ -29,7 +29,7 @@ spec:
             - --bind-address=0.0.0.0
             - --cluster-status-update-frequency=10s
             - --secure-port=10357
-            - --feature-gates=Failover=true,GracefulEviction=true,CustomizedClusterResourceModeling=true
+            - --feature-gates=CustomizedClusterResourceModeling=true
             - --failover-eviction-timeout=30s
             - --v=4
           livenessProbe:

--- a/charts/karmada/templates/karmada-scheduler.yaml
+++ b/charts/karmada/templates/karmada-scheduler.yaml
@@ -50,7 +50,6 @@ spec:
             - --kubeconfig=/etc/kubeconfig
             - --bind-address=0.0.0.0
             - --secure-port=10351
-            - --feature-gates=Failover=true
             - --leader-elect-resource-namespace={{ include "karmada.namespace" . }}
           livenessProbe:
             httpGet:

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -26,8 +26,8 @@ var (
 
 	// DefaultFeatureGates is the default feature gates of Karmada.
 	DefaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-		Failover:                          {Default: false, PreRelease: featuregate.Alpha},
-		GracefulEviction:                  {Default: false, PreRelease: featuregate.Alpha},
+		Failover:                          {Default: true, PreRelease: featuregate.Beta},
+		GracefulEviction:                  {Default: true, PreRelease: featuregate.Beta},
 		PropagateDeps:                     {Default: true, PreRelease: featuregate.Beta},
 		CustomizedClusterResourceModeling: {Default: false, PreRelease: featuregate.Alpha},
 	}

--- a/pkg/karmadactl/cmdinit/kubernetes/deployments.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deployments.go
@@ -423,7 +423,6 @@ func (i *CommandInitOption) makeKarmadaSchedulerDeployment() *appsv1.Deployment 
 					"--kubeconfig=/etc/kubeconfig",
 					"--bind-address=0.0.0.0",
 					"--secure-port=10351",
-					"--feature-gates=Failover=true",
 					"--enable-scheduler-estimator=true",
 					"--leader-elect=true",
 					fmt.Sprintf("--leader-elect-resource-namespace=%s", i.Namespace),


### PR DESCRIPTION
Signed-off-by: jwcesign <jiangwei115@huawei.com>

**What type of PR is this?**
/kind api-change

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
* The `Failover` feature has been supported from v0.4.0. It is time to enable the Failover FeatureGate by default and evolute it to beta.
* `GracefulEviction` has been supported from v1.3.0.  Enable the GracefulEviction FeatureGate by default and evolute it to beta.

**Which issue(s) this PR fixes**:
Fixes #none

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-controller-manager: evolute Failover/GracefulEviction FeatureGate to Beta and enable it by default.
```

