### PR TITLE
Adds errorlint checks to golangci-lint, standardizing the error format and error judgments

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,7 @@ linters:
   - govet
   # linters default enabled by golangci-lint .
   - errcheck
+  - errorlint
   - gosimple
   - ineffassign
   - staticcheck

--- a/cmd/aggregated-apiserver/app/options/options.go
+++ b/cmd/aggregated-apiserver/app/options/options.go
@@ -110,7 +110,7 @@ func (o *Options) Run(ctx context.Context) error {
 func (o *Options) Config() (*aggregatedapiserver.Config, error) {
 	// TODO have a "real" external address
 	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{netutils.ParseIPSloppy("127.0.0.1")}); err != nil {
-		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
+		return nil, fmt.Errorf("error creating self-signed certificates: %w", err)
 	}
 
 	o.RecommendedOptions.Etcd.StorageConfig.Paging = utilfeature.DefaultFeatureGate.Enabled(features.APIListChunking)

--- a/cmd/descheduler/app/descheduler.go
+++ b/cmd/descheduler/app/descheduler.go
@@ -101,7 +101,7 @@ func run(opts *options.Options, stopChan <-chan struct{}) error {
 
 	restConfig, err := clientcmd.BuildConfigFromFlags(opts.Master, opts.KubeConfig)
 	if err != nil {
-		return fmt.Errorf("error building kubeconfig: %s", err.Error())
+		return fmt.Errorf("error building kubeconfig: %w", err)
 	}
 	restConfig.QPS, restConfig.Burst = opts.KubeAPIQPS, opts.KubeAPIBurst
 
@@ -126,7 +126,7 @@ func run(opts *options.Options, stopChan <-chan struct{}) error {
 	}
 	hostname, err := os.Hostname()
 	if err != nil {
-		return fmt.Errorf("unable to get hostname: %v", err)
+		return fmt.Errorf("unable to get hostname: %w", err)
 	}
 	// add a uniquifier so that two processes on the same host don't accidentally both become active
 	id := hostname + "_" + string(uuid.NewUUID())
@@ -140,7 +140,7 @@ func run(opts *options.Options, stopChan <-chan struct{}) error {
 			Identity: id,
 		})
 	if err != nil {
-		return fmt.Errorf("couldn't create resource lock: %v", err)
+		return fmt.Errorf("couldn't create resource lock: %w", err)
 	}
 
 	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{

--- a/cmd/karmada-search/app/karmada-search.go
+++ b/cmd/karmada-search/app/karmada-search.go
@@ -142,7 +142,7 @@ func run(ctx context.Context, o *options.Options, registryOptions ...Option) err
 func config(o *options.Options, outOfTreeRegistryOptions ...Option) (*search.Config, error) {
 	// TODO have a "real" external address
 	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{netutils.ParseIPSloppy("127.0.0.1")}); err != nil {
-		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
+		return nil, fmt.Errorf("error creating self-signed certificates: %w", err)
 	}
 
 	o.RecommendedOptions.Features = &genericoptions.FeatureOptions{EnableProfiling: false}

--- a/cmd/scheduler-estimator/app/scheduler-estimator.go
+++ b/cmd/scheduler-estimator/app/scheduler-estimator.go
@@ -88,7 +88,7 @@ func run(ctx context.Context, opts *options.Options) error {
 
 	restConfig, err := clientcmd.BuildConfigFromFlags(opts.Master, opts.KubeConfig)
 	if err != nil {
-		return fmt.Errorf("error building kubeconfig: %s", err.Error())
+		return fmt.Errorf("error building kubeconfig: %w", err)
 	}
 	restConfig.QPS, restConfig.Burst = opts.ClusterAPIQPS, opts.ClusterAPIBurst
 

--- a/cmd/scheduler/app/scheduler.go
+++ b/cmd/scheduler/app/scheduler.go
@@ -113,7 +113,7 @@ func run(opts *options.Options, stopChan <-chan struct{}, registryOptions ...Opt
 
 	restConfig, err := clientcmd.BuildConfigFromFlags(opts.Master, opts.KubeConfig)
 	if err != nil {
-		return fmt.Errorf("error building kubeconfig: %s", err.Error())
+		return fmt.Errorf("error building kubeconfig: %w", err)
 	}
 	restConfig.QPS, restConfig.Burst = opts.KubeAPIQPS, opts.KubeAPIBurst
 
@@ -129,7 +129,7 @@ func run(opts *options.Options, stopChan <-chan struct{}, registryOptions ...Opt
 	outOfTreeRegistry := make(runtime.Registry)
 	for _, option := range registryOptions {
 		if err := option(outOfTreeRegistry); err != nil {
-			return fmt.Errorf("register out of tree plugins error: %s", err)
+			return fmt.Errorf("register out of tree plugins error: %w", err)
 		}
 	}
 
@@ -158,7 +158,7 @@ func run(opts *options.Options, stopChan <-chan struct{}, registryOptions ...Opt
 	}
 	hostname, err := os.Hostname()
 	if err != nil {
-		return fmt.Errorf("unable to get hostname: %v", err)
+		return fmt.Errorf("unable to get hostname: %w", err)
 	}
 	// add a uniquifier so that two processes on the same host don't accidentally both become active
 	id := hostname + "_" + string(uuid.NewUUID())
@@ -172,7 +172,7 @@ func run(opts *options.Options, stopChan <-chan struct{}, registryOptions ...Opt
 			Identity: id,
 		})
 	if err != nil {
-		return fmt.Errorf("couldn't create resource lock: %v", err)
+		return fmt.Errorf("couldn't create resource lock: %w", err)
 	}
 
 	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{

--- a/hack/tools/swagger/lib/render.go
+++ b/hack/tools/swagger/lib/render.go
@@ -60,7 +60,7 @@ func RenderOpenAPISpec(cfg Config) (string, error) {
 	options.Admission = nil
 
 	if err := options.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
-		klog.Fatal(fmt.Errorf("error creating self-signed certificates: %v", err))
+		klog.Fatal(fmt.Errorf("error creating self-signed certificates: %w", err))
 	}
 
 	serverConfig := genericapiserver.NewRecommendedConfig(cfg.Codecs)

--- a/pkg/controllers/cluster/cluster_controller.go
+++ b/pkg/controllers/cluster/cluster_controller.go
@@ -648,20 +648,20 @@ func (c *Controller) collectIDForClusterObjectIfNeeded(ctx context.Context) (err
 
 		clusterClient, err := util.NewClusterClientSet(cluster.Name, c.Client, nil)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("%s: %s", cluster.Name, err.Error()))
+			errs = append(errs, fmt.Errorf("%s: %w", cluster.Name, err))
 			continue
 		}
 
 		id, err := util.ObtainClusterID(clusterClient.KubeClient)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("%s: %s", cluster.Name, err.Error()))
+			errs = append(errs, fmt.Errorf("%s: %w", cluster.Name, err))
 			continue
 		}
 		cluster.Spec.ID = id
 
 		err = c.Client.Update(ctx, cluster)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("%s: %s", cluster.Name, err.Error()))
+			errs = append(errs, fmt.Errorf("%s: %w", cluster.Name, err))
 			continue
 		}
 	}

