### PR TITLE
fix dependencies distributor buildAttachedBinding Namespace

### DIFF
--- a/test/helper/resource.go
+++ b/test/helper/resource.go
@@ -302,6 +302,29 @@ func NewCustomResource(apiVersion, kind, namespace, name string) *unstructured.U
 	}
 }
 
+// NewCustomResourceWithConfigMap will build a CR object depended on across ns ConfigMap.
+func NewCustomResourceWithConfigMap(apiVersion, kind, namespace, name, configMapName string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": apiVersion,
+			"kind":       kind,
+			"metadata": map[string]string{
+				"namespace": namespace,
+				"name":      name,
+			},
+			"spec": map[string]interface{}{
+				"resource": map[string]string{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"name":       configMapName,
+					"namespace":  "default",
+				},
+				"clusters": []map[string]string{},
+			},
+		},
+	}
+}
+
 // NewJob will build a job object.
 func NewJob(namespace string, name string) *batchv1.Job {
 	return &batchv1.Job{


### PR DESCRIPTION
Signed-off-by: huangyanfeng <huangyanfeng1992@gmail.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

When creating a dependent resourceBinding, the namespace should use the namespace of the object itself to support cross-namespace references to dependent resources.

For example, we have a crd virtualmachine, create virtualmachine cr test in ns defalut, webhook get virtualmachine cr test dependece configmap test-cm in ns test-2。

**Which issue(s) this PR fixes**:
Fixes #
dependencies distributor buildAttachedBinding namespace need 
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

`karmada-controller-manager`:  fix build attached resourceBinding namespace

```

