### PR TITLE
Fix multi-manifest creation keeps failing

### DIFF
--- a/pkg/controllers/execution/execution_controller.go
+++ b/pkg/controllers/execution/execution_controller.go
@@ -206,7 +206,7 @@ func (c *Controller) syncToClusters(clusterName string, work *workv1alpha1.Work)
 			}
 		} else {
 			err = c.tryCreateWorkload(clusterName, workload)
-			if err != nil {
+			if err != nil && !apierrors.IsAlreadyExists(err) {
 				klog.Errorf("Failed to create resource(%v/%v) in the given member cluster %s, err is %v", workload.GetNamespace(), workload.GetName(), clusterName, err)
 				c.eventf(workload, corev1.EventTypeWarning, events.EventReasonSyncWorkloadFailed, "Failed to create resource(%s) in member cluster(%s): %v", klog.KObj(workload), clusterName, err)
 				errs = append(errs, err)


### PR DESCRIPTION
Signed-off-by: jwcesign <jiangwei115@huawei.com>

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
at line pkg/controllers/execution/execution_controller.go:189, if there are two Manifests(A and B).

1. creating the work for the first time, create A succeed, B failed, so the applied will be false.
2. create the work for the second time, create A failed(already exists), and create B succeed.
3. Then create the work continually, A will be failed always(always an error of already exists).

**Which issue(s) this PR fixes**:
Fixes #none

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
```

