### PR TITLE
stop proxy cache asynchronously

### DIFF
--- a/pkg/search/proxy/store/multi_cluster_cache.go
+++ b/pkg/search/proxy/store/multi_cluster_cache.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -57,6 +58,13 @@ func NewMultiClusterCache(newClientFunc func(string) (dynamic.Interface, error),
 
 // UpdateCache update cache for multi clusters
 func (c *MultiClusterCache) UpdateCache(resourcesByCluster map[string]map[schema.GroupVersionResource]struct{}) error {
+	if klog.V(3).Enabled() {
+		start := time.Now()
+		defer func() {
+			klog.Infof("MultiClusterCache update cache takes %v", time.Since(start))
+		}()
+	}
+
 	c.lock.Lock()
 	defer c.lock.Unlock()
 

--- a/pkg/search/proxy/store/resource_cache.go
+++ b/pkg/search/proxy/store/resource_cache.go
@@ -33,7 +33,7 @@ type resourceCache struct {
 
 func (c *resourceCache) stop() {
 	klog.Infof("Stop store for %s %s", c.clusterName, c.resource)
-	c.Store.DestroyFunc()
+	go c.Store.DestroyFunc()
 }
 
 func newResourceCache(clusterName string, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind,


### PR DESCRIPTION
Signed-off-by: yingjinhui <yingjinhui@didiglobal.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When a member cluster is down, stopping the proxy cache for this cluster takes a few seconds(as below log, stop the pods cache takes 9s)

```
I0106 17:25:07.764975   62644 resource_cache.go:35] Stop store for yjh-1 /v1, Resource=pods
I0106 17:25:16.609796   62644 resource_cache.go:35] Stop store for yjh-1 /v1, Resource=nodes
```

During stopping, it hold the lock of `MultiClusterCache`. This results in client requests will be blocked. Because request handlers also need this lock:

https://github.com/karmada-io/karmada/blob/7b4c541bb818fb1e2677311aa34d8ff17b73d119/pkg/search/proxy/store/multi_cluster_cache.go#L162-L168

https://github.com/karmada-io/karmada/blob/7b4c541bb818fb1e2677311aa34d8ff17b73d119/pkg/search/proxy/store/multi_cluster_cache.go#L319-L321


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-search`: avoid proxy request block when member cluster down.
```

