### PR TITLE
Ensure the latest schedulerObservedGeneration if do not need to schedule

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -334,6 +334,15 @@ func (s *Scheduler) doScheduleBinding(namespace, name string) (err error) {
 	}
 	// TODO(dddddai): reschedule bindings on cluster change
 	klog.V(3).Infof("Don't need to schedule ResourceBinding(%s/%s)", rb.Namespace, rb.Name)
+
+	// If no scheduling is required, we need to ensure that binding.Generation is equal to
+	// binding.Status.SchedulerObservedGeneration which means the current status of binding
+	// is the latest status of successful scheduling.
+	if rb.Generation != rb.Status.SchedulerObservedGeneration {
+		updateRB := rb.DeepCopy()
+		updateRB.Status.SchedulerObservedGeneration = updateRB.Generation
+		return patchBindingStatus(s.KarmadaClient, rb, updateRB)
+	}
 	return nil
 }
 
@@ -382,6 +391,15 @@ func (s *Scheduler) doScheduleClusterBinding(name string) (err error) {
 	}
 	// TODO(dddddai): reschedule bindings on cluster change
 	klog.Infof("Don't need to schedule ClusterResourceBinding(%s)", name)
+
+	// If no scheduling is required, we need to ensure that binding.Generation is equal to
+	// binding.Status.SchedulerObservedGeneration which means the current status of binding
+	// is the latest status of successful scheduling.
+	if crb.Generation != crb.Status.SchedulerObservedGeneration {
+		updateCRB := crb.DeepCopy()
+		updateCRB.Status.SchedulerObservedGeneration = updateCRB.Generation
+		return patchClusterResourceBindingStatus(s.KarmadaClient, crb, updateCRB)
+	}
 	return nil
 }
 
@@ -515,6 +533,7 @@ func (s *Scheduler) patchScheduleResultForResourceBinding(oldBinding *workv1alph
 	_, err = s.KarmadaClient.WorkV1alpha2().ResourceBindings(newBinding.Namespace).Patch(context.TODO(), newBinding.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		klog.Errorf("Failed to patch schedule to ResourceBinding(%s/%s): %v", oldBinding.Namespace, oldBinding.Name, err)
+		return err
 	}
 
 	klog.V(4).Infof("Patch schedule to ResourceBinding(%s/%s) succeed", oldBinding.Namespace, oldBinding.Name)
@@ -649,7 +668,13 @@ func (s *Scheduler) patchScheduleResultForClusterResourceBinding(oldBinding *wor
 	}
 
 	_, err = s.KarmadaClient.WorkV1alpha2().ClusterResourceBindings().Patch(context.TODO(), newBinding.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
-	return err
+	if err != nil {
+		klog.Errorf("Failed to patch schedule to ClusterResourceBinding(%s): %v", oldBinding.Name, err)
+		return err
+	}
+
+	klog.V(4).Infof("Patch schedule to ClusterResourceBinding(%s) succeed", oldBinding.Name)
+	return nil
 }
 
 func (s *Scheduler) handleErr(err error, key interface{}) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Ensure the latest schedulerObservedGeneration if do not need to schedule.

**Which issue(s) this PR fixes**:
Fixes #3454 
Fixes #3467 

**Special notes for your reviewer**:
This PR need to cherry-pick.

**Does this PR introduce a user-facing change?**:
```
`karmada-scheduler`: Fixed the issue of inconsistent Generation and SchedulerObservedGeneration.
```

