### PR TITLE
Increase `.metadata.generation` once desired state of the `Cluster` object is changed.

### DIFF
--- a/pkg/scheduler/event_handler.go
+++ b/pkg/scheduler/event_handler.go
@@ -167,7 +167,7 @@ func (s *Scheduler) updateCluster(oldObj, newObj interface{}) {
 	switch {
 	case !equality.Semantic.DeepEqual(oldCluster.Labels, newCluster.Labels):
 		fallthrough
-	case !equality.Semantic.DeepEqual(oldCluster.Spec, newCluster.Spec):
+	case oldCluster.Generation != newCluster.Generation:
 		s.enqueueAffectedBindings(oldCluster, newCluster)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

We should set the `generation` field of the Cluster object. When the `spec` part of the Cluster object changes, the `generation` value should increase. Its value begins with 1.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Do we need to pay attention to the changes in labels and annotations of the Cluster object?

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-aggregated-apiserver`: Increase `.metadata.generation` once desired state of the `Cluster` object is changed.
```

