### PR TITLE
add customizations for apps.krusie.io/v1alpha1/DaemonSet

### DIFF
--- a/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/customizations.yaml
+++ b/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/customizations.yaml
@@ -1,0 +1,297 @@
+apiVersion: config.karmada.io/v1alpha1
+kind: ResourceInterpreterCustomization
+metadata:
+  name: declarative-configuration-daemonset
+spec:
+  target:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: DaemonSet
+  customizations:
+    statusAggregation:
+      luaScript: >
+        function AggregateStatus(desiredObj, statusItems)
+          if statusItems == nil then
+            return desiredObj
+          end
+          if desiredObj.status == nil then
+            desiredObj.status = {}
+          end
+          if desiredObj.generation == nil then
+            desiredObj.generation = 0
+          end
+          generation = desiredObj.generation
+          currentNumberScheduled = 0
+          numberMisscheduled = 0 
+          desiredNumberScheduled = 0
+          numberReady = 0
+          updatedNumberScheduled = 0
+          numberAvailable = 0
+          numberUnavailable = 0
+          for i = 1, #statusItems do
+            if statusItems[i].status ~= nil and statusItems[i].status.currentNumberScheduled ~= nil then
+              currentNumberScheduled = currentNumberScheduled + statusItems[i].status.currentNumberScheduled
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.numberMisscheduled ~= nil then
+              numberMisscheduled = numberMisscheduled + statusItems[i].status.numberMisscheduled
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.desiredNumberScheduled ~= nil then
+              desiredNumberScheduled = desiredNumberScheduled + statusItems[i].status.desiredNumberScheduled
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.numberReady ~= nil then
+              numberReady = numberReady + statusItems[i].status.numberReady
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.updatedNumberScheduled ~= nil then
+              updatedNumberScheduled = updatedNumberScheduled + statusItems[i].status.updatedNumberScheduled
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.numberAvailable ~= nil then
+              numberAvailable = numberAvailable + statusItems[i].status.numberAvailable
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.numberUnavailable ~= nil then
+              numberUnavailable = numberUnavailable + statusItems[i].status.numberUnavailable
+            end
+          end
+          desiredObj.status.observedGeneration = generation
+          desiredObj.status.currentNumberScheduled = currentNumberScheduled
+          desiredObj.status.numberMisscheduled = numberMisscheduled
+          desiredObj.status.desiredNumberScheduled = desiredNumberScheduled
+          desiredObj.status.numberReady = numberReady
+          desiredObj.status.updatedNumberScheduled = updatedNumberScheduled
+          desiredObj.status.numberAvailable = numberAvailable
+          desiredObj.status.numberUnavailable = numberUnavailable
+          return desiredObj
+        end
+    statusReflection:
+      luaScript: >
+        function ReflectStatus (observedObj)
+          status = {}
+          if observedObj == nil or observedObj.status == nil then 
+            return status
+          end
+          status.currentNumberScheduled = observedObj.status.currentNumberScheduled
+          status.numberMisscheduled = observedObj.status.numberMisscheduled
+          status.desiredNumberScheduled = observedObj.status.desiredNumberScheduled
+          status.numberReady = observedObj.status.numberReady
+          status.updatedNumberScheduled = observedObj.status.updatedNumberScheduled
+          status.numberAvailable = observedObj.status.numberAvailable
+          status.numberUnavailable = observedObj.status.numberUnavailable
+          return status
+        end
+    healthInterpretation:
+      luaScript: >
+        function InterpretHealth(observedObj)
+          --[[
+          if observedObj.status.observedGeneration ~= observedObj.generation then
+            return false
+          end
+          --]]
+          if observedObj.status.updatedNumberScheduled < observedObj.status.desiredNumberScheduled then
+            return false
+          end
+          if observedObj.status.numberAvailable < observedObj.status.updatedNumberScheduled then
+            return false
+          end
+          return true
+        end
+    dependencyInterpretation:
+      luaScript: >
+        function GetDependencies(desiredObj)
+          dependentConfigMaps = {}
+          dependentSecrets = {}
+          dependentSas = {}
+          dependentPVCs = {}
+          refs = {}
+          local idx = 1
+          if desiredObj.spec.template.spec.initContainers ~= nil then
+            containers = {}
+            containers = desiredObj.spec.template.spec.initContainers
+            for key, container in pairs(containers) do
+              if container.envFrom ~= nil then
+                envFrom = {}
+                envFrom = container.envFrom
+                for indexForEnvFrom, envFromSource in pairs(envFrom) do
+                  if envFromSource.configMapRef ~= nil and envFromSource.configMapRef.name ~= nil and envFromSource.configMapRef.name ~= '' then
+                    dependentConfigMaps[envFromSource.configMapRef.name] = true
+                  end
+                  if envFromSource.secretRef ~= nil and envFromSource.secretRef.name ~= nil and envFromSource.secretRef.name ~= '' then
+                    dependentSecrets[envFromSource.secretRef.name] = true
+                  end
+                end
+              end
+              if container.env ~= nil then
+                envs = {}
+                envs = container.env
+                for indexForEnv, envVar in pairs(envs) do
+                  if envVar.valueFrom ~= nil and envVar.valueFrom.configMapKeyRef ~= nil and envVar.valueFrom.configMapKeyRef.name ~= nil and envVar.valueFrom.configMapKeyRef.name ~= '' then
+                    dependentConfigMaps[envVar.valueFrom.configMapKeyRef.name] = true
+                  end
+                  if envVar.valueFrom ~= nil and envVar.valueFrom.secretKeyRef ~= nil and envVar.valueFrom.secretKeyRef.name ~= nil and envVar.valueFrom.secretKeyRef.name ~= '' then
+                    dependentSecrets[envVar.valueFrom.secretKeyRef.name] = true
+                  end
+                end
+              end
+            end
+          end
+          if desiredObj.spec.template.spec.containers ~= nil then
+            containers = {}
+            containers = desiredObj.spec.template.spec.containers
+            for key, container in pairs(containers) do
+              if container.envFrom ~= nil then
+                envFrom = {}
+                envFrom = container.envFrom
+                for indexForEnvFrom, envFromSource in pairs(envFrom) do
+                  if envFromSource.configMapRef ~= nil and envFromSource.configMapRef.name ~= nil and envFromSource.configMapRef.name ~= nil and envFromSource.configMapRef.name ~= '' then
+                    dependentConfigMaps[envFromSource.configMapRef.name] = true
+                  end
+                  if envFromSource.secretRef ~= nil and envFromSource.secretRef.name ~= nil and envFromSource.secretRef.name ~= '' then
+                    dependentSecrets[envFromSource.secretRef.name] = true
+                  end
+                end
+              end
+              if container.env ~= nil then
+                envs = {}
+                envs = container.env
+                for indexForEnv, envVar in pairs(container.env) do
+                  if envVar.valueFrom ~= nil and envVar.valueFrom.configMapKeyRef ~= nil and envVar.valueFrom.configMapKeyRef.name ~= nil and envVar.valueFrom.configMapKeyRef.name ~= '' then
+                    dependentConfigMaps[envVar.valueFrom.configMapKeyRef.name] = true
+                  end
+                  if envVar.valueFrom ~= nil and envVar.valueFrom.secretKeyRef ~= nil and envVar.valueFrom.secretKeyRef.name ~= nil and envVar.valueFrom.secretKeyRef.name ~= '' then
+                    dependentSecrets[envVar.valueFrom.secretKeyRef.name] = true
+                  end                  
+                end
+              end
+            end            
+          end
+          if desiredObj.spec.template.spec.ephemeralContainers ~= nil then
+            containers = {}
+            containers = desiredObj.spec.template.spec.ephemeralContainers
+            for key, container in pairs(containers) do
+              if container.envFrom ~= nil then
+                envFrom = {}
+                envFrom = container.envFrom
+                for indexForEnvFrom, envFromSource in pairs(envFrom) do
+                  if envFromSource.configMapRef ~= nil and envFromSource.configMapRef.name ~= nil and envFromSource.configMapRef.name ~= '' then
+                    dependentConfigMaps[envFromSource.configMapRef.name] = true
+                  end
+                  if envFromSource.secretRef ~= nil and envFromSource.secretRef.name ~= nil and envFromSource.secretRef.name ~= '' then
+                    dependentSecrets[envFromSource.secretRef.name] = true
+                  end                  
+                end
+              end
+              if container.env ~= nil then
+                envs = {}
+                envs = container.env
+                for indexForEnv, envVar in pairs(container.env) do
+                  if envVar.valueFrom ~= nil and envVar.valueFrom.configMapKeyRef ~= nil and envVar.valueFrom.configMapKeyRef.name ~= nil and envVar.valueFrom.configMapKeyRef.name ~= '' then
+                    dependentConfigMaps[envVar.valueFrom.configMapKeyRef.name] = true
+                  end
+                  if envVar.valueFrom ~= nil and envVar.valueFrom.secretKeyRef ~= nil and envVar.valueFrom.secretKeyRef.name ~= nil and envVar.valueFrom.secretKeyRef.name ~= '' then
+                    dependentSecrets[envVar.valueFrom.secretKeyRef.name] = true
+                  end                  
+                end
+              end
+            end  
+          end
+          volumes = {}
+          if desiredObj.spec.template.spec.volumes ~= nil then
+            volumes = desiredObj.spec.template.spec.volumes
+          end
+          for volumnIndex, volume in pairs(volumes) do 
+            if volume.configMap ~= nil and volume.configMap.name ~= nil and volume.configMap.name ~= '' then
+              dependentConfigMaps[volume.configMap.name] = true
+            end
+            if volume.projected ~= nil and volume.projected.sources ~= nil then
+              sources = {}
+              sources = volume.projected.sources
+              for sourceIndex, source in pairs(sources) do
+                if source.configMap ~= nil and source.configMap.name ~= nil and source.configMap.name ~= '' then
+                  dependentConfigMaps[source.configMap.name] = true
+                end
+                if source.secret ~= nil and source.secret.name ~= nil and source.secret.name ~= '' then
+                  dependentSecrets[source.secret.name] = true
+                end
+              end
+            end
+            if volume.azureFile ~= nil and volume.azureFile.secretName ~= nil and volume.azureFile.secretName ~= '' then 
+              dependentSecrets[volume.azureFile.secretName] = true
+            end
+            if volume.cephfs ~= nil and volume.cephfs.secretRef ~= nil and volume.cephfs.secretRef.name ~= nil and volume.cephfs.secretRef.name ~= '' then
+              dependentSecrets[volume.cephfs.secretRef.name] = true
+            end
+            if volume.cinder ~= nil and volume.cinder.secretRef ~= nil and volume.cinder.secretRef.name ~= nil and volume.cinder.secretRef.name ~= '' then
+              dependentSecrets[volume.cinder.secretRef.name] = true
+            end
+            if volume.flexVolume ~= nil and volume.flexVolume.secretRef ~= nil and volume.flexVolume.secretRef.name ~= nil and volume.flexVolume.secretRef.name ~= '' then
+              dependentSecrets[volume.flexVolume.secretRef.name] = true
+            end
+            if volume.rbd ~= nil and volume.rbd.secretRef ~= nil and volume.rbd.secretRef.name ~= nil and volume.rbd.secretRef.name ~= '' then
+              dependentSecrets[volume.rbd.secretRef.name] = true
+            end
+            if volume.secret ~= nil and volume.secret.name ~= nil and volume.secret.name ~= '' then
+              dependentSecrets[volume.secret.name] = true
+            end
+            if volume.scaleIO ~= nil and volume.scaleIO.secretRef ~= nil and volume.scaleIO.secretRef.name ~= nil and volume.scaleIO.secretRef.name ~= '' then
+              dependentSecrets[volume.scaleIO.secretRef.name] = true
+            end
+            if volume.iscsi ~= nil and volume.iscsi.secretRef ~= nil and volume.iscsi.secretRef.name ~= nil and volume.iscsi.secretRef.name ~= '' then
+              dependentSecrets[volume.iscsi.secretRef.name] = true
+            end
+            if volume.storageos ~= nil and volume.storageos.secretRef ~= nil and volume.storageos.secretRef.name ~= nil and volume.storageos.secretRef.name ~= '' then
+              dependentSecrets[volume.storageos.secretRef.name] = true
+            end
+            if volume.csi ~= nil and volume.csi.nodePublishSecretRef ~= nil and volume.csi.nodePublishSecretRef.name ~= nil and volume.csi.nodePublishSecretRef.name ~= '' then
+              dependentSecrets[volume.csi.nodePublishSecretRef.name] = true
+            end
+            if volume.persistentVolumeClaim ~= nil and volume.persistentVolumeClaim.claimName ~= nil and volume.persistentVolumeClaim.claimName ~= '' then
+              dependentPVCs[volume.persistentVolumeClaim.claimName] = true
+            end
+          end
+          if desiredObj.spec.template.spec.imagePullSecrets ~= nil then
+            reference = {}
+            reference = desiredObj.spec.template.spec.imagePullSecrets
+            for key, value in pairs(reference) do
+              if value.name ~= nil and value.name ~= '' then
+                dependentSecrets[value.name] = true
+              end
+            end
+          end
+          if desiredObj.spec.template.spec.serviceAccountName ~= nil and desiredObj.spec.template.spec.serviceAccountName ~= '' and desiredObj.spec.template.spec.serviceAccountName ~= 'default' then
+              dependentSas[desiredObj.spec.template.spec.serviceAccountName] = true
+          end
+          for key, value in pairs(dependentConfigMaps) do
+            dependObj = {}
+            dependObj.apiVersion = 'v1'
+            dependObj.kind = 'ConfigMap'
+            dependObj.name = key
+            dependObj.namespace = desiredObj.metadata.namespace
+            refs[idx] = dependObj
+            idx = idx + 1
+          end
+          for key, value in pairs(dependentSecrets) do
+            dependObj = {}
+            dependObj.apiVersion = 'v1'
+            dependObj.kind = 'Secret'
+            dependObj.name = key
+            dependObj.namespace = desiredObj.metadata.namespace
+            refs[idx] = dependObj
+            idx = idx + 1
+          end
+          for key, value in pairs(dependentSas) do
+            dependObj = {}
+            dependObj.apiVersion = 'v1'
+            dependObj.kind = 'ServiceAccount'
+            dependObj.name = key
+            dependObj.namespace = desiredObj.metadata.namespace
+            refs[idx] = dependObj
+            idx = idx + 1
+          end
+          for key, value in pairs(dependentPVCs) do
+            dependObj = {}
+            dependObj.apiVersion = 'v1'
+            dependObj.kind = 'PersistentVolumeClaim'
+            dependObj.name = key
+            dependObj.namespace = desiredObj.metadata.namespace
+            refs[idx] = dependObj
+            idx = idx + 1
+          end
+          return refs
+        end

