### PR TITLE
Fixed unable to view the options for karmadactl addons enable/disable

### DIFF
--- a/pkg/karmadactl/addons/disable.go
+++ b/pkg/karmadactl/addons/disable.go
@@ -57,7 +57,7 @@ func NewCmdAddonsDisable(parentCommand string) *cobra.Command {
 			return nil
 		},
 	}
-	flags := cmd.PersistentFlags()
+	flags := cmd.Flags()
 	opts.GlobalCommandOptions.AddFlags(flags)
 	flags.BoolVarP(&opts.Force, "force", "f", false, "Disable addons without prompting for confirmation.")
 	return cmd

--- a/pkg/karmadactl/addons/enable.go
+++ b/pkg/karmadactl/addons/enable.go
@@ -70,7 +70,7 @@ func NewCmdAddonsEnable(parentCommand string) *cobra.Command {
 		releaseVer = &version.ReleaseVersion{} // initialize to avoid panic
 	}
 
-	flags := cmd.PersistentFlags()
+	flags := cmd.Flags()
 	opts.GlobalCommandOptions.AddFlags(flags)
 	flags.IntVar(&opts.WaitComponentReadyTimeout, "pod-timeout", options.WaitComponentReadyTimeout, "Wait pod ready timeout.")
 	flags.IntVar(&opts.WaitAPIServiceReadyTimeout, "apiservice-timeout", 30, "Wait apiservice ready timeout.")


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

There were no options viewing by -h, but we need them.
```
[root@master67 karmada]# karmadactl addons enable -h
Enable Karmada addons from Kubernetes

Examples:
  # Enable Karmada all addons except karmada-scheduler-estimator to Kubernetes cluster
  karmadactl addons enable all
  ......
  # Sepcify the namespace where Karmada components are installed
  karmadactl addons enable karmada-search --namespace karmada-system

Usage:
  karmadactl addons enable [options]

Use "karmadactl options" for a list of global command-line options (applies to all commands).
```

Fixed it as shown below
```
[root@master67 karmada]# _output/bin/linux/amd64/karmadactl addons enable -h
Enable Karmada addons from Kubernetes

Examples:
  # Enable Karmada all addons except karmada-scheduler-estimator to Kubernetes cluster
  karmadactl addons enable all

  ......
  # Sepcify the namespace where Karmada components are installed
  karmadactl addons enable karmada-search --namespace karmada-system

Options:
    --apiservice-timeout=30:
        Wait apiservice ready timeout.

    -C, --cluster='':
        Name of the member cluster that enables or disables the scheduler estimator.
    ......
    -n, --namespace='karmada-system':
        namespace where Karmada components are installed.

    --pod-timeout=30:
        Wait pod ready timeout.

Usage:
  karmadactl addons enable [options]

Use "karmadactl addons options" for a list of global command-line options (applies to all commands).
```

The root cause is a specific template used by `templates.ActsAsRootCommand()`.

https://github.com/karmada-io/karmada/blob/0bbf03d3238cb19722d1aeb8e3ea3915274ff380/pkg/karmadactl/karmadactl.go#L119

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @wuyingjun-lucky 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmadactl: fixed unable to view the options for karmadactl addons enable/disable
```

