### PR TITLE
reduce the number of kubernetes version support in CI E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,10 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        k8s: [ v1.21.10, v1.22.7, v1.23.4, v1.24.2, v1.25.0, v1.26.0 ]
+        # Here support the latest three minor releases of Kubernetes, this can be considered to be roughly
+        # the same as the End of Life of the Kubernetes release: https://kubernetes.io/releases/
+        # Please remember to update the CI Schedule Workflow when we add a new version.
+        k8s: [ v1.24.2, v1.25.0, v1.26.0 ]
     steps:
       - name: checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

To reduce the consumption of test resources, we can reduce the number of Kubernetes version support in CI E2E in the current CI Workflow.

We plan to change the supported versions to the latest three minor releases of Kubernetes, this can be considered to be roughly the same as the `End of Life` of the [Kubernetes release](https://kubernetes.io/releases/).

**Which issue(s) this PR fixes**:
Part of #3235 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

