### PR TITLE
add karmada operator crd validations

### DIFF
--- a/charts/karmada/_crds/bases/config.karmada.io_resourceinterpretercustomizations.yaml
+++ b/charts/karmada/_crds/bases/config.karmada.io_resourceinterpretercustomizations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.11.0
   creationTimestamp: null
   name: resourceinterpretercustomizations.config.karmada.io
 spec:
@@ -244,9 +244,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/karmada/_crds/bases/config.karmada.io_resourceinterpreterwebhookconfigurations.yaml
+++ b/charts/karmada/_crds/bases/config.karmada.io_resourceinterpreterwebhookconfigurations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.11.0
   creationTimestamp: null
   name: resourceinterpreterwebhookconfigurations.config.karmada.io
 spec:
@@ -183,9 +183,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/karmada/_crds/bases/networking.karmada.io_multiclusteringresses.yaml
+++ b/charts/karmada/_crds/bases/networking.karmada.io_multiclusteringresses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.11.0
   creationTimestamp: null
   name: multiclusteringresses.networking.karmada.io
 spec:
@@ -70,6 +70,7 @@ spec:
                     - kind
                     - name
                     type: object
+                    x-kubernetes-map-type: atomic
                   service:
                     description: Service references a Service as a Backend. This is
                       a mutually exclusive setting with "Resource".
@@ -191,6 +192,7 @@ spec:
                                     - kind
                                     - name
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   service:
                                     description: Service references a Service as a
                                       Backend. This is a mutually exclusive setting
@@ -361,9 +363,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/karmada/_crds/bases/policy.karmada.io_clusteroverridepolicies.yaml
+++ b/charts/karmada/_crds/bases/policy.karmada.io_clusteroverridepolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.11.0
   creationTimestamp: null
   name: clusteroverridepolicies.policy.karmada.io
 spec:
@@ -365,6 +365,7 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                       type: object
                   required:
                   - overriders
@@ -638,6 +639,7 @@ spec:
                             only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     name:
                       description: Name of the target resource. Default is empty,
                         which means selecting all resources.
@@ -751,6 +753,7 @@ spec:
                           "value". The requirements are ANDed.
                         type: object
                     type: object
+                    x-kubernetes-map-type: atomic
                 type: object
             type: object
         required:
@@ -758,9 +761,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/karmada/_crds/bases/policy.karmada.io_clusterpropagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy.karmada.io_clusterpropagationpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.11.0
   creationTimestamp: null
   name: clusterpropagationpolicies.policy.karmada.io
 spec:
@@ -167,6 +167,7 @@ spec:
                               only "value". The requirements are ANDed.
                             type: object
                         type: object
+                        x-kubernetes-map-type: atomic
                     type: object
                   clusterTolerations:
                     description: ClusterTolerations represents the tolerations.
@@ -373,6 +374,7 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                                 weight:
                                   description: Weight expressing the preference to
@@ -515,6 +517,7 @@ spec:
                             only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     name:
                       description: Name of the target resource. Default is empty,
                         which means selecting all resources.
@@ -543,9 +546,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/karmada/_crds/bases/policy.karmada.io_federatedresourcequotas.yaml
+++ b/charts/karmada/_crds/bases/policy.karmada.io_federatedresourcequotas.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.11.0
   creationTimestamp: null
   name: federatedresourcequotas.policy.karmada.io
 spec:
@@ -146,9 +146,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/karmada/_crds/bases/policy.karmada.io_overridepolicies.yaml
+++ b/charts/karmada/_crds/bases/policy.karmada.io_overridepolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.11.0
   creationTimestamp: null
   name: overridepolicies.policy.karmada.io
 spec:
@@ -365,6 +365,7 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                       type: object
                   required:
                   - overriders
@@ -638,6 +639,7 @@ spec:
                             only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     name:
                       description: Name of the target resource. Default is empty,
                         which means selecting all resources.
@@ -751,6 +753,7 @@ spec:
                           "value". The requirements are ANDed.
                         type: object
                     type: object
+                    x-kubernetes-map-type: atomic
                 type: object
             type: object
         required:
@@ -758,9 +761,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/karmada/_crds/bases/policy.karmada.io_propagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy.karmada.io_propagationpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.11.0
   creationTimestamp: null
   name: propagationpolicies.policy.karmada.io
 spec:
@@ -163,6 +163,7 @@ spec:
                               only "value". The requirements are ANDed.
                             type: object
                         type: object
