### PR TITLE
Automated cherry pick of #2984: Grant karmada-agent permission to access resourceinterpretercustomizations

### DIFF
--- a/pkg/karmadactl/cmdinit/karmada/rbac.go
+++ b/pkg/karmadactl/cmdinit/karmada/rbac.go
@@ -74,7 +74,7 @@ func grantAccessPermissionToAgent(clientSet kubernetes.Interface) error {
 		},
 		{
 			APIGroups: []string{"config.karmada.io"},
-			Resources: []string{"resourceinterpreterwebhookconfigurations"},
+			Resources: []string{"resourceinterpreterwebhookconfigurations", "resourceinterpretercustomizations"},
 			Verbs:     []string{"get", "list", "watch"},
 		},
 		{


### PR DESCRIPTION
Cherry pick of #2984 on release-1.4.
#2984: Grant karmada-agent permission to access resourceinterpretercustomizations
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmadactl init`: Grant karmada-agent permission to access resourceinterpretercustomizations.
```