--- a/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/customizations_overridepolicy_test.yaml
+++ b/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/customizations_overridepolicy_test.yaml
@@ -1,0 +1,25 @@
+apiVersion: policy.karmada.io/v1alpha1
+kind: OverridePolicy
+metadata:
+  name: sample-daemonset-overridepolicy
+  namespace: test-kruise-deamonset
+  labels:
+    app: sample-daemonset
+spec:
+  resourceSelectors:
+    - apiVersion: apps.kruise.io/v1alpha1
+      kind: DaemonSet
+      name: sample
+      labelSelector:
+        matchLabels:
+          app: sample-daemonset
+  overrideRules:
+    - targetCluster:
+        labelSelector:
+          matchLabels:
+            cluster: member1 
+    - overriders:
+        labelsOverrider:
+          - operator: add
+            value: 
+              bar: bar

--- a/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/customizations_propagationpolicy_test.yaml
+++ b/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/customizations_propagationpolicy_test.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-kruise-deamonset
+  labels:
+    name: test-kruise-deamonset
+---
+apiVersion: v1
+kind: ConfigMap
+metadata: 
+  name: mysql-config
+  namespace: test-kruise-deamonset
+data:
+  log: "1"
+  lower: "1"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-sample-config
+  namespace: test-kruise-deamonset
+data:
+  nginx.properties: |
+    proxy-connect-timeout: "10s"
+    proxy-read-timeout: "10s"
+    client-max-body-size: "2m"
+---
+apiVersion: apps.kruise.io/v1alpha1
+kind: DaemonSet
+metadata:
+  labels:
+    app: sample-daemonset
+  name: sample
+  namespace: test-kruise-deamonset
+spec:
+  selector:
+    matchLabels:
+      app: sample-daemonset
+  template:
+    metadata:
+      labels:
+        app: sample-daemonset
+    spec:
+      volumes:
+        - name: configmap
+          configMap:
+            name: my-sample-config    
+      containers:
+        - name: nginx
+          image: nginx:alpine
+          env: 
+          - name: logData
+            valueFrom: 
+              configMapKeyRef:
+                name: mysql-config
+                key: log
+          - name: lowerData
+            valueFrom:
+              configMapKeyRef:
+                name: mysql-config
+                key: lower
+---
+apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: sample-daemonset-propagationpolicy
+  namespace: test-kruise-deamonset
+spec:
+  propagateDeps: true
+  resourceSelectors:
+    - apiVersion: apps.kruise.io/v1alpha1
+      kind: DaemonSet
+      name: sample
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - member1
+        - member3
+    replicaScheduling:
+      replicaSchedulingType: Duplicated


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Add third-party resources apps.krusie.io/v1alpha1/DaemonSet  into Resource Interpreter framework.

