### PR TITLE
Lack of reconciling ServiceAccount as a dependency in release-1.3

### DIFF
--- a/pkg/dependenciesdistributor/dependencies_distributor.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor.go
@@ -49,6 +49,7 @@ const (
 var supportedTypes = []schema.GroupVersionResource{
 	corev1.SchemeGroupVersion.WithResource("configmaps"),
 	corev1.SchemeGroupVersion.WithResource("secrets"),
+	corev1.SchemeGroupVersion.WithResource("serviceaccounts"),
 	corev1.SchemeGroupVersion.WithResource("persistentvolumeclaims"),
 }
 

--- a/pkg/resourceinterpreter/defaultinterpreter/dependencies_test.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/dependencies_test.go
@@ -167,7 +167,16 @@ func TestGetDependenciesFromPodTemplate(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "pvc-name",
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "fake-pvc",
+				},
+			},
+		},
 	}
+	fakePod.Spec.ServiceAccountName = "fake-sa"
 
 	tests := []struct {
 		name     string
@@ -189,6 +198,18 @@ func TestGetDependenciesFromPodTemplate(t *testing.T) {
 					Kind:       "Secret",
 					Namespace:  "foo",
 					Name:       "fake-bar",
+				},
+				{
+					APIVersion: "v1",
+					Kind:       "ServiceAccount",
+					Namespace:  "foo",
+					Name:       "fake-sa",
+				},
+				{
+					APIVersion: "v1",
+					Kind:       "PersistentVolumeClaim",
+					Namespace:  "foo",
+					Name:       "fake-pvc",
 				},
 			},
 		},

--- a/test/e2e/dependenciesdistributor_test.go
+++ b/test/e2e/dependenciesdistributor_test.go
@@ -277,5 +277,54 @@ var _ = ginkgo.Describe("[DependenciesDistributor] automatically propagate relev
 				})
 			})
 		})
+
+		ginkgo.When("serviceAccount propagate automatically", func() {
+			var saName string
+			var sa *corev1.ServiceAccount
+
+			ginkgo.BeforeEach(func() {
+				saName = saNamePrefix + rand.String(RandomStrLength)
+				sa = testhelper.NewServiceaccount(testNamespace, saName)
+
+				deployment = testhelper.NewDeployment(testNamespace, deploymentName)
+				deployment.Spec.Template.Spec.ServiceAccountName = saName
+
+				policy = testhelper.NewPropagationPolicy(testNamespace, policyName, []policyv1alpha1.ResourceSelector{
+					{
+						APIVersion: deployment.APIVersion,
+						Kind:       deployment.Kind,
+						Name:       deployment.Name,
+					},
+				}, policyv1alpha1.Placement{
+					ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+						ClusterNames: initClusterNames,
+					},
+				})
+				policy.Spec.PropagateDeps = true
+			})
+
+			ginkgo.It("serviceAccount automatically propagation testing", func() {
+				framework.CreateServiceAccount(kubeClient, sa)
+				ginkgo.DeferCleanup(func() {
+					framework.RemoveServiceAccount(kubeClient, sa.GetNamespace(), sa.GetName())
+				})
+				ginkgo.By("check if the serviceAccount is propagated automatically", func() {
+					framework.WaitDeploymentPresentOnClustersFitWith(initClusterNames, deployment.Namespace, deployment.Name,
+						func(deployment *appsv1.Deployment) bool {
+							return true
+						})
+
+					framework.WaitServiceAccountPresentOnClustersFitWith(initClusterNames, sa.GetNamespace(), sa.GetName(),
+						func(sa *corev1.ServiceAccount) bool {
+							return true
+						})
+				})
+
+				ginkgo.By("make the sa is not referenced by the deployment ", func() {
+					framework.UpdateDeploymentServiceAccountName(kubeClient, deployment, "default")
+					framework.WaitServiceAccountDisappearOnClusters(initClusterNames, sa.GetNamespace(), sa.GetName())
+				})
+			})
+		})
 	})
 })

--- a/test/e2e/framework/deployment.go
+++ b/test/e2e/framework/deployment.go
@@ -126,6 +126,17 @@ func UpdateDeploymentVolumes(client kubernetes.Interface, deployment *appsv1.Dep
 	})
 }
 
