### PR TITLE
Stop update krew for release 1.3.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,3 @@ jobs:
         files: |
           _output/release/${{ matrix.target }}-${{ matrix.os }}-${{ matrix.arch }}.tgz
           _output/release/${{ matrix.target }}-${{ matrix.os }}-${{ matrix.arch }}.tgz.sha256
-  update-krew-index:
-    needs: release-assests
-    name: Update krew-index
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@master
-    - name: Update new version in krew-index
-      uses: rajatjindal/krew-release-bot@v0.0.40


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Since [krew ](https://github.com/kubernetes-sigs/krew) only caches the `latest` release, so we don't need to update it for v1.3.x releases. Otherwise, it will open an invalid PR, like https://github.com/kubernetes-sigs/krew-index/pull/2809.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

