### PR TITLE
fix the bug that the work object may contain uppercase characters

### DIFF
--- a/pkg/util/names/names.go
+++ b/pkg/util/names/names.go
@@ -81,7 +81,7 @@ func GenerateBindingReferenceKey(namespace, name string) string {
 // GenerateWorkName will generate work name by its name and the hash of its namespace, kind and name.
 func GenerateWorkName(kind, name, namespace string) string {
 	// The name of resources, like 'Role'/'ClusterRole'/'RoleBinding'/'ClusterRoleBinding',
-	// may contain symbols(like ':') that are not allowed by CRD resources which require the
+	// may contain symbols(like ':' or uppercase upper case) that are not allowed by CRD resources which require the
 	// name can be used as a DNS subdomain name. So, we need to replace it.
 	// These resources may also allow for other characters(like '&','$') that are not allowed
 	// by CRD resources, we only handle the most common ones now for performance concerns.
@@ -90,6 +90,7 @@ func GenerateWorkName(kind, name, namespace string) string {
 	if strings.Contains(name, ":") {
 		name = strings.ReplaceAll(name, ":", ".")
 	}
+	name = strings.ToLower(name)
 
 	var workName string
 	if len(namespace) == 0 {

--- a/pkg/util/names/names_test.go
+++ b/pkg/util/names/names_test.go
@@ -3,6 +3,7 @@ package names
 import (
 	"fmt"
 	"hash/fnv"
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -200,7 +201,7 @@ func TestGenerateWorkName(t *testing.T) {
 
 		hash := fnv.New32a()
 		hashutil.DeepHashObject(hash, test.workname)
-		if result := fmt.Sprintf("%s-%s", test.name, rand.SafeEncodeString(fmt.Sprint(hash.Sum32()))); result != got {
+		if result := fmt.Sprintf("%s-%s", strings.ToLower(test.name), rand.SafeEncodeString(fmt.Sprint(hash.Sum32()))); result != got {
 			t.Errorf("Test %s failed: expected %v, but got %v", test.testCase, result, got)
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
The name of some resources like `ClusterRole` can contain uppercase characters, but the work object’s name follows the DNS domain name constraint, that is, it cannot contain uppercase characters, refer to `https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names`. I happened to encounter this problem in my environment, so I submitted this PR.

`Create ClusterRole`
![1677134862656](https://user-images.githubusercontent.com/89241565/220837472-c55e8573-b5bc-4d50-a2cb-c22d5be9af84.jpg)

`Create Work`
![1677134862644](https://user-images.githubusercontent.com/89241565/220837490-cf3ce50e-e28c-48f3-a855-b16039a118b4.jpg)

**Which issue(s) this PR fixes**:
Fixes #
fix the bug that the work object may contain uppercase characters
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

