### PR TITLE
bugfix: runtime.Object apiVersion/kind is empty 

### DIFF
--- a/pkg/util/fedinformer/keys/keys.go
+++ b/pkg/util/fedinformer/keys/keys.go
@@ -74,7 +74,18 @@ func ClusterWideKeyFunc(obj interface{}) (ClusterWideKey, error) {
 		return key, fmt.Errorf("object has no meta: %v", err)
 	}
 
+	// When using a typed client, decoding to a versioned struct (not an internal API type), the apiVersion/kind
+	// information will be dropped. Therefore, the APIVersion/Kind information of runtime.Object needs to be verified.
+	// See issue: https://github.com/kubernetes/kubernetes/issues/80609
 	gvk := runtimeObject.GetObjectKind().GroupVersionKind()
+	if len(gvk.Kind) == 0 {
+		return key, fmt.Errorf("runtime object has no kind")
+	}
+
+	if len(gvk.Version) == 0 {
+		return key, fmt.Errorf("runtime object has no version")
+	}
+
 	key.Group = gvk.Group
 	key.Version = gvk.Version
 	key.Kind = gvk.Kind

--- a/pkg/util/fedinformer/keys/keys_test.go
+++ b/pkg/util/fedinformer/keys/keys_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,6 +51,12 @@ var (
 			Name:      "bar",
 		},
 	}
+	deploymentObj = appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+			Name:      "bar",
+		},
+	}
 )
 
 func TestClusterWideKeyFunc(t *testing.T) {
@@ -91,6 +98,11 @@ func TestClusterWideKeyFunc(t *testing.T) {
 		{
 			name:      "nil object should be error",
 			object:    nil,
+			expectErr: true,
+		},
+		{
+			name:      "non APIVersion and kind runtime object should be error",
+			object:    deploymentObj,
 			expectErr: true,
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
When using a typed client, decoding to a versioned struct (not an internal API type), the apiVersion/kind information will be dropped. Therefore, the APIVersion/Kind information of runtime.Object needs to be verified.
See issue: https://github.com/kubernetes/kubernetes/issues/80609

**Which issue(s) this PR fixes**:
Fixes #3275

**Special notes for your reviewer**:
@RainbowMango @whitewindmills 

**Does this PR introduce a user-facing change?**:
```
NONE
```

