### PR TITLE
Automated cherry pick of #3098: support pod subresource (attach, exec, port-forward) through

### DIFF
--- a/pkg/search/proxy/framework/plugins/cluster/cluster.go
+++ b/pkg/search/proxy/framework/plugins/cluster/cluster.go
@@ -63,7 +63,10 @@ func (c *Cluster) SupportRequest(request framework.ProxyRequest) bool {
 func (c *Cluster) Connect(ctx context.Context, request framework.ProxyRequest) (http.Handler, error) {
 	requestInfo := request.RequestInfo
 
-	if requestInfo.Verb == "create" {
+	// For creating request, cluster proxy doesn't know which cluster to create, so responses MethodNotSupported error.
+	// While for subresource request, having resource name request (like pods attach, exec and port-forward),
+	// proxy it to the cluster the resource located.
+	if requestInfo.Verb == "create" && requestInfo.Name == "" {
 		return nil, apierrors.NewMethodNotSupported(request.GroupVersionResource.GroupResource(), requestInfo.Verb)
 	}
 


### PR DESCRIPTION
Cherry pick of #3098 on release-1.4.
#3098: support pod subresource (attach, exec, port-forward) through
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-search`: support pod subresource (attach, exec, port-forward) through global proxy
```