+                        x-kubernetes-map-type: atomic
                     type: object
                   clusterTolerations:
                     description: ClusterTolerations represents the tolerations.
@@ -369,6 +370,7 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                                 weight:
                                   description: Weight expressing the preference to
@@ -511,6 +513,7 @@ spec:
                             only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     name:
                       description: Name of the target resource. Default is empty,
                         which means selecting all resources.
@@ -539,9 +542,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/karmada/_crds/bases/work.karmada.io_clusterresourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work.karmada.io_clusterresourcebindings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.11.0
   creationTimestamp: null
   name: clusterresourcebindings.work.karmada.io
 spec:
@@ -426,10 +426,12 @@ spec:
                                     type: object
                                   type: array
                               type: object
+                              x-kubernetes-map-type: atomic
                             type: array
                         required:
                         - nodeSelectorTerms
                         type: object
+                        x-kubernetes-map-type: atomic
                       nodeSelector:
                         additionalProperties:
                           type: string
@@ -693,9 +695,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/karmada/_crds/bases/work.karmada.io_resourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work.karmada.io_resourcebindings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.11.0
   creationTimestamp: null
   name: resourcebindings.work.karmada.io
 spec:
@@ -426,10 +426,12 @@ spec:
                                     type: object
                                   type: array
                               type: object
+                              x-kubernetes-map-type: atomic
                             type: array
                         required:
                         - nodeSelectorTerms
                         type: object
+                        x-kubernetes-map-type: atomic
                       nodeSelector:
                         additionalProperties:
                           type: string
@@ -693,9 +695,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/karmada/_crds/bases/work.karmada.io_works.yaml
+++ b/charts/karmada/_crds/bases/work.karmada.io_works.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.11.0
   creationTimestamp: null
   name: works.work.karmada.io
 spec:
@@ -205,9 +205,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/examples/customresourceinterpreter/apis/workload.example.io_workloads.yaml
+++ b/examples/customresourceinterpreter/apis/workload.example.io_workloads.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.11.0
   creationTimestamp: null
   name: workloads.workload.example.io
 spec:
@@ -168,6 +168,7 @@ spec:
                                             type: object
                                           type: array
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     weight:
                                       description: Weight associated with matching
                                         the corresponding nodeSelectorTerm, in the
