### PR TITLE
[WIP] Add e2e for schedule with clusterAffinities when replica scheduling type is Divided

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
         # Here support the latest three minor releases of Kubernetes, this can be considered to be roughly
         # the same as the End of Life of the Kubernetes release: https://kubernetes.io/releases/
         # Please remember to update the CI Schedule Workflow when we add a new version.
-        k8s: [ v1.24.2, v1.25.0, v1.26.0 ]
+        k8s: [ v1.24.1, v1.24.2, v1.25.0, v1.25.1, v1.26.0 ]
     steps:
       - name: checkout code
         uses: actions/checkout@v3

--- a/pkg/scheduler/event_handler.go
+++ b/pkg/scheduler/event_handler.go
@@ -251,6 +251,16 @@ func (s *Scheduler) enqueueAffectedBindings(cluster *clusterv1alpha1.Cluster) er
 			continue
 		}
 
+		if placementPtr.ClusterAffinities != nil {
+			klog.InfoS("[Debug] event_handler: RB",
+				"Namespace", binding.Namespace,
+				"Name", binding.Name,
+				"SchedulerObservedGeneration", binding.Status.SchedulerObservedGeneration,
+				"Generation", binding.Generation,
+				"ClusterAffinities", placementPtr.ClusterAffinities,
+				"SchedulerObservedAffinityName", binding.Status.SchedulerObservedAffinityName)
+		}
+
 		var affinity *policyv1alpha1.ClusterAffinity
 		if placementPtr.ClusterAffinities != nil {
 			if binding.Status.SchedulerObservedGeneration != binding.Generation {
@@ -290,6 +300,15 @@ func (s *Scheduler) enqueueAffectedCRBs(cluster *clusterv1alpha1.Cluster) error 
 		if placementPtr == nil {
 			// never reach here
 			continue
+		}
+
+		if placementPtr.ClusterAffinities != nil {
+			klog.InfoS("[Debug] event_handler: CRB",
+				"Name", binding.Name,
+				"SchedulerObservedGeneration", binding.Status.SchedulerObservedGeneration,
+				"Generation", binding.Generation,
+				"ClusterAffinities", placementPtr.ClusterAffinities,
+				"SchedulerObservedAffinityName", binding.Status.SchedulerObservedAffinityName)
 		}
 
 		var affinity *policyv1alpha1.ClusterAffinity


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Part of https://github.com/karmada-io/karmada/issues/3153

**Special notes for your reviewer**:

When the cluster label changes, resources whose scheduling policy is `Divided` cannot be scheduled again.

To solve this problem, we need to update the triggering conditions of the scheduler.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

