### PR TITLE
Avoid multiple executions after rlock in concurrent scenarios

### DIFF
--- a/pkg/util/fedinformer/genericmanager/multi-cluster-manager.go
+++ b/pkg/util/fedinformer/genericmanager/multi-cluster-manager.go
@@ -85,13 +85,14 @@ func (m *multiClusterInformerManagerImpl) getManager(cluster string) (SingleClus
 }
 
 func (m *multiClusterInformerManagerImpl) ForCluster(cluster string, client dynamic.Interface, defaultResync time.Duration) SingleClusterInformerManager {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
 	// If informer manager already exist, just return
-	if manager, exist := m.getManager(cluster); exist {
+	if manager, exist := m.managers[cluster]; exist {
 		return manager
 	}
 
-	m.lock.Lock()
-	defer m.lock.Unlock()
 	manager := NewSingleClusterInformerManager(client, defaultResync, m.stopCh)
 	m.managers[cluster] = manager
 	return manager

--- a/pkg/util/fedinformer/genericmanager/single-cluster-manager.go
+++ b/pkg/util/fedinformer/genericmanager/single-cluster-manager.go
@@ -87,8 +87,11 @@ type singleClusterInformerManagerImpl struct {
 }
 
 func (s *singleClusterInformerManagerImpl) ForResource(resource schema.GroupVersionResource, handler cache.ResourceEventHandler) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
 	// if handler already exist, just return, nothing changed.
-	if s.IsHandlerExist(resource, handler) {
+	if s.isHandlerExist(resource, handler) {
 		return
 	}
 
@@ -113,6 +116,10 @@ func (s *singleClusterInformerManagerImpl) IsHandlerExist(resource schema.GroupV
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
+	return s.isHandlerExist(resource, handler)
+}
+
+func (s *singleClusterInformerManagerImpl) isHandlerExist(resource schema.GroupVersionResource, handler cache.ResourceEventHandler) bool {
 	handlers, exist := s.handlers[resource]
 	if !exist {
 		return false
@@ -132,9 +139,6 @@ func (s *singleClusterInformerManagerImpl) Lister(resource schema.GroupVersionRe
 }
 
 func (s *singleClusterInformerManagerImpl) appendHandler(resource schema.GroupVersionResource, handler cache.ResourceEventHandler) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
 	// assume the handler list exist, caller should ensure for that.
 	handlers := s.handlers[resource]
 

--- a/pkg/util/fedinformer/typedmanager/multi-cluster-manager.go
+++ b/pkg/util/fedinformer/typedmanager/multi-cluster-manager.go
@@ -94,13 +94,14 @@ func (m *multiClusterInformerManagerImpl) getManager(cluster string) (SingleClus
 }
 
 func (m *multiClusterInformerManagerImpl) ForCluster(cluster string, client kubernetes.Interface, defaultResync time.Duration) SingleClusterInformerManager {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
 	// If informer manager already exist, just return
-	if manager, exist := m.getManager(cluster); exist {
+	if manager, exist := m.managers[cluster]; exist {
 		return manager
 	}
 
-	m.lock.Lock()
-	defer m.lock.Unlock()
 	manager := NewSingleClusterInformerManager(client, defaultResync, m.stopCh, m.transformFuncs)
 	m.managers[cluster] = manager
 	return manager


### PR DESCRIPTION
Signed-off-by: wulixuan <wulixuan@bilibili.com>

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Avoid multiple executions after rlock in concurrent scenarios
**Which issue(s) this PR fixes**:
Fixes #3122

**Special notes for your reviewer**:
NONE
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

