### PR TITLE
Cherry pick #2915 to release-1.3: fix that validating for resourceinterpreterwebhookconfigurations

### DIFF
--- a/pkg/karmadactl/cmdinit/karmada/webhook_configuration.go
+++ b/pkg/karmadactl/cmdinit/karmada/webhook_configuration.go
@@ -148,10 +148,10 @@ webhooks:
       - operations: ["CREATE", "UPDATE"]
         apiGroups: ["config.karmada.io"]
         apiVersions: ["*"]
-        resources: ["resourceexploringwebhookconfigurations"]
+        resources: ["resourceinterpreterwebhookconfigurations"]
         scope: "Cluster"
     clientConfig:
-      url: https://karmada-webhook.%[1]s.svc:443/validate-resourceexploringwebhookconfiguration
+      url: https://karmada-webhook.%[1]s.svc:443/validate-resourceinterpreterwebhookconfiguration
       caBundle: %[2]s
     failurePolicy: Fail
     sideEffects: None


### PR DESCRIPTION
… not work

Signed-off-by: hejunhua <hejunhua@cestc.cn>

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of #2921

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: Fixed the default ValidatingWebhookConfiguration for `resourceinterpreterwebhook` not working issue.
```

