### PR TITLE
Automated cherry pick of #3010: search filter out not ready cluster

### DIFF
--- a/pkg/search/proxy/controller.go
+++ b/pkg/search/proxy/controller.go
@@ -182,6 +182,12 @@ func (ctl *Controller) reconcile(util.QueueKey) error {
 			if !util.ClusterMatches(cluster, registry.Spec.TargetCluster) {
 				continue
 			}
+
+			if !util.IsClusterReady(&cluster.Status) {
+				klog.Warningf("cluster %s is notReady", cluster.Name)
+				continue
+			}
+
 			if _, exist := resourcesByClusters[cluster.Name]; !exist {
 				resourcesByClusters[cluster.Name] = make(map[schema.GroupVersionResource]struct{})
 			}

--- a/pkg/search/proxy/controller_test.go
+++ b/pkg/search/proxy/controller_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/search/proxy/framework"
 	pluginruntime "github.com/karmada-io/karmada/pkg/search/proxy/framework/runtime"
 	proxytest "github.com/karmada-io/karmada/pkg/search/proxy/testing"
+	"github.com/karmada-io/karmada/pkg/util"
 )
 
 func TestController(t *testing.T) {
@@ -493,5 +494,8 @@ func TestController_Connect_Error(t *testing.T) {
 func newCluster(name string) *clusterv1alpha1.Cluster {
 	c := &clusterv1alpha1.Cluster{}
 	c.Name = name
+	conditions := make([]metav1.Condition, 0, 1)
+	conditions = append(conditions, util.NewCondition(clusterv1alpha1.ClusterConditionReady, "", "", metav1.ConditionTrue))
+	c.Status.Conditions = conditions
 	return c
 }


### PR DESCRIPTION
Cherry pick of #3010 on release-1.4.
#3010: search filter out not ready cluster
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
karmada-search: filter out not ready clusters
```