### PR TITLE
Fix misjudgment of deployment and statefuleset health status

### DIFF
--- a/pkg/resourceinterpreter/defaultinterpreter/healthy_test.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/healthy_test.go
@@ -28,6 +28,7 @@ func Test_interpretDeploymentHealth(t *testing.T) {
 						"replicas": 3,
 					},
 					"status": map[string]interface{}{
+						"availableReplicas":  3,
 						"updatedReplicas":    3,
 						"observedGeneration": 1,
 					},
@@ -50,6 +51,7 @@ func Test_interpretDeploymentHealth(t *testing.T) {
 						"replicas": 3,
 					},
 					"status": map[string]interface{}{
+						"availableReplicas":  3,
 						"updatedReplicas":    3,
 						"observedGeneration": 2,
 					},
@@ -73,6 +75,29 @@ func Test_interpretDeploymentHealth(t *testing.T) {
 					},
 					"status": map[string]interface{}{
 						"updatedReplicas":    1,
+						"observedGeneration": 1,
+					},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "availableReplicas not equal to updatedReplicas",
+			object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":       "fake-deployment",
+						"generation": 1,
+					},
+					"spec": map[string]interface{}{
+						"replicas": 3,
+					},
+					"status": map[string]interface{}{
+						"availableReplicas":  0,
+						"updatedReplicas":    3,
 						"observedGeneration": 1,
 					},
 				},
@@ -115,6 +140,7 @@ func Test_interpretStatefulSetHealth(t *testing.T) {
 						"replicas": 3,
 					},
 					"status": map[string]interface{}{
+						"availableReplicas":  3,
 						"updatedReplicas":    3,
 						"observedGeneration": 1,
 					},
@@ -137,6 +163,7 @@ func Test_interpretStatefulSetHealth(t *testing.T) {
 						"replicas": 3,
 					},
 					"status": map[string]interface{}{
+						"availableReplicas":  3,
 						"updatedReplicas":    3,
 						"observedGeneration": 2,
 					},
@@ -160,6 +187,29 @@ func Test_interpretStatefulSetHealth(t *testing.T) {
 					},
 					"status": map[string]interface{}{
 						"updatedReplicas":    1,
+						"observedGeneration": 1,
+					},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "availableReplicas not equal to updatedReplicas",
+			object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "StatefulSet",
+					"metadata": map[string]interface{}{
+						"name":       "fake-statefulSet",
+						"generation": 1,
+					},
+					"spec": map[string]interface{}{
+						"replicas": 3,
+					},
+					"status": map[string]interface{}{
+						"availableReplicas":  1,
+						"updatedReplicas":    3,
 						"observedGeneration": 1,
 					},
 				},
@@ -195,7 +245,11 @@ func Test_interpretReplicaSetHealth(t *testing.T) {
 					"metadata": map[string]interface{}{
 						"generation": 1,
 					},
+					"spec": map[string]interface{}{
+						"replicas": 3,
+					},
 					"status": map[string]interface{}{
+						"availableReplicas":  3,
 						"observedGeneration": 1,
 					},
 				},
@@ -210,7 +264,11 @@ func Test_interpretReplicaSetHealth(t *testing.T) {
 					"metadata": map[string]interface{}{
 						"generation": 1,
 					},
+					"spec": map[string]interface{}{
+						"replicas": 3,
+					},
 					"status": map[string]interface{}{
+						"availableReplicas":  3,
 						"observedGeneration": 2,
 					},
 				},
@@ -222,11 +280,15 @@ func Test_interpretReplicaSetHealth(t *testing.T) {
 			name: "replicas not equal to availableReplicas",
 			object: &unstructured.Unstructured{
 				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"generation": 1,
+					},
 					"spec": map[string]interface{}{
 						"replicas": 3,
 					},
 					"status": map[string]interface{}{
-						"availableReplicas": 2,
+						"availableReplicas":  2,
+						"observedGeneration": 2,
 					},
 				},
 			},
@@ -290,6 +352,19 @@ func Test_interpretDaemonSetHealth(t *testing.T) {
 					"status": map[string]interface{}{
 						"updatedNumberScheduled": 3,
 						"desiredNumberScheduled": 5,
+					},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "numberAvailable < updatedNumberScheduled",
+			object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"status": map[string]interface{}{
+						"updatedNumberScheduled": 5,
+						"numberAvailable":        3,
 					},
 				},
 			},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When I apply the following yaml of the deployment and pp
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  labels:
    app: nginx
spec:
  replicas: 2
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - image: nginx:dfaadadffasdfa # image not exist
        name: nginx
---
apiVersion: policy.karmada.io/v1alpha1
kind: PropagationPolicy
metadata:
  name: nginx-propagation
spec:
  resourceSelectors:
    - apiVersion: apps/v1
      kind: Deployment
      name: nginx
  placement:
    clusterAffinity:
      clusterNames:
        - 10-29-14-21
        - 10-29-14-25
```
We can find that the health state of the resource under the resourceBinding is `Healthy`
```yaml
status:
  aggregatedStatus:
  - applied: true
    clusterName: 10-29-14-21
    health: Healthy
    status:
      replicas: 2
      unavailableReplicas: 2
      updatedReplicas: 2
  - applied: true
    clusterName: 10-29-14-25
    health: Healthy
    status:
      replicas: 2
      unavailableReplicas: 2
      updatedReplicas: 2
  conditions:
  - lastTransitionTime: "2022-12-08T08:34:03Z"
    message: All works have been successfully applied
    reason: FullyAppliedSuccess
    status: "True"
    type: FullyApplied
  - lastTransitionTime: "2022-12-08T08:34:03Z"
    message: Binding has been scheduled
    reason: BindingScheduled
    status: "True"
    type: Scheduled
  schedulerObservedGeneration: 2
```
However, the resources propagated to the member clusters at this time are not healthy
```sh
[root@dce-10-29-14-21 demo]# k -n test get deploy
NAME           READY   UP-TO-DATE   AVAILABLE   AGE
nginx          0/2     2            0           74m
```

This pr fix this problem

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Fix misjudgment of deployment and statefuleset health status
```

