### PR TITLE
add an example for examples/karmadactlinterpret/README.md

### DIFF
--- a/examples/karmadactlinterpret/README.md
+++ b/examples/karmadactlinterpret/README.md
@@ -11,13 +11,19 @@ karmadactl interpret -f resourceinterpretercustomization.yaml --check
 *Execute the InterpretReplica rule*
 
 ```shell
-karmadactl interpret -f resourceinterpretercustomization.yaml --observed-file observed-deploy-nginx.yaml --operation=InterpretReplica
+karmadactl interpret -f resourceinterpretercustomization.yaml --observed-file observed-deploy-nginx.yaml --operation InterpretReplica
 ```
 
 *Execute the Retain rule*
 
 ```shell
 karmadactl interpret -f resourceinterpretercustomization.yaml --desired-file desired-deploy-nginx.yaml --observed-file observed-deploy-nginx.yaml --operation Retain
+```
+
+*Execute the ReviseReplica rule*
+
+```shell
+karmadactl interpret -f resourceinterpretercustomization.yaml --desired-replica 3 --observed-file observed-deploy-nginx.yaml --operation ReviseReplica
 ```
 
 *Execute the InterpretStatus rule*

--- a/examples/karmadactlinterpret/resourceinterpretercustomization.yaml
+++ b/examples/karmadactlinterpret/resourceinterpretercustomization.yaml
@@ -57,21 +57,8 @@ spec:
         end
     dependencyInterpretation:
       luaScript: >
+        local kube = require("kube")
         function GetDependencies(desiredObj)
-          dependentSas = {}
-          refs = {}
-          if desiredObj.spec.template.spec.serviceAccountName ~= '' and desiredObj.spec.template.spec.serviceAccountName ~= 'default' then
-            dependentSas[desiredObj.spec.template.spec.serviceAccountName] = true
-          end
-          local idx = 1
-          for key, value in pairs(dependentSas) do
-            dependObj = {}
-            dependObj.apiVersion = 'v1'
-            dependObj.kind = 'ServiceAccount'
-            dependObj.name = key
-            dependObj.namespace = desiredObj.metadata.namespace
-            refs[idx] = dependObj
-            idx = idx + 1
-          end
+          refs = kube.getPodDependencies(desiredObj.spec.template, desiredObj.metadata.namespace)
           return refs
         end


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
If the documents are updated, users can more easily find the `karmadactl interpret --operation ReviseReplica` section.
And it updates the example resourceinterpretercustomization with kube lib for building `dependencyInterpretation` lua.

**Which issue(s) this PR fixes**:
Part of #3401 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

