### PR TITLE
fixed karmada controller flag

### DIFF
--- a/charts/karmada/templates/karmada-controller-manager.yaml
+++ b/charts/karmada/templates/karmada-controller-manager.yaml
@@ -1,5 +1,6 @@
 {{- if eq .Values.installMode "host" }}
 {{- $name := include "karmada.name" . -}}
+{{- $systemNamespace := .Values.systemNamespace -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -55,7 +56,7 @@ spec:
             - --bind-address=0.0.0.0
             - --cluster-status-update-frequency=10s
             - --secure-port=10357
-            - --leader-elect-resource-namespace={{ include "karmada.namespace" . }}
+            - --leader-elect-resource-namespace={{ $systemNamespace }}
             - --v=2
             {{- if .Values.controllerManager.controllers }}
             - --controllers={{ .Values.controllerManager.controllers }}

--- a/charts/karmada/templates/karmada-descheduler.yaml
+++ b/charts/karmada/templates/karmada-descheduler.yaml
@@ -1,4 +1,5 @@
 {{- $name := include "karmada.name" . -}}
+{{- $systemNamespace := .Values.systemNamespace -}}
 {{- if and (or (eq .Values.installMode "component") (eq .Values.installMode "host")) (has "descheduler" .Values.components) }}
 apiVersion: apps/v1
 kind: Deployment
@@ -48,7 +49,7 @@ spec:
             - /bin/karmada-descheduler
             - --kubeconfig=/etc/kubeconfig
             - --bind-address=0.0.0.0
-            - --leader-elect-resource-namespace={{ include "karmada.namespace" . }}
+            - --leader-elect-resource-namespace={{ $systemNamespace }}
             - --v=4
           livenessProbe:
             httpGet:

--- a/charts/karmada/templates/karmada-scheduler.yaml
+++ b/charts/karmada/templates/karmada-scheduler.yaml
@@ -1,5 +1,5 @@
 {{- $name := include "karmada.name" . -}}
-
+{{- $systemNamespace := .Values.systemNamespace -}}
 {{- if eq .Values.installMode "host" }}
 apiVersion: apps/v1
 kind: Deployment
@@ -50,7 +50,7 @@ spec:
             - --kubeconfig=/etc/kubeconfig
             - --bind-address=0.0.0.0
             - --secure-port=10351
-            - --leader-elect-resource-namespace={{ include "karmada.namespace" . }}
+            - --leader-elect-resource-namespace={{ $systemNamespace }}
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When Using the latest version chart to install karmada, the logger will  throw following error:

```
[root@master ~]# kubectl logs -n  e2etest-instancedefaultiqo-lpl6b --tail 10  karmada-e2etest-instancedefaultiqo-scheduler-864855df46-8rhqb
E0313 03:26:44.609404       1 leaderelection.go:334] error initially creating leader election record: namespaces "e2etest-instancedefaultiqo-lpl6b" not found
E0313 03:26:48.721652       1 leaderelection.go:334] error initially creating leader election record: namespaces "e2etest-instancedefaultiqo-lpl6b" not found
E0313 03:26:51.725115       1 leaderelection.go:334] error initially creating leader election record: namespaces "e2etest-instancedefaultiqo-lpl6b" not found
E0313 03:26:55.619363       1 leaderelection.go:334] error initially creating leader election record: namespaces "e2etest-instancedefaultiqo-lpl6b" not found
E0313 03:26:57.875700       1 leaderelection.go:334] error initially creating leader election record: namespaces "e2etest-instancedefaultiqo-lpl6b" not found
E0313 03:27:02.335276       1 leaderelection.go:334] error initially creating leader election record: namespaces "e2etest-instancedefaultiqo-lpl6b" not found
E0313 03:27:05.006108       1 leaderelection.go:334] error initially creating leader election record: namespaces "e2etest-instancedefaultiqo-lpl6b" not found
E0313 03:27:07.874375       1 leaderelection.go:334] error initially creating leader election record: namespaces "e2etest-instancedefaultiqo-lpl6b" not found
E0313 03:27:10.431378       1 leaderelection.go:334] error initially creating leader election record: namespaces "e2etest-instancedefaultiqo-lpl6b" not found
E0313 03:27:12.755740       1 leaderelection.go:334] error initially creating leader election record: namespaces "e2etest-instancedefaultiqo-lpl6b" not found
```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

