### PR TITLE
fix(chart): fix agent.tolerations type

### DIFF
--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -663,7 +663,7 @@ agent:
   ## @param agent.affinity affinity of the agent
   affinity: {}
   ## @param agent.tolerations tolerations of the agent
-  tolerations: {}
+  tolerations: []
     # - key: node-role.kubernetes.io/master
     #   operator: Exists
   ## @param agent.strategy strategy of the agent


### PR DESCRIPTION
**What type of PR is this?**
agent.tolerations in  values.yaml is a slice not a object.
In document: [https://github.com/karmada-io/karmada/blob/master/charts/karmada/README.md?plain=1#L254](https://github.com/karmada-io/karmada/blob/master/charts/karmada/README.md?plain=1#L254)
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
In most time, we change values.yaml to set value; but sometimes we use helm `--set-json` flags and will fail.
```shell
helm install xxx  --set-json 'agent={"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"}]}'

# log
coalesce.go:220: warning: cannot overwrite table with non table for karmada.agent.tolerations (map[])
```
**Which issue(s) this PR fixes**:
Fixes agent.tolerations type

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
fix(chart): fix agent.tolerations type 
```release-note

```

