### PR TITLE
Replace colon with point in the rbac resource name

### DIFF
--- a/pkg/util/names/names.go
+++ b/pkg/util/names/names.go
@@ -154,5 +154,15 @@ func GeneratePolicyName(namespace, name, gvk string) string {
 	hash := fnv.New32a()
 	hashutil.DeepHashObject(hash, namespace+gvk)
 
+	// The name of resources, like 'Role'/'ClusterRole'/'RoleBinding'/'ClusterRoleBinding',
+	// may contain symbols(like ':') that are not allowed by CRD resources which require the
+	// name can be used as a DNS subdomain name. So, we need to replace it.
+	// These resources may also allow for other characters(like '&','$') that are not allowed
+	// by CRD resources, we only handle the most common ones now for performance concerns.
+	// For more information about the DNS subdomain name, please refer to
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names.
+	if strings.Contains(name, ":") {
+		name = strings.ReplaceAll(name, ":", ".")
+	}
 	return strings.ToLower(fmt.Sprintf("%s-%s", name, rand.SafeEncodeString(fmt.Sprint(hash.Sum32()))))
 }

--- a/pkg/util/names/names_test.go
+++ b/pkg/util/names/names_test.go
@@ -413,6 +413,13 @@ func TestGeneratePolicyName(t *testing.T) {
 			gvk:          "rand",
 			expected:     "foo-b4978784",
 		},
+		{
+			name:         "generate policy name with :",
+			namespace:    "ns-foo",
+			resourcename: "system:foo",
+			gvk:          "rand",
+			expected:     "system.foo-b4978784",
+		},
 	}
 	for _, test := range tests {
 		got := GeneratePolicyName(test.namespace, test.resourcename, test.gvk)


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Use `karmadactl apply` to apply rbac resources to all clusters
```
karmadactl apply -f olm.yaml --all-clusters
```

It will auto-generate a policy, and policy name will include ":", and create failed.
The same as #2549 

olm works well with Karmada.
```
root@karmada-dev-linux-shentiecheng:~/karmada# kubectl --kubeconfig ~/.kube/members.config --context member1 get po -A 
NAMESPACE             NAME                                                              READY   STATUS      RESTARTS       AGE 
default               nginx-85b98978db-mcdxh                                            1/1     Running     0              54m
kube-system           coredns-64897985d-8b5tc                                           1/1     Running     0              43h
kube-system           coredns-64897985d-gkhjc                                           1/1     Running     0              43h
kube-system           etcd-member1-control-plane                                        1/1     Running     0              43h
kube-system           kindnet-kxkhl                                                     1/1     Running     13 (19h ago)   43h
kube-system           kube-apiserver-member1-control-plane                              1/1     Running     1 (19h ago)    43h
kube-system           kube-controller-manager-member1-control-plane                     1/1     Running     5 (19h ago)    43h
kube-system           kube-proxy-gkfjj                                                  1/1     Running     0              43h
kube-system           kube-scheduler-member1-control-plane                              1/1     Running     5 (19h ago)    43h
local-path-storage    local-path-provisioner-5ddd94ff66-zfpl7                           1/1     Running     19 (19h ago)   43h
my-grafana-operator   grafana-operator-controller-manager-787cbf857c-5tz8s              2/2     Running     0              2m6s
olm                   catalog-operator-865494bfbf-sspqj                                 1/1     Running     0              6m50s
olm                   ec41fdd641ffbaf50ad3099709aa193c6800139147ff26ead6d08bd792dw26w   0/1     Completed   0              2m48s
olm                   olm-operator-f7746965-lvm66                                       1/1     Running     0              6m51s
olm                   operatorhubio-catalog-mw229                                       1/1     Running     0              6m46s
olm                   packageserver-6884744f49-hnw6n                                    1/1     Running     0              6m47s
olm                   packageserver-6884744f49-wvdxz                                    1/1     Running     0              6m47s
```
**Which issue(s) this PR fixes**:
Fixes #2393 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
`karmadactl`: Fixed the error of resources whose name contains colons failing to be created when using `karmadactl apply`.
```

