### PR TITLE
Add log for note before get gitversion

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -640,6 +640,7 @@ function util::get_macos_ipaddress() {
 }
 
 function util::get_version() {
+  # echo "***Geting version from last tag and please make sure you have a karmada remote tag at local.***"
   git describe --tags --dirty
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind failing-test

**What this PR does / why we need it**:

With the development status of the project, people usually don't pull all the git content of the project to the local, in this case, karmada should ensure that the CI is running normally locally. Also failed at the CI of fork repo  when have not tag. https://github.com/mkloveyy/karmada/actions/runs/4793103009 🤔 

And then i try it at local and just got the error :disappointed:

```
$: k describe po -n karmada-system karmada-aggregated-apiserver-78b74b56c4-dvrzf
...
Normal   Scheduled      73s               default-scheduler  Successfully assigned karmada-system/karmada-aggregated-apiserver-78b74b56c4-dvrzf to karmada-host-control-plane
  Warning  InspectFailed  4s (x7 over 72s)  kubelet            Failed to apply default image tag "docker.io/karmada/karmada-aggregated-apiserver:<nil>": couldn't parse image reference "docker.io/karmada/karmada-aggregated-apiserver:<nil>": invalid reference format
...
```

You can see that the version of images is `<nil>`. The reason is it can not get the git tag from current git commit id when have not a correct karmada tag. No obvious hints and it's frustrating.


Easy to reproduce it:
- git clone --depth 1 https://github.com/karmada-io/karmada.git
- cd karmada
- export CLUSTER_VERSION=kindest/node:v1.26.0
- hack/cli-testing-environment.sh


This PR is Add a log for this,note the people must be exist a correct tag of karmada .

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @RainbowMango 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

