### PR TITLE
fix: cluster object apiVersion and kind is empty issue.

### DIFF
--- a/pkg/util/clusterlease.go
+++ b/pkg/util/clusterlease.go
@@ -21,8 +21,8 @@ func SetLeaseOwnerFunc(c client.Client, clusterName string) func(lease *coordina
 			if err := c.Get(context.TODO(), client.ObjectKey{Name: clusterName}, clusterObj); err == nil {
 				lease.OwnerReferences = []metav1.OwnerReference{
 					{
-						APIVersion: clusterObj.APIVersion,
-						Kind:       clusterObj.Kind,
+						APIVersion: clusterv1alpha1.GroupVersion.String(),
+						Kind:       clusterv1alpha1.SchemeGroupVersion.WithKind("Cluster").Kind,
 						Name:       clusterName,
 						UID:        clusterObj.UID,
 					},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The cluster object APIVersion and kind is empty getting from informer cache

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```
NONE
```

