### PR TITLE
Fix zero deployment can still propagate to member clusters when EnableEmptyWorkloadPropagation flag is false

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -190,7 +190,11 @@ func (g *genericScheduler) assignReplicas(
 			return nil, fmt.Errorf("unsupported replica scheduling strategy, replicaSchedulingType: %s, replicaDivisionPreference: %s, "+
 				"please try another scheduling strategy", placement.ReplicaSchedulingType(), placement.ReplicaScheduling.ReplicaDivisionPreference)
 		}
-		return assignFunc(state)
+		assignResults, err := assignFunc(state)
+		if err != nil {
+			return nil, err
+		}
+		return removeZeroReplicasCluster(assignResults), nil
 	}
 
 	// If not workload, assign all clusters without considering replicas.

--- a/pkg/scheduler/core/util.go
+++ b/pkg/scheduler/core/util.go
@@ -89,3 +89,14 @@ func attachZeroReplicasCluster(clusters []*clusterv1alpha1.Cluster, targetCluste
 	}
 	return targetClusters
 }
+
+// removeZeroReplicasCLuster remove the cluster with 0 replicas in assignResults
+func removeZeroReplicasCluster(assignResults []workv1alpha2.TargetCluster) []workv1alpha2.TargetCluster {
+	targetClusters := make([]workv1alpha2.TargetCluster, 0, len(assignResults))
+	for _, cluster := range assignResults {
+		if cluster.Replicas > 0 {
+			targetClusters = append(targetClusters, workv1alpha2.TargetCluster{Name: cluster.Name, Replicas: cluster.Replicas})
+		}
+	}
+	return targetClusters
+}

--- a/test/e2e/scheduling_test.go
+++ b/test/e2e/scheduling_test.go
@@ -537,6 +537,7 @@ var _ = ginkgo.Describe("[ReplicaScheduling] ReplicaSchedulingStrategy testing",
 	ginkgo.Context("ReplicaSchedulingType is Divided, ReplicaDivisionPreference is Weighted, WeightPreference isn't "+
 		"nil, trigger rescheduling when replicas have changed.", func() {
 		ginkgo.BeforeEach(func() {
+			sumWeight := 0
 			staticWeightLists := make([]policyv1alpha1.StaticClusterWeight, 0)
 			for index, clusterName := range framework.ClusterNames() {
 				staticWeightList := policyv1alpha1.StaticClusterWeight{
@@ -546,6 +547,7 @@ var _ = ginkgo.Describe("[ReplicaScheduling] ReplicaSchedulingStrategy testing",
 					Weight: int64(index + 1),
 				}
 				staticWeightLists = append(staticWeightLists, staticWeightList)
+				sumWeight += index + 1
 			}
 			klog.Infof("StaticWeightList of policy is %+v", staticWeightLists)
 			policy.Spec.Placement.ReplicaScheduling = &policyv1alpha1.ReplicaSchedulingStrategy{
@@ -555,6 +557,8 @@ var _ = ginkgo.Describe("[ReplicaScheduling] ReplicaSchedulingStrategy testing",
 					StaticWeightList: staticWeightLists,
 				},
 			}
+			sumReplicas := int32(sumWeight)
+			deployment.Spec.Replicas = &sumReplicas
 		})
 
 		ginkgo.It("replicas divided and weighted testing when rescheduling", func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Fix zero deployment can still propagate to member clusters when EnableEmptyWorkloadPropagation flag is false

**Which issue(s) this PR fixes**:
Fixes #3495 

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-scheduler`: Fixed the issue that empty deployment can still be propagated to member clusters even when `--enableEmptyWorkloadPropagation` flag is false.
```

