### PR TITLE
update cluster status conditions when cluster status controller stopped posting cluster status

### DIFF
--- a/pkg/controllers/cluster/cluster_controller.go
+++ b/pkg/controllers/cluster/cluster_controller.go
@@ -543,6 +543,7 @@ func (c *Controller) tryUpdateClusterHealth(ctx context.Context, cluster *cluste
 					currentCondition.Reason = "ClusterStatusUnknown"
 					currentCondition.Message = "Cluster status controller stopped posting cluster status."
 					currentCondition.LastTransitionTime = nowTimestamp
+					meta.SetStatusCondition(&cluster.Status.Conditions, *currentCondition)
 				}
 			}
 		}


### PR DESCRIPTION


**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
update cluster status conditions when cluster status controller stopped posting cluster status


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

