### PR TITLE
fix: Chinese to English term

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -14739,7 +14739,7 @@
       }
     },
     "com.github.karmada-io.karmada.pkg.apis.cluster.v1alpha1.ResourceModelRange": {
-      "description": "ResourceModelRange describes the detail of each modeling quota that ranges from min to max. Please pay attention, by default, the value of min can be inclusive, and the value of max cannot be inclusive. E.g. in an interval, min = 2, max =10 is set, which means the interval [2,10). This rule ensure that all intervals have the same meaning. If the last interval is +∞, it is definitely unreachable. Therefore, we define the right interval as the open interval. For a valid interval, the value on the right is greater than the value on the left, in other words, max must be greater than min. It is strongly recommended that the [Min, Max) of all ResourceModelRanges can make a continuous interval.",
+      "description": "ResourceModelRange describes the detail of each modeling quota that ranges from min to max. Please pay attention, by default, the value of min can be inclusive, and the value of max cannot be inclusive. E.g. in an interval, min = 2, max =10 is set, which means the interval [2,10). This rule ensure that all intervals have the same meaning. If the last interval is infinite, it is definitely unreachable. Therefore, we define the right interval as the open interval. For a valid interval, the value on the right is greater than the value on the left, in other words, max must be greater than min. It is strongly recommended that the [Min, Max) of all ResourceModelRanges can make a continuous interval.",
       "type": "object",
       "required": [
         "name",

--- a/pkg/apis/cluster/types.go
+++ b/pkg/apis/cluster/types.go
@@ -199,7 +199,7 @@ type ResourceModel struct {
 // ResourceModelRange describes the detail of each modeling quota that ranges from min to max.
 // Please pay attention, by default, the value of min can be inclusive, and the value of max cannot be inclusive.
 // E.g. in an interval, min = 2, max =10 is set, which means the interval [2,10).
-// This rule ensure that all intervals have the same meaning. If the last interval is +∞,
+// This rule ensure that all intervals have the same meaning. If the last interval is infinite,
 // it is definitely unreachable. Therefore, we define the right interval as the open interval.
 // For a valid interval, the value on the right is greater than the value on the left,
 // in other words, max must be greater than min.

--- a/pkg/apis/cluster/v1alpha1/types.go
+++ b/pkg/apis/cluster/v1alpha1/types.go
@@ -211,7 +211,7 @@ type ResourceModel struct {
 // ResourceModelRange describes the detail of each modeling quota that ranges from min to max.
 // Please pay attention, by default, the value of min can be inclusive, and the value of max cannot be inclusive.
 // E.g. in an interval, min = 2, max =10 is set, which means the interval [2,10).
-// This rule ensure that all intervals have the same meaning. If the last interval is +∞,
+// This rule ensure that all intervals have the same meaning. If the last interval is infinite,
 // it is definitely unreachable. Therefore, we define the right interval as the open interval.
 // For a valid interval, the value on the right is greater than the value on the left,
 // in other words, max must be greater than min.

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -986,7 +986,7 @@ func schema_pkg_apis_cluster_v1alpha1_ResourceModelRange(ref common.ReferenceCal
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ResourceModelRange describes the detail of each modeling quota that ranges from min to max. Please pay attention, by default, the value of min can be inclusive, and the value of max cannot be inclusive. E.g. in an interval, min = 2, max =10 is set, which means the interval [2,10). This rule ensure that all intervals have the same meaning. If the last interval is +∞, it is definitely unreachable. Therefore, we define the right interval as the open interval. For a valid interval, the value on the right is greater than the value on the left, in other words, max must be greater than min. It is strongly recommended that the [Min, Max) of all ResourceModelRanges can make a continuous interval.",
+				Description: "ResourceModelRange describes the detail of each modeling quota that ranges from min to max. Please pay attention, by default, the value of min can be inclusive, and the value of max cannot be inclusive. E.g. in an interval, min = 2, max =10 is set, which means the interval [2,10). This rule ensure that all intervals have the same meaning. If the last interval is infinite, it is definitely unreachable. Therefore, we define the right interval as the open interval. For a valid interval, the value on the right is greater than the value on the left, in other words, max must be greater than min. It is strongly recommended that the [Min, Max) of all ResourceModelRanges can make a continuous interval.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {


### PR DESCRIPTION
**What type of PR is this?**
This PR fixes the translation of one term from Chinese to english

/kind documentation


**What this PR does / why we need it**:
Considering that `pkg/apis/cluster/types.go`  and `pkg/apis/cluster/v1alpha1/types.go` contains all the phrases both are in English, but one word has to be translated into English from Chinese. 

**Which issue(s) this PR fixes**:
Fixes #3260 

**Special notes for your reviewer**:

Thanks for reviewing my PR. Feedbacks and suggestions are welcome. @RainbowMango 

**Does this PR introduce a user-facing change?**:

```
NONE
```

