### PR TITLE
Update default kind version and testing against v1.26.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        k8s: [ v1.21.10, v1.22.7, v1.23.4, v1.24.2, v1.25.0 ]
+        k8s: [ v1.21.10, v1.22.7, v1.23.4, v1.24.2, v1.25.0, v1.26.0 ]
     steps:
       - name: checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/lint-chart.yaml
+++ b/.github/workflows/lint-chart.yaml
@@ -4,7 +4,7 @@ name: Chart Lint
 env:
   HELM_VERSION: v3.8.1
   KIND_VERSION: v0.14.0
-  KIND_NODE_IMAGE: kindest/node:v1.23.4
+  KIND_NODE_IMAGE: kindest/node:v1.26.0
   K8S_VERSION: v1.23.4
 
 on:

--- a/hack/create-cluster.sh
+++ b/hack/create-cluster.sh
@@ -11,7 +11,7 @@ function usage() {
   echo "Example: hack/create-cluster.sh host /root/.kube/karmada.config"
 }
 
-CLUSTER_VERSION=${CLUSTER_VERSION:-"kindest/node:v1.23.4"}
+CLUSTER_VERSION=${CLUSTER_VERSION:-"kindest/node:v1.26.0"}
 
 if [[ $# -lt 1 ]]; then
   usage

--- a/hack/local-up-karmada.sh
+++ b/hack/local-up-karmada.sh
@@ -23,7 +23,7 @@ MEMBER_CLUSTER_2_NAME=${MEMBER_CLUSTER_2_NAME:-"member2"}
 PULL_MODE_CLUSTER_NAME=${PULL_MODE_CLUSTER_NAME:-"member3"}
 HOST_IPADDRESS=${1:-}
 
-CLUSTER_VERSION=${CLUSTER_VERSION:-"kindest/node:v1.23.4"}
+CLUSTER_VERSION=${CLUSTER_VERSION:-"kindest/node:v1.26.0"}
 KIND_LOG_FILE=${KIND_LOG_FILE:-"/tmp/karmada"}
 
 #step0: prepare
@@ -40,7 +40,7 @@ util::verify_go_version
 util::cmd_must_exist "docker"
 
 # install kind and kubectl
-kind_version=v0.15.0
+kind_version=v0.17.0
 echo -n "Preparing: 'kind' existence check - "
 if util::cmd_exist kind; then
   echo "passed"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

The default kind version is too old now when using the latest `kubectl` it rise a warning, like:
```
WARNING: version difference between client (1.26) and server (1.23) exceeds the supported minor version skew of +/-1
```

This PR also adds Kubernetes `v1.26.0` to the E2E matrix.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
1. I leave the [Kubernetes compatibility](https://github.com/karmada-io/karmada#kubernetes-compatibility) un-updated because we need to explain more about the compatibility and it is tracked by #2757.
2. We now got 6 Kubernetes versions in E2E matrix, we can't afford all versions, we need the rule to get rid of the burden. (no idea about that yet)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

