### PR TITLE
Add arg to specify cluster domain

### DIFF
--- a/pkg/karmadactl/addons/enable.go
+++ b/pkg/karmadactl/addons/enable.go
@@ -9,6 +9,7 @@ import (
 
 	addoninit "github.com/karmada-io/karmada/pkg/karmadactl/addons/init"
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
+	globaloptions "github.com/karmada-io/karmada/pkg/karmadactl/options"
 	"github.com/karmada-io/karmada/pkg/version"
 )
 
@@ -82,5 +83,6 @@ func NewCmdAddonsEnable(parentCommand string) *cobra.Command {
 	flags.Int32Var(&opts.KarmadaEstimatorReplicas, "karmada-estimator-replicas", 1, "Karmada scheduler estimator replica set")
 	flags.StringVar(&opts.MemberKubeConfig, "member-kubeconfig", "", "Member cluster's kubeconfig which to deploy scheduler estimator")
 	flags.StringVar(&opts.MemberContext, "member-context", "", "Member cluster's context which to deploy scheduler estimator")
+	flags.StringVar(&opts.HostClusterDomain, "host-cluster-domain", globaloptions.DefaultHostClusterDomain, "The cluster domain of karmada host cluster. (e.g. --host-cluster-domain=host.karmada)")
 	return cmd
 }

--- a/pkg/karmadactl/addons/init/enable_option.go
+++ b/pkg/karmadactl/addons/init/enable_option.go
@@ -39,6 +39,8 @@ type CommandAddonsEnableOption struct {
 	MemberKubeConfig string
 
 	MemberContext string
+
+	HostClusterDomain string
 }
 
 // Complete the conditions required to be able to run enable.

--- a/pkg/karmadactl/addons/search/manifests.go
+++ b/pkg/karmadactl/addons/search/manifests.go
@@ -115,7 +115,7 @@ metadata:
   namespace: {{ .Namespace }}
 spec:
   type: ExternalName
