### PR TITLE
karmada operator: support custom labels and  annotations

### DIFF
--- a/operator/pkg/controlplane/apiserver/apiserver.go
+++ b/operator/pkg/controlplane/apiserver/apiserver.go
@@ -13,6 +13,7 @@ import (
 	"github.com/karmada-io/karmada/operator/pkg/constants"
 	"github.com/karmada-io/karmada/operator/pkg/util"
 	"github.com/karmada-io/karmada/operator/pkg/util/apiclient"
+	"github.com/karmada-io/karmada/operator/pkg/util/patcher"
 )
 
 // EnsureKarmadaAPIServer creates karmada apiserver deployment and service resource
@@ -57,6 +58,8 @@ func installKarmadaAPIServer(client clientset.Interface, cfg *operatorv1alpha1.K
 	if err := kuberuntime.DecodeInto(clientsetscheme.Codecs.UniversalDecoder(), apiserverDeploymentbytes, apiserverDeployment); err != nil {
 		return fmt.Errorf("error when decoding karmadaApiserver deployment: %w", err)
 	}
+
+	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).ForDeployment(apiserverDeployment)
 
 	if err := apiclient.CreateOrUpdateDeployment(client, apiserverDeployment); err != nil {
 		return fmt.Errorf("error when creating deployment for %s, err: %w", apiserverDeployment.Name, err)
@@ -112,6 +115,8 @@ func installKarmadaAggregatedAPIServer(client clientset.Interface, cfg *operator
 	if err := kuberuntime.DecodeInto(clientsetscheme.Codecs.UniversalDecoder(), aggregatedAPIServerDeploymentBytes, aggregatedAPIServerDeployment); err != nil {
 		return fmt.Errorf("err when decoding karmadaApiserver deployment: %w", err)
 	}
+
+	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).ForDeployment(aggregatedAPIServerDeployment)
 
 	if err := apiclient.CreateOrUpdateDeployment(client, aggregatedAPIServerDeployment); err != nil {
 		return fmt.Errorf("error when creating deployment for %s, err: %w", aggregatedAPIServerDeployment.Name, err)

--- a/operator/pkg/controlplane/etcd/etcd.go
+++ b/operator/pkg/controlplane/etcd/etcd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/karmada-io/karmada/operator/pkg/constants"
 	"github.com/karmada-io/karmada/operator/pkg/util"
 	"github.com/karmada-io/karmada/operator/pkg/util/apiclient"
+	"github.com/karmada-io/karmada/operator/pkg/util/patcher"
 )
 
 // EnsureKarmadaEtcd creates etcd StatefulSet and service resource.
@@ -68,6 +69,8 @@ func installKarmadaEtcd(client clientset.Interface, name, namespace string, cfg 
 	if err := kuberuntime.DecodeInto(clientsetscheme.Codecs.UniversalDecoder(), etcdStatefuleSetBytes, etcdStatefulSet); err != nil {
 		return fmt.Errorf("error when decoding Etcd StatefulSet: %w", err)
 	}
+
+	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).ForStatefulSet(etcdStatefulSet)
 
 	if err := apiclient.CreateOrUpdateStatefulSet(client, etcdStatefulSet); err != nil {
 		return fmt.Errorf("error when creating Etcd statefulset, err: %w", err)

--- a/operator/pkg/controlplane/webhook/webhook.go
+++ b/operator/pkg/controlplane/webhook/webhook.go
@@ -12,6 +12,7 @@ import (
 	operatorv1alpha1 "github.com/karmada-io/karmada/operator/pkg/apis/operator/v1alpha1"
 	"github.com/karmada-io/karmada/operator/pkg/util"
 	"github.com/karmada-io/karmada/operator/pkg/util/apiclient"
+	"github.com/karmada-io/karmada/operator/pkg/util/patcher"
 )
 
 // EnsureKarmadaWebhook creates karmada webhook deployment and service resource.
@@ -44,6 +45,8 @@ func installKarmadaWebhook(client clientset.Interface, cfg *operatorv1alpha1.Kar
 	if err := kuberuntime.DecodeInto(clientsetscheme.Codecs.UniversalDecoder(), webhookDeploymentSetBytes, webhookDeployment); err != nil {
 		return fmt.Errorf("err when decoding KarmadaWebhook Deployment: %w", err)
 	}
+
+	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).ForDeployment(webhookDeployment)
 
 	if err := apiclient.CreateOrUpdateDeployment(client, webhookDeployment); err != nil {
 		return fmt.Errorf("error when creating deployment for %s, err: %w", webhookDeployment.Name, err)

--- a/operator/pkg/tasks/init/component.go
+++ b/operator/pkg/tasks/init/component.go
@@ -19,9 +19,9 @@ func NewComponentTask() workflow.Task {
 		Run:         runComponents,
 		RunSubTasks: true,
 		Tasks: []workflow.Task{
-			newComponentSubTask(constants.KubeControllerManagerComponent, nil),
-			newComponentSubTask(constants.KarmadaControllerManagerComponent, nil),
-			newComponentSubTask(constants.KarmadaSchedulerComponent, nil),
+			newComponentSubTask(constants.KubeControllerManagerComponent),
+			newComponentSubTask(constants.KarmadaControllerManagerComponent),
+			newComponentSubTask(constants.KarmadaSchedulerComponent),
 			{
 				Name: "KarmadaWebhook",
 				Run:  runKarmadaWebhook,
@@ -40,14 +40,14 @@ func runComponents(r workflow.RunData) error {
 	return nil
 }
 
-func newComponentSubTask(component string, patchManifestFunc controlplane.PatchManifest) workflow.Task {
+func newComponentSubTask(component string) workflow.Task {
 	return workflow.Task{
 		Name: component,
-		Run:  runComponentSubTask(component, patchManifestFunc),
+		Run:  runComponentSubTask(component),
 	}
 }
 
-func runComponentSubTask(component string, patchManifestFunc controlplane.PatchManifest) func(r workflow.RunData) error {
+func runComponentSubTask(component string) func(r workflow.RunData) error {
 	return func(r workflow.RunData) error {
 		data, ok := r.(InitData)
 		if !ok {
@@ -60,7 +60,6 @@ func runComponentSubTask(component string, patchManifestFunc controlplane.PatchM
 			data.GetNamespace(),
 			data.RemoteClient(),
 			data.Components(),
-			patchManifestFunc,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to apply component %s, err: %w", component, err)

--- a/operator/pkg/util/patcher/pather.go
+++ b/operator/pkg/util/patcher/pather.go
@@ -1,0 +1,47 @@
+package patcher
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// Patcher defines multiple variables that need to be patched.
+type Patcher struct {
+	labels      map[string]string
+	annotations map[string]string
+}
+
+// NewPatcher returns a patcher.
+func NewPatcher() *Patcher {
+	return &Patcher{}
+}
+
+// WithLabels sets labels to the patcher.
+func (p *Patcher) WithLabels(labels labels.Set) *Patcher {
+	p.labels = labels
+	return p
+}
+
+// WithAnnotations sets annotations to the patcher.
+func (p *Patcher) WithAnnotations(annotations labels.Set) *Patcher {
+	p.annotations = annotations
+	return p
+}
+
+// ForDeployment patches the deployment manifest.
+func (p *Patcher) ForDeployment(deployment *appsv1.Deployment) {
+	deployment.Labels = labels.Merge(deployment.Labels, p.labels)
+	deployment.Spec.Template.Labels = labels.Merge(deployment.Spec.Template.Labels, p.labels)
+
+	deployment.Annotations = labels.Merge(deployment.Annotations, p.annotations)
+	deployment.Spec.Template.Annotations = labels.Merge(deployment.Spec.Template.Annotations, p.annotations)
+}
+
+// ForStatefulSet patches the statefulset manifest.
+func (p *Patcher) ForStatefulSet(sts *appsv1.StatefulSet) {
+	sts.Labels = labels.Merge(sts.Labels, p.labels)
+	sts.Spec.Template.Labels = labels.Merge(sts.Spec.Template.Labels, p.labels)
+
+	sts.Annotations = labels.Merge(sts.Annotations, p.annotations)
+	sts.Spec.Template.Annotations = labels.Merge(sts.Spec.Template.Annotations, p.annotations)
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
we should support that user can set custom labels and annotations to karmada component workloads.

Here is test results:
Karmada CR yaml:
<img width="865" alt="image" src="https://user-images.githubusercontent.com/45745657/236371762-8ccbab7a-eb02-4a2a-9a6b-3563bbc9ca32.png">

The etcd pod yaml:
<img width="740" alt="image" src="https://user-images.githubusercontent.com/45745657/236371890-e1a690f2-6f71-4d46-b1a4-f5ef5fa2b0f6.png">




**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

