### PR TITLE
unjoin cluster need delete ClusterObject Background

### DIFF
--- a/pkg/karmadactl/unjoin/unjoin.go
+++ b/pkg/karmadactl/unjoin/unjoin.go
@@ -213,7 +213,11 @@ func (j *CommandUnjoinOption) deleteClusterObject(controlPlaneKarmadaClient *kar
 		return nil
 	}
 
-	err := controlPlaneKarmadaClient.ClusterV1alpha1().Clusters().Delete(context.TODO(), j.ClusterName, metav1.DeleteOptions{})
+	deleteBackground := metav1.DeletePropagationBackground
+	deleteOption := metav1.DeleteOptions{
+		PropagationPolicy: &deleteBackground,
+	}
+	err := controlPlaneKarmadaClient.ClusterV1alpha1().Clusters().Delete(context.TODO(), j.ClusterName, deleteOption)
 	if apierrors.IsNotFound(err) {
 		return fmt.Errorf("no cluster object %s found in karmada control Plane", j.ClusterName)
 	}


### PR DESCRIPTION
Signed-off-by: huangyanfeng <huangyanfeng1992@gmail.com>

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
 we have added owner reference cluster to Work
I think the deletion strategy of cluster should be the background mode, not the default orphan mode
Current implementation：delete cluster -> delete es namespace -> delete work
I think the correct implementation：delete cluster -> delete work -> delete es namespce


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmadactl: unjoin cluster need delete ClusterObject Background
```
