### PR TITLE
fix that validating for resourceinterpreterwebhookconfigurations does…

### DIFF
--- a/pkg/karmadactl/cmdinit/karmada/webhook_configuration.go
+++ b/pkg/karmadactl/cmdinit/karmada/webhook_configuration.go
@@ -149,10 +149,10 @@ webhooks:
       - operations: ["CREATE", "UPDATE"]
         apiGroups: ["config.karmada.io"]
         apiVersions: ["*"]
-        resources: ["resourceexploringwebhookconfigurations"]
+        resources: ["resourceinterpreterwebhookconfigurations"]
         scope: "Cluster"
     clientConfig:
-      url: https://karmada-webhook.%[1]s.svc:443/validate-resourceexploringwebhookconfiguration
+      url: https://karmada-webhook.%[1]s.svc:443/validate-resourceinterpreterwebhookconfiguration
       caBundle: %[2]s
     failurePolicy: Fail
     sideEffects: None


### PR DESCRIPTION
Signed-off-by: hejunhua [hejunhua@cestc.cn](mailto:hejunhua@cestc.cn)

fix the bug that resourceinterpreterwebhookconfigurations can be edited arbitrarily.

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```
`karmadactl`: Fixed the default ValidatingWebhookConfiguration for `resourceinterpreterwebhook` not working issue.
```
### Details of the reproduction of this problem are as follows:
[root@single ~]# kubectl edit --kubeconfig=/root/karmada.config resourceinterpreterwebhookconfigurations.config.karmada.io demo
`resourceinterpreterwebhookconfiguration.config.karmada.io/demo-interpreter edited`
[root@single ~]# kubectl get --kubeconfig=/root/karmada.config resourceinterpreterwebhookconfigurations.config.karmada.io demo -oyaml
```
apiVersion: config.karmada.io/v1alpha1
kind: ResourceInterpreterWebhookConfiguration
metadata:
  creationTimestamp: "2022-12-03T06:57:16Z"
  generation: 2
  name: demo
  resourceVersion: "4560303"
  uid: e81109fa-33cc-4acb-9b3b-e2f3b24f407e
webhooks:
- clientConfig:
    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM5VENDQWQyZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFTTVJBd0RnWURWUVFERXdkcllYSnQKWVdSaE1CNFhEVEl5TVRFeU9URXdNREV5TmxvWERUTXlNVEV5TmpFd01ERXlObG93RWpFUU1BNEdBMVVFQXhNSAphMkZ5YldGa1lUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQU9iUjljOFlsL2V4CmdFNDJQbVNpSmhlbG9OVVF5S1NOYS8zRUdER29uU0tKUE5QR1ZtR3gwRmtDVUV3UGt3eDd6c2lmV3luV1RsS2YKNy95REREdXZFR0VoMk5OSEF4QnZRVXZhMlArWGxXSHpabWNTbndHZWI0QVdzOHBJdkp1dnZvK3B3MGhUQ25Yawp6T2t3NWxGRzRQcHpyT0RmOVVSdlY4N3RzRnp2ZENBdUY1NVJqRVlFcllmd1NwRXE3b2ZnR2FhVStTanYzek1iCmJqbEtQWStoV2Q0UUtWYytoVlZSZi9xSHB1RFY4a2dLb1J4SWh0SGhXSE10eTcyS1RkczlGNG85cTdNMjFTZnYKaC9JL2lZU1NUZkI2ZEUzRDVSeG81alRjSmFyc2hBYVM1eDlvZ0N4Zi82clZXaTdmZUd4cGZVaG45ODdJTEJpdwpsNjZOdW9ERUNNTUNBd0VBQWFOV01GUXdEZ1lEVlIwUEFRSC9CQVFEQWdLa01BOEdBMVVkRXdFQi93UUZNQU1CCkFmOHdIUVlEVlIwT0JCWUVGSlpaUnNtQVVNU0xqRWNFYXE0QmRuNEthYlFwTUJJR0ExVWRFUVFMTUFtQ0IydGgKY20xaFpHRXdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBR05SUm9iVENwQWJPY1h2UXdQTlVWL1FJYkY1S0J3dgpUV3RabUVNRTB3NEljOEhiZzBFZWxHb0VvKy8xSVlHMENZZGo5TDZzOHlpL3k4TW1MSkY0UWV4aU5tbnkyRUNiCm11N01LeGxaMjJ6eHpkNi8xZHpiS0VCTjYwNG9yWWZ0ZmhWQytKanYvT0Z4dzBaRTd1SWR0azhsS256NHI5OXkKMkNhejZ2NisyalBQa3FYeG1rZUlqSWFCeDAvaXBOU0ZJUTAwVmVvczJVVEFjcTFkbThjVUhBRUJKUjRGMWFsbgovbWFZYlFTY2F3NStZSTB3OUJGR0o4WTFaRFlPV3VUb1FPNWlPMG5WSDBlVXRuOVZsd1djczh3cVFmU1FTTVBjCklkdmY2cmlRemFnOHhlUjhiUlB6bGZIcFFncTk3cFBOY0tldndSYVdaMlAvdnlQNUR2SGtsVGs9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
    url: https://demo-interpreter.karmada-system.svc.cluster.local:443/interpreter-workload
  interpreterContextVersions:
  - v1alpha1
  name: demo
  rules:
  - apiGroups:
    - config.demo.io
    apiVersions:
    - v1
    kinds:
    - Demo
    operations:
    - InterpretReplicaRequirement
    - Retain
    - AggregateStatus
    - InterpretHealth
    - InterpretStatus
    - Test
  timeoutSeconds: 3

```
You can see that I modified wrong name and operations successfully because the validating webhook for resourceinterpreterwebhookconfiguration does not work. In fact, the karmada-apiserver will never request the the validating webhook for resourceinterpreterwebhookconfiguration due to wrong resourceinterpreterwebhookconfiguration  URL and resource type in validating-config:
```
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingWebhookConfiguration
metadata:
  creationTimestamp: "2022-11-29T10:02:08Z"
  generation: 1
  labels:
    app: validating-config
  name: validating-config
  resourceVersion: "20127"
  uid: b8995496-c01b-4438-a802-75649de5e1fc
webhooks:
- admissionReviewVersions:
  - v1
  clientConfig:
    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM5VENDQWQyZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFTTVJBd0RnWURWUVFERXdkcllYSnQKWVdSaE1CNFhEVEl5TVRFeU9URXdNREV5TmxvWERUTXlNVEV5TmpFd01ERXlObG93RWpFUU1BNEdBMVVFQXhNSAphMkZ5YldGa1lUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQU9iUjljOFlsL2V4CmdFNDJQbVNpSmhlbG9OVVF5S1NOYS8zRUdER29uU0tKUE5QR1ZtR3gwRmtDVUV3UGt3eDd6c2lmV3luV1RsS2YKNy95REREdXZFR0VoMk5OSEF4QnZRVXZhMlArWGxXSHpabWNTbndHZWI0QVdzOHBJdkp1dnZvK3B3MGhUQ25Yawp6T2t3NWxGRzRQcHpyT0RmOVVSdlY4N3RzRnp2ZENBdUY1NVJqRVlFcllmd1NwRXE3b2ZnR2FhVStTanYzek1iCmJqbEtQWStoV2Q0UUtWYytoVlZSZi9xSHB1RFY4a2dLb1J4SWh0SGhXSE10eTcyS1RkczlGNG85cTdNMjFTZnYKaC9JL2lZU1NUZkI2ZEUzRDVSeG81alRjSmFyc2hBYVM1eDlvZ0N4Zi82clZXaTdmZUd4cGZVaG45ODdJTEJpdwpsNjZOdW9ERUNNTUNBd0VBQWFOV01GUXdEZ1lEVlIwUEFRSC9CQVFEQWdLa01BOEdBMVVkRXdFQi93UUZNQU1CCkFmOHdIUVlEVlIwT0JCWUVGSlpaUnNtQVVNU0xqRWNFYXE0QmRuNEthYlFwTUJJR0ExVWRFUVFMTUFtQ0IydGgKY20xaFpHRXdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBR05SUm9iVENwQWJPY1h2UXdQTlVWL1FJYkY1S0J3dgpUV3RabUVNRTB3NEljOEhiZzBFZWxHb0VvKy8xSVlHMENZZGo5TDZzOHlpL3k4TW1MSkY0UWV4aU5tbnkyRUNiCm11N01LeGxaMjJ6eHpkNi8xZHpiS0VCTjYwNG9yWWZ0ZmhWQytKanYvT0Z4dzBaRTd1SWR0azhsS256NHI5OXkKMkNhejZ2NisyalBQa3FYeG1rZUlqSWFCeDAvaXBOU0ZJUTAwVmVvczJVVEFjcTFkbThjVUhBRUJKUjRGMWFsbgovbWFZYlFTY2F3NStZSTB3OUJGR0o4WTFaRFlPV3VUb1FPNWlPMG5WSDBlVXRuOVZsd1djczh3cVFmU1FTTVBjCklkdmY2cmlRemFnOHhlUjhiUlB6bGZIcFFncTk3cFBOY0tldndSYVdaMlAvdnlQNUR2SGtsVGs9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
    url: https://karmada-webhook.karmada-system.svc:443/validate-propagationpolicy
  failurePolicy: Fail
  matchPolicy: Equivalent
  name: propagationpolicy.karmada.io
  namespaceSelector: {}
  objectSelector: {}
  rules:
  - apiGroups:
    - policy.karmada.io
    apiVersions:
    - '*'
    operations:
    - CREATE
    - UPDATE
    resources:
    - propagationpolicies
    scope: Namespaced
  sideEffects: None
  timeoutSeconds: 3
- admissionReviewVersions:
  - v1
  clientConfig:
    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM5VENDQWQyZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFTTVJBd0RnWURWUVFERXdkcllYSnQKWVdSaE1CNFhEVEl5TVRFeU9URXdNREV5TmxvWERUTXlNVEV5TmpFd01ERXlObG93RWpFUU1BNEdBMVVFQXhNSAphMkZ5YldGa1lUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQU9iUjljOFlsL2V4CmdFNDJQbVNpSmhlbG9OVVF5S1NOYS8zRUdER29uU0tKUE5QR1ZtR3gwRmtDVUV3UGt3eDd6c2lmV3luV1RsS2YKNy95REREdXZFR0VoMk5OSEF4QnZRVXZhMlArWGxXSHpabWNTbndHZWI0QVdzOHBJdkp1dnZvK3B3MGhUQ25Yawp6T2t3NWxGRzRQcHpyT0RmOVVSdlY4N3RzRnp2ZENBdUY1NVJqRVlFcllmd1NwRXE3b2ZnR2FhVStTanYzek1iCmJqbEtQWStoV2Q0UUtWYytoVlZSZi9xSHB1RFY4a2dLb1J4SWh0SGhXSE10eTcyS1RkczlGNG85cTdNMjFTZnYKaC9JL2lZU1NUZkI2ZEUzRDVSeG81alRjSmFyc2hBYVM1eDlvZ0N4Zi82clZXaTdmZUd4cGZVaG45ODdJTEJpdwpsNjZOdW9ERUNNTUNBd0VBQWFOV01GUXdEZ1lEVlIwUEFRSC9CQVFEQWdLa01BOEdBMVVkRXdFQi93UUZNQU1CCkFmOHdIUVlEVlIwT0JCWUVGSlpaUnNtQVVNU0xqRWNFYXE0QmRuNEthYlFwTUJJR0ExVWRFUVFMTUFtQ0IydGgKY20xaFpHRXdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBR05SUm9iVENwQWJPY1h2UXdQTlVWL1FJYkY1S0J3dgpUV3RabUVNRTB3NEljOEhiZzBFZWxHb0VvKy8xSVlHMENZZGo5TDZzOHlpL3k4TW1MSkY0UWV4aU5tbnkyRUNiCm11N01LeGxaMjJ6eHpkNi8xZHpiS0VCTjYwNG9yWWZ0ZmhWQytKanYvT0Z4dzBaRTd1SWR0azhsS256NHI5OXkKMkNhejZ2NisyalBQa3FYeG1rZUlqSWFCeDAvaXBOU0ZJUTAwVmVvczJVVEFjcTFkbThjVUhBRUJKUjRGMWFsbgovbWFZYlFTY2F3NStZSTB3OUJGR0o4WTFaRFlPV3VUb1FPNWlPMG5WSDBlVXRuOVZsd1djczh3cVFmU1FTTVBjCklkdmY2cmlRemFnOHhlUjhiUlB6bGZIcFFncTk3cFBOY0tldndSYVdaMlAvdnlQNUR2SGtsVGs9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
    url: https://karmada-webhook.karmada-system.svc:443/validate-clusterpropagationpolicy
  failurePolicy: Fail
  matchPolicy: Equivalent
  name: clusterpropagationpolicy.karmada.io
  namespaceSelector: {}
  objectSelector: {}
  rules:
  - apiGroups:
    - policy.karmada.io
    apiVersions:
    - '*'
    operations:
    - CREATE
    - UPDATE
    resources:
    - clusterpropagationpolicies
    scope: Cluster
  sideEffects: None
  timeoutSeconds: 3
- admissionReviewVersions:
  - v1
  clientConfig:
    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM5VENDQWQyZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFTTVJBd0RnWURWUVFERXdkcllYSnQKWVdSaE1CNFhEVEl5TVRFeU9URXdNREV5TmxvWERUTXlNVEV5TmpFd01ERXlObG93RWpFUU1BNEdBMVVFQXhNSAphMkZ5YldGa1lUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQU9iUjljOFlsL2V4CmdFNDJQbVNpSmhlbG9OVVF5S1NOYS8zRUdER29uU0tKUE5QR1ZtR3gwRmtDVUV3UGt3eDd6c2lmV3luV1RsS2YKNy95REREdXZFR0VoMk5OSEF4QnZRVXZhMlArWGxXSHpabWNTbndHZWI0QVdzOHBJdkp1dnZvK3B3MGhUQ25Yawp6T2t3NWxGRzRQcHpyT0RmOVVSdlY4N3RzRnp2ZENBdUY1NVJqRVlFcllmd1NwRXE3b2ZnR2FhVStTanYzek1iCmJqbEtQWStoV2Q0UUtWYytoVlZSZi9xSHB1RFY4a2dLb1J4SWh0SGhXSE10eTcyS1RkczlGNG85cTdNMjFTZnYKaC9JL2lZU1NUZkI2ZEUzRDVSeG81alRjSmFyc2hBYVM1eDlvZ0N4Zi82clZXaTdmZUd4cGZVaG45ODdJTEJpdwpsNjZOdW9ERUNNTUNBd0VBQWFOV01GUXdEZ1lEVlIwUEFRSC9CQVFEQWdLa01BOEdBMVVkRXdFQi93UUZNQU1CCkFmOHdIUVlEVlIwT0JCWUVGSlpaUnNtQVVNU0xqRWNFYXE0QmRuNEthYlFwTUJJR0ExVWRFUVFMTUFtQ0IydGgKY20xaFpHRXdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBR05SUm9iVENwQWJPY1h2UXdQTlVWL1FJYkY1S0J3dgpUV3RabUVNRTB3NEljOEhiZzBFZWxHb0VvKy8xSVlHMENZZGo5TDZzOHlpL3k4TW1MSkY0UWV4aU5tbnkyRUNiCm11N01LeGxaMjJ6eHpkNi8xZHpiS0VCTjYwNG9yWWZ0ZmhWQytKanYvT0Z4dzBaRTd1SWR0azhsS256NHI5OXkKMkNhejZ2NisyalBQa3FYeG1rZUlqSWFCeDAvaXBOU0ZJUTAwVmVvczJVVEFjcTFkbThjVUhBRUJKUjRGMWFsbgovbWFZYlFTY2F3NStZSTB3OUJGR0o4WTFaRFlPV3VUb1FPNWlPMG5WSDBlVXRuOVZsd1djczh3cVFmU1FTTVBjCklkdmY2cmlRemFnOHhlUjhiUlB6bGZIcFFncTk3cFBOY0tldndSYVdaMlAvdnlQNUR2SGtsVGs9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
    url: https://karmada-webhook.karmada-system.svc:443/validate-overridepolicy
  failurePolicy: Fail
  matchPolicy: Equivalent
  name: overridepolicy.karmada.io
  namespaceSelector: {}
  objectSelector: {}
  rules:
  - apiGroups:
    - policy.karmada.io
    apiVersions:
    - '*'
    operations:
    - CREATE
    - UPDATE
    resources:
    - overridepolicies
    scope: Namespaced
  sideEffects: None
  timeoutSeconds: 3
- admissionReviewVersions:
  - v1
  clientConfig:
    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM5VENDQWQyZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFTTVJBd0RnWURWUVFERXdkcllYSnQKWVdSaE1CNFhEVEl5TVRFeU9URXdNREV5TmxvWERUTXlNVEV5TmpFd01ERXlObG93RWpFUU1BNEdBMVVFQXhNSAphMkZ5YldGa1lUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQU9iUjljOFlsL2V4CmdFNDJQbVNpSmhlbG9OVVF5S1NOYS8zRUdER29uU0tKUE5QR1ZtR3gwRmtDVUV3UGt3eDd6c2lmV3luV1RsS2YKNy95REREdXZFR0VoMk5OSEF4QnZRVXZhMlArWGxXSHpabWNTbndHZWI0QVdzOHBJdkp1dnZvK3B3MGhUQ25Yawp6T2t3NWxGRzRQcHpyT0RmOVVSdlY4N3RzRnp2ZENBdUY1NVJqRVlFcllmd1NwRXE3b2ZnR2FhVStTanYzek1iCmJqbEtQWStoV2Q0UUtWYytoVlZSZi9xSHB1RFY4a2dLb1J4SWh0SGhXSE10eTcyS1RkczlGNG85cTdNMjFTZnYKaC9JL2lZU1NUZkI2ZEUzRDVSeG81alRjSmFyc2hBYVM1eDlvZ0N4Zi82clZXaTdmZUd4cGZVaG45ODdJTEJpdwpsNjZOdW9ERUNNTUNBd0VBQWFOV01GUXdEZ1lEVlIwUEFRSC9CQVFEQWdLa01BOEdBMVVkRXdFQi93UUZNQU1CCkFmOHdIUVlEVlIwT0JCWUVGSlpaUnNtQVVNU0xqRWNFYXE0QmRuNEthYlFwTUJJR0ExVWRFUVFMTUFtQ0IydGgKY20xaFpHRXdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBR05SUm9iVENwQWJPY1h2UXdQTlVWL1FJYkY1S0J3dgpUV3RabUVNRTB3NEljOEhiZzBFZWxHb0VvKy8xSVlHMENZZGo5TDZzOHlpL3k4TW1MSkY0UWV4aU5tbnkyRUNiCm11N01LeGxaMjJ6eHpkNi8xZHpiS0VCTjYwNG9yWWZ0ZmhWQytKanYvT0Z4dzBaRTd1SWR0azhsS256NHI5OXkKMkNhejZ2NisyalBQa3FYeG1rZUlqSWFCeDAvaXBOU0ZJUTAwVmVvczJVVEFjcTFkbThjVUhBRUJKUjRGMWFsbgovbWFZYlFTY2F3NStZSTB3OUJGR0o4WTFaRFlPV3VUb1FPNWlPMG5WSDBlVXRuOVZsd1djczh3cVFmU1FTTVBjCklkdmY2cmlRemFnOHhlUjhiUlB6bGZIcFFncTk3cFBOY0tldndSYVdaMlAvdnlQNUR2SGtsVGs9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
    url: https://karmada-webhook.karmada-system.svc:443/validate-clusteroverridepolicy
  failurePolicy: Fail
  matchPolicy: Equivalent
  name: clusteroverridepolicy.karmada.io
  namespaceSelector: {}
  objectSelector: {}
  rules:
  - apiGroups:
    - policy.karmada.io
    apiVersions:
    - '*'
    operations:
    - CREATE
    - UPDATE
    resources:
    - clusteroverridepolicies
    scope: Cluster
  sideEffects: None
  timeoutSeconds: 3
- admissionReviewVersions:
  - v1
  clientConfig:
    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM5VENDQWQyZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFTTVJBd0RnWURWUVFERXdkcllYSnQKWVdSaE1CNFhEVEl5TVRFeU9URXdNREV5TmxvWERUTXlNVEV5TmpFd01ERXlObG93RWpFUU1BNEdBMVVFQXhNSAphMkZ5YldGa1lUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQU9iUjljOFlsL2V4CmdFNDJQbVNpSmhlbG9OVVF5S1NOYS8zRUdER29uU0tKUE5QR1ZtR3gwRmtDVUV3UGt3eDd6c2lmV3luV1RsS2YKNy95REREdXZFR0VoMk5OSEF4QnZRVXZhMlArWGxXSHpabWNTbndHZWI0QVdzOHBJdkp1dnZvK3B3MGhUQ25Yawp6T2t3NWxGRzRQcHpyT0RmOVVSdlY4N3RzRnp2ZENBdUY1NVJqRVlFcllmd1NwRXE3b2ZnR2FhVStTanYzek1iCmJqbEtQWStoV2Q0UUtWYytoVlZSZi9xSHB1RFY4a2dLb1J4SWh0SGhXSE10eTcyS1RkczlGNG85cTdNMjFTZnYKaC9JL2lZU1NUZkI2ZEUzRDVSeG81alRjSmFyc2hBYVM1eDlvZ0N4Zi82clZXaTdmZUd4cGZVaG45ODdJTEJpdwpsNjZOdW9ERUNNTUNBd0VBQWFOV01GUXdEZ1lEVlIwUEFRSC9CQVFEQWdLa01BOEdBMVVkRXdFQi93UUZNQU1CCkFmOHdIUVlEVlIwT0JCWUVGSlpaUnNtQVVNU0xqRWNFYXE0QmRuNEthYlFwTUJJR0ExVWRFUVFMTUFtQ0IydGgKY20xaFpHRXdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBR05SUm9iVENwQWJPY1h2UXdQTlVWL1FJYkY1S0J3dgpUV3RabUVNRTB3NEljOEhiZzBFZWxHb0VvKy8xSVlHMENZZGo5TDZzOHlpL3k4TW1MSkY0UWV4aU5tbnkyRUNiCm11N01LeGxaMjJ6eHpkNi8xZHpiS0VCTjYwNG9yWWZ0ZmhWQytKanYvT0Z4dzBaRTd1SWR0azhsS256NHI5OXkKMkNhejZ2NisyalBQa3FYeG1rZUlqSWFCeDAvaXBOU0ZJUTAwVmVvczJVVEFjcTFkbThjVUhBRUJKUjRGMWFsbgovbWFZYlFTY2F3NStZSTB3OUJGR0o4WTFaRFlPV3VUb1FPNWlPMG5WSDBlVXRuOVZsd1djczh3cVFmU1FTTVBjCklkdmY2cmlRemFnOHhlUjhiUlB6bGZIcFFncTk3cFBOY0tldndSYVdaMlAvdnlQNUR2SGtsVGs9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
    url: https://karmada-webhook.karmada-system.svc:443/validate-resourceexploringwebhookconfiguration
  failurePolicy: Fail
  matchPolicy: Equivalent
  name: config.karmada.io
  namespaceSelector: {}
  objectSelector: {}
  rules:
  - apiGroups:
    - config.karmada.io
    apiVersions:
    - '*'
    operations:
    - CREATE
    - UPDATE
    resources:
    - resourceexploringwebhookconfigurations
    scope: Cluster
  sideEffects: None
  timeoutSeconds: 3
```