### PR TITLE
Fix UpdateOrCreateToken get secrets err handling optimization

### DIFF
--- a/pkg/karmadactl/util/bootstraptoken/bootstraptoken.go
+++ b/pkg/karmadactl/util/bootstraptoken/bootstraptoken.go
@@ -322,7 +322,7 @@ func UpdateOrCreateToken(client kubeclient.Interface, failIfExists bool, token *
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
-	if secret != nil && failIfExists {
+	if secret != nil && err == nil && failIfExists {
 		return fmt.Errorf("a token with id %q already exists", token.Token.ID)
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Currently, the `karmadactl init` could not run correctly.

```
I0215 13:34:36.991956   23895 deploy.go:126] Initialize karmada bootstrap token
I0215 13:34:36.992119   23895 round_trippers.go:466] curl -v -XGET  -H "Accept: application/json, */*" -H "User-Agent: karmadactl/v0.0.0 (linux/amd64) kubernetes/$Format" 'https://10.10.103.67:32443/api/v1/namespaces/kube-system/secrets/bootstrap-token-2yhtwh'
I0215 13:34:36.995824   23895 round_trippers.go:553] GET https://10.10.103.67:32443/api/v1/namespaces/kube-system/secrets/bootstrap-token-2yhtwh 404 Not Found in 3 milliseconds
I0215 13:34:36.995866   23895 round_trippers.go:570] HTTP Statistics: GetConnection 0 ms ServerProcessing 3 ms Duration 3 ms
I0215 13:34:36.995886   23895 round_trippers.go:577] Response Headers:
I0215 13:34:36.995906   23895 round_trippers.go:580]     Cache-Control: no-cache, private
I0215 13:34:36.995924   23895 round_trippers.go:580]     Content-Type: application/json
I0215 13:34:36.995941   23895 round_trippers.go:580]     X-Kubernetes-Pf-Flowschema-Uid: 5298a62c-e954-4c28-81cb-40148f7da4b5
I0215 13:34:36.995958   23895 round_trippers.go:580]     X-Kubernetes-Pf-Prioritylevel-Uid: 1c2c96f3-6788-44db-8309-60ddceb7490c
I0215 13:34:36.995975   23895 round_trippers.go:580]     Content-Length: 218
I0215 13:34:36.995992   23895 round_trippers.go:580]     Date: Wed, 15 Feb 2023 05:34:36 GMT
I0215 13:34:36.996008   23895 round_trippers.go:580]     Audit-Id: a01ef834-37d4-47c9-bee3-49fe04748d42
I0215 13:34:36.996056   23895 request.go:1171] Response Body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"secrets \"bootstrap-token-2yhtwh\" not found","reason":"NotFound","details":{"name":"bootstrap-token-2yhtwh","kind":"secrets"},"code":404}
secrets "bootstrap-token-2yhtwh" not found
&Secret{ObjectMeta:{      0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] [] []},Data:map[string][]byte{},Type:,StringData:map[string]string{},Immutable:nil,}
error: a token with id "2yhtwh" already exists
```

The problem is shown above.

I guess the root cause is that `secret, err := client.CoreV1().Secrets().Get()` --> `obj, err := c.Fake.Invokes()`-->`return defaultReturnObj, nil`.

The `obj`  still is not nil, lead to the `secret` is not nil that is default value `&Secret{ObjectMeta:{      0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] [] []},Data:map[string]`.

https://github.com/karmada-io/karmada/blob/a9089325dcbec52e30b00f71ac402ccb6fba29fb/pkg/karmadactl/util/bootstraptoken/bootstraptoken.go#L321-L327

https://github.com/karmada-io/karmada/blob/a9089325dcbec52e30b00f71ac402ccb6fba29fb/vendor/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_secret.go#L47-L55

https://github.com/karmada-io/karmada/blob/a9089325dcbec52e30b00f71ac402ccb6fba29fb/vendor/k8s.io/client-go/testing/fake.go#L131-L154

**Which issue(s) this PR fixes**:
Fixes #3040 

**Special notes for your reviewer**:
https://github.com/kubernetes/kubernetes/pull/115068 has reverted it.

/cc @helen-frank @RainbowMango 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

