### PR TITLE
Check for err judgments by `==` and fix it

### DIFF
--- a/pkg/karmadactl/util/genericresource/builder.go
+++ b/pkg/karmadactl/util/genericresource/builder.go
@@ -1,6 +1,7 @@
 package genericresource
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -158,7 +159,7 @@ func expandIfFilePattern(pattern string) ([]string, error) {
 		if err == nil && len(matches) == 0 {
 			return nil, fmt.Errorf("the path %q does not exist", pattern)
 		}
-		if err == filepath.ErrBadPattern {
+		if errors.Is(err, filepath.ErrBadPattern) {
 			return nil, fmt.Errorf("pattern %q is not valid: %v", pattern, err)
 		}
 		return matches, err


### PR DESCRIPTION
Signed-off-by: Fish-pro <zechun.chen@daocloud.io>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Comparing with `==` will fail on wrapped errors, use `errors.Is` to check for a specific error，select the unmodified part in the following way
```sh
➜  karmada git:(master) git grep 'err ==' | grep -v ^vendor | sed 's/.*err == \([^ :),;.]\+\).*/\1/g' | grep Err | grep -v "err == nil" | sort -u
pkg/karmadactl/util/genericresource/builder.go:         if err == filepath.ErrBadPattern {

```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

