### PR TITLE
Add SchedulerObservedAffinityName to RB/CRB

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16764,6 +16764,10 @@
           "description": "SchedulerObservedGeneration is the generation(.metadata.generation) observed by the scheduler. If SchedulerObservedGeneration is less than the generation in metadata means the scheduler hasn't confirmed the scheduling result or hasn't done the schedule yet.",
           "type": "integer",
           "format": "int64"
+        },
+        "schedulerObservingAffinityName": {
+          "description": "SchedulerObservedAffinityName is the name of affinity term that is the basis of current scheduling.",
+          "type": "string"
         }
       }
     },

--- a/charts/karmada/_crds/bases/work.karmada.io_clusterresourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work.karmada.io_clusterresourcebindings.yaml
@@ -1195,6 +1195,10 @@ spec:
                   the scheduling result or hasn't done the schedule yet.
                 format: int64
                 type: integer
+              schedulerObservingAffinityName:
+                description: SchedulerObservedAffinityName is the name of affinity
+                  term that is the basis of current scheduling.
+                type: string
             type: object
         required:
         - spec

--- a/charts/karmada/_crds/bases/work.karmada.io_resourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work.karmada.io_resourcebindings.yaml
@@ -1195,6 +1195,10 @@ spec:
                   the scheduling result or hasn't done the schedule yet.
                 format: int64
                 type: integer
+              schedulerObservingAffinityName:
+                description: SchedulerObservedAffinityName is the name of affinity
+                  term that is the basis of current scheduling.
+                type: string
             type: object
         required:
         - spec

--- a/pkg/apis/work/v1alpha2/binding_types.go
+++ b/pkg/apis/work/v1alpha2/binding_types.go
@@ -235,9 +235,16 @@ type ResourceBindingStatus struct {
 	// the scheduling result or hasn't done the schedule yet.
 	// +optional
 	SchedulerObservedGeneration int64 `json:"schedulerObservedGeneration,omitempty"`
+
+	// SchedulerObservedAffinityName is the name of affinity term that is
+	// the basis of current scheduling.
+	// +optional
+	SchedulerObservedAffinityName string `json:"schedulerObservingAffinityName,omitempty"`
+
 	// Conditions contain the different condition statuses.
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+
 	// AggregatedStatus represents status list of the resource running in each member cluster.
 	// +optional
 	AggregatedStatus []AggregatedStatusItem `json:"aggregatedStatus,omitempty"`

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -5362,6 +5362,13 @@ func schema_pkg_apis_work_v1alpha2_ResourceBindingStatus(ref common.ReferenceCal
 							Format:      "int64",
 						},
 					},
+					"schedulerObservingAffinityName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SchedulerObservedAffinityName is the name of affinity term that is the basis of current scheduling.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"conditions": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Conditions contain the different condition statuses.",


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
This PR added a `SchedulerObservedAffinityName` to ResourceBinding and ClusterResourceBinding according to [multiple scheduling group proposal](#3126).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

