### PR TITLE
karmadactl: add image pull secret flags for karmadactl init

### DIFF
--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -96,6 +96,7 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 	}
 	flags := cmd.Flags()
 	flags.StringVarP(&opts.ImageRegistry, "private-image-registry", "", "", "Private image registry where pull images from. If set, all required images will be downloaded from it, it would be useful in offline installation scenarios.  In addition, you still can use --kube-image-registry to specify the registry for Kubernetes's images.")
+	flags.StringSliceVar(&opts.PullSecrets, "image-pull-secrets", nil, "Image pull secrets are used to pull images from the private registry, could be secret list separated by comma (e.g '--image-pull-secrets PullSecret1,PullSecret2', the secrets should be pre-settled in the namespace declared by '--namespace')")
 	// kube image registry
 	flags.StringVarP(&opts.KubeImageMirrorCountry, "kube-image-mirror-country", "", "", "Country code of the kube image registry to be used. For Chinese mainland users, set it to cn")
 	flags.StringVarP(&opts.KubeImageRegistry, "kube-image-registry", "", "", "Kube image registry. For Chinese mainland users, you may use local gcr.io mirrors such as registry.cn-hangzhou.aliyuncs.com/google_containers to override default kube image registry")

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -121,6 +121,7 @@ type CommandInitOption struct {
 	CRDs                               string
 	ExternalIP                         string
 	ExternalDNS                        string
+	PullSecrets                        []string
 	CertValidity                       time.Duration
 	KubeClientSet                      kubernetes.Interface
 	CertAndKeyFileData                 map[string][]byte
@@ -611,6 +612,18 @@ func (i *CommandInitOption) karmadaAggregatedAPIServerImage() string {
 		return i.ImageRegistry + "/karmada-aggregated-apiserver:" + karmadaRelease
 	}
 	return i.KarmadaAggregatedAPIServerImage
+}
+
+// get image pull secret
+func (i *CommandInitOption) getImagePullSecrets() []corev1.LocalObjectReference {
+	var imagePullSecrets []corev1.LocalObjectReference
+	for _, val := range i.PullSecrets {
+		secret := corev1.LocalObjectReference{
+			Name: val,
+		}
+		imagePullSecrets = append(imagePullSecrets, secret)
+	}
+	return imagePullSecrets
 }
 
 func generateServerURL(serverIP string, nodePort int32) (string, error) {

--- a/pkg/karmadactl/cmdinit/kubernetes/deployments.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deployments.go
@@ -138,6 +138,7 @@ func (i *CommandInitOption) makeKarmadaAPIServerDeployment() *appsv1.Deployment 
 	}
 
 	podSpec := corev1.PodSpec{
+		ImagePullSecrets: i.getImagePullSecrets(),
 		Affinity: &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
@@ -251,6 +252,7 @@ func (i *CommandInitOption) makeKarmadaKubeControllerManagerDeployment() *appsv1
 	}
 
 	podSpec := corev1.PodSpec{
+		ImagePullSecrets: i.getImagePullSecrets(),
 		Affinity: &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
@@ -396,6 +398,7 @@ func (i *CommandInitOption) makeKarmadaSchedulerDeployment() *appsv1.Deployment 
 	}
 
 	podSpec := corev1.PodSpec{
+		ImagePullSecrets: i.getImagePullSecrets(),
 		Affinity: &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
@@ -510,6 +513,7 @@ func (i *CommandInitOption) makeKarmadaControllerManagerDeployment() *appsv1.Dep
 	}
 
 	podSpec := corev1.PodSpec{
+		ImagePullSecrets: i.getImagePullSecrets(),
 		Affinity: &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
@@ -626,6 +630,7 @@ func (i *CommandInitOption) makeKarmadaWebhookDeployment() *appsv1.Deployment {
 	}
 
 	podSpec := corev1.PodSpec{
+		ImagePullSecrets: i.getImagePullSecrets(),
 		Affinity: &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
@@ -771,6 +776,7 @@ func (i *CommandInitOption) makeKarmadaAggregatedAPIServerDeployment() *appsv1.D
 	}
 
 	podSpec := corev1.PodSpec{
+		ImagePullSecrets: i.getImagePullSecrets(),
 		Affinity: &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{

--- a/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
@@ -211,6 +211,7 @@ func (i *CommandInitOption) makeETCDStatefulSet() *appsv1.StatefulSet {
 
 	// etcd Container
 	podSpec := corev1.PodSpec{
+		ImagePullSecrets: i.getImagePullSecrets(),
 		Affinity: &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
In a production environment, registry  are generally non-public. If the registry we get from the administrator is private, we need to configure the imagepullsecret in the application's yaml file.
So I think it would be better if `karmadactl init` could specify imagepullsecret.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmadactl: Add image pull secret flags for `karmadactl init`
```

