### PR TITLE
Add validation for failover

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15044,7 +15044,7 @@
           "format": "int32"
         },
         "decisionConditions": {
-          "description": "DecisionConditions indicates the decision conditions of performing the failover process. Only when all conditions are met can the failover process be performed. Currently, DecisionConditions includes several conditions: - TolerationSeconds (optional) - HealthyState (mandatory)",
+          "description": "DecisionConditions indicates the decision conditions of performing the failover process. Only when all conditions are met can the failover process be performed. Currently, DecisionConditions includes several conditions: - TolerationSeconds (optional)",
           "default": {},
           "$ref": "#/definitions/com.github.karmada-io.karmada.pkg.apis.policy.v1alpha1.DecisionConditions"
         },

--- a/charts/karmada/_crds/bases/policy.karmada.io_clusterpropagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy.karmada.io_clusterpropagationpolicies.yaml
@@ -87,7 +87,7 @@ spec:
                           of performing the failover process. Only when all conditions
                           are met can the failover process be performed. Currently,
                           DecisionConditions includes several conditions: - TolerationSeconds
-                          (optional) - HealthyState (mandatory)'
+                          (optional)'
                         properties:
                           tolerationSeconds:
                             default: 300

--- a/charts/karmada/_crds/bases/policy.karmada.io_propagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy.karmada.io_propagationpolicies.yaml
@@ -83,7 +83,7 @@ spec:
                           of performing the failover process. Only when all conditions
                           are met can the failover process be performed. Currently,
                           DecisionConditions includes several conditions: - TolerationSeconds
-                          (optional) - HealthyState (mandatory)'
+                          (optional)'
                         properties:
                           tolerationSeconds:
                             default: 300

--- a/charts/karmada/_crds/bases/work.karmada.io_clusterresourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work.karmada.io_clusterresourcebindings.yaml
@@ -291,7 +291,7 @@ spec:
                           of performing the failover process. Only when all conditions
                           are met can the failover process be performed. Currently,
                           DecisionConditions includes several conditions: - TolerationSeconds
-                          (optional) - HealthyState (mandatory)'
+                          (optional)'
                         properties:
                           tolerationSeconds:
                             default: 300

--- a/charts/karmada/_crds/bases/work.karmada.io_resourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work.karmada.io_resourcebindings.yaml
@@ -291,7 +291,7 @@ spec:
                           of performing the failover process. Only when all conditions
                           are met can the failover process be performed. Currently,
                           DecisionConditions includes several conditions: - TolerationSeconds
-                          (optional) - HealthyState (mandatory)'
+                          (optional)'
                         properties:
                           tolerationSeconds:
                             default: 300

--- a/pkg/apis/policy/v1alpha1/propagation_types.go
+++ b/pkg/apis/policy/v1alpha1/propagation_types.go
@@ -210,7 +210,6 @@ type ApplicationFailoverBehavior struct {
 	// Only when all conditions are met can the failover process be performed.
 	// Currently, DecisionConditions includes several conditions:
 	// - TolerationSeconds (optional)
-	// - HealthyState (mandatory)
 	// +required
 	DecisionConditions DecisionConditions `json:"decisionConditions"`
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -2164,7 +2164,7 @@ func schema_pkg_apis_policy_v1alpha1_ApplicationFailoverBehavior(ref common.Refe
 					},
 					"decisionConditions": {
 						SchemaProps: spec.SchemaProps{
-							Description: "DecisionConditions indicates the decision conditions of performing the failover process. Only when all conditions are met can the failover process be performed. Currently, DecisionConditions includes several conditions: - TolerationSeconds (optional) - HealthyState (mandatory)",
+							Description: "DecisionConditions indicates the decision conditions of performing the failover process. Only when all conditions are met can the failover process be performed. Currently, DecisionConditions includes several conditions: - TolerationSeconds (optional)",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1.DecisionConditions"),
 						},


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change
/kind cleanup

**What this PR does / why we need it**:
Add validation for Failover. `TolerationSeconds`, `DelaySeconds` and `BlockPredecessorSeconds` cannot < 0.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

