### PR TITLE
Evolute CustomizedClusterResourceModeling to Beta and enable it by default

### DIFF
--- a/artifacts/deploy/karmada-aggregated-apiserver.yaml
+++ b/artifacts/deploy/karmada-aggregated-apiserver.yaml
@@ -43,7 +43,7 @@ spec:
             - --tls-cert-file=/etc/karmada/pki/karmada.crt
             - --tls-private-key-file=/etc/karmada/pki/karmada.key
             - --audit-log-path=-
-            - --feature-gates=APIPriorityAndFairness=false,CustomizedClusterResourceModeling=true
+            - --feature-gates=APIPriorityAndFairness=false
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
           resources:

--- a/artifacts/deploy/karmada-controller-manager.yaml
+++ b/artifacts/deploy/karmada-controller-manager.yaml
@@ -29,7 +29,6 @@ spec:
             - --bind-address=0.0.0.0
             - --cluster-status-update-frequency=10s
             - --secure-port=10357
-            - --feature-gates=CustomizedClusterResourceModeling=true
             - --failover-eviction-timeout=30s
             - --v=4
           livenessProbe:

--- a/artifacts/deploy/karmada-scheduler.yaml
+++ b/artifacts/deploy/karmada-scheduler.yaml
@@ -38,7 +38,6 @@ spec:
             - --bind-address=0.0.0.0
             - --secure-port=10351
             - --enable-scheduler-estimator=true
-            - --feature-gates=CustomizedClusterResourceModeling=true
             - --v=4
           volumeMounts:
             - name: kubeconfig

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -29,7 +29,7 @@ var (
 		Failover:                          {Default: true, PreRelease: featuregate.Beta},
 		GracefulEviction:                  {Default: true, PreRelease: featuregate.Beta},
 		PropagateDeps:                     {Default: true, PreRelease: featuregate.Beta},
-		CustomizedClusterResourceModeling: {Default: false, PreRelease: featuregate.Alpha},
+		CustomizedClusterResourceModeling: {Default: true, PreRelease: featuregate.Beta},
 	}
 )
 


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:

The CustomizedClusterResourceModeling feautre hes been stably supported since version v1.3. It is planned to enable the CustomizedClusterResourceModeling FeatureGate by default and evolute it to beta.

The detailed usage can be found in https://karmada.io/docs/next/userguide/scheduling/cluster-resources.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
karmada-controller-manager, karmada-aggregated-apiserver, karmada-scheduler: evolute CustomizedClusterResourceModeling FeatureGate to Beta  and enable it by default
```

