### PR TITLE
fix: OverridePolicy of labels/annotations with composed-labels

### DIFF
--- a/pkg/util/overridemanager/labelannotationoverrider.go
+++ b/pkg/util/overridemanager/labelannotationoverrider.go
@@ -47,6 +47,13 @@ func buildLabelAnnotationOverriderPatches(rawObj *unstructured.Unstructured, ove
 				continue
 			}
 		}
+		// If the key contains '/', we must replace(escape) it to '~1' according to the
+		// rule of jsonpath identifying a specific value.
+		// See https://jsonpatch.com/#json-pointer for more details.
+		// Note: here don't replace '~' because it is not a valid character for
+		// both annotations and labels, the key with '~' should be prevented at
+		// the validation phase.
+		key = strings.ReplaceAll(key, "/", "~1")
 		patches = append(patches, overrideOption{
 			Op:    string(overrider.Operator),
 			Path:  "/" + strings.Join(append(path, key), "/"),

--- a/pkg/util/overridemanager/labelannotationoverrider_test.go
+++ b/pkg/util/overridemanager/labelannotationoverrider_test.go
@@ -147,6 +147,13 @@ func Test_applyAnnotationsOverriders(t *testing.T) {
 	}
 	deployment2 := helper.NewDeployment(metav1.NamespaceDefault, "test")
 	deployment2.Annotations = nil
+
+	deployment3 := helper.NewDeployment(metav1.NamespaceDefault, "test")
+	deployment3.Annotations = map[string]string{
+		"testannotation/projectId": "c-m-lfx9lk92:p-v86cf",
+		"foo":                      "foo",
+	}
+
 	tests := []struct {
 		name    string
 		args    args
@@ -304,6 +311,48 @@ func Test_applyAnnotationsOverriders(t *testing.T) {
 				"bar": "bar",
 				"foo": "foo",
 			},
+			wantErr: false,
+		},
+		{
+			name: "test add composed annotation",
+			args: args{
+				rawObj: func() *unstructured.Unstructured {
+					deploymentObj, _ := utilhelper.ToUnstructured(deployment)
+					return deploymentObj
+				}(),
+				commandOverriders: []policyv1alpha1.LabelAnnotationOverrider{
+					{
+						Operator: policyv1alpha1.OverriderOpAdd,
+						Value: map[string]string{
+							"testannotation/projectId": "c-m-lfx9lk92:p-v86cf",
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"foo":                      "foo",
+				"bar":                      "bar",
+				"testannotation/projectId": "c-m-lfx9lk92:p-v86cf",
+			},
+			wantErr: false,
+		},
+		{
+			name: "test remove composed annotation",
+			args: args{
+				rawObj: func() *unstructured.Unstructured {
+					deploymentObj, _ := utilhelper.ToUnstructured(deployment3)
+					return deploymentObj
+				}(),
+				commandOverriders: []policyv1alpha1.LabelAnnotationOverrider{
+					{
+						Operator: policyv1alpha1.OverriderOpRemove,
+						Value: map[string]string{
+							"testannotation/projectId": "c-m-lfx9lk92:p-v86cf",
+						},
+					},
+				},
+			},
+			want:    map[string]string{"foo": "foo"},
 			wantErr: false,
 		},
 	}

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -105,6 +105,48 @@ func TestValidateOverrideSpec(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name: "invalid annotation should not be allowed",
+			overrideSpec: policyv1alpha1.OverrideSpec{
+				OverrideRules: []policyv1alpha1.RuleWithCluster{
+					{
+						TargetCluster: &policyv1alpha1.ClusterAffinity{
+							ClusterNames: []string{"cluster-name"},
+						},
+						Overriders: policyv1alpha1.Overriders{
+							AnnotationsOverrider: []policyv1alpha1.LabelAnnotationOverrider{
+								{
+									Operator: "add",
+									Value:    map[string]string{"testannotation~projectId": "c-m-lfx9lk92p-v86cf"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid label should not be allowed",
+			overrideSpec: policyv1alpha1.OverrideSpec{
+				OverrideRules: []policyv1alpha1.RuleWithCluster{
+					{
+						TargetCluster: &policyv1alpha1.ClusterAffinity{
+							ClusterNames: []string{"cluster-name"},
+						},
+						Overriders: policyv1alpha1.Overriders{
+							LabelsOverrider: []policyv1alpha1.LabelAnnotationOverrider{
+								{
+									Operator: "add",
+									Value:    map[string]string{"testannotation~projectId": "c-m-lfx9lk92p-v86cf"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Signed-off-by: chaunceyjiang <chaunceyjiang@gmail.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
fix: OverridePolicy of labels/annotations with composed-labels

**Which issue(s) this PR fixes**:
Fixes #3028 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: `labelsOverrider/annotationsOverrider` supports `composed-labels`, like testannotation/projectId: <label-value>.
```

