### PR TITLE
feat: allows users to propagate resources under the Kubernetes reserved namespace.

### DIFF
--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -185,8 +185,9 @@ func (o *Options) AddFlags(flags *pflag.FlagSet, allControllers, disabledByDefau
 		"<group> for skip resources with a specific API group(e.g. networking.k8s.io),\n"+
 		"<group>/<version> for skip resources with a specific API version(e.g. networking.k8s.io/v1beta1),\n"+
 		"<group>/<version>/<kind>,<kind> for skip one or more specific resource(e.g. networking.k8s.io/v1beta1/Ingress,IngressClass) where the kinds are case-insensitive.")
-	flags.StringSliceVar(&o.SkippedPropagatingNamespaces, "skipped-propagating-namespaces", []string{},
-		"Comma-separated namespaces that should be skipped from propagating in addition to the default skipped namespaces(karmada-system, karmada-cluster, namespaces prefixed by kube- and karmada-es-).")
+	flags.StringSliceVar(&o.SkippedPropagatingNamespaces, "skipped-propagating-namespaces", []string{"kube-.*"},
+		"Comma-separated namespaces that should be skipped from propagating.\n"+
+			"Note: 'karmada-system', 'karmada-cluster' and 'karmada-es-.*' are Karmada reserved namespaces that will always be skipped.")
 	flags.StringVar(&o.ClusterAPIContext, "cluster-api-context", "", "Name of the cluster context in cluster-api management cluster kubeconfig file.")
 	flags.StringVar(&o.ClusterAPIKubeconfig, "cluster-api-kubeconfig", "", "Path to the cluster-api management cluster kubeconfig file.")
 	flags.Float32Var(&o.ClusterAPIQPS, "cluster-api-qps", 40.0, "QPS to use while talking with cluster kube-apiserver. Doesn't cover events and node heartbeat apis which rate limiting is controlled by a different set of flags.")

--- a/pkg/util/names/names.go
+++ b/pkg/util/names/names.go
@@ -11,11 +11,6 @@ import (
 )
 
 const (
-	// KubernetesReservedNSPrefix is the prefix of namespace which reserved by Kubernetes system, such as:
-	// - kube-system
-	// - kube-public
-	// - kube-node-lease
-	KubernetesReservedNSPrefix = "kube-"
 	// NamespaceKarmadaSystem is reserved namespace
 	NamespaceKarmadaSystem = "karmada-system"
 	// NamespaceKarmadaCluster is reserved namespace
@@ -137,8 +132,7 @@ func GenerateEstimatorDeploymentName(clusterName string) string {
 func IsReservedNamespace(namespace string) bool {
 	return namespace == NamespaceKarmadaSystem ||
 		namespace == NamespaceKarmadaCluster ||
-		strings.HasPrefix(namespace, ExecutionSpacePrefix) ||
-		strings.HasPrefix(namespace, KubernetesReservedNSPrefix)
+		strings.HasPrefix(namespace, ExecutionSpacePrefix)
 }
 
 // GenerateImpersonationSecretName generates the secret name of impersonation secret.

--- a/pkg/util/names/names_test.go
+++ b/pkg/util/names/names_test.go
@@ -354,11 +354,6 @@ func TestIsReservedNamespace(t *testing.T) {
 			expected:  true,
 		},
 		{
-			name:      "kube-",
-			namespace: KubernetesReservedNSPrefix,
-			expected:  true,
-		},
-		{
 			name:      "karmada-es-",
 			namespace: ExecutionSpacePrefix,
 			expected:  true,


### PR DESCRIPTION
 Signed-off-by: chaunceyjiang <chaunceyjiang@gmail.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

allows users to propagate resources under the Kubernetes reserved namespace.

**Which issue(s) this PR fixes**:
Fixes #3369 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: The `--skipped-propagating-namespaces` flags now can take regular expressions to represent namespaces and defaults to `kube-*`.
```

