### PR TITLE
Automated cherry pick of #3256: feat: add string and math lib for lua

### DIFF
--- a/pkg/resourceinterpreter/configurableinterpreter/luavm/lua.go
+++ b/pkg/resourceinterpreter/configurableinterpreter/luavm/lua.go
@@ -168,6 +168,8 @@ func (vm *VM) setLib(l *lua.LState) error {
 		{lua.LoadLibName, lua.OpenPackage},
 		{lua.BaseLibName, lua.OpenBase},
 		{lua.TabLibName, lua.OpenTable},
+		{lua.StringLibName, lua.OpenString},
+		{lua.MathLibName, lua.OpenMath},
 		// load our 'safe' version of the OS library
 		{lua.OsLibName, lifted.OpenSafeOs},
 	} {


### PR DESCRIPTION
Cherry pick of #3256 on release-1.5.
#3256: feat: add string and math lib for lua
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmadactl`, `karmada-controller-mamager` and karmada-agent : Add a lua `string` and `math` lib to the resource interpreter.
```