### PR TITLE
[Performance] Do not schedule when status/metadata of binding update

### DIFF
--- a/pkg/scheduler/scheduler_metrics_test.go
+++ b/pkg/scheduler/scheduler_metrics_test.go
@@ -25,7 +25,12 @@ var (
 		scheduler.onResourceBindingAdd(obj)
 	}
 	updateBinding = func(scheduler *Scheduler, obj interface{}) {
-		scheduler.onResourceBindingUpdate(nil, obj)
+		oldRB := &workv1alpha2.ResourceBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation: 1,
+			},
+		}
+		scheduler.onResourceBindingUpdate(oldRB, obj)
 	}
 	policyChanged = func(scheduler *Scheduler, obj interface{}) {
 		rb := obj.(*workv1alpha2.ResourceBinding)
@@ -68,7 +73,7 @@ func TestIncomingBindingMetrics(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       fmt.Sprintf("test-rb-%d", i),
 				Namespace:  "bar",
-				Generation: 1,
+				Generation: 2,
 			},
 		}
 		rbInfos = append(rbInfos, rb)
@@ -77,7 +82,8 @@ func TestIncomingBindingMetrics(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		crb := &workv1alpha2.ClusterResourceBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("test-rb-%d", i),
+				Name:       fmt.Sprintf("test-rb-%d", i),
+				Generation: 2,
 			},
 		}
 		crbInfos = append(crbInfos, crb)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently, in our scheduler, there are many useless scheduling attempts, which may waste the performance of karmada-scheduler.

At first, I think it's due to the resourceVersion of the resource the resourceBinding is bound to. When status of resource templates is updated, the resourceVersion of this is updated which may cause the resourceBinding updated. When strategy is duplicated, it will always do a scheduling attempts. After I checked the code of detector, I found it's wrong.

```
func (d *ResourceDetector) OnUpdate(oldObj, newObj interface{}) {
	unstructuredOldObj, err := helper.ToUnstructured(oldObj)
	if err != nil {
		klog.Errorf("Failed to transform oldObj, error: %v", err)
		return
	}

	unstructuredNewObj, err := helper.ToUnstructured(newObj)
	if err != nil {
		klog.Errorf("Failed to transform newObj, error: %v", err)
		return
	}

	if !SpecificationChanged(unstructuredOldObj, unstructuredNewObj) {
		klog.V(4).Infof("Ignore update event of object (kind=%s, %s/%s) as specification no change", unstructuredOldObj.GetKind(), unstructuredOldObj.GetNamespace(), unstructuredOldObj.GetName())
		return
	}

	d.OnAdd(newObj)
}
```
Only spec changes will trigger dector to reconcile and update the binding. So status of resouce templates may not cause the update of object resourceVersion in resourceBinding. **But the update of status in resouceBinding will.**

Let's look back to the issue. For a resourceBinding, what kind of changes are worth scheduling by the scheduler? Of course, spec worth, but status does not worth.

For metadata of resourceBinding, the main change comes from labels and annotation. We have labels in resourceBinding marking the applied policy. It will change when policy changed or deleted. For policy changed, spec.Placement will also change. 
So scheduler can catch this change. For policy deleted, I think we do not do a scheduling attempt. We have annotation to mark the applied placement. It will not trigger scheduling, too. In summary, metadata changes does not worth scheduling by the scheduler.

For test, I propagated a Pod and observed the number of scheduling attemptes. It reduces almost 90% useless scheduling attempts.
Before:
karmada_scheduler_queue_incoming_bindings_total{event="BindingUpdate"} 8
After:
karmada_scheduler_queue_incoming_bindings_total{event="BindingUpdate"} 1

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

