### PR TITLE
correct context name.

### DIFF
--- a/hack/create-cluster.sh
+++ b/hack/create-cluster.sh
@@ -79,7 +79,13 @@ cp -rf "${REPO_ROOT}"/artifacts/kindClusterConfig/general-config.yaml "${TEMP_PA
 sed -i'' -e "s#{{pod_cidr}}#${POD_CIDR}#g" "${TEMP_PATH}"/"${CLUSTER_NAME}"-config.yaml
 sed -i'' -e "s#{{service_cidr}}#${SERVICE_CIDR}#g" "${TEMP_PATH}"/"${CLUSTER_NAME}"-config.yaml
 
-kind create cluster --name "${CLUSTER_NAME}" --kubeconfig="${KUBECONFIG}" --image="${CLUSTER_VERSION}" --config="${TEMP_PATH}"/"${CLUSTER_NAME}"-config.yaml
+kind_log="$(mktemp --suffix=-kind.log)"
+echo "Creating cluster \"${CLUSTER_NAME}\" ..."
+kind create cluster --name "${CLUSTER_NAME}" --kubeconfig="${KUBECONFIG}" --image="${CLUSTER_VERSION}" --config="${TEMP_PATH}"/"${CLUSTER_NAME}"-config.yaml > ${kind_log} 2>&1 || (
+  echo "Creating cluster ${CLUSTER_NAME} failed, see detail log in ${kind_log}."
+  exit 1
+)
+rm -rf "${kind_log}"
 
 # Kind cluster's context name contains a "kind-" prefix by default.
 # Change context name to cluster name.
@@ -91,3 +97,5 @@ container_ip=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IP
 kubectl config set-cluster "kind-${CLUSTER_NAME}" --server="https://${container_ip}:6443" --kubeconfig="${KUBECONFIG}"
 
 echo "cluster \"${CLUSTER_NAME}\" is created successfully!"
+echo "You can now use your cluster with:"
+echo kubectl cluster-info --context "${CLUSTER_NAME}" --kubeconfig "${KUBECONFIG}"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #392

**Special notes for your reviewer**:

Run successfully:
```bash
> hack/create-cluster.sh host ~/.kube/karmada.config
Creating cluster "host" ...
Context "kind-host" renamed to "host".
Cluster "kind-host" set.
cluster "host" is created successfully!
You can now use your cluster with:
kubectl cluster-info --context host --kubeconfig /home/yjh/.kube/karmada.config
```

When `kind` run failed:
```
> hack/create-cluster.sh host ~/.kube/karmada.config
Creating cluster "host" ...
Creating cluster host failed, see detail log in /tmp/tmp.EfC6i2XMNN-kind.log.
```

**Does this PR introduce a user-facing change?**:

```release-note
`hack`: correct context name in `hack/create-cluster.sh`
```

