### PR TITLE
Fix that karmada-agent don't have permission to delete `work` resources

### DIFF
--- a/pkg/karmadactl/cmdinit/karmada/rbac.go
+++ b/pkg/karmadactl/cmdinit/karmada/rbac.go
@@ -65,7 +65,7 @@ func grantAccessPermissionToAgent(clientSet kubernetes.Interface) error {
 		{
 			APIGroups: []string{"work.karmada.io"},
 			Resources: []string{"works"},
-			Verbs:     []string{"create", "get", "list", "watch", "update"},
+			Verbs:     []string{"create", "get", "list", "watch", "update", "delete"},
 		},
 		{
 			APIGroups: []string{"work.karmada.io"},

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -495,7 +495,7 @@ func (i *CommandInitOption) RunInit(parentCommand string) error {
 		return err
 	}
 
-	// Create bootstarp token in karmada
+	// Create bootstrap token in karmada
 	registerCommand, err := karmada.InitKarmadaBootstrapToken(i.KarmadaDataPath)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: lonelyCZ <chengzhe@zju.edu.cn>

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

`karmada-agent` need to permission to delete `work` resources.

```
E1205 07:30:10.437634       1 service_export_controller.go:459] Failed to delete work(karmada-es-member140/dc-demo-59r4p-58b774c749), Error: works.work.karmada.io "dc-demo-59r4p-58b774c749" is forbidden: User "system:node:member140" cannot delete resource "works" in API group "work.karmada.io" in the namespace "karmada-es-member140"
E1205 07:30:10.437688       1 service_export_controller.go:161] Failed to handle endpointSlice(default/dc-demo-59r4p) event, Error: works.work.karmada.io "dc-demo-59r4p-58b774c749" is forbidden: User "system:node:member140" cannot delete resource "works" in API group "work.karmada.io" in the namespace "karmada-es-member140"
```

https://github.com/karmada-io/karmada/blob/472ccb5a2d9e87a54ec8be7f5267cdae2a2bbb3f/pkg/controllers/mcs/service_export_controller.go#L312-L322

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

`release-1.3` and `release-1.4` need this patch (cherry-pick).

/cc @RainbowMango 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-register`: Fixed `karmada-agent` controller don't have `delete` permission of `works`
```

