### PR TITLE
add customizations for apps.krusie.io/v1alpha1/DaemonSet

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/customizations.yaml
@@ -1,0 +1,109 @@
+apiVersion: config.karmada.io/v1alpha1
+kind: ResourceInterpreterCustomization
+metadata:
+  name: declarative-configuration-daemonset
+spec:
+  target:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: DaemonSet
+  customizations:
+    statusAggregation:
+      luaScript: >
+        function AggregateStatus(desiredObj, statusItems)
+          if statusItems == nil then
+            return desiredObj
+          end
+          if desiredObj.status == nil then
+            desiredObj.status = {}
+          end
+          if desiredObj.metadata.generation == nil then
+            desiredObj.metadata.generation = 0
+          end
+          generation = desiredObj.metadata.generation
+          currentNumberScheduled = 0
+          numberMisscheduled = 0 
+          desiredNumberScheduled = 0
+          numberReady = 0
+          updatedNumberScheduled = 0
+          numberAvailable = 0
+          numberUnavailable = 0
+          daemonSetHash = 0
+          for i = 1, #statusItems do
+            if statusItems[i].status ~= nil and statusItems[i].status.currentNumberScheduled ~= nil then
+              currentNumberScheduled = currentNumberScheduled + statusItems[i].status.currentNumberScheduled
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.numberMisscheduled ~= nil then
+              numberMisscheduled = numberMisscheduled + statusItems[i].status.numberMisscheduled
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.desiredNumberScheduled ~= nil then
+              desiredNumberScheduled = desiredNumberScheduled + statusItems[i].status.desiredNumberScheduled
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.numberReady ~= nil then
+              numberReady = numberReady + statusItems[i].status.numberReady
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.updatedNumberScheduled ~= nil then
+              updatedNumberScheduled = updatedNumberScheduled + statusItems[i].status.updatedNumberScheduled
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.numberAvailable ~= nil then
+              numberAvailable = numberAvailable + statusItems[i].status.numberAvailable
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.numberUnavailable ~= nil then
+              numberUnavailable = numberUnavailable + statusItems[i].status.numberUnavailable
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.observedGeneration ~= nil and statusItems[i].status.observedGeneration ~= '' then
+              generation = statusItems[i].status.observedGeneration
+            end
+            if statusItems[i].status ~= nil and statusItems[i].status.daemonSetHash ~= nil and statusItems[i].status.daemonSetHash ~= '' then
+              daemonSetHash = statusItems[i].status.daemonSetHash
+            end
+          end
+          desiredObj.status.observedGeneration = generation
+          desiredObj.status.currentNumberScheduled = currentNumberScheduled
+          desiredObj.status.numberMisscheduled = numberMisscheduled
+          desiredObj.status.desiredNumberScheduled = desiredNumberScheduled
+          desiredObj.status.numberReady = numberReady
+          desiredObj.status.updatedNumberScheduled = updatedNumberScheduled
+          desiredObj.status.numberAvailable = numberAvailable
+          desiredObj.status.numberUnavailable = numberUnavailable
+          desiredObj.status.daemonSetHash = daemonSetHash
+          return desiredObj
+        end
+    statusReflection:
+      luaScript: >
+        function ReflectStatus (observedObj)
+          status = {}
+          if observedObj == nil or observedObj.status == nil then 
+            return status
+          end
+          status.observedGeneration = observedObj.status.observedGeneration
+          status.currentNumberScheduled = observedObj.status.currentNumberScheduled
+          status.numberMisscheduled = observedObj.status.numberMisscheduled
+          status.desiredNumberScheduled = observedObj.status.desiredNumberScheduled
+          status.numberReady = observedObj.status.numberReady
+          status.updatedNumberScheduled = observedObj.status.updatedNumberScheduled
+          status.numberAvailable = observedObj.status.numberAvailable
+          status.numberUnavailable = observedObj.status.numberUnavailable
+          status.daemonSetHash = observedObj.status.daemonSetHash
+          return status
+        end
+    healthInterpretation:
+      luaScript: >
+        function InterpretHealth(observedObj)
+          if observedObj.status.observedGeneration ~= observedObj.metadata.generation then
+            return false
+          end
+          if observedObj.status.updatedNumberScheduled < observedObj.status.desiredNumberScheduled then
+            return false
+          end
+          if observedObj.status.numberAvailable < observedObj.status.updatedNumberScheduled then
+            return false
+          end
+          return true
+        end
+    dependencyInterpretation:
+      luaScript: >
+        local kube = require("kube")
+        function GetDependencies(desiredObj)
+          refs = kube.getPodDependencies(desiredObj.spec.template, desiredObj.metadata.namespace)
+          return refs
+        end

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/testdata/desired-daemonset-nginx.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/testdata/desired-daemonset-nginx.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps.kruise.io/v1alpha1
+kind: DaemonSet
+metadata:
+  labels:
+    app: sample-daemonset
+  name: sample
+  namespace: test-kruise-daemonset
+spec:
+  selector:
+    matchLabels:
+      app: sample-daemonset
+  template:
+    metadata:
+      labels:
+        app: sample-daemonset
+    spec:
+      volumes:
+        - name: configmap
+          configMap:
+            name: my-sample-config    
+      containers:
+        - name: nginx
+          image: nginx:alpine
+          env: 
+          - name: logData
+            valueFrom: 
+              configMapKeyRef:
+                name: mysql-config
+                key: log
+          - name: lowerData
+            valueFrom:
+              configMapKeyRef:
+                name: mysql-config
+                key: lower

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/testdata/observed-daemonset-nginx.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/testdata/observed-daemonset-nginx.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps.kruise.io/v1alpha1
+kind: DaemonSet
+metadata:
+  labels:
+    app: sample-daemonset
+  name: sample
+  namespace: test-kruise-daemonset
+  generation: 1
+spec:
+  selector:
+    matchLabels:
+      app: sample-daemonset
+  template:
+    metadata:
+      labels:
+        app: sample-daemonset
+    spec:
+      volumes:
+        - name: configmap
+          configMap:
+            name: my-sample-config    
+      containers:
+        - name: nginx
+          image: nginx:alpine
+          env: 
+          - name: logData
+            valueFrom: 
+              configMapKeyRef:
+                name: mysql-config
+                key: log
+          - name: lowerData
+            valueFrom:
+              configMapKeyRef:
+                name: mysql-config
+                key: lower
+status:
+  currentNumberScheduled: 1
+  daemonSetHash: 7dd59cf749
+  desiredNumberScheduled: 1
+  numberAvailable: 1
+  numberMisscheduled: 0
+  numberReady: 1
+  observedGeneration: 1
+  updatedNumberScheduled: 1

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/testdata/status-file.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/testdata/status-file.yaml
@@ -1,0 +1,25 @@
+applied: true
+clusterName: member1
+health: Healthy
+status:
+  currentNumberScheduled: 1
+  daemonSetHash: 7dd59cf749
+  desiredNumberScheduled: 1
+  numberAvailable: 1
+  numberMisscheduled: 0
+  numberReady: 1
+  observedGeneration: 1
+  updatedNumberScheduled: 1
+---
+applied: true
+clusterName: member3
+health: Healthy
+status:
+  currentNumberScheduled: 1
+  daemonSetHash: 7dd59cf749
+  desiredNumberScheduled: 1
+  numberAvailable: 1
+  numberMisscheduled: 0
+  numberReady: 1
+  observedGeneration: 1
+  updatedNumberScheduled: 1


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Add third-party resources `apps.krusie.io/v1alpha1/DaemonSet`  into Resource Interpreter framework.

**Which issue(s) this PR fixes**:
Part of #3331 

**Special notes for your reviewer**:
@Poor12 

**Does this PR introduce a user-facing change?**:
NONE

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`Resource Interpreter`: Support `apps.krusie.io/v1alpha1/DaemonSet`
```
