### PR TITLE
CommandUnjoinOption wait must be a positive duration

### DIFF
--- a/pkg/karmadactl/unjoin/unjoin.go
+++ b/pkg/karmadactl/unjoin/unjoin.go
@@ -119,7 +119,7 @@ func (j *CommandUnjoinOption) Validate(args []string) error {
 	if len(j.ClusterName) == 0 {
 		return fmt.Errorf("cluster name is required")
 	}
-	if j.Wait < 0 {
+	if j.Wait <= 0 {
 		return fmt.Errorf(" --wait %v  must be a positive duration, e.g. 1m0s ", j.Wait)
 	}
 	return nil


### PR DESCRIPTION
Signed-off-by: huangyanfeng <huangyanfeng1992@gmail.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
CommandUnjoinOption wait must be a positive duration， but now allow wait = 0
if wait = 0,  when use  func poller,  timeout=0

A timeout of 0 is interpreted as an infinity, and in such a case
it would be the caller's responsibility to close the done channel.
Failure to do so would result in a leaked goroutine.

![image](https://user-images.githubusercontent.com/89568107/207015132-fc42ad1f-f0cb-4bdb-a7fd-aae3b58b9eeb.png)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
CommandUnjoinOption wait must be a positive duration
```

