### PR TITLE
fix an issue where DeepEqual becomes invalid in aggregate binding status

### DIFF
--- a/pkg/util/helper/workstatus.go
+++ b/pkg/util/helper/workstatus.go
@@ -65,7 +65,7 @@ func AggregateResourceBindingWorkStatus(
 		// set binding status with the newest condition
 		currentBindingStatus.Conditions = binding.Status.Conditions
 		meta.SetStatusCondition(&currentBindingStatus.Conditions, fullyAppliedCondition)
-		if reflect.DeepEqual(binding.Status, currentBindingStatus) {
+		if reflect.DeepEqual(binding.Status, *currentBindingStatus) {
 			klog.V(4).Infof("New aggregatedStatuses are equal with old resourceBinding(%s/%s) AggregatedStatus, no update required.",
 				binding.Namespace, binding.Name)
 			return nil
@@ -125,7 +125,7 @@ func AggregateClusterResourceBindingWorkStatus(
 		// set binding status with the newest condition
 		currentBindingStatus.Conditions = binding.Status.Conditions
 		meta.SetStatusCondition(&currentBindingStatus.Conditions, fullyAppliedCondition)
-		if reflect.DeepEqual(binding.Status, currentBindingStatus) {
+		if reflect.DeepEqual(binding.Status, *currentBindingStatus) {
 			klog.Infof("New aggregatedStatuses are equal with old clusterResourceBinding(%s) AggregatedStatus, no update required.", binding.Name)
 			return nil
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

When the binding status is collected from the work, we check whether the binding status changes to reduce the number of updated. However, the result is always false when the status pointer is compared with bindingStatus, so we need to change the pointer to the struce.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