**Which issue(s) this PR fixes**:
Part of #3331 

**Special notes for your reviewer**:

*Still work in process, please ignore it.*

**Does this PR introduce a user-facing change?**:
NONE

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
*journal*: 
1.When using the duplicated propagation strategy, the `daemonset(apps.kruise.io/v1alpha1)` is propagated to
 cluster member1 and cluster member3. It is found that the generation of member1 and member3 is 1, but the 
generation observed by karmada-apiserver is 2 according to ResourceBinding.  
2.`Update resourceBinding(test-kruise-deamonset/sample-daemonset) with AggregatedStatus successfully` but 
there is no `.status` attribute in sample which is a `daemonset.apps.kruise.io`. The ResourceBinding has 
appropriate infomation ( except `.metadate.generation` and `.status.schedulerObservedGeneration`)

please ignore it.
```
```shell
# kubectl describe daemonset.apps.kruise.io sample -n test-kruise-deamonset
...
Events:
  Type    Reason                  Age                From                                Message
  ----    ------                  ----               ----                                -------
  Normal  SyncWorkSucceed         22s (x2 over 22s)  binding-controller                  Sync work of resourceBinding(test-kruise-deamonset/sample-daemonset) successful.
  Normal  ApplyPolicySucceed      22s                resource-detector                   Apply policy(test-kruise-deamonset/sample-daemonset-propagationpolicy) succeed
  Normal  GetDependenciesSucceed  22s                dependencies-distributor            Get dependencies([{APIVersion:v1 Kind:ConfigMap Namespace:test-kruise-deamonset Name:my-sample-config} {APIVersion:v1 Kind:ConfigMap Namespace:test-kruise-deamonset Name:mysql-config}]) succeed.
  Normal  SyncSucceed             22s                execution-controller                Successfully applied resource(test-kruise-deamonset/sample) to cluster member1
  Normal  SyncSucceed             22s                execution-controller                Successfully applied resource(test-kruise-deamonset/sample) to cluster member3
  Normal  ScheduleBindingSucceed  20s (x9 over 22s)  default-scheduler                   Binding has been scheduled
  Normal  AggregateStatusSucceed  7s (x13 over 22s)  resource-binding-status-controller  Update resourceBinding(test-kruise-deamonset/sample-daemonset) with AggregatedStatus successfully.

# kubectl get daemonset.apps.kruise.io sample -n test-kruise-deamonset
NAME     DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   AGE
sample                                                        4m40s

```
