### PR TITLE
Automated cherry pick of #3393: Avoid accidental impact for rb/crb's pointer on the cache

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -299,6 +299,7 @@ func (s *Scheduler) doScheduleBinding(namespace, name string) (err error) {
 		}
 		return err
 	}
+	rb = rb.DeepCopy()
 
 	if rb.Spec.Placement == nil {
 		// never reach here
@@ -347,6 +348,7 @@ func (s *Scheduler) doScheduleClusterBinding(name string) (err error) {
 		}
 		return err
 	}
+	crb = crb.DeepCopy()
 
 	if crb.Spec.Placement == nil {
 		// never reach here


### PR DESCRIPTION
Cherry pick of #3393 on release-1.5.
#3393: Avoid accidental impact for rb/crb's pointer on the cache
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
karmada-scheduler: Fixed unexpected re-scheduling due to mutating informer cache issue.
```