### PR TITLE
Modify unit tests that never fail

### DIFF
--- a/pkg/registry/cluster/strategy_test.go
+++ b/pkg/registry/cluster/strategy_test.go
@@ -277,23 +277,30 @@ func TestStrategy_AllowUnconditionalUpdate(t *testing.T) {
 
 func TestStrategy_Canonicalize(t *testing.T) {
 	clusterStrategy := NewStrategy(clusterscheme.Scheme)
-	clusterBefore := getValidCluster("cluster")
-	clusterAfter := getValidCluster("cluster")
-	clusterAfter.Spec.Taints = []corev1.Taint{
+	cluster := getValidCluster("cluster")
+	cluster.Spec.Taints = []corev1.Taint{
 		{
 			Key:    "foo",
-			Value:  "abc",
+			Value:  "bar",
 			Effect: corev1.TaintEffectNoSchedule,
 		},
 		{
-			Key:    "bar",
+			Key:    "foo1",
+			Value:  "bar1",
 			Effect: corev1.TaintEffectNoExecute,
 		},
 	}
 
-	clusterStrategy.Canonicalize(clusterBefore)
-	if !reflect.DeepEqual(clusterAfter, clusterAfter) {
-		t.Errorf("Object mismatch! Excepted: \n%#v \ngot: \n%#v", clusterAfter, clusterAfter)
+	clusterStrategy.Canonicalize(cluster)
+	success := true
+	for _, taint := range cluster.Spec.Taints {
+		if taint.Effect == corev1.TaintEffectNoExecute && taint.TimeAdded == nil {
+			success = false
+			break
+		}
+	}
+	if !success {
+		t.Errorf("cluster canonicalize error, got: \n%#v", cluster)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Fish-pro <zechun.chen@daocloud.io>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Change will never happen wrong unit tests, from the function implementation, the need to focus only on `corev1. TaintEffectNoExecute` types of `timeAdd` isn't empty
```golang
// MutateClusterTaints add TimeAdded field for cluster NoExecute taints only if TimeAdded not set.
func MutateClusterTaints(taints []corev1.Taint) {
	for i := range taints {
		if taints[i].Effect == corev1.TaintEffectNoExecute && taints[i].TimeAdded == nil {
			now := metav1.Now()
			taints[i].TimeAdded = &now
		}
	}
}

```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