--- a/pkg/controllers/cluster/taint_manager.go
+++ b/pkg/controllers/cluster/taint_manager.go
@@ -135,7 +135,7 @@ func (tc *NoExecuteTaintManager) syncBindingEviction(key util.QueueKey) error {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to get binding %s: %v", fedKey.NamespaceKey(), err)
+		return fmt.Errorf("failed to get binding %s: %w", fedKey.NamespaceKey(), err)
 	}
 
 	if !binding.DeletionTimestamp.IsZero() || !binding.Spec.TargetContains(cluster) {
@@ -187,7 +187,7 @@ func (tc *NoExecuteTaintManager) syncClusterBindingEviction(key util.QueueKey) e
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to get cluster binding %s: %v", fedKey.Name, err)
+		return fmt.Errorf("failed to get cluster binding %s: %w", fedKey.Name, err)
 	}
 
 	if !binding.DeletionTimestamp.IsZero() || !binding.Spec.TargetContains(cluster) {

--- a/pkg/controllers/namespace/namespace_sync_controller.go
+++ b/pkg/controllers/namespace/namespace_sync_controller.go
@@ -118,14 +118,14 @@ func (c *Controller) buildWorks(namespace *corev1.Namespace, clusters []clusterv
 			cops, _, err := c.OverrideManager.ApplyOverridePolicies(clonedNamespaced, cluster.Name)
 			if err != nil {
 				klog.Errorf("Failed to apply overrides for %s/%s/%s, err is: %v", clonedNamespaced.GetKind(), clonedNamespaced.GetNamespace(), clonedNamespaced.GetName(), err)
-				ch <- fmt.Errorf("sync namespace(%s) to cluster(%s) failed due to: %v", clonedNamespaced.GetName(), cluster.GetName(), err)
+				ch <- fmt.Errorf("sync namespace(%s) to cluster(%s) failed due to: %w", clonedNamespaced.GetName(), cluster.GetName(), err)
 				return
 			}
 
 			annotations, err := binding.RecordAppliedOverrides(cops, nil, nil)
 			if err != nil {
 				klog.Errorf("Failed to record appliedOverrides, Error: %v", err)
-				ch <- fmt.Errorf("sync namespace(%s) to cluster(%s) failed due to: %v", clonedNamespaced.GetName(), cluster.GetName(), err)
+				ch <- fmt.Errorf("sync namespace(%s) to cluster(%s) failed due to: %w", clonedNamespaced.GetName(), cluster.GetName(), err)
 				return
 			}
 
@@ -146,7 +146,7 @@ func (c *Controller) buildWorks(namespace *corev1.Namespace, clusters []clusterv
 			util.MergeLabel(clonedNamespaced, workv1alpha1.WorkNameLabel, workName)
 
 			if err = helper.CreateOrUpdateWork(c.Client, objectMeta, clonedNamespaced); err != nil {
-				ch <- fmt.Errorf("sync namespace(%s) to cluster(%s) failed due to: %v", clonedNamespaced.GetName(), cluster.GetName(), err)
+				ch <- fmt.Errorf("sync namespace(%s) to cluster(%s) failed due to: %w", clonedNamespaced.GetName(), cluster.GetName(), err)
 				return
 			}
 			ch <- nil

--- a/pkg/dependenciesdistributor/dependencies_distributor.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor.go
@@ -508,7 +508,7 @@ func convertObjectsToResourceBindings(bindingList []runtime.Object) ([]*workv1al
 	for _, obj := range bindingList {
 		binding := &workv1alpha2.ResourceBinding{}
 		if err := helper.ConvertToTypedObject(obj, binding); err != nil {
-			return nil, fmt.Errorf("failed to convert unstructured to typed object: %v", err)
+			return nil, fmt.Errorf("failed to convert unstructured to typed object: %w", err)
 		}
 		bindings = append(bindings, binding)
 	}

--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -157,7 +157,7 @@ func (d *Descheduler) worker(key util.QueueKey) error {
 			klog.Infof("ResourceBinding(%s) in work queue no longer exists, ignore.", namespacedName)
 			return nil
 		}
-		return fmt.Errorf("get ResourceBinding(%s) error: %v", namespacedName, err)
+		return fmt.Errorf("get ResourceBinding(%s) error: %w", namespacedName, err)
 	}
 
 	h := core.NewSchedulingResultHelper(binding)

--- a/pkg/estimator/client/accurate.go
+++ b/pkg/estimator/client/accurate.go
@@ -85,7 +85,7 @@ func (se *SchedulerEstimator) maxAvailableReplicas(ctx context.Context, cluster 
 	}
 	res, err := client.MaxAvailableReplicas(ctx, req)
 	if err != nil {
-		return UnauthenticReplica, fmt.Errorf("gRPC request cluster(%s) estimator error when calling MaxAvailableReplicas: %v", cluster, err)
+		return UnauthenticReplica, fmt.Errorf("gRPC request cluster(%s) estimator error when calling MaxAvailableReplicas: %w", cluster, err)
 	}
 	return res.MaxReplicas, nil
 }
@@ -113,7 +113,7 @@ func (se *SchedulerEstimator) maxUnscheduableReplicas(
 	}
 	res, err := client.GetUnschedulableReplicas(ctx, req)
 	if err != nil {
-		return UnauthenticReplica, fmt.Errorf("gRPC request cluster(%s) estimator error when calling UnschedulableReplicas: %v", cluster, err)
+		return UnauthenticReplica, fmt.Errorf("gRPC request cluster(%s) estimator error when calling UnschedulableReplicas: %w", cluster, err)
 	}
 	return res.UnschedulableReplicas, nil
 }

--- a/pkg/estimator/server/replica/replica.go
+++ b/pkg/estimator/server/replica/replica.go
@@ -35,7 +35,7 @@ func GetUnschedulablePodsOfWorkload(unstructObj *unstructured.Unstructured, thre
 	case util.DeploymentKind:
 		deployment := &appsv1.Deployment{}
 		if err := helper.ConvertToTypedObject(unstructObj, deployment); err != nil {
-			return 0, fmt.Errorf("failed to convert ReplicaSet from unstructured object: %v", err)
+			return 0, fmt.Errorf("failed to convert ReplicaSet from unstructured object: %w", err)
 		}
 		pods, err := listDeploymentPods(deployment, listers)
 		if err != nil {

--- a/pkg/estimator/server/server.go
+++ b/pkg/estimator/server/server.go
@@ -126,7 +126,7 @@ func (es *AccurateSchedulerEstimatorServer) Start(ctx context.Context) error {
 	// Listen a port and register the gRPC server.
 	l, err := net.Listen("tcp", fmt.Sprintf(":%d", es.port))
 	if err != nil {
-		return fmt.Errorf("failed to listen port %d: %v", es.port, err)
+		return fmt.Errorf("failed to listen port %d: %w", es.port, err)
 	}
 	klog.Infof("Listening port: %d", es.port)
 	defer l.Close()
@@ -180,7 +180,7 @@ func (es *AccurateSchedulerEstimatorServer) MaxAvailableReplicas(ctx context.Con
 
 	maxReplicas, err := es.EstimateReplicas(ctx, object, request)
 	if err != nil {
-		return nil, fmt.Errorf("failed to estimate replicas: %v", err)
+		return nil, fmt.Errorf("failed to estimate replicas: %w", err)
 	}
 	return &pb.MaxAvailableReplicasResponse{MaxReplicas: maxReplicas}, nil
 }

--- a/pkg/karmadactl/addons/descheduler/descheduler.go
+++ b/pkg/karmadactl/addons/descheduler/descheduler.go
@@ -52,20 +52,20 @@ var enableDescheduler = func(opts *addoninit.CommandAddonsEnableOption) error {
 		Image:     opts.KarmadaDeschedulerImage,
 	})
 	if err != nil {
-		return fmt.Errorf("error when parsing karmada descheduler deployment template :%v", err)
+		return fmt.Errorf("error when parsing karmada descheduler deployment template :%w", err)
 	}
 
 	karmadaDeschedulerDeployment := &appsv1.Deployment{}
 	if err := kuberuntime.DecodeInto(clientsetscheme.Codecs.UniversalDecoder(), karmadaDeschedulerDeploymentBytes, karmadaDeschedulerDeployment); err != nil {
-		return fmt.Errorf("decode descheduler deployment error: %v", err)
+		return fmt.Errorf("decode descheduler deployment error: %w", err)
 	}
 
 	if err := cmdutil.CreateOrUpdateDeployment(opts.KubeClientSet, karmadaDeschedulerDeployment); err != nil {
-		return fmt.Errorf("create karmada descheduler deployment error: %v", err)
+		return fmt.Errorf("create karmada descheduler deployment error: %w", err)
 	}
 
 	if err := kubernetes.WaitPodReady(opts.KubeClientSet, opts.Namespace, initutils.MapToString(karmadaDeschedulerLabels), opts.WaitPodReadyTimeout); err != nil {
-		return fmt.Errorf("wait karmada descheduler pod timeout: %v", err)
+		return fmt.Errorf("wait karmada descheduler pod timeout: %w", err)
 	}
 
 	klog.Infof("Install karmada descheduler deployment on host cluster successfully")

--- a/pkg/karmadactl/addons/estimator/estimator.go
+++ b/pkg/karmadactl/addons/estimator/estimator.go
@@ -68,13 +68,13 @@ var enableEstimator = func(opts *addoninit.CommandAddonsEnableOption) error {
 	config.CurrentContext = opts.MemberContext
 	configBytes, err := clientcmd.Write(*config)
 	if err != nil {
-		return fmt.Errorf("failure while serializing admin kubeConfig. %v", err)
+		return fmt.Errorf("failure while serializing admin kubeConfig. %w", err)
 	}
 
 	secretName := fmt.Sprintf("%s-kubeconfig", opts.Cluster)
 	secret := secretFromSpec(secretName, opts.Namespace, corev1.SecretTypeOpaque, map[string]string{secretName: string(configBytes)})
 	if err := cmdutil.CreateOrUpdateSecret(opts.KubeClientSet, secret); err != nil {
-		return fmt.Errorf("create or update scheduler estimator secret error: %v", err)
+		return fmt.Errorf("create or update scheduler estimator secret error: %w", err)
 	}
 
 	// init estimator service
@@ -83,15 +83,15 @@ var enableEstimator = func(opts *addoninit.CommandAddonsEnableOption) error {
 		MemberClusterName: opts.Cluster,
 	})
 	if err != nil {
-		return fmt.Errorf("error when parsing karmada scheduler estimator service template :%v", err)
+		return fmt.Errorf("error when parsing karmada scheduler estimator service template :%w", err)
 	}
 
 	karmadaEstimatorService := &corev1.Service{}
 	if err := kuberuntime.DecodeInto(clientsetscheme.Codecs.UniversalDecoder(), karmadaEstimatorServiceBytes, karmadaEstimatorService); err != nil {
-		return fmt.Errorf("decode karmada scheduler estimator service error: %v", err)
+		return fmt.Errorf("decode karmada scheduler estimator service error: %w", err)
 	}
 	if err := cmdutil.CreateService(opts.KubeClientSet, karmadaEstimatorService); err != nil {
-		return fmt.Errorf("create or update scheduler estimator service error: %v", err)
+		return fmt.Errorf("create or update scheduler estimator service error: %w", err)
 	}
 
 	// init estimator deployment
@@ -102,15 +102,15 @@ var enableEstimator = func(opts *addoninit.CommandAddonsEnableOption) error {
 		MemberClusterName: opts.Cluster,
 	})
 	if err != nil {
-		return fmt.Errorf("error when parsing karmada scheduler estimator deployment template :%v", err)
+		return fmt.Errorf("error when parsing karmada scheduler estimator deployment template :%w", err)
 	}
 
 	karmadaEstimatorDeployment := &appsv1.Deployment{}
 	if err := kuberuntime.DecodeInto(clientsetscheme.Codecs.UniversalDecoder(), karmadaEstimatorDeploymentBytes, karmadaEstimatorDeployment); err != nil {
-		return fmt.Errorf("decode karmada scheduler estimator deployment error: %v", err)
+		return fmt.Errorf("decode karmada scheduler estimator deployment error: %w", err)
 	}
 	if err := cmdutil.CreateOrUpdateDeployment(opts.KubeClientSet, karmadaEstimatorDeployment); err != nil {
-		return fmt.Errorf("create or update scheduler estimator deployment error: %v", err)
+		return fmt.Errorf("create or update scheduler estimator deployment error: %w", err)
 	}
 
 	karmadaEstimatorLabels := map[string]string{"cluster": opts.Cluster}

--- a/pkg/karmadactl/addons/init/enable_option.go
+++ b/pkg/karmadactl/addons/init/enable_option.go
@@ -86,16 +86,16 @@ func (o *CommandAddonsEnableOption) Validate(args []string) error {
 		// Check member kubeconfig and context is valid
 		memberConfig, err := apiclient.RestConfig(o.MemberContext, o.MemberKubeConfig)
 		if err != nil {
-			return fmt.Errorf("failed to get member cluster config. error: %v", err)
+			return fmt.Errorf("failed to get member cluster config. error: %w", err)
 		}
 		memberKubeClient := kubernetes.NewForConfigOrDie(memberConfig)
 		_, err = memberKubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to get nodes from cluster %s with member-kubeconfig and member-context. error: %v, Please check the Role or ClusterRole of the serviceAccount in your member-kubeconfig", o.Cluster, err)
+			return fmt.Errorf("failed to get nodes from cluster %s with member-kubeconfig and member-context. error: %w, Please check the Role or ClusterRole of the serviceAccount in your member-kubeconfig", o.Cluster, err)
 		}
 		_, err = memberKubeClient.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to get pods from cluster %s with member-kubeconfig and member-context. error: %v, Please check the Role or ClusterRole of the serviceAccount in your member-kubeconfig", o.Cluster, err)
+			return fmt.Errorf("failed to get pods from cluster %s with member-kubeconfig and member-context. error: %w, Please check the Role or ClusterRole of the serviceAccount in your member-kubeconfig", o.Cluster, err)
 		}
 	}
 	return nil

--- a/pkg/karmadactl/addons/search/search.go
+++ b/pkg/karmadactl/addons/search/search.go
@@ -128,16 +128,16 @@ func installComponentsOnHostCluster(opts *addoninit.CommandAddonsEnableOption) e
 		Namespace: opts.Namespace,
 	})
 	if err != nil {
-		return fmt.Errorf("error when parsing karmada search service template :%v", err)
+		return fmt.Errorf("error when parsing karmada search service template :%w", err)
 	}
 
 	karmadaSearchService := &corev1.Service{}
 	if err := kuberuntime.DecodeInto(clientsetscheme.Codecs.UniversalDecoder(), karmadaSearchServiceBytes, karmadaSearchService); err != nil {
-		return fmt.Errorf("decode karmada search service error: %v", err)
+		return fmt.Errorf("decode karmada search service error: %w", err)
 	}
 
 	if err := cmdutil.CreateService(opts.KubeClientSet, karmadaSearchService); err != nil {
-		return fmt.Errorf("create karmada search service error: %v", err)
+		return fmt.Errorf("create karmada search service error: %w", err)
 	}
 
 	etcdServers, err := etcdServers(opts)
@@ -155,19 +155,19 @@ func installComponentsOnHostCluster(opts *addoninit.CommandAddonsEnableOption) e
 		Image:      opts.KarmadaSearchImage,
 	})
 	if err != nil {
-		return fmt.Errorf("error when parsing karmada search deployment template :%v", err)
+		return fmt.Errorf("error when parsing karmada search deployment template :%w", err)
 	}
 
 	karmadaSearchDeployment := &appsv1.Deployment{}
 	if err := kuberuntime.DecodeInto(clientsetscheme.Codecs.UniversalDecoder(), karmadaSearchDeploymentBytes, karmadaSearchDeployment); err != nil {
-		return fmt.Errorf("decode karmada search deployment error: %v", err)
+		return fmt.Errorf("decode karmada search deployment error: %w", err)
 	}
 	if err := cmdutil.CreateOrUpdateDeployment(opts.KubeClientSet, karmadaSearchDeployment); err != nil {
-		return fmt.Errorf("create karmada search deployment error: %v", err)
+		return fmt.Errorf("create karmada search deployment error: %w", err)
 	}
 
 	if err := kubernetes.WaitPodReady(opts.KubeClientSet, opts.Namespace, initutils.MapToString(karmadaSearchLabels), opts.WaitPodReadyTimeout); err != nil {
-		return fmt.Errorf("wait karmada search pod status ready timeout: %v", err)
+		return fmt.Errorf("wait karmada search pod status ready timeout: %w", err)
 	}
 
 	klog.Infof("Install karmada search deployment on host cluster successfully")
@@ -180,15 +180,15 @@ func installComponentsOnKarmadaControlPlane(opts *addoninit.CommandAddonsEnableO
 		Namespace: opts.Namespace,
 	})
 	if err != nil {
-		return fmt.Errorf("error when parsing karmada search AA service template :%v", err)
+		return fmt.Errorf("error when parsing karmada search AA service template :%w", err)
 	}
 
 	aaService := &corev1.Service{}
 	if err := kuberuntime.DecodeInto(clientsetscheme.Codecs.UniversalDecoder(), aaServiceBytes, aaService); err != nil {
-		return fmt.Errorf("decode karmada search AA service error: %v", err)
+		return fmt.Errorf("decode karmada search AA service error: %w", err)
 	}
 	if err := cmdutil.CreateService(opts.KarmadaKubeClientSet, aaService); err != nil {
-		return fmt.Errorf("create karmada search AA service error: %v", err)
+		return fmt.Errorf("create karmada search AA service error: %w", err)
 	}
 
 	// install karmada search apiservice on karmada control plane
