### PR TITLE
Automated cherry pick of #3402: fill cluster rv in proxying list

### DIFF
--- a/pkg/search/proxy/store/multi_cluster_cache.go
+++ b/pkg/search/proxy/store/multi_cluster_cache.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
+	utiltrace "k8s.io/utils/trace"
 )
 
 // Cache an interface for cache.
@@ -171,33 +172,57 @@ func (c *MultiClusterCache) Get(ctx context.Context, gvr schema.GroupVersionReso
 
 // List returns the object list
 // nolint:gocyclo
-func (c *MultiClusterCache) List(ctx context.Context, gvr schema.GroupVersionResource, options *metainternalversion.ListOptions) (runtime.Object, error) {
+func (c *MultiClusterCache) List(ctx context.Context, gvr schema.GroupVersionResource, o *metainternalversion.ListOptions) (runtime.Object, error) {
+	klog.V(5).Infof("Request list %v with rv=%#v, continue=%#v, limit=%v", gvr.String(),
+		newMultiClusterResourceVersionFromString(o.ResourceVersion), newMultiClusterContinueFromString(o.Continue), o.Limit)
+	requestCluster, options, requestResourceVersion := prepareBeforeList(o)
+
 	var resultObject runtime.Object
 	items := make([]runtime.Object, 0, int(math.Min(float64(options.Limit), 1024)))
 
-	requestResourceVersion := newMultiClusterResourceVersionFromString(options.ResourceVersion)
-	requestContinue := newMultiClusterContinueFromString(options.Continue)
 	clusters := c.getClusterNames()
 	sort.Strings(clusters)
-	responseResourceVersion := newMultiClusterResourceVersionWithCapacity(len(clusters))
+	responseResourceVersion := requestResourceVersion.clone()
 	responseContinue := multiClusterContinue{}
 
+	trace := utiltrace.New("MultiClusterCache.List",
+		utiltrace.Field{Key: "gvr", Value: gvr},
+		utiltrace.Field{Key: "rv", Value: newMultiClusterResourceVersionFromString(o.ResourceVersion)},
+		utiltrace.Field{Key: "continue", Value: newMultiClusterContinueFromString(o.Continue)},
+		utiltrace.Field{Key: "limit", Value: o.Limit},
+	)
+	defer trace.LogIfLong(5 * time.Second)
+
+	defer func() {
+		klog.V(5).Infof("Response list %v with rv=%#v continue=%#v", gvr.String(), responseResourceVersion, responseContinue)
+	}()
+
 	listFunc := func(cluster string) (int, string, error) {
-		if requestContinue.Cluster != "" && requestContinue.Cluster != cluster {
+		if requestCluster != "" && requestCluster != cluster {
 			return 0, "", nil
 		}
-		options.Continue = requestContinue.Continue
 		// clear the requestContinue, for searching other clusters at next list
-		requestContinue.Cluster = ""
-		requestContinue.Continue = ""
+		defer func() {
+			requestCluster = ""
+			options.Continue = ""
+		}()
 
 		cache := c.cacheForClusterResource(cluster, gvr)
 		if cache == nil {
-			// This cluster doesn't cache this resource
+			klog.V(4).Infof("cluster %v does not cache resource %v", cluster, gvr.String())
 			return 0, "", nil
 		}
 
-		options.ResourceVersion = requestResourceVersion.get(cluster)
+		if options.Continue != "" {
+			// specifying resource version is not allowed when using continue
+			options.ResourceVersion = ""
+		} else {
+			options.ResourceVersion = requestResourceVersion.get(cluster)
+		}
+		defer trace.Step("list from member cluster",
+			utiltrace.Field{Key: "cluster", Value: cluster},
+			utiltrace.Field{Key: "options", Value: fmt.Sprintf("%#v", options)},
+		)
 		obj, err := cache.List(ctx, options)
 		if err != nil {
 			return 0, "", err
@@ -260,6 +285,11 @@ func (c *MultiClusterCache) List(ctx context.Context, gvr schema.GroupVersionRes
 		}
 	}
 
+	if err := c.fillMissingClusterResourceVersion(ctx, responseResourceVersion, clusters, gvr); err != nil {
+		return nil, err
+	}
+	responseContinue.RV = responseResourceVersion.String()
+
 	if resultObject == nil {
 		resultObject = &metav1.List{
 			TypeMeta: metav1.TypeMeta{
@@ -287,6 +317,7 @@ func (c *MultiClusterCache) List(ctx context.Context, gvr schema.GroupVersionRes
 
 // Watch watches the resource
 func (c *MultiClusterCache) Watch(ctx context.Context, gvr schema.GroupVersionResource, options *metainternalversion.ListOptions) (watch.Interface, error) {
+	klog.V(5).Infof("Request watch %v with rv=%v", gvr.String(), options.ResourceVersion)
 	resourceVersion := newMultiClusterResourceVersionFromString(options.ResourceVersion)
 
 	responseResourceVersion := newMultiClusterResourceVersionFromString(options.ResourceVersion)
@@ -393,4 +424,91 @@ func (c *MultiClusterCache) clientForClusterFunc(cluster string) func() (dynamic
 	return func() (dynamic.Interface, error) {
 		return c.newClientFunc(cluster)
 	}
+}
+
+func (c *MultiClusterCache) fillMissingClusterResourceVersion(ctx context.Context, mcv *multiClusterResourceVersion, clusters []string, gvr schema.GroupVersionResource) error {
+	errChan := make(chan error)
+	var lock sync.Mutex
+	var wg sync.WaitGroup
+
+	for _, cluster := range clusters {
+		if _, ok := mcv.rvs[cluster]; ok {
+			continue
+		}
+
+		wg.Add(1)
+		go func(cluster string) {
+			defer wg.Done()
+			klog.V(5).Infof("fillMissingClusterResourceVersion gvr=%v cluster=%v", gvr, cluster)
+			rv, err := c.getClusterResourceVersion(ctx, cluster, gvr)
+			if err != nil {
+				errChan <- err
+				return
+			}
+			if rv == "" {
+				return
+			}
+
+			lock.Lock()
+			defer lock.Unlock()
+			mcv.set(cluster, rv)
+		}(cluster)
+	}
+
+	waitChan := make(chan struct{}, 1)
+	go func() {
+		wg.Wait()
+		waitChan <- struct{}{}
+	}()
+
+	var err error
+	select {
+	case <-waitChan:
+	case err = <-errChan:
+	}
+	return err
+}
+
+func (c *MultiClusterCache) getClusterResourceVersion(ctx context.Context, cluster string, gvr schema.GroupVersionResource) (string, error) {
+	cache := c.cacheForClusterResource(cluster, gvr)
+	if cache == nil {
+		klog.V(4).Infof("cluster %v does not cache resource %v", cluster, gvr.String())
+		return "", nil
+	}
+	obj, err := cache.List(ctx, &metainternalversion.ListOptions{
+		Limit: 1,
+	})
+	if err != nil {
+		return "", err
+	}
+	listObj, err := meta.ListAccessor(obj)
+	if err != nil {
+		return "", err
+	}
+	return listObj.GetResourceVersion(), nil
+}
+
+// Inputs and outputs:
+// o.ResourceVersion  o.Continue                     | cluster options.ResourceVersion options.Continue mrv
+// xxxx               ""                             | ""      xxxx                    ""               decode(xxx)
+// ""               {rv=xxx,cluster=c2,continue=}    | c2      decode(xxx)[c2]         ""               decode(xxx)
+// ""               {rv=xxx,cluster=c2,continue=yyy} | c2      ""                      yyy              decode(xxx)
+func prepareBeforeList(o *metainternalversion.ListOptions) (cluster string, options *metainternalversion.ListOptions, mrv *multiClusterResourceVersion) {
+	options = o.DeepCopy()
+	if o.Continue == "" {
+		mrv = newMultiClusterResourceVersionFromString(o.ResourceVersion)
+		return
+	}
+
+	mc := newMultiClusterContinueFromString(o.Continue)
+	cluster = mc.Cluster
+	mrv = newMultiClusterResourceVersionFromString(mc.RV)
+	if mc.Continue == "" {
+		options.ResourceVersion = mrv.get(cluster)
+		options.Continue = ""
+	} else {
+		options.ResourceVersion = ""
+		options.Continue = mc.Continue
+	}
+	return
 }

--- a/pkg/search/proxy/store/util.go
+++ b/pkg/search/proxy/store/util.go
@@ -60,6 +60,17 @@ func (m *multiClusterResourceVersion) get(cluster string) string {
 	return m.rvs[cluster]
 }
 
+func (m *multiClusterResourceVersion) clone() *multiClusterResourceVersion {
+	ret := &multiClusterResourceVersion{
+		isZero: m.isZero,
+		rvs:    make(map[string]string, len(m.rvs)),
+	}
+	for k, v := range m.rvs {
+		ret.rvs[k] = v
+	}
+	return ret
+}
+
 func (m *multiClusterResourceVersion) String() string {
 	if m.isZero {
 		return "0"
@@ -125,6 +136,7 @@ func marshalRvs(rvs map[string]string) []byte {
 }
 
 type multiClusterContinue struct {
+	RV       string `json:"rv"`
 	Cluster  string `json:"cluster,omitempty"`
 	Continue string `json:"continue,omitempty"`
 }

--- a/pkg/search/proxy/store/util_test.go
+++ b/pkg/search/proxy/store/util_test.go
@@ -1,0 +1,567 @@
+package store
+
+import (
+	"encoding/base64"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+)
+
+func Test_newMultiClusterResourceVersionFromString(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *multiClusterResourceVersion
+	}{
+		{
+			name: "empty",
+			args: args{
+				s: "",
+			},
+			want: &multiClusterResourceVersion{
+				rvs: map[string]string{},
+			},
+		},
+		{
+			name: "zero",
+			args: args{
+				s: "0",
+			},
+			want: &multiClusterResourceVersion{
+				rvs:    map[string]string{},
+				isZero: true,
+			},
+		},
+		{
+			name: "decode error",
+			args: args{
+				s: "`not encoded`",
+			},
+			want: &multiClusterResourceVersion{
+				rvs: map[string]string{},
+			},
+		},
+		{
+			name: "not a json",
+			args: args{
+				s: base64.RawURLEncoding.EncodeToString([]byte(`not a json`)),
+			},
+			want: &multiClusterResourceVersion{
+				rvs: map[string]string{},
+			},
+		},
+		{
+			name: "success - normal",
+			args: args{
+				s: base64.RawURLEncoding.EncodeToString([]byte(`{"cluster1":"1","cluster2":"2"}`)),
+			},
+			want: &multiClusterResourceVersion{
+				rvs: map[string]string{
+					"cluster1": "1",
+					"cluster2": "2",
+				},
+			},
+		},
+		{
+			name: "success - empty cluster name",
+			args: args{
+				s: base64.RawURLEncoding.EncodeToString([]byte(`{"":"1","cluster2":"2"}`)),
+			},
+			want: &multiClusterResourceVersion{
+				rvs: map[string]string{
+					"":         "1",
+					"cluster2": "2",
+				},
+			},
+		},
+		{
+			name: "success - empty ResourceVersion",
+			args: args{
+				s: base64.RawURLEncoding.EncodeToString([]byte(`{"cluster1":"","cluster2":""}`)),
+			},
+			want: &multiClusterResourceVersion{
+				rvs: map[string]string{
+					"cluster1": "",
+					"cluster2": "",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newMultiClusterResourceVersionFromString(tt.args.s)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("newMultiClusterResourceVersionFromString() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_multiClusterResourceVersion_get(t *testing.T) {
+	type fields struct {
+		rvs    map[string]string
+		isZero bool
+	}
+	type args struct {
+		cluster string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   string
+	}{
+		{
+			name: "zero",
+			fields: fields{
+				isZero: true,
+				rvs:    map[string]string{},
+			},
+			args: args{
+				cluster: "cluster1",
+			},
+			want: "0",
+		},
+		{
+			name: "not exist",
+			fields: fields{
+				rvs: map[string]string{},
+			},
+			args: args{
+				cluster: "cluster1",
+			},
+			want: "",
+		},
+		{
+			name: "get success",
+			fields: fields{
+				rvs: map[string]string{
+					"cluster1": "1",
+				},
+			},
+			args: args{
+				cluster: "cluster1",
+			},
+			want: "1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &multiClusterResourceVersion{
+				rvs:    tt.fields.rvs,
+				isZero: tt.fields.isZero,
+			}
+			if got := m.get(tt.args.cluster); got != tt.want {
+				t.Errorf("get() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_multiClusterResourceVersion_String(t *testing.T) {
+	type fields struct {
+		rvs    map[string]string
+		isZero bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "zero",
+			fields: fields{
+				isZero: true,
+				rvs:    map[string]string{},
+			},
+			want: "0",
+		},
+		{
+			name: "empty",
+			fields: fields{
+				rvs: map[string]string{},
+			},
+			want: "",
+		},
+		{
+			name: "get success - normal",
+			fields: fields{
+				rvs: map[string]string{
+					"cluster1": "1",
+					"cluster2": "2",
+				},
+			},
+			want: base64.RawURLEncoding.EncodeToString([]byte(`{"cluster1":"1","cluster2":"2"}`)),
+		},
+		{
+			name: "get success - empty cluster name",
+			fields: fields{
+				rvs: map[string]string{
+					"":         "1",
+					"cluster2": "2",
+				},
+			},
+			want: base64.RawURLEncoding.EncodeToString([]byte(`{"":"1","cluster2":"2"}`)),
+		},
+		{
+			name: "get success - empty ResourceVersion",
+			fields: fields{
+				rvs: map[string]string{
+					"cluster1": "",
+					"cluster2": "",
+				},
+			},
+			want: base64.RawURLEncoding.EncodeToString([]byte(`{"cluster1":"","cluster2":""}`)),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &multiClusterResourceVersion{
+				rvs:    tt.fields.rvs,
+				isZero: tt.fields.isZero,
+			}
+			if got := m.String(); got != tt.want {
+				t.Errorf("String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_newMultiClusterContinueFromString(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name string
+		args args
+		want multiClusterContinue
+	}{
+		{
+			name: "empty",
+			args: args{
+				s: "",
+			},
+			want: multiClusterContinue{},
+		},
+		{
+			name: "not encoded",
+			args: args{
+				s: "not encoded",
+			},
+			want: multiClusterContinue{},
+		},
+		{
+			name: "not json",
+			args: args{
+				s: base64.RawURLEncoding.EncodeToString([]byte("not json")),
+			},
+			want: multiClusterContinue{},
+		},
+		{
+			name: "success",
+			args: args{
+				s: base64.RawURLEncoding.EncodeToString([]byte(`{"cluster":"cluster1","continue":"1"}`)),
+			},
+			want: multiClusterContinue{
+				Cluster:  "cluster1",
+				Continue: "1",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := newMultiClusterContinueFromString(tt.args.s); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("newMultiClusterContinueFromString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_multiClusterContinue_String(t *testing.T) {
+	type fields struct {
+		RV       string
+		Cluster  string
+		Continue string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "empty",
+			fields: fields{
+				RV:       "",
+				Cluster:  "",
+				Continue: "",
+			},
+			want: "",
+		},
+		{
+			name: "success",
+			fields: fields{
+				RV:       "123",
+				Cluster:  "cluster1",
+				Continue: "1",
+			},
+			want: base64.RawURLEncoding.EncodeToString([]byte(`{"rv":"123","cluster":"cluster1","continue":"1"}`)),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &multiClusterContinue{
+				RV:       tt.fields.RV,
+				Cluster:  tt.fields.Cluster,
+				Continue: tt.fields.Continue,
+			}
+			if got := c.String(); got != tt.want {
+				t.Errorf("String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRemoveCacheSourceAnnotation(t *testing.T) {
+	type args struct {
+		obj runtime.Object
+	}
+	type want struct {
+		obj     runtime.Object
+		changed bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "not a meta",
+			args: args{
+				obj: &metav1.Status{},
+			},
+			want: want{
+				changed: false,
+				obj:     &metav1.Status{},
+			},
+		},
+		{
+			name: "annotation not exist",
+			args: args{
+				obj: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{},
+				},
+			},
+			want: want{
+				changed: false,
+				obj: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{},
+				},
+			},
+		},
+		{
+			name: "remove annotation",
+			args: args{
+				obj: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							clusterv1alpha1.CacheSourceAnnotationKey: "cluster1",
+						},
+					},
+				},
+			},
+			want: want{
+				changed: true,
+				obj: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RemoveCacheSourceAnnotation(tt.args.obj)
+			if got != tt.want.changed {
+				t.Errorf("RemoveCacheSourceAnnotation() = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(tt.args.obj, tt.want.obj) {
+				t.Errorf("RemoveCacheSourceAnnotation() got obj = %#v, want %#v", tt.args.obj, tt.want.obj)
+			}
+		})
+	}
+}
+
+func TestRecoverClusterResourceVersion(t *testing.T) {
+	type args struct {
+		obj     runtime.Object
+		cluster string
+	}
+	type want struct {
+		obj     runtime.Object
+		changed bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "not a meta",
+			args: args{
+				obj:     &metav1.Status{},
+				cluster: "cluster1",
+			},
+			want: want{
+				changed: false,
+				obj:     &metav1.Status{},
+			},
+		},
+		{
+			name: "rv is empty",
+			args: args{
+				obj: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: "",
+					},
+				},
+				cluster: "cluster1",
+			},
+			want: want{
+				changed: false,
+				obj: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{},
+				},
+			},
+		},
+		{
+			name: "rv is 0",
+			args: args{
+				obj: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: "0",
+					},
+				},
+				cluster: "cluster1",
+			},
+			want: want{
+				obj: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: "0",
+					},
+				},
+				changed: false,
+			},
+		},
+		{
+			name: "single cluster rv",
+			args: args{
+				obj: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: "1000",
+					},
+				},
+				cluster: "cluster1",
+			},
+			want: want{
+				obj: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: "1000",
+					},
+				},
+				changed: false,
+			},
+		},
+		{
+			name: "cluster rv not set",
+			args: args{
+				obj: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: base64.RawURLEncoding.EncodeToString([]byte(`{}`)),
+					},
+				},
+				cluster: "cluster1",
+			},
+			want: want{
+				obj: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{},
+				},
+				changed: true,
+			},
+		},
+		{
+			name: "recover cluster rv",
+			args: args{
+				obj: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: base64.RawURLEncoding.EncodeToString([]byte(`{"cluster1":"1","cluster2":"2"}`)),
+					},
+				},
+				cluster: "cluster1",
+			},
+			want: want{
+				obj: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: "1",
+					},
+				},
+				changed: true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RecoverClusterResourceVersion(tt.args.obj, tt.args.cluster)
+			if got != tt.want.changed {
+				t.Errorf("RecoverClusterResourceVersion() changed = %v, want %v", got, tt.want.changed)
+			}
+
+			if !reflect.DeepEqual(tt.args.obj, tt.want.obj) {
+				t.Errorf("RecoverClusterResourceVersion() got obj = %#v, want %#v", tt.args.obj, tt.want.obj)
+			}
+		})
+	}
+}
+
+func TestBuildMultiClusterResourceVersion(t *testing.T) {
+	type args struct {
+		clusterResourceMap map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "empty",
+			args: args{
+				clusterResourceMap: nil,
+			},
+			want: "",
+		},
+		{
+			name: "success",
+			args: args{
+				clusterResourceMap: map[string]string{
+					"cluster1": "1",
+				},
+			},
+			want: base64.RawURLEncoding.EncodeToString([]byte(`{"cluster1":"1"}`)),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := BuildMultiClusterResourceVersion(tt.args.clusterResourceMap); got != tt.want {
+				t.Errorf("BuildMultiClusterResourceVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cherry pick of #3402 on release-1.3.
#3402: fill cluster rv in proxying list
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-search`: fix paging list in karmada search proxy in large scale memeber clusters.
```