+// UpdateDeploymentServiceAccountName update Deployment's serviceAccountName.
+func UpdateDeploymentServiceAccountName(client kubernetes.Interface, deployment *appsv1.Deployment, serviceAccountName string) {
+	ginkgo.By(fmt.Sprintf("Updating Deployment(%s/%s)'s serviceAccountName to %s", deployment.Namespace, deployment.Name, serviceAccountName), func() {
+		deployment.Spec.Template.Spec.ServiceAccountName = serviceAccountName
+		gomega.Eventually(func() error {
+			_, err := client.AppsV1().Deployments(deployment.Namespace).Update(context.TODO(), deployment, metav1.UpdateOptions{})
+			return err
+		}, pollTimeout, pollInterval).ShouldNot(gomega.HaveOccurred())
+	})
+}
+
 // ExtractTargetClustersFrom extract the target cluster names from deployment's related resourceBinding Information.
 func ExtractTargetClustersFrom(c client.Client, deployment *appsv1.Deployment) []string {
 	bindingName := names.GenerateBindingName(deployment.Kind, deployment.Name)

--- a/test/e2e/framework/rbac.go
+++ b/test/e2e/framework/rbac.go
@@ -11,6 +11,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 )
 
 // CreateClusterRole create clusterRole.
@@ -67,5 +68,58 @@ func RemoveServiceAccount(client kubernetes.Interface, namespace, name string) {
 			return
 		}
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	})
+}
+
+// WaitServiceAccountPresentOnClusterFitWith wait sa present on member clusters sync with fit func.
+func WaitServiceAccountPresentOnClusterFitWith(cluster, namespace, name string, fit func(sa *corev1.ServiceAccount) bool) {
+	clusterClient := GetClusterClient(cluster)
+	gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+
+	klog.Infof("Waiting for serviceAccount(%s/%s) synced on cluster(%s)", namespace, name, cluster)
+	gomega.Eventually(func() bool {
+		sa, err := clusterClient.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return fit(sa)
+	}, pollTimeout, pollInterval).Should(gomega.Equal(true))
+}
+
+// WaitServiceAccountPresentOnClustersFitWith wait sa present on cluster sync with fit func.
+func WaitServiceAccountPresentOnClustersFitWith(clusters []string, namespace, name string, fit func(sa *corev1.ServiceAccount) bool) {
+	ginkgo.By(fmt.Sprintf("Waiting for serviceAccount(%s/%s) synced on member clusters", namespace, name), func() {
+		for _, clusterName := range clusters {
+			WaitServiceAccountPresentOnClusterFitWith(clusterName, namespace, name, fit)
+		}
+	})
+}
+
+// WaitServiceAccountDisappearOnCluster wait sa disappear on cluster until timeout.
+func WaitServiceAccountDisappearOnCluster(cluster, namespace, name string) {
+	clusterClient := GetClusterClient(cluster)
+	gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
+
+	klog.Infof("Waiting for sa(%s/%s) disappear on cluster(%s)", namespace, name, cluster)
+	gomega.Eventually(func() bool {
+		_, err := clusterClient.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err == nil {
+			return false
+		}
+		if apierrors.IsNotFound(err) {
+			return true
+		}
+
+		klog.Errorf("Failed to get sa(%s/%s) on cluster(%s), err: %v", namespace, name, cluster, err)
+		return false
+	}, pollTimeout, pollInterval).Should(gomega.Equal(true))
+}
+
+// WaitServiceAccountDisappearOnClusters wait sa disappear on member clusters until timeout.
+func WaitServiceAccountDisappearOnClusters(clusters []string, namespace, name string) {
+	ginkgo.By(fmt.Sprintf("Check if sa(%s/%s) diappeare on member clusters", namespace, name), func() {
+		for _, clusterName := range clusters {
+			WaitServiceAccountDisappearOnCluster(clusterName, namespace, name)
+		}
 	})
 }

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -47,6 +47,7 @@ const (
 	configMapNamePrefix          = "configmap-"
 	secretNamePrefix             = "secret-"
 	pvcNamePrefix                = "pvc-"
+	saNamePrefix                 = "serviceaccount-"
 	ingressNamePrefix            = "ingress-"
 	daemonSetNamePrefix          = "daemonset-"
 	statefulSetNamePrefix        = "statefulset-"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Fix the problem that serviceaccount may not be delivered as a dependency in `release-1.3` version.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

