### PR TITLE
Update Golang version from v1.18.8 to v1.18.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.8
+          go-version: 1.18.9
       - name: vendor
         run: hack/verify-vendor.sh
       - name: lint
@@ -37,7 +37,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.8
+          go-version: 1.18.9
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
       - name: verify codegen
@@ -64,7 +64,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.8
+          go-version: 1.18.9
       - name: compile
         run: make all
   test:
@@ -77,7 +77,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.8
+          go-version: 1.18.9
       - name: make test
         run: make test
   e2e:
@@ -97,7 +97,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.8
+          go-version: 1.18.9
       - name: setup e2e test environment
         run: |
           export CLUSTER_VERSION=kindest/node:${{ matrix.k8s }}

--- a/.github/workflows/dockerhub-latest-image.yml
+++ b/.github/workflows/dockerhub-latest-image.yml
@@ -34,7 +34,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.8
+          go-version: 1.18.9
       - name: install QEMU
         uses: docker/setup-qemu-action@v1
       - name: install Buildx

--- a/.github/workflows/dockerhub-released-image.yml
+++ b/.github/workflows/dockerhub-released-image.yml
@@ -30,7 +30,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.8
+          go-version: 1.18.9
       - name: install QEMU
         uses: docker/setup-qemu-action@v1
       - name: install Buildx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.8
+        go-version: 1.18.9
     - name: Making and packaging
       env:
         GOOS: ${{ matrix.os }}

--- a/.github/workflows/swr-latest-image.yml
+++ b/.github/workflows/swr-latest-image.yml
@@ -22,7 +22,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.8
+          go-version: 1.18.9
       - name: build images
         env:
           REGISTRY: ${{secrets.SWR_REGISTRY}}

--- a/.github/workflows/swr-released-image.yml
+++ b/.github/workflows/swr-released-image.yml
@@ -19,7 +19,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.8
+          go-version: 1.18.9
       - name: build images
         env:
           REGISTRY: ${{secrets.SWR_REGISTRY}}


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Golang community just released 1.18.9, this patch release addressed 2 security fixes.
See [release notes](https://go.dev/doc/devel/release#go1.18.9) for more information.

So we update the golang version from v1.18.8 to v1.18.9 .

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Karmada is now built with Go1.18.9.
```

