### PR TITLE
update cluster condition to unknow when cluster is offline

### DIFF
--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -411,7 +411,7 @@ func healthEndpointCheck(client *clientset.Clientset, path string) (int, error) 
 
 func generateReadyCondition(online, healthy bool) metav1.Condition {
 	if !online {
-		return util.NewCondition(clusterv1alpha1.ClusterConditionReady, clusterNotReachableReason, clusterNotReachableMsg, metav1.ConditionFalse)
+		return util.NewCondition(clusterv1alpha1.ClusterConditionReady, clusterNotReachableReason, clusterNotReachableMsg, metav1.ConditionUnknown)
 	}
 	if !healthy {
 		return util.NewCondition(clusterv1alpha1.ClusterConditionReady, clusterNotReady, clusterUnhealthy, metav1.ConditionFalse)

--- a/test/e2e/failover_test.go
+++ b/test/e2e/failover_test.go
@@ -95,7 +95,7 @@ var _ = framework.SerialDescribe("failover testing", func() {
 
 						// wait for the current cluster status changing to false
 						framework.WaitClusterFitWith(controlPlaneClient, targetClusterName, func(cluster *clusterv1alpha1.Cluster) bool {
-							return helper.TaintExists(cluster.Spec.Taints, controllercluster.NotReadyTaintTemplate)
+							return helper.TaintExists(cluster.Spec.Taints, controllercluster.UnreachableTaintTemplate)
 						})
 						disabledClusters = append(disabledClusters, targetClusterName)
 						temp--
@@ -130,7 +130,7 @@ var _ = framework.SerialDescribe("failover testing", func() {
 						if err != nil {
 							return false, err
 						}
-						if !helper.TaintExists(currentCluster.Spec.Taints, controllercluster.NotReadyTaintTemplate) {
+						if !helper.TaintExists(currentCluster.Spec.Taints, controllercluster.UnreachableTaintTemplate) {
 							fmt.Printf("cluster %s recovered\n", disabledCluster)
 							return true, nil
 						}

--- a/test/e2e/karmadactl_test.go
+++ b/test/e2e/karmadactl_test.go
@@ -421,7 +421,7 @@ var _ = framework.SerialDescribe("Karmadactl join/unjoin testing", ginkgo.Labels
 				err := disableCluster(controlPlaneClient, clusterName)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				framework.WaitClusterFitWith(controlPlaneClient, clusterName, func(cluster *clusterv1alpha1.Cluster) bool {
-					return meta.IsStatusConditionPresentAndEqual(cluster.Status.Conditions, clusterv1alpha1.ClusterConditionReady, metav1.ConditionFalse)
+					return meta.IsStatusConditionPresentAndEqual(cluster.Status.Conditions, clusterv1alpha1.ClusterConditionReady, metav1.ConditionUnknown)
 				})
 			})
 

--- a/test/e2e/resource_test.go
+++ b/test/e2e/resource_test.go
@@ -669,7 +669,7 @@ var _ = framework.SerialDescribe("workload status synchronization testing", func
 
 						// wait for the current cluster status changing to false
 						framework.WaitClusterFitWith(controlPlaneClient, targetClusterName, func(cluster *clusterv1alpha1.Cluster) bool {
-							return helper.TaintExists(cluster.Spec.Taints, controllercluster.NotReadyTaintTemplate)
+							return helper.TaintExists(cluster.Spec.Taints, controllercluster.UnreachableTaintTemplate)
 						})
 						disabledClusters = append(disabledClusters, targetClusterName)
 						temp--
@@ -689,7 +689,7 @@ var _ = framework.SerialDescribe("workload status synchronization testing", func
 						currentCluster, err := util.GetCluster(controlPlaneClient, disabledCluster)
 						g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-						if !helper.TaintExists(currentCluster.Spec.Taints, controllercluster.NotReadyTaintTemplate) {
+						if !helper.TaintExists(currentCluster.Spec.Taints, controllercluster.UnreachableTaintTemplate) {
 							fmt.Printf("cluster %s recovered\n", disabledCluster)
 							return true, nil
 						}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

When the cluster is offline, I think its Ready status condition should be `Unknow`, not `False`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

