### PR TITLE
Add weights for score plugins

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/scheduler/cache"
 	"github.com/karmada-io/karmada/pkg/scheduler/core/spreadconstraint"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework"
+	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework/runtime"
 	"github.com/karmada-io/karmada/pkg/scheduler/metrics"
 )
@@ -42,7 +43,7 @@ func NewGenericScheduler(
 	schedCache cache.Cache,
 	registry runtime.Registry,
 ) (ScheduleAlgorithm, error) {
-	f, err := runtime.NewFramework(registry)
+	f, err := runtime.NewFramework(registry, runtime.WithScorePluginsWeight(plugins.GetDefaultScorePluginsWeight()))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scheduler/framework/plugins/registry.go
+++ b/pkg/scheduler/framework/plugins/registry.go
@@ -19,3 +19,11 @@ func NewInTreeRegistry() runtime.Registry {
 		clusterlocality.Name:  clusterlocality.New,
 	}
 }
+
+// GetDefaultScorePluginsWeight returns the default weight for score plugins.
+func GetDefaultScorePluginsWeight() map[string]int {
+	return map[string]int{
+		clusteraffinity.Name: 1,
+		clusterlocality.Name: 10000,
+	}
+}

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -32,7 +32,8 @@ type frameworkImpl struct {
 var _ framework.Framework = &frameworkImpl{}
 
 type frameworkOptions struct {
-	metricsRecorder *metricsRecorder
+	metricsRecorder       *metricsRecorder
+	scorePluginsWeightMap map[string]int
 }
 
 // Option for the frameworkImpl.
@@ -44,6 +45,13 @@ func defaultFrameworkOptions() frameworkOptions {
 	}
 }
 
+// WithScorePluginsWeight sets the weight for score plugins.
+func WithScorePluginsWeight(m map[string]int) Option {
+	return func(options *frameworkOptions) {
+		options.scorePluginsWeightMap = m
+	}
+}
+
 // NewFramework creates a scheduling framework by registry.
 func NewFramework(r Registry, opts ...Option) (framework.Framework, error) {
 	options := defaultFrameworkOptions()
@@ -52,7 +60,8 @@ func NewFramework(r Registry, opts ...Option) (framework.Framework, error) {
 	}
 
 	f := &frameworkImpl{
-		metricsRecorder: options.metricsRecorder,
+		scorePluginsWeightMap: make(map[string]int),
+		metricsRecorder:       options.metricsRecorder,
 	}
 	filterPluginsList := reflect.ValueOf(&f.filterPlugins).Elem()
 	scorePluginsList := reflect.ValueOf(&f.scorePlugins).Elem()
@@ -69,6 +78,13 @@ func NewFramework(r Registry, opts ...Option) (framework.Framework, error) {
 		addPluginToList(p, scoreType, &scorePluginsList)
 	}
 
+	for _, p := range f.scorePlugins {
+		weight, exist := options.scorePluginsWeightMap[p.Name()]
+		if !exist {
+			return nil, fmt.Errorf("score plugin %q is not configured with weight", p.Name())
+		}
+		f.scorePluginsWeightMap[p.Name()] = weight
+	}
 	return f, nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Before we introduce a new plugins, like #3287, we need to ensure the clusterlocality has the most weight in order to keep the stability when rescheduling. In this PR, we introduce default weight for score plugins.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

