### PR TITLE
flake: [ClusterAffinities] propagation testing

### DIFF
--- a/pkg/scheduler/event_handler.go
+++ b/pkg/scheduler/event_handler.go
@@ -1,11 +1,14 @@
 package scheduler
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -186,68 +189,10 @@ func (s *Scheduler) updateCluster(oldObj, newObj interface{}) {
 	case !equality.Semantic.DeepEqual(oldCluster.Labels, newCluster.Labels):
 		fallthrough
 	case oldCluster.Generation != newCluster.Generation:
-		s.enqueueAffectedBindings(oldCluster, newCluster)
-	}
-}
-
-// enqueueAffectedBinding find all RBs/CRBs related to the cluster and reschedule them
-func (s *Scheduler) enqueueAffectedBindings(oldCluster, newCluster *clusterv1alpha1.Cluster) {
-	bindings, _ := s.bindingLister.List(labels.Everything())
-	for _, binding := range bindings {
-		placementPtr := binding.Spec.Placement
-		if placementPtr == nil {
-			// never reach here
-			continue
-		}
-
-		var affinity *policyv1alpha1.ClusterAffinity
-		if placementPtr.ClusterAffinities != nil {
-			affinityIndex := getAffinityIndex(placementPtr.ClusterAffinities, binding.Status.SchedulerObservedAffinityName)
-			affinity = &placementPtr.ClusterAffinities[affinityIndex].ClusterAffinity
-		} else {
-			affinity = placementPtr.ClusterAffinity
-		}
-
-		switch {
-		case affinity == nil:
-			// If no clusters specified, add it to the queue
-			fallthrough
-		case util.ClusterMatches(newCluster, *affinity):
-			// If the new cluster manifest match the affinity, add it to the queue, trigger rescheduling
-			fallthrough
-		case util.ClusterMatches(oldCluster, *affinity):
-			// If the old cluster manifest match the affinity, add it to the queue, trigger rescheduling
-			s.onResourceBindingRequeue(binding, metrics.ClusterChanged)
-		}
-	}
-
-	clusterBindings, _ := s.clusterBindingLister.List(labels.Everything())
-	for _, binding := range clusterBindings {
-		placementPtr := binding.Spec.Placement
-		if placementPtr == nil {
-			// never reach here
-			continue
-		}
-
-		var affinity *policyv1alpha1.ClusterAffinity
-		if placementPtr.ClusterAffinities != nil {
-			affinityIndex := getAffinityIndex(placementPtr.ClusterAffinities, binding.Status.SchedulerObservedAffinityName)
-			affinity = &placementPtr.ClusterAffinities[affinityIndex].ClusterAffinity
-		} else {
-			affinity = placementPtr.ClusterAffinity
-		}
-
-		switch {
-		case affinity == nil:
-			// If no clusters specified, add it to the queue
-			fallthrough
-		case util.ClusterMatches(newCluster, *affinity):
-			// If the new cluster manifest match the affinity, add it to the queue, trigger rescheduling
-			fallthrough
-		case util.ClusterMatches(oldCluster, *affinity):
-			// If the old cluster manifest match the affinity, add it to the queue, trigger rescheduling
-			s.onClusterResourceBindingRequeue(binding, metrics.ClusterChanged)
-		}
+		// To distinguish the obd and new cluster objects, we need to add the entire object
+		// to the worker. Therefore, call Add func instead of Enqueue func.
+		s.clusterReconcileWorker.Add(oldCluster)
+		s.clusterReconcileWorker.Add(newCluster)
 	}
 }
 
@@ -281,4 +226,97 @@ func schedulerNameFilter(schedulerNameFromOptions, schedulerName string) bool {
 	}
 
 	return schedulerNameFromOptions == schedulerName
