### PR TITLE
Support rerun github failed workflow

### DIFF
--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -1,0 +1,27 @@
+name: comments
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+
+  rerun-failed-workflow:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request }} # Only work for PR
+    permissions:
+      actions: write # To be able to rerun workflow
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: rerun failed workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_COMMENT: ${{ github.event.comment.body }}
+          PR_NUM: ${{ github.event.issue.number }}
+        run: |
+          hack/ghaction.sh

--- a/hack/README.md
+++ b/hack/README.md
@@ -60,6 +60,8 @@ ensures development quality.
 - [`run-e2e.sh`](run-e2e.sh) This script runs e2e test against on Karmada control plane. You should prepare your environment
   in advance with `local-up-karmada.sh`.
 
+- [`ghaction.sh`](ghaction.sh) This script working for rerun github action failed workflow when you create a issue comment of include "/retest-failed".
+
 ## Some internal scripts
 These scripts are not intended used by end-users, just for the development
 - [`deploy-karmada.sh`](deploy-karmada.sh) Underlying common implementation for `local-up-karmada.sh` and `remote-up-karmada.sh`.

--- a/hack/ghaction.sh
+++ b/hack/ghaction.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script is working for github action.
+# Today, it is only work for rerun workflow when the github action CI is failed.
+
+# Usage:
+# hack/ghaction.sh
+# Environments:
+#   ISSUE_COMMENT: Only support /retest to rerun workflow,Just confirm that your issue comment is include "/retest-failed"
+#   PR_NUM: Your PR number
+#   GH_TOKEN: Github Token for run workflow
+#   REPO: Github Repo, karmada-io/karmada by default
+
+function rerun_workflow(){
+
+  PR_NUM=${PR_NUM:-0}
+
+  if [ $PR_NUM -le 0 ];then
+    echo "Invalid pr num:"$PR_NUM
+    exit 0
+  fi
+
+  REPO=${REPO:-"karmada-io/karmada"}
+
+  # api doc:  https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request
+  # Get some message for pr, sha(git commitid),branch,pr author,pr title,pr url,etc...
+  EVENT=`gh api repos/$REPO/pulls/$PR_NUM `
+
+  EVENT_HEAD=$(echo $EVENT | jq .head )
+
+  SHA=$(echo $EVENT_HEAD | jq .sha | sed 's/\"//g')
+  BRANCH=$(echo $EVENT_HEAD | jq .ref | sed 's/\"//g')
+  ACTOR=$(echo $EVENT_HEAD | jq .user.login | sed 's/\"//g')
+
+  PR_TITLE=$(echo $EVENT | jq .title | sed 's/\"//g' )
+  PR_URL=$(echo $EVENT | jq .html_url | sed 's/\"//g' )
+
+  # api doc:https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository
+  # Get the failed workflow for latest commit
+  datas=$(gh api "repos/$REPO/actions/runs?actor="$ACTOR"&branch="$BRANCH"&status=failure" | jq ".workflow_runs[] | select(.head_sha==\"$SHA\") | [{id,name}] ")
+
+  echo $datas | jq -r '.[] | "\(.id)\t\(.name)"' | while read -r id name; do
+      echo -e "Reruning workflow...\nPR:"$PR_TITLE "\nURL:"$PR_URL "\nID:$id \nWorkflowRunName:$name \n==============================="
+      # api doc: https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#re-run-a-workflow
+      gh run rerun -R $REPO $id
+  done
+}
+
+ISSUE_COMMENT=${ISSUE_COMMENT:-""}
+
+if [ -z "$ISSUE_COMMENT" ];then
+    echo "Have not issue comment,exit..."
+    exit -1
+fi
+
+# Find command of "/retest-faile" from issue comment
+while read -r line; do
+  line=$(echo $line | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+
+  if [[ -z "$line" || "${line:0:1}" == "#" ]]; then
+    continue
+  fi
+
+  if [[ "$line" == "/retest-failed" ]]; then
+    echo "Matching /retest-failed and rerun workflow..."
+    rerun_workflow
+    break
+  fi
+
+done <<< "$ISSUE_COMMENT"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Create a issue comment of include "/retest" to  rerun workflow when CI failed.

**Which issue(s) this PR fixes**:
Fixes #3421

**Special notes for your reviewer**:

This event will only trigger a workflow run if the workflow file is on the default branch.

So you can comment at [this PR](https://github.com/liangyuanpeng/karmada/pull/8) for check what the happen when we create a issue comment of "/retest" on the PR.(Yes, rerun the failed workflow.)

Also run `hack/ghaction.sh` on the local,  Just like:

```shell
lan@lan:~/repo/git/karmada/hack$ GH_TOKEN=xxx  ISSUE_COMMENT="hello\r\n/retest" PR_NUM=8 REPO=liangyuanpeng/karmada ./ghaction.sh
Matching /retest and rerun workflow...
Reruning workflow...
PR:test retest github action 
URL:https://github.com/liangyuanpeng/karmada/pull/8 
ID:4763218620 
WorkflowRunName:CLI 
===============================
✓ Requested rerun of run 4763218620
Reruning workflow...
PR:test retest github action 
URL:https://github.com/liangyuanpeng/karmada/pull/8 
ID:4763218619 
WorkflowRunName:CI Workflow 
===============================
✓ Requested rerun of run 4763218619
Reruning workflow...
PR:test retest github action 
URL:https://github.com/liangyuanpeng/karmada/pull/8 
ID:4763218327 
WorkflowRunName:CLI 
===============================
✓ Requested rerun of run 4763218327
Reruning workflow...
PR:test retest github action 
URL:https://github.com/liangyuanpeng/karmada/pull/8 
ID:4763218326 
WorkflowRunName:CI Workflow 
===============================
✓ Requested rerun of run 4763218326
```

/cc @helen-frank @RainbowMango  @whitewindmills 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

