### PR TITLE
Karmadactl join: default use current context

### DIFF
--- a/hack/local-up-karmada.sh
+++ b/hack/local-up-karmada.sh
@@ -128,9 +128,9 @@ echo "cluster networks connected"
 
 #join push mode member clusters
 export KUBECONFIG="${MAIN_KUBECONFIG}"
-${KARMADACTL_BIN} join --karmada-context="${KARMADA_APISERVER_CLUSTER_NAME}" ${MEMBER_CLUSTER_1_NAME} --cluster-kubeconfig="${MEMBER_CLUSTER_KUBECONFIG}"
+${KARMADACTL_BIN} join --karmada-context="${KARMADA_APISERVER_CLUSTER_NAME}" ${MEMBER_CLUSTER_1_NAME} --cluster-kubeconfig="${MEMBER_CLUSTER_KUBECONFIG}" --cluster-context="${MEMBER_CLUSTER_1_NAME}"
 "${REPO_ROOT}"/hack/deploy-scheduler-estimator.sh "${MAIN_KUBECONFIG}" "${HOST_CLUSTER_NAME}" "${MEMBER_CLUSTER_KUBECONFIG}" "${MEMBER_CLUSTER_1_NAME}"
-${KARMADACTL_BIN} join --karmada-context="${KARMADA_APISERVER_CLUSTER_NAME}" ${MEMBER_CLUSTER_2_NAME} --cluster-kubeconfig="${MEMBER_CLUSTER_KUBECONFIG}"
+${KARMADACTL_BIN} join --karmada-context="${KARMADA_APISERVER_CLUSTER_NAME}" ${MEMBER_CLUSTER_2_NAME} --cluster-kubeconfig="${MEMBER_CLUSTER_KUBECONFIG}" --cluster-context="${MEMBER_CLUSTER_2_NAME}"
 "${REPO_ROOT}"/hack/deploy-scheduler-estimator.sh "${MAIN_KUBECONFIG}" "${HOST_CLUSTER_NAME}" "${MEMBER_CLUSTER_KUBECONFIG}" "${MEMBER_CLUSTER_2_NAME}"
 
 # wait until the pull mode cluster ready

--- a/pkg/karmadactl/join/join.go
+++ b/pkg/karmadactl/join/join.go
@@ -98,11 +98,6 @@ func (j *CommandJoinOption) Complete(args []string) error {
 		j.ClusterName = args[0]
 	}
 
-	// If '--cluster-context' not specified, take the cluster name as the context.
-	if len(j.ClusterContext) == 0 {
-		j.ClusterContext = j.ClusterName
-	}
-
 	return nil
 }
 
@@ -127,9 +122,8 @@ func (j *CommandJoinOption) Validate(args []string) error {
 // AddFlags adds flags to the specified FlagSet.
 func (j *CommandJoinOption) AddFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&j.ClusterNamespace, "cluster-namespace", options.DefaultKarmadaClusterNamespace, "Namespace in the control plane where member cluster secrets are stored.")
-
 	flags.StringVar(&j.ClusterContext, "cluster-context", "",
-		"Context name of cluster in kubeconfig. Only works when there are multiple contexts in the kubeconfig.")
+		"Name of cluster context in kubeconfig. The current context is used by default.")
 	flags.StringVar(&j.ClusterKubeConfig, "cluster-kubeconfig", "",
 		"Path of the cluster's kubeconfig.")
 	flags.StringVar(&j.ClusterProvider, "cluster-provider", "", "Provider of the joining cluster. The Karmada scheduler can use this information to spread workloads across providers for higher availability.")


### PR DESCRIPTION
Signed-off-by: helen <haitao.zhang@daocloud.io>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
The current context should be used instead of the clustername when the `--cluster-context` parameter is not set.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
When I don't want to provide the`--cluster-context` parameter and encounter obstacles customizing the clustername, clustername become the `--cluster-context`, but I don't have such a context.
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: The `--cluster-context` flag of `init` command now takes `current-context` by default.
```

