### PR TITLE
add managed-by label to resources created by karmada controllers

### DIFF
--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -137,7 +137,7 @@ func mergeLabel(workload *unstructured.Unstructured, workNamespace string, bindi
 	var workLabel = make(map[string]string)
 	util.MergeLabel(workload, workv1alpha1.WorkNamespaceLabel, workNamespace)
 	util.MergeLabel(workload, workv1alpha1.WorkNameLabel, names.GenerateWorkName(workload.GetKind(), workload.GetName(), workload.GetNamespace()))
-	util.MergeLabel(workload, util.ManagedByWellKnownLabel, util.Karmada)
+	util.MergeLabel(workload, util.ManagedByKarmadaLabel, util.ManagedByKarmadaLabelValue)
 	if scope == apiextensionsv1.NamespaceScoped {
 		util.MergeLabel(workload, workv1alpha2.ResourceBindingReferenceKey, names.GenerateBindingReferenceKey(binding.GetNamespace(), binding.GetName()))
 		workLabel[workv1alpha2.ResourceBindingReferenceKey] = names.GenerateBindingReferenceKey(binding.GetNamespace(), binding.GetName())

--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -137,6 +137,7 @@ func mergeLabel(workload *unstructured.Unstructured, workNamespace string, bindi
 	var workLabel = make(map[string]string)
 	util.MergeLabel(workload, workv1alpha1.WorkNamespaceLabel, workNamespace)
 	util.MergeLabel(workload, workv1alpha1.WorkNameLabel, names.GenerateWorkName(workload.GetKind(), workload.GetName(), workload.GetNamespace()))
+	util.MergeLabel(workload, util.ManagedByWellKnownLabel, util.Karmada)
 	if scope == apiextensionsv1.NamespaceScoped {
 		util.MergeLabel(workload, workv1alpha2.ResourceBindingReferenceKey, names.GenerateBindingReferenceKey(binding.GetNamespace(), binding.GetName()))
 		workLabel[workv1alpha2.ResourceBindingReferenceKey] = names.GenerateBindingReferenceKey(binding.GetNamespace(), binding.GetName())

--- a/pkg/controllers/certificate/cert_rotation_controller.go
+++ b/pkg/controllers/certificate/cert_rotation_controller.go
@@ -224,7 +224,7 @@ func (c *CertRotationController) createCSRInControlPlane(clusterName string, pri
 		ObjectMeta: metav1.ObjectMeta{
 			Name: csrName,
 			Labels: map[string]string{
-				util.ManagedByWellKnownLabel: util.Karmada,
+				util.ManagedByKarmadaLabel: util.ManagedByKarmadaLabelValue,
 			},
 		},
 		Spec: certificatesv1.CertificateSigningRequestSpec{

--- a/pkg/controllers/certificate/cert_rotation_controller.go
+++ b/pkg/controllers/certificate/cert_rotation_controller.go
@@ -223,6 +223,9 @@ func (c *CertRotationController) createCSRInControlPlane(clusterName string, pri
 	certificateSigningRequest := &certificatesv1.CertificateSigningRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: csrName,
+			Labels: map[string]string{
+				util.ManagedByWellKnownLabel: util.Karmada,
+			},
 		},
 		Spec: certificatesv1.CertificateSigningRequestSpec{
 			Request:           csrData,

--- a/pkg/controllers/cluster/cluster_controller.go
+++ b/pkg/controllers/cluster/cluster_controller.go
@@ -365,7 +365,7 @@ func (c *Controller) createExecutionSpace(cluster *clusterv1alpha1.Cluster) erro
 			ObjectMeta: metav1.ObjectMeta{
 				Name: executionSpaceName,
 				Labels: map[string]string{
-					util.ManagedByWellKnownLabel: util.Karmada,
+					util.ManagedByKarmadaLabel: util.ManagedByKarmadaLabelValue,
 				},
 			},
 		}

--- a/pkg/controllers/cluster/cluster_controller.go
+++ b/pkg/controllers/cluster/cluster_controller.go
@@ -364,6 +364,9 @@ func (c *Controller) createExecutionSpace(cluster *clusterv1alpha1.Cluster) erro
 		executionSpace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: executionSpaceName,
+				Labels: map[string]string{
+					util.ManagedByWellKnownLabel: util.Karmada,
+				},
 			},
 		}
 		err = c.Client.Create(context.TODO(), executionSpace)

--- a/pkg/controllers/execution/execution_controller.go
+++ b/pkg/controllers/execution/execution_controller.go
@@ -188,6 +188,7 @@ func (c *Controller) syncToClusters(clusterName string, work *workv1alpha1.Work)
 	syncSucceedNum := 0
 	for _, manifest := range work.Spec.Workload.Manifests {
 		workload := &unstructured.Unstructured{}
+		util.MergeLabel(workload, util.ManagedByWellKnownLabel, util.Karmada)
 		err := workload.UnmarshalJSON(manifest.Raw)
 		if err != nil {
 			klog.Errorf("Failed to unmarshal workload, error is: %v", err)

--- a/pkg/controllers/execution/execution_controller.go
+++ b/pkg/controllers/execution/execution_controller.go
@@ -188,7 +188,7 @@ func (c *Controller) syncToClusters(clusterName string, work *workv1alpha1.Work)
 	syncSucceedNum := 0
 	for _, manifest := range work.Spec.Workload.Manifests {
 		workload := &unstructured.Unstructured{}
-		util.MergeLabel(workload, util.ManagedByWellKnownLabel, util.Karmada)
+		util.MergeLabel(workload, util.ManagedByKarmadaLabel, util.ManagedByKarmadaLabelValue)
 		err := workload.UnmarshalJSON(manifest.Raw)
 		if err != nil {
 			klog.Errorf("Failed to unmarshal workload, error is: %v", err)

--- a/pkg/controllers/federatedresourcequota/federated_resource_quota_sync_controller.go
+++ b/pkg/controllers/federatedresourcequota/federated_resource_quota_sync_controller.go
@@ -155,7 +155,7 @@ func (c *SyncController) buildWorks(quota *policyv1alpha1.FederatedResourceQuota
 		resourceQuota.Labels = map[string]string{
 			workv1alpha1.WorkNamespaceLabel: workNamespace,
 			workv1alpha1.WorkNameLabel:      workName,
-			util.ManagedByWellKnownLabel:    util.Karmada,
+			util.ManagedByKarmadaLabel:      util.ManagedByKarmadaLabelValue,
 		}
 		resourceQuota.Spec.Hard = extractClusterHardResourceList(quota.Spec, cluster.Name)
 
@@ -173,7 +173,7 @@ func (c *SyncController) buildWorks(quota *policyv1alpha1.FederatedResourceQuota
 			Labels: map[string]string{
 				util.FederatedResourceQuotaNamespaceLabel: quota.Namespace,
 				util.FederatedResourceQuotaNameLabel:      quota.Name,
-				util.ManagedByWellKnownLabel:              util.Karmada,
+				util.ManagedByKarmadaLabel:                util.ManagedByKarmadaLabelValue,
 			},
 		}
 

--- a/pkg/controllers/federatedresourcequota/federated_resource_quota_sync_controller.go
+++ b/pkg/controllers/federatedresourcequota/federated_resource_quota_sync_controller.go
@@ -155,6 +155,7 @@ func (c *SyncController) buildWorks(quota *policyv1alpha1.FederatedResourceQuota
 		resourceQuota.Labels = map[string]string{
 			workv1alpha1.WorkNamespaceLabel: workNamespace,
 			workv1alpha1.WorkNameLabel:      workName,
+			util.ManagedByWellKnownLabel:    util.Karmada,
 		}
 		resourceQuota.Spec.Hard = extractClusterHardResourceList(quota.Spec, cluster.Name)
 
@@ -172,6 +173,7 @@ func (c *SyncController) buildWorks(quota *policyv1alpha1.FederatedResourceQuota
 			Labels: map[string]string{
 				util.FederatedResourceQuotaNamespaceLabel: quota.Namespace,
 				util.FederatedResourceQuotaNameLabel:      quota.Name,
+				util.ManagedByWellKnownLabel:              util.Karmada,
 			},
 		}
 

--- a/pkg/controllers/hpa/hpa_controller.go
+++ b/pkg/controllers/hpa/hpa_controller.go
@@ -97,7 +97,7 @@ func (c *HorizontalPodAutoscalerController) buildWorks(hpa *autoscalingv1.Horizo
 
 		util.MergeLabel(hpaObj, workv1alpha1.WorkNamespaceLabel, workNamespace)
 		util.MergeLabel(hpaObj, workv1alpha1.WorkNameLabel, workName)
-		util.MergeLabel(hpaObj, util.ManagedByWellKnownLabel, util.Karmada)
+		util.MergeLabel(hpaObj, util.ManagedByKarmadaLabel, util.ManagedByKarmadaLabelValue)
 
 		if err = helper.CreateOrUpdateWork(c.Client, objectMeta, hpaObj); err != nil {
 			return err

--- a/pkg/controllers/hpa/hpa_controller.go
+++ b/pkg/controllers/hpa/hpa_controller.go
@@ -97,6 +97,7 @@ func (c *HorizontalPodAutoscalerController) buildWorks(hpa *autoscalingv1.Horizo
 
 		util.MergeLabel(hpaObj, workv1alpha1.WorkNamespaceLabel, workNamespace)
 		util.MergeLabel(hpaObj, workv1alpha1.WorkNameLabel, workName)
+		util.MergeLabel(hpaObj, util.ManagedByWellKnownLabel, util.Karmada)
 
 		if err = helper.CreateOrUpdateWork(c.Client, objectMeta, hpaObj); err != nil {
 			return err

--- a/pkg/controllers/mcs/endpointslice_controller.go
+++ b/pkg/controllers/mcs/endpointslice_controller.go
@@ -103,7 +103,7 @@ func (c *EndpointSliceController) collectEndpointSliceFromWork(work *workv1alpha
 			workv1alpha1.WorkNamespaceLabel: work.Namespace,
 			workv1alpha1.WorkNameLabel:      work.Name,
 			discoveryv1.LabelServiceName:    names.GenerateDerivedServiceName(work.Labels[util.ServiceNameLabel]),
-			util.ManagedByWellKnownLabel:    util.Karmada,
+			util.ManagedByKarmadaLabel:      util.ManagedByKarmadaLabelValue,
 		}
 
 		if err = helper.CreateOrUpdateEndpointSlice(c.Client, desiredEndpointSlice); err != nil {

--- a/pkg/controllers/mcs/endpointslice_controller.go
+++ b/pkg/controllers/mcs/endpointslice_controller.go
@@ -103,6 +103,7 @@ func (c *EndpointSliceController) collectEndpointSliceFromWork(work *workv1alpha
 			workv1alpha1.WorkNamespaceLabel: work.Namespace,
 			workv1alpha1.WorkNameLabel:      work.Name,
 			discoveryv1.LabelServiceName:    names.GenerateDerivedServiceName(work.Labels[util.ServiceNameLabel]),
+			util.ManagedByWellKnownLabel:    util.Karmada,
 		}
 
 		if err = helper.CreateOrUpdateEndpointSlice(c.Client, desiredEndpointSlice); err != nil {

--- a/pkg/controllers/mcs/service_export_controller.go
+++ b/pkg/controllers/mcs/service_export_controller.go
@@ -392,8 +392,8 @@ func reportEndpointSlice(c client.Client, endpointSlice *unstructured.Unstructur
 			util.ServiceNamespaceLabel: endpointSlice.GetNamespace(),
 			util.ServiceNameLabel:      endpointSlice.GetLabels()[discoveryv1.LabelServiceName],
 			// indicate the Work should be not propagated since it's collected resource.
-			util.PropagationInstruction:  util.PropagationInstructionSuppressed,
-			util.ManagedByWellKnownLabel: util.Karmada,
+			util.PropagationInstruction: util.PropagationInstructionSuppressed,
+			util.ManagedByKarmadaLabel:  util.ManagedByKarmadaLabelValue,
 		},
 	}
 

--- a/pkg/controllers/mcs/service_export_controller.go
+++ b/pkg/controllers/mcs/service_export_controller.go
@@ -392,7 +392,8 @@ func reportEndpointSlice(c client.Client, endpointSlice *unstructured.Unstructur
 			util.ServiceNamespaceLabel: endpointSlice.GetNamespace(),
 			util.ServiceNameLabel:      endpointSlice.GetLabels()[discoveryv1.LabelServiceName],
 			// indicate the Work should be not propagated since it's collected resource.
-			util.PropagationInstruction: util.PropagationInstructionSuppressed,
+			util.PropagationInstruction:  util.PropagationInstructionSuppressed,
+			util.ManagedByWellKnownLabel: util.Karmada,
 		},
 	}
 

--- a/pkg/controllers/mcs/service_import_controller.go
+++ b/pkg/controllers/mcs/service_import_controller.go
@@ -15,6 +15,7 @@ import (
 	mcsv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
 	"github.com/karmada-io/karmada/pkg/events"
+	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
@@ -86,6 +87,9 @@ func (c *ServiceImportController) deriveServiceFromServiceImport(svcImport *mcsv
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: svcImport.Namespace,
 			Name:      names.GenerateDerivedServiceName(svcImport.Name),
+			Labels: map[string]string{
+				util.ManagedByWellKnownLabel: util.Karmada,
+			},
 		},
 		Spec: corev1.ServiceSpec{
 			Type:  corev1.ServiceTypeClusterIP,

--- a/pkg/controllers/mcs/service_import_controller.go
+++ b/pkg/controllers/mcs/service_import_controller.go
@@ -88,7 +88,7 @@ func (c *ServiceImportController) deriveServiceFromServiceImport(svcImport *mcsv
 			Namespace: svcImport.Namespace,
 			Name:      names.GenerateDerivedServiceName(svcImport.Name),
 			Labels: map[string]string{
-				util.ManagedByWellKnownLabel: util.Karmada,
+				util.ManagedByKarmadaLabel: util.ManagedByKarmadaLabelValue,
 			},
 		},
 		Spec: corev1.ServiceSpec{

--- a/pkg/controllers/namespace/namespace_sync_controller.go
+++ b/pkg/controllers/namespace/namespace_sync_controller.go
@@ -147,6 +147,7 @@ func (c *Controller) buildWorks(namespace *corev1.Namespace, clusters []clusterv
 
 			util.MergeLabel(clonedNamespaced, workv1alpha1.WorkNamespaceLabel, workNamespace)
 			util.MergeLabel(clonedNamespaced, workv1alpha1.WorkNameLabel, workName)
+			util.MergeLabel(clonedNamespaced, util.ManagedByWellKnownLabel, util.Karmada)
 
 			if err = helper.CreateOrUpdateWork(c.Client, objectMeta, clonedNamespaced); err != nil {
 				ch <- fmt.Errorf("sync namespace(%s) to cluster(%s) failed due to: %v", clonedNamespaced.GetName(), cluster.GetName(), err)

--- a/pkg/controllers/namespace/namespace_sync_controller.go
+++ b/pkg/controllers/namespace/namespace_sync_controller.go
@@ -147,7 +147,7 @@ func (c *Controller) buildWorks(namespace *corev1.Namespace, clusters []clusterv
 
 			util.MergeLabel(clonedNamespaced, workv1alpha1.WorkNamespaceLabel, workNamespace)
 			util.MergeLabel(clonedNamespaced, workv1alpha1.WorkNameLabel, workName)
-			util.MergeLabel(clonedNamespaced, util.ManagedByWellKnownLabel, util.Karmada)
+			util.MergeLabel(clonedNamespaced, util.ManagedByKarmadaLabel, util.ManagedByKarmadaLabelValue)
 
 			if err = helper.CreateOrUpdateWork(c.Client, objectMeta, clonedNamespaced); err != nil {
 				ch <- fmt.Errorf("sync namespace(%s) to cluster(%s) failed due to: %v", clonedNamespaced.GetName(), cluster.GetName(), err)

--- a/pkg/controllers/unifiedauth/unified_auth_controller.go
+++ b/pkg/controllers/unifiedauth/unified_auth_controller.go
@@ -222,6 +222,7 @@ func (c *Controller) buildWorks(cluster *clusterv1alpha1.Cluster, obj *unstructu
 
 	util.MergeLabel(obj, workv1alpha1.WorkNamespaceLabel, workNamespace)
 	util.MergeLabel(obj, workv1alpha1.WorkNameLabel, clusterRoleBindingWorkName)
+	util.MergeLabel(obj, util.ManagedByWellKnownLabel, util.Karmada)
 
 	if err := helper.CreateOrUpdateWork(c.Client, objectMeta, obj); err != nil {
 		return err

--- a/pkg/controllers/unifiedauth/unified_auth_controller.go
+++ b/pkg/controllers/unifiedauth/unified_auth_controller.go
@@ -222,7 +222,7 @@ func (c *Controller) buildWorks(cluster *clusterv1alpha1.Cluster, obj *unstructu
 
 	util.MergeLabel(obj, workv1alpha1.WorkNamespaceLabel, workNamespace)
 	util.MergeLabel(obj, workv1alpha1.WorkNameLabel, clusterRoleBindingWorkName)
-	util.MergeLabel(obj, util.ManagedByWellKnownLabel, util.Karmada)
+	util.MergeLabel(obj, util.ManagedByKarmadaLabel, util.ManagedByKarmadaLabelValue)
 
 	if err := helper.CreateOrUpdateWork(c.Client, objectMeta, obj); err != nil {
 		return err

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -22,6 +22,9 @@ const (
 
 	// FederatedResourceQuotaNameLabel is added to Work to specify associated FederatedResourceQuota's name.
 	FederatedResourceQuotaNameLabel = "federatedresourcequota.karmada.io/name"
+
+	// ManagedByWellKnownLabel is a well known label to specify the controller that manages the resource
+	ManagedByWellKnownLabel = "app.kubernetes.io/managed-by"
 )
 
 // Define annotations used by karmada system.
@@ -141,6 +144,9 @@ const (
 const (
 	// NamespaceKarmadaSystem is the karmada system namespace.
 	NamespaceKarmadaSystem = "karmada-system"
+
+	// Karmada is the value for managed-by label.
+	Karmada = "karmada"
 )
 
 // ContextKey is the key of context.

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -23,8 +23,11 @@ const (
 	// FederatedResourceQuotaNameLabel is added to Work to specify associated FederatedResourceQuota's name.
 	FederatedResourceQuotaNameLabel = "federatedresourcequota.karmada.io/name"
 
-	// ManagedByWellKnownLabel is a well known label to specify the controller that manages the resource
-	ManagedByWellKnownLabel = "app.kubernetes.io/managed-by"
+	// ManagedByKarmadaLabel is a reserved karmada label to indicate whether resources are managed by karmada controllers.
+	ManagedByKarmadaLabel = "karmada.io/managed"
+
+	// ManagedByKarmadaLabelValue indicates that resources are managed by karmada controllers.
+	ManagedByKarmadaLabelValue = "true"
 )
 
 // Define annotations used by karmada system.
@@ -144,9 +147,6 @@ const (
 const (
 	// NamespaceKarmadaSystem is the karmada system namespace.
 	NamespaceKarmadaSystem = "karmada-system"
-
-	// Karmada is the value for managed-by label.
-	Karmada = "karmada"
 )
 
 // ContextKey is the key of context.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Adds the well-known `"app.kubernetes.io/managed-by"` label to resources created by karmada controllers

We need a way to bypass creation of some ClusterRole/Rolebindings by our OPA Gatekeeper and we don't have a consistent label to select on. Not all the resources in this PR are needed by us (mostly just needed unified auth) but wanted to keep it consistent across controllers.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Add the reserved label `karmada.io/managed` to resources created by karmada controllers.
```

