### PR TITLE
Automated cherry pick of #3010: search filter out not ready cluster

### DIFF
--- a/pkg/search/controller.go
+++ b/pkg/search/controller.go
@@ -178,7 +178,7 @@ func (c *Controller) doCacheCluster(cluster string) error {
 		return nil
 	}
 
-	// STEP1: stop informer manager for the cluster which does not exist anymore.
+	// STEP1: stop informer manager for the cluster which does not exist anymore or is not ready.
 	cls, err := c.clusterLister.Get(cluster)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -191,6 +191,12 @@ func (c *Controller) doCacheCluster(cluster string) error {
 
 	if !cls.DeletionTimestamp.IsZero() {
 		klog.Infof("try to stop cluster informer %s", cluster)
+		c.InformerManager.Stop(cluster)
+		return nil
+	}
+
+	if !util.IsClusterReady(&cls.Status) {
+		klog.Warningf("cluster %s is notReady try to stop this cluster informer", cluster)
 		c.InformerManager.Stop(cluster)
 		return nil
 	}


### PR DESCRIPTION
Cherry pick of #3010 on release-1.2.
#3010: search filter out not ready cluster
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
karmada-search: filter out not ready clusters
```