### PR TITLE
search filter out not ready cluster

### DIFF
--- a/pkg/search/proxy/controller.go
+++ b/pkg/search/proxy/controller.go
@@ -182,6 +182,12 @@ func (ctl *Controller) reconcile(util.QueueKey) error {
 			if !util.ClusterMatches(cluster, registry.Spec.TargetCluster) {
 				continue
 			}
+
+			if !util.IsClusterReady(&cluster.Status) {
+				klog.Warningf("cluster %s is notReady", cluster.Name)
+				continue
+			}
+
 			if _, exist := resourcesByClusters[cluster.Name]; !exist {
 				resourcesByClusters[cluster.Name] = make(map[schema.GroupVersionResource]struct{})
 			}

--- a/pkg/search/proxy/controller_test.go
+++ b/pkg/search/proxy/controller_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/search/proxy/framework"
 	pluginruntime "github.com/karmada-io/karmada/pkg/search/proxy/framework/runtime"
 	proxytest "github.com/karmada-io/karmada/pkg/search/proxy/testing"
+	"github.com/karmada-io/karmada/pkg/util"
 )
 
 func TestController(t *testing.T) {
@@ -493,5 +494,8 @@ func TestController_Connect_Error(t *testing.T) {
 func newCluster(name string) *clusterv1alpha1.Cluster {
 	c := &clusterv1alpha1.Cluster{}
 	c.Name = name
+	conditions := make([]metav1.Condition, 0, 1)
+	conditions = append(conditions, util.NewCondition(clusterv1alpha1.ClusterConditionReady, "", "", metav1.ConditionTrue))
+	c.Status.Conditions = conditions
 	return c
 }


### PR DESCRIPTION
Signed-off-by: huangyanfeng <huangyanfeng1992@gmail.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

I have three cluster member1, member2, member3，member1 status is not ready

<img width="377" alt="0880c4c80710e3e9b808" src="https://user-images.githubusercontent.com/89568107/209948851-18caaf37-0d72-4406-8c1b-af4c7035f29a.png">

I did a few steps

step1 create a resourceregistries for all cluster 

<img width="991" alt="lx_clip1672312193776" src="https://user-images.githubusercontent.com/89568107/209948886-b5b569ce-766b-4215-86fc-f9601de190c0.png">


step 2  kubectl get --raw /apis/search.karmada.io/v1alpha1/search/cache/api/v1/nodes --kubeconfig /etc/karmada/karmada-apiserver.config, but get nothing

<img width="763" alt="lx_clip1672312276036" src="https://user-images.githubusercontent.com/89568107/209948904-d125ae6d-8f06-41e3-8c1c-7c4449298ee9.png">

error log in karmada-search

<img width="986" alt="lx_clip1672312065007" src="https://user-images.githubusercontent.com/89568107/209948925-a1a66760-ef9c-4c7c-a3c0-84234c684095.png">


I think the not ready cluster should be filtered out

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-search: filter out not ready clusters
```

