### PR TITLE
Cleanup the rbac that has been removed in hack/undeploy-karmada.sh

### DIFF
--- a/hack/undeploy-karmada.sh
+++ b/hack/undeploy-karmada.sh
@@ -42,12 +42,6 @@ ETCD_HOST_IP=$(kubectl get pod -l app=etcd -n karmada-system -o jsonpath='{.item
 # clear all in namespace karmada-system
 kubectl --context="${HOST_CLUSTER_NAME}" delete ns karmada-system --kubeconfig="${HOST_CLUSTER_KUBECONFIG}"
 
-# delete clusterroles
-kubectl --context="${HOST_CLUSTER_NAME}" delete clusterrole karmada-controller-manager --kubeconfig="${HOST_CLUSTER_KUBECONFIG}"
-
-# delete clusterrolebindings
-kubectl --context="${HOST_CLUSTER_NAME}" delete clusterrolebindings karmada-controller-manager --kubeconfig="${HOST_CLUSTER_KUBECONFIG}"
-
 # clear configs about karmada-apiserver in kubeconfig
 kubectl config delete-cluster karmada-apiserver --kubeconfig="${HOST_CLUSTER_KUBECONFIG}"
 kubectl config unset users.karmada-apiserver --kubeconfig="${HOST_CLUSTER_KUBECONFIG}"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

The `karmada-controller-manager` clusterrole has removed at #2511, we don't need to delete it at `hack/undeploy-karmada.sh`, otherwith there is a error.

```
[root@master67 karmada]# hack/undeploy-karmada.sh /root/.kube/config kubernetes-admin@kubernetes
namespace "karmada-system" deleted
Error from server (NotFound): clusterroles.rbac.authorization.k8s.io "karmada-controller-manager" not found
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

