### PR TITLE
Detector watch pp fields changed other than resource selector

### DIFF
--- a/test/e2e/framework/clusterpropagationpolicy.go
+++ b/test/e2e/framework/clusterpropagationpolicy.go
@@ -2,11 +2,13 @@ package framework
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	karmada "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
@@ -24,6 +26,17 @@ func CreateClusterPropagationPolicy(client karmada.Interface, policy *policyv1al
 func RemoveClusterPropagationPolicy(client karmada.Interface, name string) {
 	ginkgo.By(fmt.Sprintf("Removing ClusterPropagationPolicy(%s)", name), func() {
 		err := client.PolicyV1alpha1().ClusterPropagationPolicies().Delete(context.TODO(), name, metav1.DeleteOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+}
+
+// PatchClusterPropagationPolicy patch ClusterPropagationPolicy with karmada client.
+func PatchClusterPropagationPolicy(client karmada.Interface, name string, patch []map[string]interface{}, patchType types.PatchType) {
+	ginkgo.By(fmt.Sprintf("Patching ClusterPropagationPolicy(%s)", name), func() {
+		patchBytes, err := json.Marshal(patch)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+		_, err = client.PolicyV1alpha1().ClusterPropagationPolicies().Patch(context.TODO(), name, patchType, patchBytes, metav1.PatchOptions{})
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	})
 }


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Now detector will reconcile only when pp's resourceSelector changes. So when other fields updates, resourceBindings will not synchronize this update of the policy.

For example, if you have propagated a policy(which propagateDeps's false) and deployment, now you want to update policy's propagateDeps to true. However, resourceBinding will not update this field after policy has changed.
It will also be an issue when we add `placement` to resourceBinding #2702.

The main reason is that detector will get obj from `waitingObjects` queue, then add it to the workqueue for reconciling. However, in the above case, the binding relationship of the object will not change, so it will not be added to the `waitingObjects` queue.
```
func (d *ResourceDetector) GetMatching(resourceSelectors []policyv1alpha1.ResourceSelector) []keys.ClusterWideKey {
	d.waitingLock.RLock()
	defer d.waitingLock.RUnlock()

	var matchedResult []keys.ClusterWideKey

	for waitKey := range d.waitingObjects {
		waitObj, err := d.GetUnstructuredObject(waitKey)
		if err != nil {
			// all object in waiting list should exist. Just print a log to trace.
			klog.Errorf("Failed to get object(%s), error: %v", waitKey.String(), err)
			continue
		}

		for _, rs := range resourceSelectors {
			if util.ResourceMatches(waitObj, rs) {
				matchedResult = append(matchedResult, waitKey)
				break
			}
		}
	}

	return matchedResult
}
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

