### PR TITLE
fix paging list in karmada search proxy

### DIFF
--- a/pkg/search/proxy/store/multi_cluster_cache_test.go
+++ b/pkg/search/proxy/store/multi_cluster_cache_test.go
@@ -873,3 +873,176 @@ func enhancedListReaction(o kubetesting.ObjectTracker, v VersionTracker) kubetes
 		return true, ret, nil
 	}
 }
+
+func Test_prepareBeforeList(t *testing.T) {
+	testMRV := &multiClusterResourceVersion{rvs: map[string]string{"c1": "1234", "c2": "5678"}}
+	testMRVString := testMRV.String()
+
+	type args struct {
+		o *metainternalversion.ListOptions
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantCluster string
+		wantOptions *metainternalversion.ListOptions
+		wantMrv     *multiClusterResourceVersion
+	}{
+		{
+			name: "Continue is empty",
+			args: args{
+				o: &metainternalversion.ListOptions{
+					ResourceVersion: "0",
+				},
+			},
+			wantCluster: "",
+			wantOptions: &metainternalversion.ListOptions{
+				ResourceVersion: "0",
+				Continue:        "",
+			},
+			wantMrv: newMultiClusterResourceVersionFromString("0"),
+		},
+		{
+			name: "Continue is not empty, and has no continue",
+			args: args{
+				o: &metainternalversion.ListOptions{
+					Continue: func() string {
+						c := multiClusterContinue{RV: testMRVString, Cluster: "c2", Continue: ""}
+						return c.String()
+					}(),
+				},
+			},
+			wantCluster: "c2",
+			wantOptions: &metainternalversion.ListOptions{
+				ResourceVersion: "5678",
+				Continue:        "",
+			},
+			wantMrv: testMRV,
+		},
+		{
+			name: "Continue is not empty, and has continue",
+			args: args{
+				o: &metainternalversion.ListOptions{
+					Continue: func() string {
+						c := multiClusterContinue{RV: testMRVString, Cluster: "c2", Continue: "xxx"}
+						return c.String()
+					}(),
+				},
+			},
+			wantCluster: "c2",
+			wantOptions: &metainternalversion.ListOptions{
+				Continue: "xxx",
+			},
+			wantMrv: testMRV,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCluster, gotOptions, gotMrv := prepareBeforeList(tt.args.o)
+			if gotCluster != tt.wantCluster {
+				t.Errorf("prepareBeforeList() gotCluster = %v, want %v", gotCluster, tt.wantCluster)
+			}
+			if !reflect.DeepEqual(gotOptions, tt.wantOptions) {
+				t.Errorf("prepareBeforeList() gotOptions = %v, want %v", gotOptions, tt.wantOptions)
+			}
+			if !reflect.DeepEqual(gotMrv, tt.wantMrv) {
+				t.Errorf("prepareBeforeList() gotMrv = %v, want %v", gotMrv, tt.wantMrv)
+			}
+		})
+	}
+}
+
+func TestMultiClusterCache_fillMissingClusterResourceVersion(t *testing.T) {
+	cluster1 := newCluster("cluster1")
+	cluster1Client := NewEnhancedFakeDynamicClientWithResourceVersion(scheme, "1000")
+	cluster1Client.AddReactor("*", "nodes", func(kubetesting.Action) (bool, runtime.Object, error) {
+		return false, nil, fmt.Errorf("error")
+	})
+
+	newClientFunc := func(cluster string) (dynamic.Interface, error) {
+		switch cluster {
+		case cluster1.Name:
+			return cluster1Client, nil
+		default:
+			return nil, fmt.Errorf("unknown cluster %v", cluster)
+		}
+	}
+	cache := NewMultiClusterCache(newClientFunc, restMapper)
+	defer cache.Stop()
+	err := cache.UpdateCache(map[string]map[schema.GroupVersionResource]struct{}{
+		cluster1.Name: resourceSet(podGVR),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// wait cache synced
+	time.Sleep(time.Second)
+
+	type args struct {
+		mcv      *multiClusterResourceVersion
+		clusters []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		wantMCV *multiClusterResourceVersion
+	}{
+		{
+			name: "no missing cluster rv",
+			args: args{
+				mcv: &multiClusterResourceVersion{
+					rvs: map[string]string{
+						"cluster1": "1234",
+					},
+				},
+				clusters: []string{"cluster1"},
+			},
+			wantMCV: &multiClusterResourceVersion{
+				rvs: map[string]string{
+					"cluster1": "1234",
+				},
+			},
+		},
+		{
+			name: "has missing cluster rv",
+			args: args{
+				mcv: &multiClusterResourceVersion{
+					rvs: map[string]string{},
+				},
+				clusters: []string{"cluster1"},
+			},
+			wantMCV: &multiClusterResourceVersion{
+				rvs: map[string]string{
+					"cluster1": "1000",
+				},
+			},
+		},
+		{
+			name: "cluster not exist",
+			args: args{
+				mcv: &multiClusterResourceVersion{
+					rvs: map[string]string{},
+				},
+				clusters: []string{"non-exist"},
+			},
+			wantMCV: &multiClusterResourceVersion{
+				rvs: map[string]string{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			defer cancel()
+
+			if err = cache.fillMissingClusterResourceVersion(ctx, tt.args.mcv, tt.args.clusters, podGVR); (err != nil) != tt.wantErr {
+				t.Fatalf("fillMissingClusterResourceVersion() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if got := tt.args.mcv; !reflect.DeepEqual(got, tt.wantMCV) {
+				t.Fatalf("fillMissingClusterResourceVersion() mcv = %v, want %v", got.String(), tt.wantMCV.String())
+			}
+		})
+	}
+}

--- a/pkg/search/proxy/store/util.go
+++ b/pkg/search/proxy/store/util.go
@@ -60,6 +60,17 @@ func (m *multiClusterResourceVersion) get(cluster string) string {
 	return m.rvs[cluster]
 }
 
+func (m *multiClusterResourceVersion) clone() *multiClusterResourceVersion {
+	ret := &multiClusterResourceVersion{
+		isZero: m.isZero,
+		rvs:    make(map[string]string, len(m.rvs)),
+	}
+	for k, v := range m.rvs {
+		ret.rvs[k] = v
+	}
+	return ret
+}
+
 func (m *multiClusterResourceVersion) String() string {
 	if m.isZero {
 		return "0"
@@ -125,6 +136,7 @@ func marshalRvs(rvs map[string]string) []byte {
 }
 
 type multiClusterContinue struct {
+	RV       string `json:"rv"`
 	Cluster  string `json:"cluster,omitempty"`
 	Continue string `json:"continue,omitempty"`
 }

--- a/pkg/search/proxy/store/util_test.go
+++ b/pkg/search/proxy/store/util_test.go
@@ -429,6 +429,7 @@ func Test_newMultiClusterContinueFromString(t *testing.T) {
 
 func Test_multiClusterContinue_String(t *testing.T) {
 	type fields struct {
+		RV       string
 		Cluster  string
 		Continue string
 	}
@@ -440,6 +441,7 @@ func Test_multiClusterContinue_String(t *testing.T) {
 		{
 			name: "empty",
 			fields: fields{
+				RV:       "",
 				Cluster:  "",
 				Continue: "",
 			},
@@ -448,15 +450,17 @@ func Test_multiClusterContinue_String(t *testing.T) {
 		{
 			name: "success",
 			fields: fields{
+				RV:       "123",
 				Cluster:  "cluster1",
 				Continue: "1",
 			},
-			want: base64.RawURLEncoding.EncodeToString([]byte(`{"cluster":"cluster1","continue":"1"}`)),
+			want: base64.RawURLEncoding.EncodeToString([]byte(`{"rv":"123","cluster":"cluster1","continue":"1"}`)),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &multiClusterContinue{
+				RV:       tt.fields.RV,
 				Cluster:  tt.fields.Cluster,
 				Continue: tt.fields.Continue,
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When paging query via karmada search proxy, if member cluster resources number is larger than page size (`limit`), the return `resourceVersion` and `continue` is not incorrect.

For example, there are two member clusters:
|    | Cluster1 | Cluster2 |
|--------|--------|--------|
| RV       | 123 | 456 |
| Pods   | 10 | 10 |

And client request with:
```
/apis/search.karmada.io/v1alpha1/proxying/karmada/proxy/api/v1/namespaces/default/pods?limit=5
```
**Incomplete  `resourceVersion`**
got:`{"cluster1":"123"}` (decoded), while want `{"cluster1":"123","cluster2":"456"}`

**Unreasonable `continue`**
There's no resource version in `continue`, and next page query will got a wrong rv.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-search`: fix paging list in karmada search proxy in large scale memeber clusters.
```

