### PR TITLE
fix: affinityName can be set to an empty string

### DIFF
--- a/charts/karmada/_crds/bases/policy.karmada.io_clusterpropagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy.karmada.io_clusterpropagationpolicies.yaml
@@ -168,6 +168,8 @@ spec:
                       properties:
                         affinityName:
                           description: AffinityName is the name of the cluster group.
+                          maxLength: 32
+                          minLength: 1
                           type: string
                         clusterNames:
                           description: ClusterNames is the list of clusters to be

--- a/charts/karmada/_crds/bases/policy.karmada.io_propagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy.karmada.io_propagationpolicies.yaml
@@ -164,6 +164,8 @@ spec:
                       properties:
                         affinityName:
                           description: AffinityName is the name of the cluster group.
+                          maxLength: 32
+                          minLength: 1
                           type: string
                         clusterNames:
                           description: ClusterNames is the list of clusters to be

--- a/charts/karmada/_crds/bases/work.karmada.io_clusterresourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work.karmada.io_clusterresourcebindings.yaml
@@ -432,6 +432,8 @@ spec:
                       properties:
                         affinityName:
                           description: AffinityName is the name of the cluster group.
+                          maxLength: 32
+                          minLength: 1
                           type: string
                         clusterNames:
                           description: ClusterNames is the list of clusters to be

--- a/charts/karmada/_crds/bases/work.karmada.io_resourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work.karmada.io_resourcebindings.yaml
@@ -432,6 +432,8 @@ spec:
                       properties:
                         affinityName:
                           description: AffinityName is the name of the cluster group.
+                          maxLength: 32
+                          minLength: 1
                           type: string
                         clusterNames:
                           description: ClusterNames is the list of clusters to be

--- a/pkg/apis/policy/v1alpha1/propagation_types.go
+++ b/pkg/apis/policy/v1alpha1/propagation_types.go
@@ -383,6 +383,8 @@ type ClusterAffinity struct {
 // ClusterAffinityTerm selects a set of cluster.
 type ClusterAffinityTerm struct {
 	// AffinityName is the name of the cluster group.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=32
 	// +required
 	AffinityName string `json:"affinityName"`
 

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -7,6 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/pointer"
 
@@ -59,6 +60,9 @@ func ValidateClusterAffinities(affinities []policyv1alpha1.ClusterAffinityTerm, 
 
 	affinityNames := make(map[string]bool)
 	for index, term := range affinities {
+		for _, err := range validation.IsQualifiedName(term.AffinityName) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Index(index), term.AffinityName, err))
+		}
 		if _, exist := affinityNames[term.AffinityName]; exist {
 			allErrs = append(allErrs, field.Invalid(fldPath, affinities, "each affinity term in a policy must have a unique name"))
 		} else {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

affinityName cannot be set to an empty string.



**Which issue(s) this PR fixes**:
Fixes #3441

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
API change: The length of `AffinityName` in `PropagationPolicy` now be restricted to (1, 32], and must be a qualified name.
```

