### PR TITLE
add customizations for apps.krusie.io/v1beta1/StatefulSet

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/customizations.yaml
@@ -1,0 +1,125 @@
+apiVersion: config.karmada.io/v1alpha1
+kind: ResourceInterpreterCustomization
+metadata:
+  name: declarative-configuration-statefulset
+spec:
+  target:
+    apiVersion: apps.kruise.io/v1beta1
+    kind: StatefulSet
+  customizations:
+    replicaResource:
+      luaScript: >
+        local kube = require("kube")
+        function GetReplicas(obj)
+          replica = obj.spec.replicas
+          requirement = kube.accuratePodRequirements(obj.spec.template)
+          return replica, requirement
+        end
+    replicaRevision:
+      luaScript: >
+        function ReviseReplica(obj, desiredReplica)
+          obj.spec.replicas = desiredReplica
+          return obj
+        end
+    statusAggregation:
+      luaScript: >
+        function AggregateStatus(desiredObj, statusItems)
+          if statusItems == nil then
+            return desiredObj
+          end
+          if desiredObj.status == nil then
+            desiredObj.status = {}
+          end
+          if desiredObj.metadata.generation == nil then
+            desiredObj.metadata.generation = 0
+          end
+          generation = desiredObj.metadata.generation
+          replicas = 0
+          readyReplicas = 0 
+          currentReplicas = 0
+          updatedReplicas = 0
+          availableReplicas = 0
+          updatedReadyReplicas = 0
+          updateRevision = ''
+          currentRevision = ''
+          for i = 1, #statusItems do
+            if statusItems[i].status ~= nil and statusItems[i].status.replicas ~= nil then
+              replicas = replicas + statusItems[i].status.replicas
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.readyReplicas ~= nil then
+              readyReplicas = readyReplicas + statusItems[i].status.readyReplicas
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.currentReplicas ~= nil then
+              currentReplicas = currentReplicas + statusItems[i].status.currentReplicas
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.updatedReplicas ~= nil then
+              updatedReplicas = updatedReplicas + statusItems[i].status.updatedReplicas
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.availableReplicas ~= nil then
+              availableReplicas = availableReplicas + statusItems[i].status.availableReplicas
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.updatedReadyReplicas ~= nil then
+              updatedReadyReplicas = updatedReadyReplicas + statusItems[i].status.updatedReadyReplicas
+            end            
+            if statusItems[i].status ~= nil and statusItems[i].status.updateRevision ~= nil and statusItems[i].status.updateRevision ~= '' then
+              updateRevision = statusItems[i].status.updateRevision
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.currentRevision ~= nil and statusItems[i].status.currentRevision ~= '' then
+              currentRevision = statusItems[i].status.currentRevision
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.observedGeneration ~= nil and statusItems[i].status.observedGeneration ~= '' then
+              generation = statusItems[i].status.observedGeneration
+            end            
+          end
+          desiredObj.status.observedGeneration = generation
+          desiredObj.status.replicas = replicas
+          desiredObj.status.readyReplicas = readyReplicas
+          desiredObj.status.currentReplicas = currentReplicas
+          desiredObj.status.updatedReplicas = updatedReplicas
+          desiredObj.status.availableReplicas = availableReplicas
+          desiredObj.status.updatedReadyReplicas = updatedReadyReplicas
+          desiredObj.status.updateRevision = updateRevision
+          desiredObj.status.currentRevision = currentRevision
+          return desiredObj
+        end
+    statusReflection:
+      luaScript: >
+        function ReflectStatus (observedObj)
+          status = {}
+          if observedObj == nil or observedObj.status == nil then
+            return status
+          end
+          status.replicas = observedObj.status.replicas
+          status.readyReplicas = observedObj.status.readyReplicas
+          status.currentReplicas = observedObj.status.currentReplicas
+          status.updatedReplicas = observedObj.status.updatedReplicas
+          status.availableReplicas = observedObj.status.availableReplicas
+          status.updateRevision = observedObj.status.updateRevision
+          status.currentRevision = observedObj.status.currentRevision
+          status.updatedReadyReplicas = observedObj.status.updatedReadyReplicas
+          status.observedGeneration = observedObj.status.observedGeneration
+          return status
+        end
+    healthInterpretation:
+      luaScript: >
+        function InterpretHealth(observedObj)
+          if observedObj.status.observedGeneration ~= observedObj.metadata.generation then
+            return false
+          end
+          if observedObj.spec.replicas ~= nil then
+            if observedObj.status.updatedReplicas < observedObj.spec.replicas then
+              return false
+            end
+          end
+          if observedObj.status.availableReplicas < observedObj.status.updatedReplicas then
+            return false
+          end
+          return true
+        end
+    dependencyInterpretation:
+      luaScript: >
+        local kube = require("kube")
+        function GetDependencies(desiredObj)
+          refs = kube.getPodDependencies(desiredObj.spec.template, desiredObj.metadata.namespace)
+          return refs
+        end

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/desired-statefulset-nginx.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/desired-statefulset-nginx.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps.kruise.io/v1beta1
+kind: StatefulSet
+metadata:
+  name: sample
+  namespace: test-statefulset
+spec:
+  replicas: 2
+  serviceName: sample-statefulset-headless-service
+  selector:
+    matchLabels:
+      app: sample
+  template:
+    metadata:
+      labels:
+        app: sample
+    spec:
+      volumes:
+        - name: configmap
+          configMap:
+            name: my-sample-config  
+      readinessGates:
+      # A new condition that ensures the pod remains at NotReady state while the in-place update is happening
+      - conditionType: InPlaceUpdateReady
+      containers:
+        - name: nginx
+          image: nginx:alpine
+          ports:
+          - containerPort: 80
+            name: web          
+          env: 
+          - name: logData
+            valueFrom: 
+              configMapKeyRef:
+                name: mysql-config
+                key: log
+          - name: lowerData
+            valueFrom:
+              configMapKeyRef:
+                name: mysql-config
+                key: lower
+  podManagementPolicy: Parallel # allow parallel updates, works together with maxUnavailable
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # Do in-place update if possible, currently only image update is supported for in-place update
+      podUpdatePolicy: InPlaceIfPossible
+      # Allow parallel updates with max number of unavailable instances equals to 2
+      maxUnavailable: 2

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/observed-statefulset-nginx.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/observed-statefulset-nginx.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps.kruise.io/v1beta1
+kind: StatefulSet
+metadata:
+  name: sample
+  namespace: test-statefulset
+  generation: 1
+spec:
+  replicas: 2
+  serviceName: sample-statefulset-headless-service
+  selector:
+    matchLabels:
+      app: sample
+  template:
+    metadata:
+      labels:
+        app: sample
+    spec:
+      volumes:
+        - name: configmap
+          configMap:
+            name: my-sample-config  
+      readinessGates:
+      - conditionType: InPlaceUpdateReady
+      containers:
+        - name: nginx
+          image: nginx:alpine
+          ports:
+          - containerPort: 80
+            name: web          
+          env: 
+          - name: logData
+            valueFrom: 
+              configMapKeyRef:
+                name: mysql-config
+                key: log
+          - name: lowerData
+            valueFrom:
+              configMapKeyRef:
+                name: mysql-config
+                key: lower
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      podUpdatePolicy: InPlaceIfPossible
+      maxUnavailable: 2
+status:
+  availableReplicas: 2
+  collisionCount: 0
+  currentReplicas: 2
+  currentRevision: sample-5675547df7
+  labelSelector: app=sample
+  observedGeneration: 1
+  readyReplicas: 2
+  replicas: 2
+  updateRevision: sample-5675547df7
+  updatedReadyReplicas: 2
+  updatedReplicas: 2

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/status-file.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/status-file.yaml
@@ -1,0 +1,27 @@
+applied: true
+clusterName: member1
+health: Healthy
+status:
+  availableReplicas: 2
+  currentReplicas: 2
+  currentRevision: sample-5675547df7
+  observedGeneration: 1
+  readyReplicas: 2
+  replicas: 2
+  updateRevision: sample-5675547df7
+  updatedReadyReplicas: 2
+  updatedReplicas: 2
+---
+applied: true
+clusterName: member3
+health: Healthy
+status:
+  availableReplicas: 2
+  currentReplicas: 2
+  currentRevision: sample-5675547df7
+  observedGeneration: 1
+  readyReplicas: 2
+  replicas: 2
+  updateRevision: sample-5675547df7
+  updatedReadyReplicas: 2
+  updatedReplicas: 2


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Add third-party resources `apps.krusie.io/v1beta1/StatefulSet` into Resource Interpreter framework.
According to [Note](https://openkruise.io/docs/user-manuals/advancedstatefulset), we can find that since Kruise v0.7.0, Advanced StatefulSet has been promoted to v1beta1, which is compatible with v1alpha1.

**Which issue(s) this PR fixes**:
Part of #3331 

**Special notes for your reviewer**:
@Poor12 

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`Resource Interpreter`: Support `apps.krusie.io/v1beta1/StatefulSet`
```