### PR TITLE
Automated cherry pick of #2916: fix resourceinterpretercustomizations webhook

### DIFF
--- a/pkg/karmadactl/cmdinit/karmada/webhook_configuration.go
+++ b/pkg/karmadactl/cmdinit/karmada/webhook_configuration.go
@@ -163,7 +163,7 @@ webhooks:
       - operations: ["CREATE", "UPDATE"]
         apiGroups: ["config.karmada.io"]
         apiVersions: ["*"]
-        resources: ["resourceexploringwebhookconfigurations"]
+        resources: ["resourceinterpretercustomizations"]
         scope: "Cluster"
     clientConfig:
       url: https://karmada-webhook.%[1]s.svc:443/validate-resourceinterpretercustomization


### PR DESCRIPTION
Cherry pick of #2916 on release-1.4.
#2916: fix resourceinterpretercustomizations webhook
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
```