### PR TITLE
karmada operator: optimize karmada aggregated apiserver startup

### DIFF
--- a/operator/pkg/init.go
+++ b/operator/pkg/init.go
@@ -75,7 +75,7 @@ func NewInitJob(opt *InitOptions) *workflow.Job {
 	initJob.AppendTask(tasks.NewUploadCertsTask())
 	initJob.AppendTask(tasks.NewEtcdTask())
 	initJob.AppendTask(tasks.NewKarmadaApiserverTask())
-	initJob.AppendTask(tasks.NewWaitApiserverTask())
+	initJob.AppendTask(tasks.NewCheckApiserverHealthTask())
 	initJob.AppendTask(tasks.NewKarmadaResourcesTask())
 	initJob.AppendTask(tasks.NewComponentTask())
 	initJob.AppendTask(tasks.NewWaitControlPlaneTask())

--- a/operator/pkg/tasks/init/etcd.go
+++ b/operator/pkg/tasks/init/etcd.go
@@ -3,18 +3,31 @@ package tasks
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"k8s.io/klog/v2"
 
 	"github.com/karmada-io/karmada/operator/pkg/controlplane/etcd"
+	"github.com/karmada-io/karmada/operator/pkg/util/apiclient"
 	"github.com/karmada-io/karmada/operator/pkg/workflow"
 )
 
 // NewEtcdTask init a etcd task to install etcd component
 func NewEtcdTask() workflow.Task {
 	return workflow.Task{
-		Name: "Etcd",
-		Run:  runEtcd,
+		Name:        "Etcd",
+		Run:         runEtcd,
+		RunSubTasks: true,
+		Tasks: []workflow.Task{
+			{
+				Name: "deploy-etcd",
+				Run:  runDeployEtcd,
+			},
+			{
+				Name: "wait-etcd",
+				Run:  runWaitEtcd,
+			},
+		},
 	}
 }
 
@@ -23,7 +36,16 @@ func runEtcd(r workflow.RunData) error {
 	if !ok {
 		return errors.New("etcd task invoked with an invalid data struct")
 	}
+
 	klog.V(4).InfoS("[etcd] Running etcd task", "karmada", klog.KObj(data))
+	return nil
+}
+
+func runDeployEtcd(r workflow.RunData) error {
+	data, ok := r.(InitData)
+	if !ok {
+		return errors.New("deploy-etcd task invoked with an invalid data struct")
+	}
 
 	cfg := data.Components()
 	if cfg.Etcd.External != nil {
@@ -40,6 +62,24 @@ func runEtcd(r workflow.RunData) error {
 		return fmt.Errorf("failed to install etcd component, err: %w", err)
 	}
 
-	klog.V(2).InfoS("[etcd] Successfully installed etcd component", "karmada", klog.KObj(data))
+	klog.V(2).InfoS("[deploy-etcd] Successfully installed etcd component", "karmada", klog.KObj(data))
+	return nil
+}
+
+func runWaitEtcd(r workflow.RunData) error {
+	data, ok := r.(InitData)
+	if !ok {
+		return errors.New("wait-etcd task invoked with an invalid data struct")
+	}
+
+	waiter := apiclient.NewKarmadaWaiter(data.ControlplaneConifg(), data.RemoteClient(), time.Second*30)
+
+	// wait etcd, karmada apiserver and aggregated apiserver to ready
+	// as long as a replica of pod is ready, we consider the service available.
+	if err := waiter.WaitForSomePods(etcdLabels.String(), data.GetNamespace(), 1); err != nil {
+		return fmt.Errorf("waiting for etcd to ready timeout, err: %w", err)
+	}
+
+	klog.V(2).InfoS("[wait-etcd] the etcd pods is ready", "karmada", klog.KObj(data))
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
I found ETCD, karmada apiserver and karmada aggregated apiserver have dependencies,  Their startup order should be：
etcd -> karmada apiserver -> karmada aggregated apiserver.

The karmada aggregated apiserver restart twice：

![image](https://user-images.githubusercontent.com/45745657/231442923-470500d1-f688-4e6d-9237-934aaaf04722.png)



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

