### PR TITLE
resourceRegistry need add scope="Cluster"

### DIFF
--- a/pkg/apis/search/v1alpha1/searchregistry_types.go
+++ b/pkg/apis/search/v1alpha1/searchregistry_types.go
@@ -20,6 +20,7 @@ const (
 
 // +genclient
 // +genclient:nonNamespaced
+// +kubebuilder:resource:scope="Cluster"
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ResourceRegistry represents the configuration of the cache scope, mainly describes which resources in


### PR DESCRIPTION
Signed-off-by: huangyanfeng <huangyanfeng1992@gmail.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

When I generate the crd with the following command：controller-gen crd paths=./pkg/apis/search/v1alpha1/... output:crd:dir=./charts/_crds/bases

Generated a crd with the wrong scope

![image](https://user-images.githubusercontent.com/89568107/215427925-08410889-3155-45dc-ba4d-b74b827ebd87.png)



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-search: resourceRegistry type add scope="Cluster"
```

