### PR TITLE
remove code for collecting clusterID under upgrading

### DIFF
--- a/pkg/controllers/cluster/cluster_controller.go
+++ b/pkg/controllers/cluster/cluster_controller.go
@@ -177,18 +177,6 @@ func (c *Controller) Reconcile(ctx context.Context, req controllerruntime.Reques
 
 // Start starts an asynchronous loop that monitors the status of cluster.
 func (c *Controller) Start(ctx context.Context) error {
-	// starts a goroutine to collect existed clusters' ID for upgrade scenario
-	// And can be removed in next version
-	klog.Infof("Starting collect ID of already existed clusters")
-	go func() {
-		err := c.collectIDForClusterObjectIfNeeded(ctx)
-		if err != nil {
-			klog.Errorf("Error collecting clusters' ID: %v", err)
-		}
-
-		klog.Infof("Finishing collect ID of already existed clusters")
-	}()
-
 	klog.Infof("Starting cluster health monitor")
 	defer klog.Infof("Shutting cluster health monitor")
 
@@ -625,45 +613,4 @@ func (c *Controller) taintClusterByCondition(ctx context.Context, cluster *clust
 		}
 	}
 	return err
-}
-
-func (c *Controller) collectIDForClusterObjectIfNeeded(ctx context.Context) (err error) {
-	clusterList := &clusterv1alpha1.ClusterList{}
-	if err := c.Client.List(ctx, clusterList); err != nil {
-		return err
-	}
-
-	clusters := clusterList.Items
-	var errs []error
-
-	for i := range clusters {
-		cluster := &clusters[i]
-		if cluster.Spec.ID != "" {
-			continue
-		}
-
-		if cluster.Spec.SyncMode == clusterv1alpha1.Pull {
-			continue
-		}
-
-		clusterClient, err := util.NewClusterClientSet(cluster.Name, c.Client, nil)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("%s: %s", cluster.Name, err.Error()))
-			continue
-		}
-
-		id, err := util.ObtainClusterID(clusterClient.KubeClient)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("%s: %s", cluster.Name, err.Error()))
-			continue
-		}
-		cluster.Spec.ID = id
-
-		err = c.Client.Update(ctx, cluster)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("%s: %s", cluster.Name, err.Error()))
-			continue
-		}
-	}
-	return utilerrors.NewAggregate(errs)
 }


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

In the previous version, we added the code for collecting clusterIDs to consider upgrade compatibility, now this logic can be removed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

