### PR TITLE
Install golangci-lint binary instead of from source

### DIFF
--- a/hack/verify-staticcheck.sh
+++ b/hack/verify-staticcheck.sh
@@ -5,13 +5,19 @@ set -o nounset
 set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-GOLANGCI_LINT_PKG="github.com/golangci/golangci-lint/cmd/golangci-lint"
 GOLANGCI_LINT_VER="v1.49.0"
 
 cd "${REPO_ROOT}"
 source "hack/util.sh"
 
-util::install_tools ${GOLANGCI_LINT_PKG} ${GOLANGCI_LINT_VER}
+if util::cmd_exist golangci-lint ; then
+  echo "Using golangci-lint version:"
+  golangci-lint version
+else
+  echo "Installing golangci-lint ${GOLANGCI_LINT_VER}"
+  # https://golangci-lint.run/usage/install/#other-ci
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VER}
+fi
 
 if golangci-lint run; then
   echo 'Congratulations!  All Go source files have passed staticcheck.'


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
This PR updates the way we setup golangci-lint, it will improve the efficiency.

`go install`/`go get` installation isn't recommended according to [golangci-lint documents](https://golangci-lint.run/usage/install/#install-from-source), one of the reasons is `it's slower than binary installation`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Before the patch:
```bash
-bash-5.0# time hack/verify-staticcheck.sh 
go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
Congratulations!  All Go source files have passed staticcheck.

real	4m55.925s
user	13m54.114s
sys	1m19.474s
```

After this patch:
```bash
-bash-5.0# time hack/verify-staticcheck.sh 
Installing golangci-lint v1.49.0
golangci/golangci-lint info checking GitHub for tag 'v1.49.0'
golangci/golangci-lint info found version: 1.49.0 for v1.49.0/linux/amd64
golangci/golangci-lint info installed /root/go/bin/golangci-lint
Congratulations!  All Go source files have passed staticcheck.

real	2m10.264s
user	6m31.038s
sys	0m14.875s
```

And, if the golangci-lint already installed, the output is:
```bash
-bash-5.0# time hack/verify-staticcheck.sh 
Using golangci-lint version:
golangci-lint has version 1.49.0 built from cc2d97f3 on 2022-08-24T10:24:37Z
Congratulations!  All Go source files have passed staticcheck.

real	0m2.596s
user	0m5.116s
sys	0m0.620s
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```


