### PR TITLE
Remove association field in PropagationPolicy/ClusterPropagationPolicy Spec

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15764,10 +15764,6 @@
         "resourceSelectors"
       ],
       "properties": {
-        "association": {
-          "description": "Association tells if relevant resources should be selected automatically. e.g. a ConfigMap referred by a Deployment. default false. Deprecated: in favor of PropagateDeps.",
-          "type": "boolean"
-        },
         "dependentOverrides": {
           "description": "DependentOverrides represents the list of overrides(OverridePolicy) which must present before the current PropagationPolicy takes effect.\n\nIt used to explicitly specify overrides which current PropagationPolicy rely on. A typical scenario is the users create OverridePolicy(ies) and resources at the same time, they want to ensure the new-created policies would be adopted.\n\nNote: For the overrides, OverridePolicy(ies) in current namespace and ClusterOverridePolicy(ies), which not present in this list will still be applied if they matches the resources.",
           "type": "array",

--- a/charts/karmada/_crds/bases/policy.karmada.io_clusterpropagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy.karmada.io_clusterpropagationpolicies.yaml
@@ -44,11 +44,6 @@ spec:
           spec:
             description: Spec represents the desired behavior of ClusterPropagationPolicy.
             properties:
-              association:
-                description: 'Association tells if relevant resources should be selected
-                  automatically. e.g. a ConfigMap referred by a Deployment. default
-                  false. Deprecated: in favor of PropagateDeps.'
-                type: boolean
               dependentOverrides:
                 description: "DependentOverrides represents the list of overrides(OverridePolicy)
                   which must present before the current PropagationPolicy takes effect.

--- a/charts/karmada/_crds/bases/policy.karmada.io_propagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy.karmada.io_propagationpolicies.yaml
@@ -40,11 +40,6 @@ spec:
           spec:
             description: Spec represents the desired behavior of PropagationPolicy.
             properties:
-              association:
-                description: 'Association tells if relevant resources should be selected
-                  automatically. e.g. a ConfigMap referred by a Deployment. default
-                  false. Deprecated: in favor of PropagateDeps.'
-                type: boolean
               dependentOverrides:
                 description: "DependentOverrides represents the list of overrides(OverridePolicy)
                   which must present before the current PropagationPolicy takes effect.

--- a/pkg/apis/policy/v1alpha1/propagation_types.go
+++ b/pkg/apis/policy/v1alpha1/propagation_types.go
@@ -49,13 +49,6 @@ type PropagationSpec struct {
 	// +kubebuilder:validation:MinItems=1
 	ResourceSelectors []ResourceSelector `json:"resourceSelectors"`
 
-	// Association tells if relevant resources should be selected automatically.
-	// e.g. a ConfigMap referred by a Deployment.
-	// default false.
-	// Deprecated: in favor of PropagateDeps.
-	// +optional
-	Association bool `json:"association,omitempty"`
-
 	// PropagateDeps tells if relevant resources should be propagated automatically.
 	// Take 'Deployment' which referencing 'ConfigMap' and 'Secret' as an example, when 'propagateDeps' is 'true',
 	// the referencing resources could be omitted(for saving config effort) from 'resourceSelectors' as they will be

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -3313,13 +3313,6 @@ func schema_pkg_apis_policy_v1alpha1_PropagationSpec(ref common.ReferenceCallbac
 							},
 						},
 					},
-					"association": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Association tells if relevant resources should be selected automatically. e.g. a ConfigMap referred by a Deployment. default false. Deprecated: in favor of PropagateDeps.",
-							Type:        []string{"boolean"},
-							Format:      "",
-						},
-					},
 					"propagateDeps": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PropagateDeps tells if relevant resources should be propagated automatically. Take 'Deployment' which referencing 'ConfigMap' and 'Secret' as an example, when 'propagateDeps' is 'true', the referencing resources could be omitted(for saving config effort) from 'resourceSelectors' as they will be propagated along with the Deployment. In addition to the propagating process, the referencing resources will be migrated along with the Deployment in the fail-over scenario.\n\nDefaults to false.",


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind api-change
/kind cleanup

**What this PR does / why we need it**:

The `Association` filed has been deprecated since release-1.0: 
[ocs.google.com/document/d/1PtlQPhtiaZJ6lkcGXmQpaYh7J05UoAYn8XvX7cciNmQ/edit](https://github.com/karmada-io/karmada/blob/release-1.1/pkg/apis/policy/v1alpha1/propagation_types.go#L31)
So I think we can remove this filed from the API.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
API: Remove `Association` field in PropagationPolicy/ClusterPropagationPolicy Spec
```

