### PR TITLE
fix that the InterpretDependency operation is absent in the validatin…

### DIFF
--- a/examples/customresourceinterpreter/webhook-configuration.yaml
+++ b/examples/customresourceinterpreter/webhook-configuration.yaml
@@ -6,7 +6,7 @@ metadata:
 webhooks:
   - name: workloads.example.com
     rules:
-      - operations: [ "InterpretReplica","ReviseReplica","Retain","AggregateStatus", "InterpretHealth", "InterpretStatus" ]
+      - operations: [ "InterpretReplica","ReviseReplica","Retain","AggregateStatus", "InterpretHealth", "InterpretStatus", "InterpretDependency" ]
         apiGroups: [ "workload.example.io" ]
         apiVersions: [ "v1alpha1" ]
         kinds: [ "Workload" ]

--- a/examples/customresourceinterpreter/webhook/app/workloadwebhook.go
+++ b/examples/customresourceinterpreter/webhook/app/workloadwebhook.go
@@ -47,6 +47,8 @@ func (e *workloadInterpreter) Handle(ctx context.Context, req interpreter.Reques
 		return e.responseWithExploreInterpretHealth(workload)
 	case configv1alpha1.InterpreterOperationInterpretStatus:
 		return e.responseWithExploreInterpretStatus(workload)
+	case configv1alpha1.InterpreterOperationInterpretDependency:
+		return e.responseWithExploreDependency(workload)
 	default:
 		return interpreter.Errored(http.StatusBadRequest, fmt.Errorf("wrong request operation type: %s", req.Operation))
 	}
@@ -60,6 +62,13 @@ func (e *workloadInterpreter) InjectDecoder(d *interpreter.Decoder) {
 func (e *workloadInterpreter) responseWithExploreReplica(workload *workloadv1alpha1.Workload) interpreter.Response {
 	res := interpreter.Succeeded("")
 	res.Replicas = workload.Spec.Replicas
+	return res
+}
+
+func (e *workloadInterpreter) responseWithExploreDependency(workload *workloadv1alpha1.Workload) interpreter.Response {
+	res := interpreter.Succeeded("")
+	res.Dependencies = []configv1alpha1.DependentObjectReference{{APIVersion: "v1", Kind: "ConfigMap",
+		Namespace: workload.Namespace, Name: workload.Spec.Template.Spec.Containers[0].EnvFrom[0].ConfigMapRef.Name}}
 	return res
 }
 

--- a/pkg/webhook/configuration/validating.go
+++ b/pkg/webhook/configuration/validating.go
@@ -65,6 +65,7 @@ func (v *ValidatingAdmission) InjectDecoder(d *admission.Decoder) error {
 var supportedInterpreterOperation = sets.NewString(
 	string(configv1alpha1.InterpreterOperationAll),
 	string(configv1alpha1.InterpreterOperationInterpretReplica),
+	string(configv1alpha1.InterpreterOperationInterpretDependency),
 	string(configv1alpha1.InterpreterOperationReviseReplica),
 	string(configv1alpha1.InterpreterOperationRetain),
 	string(configv1alpha1.InterpreterOperationAggregateStatus),

--- a/test/helper/resource.go
+++ b/test/helper/resource.go
@@ -506,7 +506,7 @@ func NewClusterWithResource(name string, allocatable, allocating, allocated core
 }
 
 // NewWorkload will build a workload object.
-func NewWorkload(namespace string, name string) *workloadv1alpha1.Workload {
+func NewWorkload(namespace, name string) *workloadv1alpha1.Workload {
 	podLabels := map[string]string{"app": "nginx"}
 
 	return &workloadv1alpha1.Workload{


### PR DESCRIPTION
The following error occurred when registering the InterpretDependency operation.
```
webhook.go:189] failed to register the ResourceInterpreterWebhookConfiguration to Karmada: admission webhook "resourceinterpreter.config.karmada.io" denied the request: webhooks[0].rules[0].operations[5]: Unsupported value: "InterpretDependency": supported values: "*", "AggregateStatus", "InterpretHealth", "InterpretReplica", "InterpretReplicaRequirement", "InterpretStatus", "Retain", "ReviseReplica"
```

Signed-off-by: hejunhua <jayfantasyhjh@gmail.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-webhook: Fixed the issue that the InterpretDependency operation can't be registered.
```