### PR TITLE
fix typo note for pkg/sharedcli/profileflag/profileflag.go

### DIFF
--- a/pkg/sharedcli/profileflag/profileflag.go
+++ b/pkg/sharedcli/profileflag/profileflag.go
@@ -27,8 +27,8 @@ const (
 type Options struct {
 	// EnableProfile is the flag about whether to enable pprof profiling.
 	EnableProfile bool
-	// ProfilePort is the TCP address for pprof profiling.
-	// Defaults to 127.0.0.1:6060 if unspecified.
+	// ProfilingBindAddress is the TCP address for pprof profiling.
+	// Defaults to :6060 if unspecified.
 	ProfilingBindAddress string
 }
 


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
fix typo note for pkg/sharedcli/profileflag/profileflag.go



