### PR TITLE
Automated cherry pick of #3052: fix that the InterpretDependency operation is absent in the

### DIFF
--- a/examples/customresourceinterpreter/webhook-configuration.yaml
+++ b/examples/customresourceinterpreter/webhook-configuration.yaml
@@ -6,7 +6,7 @@ metadata:
 webhooks:
   - name: workloads.example.com
     rules:
-      - operations: [ "InterpretReplica","ReviseReplica","Retain","AggregateStatus" ]
+      - operations: [ "InterpretReplica","ReviseReplica","Retain","AggregateStatus", "InterpretDependency" ]
         apiGroups: [ "workload.example.io" ]
         apiVersions: [ "v1alpha1" ]
         kinds: [ "Workload" ]

--- a/examples/customresourceinterpreter/webhook/app/workloadwebhook.go
+++ b/examples/customresourceinterpreter/webhook/app/workloadwebhook.go
@@ -41,6 +41,8 @@ func (e *workloadInterpreter) Handle(ctx context.Context, req interpreter.Reques
 		return e.responseWithExploreRetaining(workload, req)
 	case configv1alpha1.InterpreterOperationAggregateStatus:
 		return e.responseWithExploreAggregateStatus(workload, req)
+	case configv1alpha1.InterpreterOperationInterpretDependency:
+		return e.responseWithExploreDependency(workload)
 	default:
 		return interpreter.Errored(http.StatusBadRequest, fmt.Errorf("wrong request operation type: %s", req.Operation))
 	}
@@ -54,6 +56,13 @@ func (e *workloadInterpreter) InjectDecoder(d *interpreter.Decoder) {
 func (e *workloadInterpreter) responseWithExploreReplica(workload *workloadv1alpha1.Workload) interpreter.Response {
 	res := interpreter.Succeeded("")
 	res.Replicas = workload.Spec.Replicas
+	return res
+}
+
+func (e *workloadInterpreter) responseWithExploreDependency(workload *workloadv1alpha1.Workload) interpreter.Response {
+	res := interpreter.Succeeded("")
+	res.Dependencies = []configv1alpha1.DependentObjectReference{{APIVersion: "v1", Kind: "ConfigMap",
+		Namespace: workload.Namespace, Name: workload.Spec.Template.Spec.Containers[0].EnvFrom[0].ConfigMapRef.Name}}
 	return res
 }
 

--- a/pkg/webhook/configuration/validating.go
+++ b/pkg/webhook/configuration/validating.go
@@ -65,6 +65,7 @@ func (v *ValidatingAdmission) InjectDecoder(d *admission.Decoder) error {
 var supportedInterpreterOperation = sets.NewString(
 	string(configv1alpha1.InterpreterOperationAll),
 	string(configv1alpha1.InterpreterOperationInterpretReplica),
+	string(configv1alpha1.InterpreterOperationInterpretDependency),
 	string(configv1alpha1.InterpreterOperationReviseReplica),
 	string(configv1alpha1.InterpreterOperationRetain),
 	string(configv1alpha1.InterpreterOperationAggregateStatus),

--- a/test/e2e/resourceinterpreter_test.go
+++ b/test/e2e/resourceinterpreter_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -187,6 +189,50 @@ var _ = ginkgo.Describe("Resource interpreter webhook testing", func() {
 					return false, nil
 				})
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+	})
+
+	ginkgo.Context("InterpreterOperation InterpretDependency testing", func() {
+		var configMapNamespace, configMapName string
+
+		ginkgo.BeforeEach(func() {
+			configMapNamespace = testNamespace
+			configMapName = configMapNamePrefix + rand.String(RandomStrLength)
+
+			workload.Spec.Template.Spec.Containers[0].EnvFrom = []corev1.EnvFromSource{{
+				ConfigMapRef: &corev1.ConfigMapEnvSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: configMapName},
+				}}}
+			// configmaps should be propagated automatically.
+			policy.Spec.PropagateDeps = true
+
+			cm := testhelper.NewConfigMap(configMapNamespace, configMapName, map[string]string{"RUN_ENV": "test"})
+
+			framework.CreateConfigMap(kubeClient, cm)
+			ginkgo.DeferCleanup(func() {
+				framework.RemoveConfigMap(kubeClient, configMapNamespace, configMapName)
+			})
+		})
+
+		ginkgo.It("InterpretDependency testing", func() {
+			ginkgo.By("check if workload's dependency is interpreted", func() {
+				clusterNames := framework.ClusterNames()
+				gomega.Eventually(func(g gomega.Gomega) (int, error) {
+					var configmapNum int
+					for _, clusterName := range clusterNames {
+						clusterClient := framework.GetClusterClient(clusterName)
+						gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+						if _, err := clusterClient.CoreV1().ConfigMaps(configMapNamespace).Get(context.TODO(), configMapName, metav1.GetOptions{}); err != nil {
+							if apierrors.IsNotFound(err) {
+								continue
+							}
+							g.Expect(err).NotTo(gomega.HaveOccurred())
+						}
+						configmapNum++
+					}
+					return configmapNum, nil
+				}, pollTimeout, pollInterval).Should(gomega.Equal(len(clusterNames)))
 			})
 		})
 	})

--- a/test/helper/resource.go
+++ b/test/helper/resource.go
@@ -496,7 +496,7 @@ func NewClusterWithResource(name string, allocatable, allocating, allocated core
 }
 
 // NewWorkload will build a workload object.
-func NewWorkload(namespace string, name string) *workloadv1alpha1.Workload {
+func NewWorkload(namespace, name string) *workloadv1alpha1.Workload {
 	podLabels := map[string]string{"app": "nginx"}
 
 	return &workloadv1alpha1.Workload{


### PR DESCRIPTION
Cherry pick of #3052 on release-1.2.
#3052: fix that the InterpretDependency operation is absent in the
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
karmada-webhook: Fixed the issue that the InterpretDependency operation can't be registered.
```