### PR TITLE
Automated cherry pick of #3201: fix the bug that the work object may contain uppercase

### DIFF
--- a/pkg/util/names/names.go
+++ b/pkg/util/names/names.go
@@ -73,6 +73,18 @@ func GenerateBindingReferenceKey(namespace, name string) string {
 
 // GenerateWorkName will generate work name by its name and the hash of its namespace, kind and name.
 func GenerateWorkName(kind, name, namespace string) string {
+	// The name of resources, like 'Role'/'ClusterRole'/'RoleBinding'/'ClusterRoleBinding',
+	// may contain symbols(like ':' or uppercase upper case) that are not allowed by CRD resources which require the
+	// name can be used as a DNS subdomain name. So, we need to replace it.
+	// These resources may also allow for other characters(like '&','$') that are not allowed
+	// by CRD resources, we only handle the most common ones now for performance concerns.
+	// For more information about the DNS subdomain name, please refer to
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names.
+	if strings.Contains(name, ":") {
+		name = strings.ReplaceAll(name, ":", ".")
+	}
+	name = strings.ToLower(name)
+
 	var workName string
 	if len(namespace) == 0 {
 		workName = strings.ToLower(name + "-" + kind)

--- a/pkg/util/names/names_test.go
+++ b/pkg/util/names/names_test.go
@@ -3,6 +3,7 @@ package names
 import (
 	"fmt"
 	"hash/fnv"
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -177,7 +178,7 @@ func TestGenerateWorkName(t *testing.T) {
 
 		hash := fnv.New32a()
 		hashutil.DeepHashObject(hash, test.workname)
-		if result := fmt.Sprintf("%s-%s", test.name, rand.SafeEncodeString(fmt.Sprint(hash.Sum32()))); result != got {
+		if result := fmt.Sprintf("%s-%s", strings.ToLower(test.name), rand.SafeEncodeString(fmt.Sprint(hash.Sum32()))); result != got {
 			t.Errorf("Test %s failed: expected %v, but got %v", test.testCase, result, got)
 		}
 	}


### PR DESCRIPTION
Cherry pick of #3201 on release-1.3.
#3201: fix the bug that the work object may contain uppercase
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`: Fixed the issue that RBAC resources whose name contains uppercase characters can not be propagated.
```