### PR TITLE
generate PolicyRules from given subjects for impersonation deduplicate

### DIFF
--- a/pkg/util/rbac.go
+++ b/pkg/util/rbac.go
@@ -7,6 +7,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeclient "k8s.io/client-go/kubernetes"
+	stringslices "k8s.io/utils/strings/slices"
 )
 
 // IsClusterRoleExist tells if specific ClusterRole already exists.
@@ -136,11 +137,17 @@ func GenerateImpersonationRules(allSubjects []rbacv1.Subject) []rbacv1.PolicyRul
 	for _, subject := range allSubjects {
 		switch subject.Kind {
 		case rbacv1.UserKind:
-			users = append(users, subject.Name)
+			if !stringslices.Contains(users, subject.Name) {
+				users = append(users, subject.Name)
+			}
 		case rbacv1.ServiceAccountKind:
-			serviceAccounts = append(serviceAccounts, subject.Name)
+			if !stringslices.Contains(serviceAccounts, subject.Name) {
+				serviceAccounts = append(serviceAccounts, subject.Name)
+			}
 		case rbacv1.GroupKind:
-			groups = append(groups, subject.Name)
+			if !stringslices.Contains(groups, subject.Name) {
+				groups = append(groups, subject.Name)
+			}
 		}
 	}
 

--- a/pkg/util/rbac_test.go
+++ b/pkg/util/rbac_test.go
@@ -237,6 +237,24 @@ func TestGenerateImpersonationRules(t *testing.T) {
 				{Verbs: []string{"impersonate"}, Resources: []string{"groups"}, APIGroups: []string{""}, ResourceNames: []string{"group1", "group2"}},
 			},
 		},
+		{
+			name: "generate and deduplicate subject success",
+			args: args{
+				allSubjects: []rbacv1.Subject{
+					{Kind: rbacv1.UserKind, Name: "user1"},
+					{Kind: rbacv1.UserKind, Name: "user1"},
+					{Kind: rbacv1.ServiceAccountKind, Name: "sa1"},
+					{Kind: rbacv1.ServiceAccountKind, Name: "sa1"},
+					{Kind: rbacv1.GroupKind, Name: "group1"},
+					{Kind: rbacv1.GroupKind, Name: "group1"},
+				},
+			},
+			want: []rbacv1.PolicyRule{
+				{Verbs: []string{"impersonate"}, Resources: []string{"users"}, APIGroups: []string{""}, ResourceNames: []string{"user1"}},
+				{Verbs: []string{"impersonate"}, Resources: []string{"serviceaccounts"}, APIGroups: []string{""}, ResourceNames: []string{"sa1"}},
+				{Verbs: []string{"impersonate"}, Resources: []string{"groups"}, APIGroups: []string{""}, ResourceNames: []string{"group1"}},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: huangyanfeng <huangyanfeng1992@gmail.com>

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

unified-auth-controller generates PolicyRules from given subjects for impersonation need deduplicate by name

![image](https://user-images.githubusercontent.com/89568107/206106501-8fcf83c4-21f1-412f-9fe7-a9413e86f939.png)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

`karmada-controller-manager`: generate PolicyRules from given subjects for impersonation deduplicate

```

