### PR TITLE
Check if the resource exists before creating it

### DIFF
--- a/pkg/util/serviceaccount.go
+++ b/pkg/util/serviceaccount.go
@@ -26,6 +26,20 @@ func CreateServiceAccount(client kubeclient.Interface, saObj *corev1.ServiceAcco
 	return saObj, nil
 }
 
+// IsServiceAccountExist tells if specific service account already exists.
+func IsServiceAccountExist(client kubeclient.Interface, namespace string, name string) (bool, error) {
+	_, err := client.CoreV1().ServiceAccounts(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
+}
+
 // DeleteServiceAccount just try to delete the ServiceAccount.
 func DeleteServiceAccount(client kubeclient.Interface, namespace, name string) error {
 	err := client.CoreV1().ServiceAccounts(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
@@ -39,6 +53,14 @@ func DeleteServiceAccount(client kubeclient.Interface, namespace, name string) e
 // If service account not exit, just create it.
 func EnsureServiceAccountExist(client kubeclient.Interface, serviceAccountObj *corev1.ServiceAccount, dryRun bool) (*corev1.ServiceAccount, error) {
 	if dryRun {
+		return serviceAccountObj, nil
+	}
+
+	exist, err := IsServiceAccountExist(client, serviceAccountObj.Namespace, serviceAccountObj.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if service account exist. service account: %s/%s, error: %v", serviceAccountObj.Namespace, serviceAccountObj.Name, err)
+	}
+	if exist {
 		return serviceAccountObj, nil
 	}
 


### PR DESCRIPTION
Signed-off-by: jwcesign <jiangwei115@huawei.com>

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Referring to #2981, sometimes the namespace is created in advance, to give less privilege to Karmada. So if we want to create resource, checking if it exists is necessary

**Which issue(s) this PR fixes**:
Fixes #2981 

**Special notes for your reviewer**:
@lonelyCZ 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-agent`: Check if the resource exists before creating it. Sometimes the resource is created in advance, to give less privilege to Karmada.
```

