### PR TITLE
Update protoc setup token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,9 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           version: '3.x'
-          repo-token: ${{ secrets.GITHUB_TOKEN_FOR_SETUP_PROTOC }}
+          # Use the automatic token, so that this task can be run in the forked repo.
+          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: verify codegen
         run: hack/verify-codegen.sh
       - name: verify crdgen


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Use the automatic token, so that the task(`Install Protoc`) can be run in the forked repo.

https://docs.github.com/en/actions/security-guides/automatic-token-authentication

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

