### PR TITLE
Automated cherry pick of #2902: Fix that karmada-agent don't have permission to delete work

### DIFF
--- a/pkg/karmadactl/cmdinit/karmada/rbac.go
+++ b/pkg/karmadactl/cmdinit/karmada/rbac.go
@@ -65,7 +65,7 @@ func grantAccessPermissionToAgent(clientSet kubernetes.Interface) error {
 		{
 			APIGroups: []string{"work.karmada.io"},
 			Resources: []string{"works"},
-			Verbs:     []string{"create", "get", "list", "watch", "update"},
+			Verbs:     []string{"create", "get", "list", "watch", "update", "delete"},
 		},
 		{
 			APIGroups: []string{"work.karmada.io"},

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -495,7 +495,7 @@ func (i *CommandInitOption) RunInit(parentCommand string) error {
 		return err
 	}
 
-	// Create bootstarp token in karmada
+	// Create bootstrap token in karmada
 	registerCommand, err := karmada.InitKarmadaBootstrapToken(i.KarmadaDataPath)
 	if err != nil {
 		return err


### PR DESCRIPTION
Cherry pick of #2902 on release-1.4.
#2902: Fix that karmada-agent don't have permission to delete work
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmadactl`: Fixed `karmada-agent` installed by the `register` command can not delete works due to lack of permission issue.
```