### PR TITLE
Add customizations for apps.krusie.io/v1alpha1/CloneSet

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/customizations.yaml
@@ -1,0 +1,125 @@
+apiVersion: config.karmada.io/v1alpha1
+kind: ResourceInterpreterCustomization
+metadata:
+  name: declarative-configuration-cloneset
+spec:
+  target:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: CloneSet
+  customizations:
+    replicaResource:
+      luaScript: >
+        local kube = require("kube")
+        function GetReplicas(obj)
+          replica = obj.spec.replicas
+          requirement = kube.accuratePodRequirements(obj.spec.template)
+          return replica, requirement
+        end
+    replicaRevision:
+      luaScript: >
+        function ReviseReplica(obj, desiredReplica)
+          obj.spec.replicas = desiredReplica
+          return obj
+        end
+    statusAggregation:
+      luaScript: >
+        function AggregateStatus(desiredObj, statusItems)
+          if statusItems == nil then
+            return desiredObj
+          end
+          if desiredObj.status == nil then
+            desiredObj.status = {}
+          end
+          if desiredObj.metadata.generation == nil then
+            desiredObj.metadata.generation = 0
+          end
+          generation = desiredObj.metadata.generation
+          replicas = 0
+          updatedReplicas = 0 
+          readyReplicas = 0
+          availableReplicas = 0
+          updatedReadyReplicas = 0
+          expectedUpdatedReplicas = 0
+          updateRevision = ''
+          currentRevision = ''
+          for i = 1, #statusItems do
+            if statusItems[i].status ~= nil and statusItems[i].status.replicas ~= nil then
+              replicas = replicas + statusItems[i].status.replicas
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.updatedReplicas ~= nil then
+              updatedReplicas = updatedReplicas + statusItems[i].status.updatedReplicas
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.readyReplicas ~= nil then
+              readyReplicas = readyReplicas + statusItems[i].status.readyReplicas
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.availableReplicas ~= nil then
+              availableReplicas = availableReplicas + statusItems[i].status.availableReplicas
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.updatedReadyReplicas ~= nil then
+              updatedReadyReplicas = updatedReadyReplicas + statusItems[i].status.updatedReadyReplicas
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.expectedUpdatedReplicas ~= nil then
+              expectedUpdatedReplicas = expectedUpdatedReplicas + statusItems[i].status.expectedUpdatedReplicas
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.updateRevision ~= nil and statusItems[i].status.updateRevision ~= '' then
+              updateRevision = statusItems[i].status.updateRevision
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.currentRevision ~= nil and statusItems[i].status.currentRevision ~= '' then
+              currentRevision = statusItems[i].status.currentRevision
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.observedGeneration ~= nil and statusItems[i].status.observedGeneration ~= '' then
+              generation = statusItems[i].status.observedGeneration
+            end
+          end
+          desiredObj.status.observedGeneration = generation
+          desiredObj.status.replicas = replicas
+          desiredObj.status.updatedReplicas = updatedReplicas
+          desiredObj.status.readyReplicas = readyReplicas
+          desiredObj.status.availableReplicas = availableReplicas
+          desiredObj.status.updatedReadyReplicas = updatedReadyReplicas
+          desiredObj.status.expectedUpdatedReplicas = expectedUpdatedReplicas
+          desiredObj.status.updateRevision = updateRevision
+          desiredObj.status.currentRevision = currentRevision
+          return desiredObj
+        end
+    statusReflection:
+      luaScript: >
+        function ReflectStatus (observedObj)
+          status = {}
+          if observedObj == nil or observedObj.status == nil then 
+            return status
+          end
+          status.replicas = observedObj.status.replicas
+          status.updatedReplicas = observedObj.status.updatedReplicas
+          status.readyReplicas = observedObj.status.readyReplicas
+          status.availableReplicas = observedObj.status.availableReplicas
+          status.updatedReadyReplicas = observedObj.status.updatedReadyReplicas
+          status.expectedUpdatedReplicas = observedObj.status.expectedUpdatedReplicas
+          status.updateRevision = observedObj.status.updateRevision
+          status.currentRevision = observedObj.status.currentRevision
+          status.observedGeneration = observedObj.status.observedGeneration
+          return status
+        end
+    healthInterpretation:
+      luaScript: >
+        function InterpretHealth(observedObj)
+          if observedObj.status.observedGeneration ~= observedObj.metadata.generation then
+            return false
+          end
+          if observedObj.spec.replicas ~= nil then
+            if observedObj.status.updatedReplicas < observedObj.spec.replicas then
+              return false
+            end
+          end
+          if observedObj.status.availableReplicas < observedObj.status.updatedReplicas then
+            return false
+          end
+          return true
+        end
+    dependencyInterpretation:
+      luaScript: >
+        local kube = require("kube")
+        function GetDependencies(desiredObj)
+          refs = kube.getPodDependencies(desiredObj.spec.template, desiredObj.metadata.namespace)
+          return refs
+        end

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/desired-cloneset-nginx.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/desired-cloneset-nginx.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps.kruise.io/v1alpha1
+kind: CloneSet
+metadata:
+  labels:
+    app: sample
+  name: sample
+  namespace: test-cloneset
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: sample
+  template:
+    metadata:
+      labels:
+        app: sample
+    spec:
+      volumes:
+        - name: configmap
+          configMap:
+            name: my-sample-config    
+      containers:
+        - name: nginx
+          image: nginx:alpine
+          env: 
+          - name: logData
+            valueFrom: 
+              configMapKeyRef:
+                name: mysql-config
+                key: log
+          - name: lowerData
+            valueFrom:
+              configMapKeyRef:
+                name: mysql-config
+                key: lower

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/observed-cloneset-nginx.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/observed-cloneset-nginx.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps.kruise.io/v1alpha1
+kind: CloneSet
+metadata:
+  labels:
+    app: sample
+  name: sample
+  namespace: test-cloneset
+  generation: 1
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: sample
+  template:
+    metadata:
+      labels:
+        app: sample
+    spec:
+      volumes:
+        - name: configmap
+          configMap:
+            name: my-sample-config    
+      containers:
+        - name: nginx
+          image: nginx:alpine
+          env: 
+          - name: logData
+            valueFrom: 
+              configMapKeyRef:
+                name: mysql-config
+                key: log
+          - name: lowerData
+            valueFrom:
+              configMapKeyRef:
+                name: mysql-config
+                key: lower
+status:
+  availableReplicas: 2
+  collisionCount: 0
+  currentRevision: sample-59df6bd888
+  expectedUpdatedReplicas: 2
+  labelSelector: app=sample
+  observedGeneration: 1
+  readyReplicas: 2
+  replicas: 2
+  updateRevision: sample-59df6bd888
+  updatedReadyReplicas: 2
+  updatedReplicas: 2

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/status-file.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/status-file.yaml
@@ -1,0 +1,27 @@
+applied: true
+clusterName: member1
+health: Healthy
+status:
+  availableReplicas: 2
+  currentRevision: sample-59df6bd888
+  expectedUpdatedReplicas: 2
+  observedGeneration: 1
+  readyReplicas: 2
+  replicas: 2
+  updateRevision: sample-59df6bd888
+  updatedReadyReplicas: 2
+  updatedReplicas: 2
+---
+applied: true
+clusterName: member3
+health: Healthy
+status:
+  availableReplicas: 2
+  currentRevision: sample-59df6bd888
+  expectedUpdatedReplicas: 2
+  observedGeneration: 1
+  readyReplicas: 2
+  replicas: 2
+  updateRevision: sample-59df6bd888
+  updatedReadyReplicas: 2
+  updatedReplicas: 2


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Add third-party resources `apps.krusie.io/v1alpha1/CloneSet` into Resource Interpreter framework.

**Which issue(s) this PR fixes**:
Part of #3331

**Special notes for your reviewer**:
@Poor12 

**Does this PR introduce a user-facing change?**:
 NONE

```release-note
This is the first resourceinterpretercustomization for krusie.
Maybe it's useful to add a function `getDependenciesFromPodTemplate` in `pkg\resourceinterpreter\configurableinterpreter\luavm\kube.go`.
The directory for those customizatons is pending.
```

