### PR TITLE
Make the result unique for GenerateBindingReferenceKey function

### DIFF
--- a/pkg/util/names/names.go
+++ b/pkg/util/names/names.go
@@ -69,7 +69,7 @@ func GenerateBindingName(kind, name string) string {
 func GenerateBindingReferenceKey(namespace, name string) string {
 	var bindingName string
 	if len(namespace) > 0 {
-		bindingName = namespace + "-" + name
+		bindingName = namespace + "/" + name
 	} else {
 		bindingName = name
 	}

--- a/pkg/util/names/names_test.go
+++ b/pkg/util/names/names_test.go
@@ -92,6 +92,14 @@ func TestGenerateBindingReferenceKey(t *testing.T) {
 			name:      "mytest-deployment",
 			namespace: "",
 		},
+		{
+			name:      "b-c",
+			namespace: "a",
+		},
+		{
+			name:      "c",
+			namespace: "a-b",
+		},
 	}
 	result := map[string]struct{}{}
 	for _, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**
Use `/` as the delimiter for  `GenerateBindingReferenceKey` function

<!--
Add one of the following kinds:
/kind bug
/kind api-change

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
In the following case, the key is not unique:
```go
left := names.GenerateBindingReferenceKey("a","b-c") 
right := names.GenerateBindingReferenceKey("a-b","c") 
```

**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/karmada/issues/3143


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Make the result unique for `GenerateBindingReferenceKey` function.
```

