### PR TITLE
Automated cherry pick of #2919: replace colon with point in the rbac resource name

### DIFF
--- a/pkg/util/names/names.go
+++ b/pkg/util/names/names.go
@@ -127,5 +127,15 @@ func GeneratePolicyName(namespace, name, gvk string) string {
 	hash := fnv.New32a()
 	hashutil.DeepHashObject(hash, namespace+gvk)
 
+	// The name of resources, like 'Role'/'ClusterRole'/'RoleBinding'/'ClusterRoleBinding',
+	// may contain symbols(like ':') that are not allowed by CRD resources which require the
+	// name can be used as a DNS subdomain name. So, we need to replace it.
+	// These resources may also allow for other characters(like '&','$') that are not allowed
+	// by CRD resources, we only handle the most common ones now for performance concerns.
+	// For more information about the DNS subdomain name, please refer to
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names.
+	if strings.Contains(name, ":") {
+		name = strings.ReplaceAll(name, ":", ".")
+	}
 	return strings.ToLower(fmt.Sprintf("%s-%s", name, rand.SafeEncodeString(fmt.Sprint(hash.Sum32()))))
 }

--- a/pkg/util/names/names_test.go
+++ b/pkg/util/names/names_test.go
@@ -344,3 +344,34 @@ func TestGenerateImpersonationSecretName(t *testing.T) {
 		}
 	}
 }
+
+func TestGeneratePolicyName(t *testing.T) {
+	tests := []struct {
+		name         string
+		namespace    string
+		resourcename string
+		gvk          string
+		expected     string
+	}{
+		{
+			name:         "generate policy name",
+			namespace:    "ns-foo",
+			resourcename: "foo",
+			gvk:          "rand",
+			expected:     "foo-b4978784",
+		},
+		{
+			name:         "generate policy name with :",
+			namespace:    "ns-foo",
+			resourcename: "system:foo",
+			gvk:          "rand",
+			expected:     "system.foo-b4978784",
+		},
+	}
+	for _, test := range tests {
+		got := GeneratePolicyName(test.namespace, test.resourcename, test.gvk)
+		if got != test.expected {
+			t.Errorf("Test %s failed: expected %v, but got %v", test.name, test.expected, got)
+		}
+	}
+}


### PR DESCRIPTION
Cherry pick of #2919 on release-1.2.
#2919: replace colon with point in the rbac resource name
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmadactl`: Fixed the error of resources whose name contains colons failing to be created when using `karmadactl promote`.
```