### PR TITLE
feat: Retain the labels added to resources by member clusters

### DIFF
--- a/pkg/util/annotation.go
+++ b/pkg/util/annotation.go
@@ -15,7 +15,7 @@ func MergeAnnotation(obj *unstructured.Unstructured, annotationKey string, annot
 	}
 }
 
-// MergeAnnotations merges the annotations from 'src' to 'dst'.
+// MergeAnnotations merges the annotations from 'src' to 'dst', identical keys will not be merged.
 func MergeAnnotations(dst *unstructured.Unstructured, src *unstructured.Unstructured) {
 	for key, value := range src.GetAnnotations() {
 		MergeAnnotation(dst, key, value)

--- a/pkg/util/annotation_test.go
+++ b/pkg/util/annotation_test.go
@@ -206,6 +206,48 @@ func TestMergeAnnotations(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "src and dst have the same annotation key",
+			dst: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":        "demo-deployment",
+						"annotations": map[string]interface{}{"foo": "foo"},
+					},
+					"spec": map[string]interface{}{
+						"replicas": 2,
+					},
+				},
+			},
+			src: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":        "demo-deployment-1",
+						"annotations": map[string]interface{}{"foo": "bar"},
+					},
+					"spec": map[string]interface{}{
+						"replicas": 2,
+					},
+				},
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":        "demo-deployment",
+						"annotations": map[string]interface{}{"foo": "foo"},
+					},
+					"spec": map[string]interface{}{
+						"replicas": 2,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/util/label.go
+++ b/pkg/util/label.go
@@ -13,6 +13,20 @@ func GetLabelValue(labels map[string]string, labelKey string) string {
 	return labels[labelKey]
 }
 
+// MergeLabels merges the labels from 'src' to 'dst', identical keys will not be merged.
+func MergeLabels(dst *unstructured.Unstructured, src *unstructured.Unstructured) {
+	for key, value := range src.GetLabels() {
+		labels := dst.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string, 1)
+		}
+		if _, exist := labels[key]; !exist {
+			labels[key] = value
+			dst.SetLabels(labels)
+		}
+	}
+}
+
 // MergeLabel adds label for the given object.
 func MergeLabel(obj *unstructured.Unstructured, labelKey string, labelValue string) {
 	labels := obj.GetLabels()

--- a/pkg/util/label_test.go
+++ b/pkg/util/label_test.go
@@ -311,3 +311,144 @@ func TestRemoveLabel(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeLabels(t *testing.T) {
+	tests := []struct {
+		name     string
+		dst      *unstructured.Unstructured
+		src      *unstructured.Unstructured
+		expected *unstructured.Unstructured
+	}{
+		{
+			name: "src has nil labels",
+			dst: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "demo-deployment",
+					},
+					"spec": map[string]interface{}{
+						"replicas": 2,
+					},
+				},
+			},
+			src: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "demo-deployment-1",
+					},
+					"spec": map[string]interface{}{
+						"replicas": 2,
+					},
+				},
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "demo-deployment",
+					},
+					"spec": map[string]interface{}{
+						"replicas": 2,
+					},
+				},
+			},
+		},
+		{
+			name: "src has labels",
+			dst: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "demo-deployment",
+					},
+					"spec": map[string]interface{}{
+						"replicas": 2,
+					},
+				},
+			},
+			src: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":   "demo-deployment-1",
+						"labels": map[string]interface{}{"foo": "bar"},
+					},
+					"spec": map[string]interface{}{
+						"replicas": 2,
+					},
+				},
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":   "demo-deployment",
+						"labels": map[string]interface{}{"foo": "bar"},
+					},
+					"spec": map[string]interface{}{
+						"replicas": 2,
+					},
+				},
+			},
+		},
+		{
+			name: "src and dst have the same label key",
+			dst: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":   "demo-deployment",
+						"labels": map[string]interface{}{"foo": "foo"},
+					},
+					"spec": map[string]interface{}{
+						"replicas": 2,
+					},
+				},
+			},
+			src: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":   "demo-deployment-1",
+						"labels": map[string]interface{}{"foo": "bar"},
+					},
+					"spec": map[string]interface{}{
+						"replicas": 2,
+					},
+				},
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":   "demo-deployment",
+						"labels": map[string]interface{}{"foo": "foo"},
+					},
+					"spec": map[string]interface{}{
+						"replicas": 2,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			MergeLabels(tt.dst, tt.src)
+			if !reflect.DeepEqual(tt.dst, tt.expected) {
+				t.Errorf("MergeLabels() = %v, want %v", tt.dst, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/util/objectwatcher/objectwatcher.go
+++ b/pkg/util/objectwatcher/objectwatcher.go
@@ -138,6 +138,10 @@ func (o *objectWatcherImpl) retainClusterFields(desired, observed *unstructured.
 	// and be set by user in karmada-controller-plane.
 	util.MergeAnnotations(desired, observed)
 
+	// Merge labels since they will typically be set by controllers in a member cluster
+	// and be set by user in karmada-controller-plane.
+	util.MergeLabels(desired, observed)
+
 	if o.resourceInterpreter.HookEnabled(desired.GroupVersionKind(), configv1alpha1.InterpreterOperationRetain) {
 		return o.resourceInterpreter.Retain(desired, observed)
 	}


### PR DESCRIPTION
Signed-off-by: chaunceyjiang <chaunceyjiang@gmail.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #2896 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`:  Retain the labels added to resources by member clusters
```