+}
+
+func (s *Scheduler) reconcileCluster(key util.QueueKey) error {
+	cluster, ok := key.(*clusterv1alpha1.Cluster)
+	if !ok {
+		return fmt.Errorf("invalid cluster key: %s", key)
+	}
+	return utilerrors.NewAggregate([]error{
+		s.enqueueAffectedBindings(cluster),
+		s.enqueueAffectedCRBs(cluster)},
+	)
+}
+
+// enqueueAffectedBindings find all RBs related to the cluster and reschedule them
+func (s *Scheduler) enqueueAffectedBindings(cluster *clusterv1alpha1.Cluster) error {
+	klog.V(4).Infof("Enqueue affected ResourceBinding with cluster %s", cluster.Name)
+
+	bindings, _ := s.bindingLister.List(labels.Everything())
+	for _, binding := range bindings {
+		placementPtr := binding.Spec.Placement
+		if placementPtr == nil {
+			// never reach here
+			continue
+		}
+
+		var affinity *policyv1alpha1.ClusterAffinity
+		if placementPtr.ClusterAffinities != nil {
+			if binding.Status.SchedulerObservedGeneration != binding.Generation {
+				// Hit here means the binding maybe still in the queue waiting
+				// for scheduling or its status has not been synced to the
+				// cache. Just enqueue the binding to avoid missing the cluster
+				// update event.
+				s.onResourceBindingRequeue(binding, metrics.ClusterChanged)
+				continue
+			}
+			affinityIndex := getAffinityIndex(placementPtr.ClusterAffinities, binding.Status.SchedulerObservedAffinityName)
+			affinity = &placementPtr.ClusterAffinities[affinityIndex].ClusterAffinity
+		} else {
+			affinity = placementPtr.ClusterAffinity
+		}
+
+		switch {
+		case affinity == nil:
+			// If no clusters specified, add it to the queue
+			fallthrough
+		case util.ClusterMatches(cluster, *affinity):
+			// If the cluster manifest match the affinity, add it to the queue, trigger rescheduling
+			s.onResourceBindingRequeue(binding, metrics.ClusterChanged)
+		}
+	}
+
+	return nil
+}
+
+// enqueueAffectedCRBs find all CRBs related to the cluster and reschedule them
+func (s *Scheduler) enqueueAffectedCRBs(cluster *clusterv1alpha1.Cluster) error {
+	klog.V(4).Infof("Enqueue affected ClusterResourceBinding with cluster %s", cluster.Name)
+
+	clusterBindings, _ := s.clusterBindingLister.List(labels.Everything())
+	for _, binding := range clusterBindings {
+		placementPtr := binding.Spec.Placement
+		if placementPtr == nil {
+			// never reach here
+			continue
+		}
+
+		var affinity *policyv1alpha1.ClusterAffinity
+		if placementPtr.ClusterAffinities != nil {
+			if binding.Status.SchedulerObservedGeneration != binding.Generation {
+				// Hit here means the binding maybe still in the queue waiting
+				// for scheduling or its status has not been synced to the
+				// cache. Just enqueue the binding to avoid missing the cluster
+				// update event.
+				s.onClusterResourceBindingRequeue(binding, metrics.ClusterChanged)
+				continue
+			}
+			affinityIndex := getAffinityIndex(placementPtr.ClusterAffinities, binding.Status.SchedulerObservedAffinityName)
+			affinity = &placementPtr.ClusterAffinities[affinityIndex].ClusterAffinity
+		} else {
+			affinity = placementPtr.ClusterAffinity
+		}
+
+		switch {
+		case affinity == nil:
+			// If no clusters specified, add it to the queue
+			fallthrough
+		case util.ClusterMatches(cluster, *affinity):
+			// If the cluster manifest match the affinity, add it to the queue, trigger rescheduling
+			s.onClusterResourceBindingRequeue(binding, metrics.ClusterChanged)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

By analyzing: https://github.com/karmada-io/karmada/issues/3390#issuecomment-1506471651

When processing `clusteraffinities`, we can determine whether the current binding has been synchronized by checking `SchedulerObservedGeneration`. Otherwise, we can obtain the latest binding object through the `karmadaClient`.

**Which issue(s) this PR fixes**:
Fixes #3390 

**Special notes for your reviewer**:

Alternative solution:

Place `SchedulerObservedAffinityName` filed into `binding.spec`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

