### PR TITLE
Correct the issue of adding duplicate eviction tasks

### DIFF
--- a/pkg/apis/work/v1alpha2/binding_types_helper_test.go
+++ b/pkg/apis/work/v1alpha2/binding_types_helper_test.go
@@ -254,6 +254,40 @@ func TestResourceBindingSpec_GracefulEvictCluster(t *testing.T) {
 			InputSpec:  ResourceBindingSpec{Clusters: []TargetCluster{}},
 			ExpectSpec: ResourceBindingSpec{Clusters: []TargetCluster{}},
 		},
+		{
+			Name: "same eviction task should not be appended multiple times",
+			InputSpec: ResourceBindingSpec{
+				Clusters: []TargetCluster{{Name: "m1", Replicas: 1}, {Name: "m2", Replicas: 2}},
+				GracefulEvictionTasks: []GracefulEvictionTask{
+					{
+						FromCluster: "m1",
+						Replicas:    pointer.Int32(1),
+						Reason:      EvictionReasonTaintUntolerated,
+						Message:     "graceful eviction v1",
+						Producer:    EvictionProducerTaintManager,
+					},
+				},
+			},
+			EvictEvent: GracefulEvictionTask{
+				FromCluster: "m1",
+				Replicas:    pointer.Int32(1),
+				Reason:      EvictionReasonTaintUntolerated,
+				Message:     "graceful eviction v2",
+				Producer:    EvictionProducerTaintManager,
+			},
+			ExpectSpec: ResourceBindingSpec{
+				Clusters: []TargetCluster{{Name: "m2", Replicas: 2}},
+				GracefulEvictionTasks: []GracefulEvictionTask{
+					{
+						FromCluster: "m1",
+						Replicas:    pointer.Int32(1),
+						Reason:      EvictionReasonTaintUntolerated,
+						Message:     "graceful eviction v1",
+						Producer:    EvictionProducerTaintManager,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
1.apply following yaml:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  labels:
    app: nginx
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - image: nginx
        name: nginx
---
apiVersion: policy.karmada.io/v1alpha1
kind: PropagationPolicy
metadata:
  name: nginx-propagation
spec:
  resourceSelectors:
    - apiVersion: apps/v1
      kind: Deployment
      name: nginx
  placement:
    clusterAffinity:
      clusterNames:
        - member1
        - member2
      clusterTolerations:
      - effect: NoExecute
        key: fail-test
        operator: Exists
        tolerationSeconds: 10
    replicaScheduling:
      replicaDivisionPreference: Weighted
      replicaSchedulingType: Divided
      weightPreference:
        staticWeightList:
          - targetCluster:
              clusterNames:
                - member1
            weight: 1
          - targetCluster:
              clusterNames:
                - member2
            weight: 2
```
2.taint the cluster
```sh
karmadactl taint cluster member2 fail-test=:NoExecute
```
3.check rb
```yaml
  spec:
    clusters:
    - name: member2
      replicas: 2
    - name: member1
      replicas: 1
    gracefulEvictionTasks:
    - fromCluster: member2
      producer: TaintManager
      reason: TaintUntolerated
      replicas: 2
    - fromCluster: member2
      producer: TaintManager
      reason: TaintUntolerated
      replicas: 2
    - fromCluster: member2
      producer: TaintManager
      reason: TaintUntolerated
      replicas: 2
```
The tasks will be added multiple times.

**Which issue(s) this PR fixes**:
Fixes #none

**Special notes for your reviewer**:
@XiShanYongYe-Chang 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Correct the issue of adding duplicate eviction tasks.
```