@@ -274,10 +275,12 @@ spec:
                                             type: object
                                           type: array
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     type: array
                                 required:
                                 - nodeSelectorTerms
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           podAffinity:
                             description: Describes pod affinity scheduling rules (e.g.
@@ -362,6 +365,7 @@ spec:
                                                 ANDed.
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         namespaceSelector:
                                           description: A label query over the set
                                             of namespaces that the term applies to.
@@ -423,6 +427,7 @@ spec:
                                                 ANDed.
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         namespaces:
                                           description: namespaces specifies a static
                                             list of namespace names that the term
@@ -532,6 +537,7 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -589,6 +595,7 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaces:
                                       description: namespaces specifies a static list
                                         of namespace names that the term applies to.
@@ -698,6 +705,7 @@ spec:
                                                 ANDed.
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         namespaceSelector:
                                           description: A label query over the set
                                             of namespaces that the term applies to.
@@ -759,6 +767,7 @@ spec:
                                                 ANDed.
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         namespaces:
                                           description: namespaces specifies a static
                                             list of namespace names that the term
@@ -868,6 +877,7 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -925,6 +935,7 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaces:
                                       description: namespaces specifies a static list
                                         of namespace names that the term applies to.
@@ -1041,6 +1052,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       fieldRef:
                                         description: 'Selects a field of the pod:
                                           supports metadata.name, metadata.namespace,
@@ -1060,6 +1072,7 @@ spec:
                                         required:
                                         - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         description: 'Selects a resource of the container:
                                           only resources limits and requests (limits.cpu,
@@ -1086,6 +1099,7 @@ spec:
                                         required:
                                         - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       secretKeyRef:
                                         description: Selects a key of a secret in
                                           the pod's namespace
@@ -1108,6 +1122,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                 required:
                                 - name
@@ -1140,6 +1155,7 @@ spec:
                                           must be defined
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   prefix:
                                     description: An optional identifier to prepend
                                       to each key in the ConfigMap. Must be a C_IDENTIFIER.
@@ -1158,6 +1174,7 @@ spec:
                                           be defined
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               type: array
                             image:
@@ -2396,6 +2413,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       fieldRef:
                                         description: 'Selects a field of the pod:
                                           supports metadata.name, metadata.namespace,
@@ -2415,6 +2433,7 @@ spec:
                                         required:
                                         - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         description: 'Selects a resource of the container:
                                           only resources limits and requests (limits.cpu,
@@ -2441,6 +2460,7 @@ spec:
                                         required:
                                         - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       secretKeyRef:
                                         description: Selects a key of a secret in
                                           the pod's namespace
@@ -2463,6 +2483,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                 required:
                                 - name
@@ -2495,6 +2516,7 @@ spec:
                                           must be defined
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   prefix:
                                     description: An optional identifier to prepend
                                       to each key in the ConfigMap. Must be a C_IDENTIFIER.
@@ -2513,6 +2535,7 @@ spec:
                                           be defined
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               type: array
                             image:
@@ -3658,6 +3681,7 @@ spec:
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
+                          x-kubernetes-map-type: atomic
                         type: array
                       initContainers:
                         description: 'List of initialization containers belonging
@@ -3755,6 +3779,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       fieldRef:
                                         description: 'Selects a field of the pod:
                                           supports metadata.name, metadata.namespace,
@@ -3774,6 +3799,7 @@ spec:
                                         required:
                                         - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         description: 'Selects a resource of the container:
                                           only resources limits and requests (limits.cpu,
@@ -3800,6 +3826,7 @@ spec:
                                         required:
                                         - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       secretKeyRef:
                                         description: Selects a key of a secret in
                                           the pod's namespace
@@ -3822,6 +3849,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                 required:
                                 - name
@@ -3854,6 +3882,7 @@ spec:
                                           must be defined
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   prefix:
                                     description: An optional identifier to prepend
                                       to each key in the ConfigMap. Must be a C_IDENTIFIER.
@@ -3872,6 +3901,7 @@ spec:
                                           be defined
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               type: array
                             image:
@@ -5409,6 +5439,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             matchLabelKeys:
                               description: MatchLabelKeys is a set of pod label keys
                                 to select the pods over which spreading will be calculated.
@@ -5678,6 +5709,7 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 user:
                                   description: 'user is optional: User is the rados
                                     user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
@@ -5713,6 +5745,7 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 volumeID:
                                   description: 'volumeID used to identify the volume
                                     in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
@@ -5792,6 +5825,7 @@ spec:
                                     or its keys must be defined
                                   type: boolean
                               type: object
+                              x-kubernetes-map-type: atomic
                             csi:
                               description: csi (Container Storage Interface) represents
                                 ephemeral storage that is handled by certain external
@@ -5825,6 +5859,7 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 readOnly:
                                   description: readOnly specifies a read-only configuration
                                     for the volume. Defaults to false (read/write).
@@ -5883,6 +5918,7 @@ spec:
                                         required:
                                         - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       mode:
                                         description: 'Optional: mode bits used to
                                           set permissions on this file, must be an
@@ -5928,6 +5964,7 @@ spec:
                                         required:
                                         - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     required:
                                     - path
                                     type: object
@@ -6059,6 +6096,7 @@ spec:
                                           - kind
                                           - name
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         dataSourceRef:
                                           description: 'dataSourceRef specifies the
                                             object from which to populate the volume
@@ -6109,6 +6147,7 @@ spec:
                                           - kind
                                           - name
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         resources:
                                           description: 'resources represents the minimum
                                             resources the volume should have. If RecoverVolumeExpansionFailure
@@ -6201,6 +6240,7 @@ spec:
                                                 ANDed.
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         storageClassName:
                                           description: 'storageClassName is the name
                                             of the StorageClass required by the claim.
@@ -6299,6 +6339,7 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               required:
                               - driver
                               type: object
@@ -6489,6 +6530,7 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 targetPortal:
                                   description: targetPortal is iSCSI Target Portal.
                                     The Portal is either an IP or ip_addr:port if
@@ -6671,6 +6713,7 @@ spec:
                                               the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       downwardAPI:
                                         description: downwardAPI information about
                                           the downwardAPI data to project
@@ -6702,6 +6745,7 @@ spec:
                                                   required:
                                                   - fieldPath
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 mode:
                                                   description: 'Optional: mode bits
                                                     used to set permissions on this
@@ -6757,6 +6801,7 @@ spec:
                                                   required:
                                                   - resource
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                               required:
                                               - path
                                               type: object
@@ -6828,6 +6873,7 @@ spec:
                                               the Secret or its key must be defined
                                             type: boolean
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       serviceAccountToken:
                                         description: serviceAccountToken is information
                                           about the serviceAccountToken data to project
@@ -6954,6 +7000,7 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 user:
                                   description: 'user is the rados user name. Default
                                     is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
@@ -6998,6 +7045,7 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 sslEnabled:
                                   description: sslEnabled Flag enable/disable SSL
                                     communication with Gateway, default false
@@ -7123,6 +7171,7 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 volumeName:
                                   description: volumeName is the human-readable name
                                     of the StorageOS volume.  Volume names are only
@@ -7262,9 +7311,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/hack/update-crdgen.sh
+++ b/hack/update-crdgen.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 CONTROLLER_GEN_PKG="sigs.k8s.io/controller-tools/cmd/controller-gen"
-CONTROLLER_GEN_VER="v0.8.0"
+CONTROLLER_GEN_VER="v0.11.0"
 
 source hack/util.sh
 

--- a/operator/config/crds/operator.karmada.io_karmadas.yaml
+++ b/operator/config/crds/operator.karmada.io_karmadas.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.11.0
   creationTimestamp: null
   name: karmadas.operator.karmada.io
 spec:
@@ -40,9 +40,13 @@ spec:
           metadata:
             type: object
           spec:
+            default:
+              spec: null
             description: Spec defines the desired behavior of the Karmada.
             properties:
               components:
+                default:
+                  components: null
                 description: Components define all of karmada components. not all
                   of these components need to be installed.
                 properties:
@@ -70,7 +74,7 @@ spec:
                           component. In the future, we will provide a more structured
                           way to configure the component. Once that is done, this
                           field will be discouraged to be used. Incorrect settings
-                          on this feild maybe lead to the corresponding component
+                          on this field maybe lead to the corresponding component
                           in an unhealthy state. Before you do it, please confirm
                           that you understand the risks of this configuration. \n
                           For supported flags, please see https://github.com/karmada-io/karmada/blob/master/cmd/descheduler/app/options/options.go
@@ -130,6 +134,8 @@ spec:
                         type: object
                     type: object
                   etcd:
+                    default:
+                      etcd: null
                     description: Etcd holds configuration for etcd.
                     properties:
                       external:
@@ -165,6 +171,9 @@ spec:
                         - keyData
                         type: object
                       local:
+                        default:
+                          imageRepository: registry.k8s.io
+                          imageTag: 3.5.3-0
                         description: Local provides configuration knobs for configuring
                           the built-in etcd instance Local and External are mutually
                           exclusive
@@ -193,11 +202,15 @@ spec:
                               type: string
                             type: array
                           volumeData:
+                            default:
+                              volumeData: null
                             description: 'VolumeData describes the settings of etcd
                               data store. We will support 3 modes: emtydir, hostPath,
                               PVC. default by hostPath.'
                             properties:
                               emptyDir:
+                                default:
+                                  emptyDir: null
                                 description: 'EmptyDir represents a temporary directory
                                   that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                 properties:
@@ -307,6 +320,7 @@ spec:
                                         - kind
                                         - name
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       dataSourceRef:
                                         description: 'dataSourceRef specifies the
                                           object from which to populate the volume
@@ -356,6 +370,7 @@ spec:
                                         - kind
                                         - name
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resources:
                                         description: 'resources represents the minimum
                                           resources the volume should have. If RecoverVolumeExpansionFailure
@@ -443,6 +458,7 @@ spec:
                                               only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       storageClassName:
                                         description: 'storageClassName is the name
                                           of the StorageClass required by the claim.
@@ -466,6 +482,10 @@ spec:
                         type: object
                     type: object
                   karmadaAPIServer:
+                    default:
+                      imageRepository: registry.k8s.io
+                      imageTag: v1.25.2
+                      replicas: 1
                     description: KarmadaAPIServer holds settings to kube-apiserver
                       component. Currently, kube-apiserver is used as the apiserver
                       of karmada. we had the same experience as k8s apiserver.
@@ -495,7 +515,7 @@ spec:
                           to allow for the configuration of the kube-apiserver component.
                           In the future, we will provide a more structured way to
                           configure the component. Once that is done, this field will
-                          be discouraged to be used. Incorrect settings on this feild
+                          be discouraged to be used. Incorrect settings on this field
                           maybe lead to the corresponding component in an unhealthy
                           state. Before you do it, please confirm that you understand
                           the risks of this configuration. \n For supported flags,
@@ -561,11 +581,16 @@ spec:
                             type: object
                         type: object
                       serviceSubnet:
+                        default: 10.96.0.0/12
                         description: ServiceSubnet is the subnet used by k8s services.
                           Defaults to "10.96.0.0/12".
                         type: string
                     type: object
                   karmadaAggregratedAPIServer:
+                    default:
+                      imageRepository: docker.io
+                      imageTag: v1.4.0
+                      replicas: 1
                     description: KarmadaAggregratedAPIServer holds settings to karmada-aggregated-apiserver
                       component of the karmada.
                     properties:
@@ -595,7 +620,7 @@ spec:
                           the karmada-aggregated-apiserver component. In the future,
                           we will provide a more structured way to configure the component.
                           Once that is done, this field will be discouraged to be
-                          used. Incorrect settings on this feild maybe lead to the
+                          used. Incorrect settings on this field maybe lead to the
                           corresponding component in an unhealthy state. Before you
                           do it, please confirm that you understand the risks of this
                           configuration. \n For supported flags, please see https://github.com/karmada-io/karmada/blob/master/cmd/aggregated-apiserver/app/options/options.go
@@ -661,11 +686,20 @@ spec:
                             type: object
                         type: object
                       serviceType:
+                        default: NodePort
                         description: ServiceType represents the service type of karmada
                           apiserver. it is Nodeport by default.
+                        enum:
+                        - ClusterIP
+                        - NodePort
+                        - LoadBalancer
                         type: string
                     type: object
                   karmadaControllerManager:
+                    default:
+                      imageRepository: docker.io
+                      imageTag: v1.4.0
+                      replicas: 1
                     description: KarmadaControllerManager holds settings to karmada-controller-manager
                       component of the karmada.
                     properties:
@@ -703,7 +737,7 @@ spec:
                           karmada-controller-manager component. In the future, we
                           will provide a more structured way to configure the component.
                           Once that is done, this field will be discouraged to be
-                          used. Incorrect settings on this feild maybe lead to the
+                          used. Incorrect settings on this field maybe lead to the
                           corresponding component in an unhealthy state. Before you
                           do it, please confirm that you understand the risks of this
                           configuration. \n For supported flags, please see https://github.com/karmada-io/karmada/blob/master/cmd/controller-manager/app/options/options.go
@@ -773,6 +807,10 @@ spec:
                         type: object
                     type: object
                   karmadaScheduler:
+                    default:
+                      imageRepository: docker.io
+                      imageTag: v1.4.0
+                      replicas: 1
                     description: KarmadaScheduler holds settings to karmada-scheduler
                       component of the karmada.
                     properties:
@@ -796,7 +834,7 @@ spec:
                           component. In the future, we will provide a more structured
                           way to configure the component. Once that is done, this
                           field will be discouraged to be used. Incorrect settings
-                          on this feild maybe lead to the corresponding component
+                          on this field maybe lead to the corresponding component
                           in an unhealthy state. Before you do it, please confirm
                           that you understand the risks of this configuration. \n
                           For supported flags, please see https://github.com/karmada-io/karmada/blob/master/cmd/scheduler/app/options/options.go
@@ -886,7 +924,7 @@ spec:
                           component. In the future, we will provide a more structured
                           way to configure the component. Once that is done, this
                           field will be discouraged to be used. Incorrect settings
-                          on this feild maybe lead to the corresponding component
+                          on this field maybe lead to the corresponding component
                           in an unhealthy state. Before you do it, please confirm
                           that you understand the risks of this configuration. \n
                           For supported flags, please see https://github.com/karmada-io/karmada/blob/master/cmd/descheduler/app/options/options.go
@@ -946,6 +984,10 @@ spec:
                         type: object
                     type: object
                   karmadaWebhook:
+                    default:
+                      imageRepository: docker.io
+                      imageTag: v1.4.0
+                      replicas: 1
                     description: KarmadaWebhook holds settings to karmada-webook component
                       of the karmada.
                     properties:
@@ -968,7 +1010,7 @@ spec:
                           to allow for the configuration of the karmada-webhook component.
                           In the future, we will provide a more structured way to
                           configure the component. Once that is done, this field will
-                          be discouraged to be used. Incorrect settings on this feild
+                          be discouraged to be used. Incorrect settings on this field
                           maybe lead to the corresponding component in an unhealthy
                           state. Before you do it, please confirm that you understand
                           the risks of this configuration. \n For supported flags,
@@ -1029,6 +1071,10 @@ spec:
                         type: object
                     type: object
                   kubeControllerManager:
+                    default:
+                      imageRepository: registry.k8s.io
+                      imageTag: v1.25.2
+                      replicas: 1
                     description: KubeControllerManager holds settings to kube-controller-manager
                       component of the karmada.
                     properties:
@@ -1089,7 +1135,7 @@ spec:
                           kube-controller-manager component. In the future, we will
                           provide a more structured way to configure the component.
                           Once that is done, this field will be discouraged to be
-                          used. Incorrect settings on this feild maybe lead to the
+                          used. Incorrect settings on this field maybe lead to the
                           corresponding component in an unhealthy state. Before you
                           do it, please confirm that you understand the risks of this
                           configuration. \n For supported flags, please see https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/
@@ -1165,6 +1211,8 @@ spec:
                   More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go'
                 type: object
               hostCluster:
+                default:
+                  hostCluster: null
                 description: HostCluster represents the cluster where to install the
                   Karmada control plane. If not set, the control plane will be installed
                   on the cluster where running the operator.
@@ -1175,10 +1223,13 @@ spec:
                       IP or IP:port.
                     type: string
                   networking:
+                    default:
+                      networking: null
                     description: Networking holds configuration for the networking
                       topology of the cluster.
                     properties:
                       dnsDomain:
+                        default: cluster.local
                         description: DNSDomain is the dns domain used by k8s services.
                           Defaults to "cluster.local".
                         type: string
@@ -1197,6 +1248,9 @@ spec:
                         type: string
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: The value is immutable
+                  rule: self == oldSelf
               privateRegistry:
                 description: PrivateRegistry is the global image registry. If set,
                   the operator will pull all required images from it, no matter the
@@ -1312,9 +1366,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/operator/pkg/apis/operator/v1alpha1/type.go
+++ b/operator/pkg/apis/operator/v1alpha1/type.go
@@ -37,6 +37,7 @@ type Karmada struct {
 
 	// Spec defines the desired behavior of the Karmada.
 	// +optional
+	// +kubebuilder:default:={spec: {}}
 	Spec KarmadaSpec `json:"spec,omitempty"`
 
 	// Most recently observed status of the Karmada.
@@ -49,7 +50,9 @@ type KarmadaSpec struct {
 	// HostCluster represents the cluster where to install the Karmada control plane.
 	// If not set, the control plane will be installed on the cluster where
 	// running the operator.
-	// +optional
+	// +required
+	// +kubebuilder:default:={hostCluster: {}}
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="The value is immutable"
 	HostCluster *HostCluster `json:"hostCluster,omitempty"`
 
 	// PrivateRegistry is the global image registry.
@@ -61,7 +64,8 @@ type KarmadaSpec struct {
 
 	// Components define all of karmada components.
 	// not all of these components need to be installed.
-	// +optional
+	// +required
+	// +kubebuilder:default={components: {}}
 	Components *KarmadaComponents `json:"components,omitempty"`
 
 	// FeatureGates enabled by the user.
@@ -89,31 +93,38 @@ type ImageRegistry struct {
 type KarmadaComponents struct {
 	// Etcd holds configuration for etcd.
 	// +required
+	// +kubebuilder:default:={etcd: {}}
 	Etcd *Etcd `json:"etcd,omitempty"`
 
 	// KarmadaAPIServer holds settings to kube-apiserver component. Currently, kube-apiserver
 	// is used as the apiserver of karmada. we had the same experience as k8s apiserver.
 	// +optional
+	// +kubebuilder:default:={imageRepository: "registry.k8s.io", imageTag: "v1.25.2", replicas: 1}
 	KarmadaAPIServer *KarmadaAPIServer `json:"karmadaAPIServer,omitempty"`
 
 	// KarmadaAggregratedAPIServer holds settings to karmada-aggregated-apiserver component of the karmada.
 	// +optional
+	// +kubebuilder:default:={imageRepository: "docker.io", imageTag: "v1.4.0", replicas: 1}
 	KarmadaAggregratedAPIServer *KarmadaAggregratedAPIServer `json:"karmadaAggregratedAPIServer,omitempty"`
 
 	// KubeControllerManager holds settings to kube-controller-manager component of the karmada.
 	// +optional
+	// +kubebuilder:default:={imageRepository: "registry.k8s.io", imageTag: "v1.25.2", replicas: 1}
 	KubeControllerManager *KubeControllerManager `json:"kubeControllerManager,omitempty"`
 
 	// KarmadaControllerManager holds settings to karmada-controller-manager component of the karmada.
 	// +optional
+	// +kubebuilder:default:={imageRepository: "docker.io", imageTag: "v1.4.0", replicas: 1}
 	KarmadaControllerManager *KarmadaControllerManager `json:"karmadaControllerManager,omitempty"`
 
 	// KarmadaScheduler holds settings to karmada-scheduler component of the karmada.
 	// +optional
+	// +kubebuilder:default:={imageRepository: "docker.io", imageTag: "v1.4.0", replicas: 1}
 	KarmadaScheduler *KarmadaScheduler `json:"karmadaScheduler,omitempty"`
 
 	// KarmadaWebhook holds settings to karmada-webook component of the karmada.
 	// +optional
+	// +kubebuilder:default:={imageRepository: "docker.io", imageTag: "v1.4.0", replicas: 1}
 	KarmadaWebhook *KarmadaWebhook `json:"karmadaWebhook,omitempty"`
 
 	// KarmadaDescheduler holds settings to karmada-descheduler component of the karmada.
@@ -128,7 +139,8 @@ type KarmadaComponents struct {
 // Networking contains elements describing cluster's networking configuration
 type Networking struct {
 	// DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
-	// +optional
+	// +required
+	// +kubebuilder:default:="cluster.local"
 	DNSDomain *string `json:"dnsDomain,omitempty"`
 }
 
@@ -137,10 +149,11 @@ type Etcd struct {
 	// Local provides configuration knobs for configuring the built-in etcd instance
 	// Local and External are mutually exclusive
 	// +optional
+	// +kubebuilder:default:={imageRepository:"registry.k8s.io", imageTag: "3.5.3-0"}
 	Local *LocalEtcd `json:"local,omitempty"`
 
 	// External describes how to connect to an external etcd cluster
-	// Local and External are mutually exclusive
+	// Local and External are mutually exclusive.
 	// +optional
 	External *ExternalEtcd `json:"external,omitempty"`
 }
@@ -153,6 +166,7 @@ type LocalEtcd struct {
 	// VolumeData describes the settings of etcd data store.
 	// We will support 3 modes: emtydir, hostPath, PVC. default by hostPath.
 	// +optional
+	// +kubebuilder:default:={volumeData: {}}
 	VolumeData *VolumeData `json:"volumeData,omitempty"`
 
 	// ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.
@@ -187,6 +201,7 @@ type VolumeData struct {
 	// EmptyDir represents a temporary directory that shares a pod's lifetime.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
 	// +optional
+	// +kubebuilder:default:={emptyDir: {}}
 	EmptyDir *corev1.EmptyDirVolumeSource `json:"emptyDir,omitempty"`
 }
 
@@ -217,6 +232,7 @@ type KarmadaAPIServer struct {
 
 	// ServiceSubnet is the subnet used by k8s services. Defaults to "10.96.0.0/12".
 	// +optional
+	// +kubebuilder:default:="10.96.0.0/12"
 	ServiceSubnet *string `json:"serviceSubnet,omitempty"`
 
 	// ExtraArgs is an extra set of flags to pass to the kube-apiserver component or
@@ -226,7 +242,7 @@ type KarmadaAPIServer struct {
 	// Note: This is a temporary solution to allow for the configuration of the
 	// kube-apiserver component. In the future, we will provide a more structured way
 	// to configure the component. Once that is done, this field will be discouraged to be used.
-	// Incorrect settings on this feild maybe lead to the corresponding component in an unhealthy
+	// Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
 	// state. Before you do it, please confirm that you understand the risks of this configuration.
 	//
 	// For supported flags, please see
@@ -257,7 +273,7 @@ type KarmadaAggregratedAPIServer struct {
 	// Note: This is a temporary solution to allow for the configuration of the
 	// karmada-aggregated-apiserver component. In the future, we will provide a more structured way
 	// to configure the component. Once that is done, this field will be discouraged to be used.
-	// Incorrect settings on this feild maybe lead to the corresponding component in an unhealthy
+	// Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
 	// state. Before you do it, please confirm that you understand the risks of this configuration.
 	//
 	// For supported flags, please see
@@ -273,6 +289,8 @@ type KarmadaAggregratedAPIServer struct {
 	// ServiceType represents the service type of karmada apiserver.
 	// it is Nodeport by default.
 	// +optional
+	// +kubebuilder:default:="NodePort"
+	// +kubebuilder:validation:Enum:={"ClusterIP", "NodePort", "LoadBalancer"}
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 
 	// FeatureGates enabled by the user.
@@ -333,7 +351,7 @@ type KubeControllerManager struct {
 	// Note: This is a temporary solution to allow for the configuration of the
 	// kube-controller-manager component. In the future, we will provide a more structured way
 	// to configure the component. Once that is done, this field will be discouraged to be used.
-	// Incorrect settings on this feild maybe lead to the corresponding component in an unhealthy
+	// Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
 	// state. Before you do it, please confirm that you understand the risks of this configuration.
 	//
 	// For supported flags, please see
@@ -375,7 +393,7 @@ type KarmadaControllerManager struct {
 	// Note: This is a temporary solution to allow for the configuration of the
 	// karmada-controller-manager component. In the future, we will provide a more structured way
 	// to configure the component. Once that is done, this field will be discouraged to be used.
-	// Incorrect settings on this feild maybe lead to the corresponding component in an unhealthy
+	// Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
 	// state. Before you do it, please confirm that you understand the risks of this configuration.
 	//
 	// For supported flags, please see
@@ -406,7 +424,7 @@ type KarmadaScheduler struct {
 	// Note: This is a temporary solution to allow for the configuration of the karmada-scheduler
 	// component. In the future, we will provide a more structured way to configure the component.
 	// Once that is done, this field will be discouraged to be used.
-	// Incorrect settings on this feild maybe lead to the corresponding component in an unhealthy
+	// Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
 	// state. Before you do it, please confirm that you understand the risks of this configuration.
 	//
 	// For supported flags, please see
@@ -434,7 +452,7 @@ type KarmadaDescheduler struct {
 	// Note: This is a temporary solution to allow for the configuration of the karmada-descheduler
 	// component. In the future, we will provide a more structured way to configure the component.
 	// Once that is done, this field will be discouraged to be used.
-	// Incorrect settings on this feild maybe lead to the corresponding component in an unhealthy
+	// Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
 	// state. Before you do it, please confirm that you understand the risks of this configuration.
 	//
 	// For supported flags, please see
@@ -456,7 +474,7 @@ type KarmadaSearch struct {
 	// Note: This is a temporary solution to allow for the configuration of the karmada-descheduler
 	// component. In the future, we will provide a more structured way to configure the component.
 	// Once that is done, this field will be discouraged to be used.
-	// Incorrect settings on this feild maybe lead to the corresponding component in an unhealthy
+	// Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
 	// state. Before you do it, please confirm that you understand the risks of this configuration.
 	//
 	// For supported flags, please see
@@ -478,7 +496,7 @@ type KarmadaWebhook struct {
 	// Note: This is a temporary solution to allow for the configuration of the
 	// karmada-webhook component. In the future, we will provide a more structured way
 	// to configure the component. Once that is done, this field will be discouraged to be used.
-	// Incorrect settings on this feild maybe lead to the corresponding component in an unhealthy
+	// Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
 	// state. Before you do it, please confirm that you understand the risks of this configuration.
 	//
 	// For supported flags, please see
@@ -550,6 +568,7 @@ type HostCluster struct {
 
 	// Networking holds configuration for the networking topology of the cluster.
 	// +optional
+	// +kubebuilder:default:={networking:{}}
 	Networking *Networking `json:"networking,omitempty"`
 }
 
@@ -592,6 +611,7 @@ type KarmadaStatus struct {
 // namespace.
 type LocalSecretReference struct {
 	// Namespace is the namespace for the resource being referenced.
+	// +optional
 	Namespace string `json:"namespace,omitempty"`
 
 	// Name is the name of resource being referenced.


### PR DESCRIPTION
Signed-off-by: calvin <wen.chen@daocloud.io>

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Before, I want to implement a build-in webhook for karmada operator and I think it's very complex and troublesome for both developers and users. 

The main reason is that the webhook need the tls to connect with apiserver, the means that before running karmada-operator pod, we need generate a certificate and mount to the pod. the pod  and apiserver can be used for authentication each other. It's very unfriendly to users.
In our scenario is every simple, we only need populate defaults to some fields, so, It,s too heavy for us to develop a webhook.

In k8s community, there are two ways replace webhook in simple scenario:
1. replace mutaing webhook with the way add `+kubebuilder:default` annotations to required fields and generate schama.
https://kubernetes.io/zh-cn/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#efaulting

2. replace validation webhook with CEL https://kubernetes.io/blog/2022/09/29/enforce-immutability-using-cel/#basics-of-validation-rules 


**Which issue(s) this PR fixes**:
Part of # https://github.com/karmada-io/karmada/issues/2979

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