@@ -197,16 +197,16 @@ func installComponentsOnKarmadaControlPlane(opts *addoninit.CommandAddonsEnableO
 		Namespace: opts.Namespace,
 	})
 	if err != nil {
-		return fmt.Errorf("error when parsing karmada search AA apiservice template :%v", err)
+		return fmt.Errorf("error when parsing karmada search AA apiservice template :%w", err)
 	}
 
 	aaAPIService := &apiregistrationv1.APIService{}
 	if err := kuberuntime.DecodeInto(clientsetscheme.Codecs.UniversalDecoder(), aaAPIServiceBytes, aaAPIService); err != nil {
-		return fmt.Errorf("decode karmada search AA apiservice error: %v", err)
+		return fmt.Errorf("decode karmada search AA apiservice error: %w", err)
 	}
 
 	if err = cmdutil.CreateOrUpdateAPIService(opts.KarmadaAggregatorClientSet, aaAPIService); err != nil {
-		return fmt.Errorf("craete karmada search AA apiservice error: %v", err)
+		return fmt.Errorf("craete karmada search AA apiservice error: %w", err)
 	}
 
 	if err := initkarmada.WaitAPIServiceReady(opts.KarmadaAggregatorClientSet, aaAPIServiceName, time.Duration(opts.WaitAPIServiceReadyTimeout)*time.Second); err != nil {

--- a/pkg/karmadactl/addons/utils/template.go
+++ b/pkg/karmadactl/addons/utils/template.go
@@ -11,11 +11,11 @@ func ParseTemplate(strTmpl string, obj interface{}) ([]byte, error) {
 	var buf bytes.Buffer
 	tmpl, err := template.New("template").Parse(strTmpl)
 	if err != nil {
-		return nil, fmt.Errorf("error when parsing template: %v", err)
+		return nil, fmt.Errorf("error when parsing template: %w", err)
 	}
 	err = tmpl.Execute(&buf, obj)
 	if err != nil {
-		return nil, fmt.Errorf("error when executing template: %v", err)
+		return nil, fmt.Errorf("error when executing template: %w", err)
 	}
 	return buf.Bytes(), nil
 }

--- a/pkg/karmadactl/apply/apply.go
+++ b/pkg/karmadactl/apply/apply.go
@@ -169,11 +169,11 @@ func (o *CommandApplyOptions) generateAndInjectPolices() error {
 		gvk := obj.GetObjectKind().GroupVersionKind()
 		mapping, err := o.kubectlApplyOptions.Mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 		if err != nil {
-			return fmt.Errorf("unable to recognize resource: %v", err)
+			return fmt.Errorf("unable to recognize resource: %w", err)
 		}
 		client, err := o.KubectlApplyFlags.Factory.UnstructuredClientForMapping(mapping)
 		if err != nil {
-			return fmt.Errorf("unable to connect to a server to handle %q: %v", mapping.Resource, err)
+			return fmt.Errorf("unable to connect to a server to handle %q: %w", mapping.Resource, err)
 		}
 		policyName, _ := metadataAccessor.Name(obj)
 		ret := &resource.Info{

--- a/pkg/karmadactl/cmdinit/cert/cert.go
+++ b/pkg/karmadactl/cmdinit/cert/cert.go
@@ -65,12 +65,12 @@ func EncodeCertPEM(cert *x509.Certificate) []byte {
 func NewCertificateAuthority(config *CertsConfig) (*x509.Certificate, crypto.Signer, error) {
 	key, err := NewPrivateKey(config.PublicKeyAlgorithm)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to create private key while generating CA certificate %v", err)
+		return nil, nil, fmt.Errorf("unable to create private key while generating CA certificate %w", err)
 	}
 
 	cert, err := certutil.NewSelfSignedCACert(config.Config, key)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to create self-signed CA certificate %v", err)
+		return nil, nil, fmt.Errorf("unable to create self-signed CA certificate %w", err)
 	}
 
 	return cert, key, nil
@@ -84,7 +84,7 @@ func NewCACertAndKey(cn string) (*x509.Certificate, *crypto.Signer, error) {
 	}
 	caCert, caKey, err := NewCertificateAuthority(certCfg)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failure while generating CA certificate and key: %v", err)
+		return nil, nil, fmt.Errorf("failure while generating CA certificate and key: %w", err)
 	}
 
 	return caCert, &caKey, nil
@@ -163,12 +163,12 @@ func NewCertAndKey(caCert *x509.Certificate, caKey crypto.Signer, config *CertsC
 
 	key, err := NewPrivateKey(config.PublicKeyAlgorithm)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to create private key %v", err)
+		return nil, nil, fmt.Errorf("unable to create private key %w", err)
 	}
 
 	cert, err := NewSignedCert(config, key, caCert, caKey, false)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to sign certificate. %v", err)
+		return nil, nil, fmt.Errorf("unable to sign certificate. %w", err)
 	}
 
 	return cert, key, nil
@@ -192,7 +192,7 @@ func WriteCert(pkiPath, name string, cert *x509.Certificate) error {
 
 	certificatePath := PathForCert(pkiPath, name)
 	if err := certutil.WriteCert(certificatePath, EncodeCertPEM(cert)); err != nil {
-		return fmt.Errorf("unable to write certificate to file %v", err)
+		return fmt.Errorf("unable to write certificate to file %w", err)
 	}
 
 	return nil
@@ -207,10 +207,10 @@ func WriteKey(pkiPath, name string, key crypto.Signer) error {
 	privateKeyPath := PathForKey(pkiPath, name)
 	encoded, err := keyutil.MarshalPrivateKeyToPEM(key)
 	if err != nil {
-		return fmt.Errorf("unable to marshal private key to PEM %v", err)
+		return fmt.Errorf("unable to marshal private key to PEM %w", err)
 	}
 	if err := keyutil.WriteKey(privateKeyPath, encoded); err != nil {
-		return fmt.Errorf("unable to write private key to file %v", err)
+		return fmt.Errorf("unable to write private key to file %w", err)
 	}
 
 	return nil

--- a/pkg/karmadactl/cmdinit/karmada/deploy.go
+++ b/pkg/karmadactl/cmdinit/karmada/deploy.go
@@ -152,11 +152,11 @@ func createExtralResources(clientSet *kubernetes.Clientset, dir string) error {
 
 	// Create the cluster-info ConfigMap with the associated RBAC rules
 	if err := clusterinfo.CreateBootstrapConfigMapIfNotExists(clientSet, filepath.Join(dir, options.KarmadaKubeConfigName)); err != nil {
-		return fmt.Errorf("error creating bootstrap ConfigMap: %v", err)
+		return fmt.Errorf("error creating bootstrap ConfigMap: %w", err)
 	}
 
 	if err := clusterinfo.CreateClusterInfoRBACRules(clientSet); err != nil {
-		return fmt.Errorf("error creating clusterinfo RBAC rules: %v", err)
+		return fmt.Errorf("error creating clusterinfo RBAC rules: %w", err)
 	}
 
 	// grant limited access permission to 'karmada-agent'

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -210,7 +210,7 @@ func initializeDirectory(path string) error {
 		}
 	}
 	if err := os.MkdirAll(path, os.FileMode(0o755)); err != nil {
-		return fmt.Errorf("failed to create directory: %s, error: %v", path, err)
+		return fmt.Errorf("failed to create directory: %s, error: %w", path, err)
 	}
 
 	return nil
@@ -304,7 +304,7 @@ func (i *CommandInitOption) createCertsSecrets() error {
 		i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaCertAndKeyName)], i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaCertAndKeyName)])
 	configBytes, err := clientcmd.Write(*config)
 	if err != nil {
-		return fmt.Errorf("failure while serializing admin kubeConfig. %v", err)
+		return fmt.Errorf("failure while serializing admin kubeConfig. %w", err)
 	}
 
 	kubeConfigSecret := i.SecretFromSpec(KubeConfigSecretAndMountName, corev1.SecretTypeOpaque, map[string]string{KubeConfigSecretAndMountName: string(configBytes)})
@@ -443,7 +443,7 @@ func (i *CommandInitOption) initKarmadaComponent() error {
 func (i *CommandInitOption) RunInit(parentCommand string) error {
 	// generate certificate
 	if err := i.genCerts(); err != nil {
-		return fmt.Errorf("certificate generation failed.%v", err)
+		return fmt.Errorf("certificate generation failed.%w", err)
 	}
 
 	i.CertAndKeyFileData = map[string][]byte{}
@@ -451,31 +451,31 @@ func (i *CommandInitOption) RunInit(parentCommand string) error {
 	for _, v := range certList {
 		certs, err := utils.FileToBytes(i.KarmadaPkiPath, fmt.Sprintf("%s.crt", v))
 		if err != nil {
-			return fmt.Errorf("'%s.crt' conversion failed. %v", v, err)
+			return fmt.Errorf("'%s.crt' conversion failed. %w", v, err)
 		}
 		i.CertAndKeyFileData[fmt.Sprintf("%s.crt", v)] = certs
 
 		key, err := utils.FileToBytes(i.KarmadaPkiPath, fmt.Sprintf("%s.key", v))
 		if err != nil {
-			return fmt.Errorf("'%s.key' conversion failed. %v", v, err)
+			return fmt.Errorf("'%s.key' conversion failed. %w", v, err)
 		}
 		i.CertAndKeyFileData[fmt.Sprintf("%s.key", v)] = key
 	}
 
 	// prepare karmada CRD resources
 	if err := i.prepareCRD(); err != nil {
-		return fmt.Errorf("prepare karmada failed.%v", err)
+		return fmt.Errorf("prepare karmada failed. %w", err)
 	}
 
 	// Create karmada kubeconfig
 	err := i.createKarmadaConfig()
 	if err != nil {
-		return fmt.Errorf("create karmada kubeconfig failed.%v", err)
+		return fmt.Errorf("create karmada kubeconfig failed.%w", err)
 	}
 
 	// Create ns
 	if err := util.CreateOrUpdateNamespace(i.KubeClientSet, util.NewNamespace(i.Namespace)); err != nil {
-		return fmt.Errorf("create namespace %s failed: %v", i.Namespace, err)
+		return fmt.Errorf("create namespace %s failed: %w", i.Namespace, err)
 	}
 
 	// Create Secrets
@@ -518,7 +518,7 @@ func (i *CommandInitOption) createKarmadaConfig() error {
 	if err := utils.WriteKubeConfigFromSpec(serverURL, options.UserName, options.ClusterName, i.KarmadaDataPath, options.KarmadaKubeConfigName,
 		i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.CaCertAndKeyName)], i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaCertAndKeyName)],
 		i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaCertAndKeyName)]); err != nil {
-		return fmt.Errorf("failed to create karmada kubeconfig file. %v", err)
+		return fmt.Errorf("failed to create karmada kubeconfig file. %w", err)
 	}
 	klog.Info("Create karmada kubeconfig success.")
 	return err

--- a/pkg/karmadactl/cmdinit/utils/util.go
+++ b/pkg/karmadactl/cmdinit/utils/util.go
@@ -78,7 +78,7 @@ func DeCompress(file, targetPath string) error {
 
 	gr, err := gzip.NewReader(r)
 	if err != nil {
-		return fmt.Errorf("new reader failed. %v", err)
+		return fmt.Errorf("new reader failed. %w", err)
 	}
 	defer gr.Close()
 

--- a/pkg/karmadactl/get/get.go
+++ b/pkg/karmadactl/get/get.go
@@ -494,7 +494,7 @@ func (g *CommandGetOptions) getObjInfo(wg *sync.WaitGroup, mux *sync.Mutex, f cm
 	}
 
 	if err := r.Err(); err != nil {
-		*allErrs = append(*allErrs, fmt.Errorf("cluster(%s): %s", cluster, err))
+		*allErrs = append(*allErrs, fmt.Errorf("cluster(%s): %w", cluster, err))
 		return
 	}
 
@@ -511,14 +511,14 @@ func (g *CommandGetOptions) getObjInfo(wg *sync.WaitGroup, mux *sync.Mutex, f cm
 
 	if !g.IsHumanReadablePrinter {
 		if err := g.printGeneric(r); err != nil {
-			*allErrs = append(*allErrs, fmt.Errorf("cluster(%s): %s", cluster, err))
+			*allErrs = append(*allErrs, fmt.Errorf("cluster(%s): %w", cluster, err))
 		}
 		return
 	}
 
 	infos, err := r.Infos()
 	if err != nil {
-		*allErrs = append(*allErrs, fmt.Errorf("cluster(%s): %s", cluster, err))
+		*allErrs = append(*allErrs, fmt.Errorf("cluster(%s): %w", cluster, err))
 		return
 	}
 
@@ -666,7 +666,7 @@ func (g *CommandGetOptions) watch(watchObjs []WatchObj) error {
 			}
 
 			if err := printer.PrintObj(printObj, writer); err != nil {
-				return fmt.Errorf("unable to output the provided object: %v", err)
+				return fmt.Errorf("unable to output the provided object: %w", err)
 			}
 		}
 	}

