### PR TITLE
Fix work status not sync to control plane when apiserver failed and recovered soon

### DIFF
--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -177,8 +177,6 @@ func (c *ClusterStatusController) syncClusterStatus(cluster *clusterv1alpha1.Clu
 	if !online && readyCondition.Status != metav1.ConditionTrue {
 		klog.V(2).Infof("Cluster(%s) still offline after %s, ensuring offline is set.",
 			cluster.Name, c.ClusterFailureThreshold.Duration)
-		c.GenericInformerManager.Stop(cluster.Name)
-		c.TypedInformerManager.Stop(cluster.Name)
 		setTransitionTime(cluster.Status.Conditions, readyCondition)
 		meta.SetStatusCondition(&currentClusterStatus.Conditions, *readyCondition)
 		return c.updateStatusIfNeeded(cluster, currentClusterStatus)


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When cluster status is unhealthy, we should not stop informer manager because when apiserver recovered, workload can not sync to karmada control plane.

Reproduction：
1.Failover is close.
2.Deploy a deployment to m1 and m2.
3.m1 apiserver failed. The cluster status of m1 became false. Soon it recovered. The cluster status of m1 became true again.
4.Update the deployment in m1. But the control plane cannot perceive the change of deployment in m1.

Reason:
Informer of m1 didn't work and could not collect update events.

**Which issue(s) this PR fixes**:
Fixes #2863 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
karmada-controller-manager/karmada-agent: fix work status not sync to control plane when apiserver failed and recovered soon.
```

