### PR TITLE
[bug-fix] update clueter-cluster shell

### DIFF
--- a/artifacts/kindClusterConfig/general-config.yaml
+++ b/artifacts/kindClusterConfig/general-config.yaml
@@ -1,7 +1,6 @@
 kind: Cluster
 apiVersion: "kind.x-k8s.io/v1alpha4"
 networking:
-  disableDefaultCNI: {{disable_cni}}
   podSubnet: {{pod_cidr}}
   serviceSubnet: {{service_cidr}}
 nodes:

--- a/hack/create-cluster.sh
+++ b/hack/create-cluster.sh
@@ -72,20 +72,10 @@ if [[ -z "${SERVICE_CIDR}" ]]; then
     SERVICE_CIDR=$(generate_cidr 100)
 fi
 
-function deploy_weave_cni() {
-  echo "Applying weave network..."
-  kubectl --kubeconfig=$1 apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl --kubeconfig=$1 version | base64 | tr -d '\n')&env.IPALLOC_RANGE=$2"
-  echo "Waiting for weave-net pods to be ready..."
-  kubectl --kubeconfig=$1 wait --for=condition=Ready pods -l name=weave-net -n kube-system --timeout=10m
-  echo "Waiting for core-dns deployment to be ready..."
-  kubectl --kubeconfig=$1 -n kube-system rollout status deploy/coredns --timeout=5m
-}
-
 #generate for kindClusterConfig
 TEMP_PATH=$(mktemp -d)
 trap '{ rm -rf ${TEMP_PATH}; }' EXIT
 cp -rf "${REPO_ROOT}"/artifacts/kindClusterConfig/general-config.yaml "${TEMP_PATH}"/"${CLUSTER_NAME}"-config.yaml
-sed -i'' -e "s#{{disable_cni}}#true#g" "${TEMP_PATH}"/"${CLUSTER_NAME}"-config.yaml
 sed -i'' -e "s#{{pod_cidr}}#${POD_CIDR}#g" "${TEMP_PATH}"/"${CLUSTER_NAME}"-config.yaml
 sed -i'' -e "s#{{service_cidr}}#${SERVICE_CIDR}#g" "${TEMP_PATH}"/"${CLUSTER_NAME}"-config.yaml
 
@@ -99,7 +89,5 @@ kubectl config rename-context "kind-${CLUSTER_NAME}" "${CLUSTER_NAME}" --kubecon
 # So we need to update endpoint with container IP.
 container_ip=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${CLUSTER_NAME}-control-plane")
 kubectl config set-cluster "kind-${CLUSTER_NAME}" --server="https://${container_ip}:6443" --kubeconfig="${KUBECONFIG}"
-
-deploy_weave_cni "${KUBECONFIG}" "${POD_CIDR}"
 
 echo "cluster \"${CLUSTER_NAME}\" is created successfully!"


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

![image](https://user-images.githubusercontent.com/78244870/217816151-0af76eba-8334-4eee-90a2-c99c968e627f.png)

The cluster fails to be created using the `hack/create-cluster.sh` script, and the installation of the weave fails because the installation address of the weave is changed. We installed the weave to use the submarier, but now the submarier does not use the weave. For details, see [here](https://github.com/submariner-io/shipyard/issues/858). Therefore, we also modify the weave accordingly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

