### PR TITLE
Automated cherry pick of #3037: fix: OverridePolicy of labels/annotations with

### DIFF
--- a/pkg/util/overridemanager/labelannotationoverrider.go
+++ b/pkg/util/overridemanager/labelannotationoverrider.go
@@ -47,6 +47,13 @@ func buildLabelAnnotationOverriderPatches(rawObj *unstructured.Unstructured, ove
 				continue
 			}
 		}
+		// If the key contains '/', we must replace(escape) it to '~1' according to the
+		// rule of jsonpath identifying a specific value.
+		// See https://jsonpatch.com/#json-pointer for more details.
+		// Note: here don't replace '~' because it is not a valid character for
+		// both annotations and labels, the key with '~' should be prevented at
+		// the validation phase.
+		key = strings.ReplaceAll(key, "/", "~1")
 		patches = append(patches, overrideOption{
 			Op:    string(overrider.Operator),
 			Path:  "/" + strings.Join(append(path, key), "/"),

--- a/pkg/util/overridemanager/labelannotationoverrider_test.go
+++ b/pkg/util/overridemanager/labelannotationoverrider_test.go
@@ -147,6 +147,13 @@ func Test_applyAnnotationsOverriders(t *testing.T) {
 	}
 	deployment2 := helper.NewDeployment(metav1.NamespaceDefault, "test")
 	deployment2.Annotations = nil
+
+	deployment3 := helper.NewDeployment(metav1.NamespaceDefault, "test")
+	deployment3.Annotations = map[string]string{
+		"testannotation/projectId": "c-m-lfx9lk92:p-v86cf",
+		"foo":                      "foo",
+	}
+
 	tests := []struct {
 		name    string
 		args    args
@@ -304,6 +311,48 @@ func Test_applyAnnotationsOverriders(t *testing.T) {
 				"bar": "bar",
 				"foo": "foo",
 			},
+			wantErr: false,
+		},
+		{
+			name: "test add composed annotation",
+			args: args{
+				rawObj: func() *unstructured.Unstructured {
+					deploymentObj, _ := utilhelper.ToUnstructured(deployment)
+					return deploymentObj
+				}(),
+				commandOverriders: []policyv1alpha1.LabelAnnotationOverrider{
+					{
+						Operator: policyv1alpha1.OverriderOpAdd,
+						Value: map[string]string{
+							"testannotation/projectId": "c-m-lfx9lk92:p-v86cf",
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"foo":                      "foo",
+				"bar":                      "bar",
+				"testannotation/projectId": "c-m-lfx9lk92:p-v86cf",
+			},
+			wantErr: false,
+		},
+		{
+			name: "test remove composed annotation",
+			args: args{
+				rawObj: func() *unstructured.Unstructured {
+					deploymentObj, _ := utilhelper.ToUnstructured(deployment3)
+					return deploymentObj
+				}(),
+				commandOverriders: []policyv1alpha1.LabelAnnotationOverrider{
+					{
+						Operator: policyv1alpha1.OverriderOpRemove,
+						Value: map[string]string{
+							"testannotation/projectId": "c-m-lfx9lk92:p-v86cf",
+						},
+					},
+				},
+			},
+			want:    map[string]string{"foo": "foo"},
 			wantErr: false,
 		},
 	}

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -4,6 +4,10 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/util"
@@ -35,7 +39,39 @@ func ValidatePolicyFieldSelector(fieldSelector *policyv1alpha1.FieldSelector) er
 	return nil
 }
 
-// ValidateOverrideSpec tests if the overrideRules and (overriders or targetCluster) co-exist
+// ValidateSpreadConstraint tests if the constraints is valid.
+func ValidateSpreadConstraint(spreadConstraints []policyv1alpha1.SpreadConstraint) error {
+	spreadByFields := sets.NewString()
+
+	for _, constraint := range spreadConstraints {
+		// SpreadByField and SpreadByLabel should not co-exist
+		if len(constraint.SpreadByField) > 0 && len(constraint.SpreadByLabel) > 0 {
+			return fmt.Errorf("invalid constraints: SpreadByLabel(%s) should not co-exist with spreadByField(%s)", constraint.SpreadByLabel, constraint.SpreadByField)
+		}
+
+		// If MaxGroups provided, it should greater or equal than MinGroups.
+		if constraint.MaxGroups > 0 && constraint.MaxGroups < constraint.MinGroups {
+			return fmt.Errorf("maxGroups(%d) lower than minGroups(%d) is not allowed", constraint.MaxGroups, constraint.MinGroups)
+		}
+
+		if len(constraint.SpreadByField) > 0 {
+			spreadByFields.Insert(string(constraint.SpreadByField))
+		}
+	}
+
+	if spreadByFields.Len() > 0 {
+		// If one of spread constraints are using 'SpreadByField', the 'SpreadByFieldCluster' must be included.
+		// For example, when using 'SpreadByFieldRegion' to specify region groups, at the meantime, you must use
+		// 'SpreadByFieldCluster' to specify how many clusters should be selected.
+		if !spreadByFields.Has(string(policyv1alpha1.SpreadByFieldCluster)) {
+			return fmt.Errorf("the cluster spread constraint must be enabled in one of the constraints in case of SpreadByField is enabled")
+		}
+	}
+
+	return nil
+}
+
+// ValidateOverrideSpec validates that the overrider specification is correctly defined.
 func ValidateOverrideSpec(overrideSpec *policyv1alpha1.OverrideSpec) error {
 	if overrideSpec == nil {
 		return nil
@@ -51,6 +87,25 @@ func ValidateOverrideSpec(overrideSpec *policyv1alpha1.OverrideSpec) error {
 		return fmt.Errorf("overrideRules and (overriders or targetCluster) can't co-exist")
 	}
 
+	for overrideRuleIndex, rule := range overrideSpec.OverrideRules {
+		rulePath := field.NewPath("spec").Child("overrideRules").Index(overrideRuleIndex)
+
+		// validates provided annotations.
+		for annotationIndex, annotation := range rule.Overriders.AnnotationsOverrider {
+			annotationPath := rulePath.Child("overriders").Child("annotationsOverrider").Index(annotationIndex)
+			if err := apivalidation.ValidateAnnotations(annotation.Value, annotationPath.Child("value")).ToAggregate(); err != nil {
+				return err
+			}
+		}
+
+		// validates provided labels.
+		for labelIndex, label := range rule.Overriders.LabelsOverrider {
+			labelPath := rulePath.Child("overriders").Child("labelsOverrider").Index(labelIndex)
+			if err := metav1validation.ValidateLabels(label.Value, labelPath.Child("value")).ToAggregate(); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -103,6 +103,48 @@ func TestValidateOverrideSpec(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name: "invalid annotation should not be allowed",
+			overrideSpec: policyv1alpha1.OverrideSpec{
+				OverrideRules: []policyv1alpha1.RuleWithCluster{
+					{
+						TargetCluster: &policyv1alpha1.ClusterAffinity{
+							ClusterNames: []string{"cluster-name"},
+						},
+						Overriders: policyv1alpha1.Overriders{
+							AnnotationsOverrider: []policyv1alpha1.LabelAnnotationOverrider{
+								{
+									Operator: "add",
+									Value:    map[string]string{"testannotation~projectId": "c-m-lfx9lk92p-v86cf"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid label should not be allowed",
+			overrideSpec: policyv1alpha1.OverrideSpec{
+				OverrideRules: []policyv1alpha1.RuleWithCluster{
+					{
+						TargetCluster: &policyv1alpha1.ClusterAffinity{
+							ClusterNames: []string{"cluster-name"},
+						},
+						Overriders: policyv1alpha1.Overriders{
+							LabelsOverrider: []policyv1alpha1.LabelAnnotationOverrider{
+								{
+									Operator: "add",
+									Value:    map[string]string{"testannotation~projectId": "c-m-lfx9lk92p-v86cf"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Cherry pick of #3037 on release-1.4.
#3037: fix: OverridePolicy of labels/annotations with
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
```