### PR TITLE
Automated cherry pick of #3298: Fixed unable to view the options for karmadactl addons

### DIFF
--- a/pkg/karmadactl/addons/disable.go
+++ b/pkg/karmadactl/addons/disable.go
@@ -57,6 +57,6 @@ func NewCmdAddonsDisable(parentCommand string) *cobra.Command {
 			return nil
 		},
 	}
-	opts.GlobalCommandOptions.AddFlags(cmd.PersistentFlags())
+	opts.GlobalCommandOptions.AddFlags(cmd.Flags())
 	return cmd
 }

--- a/pkg/karmadactl/addons/enable.go
+++ b/pkg/karmadactl/addons/enable.go
@@ -69,7 +69,7 @@ func NewCmdAddonsEnable(parentCommand string) *cobra.Command {
 		releaseVer = &version.ReleaseVersion{} // initialize to avoid panic
 	}
 
-	flags := cmd.PersistentFlags()
+	flags := cmd.Flags()
 	opts.GlobalCommandOptions.AddFlags(flags)
 	flags.IntVar(&opts.WaitPodReadyTimeout, "pod-timeout", 30, "Wait pod ready timeout.")
 	flags.IntVar(&opts.WaitAPIServiceReadyTimeout, "apiservice-timeout", 30, "Wait apiservice ready timeout.")


### PR DESCRIPTION
Cherry pick of #3298 on release-1.4.
#3298: Fixed unable to view the options for karmadactl addons
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
karmadactl: fixed unable to view the options of `karmadactl addons enable/disable`.
```