### PR TITLE
Fix aggregate pod status when aggregateStatusItems are empty

### DIFF
--- a/pkg/resourceinterpreter/defaultinterpreter/aggregatestatus.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/aggregatestatus.go
@@ -314,6 +314,10 @@ func aggregatePodStatus(object *unstructured.Unstructured, aggregatedStatusItems
 		return nil, err
 	}
 
+	if aggregatedStatusItems == nil {
+		return helper.ToUnstructured(pod)
+	}
+
 	newStatus := &corev1.PodStatus{}
 	newStatus.ContainerStatuses = make([]corev1.ContainerStatus, 0)
 	podPhases := sets.NewString()


### PR DESCRIPTION
Signed-off-by: Poor12 <shentiecheng@huawei.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
When the Pod has just been delivered and the status has not been received, aggregateStatusItems will be empty.
It will print "SHOULD-NEVER-HAPPEN, maybe Pod added a new state that Karmada don't know about." log which may confuse users.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None
