### PR TITLE
Automated cherry pick of #3027: stop proxy cache asynchronously

### DIFF
--- a/pkg/search/proxy/store/multi_cluster_cache.go
+++ b/pkg/search/proxy/store/multi_cluster_cache.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -61,6 +62,13 @@ func NewMultiClusterCache(newClientFunc func(string) (dynamic.Interface, error),
 
 // UpdateCache update cache for multi clusters
 func (c *MultiClusterCache) UpdateCache(resourcesByCluster map[string]map[schema.GroupVersionResource]struct{}) error {
+	if klog.V(3).Enabled() {
+		start := time.Now()
+		defer func() {
+			klog.Infof("MultiClusterCache update cache takes %v", time.Since(start))
+		}()
+	}
+
 	c.lock.Lock()
 	defer c.lock.Unlock()
 

--- a/pkg/search/proxy/store/resource_cache.go
+++ b/pkg/search/proxy/store/resource_cache.go
@@ -34,7 +34,7 @@ type resourceCache struct {
 
 func (c *resourceCache) stop() {
 	klog.Infof("Stop store for %s %s", c.clusterName, c.resource)
-	c.Store.DestroyFunc()
+	go c.Store.DestroyFunc()
 }
 
 func newResourceCache(clusterName string, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind,


### PR DESCRIPTION
Cherry pick of #3027 on release-1.3.
#3027: stop proxy cache asynchronously
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-search`: avoid proxy request block when member cluster down.
```