### PR TITLE
Automated cherry pick of #2524: propagate dependencies support propagate sa

### DIFF
--- a/pkg/dependenciesdistributor/dependencies_distributor.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor.go
@@ -49,6 +49,7 @@ const (
 var supportedTypes = []schema.GroupVersionResource{
 	corev1.SchemeGroupVersion.WithResource("configmaps"),
 	corev1.SchemeGroupVersion.WithResource("secrets"),
+	corev1.SchemeGroupVersion.WithResource("serviceaccounts"),
 	corev1.SchemeGroupVersion.WithResource("persistentvolumeclaims"),
 }
 

--- a/pkg/resourceinterpreter/defaultinterpreter/dependencies_test.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/dependencies_test.go
@@ -167,7 +167,16 @@ func TestGetDependenciesFromPodTemplate(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "pvc-name",
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "fake-pvc",
+				},
+			},
+		},
 	}
+	fakePod.Spec.ServiceAccountName = "fake-sa"
 
 	tests := []struct {
 		name     string
@@ -189,6 +198,18 @@ func TestGetDependenciesFromPodTemplate(t *testing.T) {
 					Kind:       "Secret",
 					Namespace:  "foo",
 					Name:       "fake-bar",
+				},
+				{
+					APIVersion: "v1",
+					Kind:       "ServiceAccount",
+					Namespace:  "foo",
+					Name:       "fake-sa",
+				},
+				{
+					APIVersion: "v1",
+					Kind:       "PersistentVolumeClaim",
+					Namespace:  "foo",
+					Name:       "fake-pvc",
 				},
 			},
 		},

--- a/test/e2e/framework/deployment.go
+++ b/test/e2e/framework/deployment.go
@@ -126,6 +126,17 @@ func UpdateDeploymentVolumes(client kubernetes.Interface, deployment *appsv1.Dep
 	})
 }
 
+// UpdateDeploymentServiceAccountName update Deployment's serviceAccountName.
+func UpdateDeploymentServiceAccountName(client kubernetes.Interface, deployment *appsv1.Deployment, serviceAccountName string) {
+	ginkgo.By(fmt.Sprintf("Updating Deployment(%s/%s)'s serviceAccountName", deployment.Namespace, deployment.Name), func() {
+		deployment.Spec.Template.Spec.ServiceAccountName = serviceAccountName
+		gomega.Eventually(func() error {
+			_, err := client.AppsV1().Deployments(deployment.Namespace).Update(context.TODO(), deployment, metav1.UpdateOptions{})
+			return err
+		}, pollTimeout, pollInterval).ShouldNot(gomega.HaveOccurred())
+	})
+}
+
 // ExtractTargetClustersFrom extract the target cluster names from deployment's related resourceBinding Information.
 func ExtractTargetClustersFrom(c client.Client, deployment *appsv1.Deployment) []string {
 	bindingName := names.GenerateBindingName(deployment.Kind, deployment.Name)

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -47,6 +47,7 @@ const (
 	configMapNamePrefix          = "configmap-"
 	secretNamePrefix             = "secret-"
 	pvcNamePrefix                = "pvc-"
+	saNamePrefix                 = "sa-"
 	ingressNamePrefix            = "ingress-"
 	daemonSetNamePrefix          = "daemonset-"
 	statefulSetNamePrefix        = "statefulset-"

--- a/test/helper/resource.go
+++ b/test/helper/resource.go
@@ -559,6 +559,41 @@ func NewDeploymentWithVolumes(namespace, deploymentName string, volumes []corev1
 	}
 }
 
+// NewDeploymentWithServiceAccount will build a deployment object that with serviceAccount.
+func NewDeploymentWithServiceAccount(namespace, deploymentName string, serviceAccountName string) *appsv1.Deployment {
+	podLabels := map[string]string{"app": "nginx"}
+
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      deploymentName,
+		},
+		Spec: appsv1.DeploymentSpec{
+
+			Replicas: pointer.Int32Ptr(3),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: podLabels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabels,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "nginx",
+						Image: "nginx:1.19.0",
+					}},
+					ServiceAccountName: serviceAccountName,
+				},
+			},
+		},
+	}
+}
+
 // NewSecret will build a secret object.
 func NewSecret(namespace string, name string, data map[string][]byte) *corev1.Secret {
 	return &corev1.Secret{


### PR DESCRIPTION
Cherry pick of #2524 on release-1.3.
#2524: propagate dependencies support propagate sa
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
karmada-controller-manager: Fix the problem that ServiceAccount can be interpreted as a dependency, but may not be delivered
```