### PR TITLE
Fix potential failure in CLI workflow.

### DIFF
--- a/hack/cli-testing-environment.sh
+++ b/hack/cli-testing-environment.sh
@@ -38,11 +38,16 @@ hack/create-cluster.sh ${MEMBER_CLUSTER_2_NAME} ${KUBECONFIG_PATH}/${MEMBER_CLUS
 # wait cluster ready
 echo "Wait clusters ready..."
 util::wait_file_exist ${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config 300
-util::wait_file_exist ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_1_NAME}.config 300
-util::wait_file_exist ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_2_NAME}.config 300
 kubectl wait --for=condition=Ready nodes --all --timeout=800s --kubeconfig=${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config
+util::wait_nodes_taint_disappear 800 ${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config
+
+util::wait_file_exist ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_1_NAME}.config 300
 kubectl wait --for=condition=Ready nodes --all --timeout=800s --kubeconfig=${KUBECONFIG_PATH}/${MEMBER_CLUSTER_1_NAME}.config
+util::wait_nodes_taint_disappear 800 ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_1_NAME}.config
+
+util::wait_file_exist ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_2_NAME}.config 300
 kubectl wait --for=condition=Ready nodes --all --timeout=800s --kubeconfig=${KUBECONFIG_PATH}/${MEMBER_CLUSTER_2_NAME}.config
+util::wait_nodes_taint_disappear 800 ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_2_NAME}.config
 
 # init Karmada control plane
 echo "Start init karmada control plane..."

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -693,3 +693,25 @@ RUN echo -e http://mirrors.ustc.edu.cn/alpine/v3.17/main/ > /etc/apk/repositorie
   done
 }
 
+# util::wait_nodes_taint_disappear will wait for all the nodes' taint to disappear
+# Parameters:
+#  - timeout: Timeout in seconds.
+#  - kubeconfig_path: The path of kubeconfig.
+# Returns:
+#  1 if the condition is not met before the timeout, else 0
+function util::wait_nodes_taint_disappear() {
+  local timeout=${1}
+  local kubeconfig_path=${2}
+
+  timeout "${timeout}" bash <<EOF && return 0
+    while true
+    do
+      taints=\$(kubectl get nodes --kubeconfig=${kubeconfig_path} -o=jsonpath="{.items[*].spec.taints}")
+      if [ -z \$taints ]; then
+        exit
+      fi
+    done
+EOF
+  echo "Timeout for nodes' taint to disappear"
+  return 1
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
The CLI test workflow may fail intermittently due to node taints. For instance, refer to this example: https://github.com/karmada-io/karmada/actions/runs/4497846194/jobs/7913834536.

```
Start init karmada control plane...
I0323 06:57:27.213231   17694 deploy.go:176] kubeconfig file: /home/runner/.kube/karmada-host.config, kubernetes: https://172.18.0.3:6443/
error: failed to find a healthy node for karmada-etcd
```

And I checked when the node is ready, there are still taints:
node.kubernetes.io/not-ready:NoExecute
```json
[
    {
        "MemoryPressure":false,
        "LastHeartbeatTime":"2023-03-23 02:23:39 +0000 UTC",
        "LastTransitionTime":"2023-03-23 02:23:17 +0000 UTC",
        "Reason":"KubeletHasSufficientMemory",
        "Status":"kubelet has sufficient memory available"
    },
    {
        "DiskPressure":false,
        "LastHeartbeatTime":"2023-03-23 02:23:39 +0000 UTC",
        "LastTransitionTime":"2023-03-23 02:23:17 +0000 UTC",
        "Reason":"KubeletHasNoDiskPressure",
        "Status":"kubelet has no disk pressure"
    },
    {
        "PIDPressure":false,
        "LastHeartbeatTime":"2023-03-23 02:23:39 +0000 UTC",
        "LastTransitionTime":"2023-03-23 02:23:17 +0000 UTC",
        "Reason":"KubeletHasSufficientPID",
        "Status":"kubelet has sufficient PID available"
    },
    {
        "Ready":true,
        "LastHeartbeatTime":"2023-03-23 02:23:39 +0000 UTC",
        "LastTransitionTime":"2023-03-23 02:23:39 +0000 UTC",
        "Reason":"KubeletReady",
        "Status":"kubelet is posting ready status"
    }
]
```
So we should wait for the taint to be deleted when the node ready.

**Which issue(s) this PR fixes**:
Fixes #none

**Special notes for your reviewer**:
@XiShanYongYe-Chang 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

