### PR TITLE
Using schema.GroupVersionKind instead of Kind when determining object types

### DIFF
--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -1,6 +1,7 @@
 package binding
 
 import (
+	batchv1 "k8s.io/api/batch/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -39,7 +40,7 @@ func ensureWork(
 
 	var jobCompletions []workv1alpha2.TargetCluster
 	var err error
-	if workload.GetKind() == util.JobKind {
+	if workload.GroupVersionKind() == batchv1.SchemeGroupVersion.WithKind(util.JobKind) {
 		jobCompletions, err = divideReplicasByJobCompletions(workload, targetClusters)
 		if err != nil {
 			return err

--- a/pkg/controllers/mcs/service_export_controller.go
+++ b/pkg/controllers/mcs/service_export_controller.go
@@ -149,14 +149,14 @@ func (c *ServiceExportController) syncServiceExportOrEndpointSlice(key util.Queu
 
 	klog.V(4).Infof("Begin to sync %s %s.", fedKey.Kind, fedKey.NamespaceKey())
 
-	switch fedKey.Kind {
-	case util.ServiceExportKind:
+	switch fedKey.GroupVersionKind() {
+	case serviceExportGVK:
 		if err := c.handleServiceExportEvent(fedKey); err != nil {
 			klog.Errorf("Failed to handle serviceExport(%s) event, Error: %v",
 				fedKey.NamespaceKey(), err)
 			return err
 		}
-	case util.EndpointSliceKind:
+	case discoveryv1.SchemeGroupVersion.WithKind(util.EndpointSliceKind):
 		if err := c.handleEndpointSliceEvent(fedKey); err != nil {
 			klog.Errorf("Failed to handle endpointSlice(%s) event, Error: %v",
 				fedKey.NamespaceKey(), err)

--- a/pkg/controllers/unifiedauth/unified_auth_controller.go
+++ b/pkg/controllers/unifiedauth/unified_auth_controller.go
@@ -147,6 +147,7 @@ func findRBACSubjectsWithCluster(c client.Client, cluster string) ([]rbacv1.Subj
 	var targetSubjects []rbacv1.Subject
 	for _, clusterRoleBinding := range clusterRoleBindings.Items {
 		if clusterRoleBinding.RoleRef.Kind == util.ClusterRoleKind &&
+			clusterRoleBinding.RoleRef.APIGroup == rbacv1.GroupName &&
 			matchedClusterRoles.Has(clusterRoleBinding.RoleRef.Name) {
 			targetSubjects = append(targetSubjects, clusterRoleBinding.Subjects...)
 		}
@@ -257,7 +258,7 @@ func (c *Controller) newClusterRoleMapFunc() handler.MapFunc {
 func (c *Controller) newClusterRoleBindingMapFunc() handler.MapFunc {
 	return func(a client.Object) []reconcile.Request {
 		clusterRoleBinding := a.(*rbacv1.ClusterRoleBinding)
-		if clusterRoleBinding.RoleRef.Kind != util.ClusterRoleKind {
+		if clusterRoleBinding.RoleRef.Kind != util.ClusterRoleKind || clusterRoleBinding.RoleRef.APIGroup != rbacv1.GroupName {
 			return nil
 		}
 

--- a/pkg/estimator/server/replica/replica.go
+++ b/pkg/estimator/server/replica/replica.go
@@ -31,8 +31,8 @@ func GetUnschedulablePodsOfWorkload(unstructObj *unstructured.Unstructured, thre
 	unschedulable := 0
 	// Workloads could be classified into two types. The one is which owns ReplicaSet
 	// and the other is which owns Pod directly.
-	switch unstructObj.GetKind() {
-	case util.DeploymentKind:
+	switch unstructObj.GroupVersionKind() {
+	case appsv1.SchemeGroupVersion.WithKind(util.DeploymentKind):
 		deployment := &appsv1.Deployment{}
 		if err := helper.ConvertToTypedObject(unstructObj, deployment); err != nil {
 			return 0, fmt.Errorf("failed to convert ReplicaSet from unstructured object: %v", err)

--- a/pkg/resourceinterpreter/defaultinterpreter/prune/prune.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/prune/prune.go
@@ -50,7 +50,7 @@ func RemoveIrrelevantField(workload *unstructured.Unstructured, extraHooks ...fu
 
 	unstructured.RemoveNestedField(workload.Object, "status")
 
-	if workload.GetKind() == util.ServiceKind {
+	if workload.GroupVersionKind() == corev1.SchemeGroupVersion.WithKind(util.ServiceKind) {
 		// In the case spec.clusterIP is set to `None`, means user want a headless service,  then it shouldn't be removed.
 		clusterIP, exist, _ := unstructured.NestedString(workload.Object, "spec", "clusterIP")
 		if exist && clusterIP != corev1.ClusterIPNone {
@@ -59,7 +59,7 @@ func RemoveIrrelevantField(workload *unstructured.Unstructured, extraHooks ...fu
 		}
 	}
 
-	if workload.GetKind() == util.JobKind {
+	if workload.GroupVersionKind() == batchv1.SchemeGroupVersion.WithKind(util.JobKind) {
 		job := &batchv1.Job{}
 		err := helper.ConvertToTypedObject(workload, job)
 		if err != nil {
@@ -72,7 +72,7 @@ func RemoveIrrelevantField(workload *unstructured.Unstructured, extraHooks ...fu
 		}
 	}
 
-	if workload.GetKind() == util.ServiceAccountKind {
+	if workload.GroupVersionKind() == corev1.SchemeGroupVersion.WithKind(util.ServiceAccountKind) {
 		secrets, exist, _ := unstructured.NestedSlice(workload.Object, "secrets")
 		// If 'secrets' exists in ServiceAccount, remove the automatic generation secrets(e.g. default-token-xxx)
 		if exist && len(secrets) > 0 {
@@ -136,7 +136,7 @@ func removeGenerateSelectorOfJob(workload *unstructured.Unstructured) error {
 // It is recommended to enable the `ttl-after-finished` controller in the Karmada control plane.
 // See https://karmada.io/docs/administrator/configuration/configure-controllers#ttl-after-finished for more details.
 func RemoveJobTTLSeconds(workload *unstructured.Unstructured) {
-	if workload.GetKind() == util.JobKind {
+	if workload.GroupVersionKind() == batchv1.SchemeGroupVersion.WithKind(util.JobKind) {
 		unstructured.RemoveNestedField(workload.Object, "spec", "ttlSecondsAfterFinished")
 	}
 }

--- a/pkg/resourceinterpreter/defaultinterpreter/prune/prune_test.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/prune/prune_test.go
@@ -81,7 +81,8 @@ func TestRemoveIrrelevantField(t *testing.T) {
 			name: "remove service irrelevant fields",
 			workload: &unstructured.Unstructured{
 				Object: map[string]interface{}{
-					"kind": util.ServiceKind,
+					"apiVersion": "v1",
+					"kind":       util.ServiceKind,
 					"spec": map[string]interface{}{
 						"clusterIP":  "10.10.10.10",
 						"clusterIPs": []string{"10.10.10.10"},
@@ -98,7 +99,8 @@ func TestRemoveIrrelevantField(t *testing.T) {
 			name: "remove job irrelevant fields",
 			workload: &unstructured.Unstructured{
 				Object: map[string]interface{}{
-					"kind": util.JobKind,
+					"apiVersion": "batch/v1",
+					"kind":       util.JobKind,
 					"spec": map[string]interface{}{
 						"selector": map[string]interface{}{
 							"matchLabels": map[string]interface{}{
@@ -135,7 +137,8 @@ func TestRemoveIrrelevantField(t *testing.T) {
 			name: "remove serviceaccount irrelevant fields",
 			workload: &unstructured.Unstructured{
 				Object: map[string]interface{}{
-					"kind": util.ServiceAccountKind,
+					"apiVersion": "v1",
+					"kind":       util.ServiceAccountKind,
 					"metadata": map[string]interface{}{
 						"name": "foo",
 					},

--- a/pkg/util/helper/policy.go
+++ b/pkg/util/helper/policy.go
@@ -7,6 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	mcsv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/util"
@@ -65,7 +66,7 @@ func GetFollowedResourceSelectorsWhenMatchServiceImport(resourceSelectors []poli
 	var addedResourceSelectors []policyv1alpha1.ResourceSelector
 
 	for _, resourceSelector := range resourceSelectors {
-		if resourceSelector.Kind != util.ServiceImportKind {
+		if resourceSelector.Kind != util.ServiceImportKind || resourceSelector.APIVersion != mcsv1alpha1.GroupVersion.String() {
 			continue
 		}
 

--- a/pkg/util/helper/policy_test.go
+++ b/pkg/util/helper/policy_test.go
@@ -8,6 +8,7 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	mcsv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/util"
@@ -186,18 +187,21 @@ func TestGetFollowedResourceSelectorsWhenMatchServiceImport(t *testing.T) {
 			name: " get followed resource selector",
 			resourceSelectors: []policyv1alpha1.ResourceSelector{
 				{
-					Name: "foo1",
-					Kind: util.ServiceImportKind,
+					Name:       "foo1",
+					Kind:       util.ServiceImportKind,
+					APIVersion: mcsv1alpha1.GroupVersion.String(),
 				},
 				{
-					Name:      "foo2",
-					Namespace: "bar",
-					Kind:      util.ServiceKind,
+					Name:       "foo2",
+					Namespace:  "bar",
+					Kind:       util.ServiceKind,
+					APIVersion: "v1",
 				},
 				{
-					Name:      "foo3",
-					Namespace: "bar",
-					Kind:      util.ServiceImportKind,
+					Name:       "foo3",
+					Namespace:  "bar",
+					Kind:       util.ServiceImportKind,
+					APIVersion: mcsv1alpha1.GroupVersion.String(),
 				},
 			},
 			expected: []policyv1alpha1.ResourceSelector{

--- a/pkg/util/overridemanager/commandargsoverride.go
+++ b/pkg/util/overridemanager/commandargsoverride.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
@@ -21,16 +23,16 @@ const (
 
 // buildCommandArgsPatches build JSON patches for the resource object according to override declaration.
 func buildCommandArgsPatches(target string, rawObj *unstructured.Unstructured, commandRunOverrider *policyv1alpha1.CommandArgsOverrider) ([]overrideOption, error) {
-	switch rawObj.GetKind() {
-	case util.PodKind:
+	switch rawObj.GroupVersionKind() {
+	case corev1.SchemeGroupVersion.WithKind(util.PodKind):
 		return buildCommandArgsPatchesWithPath(target, "spec/containers", rawObj, commandRunOverrider)
-	case util.ReplicaSetKind:
+	case appsv1.SchemeGroupVersion.WithKind(util.ReplicaSetKind):
 		fallthrough
-	case util.DeploymentKind:
+	case appsv1.SchemeGroupVersion.WithKind(util.DeploymentKind):
 		fallthrough
-	case util.DaemonSetKind:
+	case appsv1.SchemeGroupVersion.WithKind(util.DaemonSetKind):
 		fallthrough
-	case util.StatefulSetKind:
+	case appsv1.SchemeGroupVersion.WithKind(util.StatefulSetKind):
 		return buildCommandArgsPatchesWithPath(target, "spec/template/spec/containers", rawObj, commandRunOverrider)
 	}
 	return nil, nil

--- a/pkg/util/overridemanager/imageoverride.go
+++ b/pkg/util/overridemanager/imageoverride.go
@@ -32,38 +32,38 @@ func buildPatches(rawObj *unstructured.Unstructured, imageOverrider *policyv1alp
 }
 
 func buildPatchesWithEmptyPredicate(rawObj *unstructured.Unstructured, imageOverrider *policyv1alpha1.ImageOverrider) ([]overrideOption, error) {
-	switch rawObj.GetKind() {
-	case util.PodKind:
+	switch rawObj.GroupVersionKind() {
+	case corev1.SchemeGroupVersion.WithKind(util.PodKind):
 		podObj := &corev1.Pod{}
 		if err := helper.ConvertToTypedObject(rawObj, podObj); err != nil {
 			return nil, fmt.Errorf("failed to convert Pod from unstructured object: %v", err)
 		}
 		return extractPatchesBy(podObj.Spec, podSpecPrefix, imageOverrider)
-	case util.ReplicaSetKind:
+	case appsv1.SchemeGroupVersion.WithKind(util.ReplicaSetKind):
 		replicaSetObj := &appsv1.ReplicaSet{}
 		if err := helper.ConvertToTypedObject(rawObj, replicaSetObj); err != nil {
 			return nil, fmt.Errorf("failed to convert ReplicaSet from unstructured object: %v", err)
 		}
 		return extractPatchesBy(replicaSetObj.Spec.Template.Spec, podTemplatePrefix, imageOverrider)
-	case util.DeploymentKind:
+	case appsv1.SchemeGroupVersion.WithKind(util.DeploymentKind):
 		deploymentObj := &appsv1.Deployment{}
 		if err := helper.ConvertToTypedObject(rawObj, deploymentObj); err != nil {
 			return nil, fmt.Errorf("failed to convert Deployment from unstructured object: %v", err)
 		}
 		return extractPatchesBy(deploymentObj.Spec.Template.Spec, podTemplatePrefix, imageOverrider)
-	case util.DaemonSetKind:
+	case appsv1.SchemeGroupVersion.WithKind(util.DaemonSetKind):
 		daemonSetObj := &appsv1.DaemonSet{}
 		if err := helper.ConvertToTypedObject(rawObj, daemonSetObj); err != nil {
 			return nil, fmt.Errorf("failed to convert DaemonSet from unstructured object: %v", err)
 		}
 		return extractPatchesBy(daemonSetObj.Spec.Template.Spec, podTemplatePrefix, imageOverrider)
-	case util.StatefulSetKind:
+	case appsv1.SchemeGroupVersion.WithKind(util.StatefulSetKind):
 		statefulSetObj := &appsv1.StatefulSet{}
 		if err := helper.ConvertToTypedObject(rawObj, statefulSetObj); err != nil {
 			return nil, fmt.Errorf("failed to convert StatefulSet from unstructured object: %v", err)
 		}
 		return extractPatchesBy(statefulSetObj.Spec.Template.Spec, podTemplatePrefix, imageOverrider)
-	case util.JobKind:
+	case batchv1.SchemeGroupVersion.WithKind(util.JobKind):
 		jobObj := &batchv1.Job{}
 		if err := helper.ConvertToTypedObject(rawObj, jobObj); err != nil {
 			return nil, fmt.Errorf("failed to convert Job from unstructured object: %v", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Using schema.GroupVersionKind instead of Kind when determining object types.
I'd like to user GroupVersionKind rather than GroupKind because we finally use the resource objects with specific version.

**Which issue(s) this PR fixes**:
Fixes #3011 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

