### PR TITLE
Add kubebuilder shortName for work

### DIFF
--- a/charts/karmada/_crds/bases/work.karmada.io_works.yaml
+++ b/charts/karmada/_crds/bases/work.karmada.io_works.yaml
@@ -14,6 +14,8 @@ spec:
     kind: Work
     listKind: WorkList
     plural: works
+    shortNames:
+    - wk
     singular: work
   scope: Namespaced
   versions:

--- a/pkg/apis/work/v1alpha1/work_types.go
+++ b/pkg/apis/work/v1alpha1/work_types.go
@@ -19,7 +19,7 @@ const (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:categories={karmada-io}
+// +kubebuilder:resource:categories={karmada-io},shortName=wk
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Applied")].status`,name="Applied",type=string
 // +kubebuilder:printcolumn:JSONPath=`.metadata.creationTimestamp`,name="Age",type=date
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Consider adding a shortname to work? Because in our environment, I found that the resources of other teams are also called work. Is the name work too generic? Add a shortname to facilitate the distinction

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
API change:  Introduced short name `wk` for `Work` resource.
```

