### PR TITLE
Avoid the same cluster appearing in both spec.clusters and spec.gracefulEvictionTasks

### DIFF
--- a/pkg/controllers/gracefuleviction/evictiontask.go
+++ b/pkg/controllers/gracefuleviction/evictiontask.go
@@ -48,6 +48,13 @@ func assessEvictionTasks(bindingSpec workv1alpha2.ResourceBindingSpec,
 }
 
 func assessSingleTask(task workv1alpha2.GracefulEvictionTask, opt assessmentOption) *workv1alpha2.GracefulEvictionTask {
+	// avoid the same cluster appearing in both spec.clusters and spec.gracefulEvictionTasks
+	for _, targetCluster := range opt.scheduleResult {
+		if task.FromCluster == targetCluster.Name {
+			return nil
+		}
+	}
+
 	if task.SuppressDeletion != nil {
 		if *task.SuppressDeletion {
 			return &task

--- a/pkg/controllers/gracefuleviction/evictiontask_test.go
+++ b/pkg/controllers/gracefuleviction/evictiontask_test.go
@@ -210,6 +210,25 @@ func Test_assessSingleTask(t *testing.T) {
 			},
 			want: nil,
 		},
+		{
+			name: "cluster appears both in targetClusters and gracefulEvictionTasks",
+			args: args{
+				task: workv1alpha2.GracefulEvictionTask{
+					FromCluster:       "member1",
+					CreationTimestamp: metav1.Time{Time: timeNow.Add(time.Minute * -1)},
+				},
+				opt: assessmentOption{
+					timeout: timeout,
+					scheduleResult: []workv1alpha2.TargetCluster{
+						{Name: "member1"},
+					},
+					observedStatus: []workv1alpha2.AggregatedStatusItem{
+						{ClusterName: "member1", Health: workv1alpha2.ResourceHealthy},
+					},
+				},
+			},
+			want: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Avoid the same cluster appearing in both spec.clusters and spec.gracefulEvictionTasks.
There are basicly two solutions:
1. Adjust the scheduler. Make sure that scheduler will not schedule resource templates to those cluster in gracefulEvictionTasks.
2. Adjust the controller. For those clusters that appear at the same time, keep the clusters in spec.clusters and delete the clusters in spec.gracefulEvictionTask.

When the scheduler can dispatch to a cluster in gracefulEvictionTasks, it means that the cluster has a high probability of recovering from the abnormal state when it was evicted. From this point of view, option 2 is a better choise.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

