### PR TITLE
use patch helper instead of jsonpatch

### DIFF
--- a/pkg/util/helper/patch.go
+++ b/pkg/util/helper/patch.go
@@ -11,7 +11,7 @@ import (
 // original object to the modified object.
 // The merge patch format is primarily intended for use with the HTTP PATCH method
 // as a means of describing a set of modifications to a target resource's content.
-func GenMergePatch(originalObj interface{}, modifiedObj interface{}) (patchBytes []byte, err error) {
+func GenMergePatch(originalObj interface{}, modifiedObj interface{}) ([]byte, error) {
 	originalBytes, err := json.Marshal(originalObj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal original object: %w", err)
@@ -20,9 +20,14 @@ func GenMergePatch(originalObj interface{}, modifiedObj interface{}) (patchBytes
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal modified object: %w", err)
 	}
-	patchBytes, err = jsonpatch.CreateMergePatch(originalBytes, modifiedBytes)
+	patchBytes, err := jsonpatch.CreateMergePatch(originalBytes, modifiedBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a merge patch: %w", err)
+	}
+
+	// It's unnecessary to patch.
+	if string(patchBytes) == "{}" {
+		return nil, nil
 	}
 
 	return patchBytes, nil


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
We should use patch helper instead of `jsonpatch`, it's reusable code for easy maintenance.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

