### PR TITLE
Automated cherry pick of #2980: Setup github token for action protoc
#3025: Update protoc setup token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,9 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           version: '3.x'
-          repo-token: ${{ secrets.GITHUB_TOKEN_FOR_SETUP_PROTOC }}
+          # Use the automatic token, so that this task can be run in the forked repo.
+          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: verify codegen
         run: hack/verify-codegen.sh
       - name: verify crdgen

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,12 @@ jobs:
         with:
           go-version: 1.19.4
       - name: Install Protoc
+        # TODO(@RainbowMango): Update the action version to adopt Node16
+        # track issue: https://github.com/arduino/setup-protoc/issues/59
         uses: arduino/setup-protoc@v1
+        with:
+          version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN_FOR_SETUP_PROTOC }}
       - name: verify codegen
         run: hack/verify-codegen.sh
       - name: verify crdgen


### PR DESCRIPTION
Cherry pick of #2980 #3025 on release-1.4.
#2980: Setup github token for action protoc
#3025: Update protoc setup token
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
NONE(ci infrastructure)
```