### PR TITLE
Set aggregatedapiserver owners

### DIFF
--- a/cmd/aggregated-apiserver/OWNERS
+++ b/cmd/aggregated-apiserver/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+- XiShanYongYe-Chang
+approvers:
+- XiShanYongYe-Chang

--- a/pkg/aggregatedapiserver/OWNERS
+++ b/pkg/aggregatedapiserver/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+- XiShanYongYe-Chang
+approvers:
+- XiShanYongYe-Chang

--- a/pkg/registry/OWNERS
+++ b/pkg/registry/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+- XiShanYongYe-Chang
+approvers:
+- XiShanYongYe-Chang


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
This PR set the owners of [karmada-aggregated-apiserver](https://github.com/karmada-io/karmada/tree/master/cmd) as well as relevant package([registry](https://github.com/karmada-io/karmada/tree/master/pkg/registry)).

@XiShanYongYe-Chang leads the effort for this component, he should be on the owner list for faster iterations.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

