### PR TITLE
karmada-search should take namespace into account for less memory usage

### DIFF
--- a/pkg/search/proxy/controller_test.go
+++ b/pkg/search/proxy/controller_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"fmt"
+	"github.com/karmada-io/karmada/pkg/search/proxy/store"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -79,7 +80,7 @@ func TestController(t *testing.T) {
 	// wait for controller synced
 	time.Sleep(time.Second)
 
-	hasPod := ctrl.store.HasResource(proxytest.PodGVR)
+	hasPod := ctrl.store.HasResource(proxytest.PodGVR, "")
 	if !hasPod {
 		t.Error("has no pod resource")
 		return
@@ -276,7 +277,7 @@ func TestController_reconcile(t *testing.T) {
 				clusterLister:  karmadaFactory.Cluster().V1alpha1().Clusters().Lister(),
 				registryLister: karmadaFactory.Search().V1alpha1().ResourceRegistries().Lister(),
 				store: &proxytest.MockStore{
-					UpdateCacheFunc: func(m map[string]map[schema.GroupVersionResource]struct{}) error {
+					UpdateCacheFunc: func(m map[string]map[schema.GroupVersionResource]*store.NamespaceScope) error {
 						for clusterName, resources := range m {
 							resourceNames := make([]string, 0, len(resources))
 							for resource := range resources {

--- a/pkg/search/proxy/framework/plugins/cache/cache.go
+++ b/pkg/search/proxy/framework/plugins/cache/cache.go
@@ -56,7 +56,7 @@ func (c *Cache) SupportRequest(request framework.ProxyRequest) bool {
 	requestInfo := request.RequestInfo
 
 	return requestInfo.IsResourceRequest &&
-		c.store.HasResource(request.GroupVersionResource) &&
+		c.store.HasResource(request.GroupVersionResource, requestInfo.Namespace) &&
 		requestInfo.Subresource == "" &&
 		(requestInfo.Verb == "get" ||
 			requestInfo.Verb == "list" ||

--- a/pkg/search/proxy/framework/plugins/cluster/cluster.go
+++ b/pkg/search/proxy/framework/plugins/cluster/cluster.go
@@ -56,7 +56,7 @@ func (c *Cluster) Order() int {
 
 // SupportRequest implements Plugin
 func (c *Cluster) SupportRequest(request framework.ProxyRequest) bool {
-	return request.RequestInfo.IsResourceRequest && c.store.HasResource(request.GroupVersionResource)
+	return request.RequestInfo.IsResourceRequest && c.store.HasResource(request.GroupVersionResource, request.RequestInfo.Namespace)
 }
 
 // Connect implements Plugin

--- a/pkg/search/proxy/store/cluster_cache.go
+++ b/pkg/search/proxy/store/cluster_cache.go
@@ -11,24 +11,26 @@ import (
 
 // clusterCache caches resources for single member cluster
 type clusterCache struct {
-	lock        sync.RWMutex
-	cache       map[schema.GroupVersionResource]*resourceCache
-	clusterName string
-	restMapper  meta.RESTMapper
+	lock            sync.RWMutex
+	cache           map[schema.GroupVersionResource]*resourceCache
+	namespacedCache map[schema.GroupVersionResource]map[string]*resourceCache
+	clusterName     string
+	restMapper      meta.RESTMapper
 	// newClientFunc returns a dynamic client for member cluster apiserver
 	newClientFunc func() (dynamic.Interface, error)
 }
 
 func newClusterCache(clusterName string, newClientFunc func() (dynamic.Interface, error), restMapper meta.RESTMapper) *clusterCache {
 	return &clusterCache{
-		clusterName:   clusterName,
-		newClientFunc: newClientFunc,
-		restMapper:    restMapper,
-		cache:         map[schema.GroupVersionResource]*resourceCache{},
+		clusterName:     clusterName,
+		newClientFunc:   newClientFunc,
+		restMapper:      restMapper,
+		cache:           map[schema.GroupVersionResource]*resourceCache{},
+		namespacedCache: map[schema.GroupVersionResource]map[string]*resourceCache{},
 	}
 }
 
-func (c *clusterCache) updateCache(resources map[schema.GroupVersionResource]struct{}) error {
+func (c *clusterCache) updateCache(resources map[schema.GroupVersionResource]*NamespaceScope) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -40,27 +42,112 @@ func (c *clusterCache) updateCache(resources map[schema.GroupVersionResource]str
 			delete(c.cache, resource)
 		}
 	}
+	for resource := range c.namespacedCache {
+		if _, exist := resources[resource]; !exist {
+			for _, cache := range c.namespacedCache[resource] {
+				klog.Infof("Remove cache for %s %s", c.clusterName, resource.String())
+				cache.stop()
+			}
+			delete(c.namespacedCache, resource)
+		}
+	}
 
 	// add resource cache
-	for resource := range resources {
-		_, exist := c.cache[resource]
-		if !exist {
-			kind, err := c.restMapper.KindFor(resource)
-			if err != nil {
-				return err
-			}
-			mapping, err := c.restMapper.RESTMapping(kind.GroupKind(), kind.Version)
-			if err != nil {
-				return err
-			}
-			namespaced := mapping.Scope.Name() == meta.RESTScopeNameNamespace
+	for resource, nsScope := range resources {
+		kind, err := c.restMapper.KindFor(resource)
+		if err != nil {
+			return err
+		}
+		mapping, err := c.restMapper.RESTMapping(kind.GroupKind(), kind.Version)
+		if err != nil {
+			return err
+		}
+		namespaced := mapping.Scope.Name() == meta.RESTScopeNameNamespace
+		if namespaced {
+			if cacheMap, exist := c.namespacedCache[resource]; !exist {
+				cacheMap = map[string]*resourceCache{}
+				c.namespacedCache[resource] = cacheMap
+				if nsScope.allNamespaces {
+					klog.Infof("Add cache for %s %s", c.clusterName, resource.String())
+					cache, err := newNamespacedResourceCache(c.clusterName, resource, kind, namespaced, AllNamespace, c.clientForResourceFunc(resource))
+					if err != nil {
+						return err
+					}
+					cacheMap[AllNamespace] = cache
+				} else {
+					for ns := range nsScope.namespaces {
+						klog.Infof("Add cache for %s %s in %s", c.clusterName, resource.String(), ns)
+						cache, err := newNamespacedResourceCache(c.clusterName, resource, kind, namespaced, ns, c.clientForResourceFunc(resource))
+						if err != nil {
+							return err
+						}
+						cacheMap[ns] = cache
+					}
+				}
+			} else {
+				if nsScope.allNamespaces {
+					if _, exist := cacheMap[AllNamespace]; !exist {
+						klog.Infof("Add cache for %s %s", c.clusterName, resource.String())
+						cache, err := newNamespacedResourceCache(c.clusterName, resource, kind, namespaced, AllNamespace, c.clientForResourceFunc(resource))
+						if err != nil {
+							return err
+						}
+						newCacheMap := map[string]*resourceCache{
+							AllNamespace: cache,
+						}
+						oldCacheMap := c.namespacedCache[resource]
+						c.namespacedCache[resource] = newCacheMap
+						for _, oldCache := range oldCacheMap {
+							oldCache.stop()
+						}
+					}
+				} else {
+					if cache, exist := cacheMap[AllNamespace]; exist {
+						for ns := range nsScope.namespaces {
+							klog.Infof("Add cache for %s %s in %s", c.clusterName, resource.String(), ns)
+							cache, err := newNamespacedResourceCache(c.clusterName, resource, kind, namespaced, ns, c.clientForResourceFunc(resource))
+							if err != nil {
+								return err
+							}
+							cacheMap[ns] = cache
+						}
+						cache.stop()
+						delete(cacheMap, AllNamespace)
+					} else {
+						//remove
+						for ns, cache := range cacheMap {
+							if !nsScope.Has(ns) {
+								klog.Infof("Remove cache for %s %s in %s", c.clusterName, resource.String(), ns)
+								cache.stop()
+								delete(cacheMap, ns)
+							}
+						}
+						//add
+						for ns := range nsScope.namespaces {
+							if _, exist := cacheMap[ns]; !exist {
+								klog.Infof("Add cache for %s %s in %s", c.clusterName, resource.String(), ns)
+								cache, err := newNamespacedResourceCache(c.clusterName, resource, kind, namespaced, ns, c.clientForResourceFunc(resource))
+								if err != nil {
+									return err
+								}
+								cacheMap[ns] = cache
+							}
+						}
 
-			klog.Infof("Add cache for %s %s", c.clusterName, resource.String())
-			cache, err := newResourceCache(c.clusterName, resource, kind, namespaced, c.clientForResourceFunc(resource))
-			if err != nil {
-				return err
+					}
+
+				}
 			}
-			c.cache[resource] = cache
+		} else {
+			_, exist := c.cache[resource]
+			if !exist {
+				klog.Infof("Add cache for %s %s", c.clusterName, resource.String())
+				cache, err := newResourceCache(c.clusterName, resource, kind, namespaced, c.clientForResourceFunc(resource))
+				if err != nil {
+					return err
+				}
+				c.cache[resource] = cache
+			}
 		}
 	}
 	return nil
@@ -72,6 +159,11 @@ func (c *clusterCache) stop() {
 
 	for _, cache := range c.cache {
 		cache.stop()
+	}
+	for _, cacheMap := range c.namespacedCache {
+		for _, cache := range cacheMap {
+			cache.stop()
+		}
 	}
 }
 
@@ -85,8 +177,25 @@ func (c *clusterCache) clientForResourceFunc(resource schema.GroupVersionResourc
 	}
 }
 
-func (c *clusterCache) cacheForResource(gvr schema.GroupVersionResource) *resourceCache {
+func (c *clusterCache) cacheForResource(gvr schema.GroupVersionResource, namespace string) *resourceCache {
+	kind, err := c.restMapper.KindFor(gvr)
+	if err != nil {
+		return nil
+	}
+	mapping, err := c.restMapper.RESTMapping(kind.GroupKind(), kind.Version)
+	if err != nil {
+		return nil
+	}
+	namespaced := mapping.Scope.Name() == meta.RESTScopeNameNamespace
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.cache[gvr]
+	if namespaced {
+		if cache, ok := c.namespacedCache[gvr][AllNamespace]; ok {
+			return cache
+		} else {
+			return c.namespacedCache[gvr][namespace]
+		}
+	} else {
+		return c.cache[gvr]
+	}
 }

--- a/pkg/search/proxy/store/namespaced_resource_cache.go
+++ b/pkg/search/proxy/store/namespaced_resource_cache.go
@@ -1,0 +1,97 @@
+package store
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/registry/generic"
+	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/apiserver/pkg/storage"
+	cacherstorage "k8s.io/apiserver/pkg/storage/cacher"
+	"k8s.io/apiserver/pkg/storage/storagebackend"
+	"k8s.io/apiserver/pkg/storage/storagebackend/factory"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
+)
+
+func newNamespacedResourceCache(clusterName string, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind,
+	namespaced bool, namespace string, newClientFunc func() (dynamic.NamespaceableResourceInterface, error)) (*resourceCache, error) {
+	s := &genericregistry.Store{
+		DefaultQualifiedResource: gvr.GroupResource(),
+		NewFunc: func() runtime.Object {
+			o := &unstructured.Unstructured{}
+			o.SetAPIVersion(gvk.GroupVersion().String())
+			o.SetKind(gvk.Kind)
+			return o
+		},
+		NewListFunc: func() runtime.Object {
+			o := &unstructured.UnstructuredList{}
+			o.SetAPIVersion(gvk.GroupVersion().String())
+			// TODO: it's unsafe guesses kind name for resource list
+			o.SetKind(gvk.Kind + "List")
+			return o
+		},
+		TableConvertor: rest.NewDefaultTableConvertor(gvr.GroupResource()),
+		// CreateStrategy tells whether the resource is namespaced.
+		// see: vendor/k8s.io/apiserver/pkg/registry/generic/registry/store.go#L1310-L1318
+		CreateStrategy: restCreateStrategy(namespaced),
+		// Assign `DeleteStrategy` to pass vendor/k8s.io/apiserver/pkg/registry/generic/registry/store.go#L1320-L1322
+		DeleteStrategy: restDeleteStrategy,
+	}
+
+	err := s.CompleteWithOptions(&generic.StoreOptions{
+		RESTOptions: &generic.RESTOptions{
+			StorageConfig: &storagebackend.ConfigForResource{
+				Config: storagebackend.Config{
+					Paging: utilfeature.DefaultFeatureGate.Enabled(features.APIListChunking),
+					Codec:  unstructured.UnstructuredJSONScheme,
+				},
+				GroupResource: gvr.GroupResource(),
+			},
+			ResourcePrefix: gvr.Group + "/" + gvr.Resource,
+			Decorator:      namespacedStorageWithCacher(newClientFunc, namespace, defaultVersioner),
+		},
+		AttrFunc: getAttrsFunc(namespaced),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &resourceCache{
+		clusterName: clusterName,
+		Store:       s,
+		resource:    gvr,
+	}, nil
+}
+
+func namespacedStorageWithCacher(newClientFunc func() (dynamic.NamespaceableResourceInterface, error), namespace string, versioner storage.Versioner) generic.StorageDecorator {
+	return func(
+		storageConfig *storagebackend.ConfigForResource,
+		resourcePrefix string,
+		keyFunc func(obj runtime.Object) (string, error),
+		newFunc func() runtime.Object,
+		newListFunc func() runtime.Object,
+		getAttrsFunc storage.AttrFunc,
+		triggerFuncs storage.IndexerFuncs,
+		indexers *cache.Indexers) (storage.Interface, factory.DestroyFunc, error) {
+		cacherConfig := cacherstorage.Config{
+			Storage:        newStore(newClientFunc, versioner, resourcePrefix),
+			Versioner:      versioner,
+			ResourcePrefix: resourcePrefix + "/" + namespace,
+			KeyFunc:        keyFunc,
+			GetAttrsFunc:   getAttrsFunc,
+			Indexers:       indexers,
+			NewFunc:        newFunc,
+			NewListFunc:    newListFunc,
+			Codec:          storageConfig.Codec,
+		}
+		cacher, err := cacherstorage.NewCacherFromConfig(cacherConfig)
+		if err != nil {
+			return nil, nil, err
+		}
+		return cacher, cacher.Stop, nil
+	}
+}

--- a/pkg/search/proxy/store/util.go
+++ b/pkg/search/proxy/store/util.go
@@ -331,3 +331,57 @@ func BuildMultiClusterResourceVersion(clusterResourceMap map[string]string) stri
 	}
 	return m.String()
 }
+
+const (
+	AllNamespace = ""
+)
+
+type NamespaceScope struct {
+	namespaces    map[string]struct{} // ignored when allNamespaces is true
+	allNamespaces bool
+}
+
+func (namespaceScope *NamespaceScope) AddAll(namespaces []string) {
+	for _, namespace := range namespaces {
+		if namespace == AllNamespace {
+			namespaceScope.allNamespaces = true
+			namespaceScope.namespaces = nil
+		} else if !namespaceScope.allNamespaces {
+			if namespaceScope.namespaces == nil {
+				namespaceScope.namespaces = make(map[string]struct{})
+			}
+			namespaceScope.namespaces[namespace] = struct{}{}
+		}
+	}
+}
+
+func (namespaceScope *NamespaceScope) Merge(src *NamespaceScope) {
+	if src.allNamespaces {
+		namespaceScope.allNamespaces = true
+		namespaceScope.namespaces = nil
+	} else {
+		for namespace := range src.namespaces {
+			if !namespaceScope.allNamespaces {
+				if namespaceScope.namespaces == nil {
+					namespaceScope.namespaces = make(map[string]struct{})
+				}
+				namespaceScope.namespaces[namespace] = struct{}{}
+			}
+		}
+	}
+
+}
+
+func (namespaceScope *NamespaceScope) Has(ns string) bool {
+	if namespaceScope.allNamespaces {
+		return true
+	} else {
+		if _, ok := namespaceScope.namespaces[ns]; ok {
+			return true
+		} else {
+			return false
+		}
+	}
+
+}
+

--- a/pkg/search/proxy/testing/mock_store.go
+++ b/pkg/search/proxy/testing/mock_store.go
@@ -14,7 +14,7 @@ import (
 
 // MockStore is a mock for store.Store interface
 type MockStore struct {
-	UpdateCacheFunc          func(resourcesByCluster map[string]map[schema.GroupVersionResource]struct{}) error
+	UpdateCacheFunc          func(resourcesByCluster map[string]map[schema.GroupVersionResource]*store.NamespaceScope) error
 	HasResourceFunc          func(resource schema.GroupVersionResource) bool
 	GetResourceFromCacheFunc func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string) (runtime.Object, string, error)
 	StopFunc                 func()
@@ -26,7 +26,7 @@ type MockStore struct {
 var _ store.Store = &MockStore{}
 
 // UpdateCache implements store.Store interface
-func (c *MockStore) UpdateCache(resourcesByCluster map[string]map[schema.GroupVersionResource]struct{}) error {
+func (c *MockStore) UpdateCache(resourcesByCluster map[string]map[schema.GroupVersionResource]*store.NamespaceScope) error {
 	if c.UpdateCacheFunc == nil {
 		panic("implement me")
 	}
@@ -34,7 +34,7 @@ func (c *MockStore) UpdateCache(resourcesByCluster map[string]map[schema.GroupVe
 }
 
 // HasResource implements store.Store interface
-func (c *MockStore) HasResource(resource schema.GroupVersionResource) bool {
+func (c *MockStore) HasResource(resource schema.GroupVersionResource, namespace string) bool {
 	if c.HasResourceFunc == nil {
 		panic("implement me")
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Namespace of resourceSelectors in ResourceRegistry is ignored by karmada-search.  
For example, karmada-search caches pods of all namespaces even when namespace is specified in ResourceRegistry .
```
apiVersion: search.karmada.io/v1alpha1
kind:  ResourceRegistry
metadata:
  name: example
spec:
  targetCluster:
    clusterNames:
    - rancher
  resourceSelectors:
    - apiVersion: v1
      kind: Pod
      namespace: test
```
Taking namespace into account  can reduce memory usage significantly in the proxy feature.

![image](https://user-images.githubusercontent.com/1121360/233574245-13dcd65e-74b1-45c9-b9f7-cd26acb3ce4b.png)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Karmada-search only cache resources of the namespace specified by ResourceRegistry in the proxy feature.
```

