### PR TITLE
avoid calling apiserver when scheduling result has no changes

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -511,6 +511,9 @@ func (s *Scheduler) patchScheduleResultForResourceBinding(oldBinding *workv1alph
 	if err != nil {
 		return fmt.Errorf("failed to create a merge patch: %v", err)
 	}
+	if "{}" == string(patchBytes) {
+		return nil
+	}
 
 	_, err = s.KarmadaClient.WorkV1alpha2().ResourceBindings(newBinding.Namespace).Patch(context.TODO(), newBinding.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 	return err
@@ -564,6 +567,9 @@ func (s *Scheduler) patchScheduleResultForClusterResourceBinding(oldBinding *wor
 	patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)
 	if err != nil {
 		return fmt.Errorf("failed to create a merge patch: %v", err)
+	}
+	if "{}" == string(patchBytes) {
+		return nil
 	}
 
 	_, err = s.KarmadaClient.WorkV1alpha2().ClusterResourceBindings().Patch(context.TODO(), newBinding.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})


### PR DESCRIPTION
Signed-off-by: Garrybest <garrybest@foxmail.com>

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Refer to https://github.com/kubernetes/kubernetes/blob/release-1.26/pkg/scheduler/util/utils.go#L123-L125

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

