### PR TITLE
Unify the assign replicas when duplicated

### DIFF
--- a/pkg/scheduler/core/assignment.go
+++ b/pkg/scheduler/core/assignment.go
@@ -51,18 +51,18 @@ type assignState struct {
 	targetReplicas int32
 }
 
-func newAssignState(candidates []*clusterv1alpha1.Cluster, strategy *policyv1alpha1.ReplicaSchedulingStrategy, obj *workv1alpha2.ResourceBindingSpec) *assignState {
+func newAssignState(candidates []*clusterv1alpha1.Cluster, placement *policyv1alpha1.Placement, obj *workv1alpha2.ResourceBindingSpec) *assignState {
 	var strategyType string
 
-	switch strategy.ReplicaSchedulingType {
+	switch placement.ReplicaSchedulingType() {
 	case policyv1alpha1.ReplicaSchedulingTypeDuplicated:
 		strategyType = DuplicatedStrategy
 	case policyv1alpha1.ReplicaSchedulingTypeDivided:
-		switch strategy.ReplicaDivisionPreference {
+		switch placement.ReplicaScheduling.ReplicaDivisionPreference {
 		case policyv1alpha1.ReplicaDivisionPreferenceAggregated:
 			strategyType = AggregatedStrategy
 		case policyv1alpha1.ReplicaDivisionPreferenceWeighted:
-			if strategy.WeightPreference != nil && len(strategy.WeightPreference.DynamicWeight) != 0 {
+			if placement.ReplicaScheduling.WeightPreference != nil && len(placement.ReplicaScheduling.WeightPreference.DynamicWeight) != 0 {
 				strategyType = DynamicWeightStrategy
 			} else {
 				strategyType = StaticWeightStrategy
@@ -70,7 +70,7 @@ func newAssignState(candidates []*clusterv1alpha1.Cluster, strategy *policyv1alp
 		}
 	}
 
-	return &assignState{candidates: candidates, strategy: strategy, spec: obj, strategyType: strategyType}
+	return &assignState{candidates: candidates, strategy: placement.ReplicaScheduling, spec: obj, strategyType: strategyType}
 }
 
 func (as *assignState) buildScheduledClusters() {

--- a/pkg/scheduler/core/assignment_test.go
+++ b/pkg/scheduler/core/assignment_test.go
@@ -283,7 +283,7 @@ func Test_dynamicScale(t *testing.T) {
 		name       string
 		candidates []*clusterv1alpha1.Cluster
 		object     *workv1alpha2.ResourceBindingSpec
-		strategy   *policyv1alpha1.ReplicaSchedulingStrategy
+		placement  *policyv1alpha1.Placement
 		want       []workv1alpha2.TargetCluster
 		wantErr    bool
 	}{
@@ -311,7 +311,9 @@ func Test_dynamicScale(t *testing.T) {
 					{Name: ClusterMember3, Replicas: 6},
 				},
 			},
-			strategy: dynamicWeightStrategy,
+			placement: &policyv1alpha1.Placement{
+				ReplicaScheduling: dynamicWeightStrategy,
+			},
 			want: []workv1alpha2.TargetCluster{
 				{Name: ClusterMember1, Replicas: 1},
 				{Name: ClusterMember2, Replicas: 2},
@@ -343,7 +345,9 @@ func Test_dynamicScale(t *testing.T) {
 					{Name: ClusterMember3, Replicas: 6},
 				},
 			},
-			strategy: dynamicWeightStrategy,
+			placement: &policyv1alpha1.Placement{
+				ReplicaScheduling: dynamicWeightStrategy,
+			},
 			want: []workv1alpha2.TargetCluster{
 				{Name: ClusterMember1, Replicas: 6},
 				{Name: ClusterMember2, Replicas: 8},
@@ -375,8 +379,10 @@ func Test_dynamicScale(t *testing.T) {
 					{Name: ClusterMember3, Replicas: 6},
 				},
 			},
-			strategy: dynamicWeightStrategy,
-			wantErr:  true,
+			placement: &policyv1alpha1.Placement{
+				ReplicaScheduling: dynamicWeightStrategy,
+			},
+			wantErr: true,
 		},
 		{
 			name: "replica 12 -> 6, aggregated 1:1:1",
@@ -401,7 +407,9 @@ func Test_dynamicScale(t *testing.T) {
 					{Name: ClusterMember2, Replicas: 8},
 				},
 			},
-			strategy: aggregatedStrategy,
+			placement: &policyv1alpha1.Placement{
+				ReplicaScheduling: aggregatedStrategy,
+			},
 			want: []workv1alpha2.TargetCluster{
 				{Name: ClusterMember2, Replicas: 6},
 			},
@@ -427,7 +435,9 @@ func Test_dynamicScale(t *testing.T) {
 					{Name: ClusterMember2, Replicas: 8},
 				},
 			},
-			strategy: aggregatedStrategy,
+			placement: &policyv1alpha1.Placement{
+				ReplicaScheduling: aggregatedStrategy,
+			},
 			want: []workv1alpha2.TargetCluster{
 				{Name: ClusterMember2, Replicas: 8},
 			},
@@ -456,7 +466,9 @@ func Test_dynamicScale(t *testing.T) {
 					{Name: ClusterMember2, Replicas: 8},
 				},
 			},
-			strategy: aggregatedStrategy,
+			placement: &policyv1alpha1.Placement{
+				ReplicaScheduling: aggregatedStrategy,
+			},
 			want: []workv1alpha2.TargetCluster{
 				{Name: ClusterMember1, Replicas: 6},
 				{Name: ClusterMember2, Replicas: 12},
@@ -487,7 +499,9 @@ func Test_dynamicScale(t *testing.T) {
 					{Name: ClusterMember2, Replicas: 8},
 				},
 			},
-			strategy: aggregatedStrategy,
+			placement: &policyv1alpha1.Placement{
+				ReplicaScheduling: aggregatedStrategy,
+			},
 			want: []workv1alpha2.TargetCluster{
 				{Name: ClusterMember1, Replicas: 10},
 				{Name: ClusterMember2, Replicas: 14},
@@ -517,8 +531,10 @@ func Test_dynamicScale(t *testing.T) {
 					{Name: ClusterMember2, Replicas: 8},
 				},
 			},
-			strategy: aggregatedStrategy,
-			wantErr:  true,
+			placement: &policyv1alpha1.Placement{
+				ReplicaScheduling: aggregatedStrategy,
+			},
+			wantErr: true,
 		},
 		{
 			name: "replica 12 -> 24, aggregated 4:8:12, with cluster2 disappeared and cluster4 appeared",
@@ -543,7 +559,9 @@ func Test_dynamicScale(t *testing.T) {
 					{Name: ClusterMember2, Replicas: 8},
 				},
 			},
-			strategy: aggregatedStrategy,
+			placement: &policyv1alpha1.Placement{
+				ReplicaScheduling: aggregatedStrategy,
+			},
 			want: []workv1alpha2.TargetCluster{
 				{Name: ClusterMember1, Replicas: 7},
 				{Name: ClusterMember2, Replicas: 8},
@@ -554,7 +572,7 @@ func Test_dynamicScale(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			state := newAssignState(tt.candidates, tt.strategy, tt.object)
+			state := newAssignState(tt.candidates, tt.placement, tt.object)
 			got, err := assignByDynamicStrategy(state)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("assignByDynamicStrategy() error = %v, wantErr %v", err, tt.wantErr)
@@ -572,7 +590,7 @@ func Test_dynamicScaleUp(t *testing.T) {
 		name       string
 		candidates []*clusterv1alpha1.Cluster
 		object     *workv1alpha2.ResourceBindingSpec
-		strategy   *policyv1alpha1.ReplicaSchedulingStrategy
+		placement  *policyv1alpha1.Placement
 		want       []workv1alpha2.TargetCluster
 		wantErr    bool
 	}{
@@ -595,7 +613,9 @@ func Test_dynamicScaleUp(t *testing.T) {
 				},
 				Replicas: 12,
 			},
-			strategy: dynamicWeightStrategy,
+			placement: &policyv1alpha1.Placement{
+				ReplicaScheduling: dynamicWeightStrategy,
+			},
 			want: []workv1alpha2.TargetCluster{
 				{Name: ClusterMember1, Replicas: 3},
 				{Name: ClusterMember2, Replicas: 4},
@@ -622,7 +642,9 @@ func Test_dynamicScaleUp(t *testing.T) {
 				},
 				Replicas: 12,
 			},
-			strategy: dynamicWeightStrategy,
+			placement: &policyv1alpha1.Placement{
+				ReplicaScheduling: dynamicWeightStrategy,
+			},
 			want: []workv1alpha2.TargetCluster{
 				{Name: ClusterMember1, Replicas: 4},
 				{Name: ClusterMember2, Replicas: 3},
@@ -649,8 +671,10 @@ func Test_dynamicScaleUp(t *testing.T) {
 				},
 				Replicas: 12,
 			},
-			strategy: dynamicWeightStrategy,
-			wantErr:  true,
+			placement: &policyv1alpha1.Placement{
+				ReplicaScheduling: dynamicWeightStrategy,
+			},
+			wantErr: true,
 		},
 		{
 			name: "replica 12, aggregated 6:8:10",
@@ -671,7 +695,9 @@ func Test_dynamicScaleUp(t *testing.T) {
 				},
 				Replicas: 12,
 			},
-			strategy: aggregatedStrategy,
+			placement: &policyv1alpha1.Placement{
+				ReplicaScheduling: aggregatedStrategy,
+			},
 			want: []workv1alpha2.TargetCluster{
 				{Name: ClusterMember2, Replicas: 5},
 				{Name: ClusterMember3, Replicas: 7},
@@ -697,7 +723,9 @@ func Test_dynamicScaleUp(t *testing.T) {
 				},
 				Replicas: 12,
 			},
-			strategy: aggregatedStrategy,
+			placement: &policyv1alpha1.Placement{
+				ReplicaScheduling: aggregatedStrategy,
+			},
 			want: []workv1alpha2.TargetCluster{
 				{Name: ClusterMember1, Replicas: 12},
 			},
@@ -722,13 +750,15 @@ func Test_dynamicScaleUp(t *testing.T) {
 				},
 				Replicas: 12,
 			},
-			strategy: aggregatedStrategy,
-			wantErr:  true,
+			placement: &policyv1alpha1.Placement{
+				ReplicaScheduling: aggregatedStrategy,
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			state := newAssignState(tt.candidates, tt.strategy, tt.object)
+			state := newAssignState(tt.candidates, tt.placement, tt.object)
 			state.buildScheduledClusters()
 			got, err := dynamicScaleUp(state)
 			if (err != nil) != tt.wantErr {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -316,7 +316,7 @@ func (s *Scheduler) doScheduleBinding(namespace, name string) (err error) {
 		metrics.BindingSchedule(string(ReconcileSchedule), utilmetrics.DurationInSeconds(start), err)
 		return err
 	}
-	if rb.Spec.Placement.ReplicaScheduling != nil && util.IsBindingReplicasChanged(&rb.Spec, rb.Spec.Placement.ReplicaScheduling) {
+	if util.IsBindingReplicasChanged(&rb.Spec, rb.Spec.Placement.ReplicaScheduling) {
 		// binding replicas changed, need reschedule
 		klog.Infof("Reschedule ResourceBinding(%s/%s) as replicas scaled down or scaled up", namespace, name)
 		err = s.scheduleResourceBinding(rb)
@@ -324,8 +324,7 @@ func (s *Scheduler) doScheduleBinding(namespace, name string) (err error) {
 		return err
 	}
 	if rb.Spec.Replicas == 0 ||
-		rb.Spec.Placement.ReplicaScheduling == nil ||
-		rb.Spec.Placement.ReplicaScheduling.ReplicaSchedulingType == policyv1alpha1.ReplicaSchedulingTypeDuplicated {
+		rb.Spec.Placement.ReplicaSchedulingType() == policyv1alpha1.ReplicaSchedulingTypeDuplicated {
 		// Duplicated resources should always be scheduled. Note: non-workload is considered as duplicated
 		// even if scheduling type is divided.
 		klog.V(3).Infof("Start to schedule ResourceBinding(%s/%s) as scheduling type is duplicated", namespace, name)
@@ -364,7 +363,7 @@ func (s *Scheduler) doScheduleClusterBinding(name string) (err error) {
 		metrics.BindingSchedule(string(ReconcileSchedule), utilmetrics.DurationInSeconds(start), err)
 		return err
 	}
-	if crb.Spec.Placement.ReplicaScheduling != nil && util.IsBindingReplicasChanged(&crb.Spec, crb.Spec.Placement.ReplicaScheduling) {
+	if util.IsBindingReplicasChanged(&crb.Spec, crb.Spec.Placement.ReplicaScheduling) {
 		// binding replicas changed, need reschedule
 		klog.Infof("Reschedule ClusterResourceBinding(%s) as replicas scaled down or scaled up", name)
 		err = s.scheduleClusterResourceBinding(crb)
@@ -372,8 +371,7 @@ func (s *Scheduler) doScheduleClusterBinding(name string) (err error) {
 		return err
 	}
 	if crb.Spec.Replicas == 0 ||
-		crb.Spec.Placement.ReplicaScheduling == nil ||
-		crb.Spec.Placement.ReplicaScheduling.ReplicaSchedulingType == policyv1alpha1.ReplicaSchedulingTypeDuplicated {
+		crb.Spec.Placement.ReplicaSchedulingType() == policyv1alpha1.ReplicaSchedulingTypeDuplicated {
 		// Duplicated resources should always be scheduled. Note: non-workload is considered as duplicated
 		// even if scheduling type is divided.
 		klog.V(3).Infof("Start to schedule ClusterResourceBinding(%s) as scheduling type is duplicated", name)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
1. Unify the `assignReplicas` function when `placement.ReplicaSchedulingType()` is equal to `Duplicated`.
2. Refactor some codes to make it clearer.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