-  externalName: karmada-search.{{ .Namespace }}.svc.cluster.local
+  externalName: karmada-search.{{ .Namespace }}.svc.{{ .HostClusterDomain }}
 `
 )
 
@@ -144,5 +144,6 @@ type AAApiServiceReplace struct {
 // AAServiceReplace is a struct to help to concrete
 // the karmada-search AA Service bytes with the AAService template
 type AAServiceReplace struct {
-	Namespace string
+	Namespace         string
+	HostClusterDomain string
 }

--- a/pkg/karmadactl/addons/search/search.go
+++ b/pkg/karmadactl/addons/search/search.go
@@ -171,7 +171,8 @@ func installComponentsOnHostCluster(opts *addoninit.CommandAddonsEnableOption) e
 func installComponentsOnKarmadaControlPlane(opts *addoninit.CommandAddonsEnableOption) error {
 	// install karmada search AA service on karmada control plane
 	aaServiceBytes, err := addonutils.ParseTemplate(karmadaSearchAAService, AAServiceReplace{
-		Namespace: opts.Namespace,
+		Namespace:         opts.Namespace,
+		HostClusterDomain: opts.HostClusterDomain,
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing karmada search AA service template :%v", err)
@@ -221,7 +222,7 @@ func etcdServers(opts *addoninit.CommandAddonsEnableOption) (string, error) {
 	etcdServers := ""
 
 	for v := int32(0); v < etcdReplicas; v++ {
-		etcdServers += fmt.Sprintf("https://%s-%v.%s.%s.svc.cluster.local:%v", etcdStatefulSetAndServiceName, v, etcdStatefulSetAndServiceName, opts.Namespace, etcdContainerClientPort) + ","
+		etcdServers += fmt.Sprintf("https://%s-%v.%s.%s.svc.%s:%v", etcdStatefulSetAndServiceName, v, etcdStatefulSetAndServiceName, opts.Namespace, opts.HostClusterDomain, etcdContainerClientPort) + ","
 	}
 
 	return strings.TrimRight(etcdServers, ","), nil

--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/cert"
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/kubernetes"
+	"github.com/karmada-io/karmada/pkg/karmadactl/options"
 	"github.com/karmada-io/karmada/pkg/karmadactl/util"
 	"github.com/karmada-io/karmada/pkg/version"
 )
@@ -110,6 +111,7 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 	flags.StringVar(&opts.StorageClassesName, "storage-classes-name", "", "Kubernetes StorageClasses Name")
 	flags.StringVar(&opts.KubeConfig, "kubeconfig", "", "absolute path to the kubeconfig file")
 	flags.StringVar(&opts.Context, "context", "", "The name of the kubeconfig context to use")
+	flags.StringVar(&opts.HostClusterDomain, "host-cluster-domain", options.DefaultHostClusterDomain, "The cluster domain of karmada host cluster. (e.g. --host-cluster-domain=host.karmada)")
 	// etcd
 	flags.StringVarP(&opts.EtcdStorageMode, "etcd-storage-mode", "", "hostPath",
 		fmt.Sprintf("etcd data storage mode(%s). value is PVC, specify --storage-classes-name", strings.Join(kubernetes.SupportedStorageMode(), ",")))

--- a/pkg/karmadactl/cmdinit/kubernetes/deployments.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deployments.go
@@ -53,7 +53,7 @@ var (
 func (i *CommandInitOption) etcdServers() string {
 	etcdClusterConfig := ""
 	for v := int32(0); v < i.EtcdReplicas; v++ {
-		etcdClusterConfig += fmt.Sprintf("https://%s-%v.%s.%s.svc.cluster.local:%v", etcdStatefulSetAndServiceName, v, etcdStatefulSetAndServiceName, i.Namespace, etcdContainerClientPort) + ","
+		etcdClusterConfig += fmt.Sprintf("https://%s-%v.%s.%s.svc.%s:%v", etcdStatefulSetAndServiceName, v, etcdStatefulSetAndServiceName, i.Namespace, i.HostClusterDomain, etcdContainerClientPort) + ","
 	}
 	return etcdClusterConfig
 }
@@ -77,7 +77,7 @@ func (i *CommandInitOption) karmadaAPIServerContainerCommand() []string {
 		"--runtime-config=",
 		fmt.Sprintf("--apiserver-count=%v", i.KarmadaAPIServerReplicas),
 		fmt.Sprintf("--secure-port=%v", karmadaAPIServerContainerPort),
-		"--service-account-issuer=https://kubernetes.default.svc.cluster.local",
+		fmt.Sprintf("--service-account-issuer=https://kubernetes.default.svc.%s", i.HostClusterDomain),
 		fmt.Sprintf("--service-account-key-file=%s/%s.key", karmadaCertsVolumeMountPath, options.KarmadaCertAndKeyName),
 		fmt.Sprintf("--service-account-signing-key-file=%s/%s.key", karmadaCertsVolumeMountPath, options.KarmadaCertAndKeyName),
 		fmt.Sprintf("--service-cluster-ip-range=%s", serviceClusterIP),

--- a/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
@@ -113,7 +113,7 @@ func (i CommandInitOption) etcdVolume() (*[]corev1.Volume, *corev1.PersistentVol
 func (i *CommandInitOption) etcdInitContainerCommand() []string {
 	etcdClusterConfig := ""
 	for v := int32(0); v < i.EtcdReplicas; v++ {
-		etcdClusterConfig += fmt.Sprintf("%s-%v=http://%s-%v.%s.%s.svc.cluster.local:%v", etcdStatefulSetAndServiceName, v, etcdStatefulSetAndServiceName, v, etcdStatefulSetAndServiceName, i.Namespace, etcdContainerServerPort) + ","
+		etcdClusterConfig += fmt.Sprintf("%s-%v=http://%s-%v.%s.%s.svc.%s:%v", etcdStatefulSetAndServiceName, v, etcdStatefulSetAndServiceName, v, etcdStatefulSetAndServiceName, i.Namespace, i.HostClusterDomain, etcdContainerServerPort) + ","
 	}
 
 	command := []string{
@@ -139,7 +139,7 @@ initial-cluster: %s
 listen-peer-urls: http://${%s}:%v
 listen-client-urls: https://${%s}:%v,http://127.0.0.1:%v
 initial-advertise-peer-urls: http://${%s}:%v
-advertise-client-urls: https://${%s}.%s.%s.svc.cluster.local:%v
+advertise-client-urls: https://${%s}.%s.%s.svc.%s:%v
 data-dir: %s
 
 `,
@@ -155,7 +155,9 @@ data-dir: %s
 			etcdEnvPodIP, etcdContainerServerPort,
 			etcdEnvPodIP, etcdContainerClientPort, etcdContainerClientPort,
 			etcdEnvPodIP, etcdContainerServerPort,
-			etcdEnvPodName, etcdStatefulSetAndServiceName, i.Namespace, etcdContainerClientPort,
+			etcdEnvPodName, etcdStatefulSetAndServiceName,
+			i.Namespace, i.HostClusterDomain,
+			etcdContainerClientPort,
 			etcdContainerDataVolumeMountPath,
 		),
 	}

--- a/pkg/karmadactl/options/global.go
+++ b/pkg/karmadactl/options/global.go
@@ -10,6 +10,9 @@ import (
 // DefaultKarmadaClusterNamespace defines the default namespace where the member cluster secrets are stored.
 const DefaultKarmadaClusterNamespace = "karmada-cluster"
 
+// DefaultHostClusterDomain defines the default cluster domain of karmada host cluster.
+const DefaultHostClusterDomain = "cluster.local"
+
 // DefaultKarmadactlCommandDuration defines the default timeout for karmadactl execute
 const DefaultKarmadactlCommandDuration = 60 * time.Second
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change

/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind bug

**What this PR does / why we need it**:

Because currently, kubectl-karmada hardcoded cluster domain to `cluster.local`, it faild init control plane in a host cluster has cluster domain other than `cluster.local`

**Which issue(s) this PR fixes**:
Fixes #3291

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
`karmadactl`: Introduced `--host-cluster-domain` flag to command `init` and `addons` to specify the host cluster domain.
```