--- a/pkg/karmadactl/interpret/edit.go
+++ b/pkg/karmadactl/interpret/edit.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -450,8 +451,9 @@ func (r *editResults) addError(err error, info *resource.Info) string {
 		reason := editReason{
 			head: fmt.Sprintf("%s %q was not valid", customizationResourceName, info.Name),
 		}
-		if err, ok := err.(apierrors.APIStatus); ok {
-			if details := err.Status().Details; details != nil {
+		var tErr apierrors.APIStatus
+		if errors.As(err, &tErr) {
+			if details := tErr.Status().Details; details != nil {
 				for _, cause := range details.Causes {
 					reason.other = append(reason.other, fmt.Sprintf("%s: %s", cause.Field, cause.Message))
 				}

--- a/pkg/karmadactl/interpret/execute.go
+++ b/pkg/karmadactl/interpret/execute.go
@@ -55,22 +55,22 @@ func (o *Options) runExecute() error {
 
 	customizations, err := o.getCustomizationObject()
 	if err != nil {
-		return fmt.Errorf("fail to get customization object: %v", err)
+		return fmt.Errorf("fail to get customization object: %w", err)
 	}
 
 	desired, err := getUnstructuredObjectFromResult(o.DesiredResult)
 	if err != nil {
-		return fmt.Errorf("fail to get desired object: %v", err)
+		return fmt.Errorf("fail to get desired object: %w", err)
 	}
 
 	observed, err := getUnstructuredObjectFromResult(o.ObservedResult)
 	if err != nil {
-		return fmt.Errorf("fail to get observed object: %v", err)
+		return fmt.Errorf("fail to get observed object: %w", err)
 	}
 
 	status, err := o.getAggregatedStatusItems()
 	if err != nil {
-		return fmt.Errorf("fail to get status items: %v", err)
+		return fmt.Errorf("fail to get status items: %w", err)
 	}
 
 	args := interpreter.RuleArgs{

--- a/pkg/karmadactl/join/join.go
+++ b/pkg/karmadactl/join/join.go
@@ -140,14 +140,14 @@ func (j *CommandJoinOption) Run(f cmdutil.Factory) error {
 	// Get control plane karmada-apiserver client
 	controlPlaneRestConfig, err := f.ToRawKubeConfigLoader().ClientConfig()
 	if err != nil {
-		return fmt.Errorf("failed to get control plane rest config. context: %s, kube-config: %s, error: %v",
+		return fmt.Errorf("failed to get control plane rest config. context: %s, kube-config: %s, error: %w",
 			*options.DefaultConfigFlags.Context, *options.DefaultConfigFlags.KubeConfig, err)
 	}
 
 	// Get cluster config
 	clusterConfig, err := apiclient.RestConfig(j.ClusterContext, j.ClusterKubeConfig)
 	if err != nil {
-		return fmt.Errorf("failed to get joining cluster config. error: %v", err)
+		return fmt.Errorf("failed to get joining cluster config. error: %w", err)
 	}
 
 	return j.RunJoinCluster(controlPlaneRestConfig, clusterConfig)
@@ -242,7 +242,7 @@ func generateClusterInControllerPlane(opts util.ClusterRegisterOption) (*cluster
 	if opts.ClusterConfig.Proxy != nil {
 		url, err := opts.ClusterConfig.Proxy(nil)
 		if err != nil {
-			return nil, fmt.Errorf("clusterConfig.Proxy error, %v", err)
+			return nil, fmt.Errorf("clusterConfig.Proxy error, %w", err)
 		}
 		clusterObj.Spec.ProxyURL = url.String()
 	}
@@ -250,7 +250,7 @@ func generateClusterInControllerPlane(opts util.ClusterRegisterOption) (*cluster
 	controlPlaneKarmadaClient := karmadaclientset.NewForConfigOrDie(opts.ControlPlaneConfig)
 	cluster, err := util.CreateClusterObject(controlPlaneKarmadaClient, clusterObj)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create cluster(%s) object. error: %v", opts.ClusterName, err)
+		return nil, fmt.Errorf("failed to create cluster(%s) object. error: %w", opts.ClusterName, err)
 	}
 
 	return cluster, nil

--- a/pkg/karmadactl/promote/promote.go
+++ b/pkg/karmadactl/promote/promote.go
@@ -227,12 +227,12 @@ func (o *CommandPromoteOption) Run(f util.Factory, args []string) error {
 
 	mapper, err := restmapper.MapperProvider(controlPlaneRestConfig)
 	if err != nil {
-		return fmt.Errorf("failed to create restmapper: %v", err)
+		return fmt.Errorf("failed to create restmapper: %w", err)
 	}
 
 	gvr, err := restmapper.GetGroupVersionResource(mapper, o.gvk)
 	if err != nil {
-		return fmt.Errorf("failed to get gvr from %q: %v", o.gvk, err)
+		return fmt.Errorf("failed to get gvr from %q: %w", o.gvk, err)
 	}
 
 	return o.promote(controlPlaneRestConfig, obj, gvr)
@@ -240,7 +240,7 @@ func (o *CommandPromoteOption) Run(f util.Factory, args []string) error {
 
 func (o *CommandPromoteOption) promote(controlPlaneRestConfig *rest.Config, obj *unstructured.Unstructured, gvr schema.GroupVersionResource) error {
 	if err := preprocessResource(obj); err != nil {
-		return fmt.Errorf("failed to preprocess resource %q(%s/%s) in control plane: %v", gvr, o.Namespace, o.name, err)
+		return fmt.Errorf("failed to preprocess resource %q(%s/%s) in control plane: %w", gvr, o.Namespace, o.name, err)
 	}
 
 	if o.OutputFormat != "" {
@@ -267,12 +267,12 @@ func (o *CommandPromoteOption) promote(controlPlaneRestConfig *rest.Config, obj 
 		}
 
 		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to get resource %q(%s) in control plane: %v", gvr, o.name, err)
+			return fmt.Errorf("failed to get resource %q(%s) in control plane: %w", gvr, o.name, err)
 		}
 
 		_, err = controlPlaneDynamicClient.Resource(gvr).Create(context.TODO(), obj, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to create resource %q(%s) in control plane: %v", gvr, o.name, err)
+			return fmt.Errorf("failed to create resource %q(%s) in control plane: %w", gvr, o.name, err)
 		}
 
 		err = o.createClusterPropagationPolicy(karmadaClient, gvr)
@@ -290,12 +290,12 @@ func (o *CommandPromoteOption) promote(controlPlaneRestConfig *rest.Config, obj 
 		}
 
 		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to get resource %q(%s/%s) in control plane: %v", gvr, o.Namespace, o.name, err)
+			return fmt.Errorf("failed to get resource %q(%s/%s) in control plane: %w", gvr, o.Namespace, o.name, err)
 		}
 
 		_, err = controlPlaneDynamicClient.Resource(gvr).Namespace(o.Namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to create resource %q(%s/%s) in control plane: %v", gvr, o.Namespace, o.name, err)
+			return fmt.Errorf("failed to create resource %q(%s/%s) in control plane: %w", gvr, o.Namespace, o.name, err)
 		}
 
 		err = o.createPropagationPolicy(karmadaClient, gvr)
@@ -345,22 +345,22 @@ func (o *CommandPromoteOption) getObjInfo(f cmdutil.Factory, cluster string, arg
 func (o *CommandPromoteOption) printObjectAndPolicy(obj *unstructured.Unstructured, gvr schema.GroupVersionResource) error {
 	printer, err := o.Printer(nil, nil, false, false)
 	if err != nil {
-		return fmt.Errorf("failed to initialize k8s printer. err: %v", err)
+		return fmt.Errorf("failed to initialize k8s printer. err: %w", err)
 	}
 
 	if err = printer.PrintObj(obj, os.Stdout); err != nil {
-		return fmt.Errorf("failed to print the resource template. err: %v", err)
+		return fmt.Errorf("failed to print the resource template. err: %w", err)
 	}
 
 	if len(obj.GetNamespace()) == 0 {
 		cpp := buildClusterPropagationPolicy(o.name, o.Cluster, gvr, o.gvk)
 		if err = printer.PrintObj(cpp, os.Stdout); err != nil {
-			return fmt.Errorf("failed to print the ClusterPropagationPolicy. err: %v", err)
+			return fmt.Errorf("failed to print the ClusterPropagationPolicy. err: %w", err)
 		}
 	} else {
 		pp := buildPropagationPolicy(o.name, o.Namespace, o.Cluster, gvr, o.gvk)
 		if err = printer.PrintObj(pp, os.Stdout); err != nil {
-			return fmt.Errorf("failed to print the PropagationPolicy. err: %v", err)
+			return fmt.Errorf("failed to print the PropagationPolicy. err: %w", err)
 		}
 	}
 
@@ -379,7 +379,7 @@ func (o *CommandPromoteOption) createPropagationPolicy(karmadaClient *karmadacli
 		return err
 	}
 	if err != nil {
-		return fmt.Errorf("failed to get PropagationPolicy(%s/%s) in control plane: %v", o.Namespace, name, err)
+		return fmt.Errorf("failed to get PropagationPolicy(%s/%s) in control plane: %w", o.Namespace, name, err)
 	}
 
 	// PropagationPolicy already exists, not to create it
@@ -398,7 +398,7 @@ func (o *CommandPromoteOption) createClusterPropagationPolicy(karmadaClient *kar
 		return err
 	}
 	if err != nil {
-		return fmt.Errorf("failed to get ClusterPropagationPolicy(%s) in control plane: %v", name, err)
+		return fmt.Errorf("failed to get ClusterPropagationPolicy(%s) in control plane: %w", name, err)
 	}
 
 	// ClusterPropagationPolicy already exists, not to create it

--- a/pkg/karmadactl/register/register.go
+++ b/pkg/karmadactl/register/register.go
@@ -503,7 +503,7 @@ func (o *CommandRegisterOption) constructKarmadaAgentConfig(bootstrapClient *kub
 	err = wait.Poll(1*time.Second, o.Timeout, func() (done bool, err error) {
 		csrOK, err := bootstrapClient.CertificatesV1().CertificateSigningRequests().Get(context.TODO(), csrName, metav1.GetOptions{})
 		if err != nil {
-			return false, fmt.Errorf("failed to get the cluster csr %s. err: %v", o.ClusterName, err)
+			return false, fmt.Errorf("failed to get the cluster csr %s. err: %w", o.ClusterName, err)
 		}
 
 		if csrOK.Status.Certificate != nil {
@@ -561,7 +561,7 @@ func (o *CommandRegisterOption) createSecretAndRBACInMemberCluster(karmadaAgentC
 
 	// cerate karmada-kubeconfig secret to be used by karmada-agent component.
 	if err := cmdutil.CreateOrUpdateSecret(o.memberClusterClient, kubeConfigSecret); err != nil {
-		return fmt.Errorf("create secret %s failed: %v", kubeConfigSecret.Name, err)
+		return fmt.Errorf("create secret %s failed: %w", kubeConfigSecret.Name, err)
 	}
 
 	clusterRole := &rbacv1.ClusterRole{
@@ -741,7 +741,7 @@ func retrieveValidatedConfigInfo(client kubeclient.Interface, bootstrapTokenDisc
 	// Load the CACertHashes into a pubkeypin.Set
 	pubKeyPins := pubkeypin.NewSet()
 	if err = pubKeyPins.Allow(bootstrapTokenDiscovery.CACertHashes...); err != nil {
-		return nil, fmt.Errorf("invalid discovery token CA certificate hash: %v", err)
+		return nil, fmt.Errorf("invalid discovery token CA certificate hash: %w", err)
 	}
 
 	// Make sure the interval is not bigger than the duration

--- a/pkg/karmadactl/util/genericresource/builder.go
+++ b/pkg/karmadactl/util/genericresource/builder.go
@@ -61,7 +61,7 @@ func (b *Builder) Filename(recursive bool, filenames ...string) *Builder {
 		case strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://"):
 			u, err := url.Parse(s)
 			if err != nil {
-				b.errs = append(b.errs, fmt.Errorf("the URL passed to filename %q is not valid: %v", s, err))
+				b.errs = append(b.errs, fmt.Errorf("the URL passed to filename %q is not valid: %w", s, err))
 				continue
 			}
 			b.URL(defaultHTTPGetAttempts, u)
@@ -106,13 +106,13 @@ func (b *Builder) Path(recursive bool, paths ...string) *Builder {
 			continue
 		}
 		if err != nil {
-			b.errs = append(b.errs, fmt.Errorf("the path %q cannot be accessed: %v", p, err))
+			b.errs = append(b.errs, fmt.Errorf("the path %q cannot be accessed: %w", p, err))
 			continue
 		}
 
 		visitors, err := ExpandPathsToFileVisitors(b.mapper, p, recursive, resource.FileExtensions, b.schema)
 		if err != nil {
-			b.errs = append(b.errs, fmt.Errorf("error reading %q: %v", p, err))
+			b.errs = append(b.errs, fmt.Errorf("error reading %q: %w", p, err))
 		}
 
 		b.paths = append(b.paths, visitors...)
@@ -160,7 +160,7 @@ func expandIfFilePattern(pattern string) ([]string, error) {
 			return nil, fmt.Errorf("the path %q does not exist", pattern)
 		}
 		if errors.Is(err, filepath.ErrBadPattern) {
-			return nil, fmt.Errorf("pattern %q is not valid: %v", pattern, err)
+			return nil, fmt.Errorf("pattern %q is not valid: %w", pattern, err)
 		}
 		return matches, err
 	}

--- a/pkg/karmadactl/util/genericresource/visitor.go
+++ b/pkg/karmadactl/util/genericresource/visitor.go
@@ -180,7 +180,7 @@ func (v *StreamVisitor) Visit(fn VisitorFunc) error {
 			if errors.Is(err, io.EOF) {
 				return nil
 			}
-			return fmt.Errorf("error parsing %s: %v", v.Source, err)
+			return fmt.Errorf("error parsing %s: %w", v.Source, err)
 		}
 		// TODO: This needs to be able to handle object in other encodings and schemas.
 		ext.Raw = bytes.TrimSpace(ext.Raw)
@@ -188,7 +188,7 @@ func (v *StreamVisitor) Visit(fn VisitorFunc) error {
 			continue
 		}
 		if err := resource.ValidateSchema(ext.Raw, v.Schema); err != nil {
-			return fmt.Errorf("error validating %q: %v", v.Source, err)
+			return fmt.Errorf("error validating %q: %w", v.Source, err)
 		}
 		info, err := v.infoForData(ext.Raw, v.Source)
 		if err != nil {

--- a/pkg/karmadactl/util/idempotency.go
+++ b/pkg/karmadactl/util/idempotency.go
@@ -21,7 +21,7 @@ import (
 func CreateService(client kubeclient.Interface, service *corev1.Service) error {
 	if _, err := client.CoreV1().Services(service.Namespace).Create(context.TODO(), service, metav1.CreateOptions{}); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("unable to create Service: %v", err)
+			return fmt.Errorf("unable to create Service: %w", err)
 		}
 
 		klog.Warningf("Service %s is existed, creation process will skip", service.Name)
@@ -34,7 +34,7 @@ func CreateService(client kubeclient.Interface, service *corev1.Service) error {
 func CreateOrUpdateSecret(client kubeclient.Interface, secret *corev1.Secret) error {
 	if _, err := client.CoreV1().Secrets(secret.Namespace).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("unable to create Secret: %v", err)
+			return fmt.Errorf("unable to create Secret: %w", err)
 		}
 
 		existSecret, err := client.CoreV1().Secrets(secret.Namespace).Get(context.TODO(), secret.Name, metav1.GetOptions{})
@@ -45,7 +45,7 @@ func CreateOrUpdateSecret(client kubeclient.Interface, secret *corev1.Secret) er
 		secret.ResourceVersion = existSecret.ResourceVersion
 
 		if _, err := client.CoreV1().Secrets(secret.Namespace).Update(context.TODO(), secret, metav1.UpdateOptions{}); err != nil {
-			return fmt.Errorf("unable to update Secret: %v", err)
+			return fmt.Errorf("unable to update Secret: %w", err)
 		}
 	}
 	klog.V(2).Infof("Secret %s/%s has been created or updated.", secret.Namespace, secret.Name)
@@ -58,7 +58,7 @@ func CreateOrUpdateSecret(client kubeclient.Interface, secret *corev1.Secret) er
 func CreateOrUpdateDeployment(client kubeclient.Interface, deploy *appsv1.Deployment) error {
 	if _, err := client.AppsV1().Deployments(deploy.Namespace).Create(context.TODO(), deploy, metav1.CreateOptions{}); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("unable to create Deployment: %v", err)
+			return fmt.Errorf("unable to create Deployment: %w", err)
 		}
 
 		existDeployment, err := client.AppsV1().Deployments(deploy.Namespace).Get(context.TODO(), deploy.Name, metav1.GetOptions{})
@@ -69,7 +69,7 @@ func CreateOrUpdateDeployment(client kubeclient.Interface, deploy *appsv1.Deploy
 		deploy.ResourceVersion = existDeployment.ResourceVersion
 
 		if _, err := client.AppsV1().Deployments(deploy.Namespace).Update(context.TODO(), deploy, metav1.UpdateOptions{}); err != nil {
-			return fmt.Errorf("unable to update Deployment: %v", err)
+			return fmt.Errorf("unable to update Deployment: %w", err)
 		}
 	}
 	klog.V(2).Infof("Deployment %s/%s has been created or updated.", deploy.Namespace, deploy.Name)
@@ -82,7 +82,7 @@ func CreateOrUpdateDeployment(client kubeclient.Interface, deploy *appsv1.Deploy
 func CreateOrUpdateAPIService(apiRegistrationClient *aggregator.Clientset, apiservice *apiregistrationv1.APIService) error {
 	if _, err := apiRegistrationClient.ApiregistrationV1().APIServices().Create(context.TODO(), apiservice, metav1.CreateOptions{}); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("unable to create APIService: %v", err)
+			return fmt.Errorf("unable to create APIService: %w", err)
 		}
 
 		existAPIService, err := apiRegistrationClient.ApiregistrationV1().APIServices().Get(context.TODO(), apiservice.Name, metav1.GetOptions{})
@@ -93,7 +93,7 @@ func CreateOrUpdateAPIService(apiRegistrationClient *aggregator.Clientset, apise
 		apiservice.ResourceVersion = existAPIService.ResourceVersion
 
 		if _, err := apiRegistrationClient.ApiregistrationV1().APIServices().Update(context.TODO(), apiservice, metav1.UpdateOptions{}); err != nil {
-			return fmt.Errorf("unable to update APIService: %v", err)
+			return fmt.Errorf("unable to update APIService: %w", err)
 		}
 	}
 
@@ -106,7 +106,7 @@ func CreateOrUpdateAPIService(apiRegistrationClient *aggregator.Clientset, apise
 func CreateOrUpdateRole(client kubeclient.Interface, role *rbacv1.Role) error {
 	if _, err := client.RbacV1().Roles(role.Namespace).Create(context.TODO(), role, metav1.CreateOptions{}); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("unable to create RBAC role: %v", err)
+			return fmt.Errorf("unable to create RBAC role: %w", err)
 		}
 
 		existRole, err := client.RbacV1().Roles(role.Namespace).Get(context.TODO(), role.Name, metav1.GetOptions{})
@@ -117,7 +117,7 @@ func CreateOrUpdateRole(client kubeclient.Interface, role *rbacv1.Role) error {
 		role.ResourceVersion = existRole.ResourceVersion
 
 		if _, err := client.RbacV1().Roles(role.Namespace).Update(context.TODO(), role, metav1.UpdateOptions{}); err != nil {
-			return fmt.Errorf("unable to update RBAC role: %v", err)
+			return fmt.Errorf("unable to update RBAC role: %w", err)
 		}
 	}
 	klog.V(2).Infof("Role %s/%s has been created or updated.", role.Namespace, role.Name)
@@ -130,7 +130,7 @@ func CreateOrUpdateRole(client kubeclient.Interface, role *rbacv1.Role) error {
 func CreateOrUpdateRoleBinding(client kubeclient.Interface, roleBinding *rbacv1.RoleBinding) error {
 	if _, err := client.RbacV1().RoleBindings(roleBinding.Namespace).Create(context.TODO(), roleBinding, metav1.CreateOptions{}); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("unable to create RBAC rolebinding: %v", err)
+			return fmt.Errorf("unable to create RBAC rolebinding: %w", err)
 		}
 
 		existRoleBinding, err := client.RbacV1().RoleBindings(roleBinding.Namespace).Get(context.TODO(), roleBinding.Name, metav1.GetOptions{})
@@ -141,7 +141,7 @@ func CreateOrUpdateRoleBinding(client kubeclient.Interface, roleBinding *rbacv1.
 		roleBinding.ResourceVersion = existRoleBinding.ResourceVersion
 
 		if _, err := client.RbacV1().RoleBindings(roleBinding.Namespace).Update(context.TODO(), roleBinding, metav1.UpdateOptions{}); err != nil {
-			return fmt.Errorf("unable to update RBAC rolebinding: %v", err)
+			return fmt.Errorf("unable to update RBAC rolebinding: %w", err)
 		}
 	}
 	klog.V(2).Infof("RoleBinding %s/%s has been created or updated.", roleBinding.Namespace, roleBinding.Name)
@@ -154,7 +154,7 @@ func CreateOrUpdateRoleBinding(client kubeclient.Interface, roleBinding *rbacv1.
 func CreateOrUpdateClusterRole(client kubeclient.Interface, clusterRole *rbacv1.ClusterRole) error {
 	if _, err := client.RbacV1().ClusterRoles().Create(context.TODO(), clusterRole, metav1.CreateOptions{}); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("unable to create ClusterRole: %v", err)
+			return fmt.Errorf("unable to create ClusterRole: %w", err)
 		}
 
 		existClusterRole, err := client.RbacV1().ClusterRoles().Get(context.TODO(), clusterRole.Name, metav1.GetOptions{})
@@ -165,7 +165,7 @@ func CreateOrUpdateClusterRole(client kubeclient.Interface, clusterRole *rbacv1.
 		clusterRole.ResourceVersion = existClusterRole.ResourceVersion
 
 		if _, err := client.RbacV1().ClusterRoles().Update(context.TODO(), clusterRole, metav1.UpdateOptions{}); err != nil {
-			return fmt.Errorf("unable to update ClusterRole: %v", err)
+			return fmt.Errorf("unable to update ClusterRole: %w", err)
 		}
 	}
 	klog.V(2).Infof("ClusterRole %s has been created or updated.", clusterRole.Name)
@@ -178,7 +178,7 @@ func CreateOrUpdateClusterRole(client kubeclient.Interface, clusterRole *rbacv1.
 func CreateOrUpdateClusterRoleBinding(client kubernetes.Interface, clusterRoleBinding *rbacv1.ClusterRoleBinding) error {
 	if _, err := client.RbacV1().ClusterRoleBindings().Create(context.TODO(), clusterRoleBinding, metav1.CreateOptions{}); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("unable to create ClusterRoleBinding: %v", err)
+			return fmt.Errorf("unable to create ClusterRoleBinding: %w", err)
 		}
 
 		existCrb, err := client.RbacV1().ClusterRoleBindings().Get(context.TODO(), clusterRoleBinding.Name, metav1.GetOptions{})
@@ -189,7 +189,7 @@ func CreateOrUpdateClusterRoleBinding(client kubernetes.Interface, clusterRoleBi
 		clusterRoleBinding.ResourceVersion = existCrb.ResourceVersion
 
 		if _, err := client.RbacV1().ClusterRoleBindings().Update(context.TODO(), clusterRoleBinding, metav1.UpdateOptions{}); err != nil {
-			return fmt.Errorf("unable to update ClusterRolebinding: %v", err)
+			return fmt.Errorf("unable to update ClusterRolebinding: %w", err)
 		}
 	}
 	klog.V(2).Infof("ClusterRolebinding %s has been created or updated.", clusterRoleBinding.Name)
@@ -202,7 +202,7 @@ func CreateOrUpdateClusterRoleBinding(client kubernetes.Interface, clusterRoleBi
 func CreateOrUpdateConfigMap(client *kubeclient.Clientset, cm *corev1.ConfigMap) error {
 	if _, err := client.CoreV1().ConfigMaps(cm.Namespace).Create(context.TODO(), cm, metav1.CreateOptions{}); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("unable to create ConfigMap: %v", err)
+			return fmt.Errorf("unable to create ConfigMap: %w", err)
 		}
 
 		existCm, err := client.CoreV1().ConfigMaps(cm.Namespace).Get(context.TODO(), cm.Name, metav1.GetOptions{})
@@ -213,7 +213,7 @@ func CreateOrUpdateConfigMap(client *kubeclient.Clientset, cm *corev1.ConfigMap)
 		cm.ResourceVersion = existCm.ResourceVersion
 
 		if _, err := client.CoreV1().ConfigMaps(cm.Namespace).Update(context.TODO(), cm, metav1.UpdateOptions{}); err != nil {
-			return fmt.Errorf("unable to update ConfigMap: %v", err)
+			return fmt.Errorf("unable to update ConfigMap: %w", err)
 		}
 	}
 	klog.V(2).Infof("ConfigMap %s/%s has been created or updated.", cm.Namespace, cm.Name)
@@ -235,7 +235,7 @@ func NewNamespace(name string) *corev1.Namespace {
 func CreateOrUpdateNamespace(client kubeclient.Interface, ns *corev1.Namespace) error {
 	if _, err := client.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{}); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("unable to create Namespace: %v", err)
+			return fmt.Errorf("unable to create Namespace: %w", err)
 		}
 
 		existNs, err := client.CoreV1().Namespaces().Get(context.TODO(), ns.Name, metav1.GetOptions{})
@@ -246,7 +246,7 @@ func CreateOrUpdateNamespace(client kubeclient.Interface, ns *corev1.Namespace) 
 		ns.ResourceVersion = existNs.ResourceVersion
 
 		if _, err := client.CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{}); err != nil {
-			return fmt.Errorf("unable to update Namespace: %v", err)
+			return fmt.Errorf("unable to update Namespace: %w", err)
 		}
 	}
 	klog.Infof("Namespace %s has been created or updated.", ns.Name)
@@ -259,7 +259,7 @@ func CreateOrUpdateNamespace(client kubeclient.Interface, ns *corev1.Namespace) 
 func CreateOrUpdateService(client kubernetes.Interface, svc *corev1.Service) error {
 	if _, err := client.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{}); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("unable to create Service: %v", err)
+			return fmt.Errorf("unable to create Service: %w", err)
 		}
 
 		existSvc, err := client.CoreV1().Services(svc.Namespace).Get(context.TODO(), svc.Name, metav1.GetOptions{})
@@ -270,7 +270,7 @@ func CreateOrUpdateService(client kubernetes.Interface, svc *corev1.Service) err
 		svc.ResourceVersion = existSvc.ResourceVersion
 
 		if _, err := client.CoreV1().Services(svc.Namespace).Update(context.TODO(), svc, metav1.UpdateOptions{}); err != nil {
-			return fmt.Errorf("unable to update Service: %v", err)
+			return fmt.Errorf("unable to update Service: %w", err)
 		}
 	}
 	klog.Infof("Service %s/%s has been created or updated.", svc.Namespace, svc.Name)

--- a/pkg/printers/tablegenerator.go
+++ b/pkg/printers/tablegenerator.go
@@ -125,7 +125,7 @@ func (h *HumanReadableGenerator) GenerateTable(obj runtime.Object, options Gener
 func (h *HumanReadableGenerator) TableHandler(columnDefinitions []metav1.TableColumnDefinition, printFunc interface{}) error {
 	printFuncValue := reflect.ValueOf(printFunc)
 	if err := ValidateRowPrintHandlerFunc(printFuncValue); err != nil {
-		utilruntime.HandleError(fmt.Errorf("unable to register print function: %v", err))
+		utilruntime.HandleError(fmt.Errorf("unable to register print function: %w", err))
 		return err
 	}
 	entry := &handlerEntry{

--- a/pkg/resourceinterpreter/configurableinterpreter/configmanager/manager.go
+++ b/pkg/resourceinterpreter/configurableinterpreter/configmanager/manager.go
@@ -82,7 +82,7 @@ func NewInterpreterConfigManager(informer genericmanager.SingleClusterInformerMa
 func (configManager *interpreterConfigManager) updateConfiguration() {
 	configurations, err := configManager.lister.List(labels.Everything())
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("error updating configuration: %v", err))
+		utilruntime.HandleError(fmt.Errorf("error updating configuration: %w", err))
 		return
 	}
 

--- a/pkg/resourceinterpreter/configurableinterpreter/luavm/lua.go
+++ b/pkg/resourceinterpreter/configurableinterpreter/luavm/lua.go
@@ -341,12 +341,12 @@ func decodeValue(L *lua.LState, value interface{}) (lua.LValue, error) {
 	// Other types can't be handled, ask for help from json
 	data, err := json.Marshal(value)
 	if err != nil {
-		return nil, fmt.Errorf("json Marshal obj %#v error: %v", value, err)
+		return nil, fmt.Errorf("json Marshal obj %#v error: %w", value, err)
 	}
 
 	lv, err := luajson.Decode(L, data)
 	if err != nil {
-		return nil, fmt.Errorf("lua Decode obj %#v error: %v", value, err)
+		return nil, fmt.Errorf("lua Decode obj %#v error: %w", value, err)
 	}
 	return lv, nil
 }

--- a/pkg/resourceinterpreter/configurableinterpreter/luavm/lua_convert.go
+++ b/pkg/resourceinterpreter/configurableinterpreter/luavm/lua_convert.go
@@ -72,7 +72,7 @@ func ConvertLuaResultInto(luaResult lua.LValue, obj interface{}) error {
 
 	jsonBytes, err := luajson.Encode(luaResult)
 	if err != nil {
-		return fmt.Errorf("json Encode obj eroor %v", err)
+		return fmt.Errorf("json Encode obj eroor %w", err)
 	}
 
 	//  for lua an empty object by json encode be [] not {}
@@ -82,7 +82,7 @@ func ConvertLuaResultInto(luaResult lua.LValue, obj interface{}) error {
 
 	err = json.Unmarshal(jsonBytes, obj)
 	if err != nil {
-		return fmt.Errorf("can not unmarshal %v to %#v：%v", string(jsonBytes), obj, err)
+		return fmt.Errorf("can not unmarshal %v to %#v：%w", string(jsonBytes), obj, err)
 	}
 	return nil
 }

--- a/pkg/resourceinterpreter/customizedinterpreter/configmanager/manager.go
+++ b/pkg/resourceinterpreter/customizedinterpreter/configmanager/manager.go
@@ -79,7 +79,7 @@ func NewExploreConfigManager(inform genericmanager.SingleClusterInformerManager)
 func (m *interpreterConfigManager) updateConfiguration() {
 	configurations, err := m.lister.List(labels.Everything())
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("error updating configuration: %v", err))
+		utilruntime.HandleError(fmt.Errorf("error updating configuration: %w", err))
 		return
 	}
 

--- a/pkg/resourceinterpreter/defaultinterpreter/dependencies.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/dependencies.go
@@ -32,7 +32,7 @@ func getAllDefaultDependenciesInterpreter() map[schema.GroupVersionKind]dependen
 func getDeploymentDependencies(object *unstructured.Unstructured) ([]configv1alpha1.DependentObjectReference, error) {
 	deploymentObj := &appsv1.Deployment{}
 	if err := helper.ConvertToTypedObject(object, deploymentObj); err != nil {
-		return nil, fmt.Errorf("failed to convert Deployment from unstructured object: %v", err)
+		return nil, fmt.Errorf("failed to convert Deployment from unstructured object: %w", err)
 	}
 
 	podObj, err := lifted.GetPodFromTemplate(&deploymentObj.Spec.Template, deploymentObj, nil)
@@ -47,7 +47,7 @@ func getJobDependencies(object *unstructured.Unstructured) ([]configv1alpha1.Dep
 	jobObj := &batchv1.Job{}
 	err := helper.ConvertToTypedObject(object, jobObj)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert Job from unstructured object: %v", err)
+		return nil, fmt.Errorf("failed to convert Job from unstructured object: %w", err)
 	}
 
 	podObj, err := lifted.GetPodFromTemplate(&jobObj.Spec.Template, jobObj, nil)
@@ -62,7 +62,7 @@ func getCronJobDependencies(object *unstructured.Unstructured) ([]configv1alpha1
 	cronjobObj := &batchv1.CronJob{}
 	err := helper.ConvertToTypedObject(object, cronjobObj)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert CronJob from unstructured object: %v", err)
+		return nil, fmt.Errorf("failed to convert CronJob from unstructured object: %w", err)
 	}
 
 	podObj, err := lifted.GetPodFromTemplate(&cronjobObj.Spec.JobTemplate.Spec.Template, cronjobObj, nil)
@@ -77,7 +77,7 @@ func getPodDependencies(object *unstructured.Unstructured) ([]configv1alpha1.Dep
 	podObj := &corev1.Pod{}
 	err := helper.ConvertToTypedObject(object, podObj)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert Pod from unstructured object: %v", err)
+		return nil, fmt.Errorf("failed to convert Pod from unstructured object: %w", err)
 	}
 
 	return getDependenciesFromPodTemplate(podObj)
@@ -87,7 +87,7 @@ func getDaemonSetDependencies(object *unstructured.Unstructured) ([]configv1alph
 	daemonSetObj := &appsv1.DaemonSet{}
 	err := helper.ConvertToTypedObject(object, daemonSetObj)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert DaemonSet from unstructured object: %v", err)
+		return nil, fmt.Errorf("failed to convert DaemonSet from unstructured object: %w", err)
 	}
 
 	podObj, err := lifted.GetPodFromTemplate(&daemonSetObj.Spec.Template, daemonSetObj, nil)
@@ -102,7 +102,7 @@ func getStatefulSetDependencies(object *unstructured.Unstructured) ([]configv1al
 	statefulSetObj := &appsv1.StatefulSet{}
 	err := helper.ConvertToTypedObject(object, statefulSetObj)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert StatefulSet from unstructured object: %v", err)
+		return nil, fmt.Errorf("failed to convert StatefulSet from unstructured object: %w", err)
 	}
 
 	podObj, err := lifted.GetPodFromTemplate(&statefulSetObj.Spec.Template, statefulSetObj, nil)

--- a/pkg/resourceinterpreter/defaultinterpreter/reflectstatus.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/reflectstatus.go
@@ -46,7 +46,7 @@ func reflectDeploymentStatus(object *unstructured.Unstructured) (*runtime.RawExt
 
 	deploymentStatus := &appsv1.DeploymentStatus{}
 	if err = helper.ConvertToTypedObject(statusMap, deploymentStatus); err != nil {
-		return nil, fmt.Errorf("failed to convert DeploymentStatus from map[string]interface{}: %v", err)
+		return nil, fmt.Errorf("failed to convert DeploymentStatus from map[string]interface{}: %w", err)
 	}
 
 	grabStatus := appsv1.DeploymentStatus{
@@ -88,7 +88,7 @@ func reflectServiceStatus(object *unstructured.Unstructured) (*runtime.RawExtens
 	serviceStatus := &corev1.ServiceStatus{}
 	err = helper.ConvertToTypedObject(statusMap, serviceStatus)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert ServiceStatus from map[string]interface{}: %v", err)
+		return nil, fmt.Errorf("failed to convert ServiceStatus from map[string]interface{}: %w", err)
 	}
 
 	grabStatus := corev1.ServiceStatus{
@@ -117,7 +117,7 @@ func reflectJobStatus(object *unstructured.Unstructured) (*runtime.RawExtension,
 	jobStatus := &batchv1.JobStatus{}
 	err = helper.ConvertToTypedObject(statusMap, jobStatus)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert JobStatus from map[string]interface{}: %v", err)
+		return nil, fmt.Errorf("failed to convert JobStatus from map[string]interface{}: %w", err)
 	}
 
 	grabStatus := batchv1.JobStatus{
@@ -147,7 +147,7 @@ func reflectDaemonSetStatus(object *unstructured.Unstructured) (*runtime.RawExte
 	daemonSetStatus := &appsv1.DaemonSetStatus{}
 	err = helper.ConvertToTypedObject(statusMap, daemonSetStatus)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert DaemonSetStatus from map[string]interface{}: %v", err)
+		return nil, fmt.Errorf("failed to convert DaemonSetStatus from map[string]interface{}: %w", err)
 	}
 
 	grabStatus := appsv1.DaemonSetStatus{
@@ -178,7 +178,7 @@ func reflectStatefulSetStatus(object *unstructured.Unstructured) (*runtime.RawEx
 	statefulSetStatus := &appsv1.StatefulSetStatus{}
 	err = helper.ConvertToTypedObject(statusMap, statefulSetStatus)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert StatefulSetStatus from map[string]interface{}: %v", err)
+		return nil, fmt.Errorf("failed to convert StatefulSetStatus from map[string]interface{}: %w", err)
 	}
 
 	grabStatus := appsv1.StatefulSetStatus{
@@ -207,7 +207,7 @@ func reflectPodDisruptionBudgetStatus(object *unstructured.Unstructured) (*runti
 	pdbStatus := &policyv1.PodDisruptionBudgetStatus{}
 	err = helper.ConvertToTypedObject(statusMap, pdbStatus)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert PodDisruptionBudget from map[string]interface{}: %v", err)
+		return nil, fmt.Errorf("failed to convert PodDisruptionBudget from map[string]interface{}: %w", err)
 	}
 
 	grabStatus := policyv1.PodDisruptionBudgetStatus{

--- a/pkg/resourceinterpreter/defaultinterpreter/retain.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/retain.go
@@ -31,13 +31,13 @@ func retainPodFields(desired, observed *unstructured.Unstructured) (*unstructure
 	desiredPod := &corev1.Pod{}
 	err := helper.ConvertToTypedObject(desired, desiredPod)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert desiredPod from unstructured object: %v", err)
+		return nil, fmt.Errorf("failed to convert desiredPod from unstructured object: %w", err)
 	}
 
 	clusterPod := &corev1.Pod{}
 	err = helper.ConvertToTypedObject(observed, clusterPod)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert clusterPod from unstructured object: %v", err)
+		return nil, fmt.Errorf("failed to convert clusterPod from unstructured object: %w", err)
 	}
 
 	desiredPod.Spec.NodeName = clusterPod.Spec.NodeName
@@ -55,7 +55,7 @@ func retainPodFields(desired, observed *unstructured.Unstructured) (*unstructure
 
 	unstructuredObj, err := helper.ToUnstructured(desiredPod)
 	if err != nil {
-		return nil, fmt.Errorf("failed to transform Pod: %v", err)
+		return nil, fmt.Errorf("failed to transform Pod: %w", err)
 	}
 
 	return unstructuredObj, nil
@@ -79,11 +79,11 @@ func retainPersistentVolumeFields(desired, observed *unstructured.Unstructured) 
 	// claimRef is updated by kube-controller-manager.
 	claimRef, ok, err := unstructured.NestedFieldNoCopy(observed.Object, "spec", "claimRef")
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve claimRef from pv: %v", err)
+		return nil, fmt.Errorf("failed to retrieve claimRef from pv: %w", err)
 	}
 	if ok {
 		if err = unstructured.SetNestedField(desired.Object, claimRef, "spec", "claimRef"); err != nil {
-			return nil, fmt.Errorf("failed to set claimRef for pv: %v", err)
+			return nil, fmt.Errorf("failed to set claimRef for pv: %w", err)
 		}
 	}
 	return desired, nil

--- a/pkg/scheduler/core/assignment.go
+++ b/pkg/scheduler/core/assignment.go
@@ -153,7 +153,7 @@ func assignByDynamicStrategy(state *assignState) ([]workv1alpha2.TargetCluster, 
 		// We need to reduce the replicas in terms of the previous result.
 		result, err := dynamicScaleDown(state)
 		if err != nil {
-			return nil, fmt.Errorf("failed to scale down: %v", err)
+			return nil, fmt.Errorf("failed to scale down: %w", err)
 		}
 		return result, nil
 	} else if state.assignedReplicas < state.spec.Replicas {
@@ -161,7 +161,7 @@ func assignByDynamicStrategy(state *assignState) ([]workv1alpha2.TargetCluster, 
 		// First scheduling is considered as a special kind of scaling up.
 		result, err := dynamicScaleUp(state)
 		if err != nil {
-			return nil, fmt.Errorf("failed to scale up: %v", err)
+			return nil, fmt.Errorf("failed to scale up: %w", err)
 		}
 		return result, nil
 	} else {

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -60,7 +60,7 @@ func (g *genericScheduler) Schedule(ctx context.Context, placement *policyv1alph
 
 	feasibleClusters, diagnosis, err := g.findClustersThatFit(ctx, g.scheduleFramework, placement, spec, &clusterInfoSnapshot)
 	if err != nil {
-		return result, fmt.Errorf("failed to findClustersThatFit: %v", err)
+		return result, fmt.Errorf("failed to findClustersThatFit: %w", err)
 	}
 
 	// Short path for case no cluster fit.
@@ -74,19 +74,19 @@ func (g *genericScheduler) Schedule(ctx context.Context, placement *policyv1alph
 
 	clustersScore, err := g.prioritizeClusters(ctx, g.scheduleFramework, placement, spec, feasibleClusters)
 	if err != nil {
-		return result, fmt.Errorf("failed to prioritizeClusters: %v", err)
+		return result, fmt.Errorf("failed to prioritizeClusters: %w", err)
 	}
 	klog.V(4).Infof("Feasible clusters scores: %v", clustersScore)
 
 	clusters, err := g.selectClusters(clustersScore, placement, spec)
 	if err != nil {
-		return result, fmt.Errorf("failed to select clusters: %v", err)
+		return result, fmt.Errorf("failed to select clusters: %w", err)
 	}
 	klog.V(4).Infof("Selected clusters: %v", clusters)
 
 	clustersWithReplicas, err := g.assignReplicas(clusters, placement.ReplicaScheduling, spec)
 	if err != nil {
-		return result, fmt.Errorf("failed to assignReplicas: %v", err)
+		return result, fmt.Errorf("failed to assignReplicas: %w", err)
 	}
 	if scheduleAlgorithmOption.EnableEmptyWorkloadPropagation {
 		clustersWithReplicas = attachZeroReplicasCluster(clusters, clustersWithReplicas)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -501,15 +501,15 @@ func (s *Scheduler) patchScheduleResultForResourceBinding(oldBinding *workv1alph
 
 	oldData, err := json.Marshal(oldBinding)
 	if err != nil {
-		return fmt.Errorf("failed to marshal the existing resource binding(%s/%s): %v", oldBinding.Namespace, oldBinding.Name, err)
+		return fmt.Errorf("failed to marshal the existing resource binding(%s/%s): %w", oldBinding.Namespace, oldBinding.Name, err)
 	}
 	newData, err := json.Marshal(newBinding)
 	if err != nil {
-		return fmt.Errorf("failed to marshal the new resource binding(%s/%s): %v", newBinding.Namespace, newBinding.Name, err)
+		return fmt.Errorf("failed to marshal the new resource binding(%s/%s): %w", newBinding.Namespace, newBinding.Name, err)
 	}
 	patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)
 	if err != nil {
-		return fmt.Errorf("failed to create a merge patch: %v", err)
+		return fmt.Errorf("failed to create a merge patch: %w", err)
 	}
 	if "{}" == string(patchBytes) {
 		return nil
@@ -558,15 +558,15 @@ func (s *Scheduler) patchScheduleResultForClusterResourceBinding(oldBinding *wor
 
 	oldData, err := json.Marshal(oldBinding)
 	if err != nil {
-		return fmt.Errorf("failed to marshal the existing cluster resource binding(%s): %v", oldBinding.Name, err)
+		return fmt.Errorf("failed to marshal the existing cluster resource binding(%s): %w", oldBinding.Name, err)
 	}
 	newData, err := json.Marshal(newBinding)
 	if err != nil {
-		return fmt.Errorf("failed to marshal the new resource binding(%s): %v", newBinding.Name, err)
+		return fmt.Errorf("failed to marshal the new resource binding(%s): %w", newBinding.Name, err)
 	}
 	patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)
 	if err != nil {
-		return fmt.Errorf("failed to create a merge patch: %v", err)
+		return fmt.Errorf("failed to create a merge patch: %w", err)
 	}
 	if "{}" == string(patchBytes) {
 		return nil
@@ -644,7 +644,7 @@ func (s *Scheduler) patchBindingScheduleStatus(rb *workv1alpha2.ResourceBinding,
 
 	patchBytes, err := helper.GenMergePatch(rb, modifiedObj)
 	if err != nil {
-		return fmt.Errorf("failed to create a merge patch: %v", err)
+		return fmt.Errorf("failed to create a merge patch: %w", err)
 	}
 
 	_, err = s.KarmadaClient.WorkV1alpha2().ResourceBindings(rb.Namespace).Patch(context.TODO(), rb.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}, "status")
@@ -678,7 +678,7 @@ func (s *Scheduler) patchClusterBindingScheduleStatus(crb *workv1alpha2.ClusterR
 
 	patchBytes, err := helper.GenMergePatch(crb, modifiedObj)
 	if err != nil {
-		return fmt.Errorf("failed to create a merge patch: %v", err)
+		return fmt.Errorf("failed to create a merge patch: %w", err)
 	}
 
 	_, err = s.KarmadaClient.WorkV1alpha2().ClusterResourceBindings().Patch(context.TODO(), crb.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}, "status")

--- a/pkg/search/backendstore/opensearch.go
+++ b/pkg/search/backendstore/opensearch.go
@@ -115,7 +115,7 @@ func NewOpenSearch(cluster string, cfg *searchv1alpha1.BackendStoreConfig) (*Ope
 		indices: make(map[string]struct{})}
 
 	if err := os.initClient(cfg); err != nil {
-		return nil, fmt.Errorf("cannot init client: %v", err)
+		return nil, fmt.Errorf("cannot init client: %w", err)
 	}
 
 	return os, nil
@@ -249,7 +249,7 @@ func (os *OpenSearch) indexName(us *unstructured.Unstructured) (string, error) {
 			os.indices[name] = struct{}{}
 			return name, nil
 		}
-		return name, fmt.Errorf("cannot create index: %v", err)
+		return name, fmt.Errorf("cannot create index: %w", err)
 	}
 	if resp.IsError() {
 		if strings.Contains(resp.String(), "resource_already_exists_exception") {
@@ -298,12 +298,12 @@ func (os *OpenSearch) initClient(bsc *searchv1alpha1.BackendStoreConfig) error {
 
 	client, err := opensearch.NewClient(cfg)
 	if err != nil {
-		return fmt.Errorf("cannot create opensearch client: %v", err)
+		return fmt.Errorf("cannot create opensearch client: %w", err)
 	}
 
 	info, err := client.Info()
 	if err != nil {
-		return fmt.Errorf("cannot get opensearch info: %v", err)
+		return fmt.Errorf("cannot get opensearch info: %w", err)
 	}
 
 	klog.V(4).Infof("Opensearch client: %v", info)

--- a/pkg/search/proxy/store/multi_cluster_cache.go
+++ b/pkg/search/proxy/store/multi_cluster_cache.go
@@ -366,7 +366,7 @@ func (c *MultiClusterCache) getResourceFromCache(ctx context.Context, gvr schema
 			continue
 		}
 		if err != nil {
-			return nil, "", nil, fmt.Errorf("fail to get %v %v from %v: %v", namespace, name, clusterName, err)
+			return nil, "", nil, fmt.Errorf("fail to get %v %v from %v: %w", namespace, name, clusterName, err)
 		}
 		findObjects = append(findObjects, obj)
 		findCaches = append(findCaches, cache)

--- a/pkg/util/clusterrole.go
+++ b/pkg/util/clusterrole.go
@@ -17,7 +17,7 @@ func EnsureClusterRoleExist(client kubeclient.Interface, clusterRole *rbacv1.Clu
 
 	exist, err := IsClusterRoleExist(client, clusterRole.Name)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check if ClusterRole exist. ClusterRole: %s, error: %v", clusterRole.Name, err)
+		return nil, fmt.Errorf("failed to check if ClusterRole exist. ClusterRole: %s, error: %w", clusterRole.Name, err)
 	}
 	if exist {
 		klog.V(1).Infof("Ensure ClusterRole succeed as already exist. ClusterRole: %s", clusterRole.Name)
@@ -26,7 +26,7 @@ func EnsureClusterRoleExist(client kubeclient.Interface, clusterRole *rbacv1.Clu
 
 	createdObj, err := CreateClusterRole(client, clusterRole)
 	if err != nil {
-		return nil, fmt.Errorf("ensure ClusterRole failed due to create failed. ClusterRole: %s, error: %v", clusterRole.Name, err)
+		return nil, fmt.Errorf("ensure ClusterRole failed due to create failed. ClusterRole: %s, error: %w", clusterRole.Name, err)
 	}
 
 	return createdObj, nil
@@ -41,7 +41,7 @@ func EnsureClusterRoleBindingExist(client kubeclient.Interface, clusterRoleBindi
 
 	exist, err := IsClusterRoleBindingExist(client, clusterRoleBinding.Name)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check if ClusterRole exist. ClusterRole: %s, error: %v", clusterRoleBinding.Name, err)
+		return nil, fmt.Errorf("failed to check if ClusterRole exist. ClusterRole: %s, error: %w", clusterRoleBinding.Name, err)
 	}
 	if exist {
 		klog.V(1).Infof("Ensure ClusterRole succeed as already exist. ClusterRole: %s", clusterRoleBinding.Name)
@@ -50,7 +50,7 @@ func EnsureClusterRoleBindingExist(client kubeclient.Interface, clusterRoleBindi
 
 	createdObj, err := CreateClusterRoleBinding(client, clusterRoleBinding)
 	if err != nil {
-		return nil, fmt.Errorf("ensure ClusterRole failed due to create failed. ClusterRole: %s, error: %v", clusterRoleBinding.Name, err)
+		return nil, fmt.Errorf("ensure ClusterRole failed due to create failed. ClusterRole: %s, error: %w", clusterRoleBinding.Name, err)
 	}
 
 	return createdObj, nil

--- a/pkg/util/credential.go
+++ b/pkg/util/credential.go
@@ -57,7 +57,7 @@ func ObtainCredentialsFromMemberCluster(clusterKubeClient kubeclient.Interface, 
 
 		impersonatorSecret, err = WaitForServiceAccountSecretCreation(clusterKubeClient, impersonationSA)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to get serviceAccount secret for impersonation from cluster(%s), error: %v", opts.ClusterName, err)
+			return nil, nil, fmt.Errorf("failed to get serviceAccount secret for impersonation from cluster(%s), error: %w", opts.ClusterName, err)
 		}
 	}
 	if opts.IsKubeCredentialsEnabled() {
@@ -87,7 +87,7 @@ func ObtainCredentialsFromMemberCluster(clusterKubeClient kubeclient.Interface, 
 		}
 		clusterSecret, err = WaitForServiceAccountSecretCreation(clusterKubeClient, serviceAccountObj)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to get serviceAccount secret from cluster(%s), error: %v", opts.ClusterName, err)
+			return nil, nil, fmt.Errorf("failed to get serviceAccount secret from cluster(%s), error: %w", opts.ClusterName, err)
 		}
 	}
 	if opts.DryRun {
@@ -120,7 +120,7 @@ func RegisterClusterInControllerPlane(opts ClusterRegisterOption, controlPlaneKu
 		}
 		impersonatorSecret, err = CreateSecret(controlPlaneKubeClient, impersonatorSecret)
 		if err != nil {
-			return fmt.Errorf("failed to create impersonator secret in control plane. error: %v", err)
+			return fmt.Errorf("failed to create impersonator secret in control plane. error: %w", err)
 		}
 		opts.ImpersonatorSecret = *impersonatorSecret
 	}
@@ -139,7 +139,7 @@ func RegisterClusterInControllerPlane(opts ClusterRegisterOption, controlPlaneKu
 
 		secret, err = CreateSecret(controlPlaneKubeClient, secret)
 		if err != nil {
-			return fmt.Errorf("failed to create secret in control plane. error: %v", err)
+			return fmt.Errorf("failed to create secret in control plane. error: %w", err)
 		}
 		opts.Secret = *secret
 	}
@@ -157,14 +157,14 @@ func RegisterClusterInControllerPlane(opts ClusterRegisterOption, controlPlaneKu
 	if opts.IsKubeImpersonatorEnabled() {
 		err = PatchSecret(controlPlaneKubeClient, impersonatorSecret.Namespace, impersonatorSecret.Name, types.MergePatchType, patchSecretBody)
 		if err != nil {
-			return fmt.Errorf("failed to patch impersonator secret %s/%s, error: %v", impersonatorSecret.Namespace, impersonatorSecret.Name, err)
+			return fmt.Errorf("failed to patch impersonator secret %s/%s, error: %w", impersonatorSecret.Namespace, impersonatorSecret.Name, err)
 		}
 	}
 
 	if opts.IsKubeCredentialsEnabled() {
 		err = PatchSecret(controlPlaneKubeClient, secret.Namespace, secret.Name, types.MergePatchType, patchSecretBody)
 		if err != nil {
-			return fmt.Errorf("failed to patch secret %s/%s, error: %v", secret.Namespace, secret.Name, err)
+			return fmt.Errorf("failed to patch secret %s/%s, error: %w", secret.Namespace, secret.Name, err)
 		}
 	}
 	return nil

--- a/pkg/util/dial.go
+++ b/pkg/util/dial.go
@@ -20,7 +20,7 @@ func Dial(path string, timeout time.Duration) (*grpc.ClientConn, error) {
 	}
 	cc, err := grpc.DialContext(ctx, path, opts...)
 	if err != nil {
-		return nil, fmt.Errorf("dial %s error: %v", path, err)
+		return nil, fmt.Errorf("dial %s error: %w", path, err)
 	}
 
 	return cc, nil

--- a/pkg/util/fedinformer/keys/keys.go
+++ b/pkg/util/fedinformer/keys/keys.go
@@ -71,7 +71,7 @@ func ClusterWideKeyFunc(obj interface{}) (ClusterWideKey, error) {
 
 	metaInfo, err := meta.Accessor(obj)
 	if err != nil { // should not happen
-		return key, fmt.Errorf("object has no meta: %v", err)
+		return key, fmt.Errorf("object has no meta: %w", err)
 	}
 
 	gvk := runtimeObject.GetObjectKind().GroupVersionKind()

--- a/pkg/util/helper/policy_test.go
+++ b/pkg/util/helper/policy_test.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -355,7 +356,7 @@ func TestGetAppliedPlacement(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res, err := GetAppliedPlacement(tt.annotations)
-			if !reflect.DeepEqual(res, tt.expectedPlacement) || err != tt.expectedErr {
+			if !reflect.DeepEqual(res, tt.expectedPlacement) || !errors.Is(err, tt.expectedErr) {
 				t.Errorf("expected %v and %v, but got %v and %v", tt.expectedPlacement, tt.expectedErr, res, err)
 			}
 		})

--- a/pkg/util/lifted/discovery.go
+++ b/pkg/util/lifted/discovery.go
@@ -38,6 +38,8 @@ import (
 func GetDeletableResources(discoveryClient discovery.ServerResourcesInterface) map[schema.GroupVersionResource]struct{} {
 	preferredResources, err := discoveryClient.ServerPreferredResources()
 	if err != nil {
+		//nolint:errorlint
+		// disable `error format` check for backward compatibility.
 		if discovery.IsGroupDiscoveryFailedError(err) {
 			klog.Warningf("Failed to discover some groups: %v", err.(*discovery.ErrGroupDiscoveryFailed).Groups)
 		} else {

--- a/pkg/util/lifted/podtemplate.go
+++ b/pkg/util/lifted/podtemplate.go
@@ -75,6 +75,8 @@ func GetPodFromTemplate(template *corev1.PodTemplateSpec, parentObject runtime.O
 	desiredFinalizers := getPodsFinalizers(template)
 	desiredAnnotations := getPodsAnnotationSet(template)
 	accessor, err := meta.Accessor(parentObject)
+	//nolint:errorlint
+	// disable `error format` check for backward compatibility.
 	if err != nil {
 		return nil, fmt.Errorf("parentObject does not have ObjectMeta, %v", err)
 	}

--- a/pkg/util/lifted/pubkeypin/pubkeypin.go
+++ b/pkg/util/lifted/pubkeypin/pubkeypin.go
@@ -63,6 +63,8 @@ func (s *Set) Allow(pubKeyHashes ...string) error {
 
 		switch strings.ToLower(format) {
 		case "sha256":
+			//nolint:errorlint
+			// disable `error format` check for backward compatibility.
 			if err := s.allowSHA256(value); err != nil {
 				return fmt.Errorf("invalid hash %q, %v", pubKeyHash, err)
 			}

--- a/pkg/util/membercluster_client.go
+++ b/pkg/util/membercluster_client.go
@@ -68,7 +68,7 @@ func NewClusterClientSet(clusterName string, client client.Client, clientOption 
 func NewClusterClientSetForAgent(clusterName string, client client.Client, clientOption *ClientOption) (*ClusterClient, error) {
 	clusterConfig, err := controllerruntime.GetConfig()
 	if err != nil {
-		return nil, fmt.Errorf("error building kubeconfig of member cluster: %s", err.Error())
+		return nil, fmt.Errorf("error building kubeconfig of member cluster: %w", err)
 	}
 
 	var clusterClientSet = ClusterClient{ClusterName: clusterName}
@@ -101,7 +101,7 @@ func NewClusterDynamicClientSet(clusterName string, client client.Client) (*Dyna
 func NewClusterDynamicClientSetForAgent(clusterName string, client client.Client) (*DynamicClusterClient, error) {
 	clusterConfig, err := controllerruntime.GetConfig()
 	if err != nil {
-		return nil, fmt.Errorf("error building kubeconfig of member cluster: %s", err.Error())
+		return nil, fmt.Errorf("error building kubeconfig of member cluster: %w", err)
 	}
 	var clusterClientSet = DynamicClusterClient{ClusterName: clusterName}
 

--- a/pkg/util/namespace.go
+++ b/pkg/util/namespace.go
@@ -61,7 +61,7 @@ func EnsureNamespaceExist(client kubeclient.Interface, namespace string, dryRun 
 	// Sometimes the namespace is created in advance, to give less privilege to Karmada.
 	exist, err := IsNamespaceExist(client, namespace)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check if namespace exist. namespace: %s, error: %v", namespace, err)
+		return nil, fmt.Errorf("failed to check if namespace exist. namespace: %s, error: %w", namespace, err)
 	}
 	if exist {
 		return namespaceObj, nil
@@ -69,7 +69,7 @@ func EnsureNamespaceExist(client kubeclient.Interface, namespace string, dryRun 
 
 	createdObj, err := CreateNamespace(client, namespaceObj)
 	if err != nil {
-		return nil, fmt.Errorf("ensure namespace failed due to create failed. namespace: %s, error: %v", namespace, err)
+		return nil, fmt.Errorf("ensure namespace failed due to create failed. namespace: %s, error: %w", namespace, err)
 	}
 
 	return createdObj, nil

--- a/pkg/util/objectwatcher/objectwatcher.go
+++ b/pkg/util/objectwatcher/objectwatcher.go
@@ -99,7 +99,7 @@ func (o *objectWatcherImpl) Create(clusterName string, desireObj *unstructured.U
 		// update the resource if a conflict resolution instruction is existed in annotation.
 		err = o.resourceConflictOverwrite(clusterName, desireObj, existObj)
 		if err != nil {
-			return fmt.Errorf("failed to update exist resource(kind=%s, %s/%s) in cluster %v: %v", desireObj.GetKind(), desireObj.GetNamespace(), desireObj.GetName(), clusterName, err)
+			return fmt.Errorf("failed to update exist resource(kind=%s, %s/%s) in cluster %v: %w", desireObj.GetKind(), desireObj.GetNamespace(), desireObj.GetName(), clusterName, err)
 		}
 	}
 

--- a/pkg/util/overridemanager/commandargsoverride.go
+++ b/pkg/util/overridemanager/commandargsoverride.go
@@ -39,7 +39,7 @@ func buildCommandArgsPatchesWithPath(target string, specContainersPath string, r
 	patches := make([]overrideOption, 0)
 	containers, ok, err := unstructured.NestedSlice(rawObj.Object, strings.Split(specContainersPath, pathSplit)...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieves path(%s) from rawObj, error: %v", specContainersPath, err)
+		return nil, fmt.Errorf("failed to retrieves path(%s) from rawObj, error: %w", specContainersPath, err)
 	}
 	if !ok || len(containers) == 0 {
 		return nil, nil

--- a/pkg/util/overridemanager/imageoverride.go
+++ b/pkg/util/overridemanager/imageoverride.go
@@ -36,37 +36,37 @@ func buildPatchesWithEmptyPredicate(rawObj *unstructured.Unstructured, imageOver
 	case util.PodKind:
 		podObj := &corev1.Pod{}
 		if err := helper.ConvertToTypedObject(rawObj, podObj); err != nil {
-			return nil, fmt.Errorf("failed to convert Pod from unstructured object: %v", err)
+			return nil, fmt.Errorf("failed to convert Pod from unstructured object: %w", err)
 		}
 		return extractPatchesBy(podObj.Spec, podSpecPrefix, imageOverrider)
 	case util.ReplicaSetKind:
 		replicaSetObj := &appsv1.ReplicaSet{}
 		if err := helper.ConvertToTypedObject(rawObj, replicaSetObj); err != nil {
-			return nil, fmt.Errorf("failed to convert ReplicaSet from unstructured object: %v", err)
+			return nil, fmt.Errorf("failed to convert ReplicaSet from unstructured object: %w", err)
 		}
 		return extractPatchesBy(replicaSetObj.Spec.Template.Spec, podTemplatePrefix, imageOverrider)
 	case util.DeploymentKind:
 		deploymentObj := &appsv1.Deployment{}
 		if err := helper.ConvertToTypedObject(rawObj, deploymentObj); err != nil {
-			return nil, fmt.Errorf("failed to convert Deployment from unstructured object: %v", err)
+			return nil, fmt.Errorf("failed to convert Deployment from unstructured object: %w", err)
 		}
 		return extractPatchesBy(deploymentObj.Spec.Template.Spec, podTemplatePrefix, imageOverrider)
 	case util.DaemonSetKind:
 		daemonSetObj := &appsv1.DaemonSet{}
 		if err := helper.ConvertToTypedObject(rawObj, daemonSetObj); err != nil {
-			return nil, fmt.Errorf("failed to convert DaemonSet from unstructured object: %v", err)
+			return nil, fmt.Errorf("failed to convert DaemonSet from unstructured object: %w", err)
 		}
 		return extractPatchesBy(daemonSetObj.Spec.Template.Spec, podTemplatePrefix, imageOverrider)
 	case util.StatefulSetKind:
 		statefulSetObj := &appsv1.StatefulSet{}
 		if err := helper.ConvertToTypedObject(rawObj, statefulSetObj); err != nil {
-			return nil, fmt.Errorf("failed to convert StatefulSet from unstructured object: %v", err)
+			return nil, fmt.Errorf("failed to convert StatefulSet from unstructured object: %w", err)
 		}
 		return extractPatchesBy(statefulSetObj.Spec.Template.Spec, podTemplatePrefix, imageOverrider)
 	case util.JobKind:
 		jobObj := &batchv1.Job{}
 		if err := helper.ConvertToTypedObject(rawObj, jobObj); err != nil {
-			return nil, fmt.Errorf("failed to convert Job from unstructured object: %v", err)
+			return nil, fmt.Errorf("failed to convert Job from unstructured object: %w", err)
 		}
 		return extractPatchesBy(jobObj.Spec.Template.Spec, podTemplatePrefix, imageOverrider)
 	}
@@ -98,7 +98,7 @@ func buildPatchesWithPredicate(rawObj *unstructured.Unstructured, imageOverrider
 
 	imageValue, err := obtainImageValue(rawObj, imageOverrider.Predicate.Path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to obtain imageValue with predicate path(%s), error: %v", imageOverrider.Predicate.Path, err)
+		return nil, fmt.Errorf("failed to obtain imageValue with predicate path(%s), error: %w", imageOverrider.Predicate.Path, err)
 	}
 
 	patch, err := acquireOverrideOption(imageOverrider.Predicate.Path, imageValue, imageOverrider)
@@ -160,7 +160,7 @@ func acquireOverrideOption(imagePath, curImage string, imageOverrider *policyv1a
 func overrideImage(curImage string, imageOverrider *policyv1alpha1.ImageOverrider) (string, error) {
 	imageComponent, err := imageparser.Parse(curImage)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse image value(%s), error: %v", curImage, err)
+		return "", fmt.Errorf("failed to parse image value(%s), error: %w", curImage, err)
 	}
 
 	switch imageOverrider.Component {

--- a/pkg/util/proxy/proxy.go
+++ b/pkg/util/proxy/proxy.go
@@ -42,7 +42,7 @@ func ConnectCluster(ctx context.Context, cluster *clusterapis.Cluster, proxyPath
 
 	impersonateToken, err := getImpersonateToken(cluster.Name, secret)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get impresonateToken for cluster %s: %v", cluster.Name, err)
+		return nil, fmt.Errorf("failed to get impresonateToken for cluster %s: %w", cluster.Name, err)
 	}
 
 	return newProxyHandler(location, transport, impersonateToken, responder)
@@ -77,7 +77,7 @@ func constructLocation(cluster *clusterapis.Cluster) (*url.URL, error) {
 
 	uri, err := url.Parse(apiEndpoint)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse api endpoint %s: %v", apiEndpoint, err)
+		return nil, fmt.Errorf("failed to parse api endpoint %s: %w", apiEndpoint, err)
 	}
 	return uri, nil
 }
@@ -93,7 +93,7 @@ func createProxyTransport(cluster *clusterapis.Cluster) (*http.Transport, error)
 	if proxyURL := cluster.Spec.ProxyURL; proxyURL != "" {
 		u, err := url.Parse(proxyURL)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse url of proxy url %s: %v", proxyURL, err)
+			return nil, fmt.Errorf("failed to parse url of proxy url %s: %w", proxyURL, err)
 		}
 		trans.Proxy = http.ProxyURL(u)
 	}

--- a/pkg/util/serviceaccount.go
+++ b/pkg/util/serviceaccount.go
@@ -58,7 +58,7 @@ func EnsureServiceAccountExist(client kubeclient.Interface, serviceAccountObj *c
 
 	exist, err := IsServiceAccountExist(client, serviceAccountObj.Namespace, serviceAccountObj.Name)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check if service account exist. service account: %s/%s, error: %v", serviceAccountObj.Namespace, serviceAccountObj.Name, err)
+		return nil, fmt.Errorf("failed to check if service account exist. service account: %s/%s, error: %w", serviceAccountObj.Namespace, serviceAccountObj.Name, err)
 	}
 	if exist {
 		return serviceAccountObj, nil
@@ -66,7 +66,7 @@ func EnsureServiceAccountExist(client kubeclient.Interface, serviceAccountObj *c
 
 	createdObj, err := CreateServiceAccount(client, serviceAccountObj)
 	if err != nil {
-		return nil, fmt.Errorf("ensure service account failed due to create failed. service account: %s/%s, error: %v", serviceAccountObj.Namespace, serviceAccountObj.Name, err)
+		return nil, fmt.Errorf("ensure service account failed due to create failed. service account: %s/%s, error: %w", serviceAccountObj.Namespace, serviceAccountObj.Name, err)
 	}
 
 	return createdObj, nil
@@ -81,7 +81,7 @@ func WaitForServiceAccountSecretCreation(client kubeclient.Interface, asObj *cor
 			if apierrors.IsNotFound(err) {
 				return false, nil
 			}
-			return false, fmt.Errorf("failed to retrieve service account(%s/%s) from cluster, err: %v", asObj.Namespace, asObj.Name, err)
+			return false, fmt.Errorf("failed to retrieve service account(%s/%s) from cluster, err: %w", asObj.Namespace, asObj.Name, err)
 		}
 		clusterSecret, err = GetSecret(client, serviceAccount.Namespace, serviceAccount.Name)
 		if apierrors.IsNotFound(err) {
@@ -106,7 +106,7 @@ func WaitForServiceAccountSecretCreation(client kubeclient.Interface, asObj *cor
 		return true, nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get serviceAccount secret, error: %v", err)
+		return nil, fmt.Errorf("failed to get serviceAccount secret, error: %w", err)
 	}
 	return clusterSecret, nil
 }

--- a/pkg/util/serviceaccount_test.go
+++ b/pkg/util/serviceaccount_test.go
@@ -288,7 +288,7 @@ func TestWaitForServiceAccountSecretCreation(t *testing.T) {
 		if secretVisitCount == 2 {
 			s, err := client.Tracker().Get(action.GetResource(), action.GetNamespace(), "test")
 			if err != nil {
-				return true, nil, fmt.Errorf("secret shall be found: %v", err)
+				return true, nil, fmt.Errorf("secret shall be found: %w", err)
 			}
 
 			// We inject token here, so that next round will see the token

--- a/pkg/webhook/resourceinterpretercustomization/helper.go
+++ b/pkg/webhook/resourceinterpretercustomization/helper.go
@@ -40,7 +40,7 @@ func checkCustomizationsRule(customization *configv1alpha1.ResourceInterpreterCu
 	for _, rule := range interpreter.AllResourceInterpreterCustomizationRules {
 		if script := rule.GetScript(customization); script != "" {
 			if _, err = l.LoadString(script); err != nil {
-				return fmt.Errorf("InterpreterOperation(%s) Lua script error: %v", rule.Name(), err)
+				return fmt.Errorf("InterpreterOperation(%s) Lua script error: %w", rule.Name(), err)
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Fish-pro <zechun.chen@daocloud.io>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add an errorlint check to make it easier to provide standard error output

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

