### PR TITLE
Automated cherry pick of #3376: if start many watcher to watch pod. pod resourceVersion will

### DIFF
--- a/pkg/search/proxy/store/multi_cluster_cache.go
+++ b/pkg/search/proxy/store/multi_cluster_cache.go
@@ -315,7 +315,6 @@ func (c *MultiClusterCache) Watch(ctx context.Context, gvr schema.GroupVersionRe
 		}
 
 		mux.AddSource(w, func(e watch.Event) {
-			// We can safely modify data because it is deepCopied in cacheWatcher.convertToWatchEvent
 			setObjectResourceVersionFunc(cluster, e.Object)
 			addCacheSourceAnnotation(e.Object, cluster)
 		})


### PR DESCRIPTION
Cherry pick of #3376 on release-1.5.
#3376: if start many watcher to watch pod. pod resourceVersion will
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
karmada-search: fix the problem that ResourceVersion base64 encrypted repeatedly when starting multiple informer to watch resource
```