### PR TITLE
Automated cherry pick of #3010: search filter out not ready cluster

### DIFF
--- a/pkg/search/controller.go
+++ b/pkg/search/controller.go
@@ -177,7 +177,7 @@ func (c *Controller) doCacheCluster(cluster string) error {
 		return nil
 	}
 
-	// STEP1: stop informer manager for the cluster which does not exist anymore.
+	// STEP1: stop informer manager for the cluster which does not exist anymore or is not ready.
 	cls, err := c.clusterLister.Get(cluster)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -190,6 +190,12 @@ func (c *Controller) doCacheCluster(cluster string) error {
 
 	if !cls.DeletionTimestamp.IsZero() {
 		klog.Infof("try to stop cluster informer %s", cluster)
+		c.InformerManager.Stop(cluster)
+		return nil
+	}
+
+	if !util.IsClusterReady(&cls.Status) {
+		klog.Warningf("cluster %s is notReady try to stop this cluster informer", cluster)
 		c.InformerManager.Stop(cluster)
 		return nil
 	}

--- a/pkg/search/proxy/controller.go
+++ b/pkg/search/proxy/controller.go
@@ -136,6 +136,12 @@ func (ctl *Controller) reconcile(util.QueueKey) error {
 			if !util.ClusterMatches(cluster, registry.Spec.TargetCluster) {
 				continue
 			}
+
+			if !util.IsClusterReady(&cluster.Status) {
+				klog.Warningf("cluster %s is notReady", cluster.Name)
+				continue
+			}
+
 			if _, exist := resourcesByClusters[cluster.Name]; !exist {
 				resourcesByClusters[cluster.Name] = make(map[schema.GroupVersionResource]struct{})
 			}

--- a/pkg/search/proxy/controller_test.go
+++ b/pkg/search/proxy/controller_test.go
@@ -21,6 +21,7 @@ import (
 	karmadafake "github.com/karmada-io/karmada/pkg/generated/clientset/versioned/fake"
 	karmadainformers "github.com/karmada-io/karmada/pkg/generated/informers/externalversions"
 	"github.com/karmada-io/karmada/pkg/search/proxy/store"
+	"github.com/karmada-io/karmada/pkg/util"
 )
 
 var (
@@ -245,6 +246,9 @@ func TestController_reconcile(t *testing.T) {
 func newCluster(name string) *clusterv1alpha1.Cluster {
 	c := &clusterv1alpha1.Cluster{}
 	c.Name = name
+	conditions := make([]metav1.Condition, 0, 1)
+	conditions = append(conditions, util.NewCondition(clusterv1alpha1.ClusterConditionReady, "", "", metav1.ConditionTrue))
+	c.Status.Conditions = conditions
 	return c
 }
 


### PR DESCRIPTION
Cherry pick of #3010 on release-1.3.
#3010: search filter out not ready cluster
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
karmada-search: filter out not ready clusters
```