### PR TITLE
Remove redundant pointer use of atomic types

### DIFF
--- a/pkg/resourceinterpreter/configurableinterpreter/configmanager/manager.go
+++ b/pkg/resourceinterpreter/configurableinterpreter/configmanager/manager.go
@@ -32,9 +32,9 @@ type ConfigManager interface {
 
 // interpreterConfigManager collects the resource interpreter customization.
 type interpreterConfigManager struct {
-	initialSynced *atomic.Bool
+	initialSynced atomic.Bool
 	lister        cache.GenericLister
-	configuration *atomic.Value
+	configuration atomic.Value
 }
 
 // LuaScriptAccessors returns all cached configurations.
@@ -63,12 +63,8 @@ func (configManager *interpreterConfigManager) HasSynced() bool {
 // NewInterpreterConfigManager watches ResourceInterpreterCustomization and organizes
 // the configurations in the cache.
 func NewInterpreterConfigManager(informer genericmanager.SingleClusterInformerManager) ConfigManager {
-	manager := &interpreterConfigManager{
-		initialSynced: &atomic.Bool{},
-		configuration: &atomic.Value{},
-	}
+	manager := &interpreterConfigManager{}
 	manager.configuration.Store(make(map[schema.GroupVersionKind]CustomAccessor))
-	manager.initialSynced.Store(false)
 
 	// In interpret command, rules are not loaded from server, so we don't start informer for it.
 	if informer != nil {

--- a/pkg/resourceinterpreter/customizedinterpreter/configmanager/manager.go
+++ b/pkg/resourceinterpreter/customizedinterpreter/configmanager/manager.go
@@ -31,9 +31,9 @@ type ConfigManager interface {
 
 // interpreterConfigManager collect the resource interpreter webhook configuration.
 type interpreterConfigManager struct {
-	configuration *atomic.Value
+	configuration atomic.Value
 	lister        cache.GenericLister
-	initialSynced *atomic.Bool
+	initialSynced atomic.Bool
 }
 
 // HookAccessors return all configured resource interpreter webhook.
@@ -62,13 +62,10 @@ func (m *interpreterConfigManager) HasSynced() bool {
 // NewExploreConfigManager return a new interpreterConfigManager with resourceinterpreterwebhookconfigurations handlers.
 func NewExploreConfigManager(inform genericmanager.SingleClusterInformerManager) ConfigManager {
 	manager := &interpreterConfigManager{
-		configuration: &atomic.Value{},
-		lister:        inform.Lister(resourceExploringWebhookConfigurationsGVR),
-		initialSynced: &atomic.Bool{},
+		lister: inform.Lister(resourceExploringWebhookConfigurationsGVR),
 	}
 
 	manager.configuration.Store([]WebhookAccessor{})
-	manager.initialSynced.Store(false)
 
 	configHandlers := fedinformer.NewHandlerOnEvents(
 		func(_ interface{}) { manager.updateConfiguration() },


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
This PR cleanup redundant pointer usage of atomic types for both `atomic.Value` and `atomic.Bool`,
they are safe to use the zero value.

echo from `atomic.Value`'s comment:
> The zero value for a Value returns nil from Load.

echo from `atomic.Bool`'s comment:
> The zero value is false.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

