### PR TITLE
karmada operator: fixed adding altName to certification

### DIFF
--- a/operator/pkg/certs/certs.go
+++ b/operator/pkg/certs/certs.go
@@ -459,16 +459,17 @@ func apiServerAltNamesMutator(cfg *AltNamesMutatorConfig) (*certutil.AltNames, e
 			"kubernetes.default.svc",
 			fmt.Sprintf("*.%s.svc.cluster.local", cfg.Namespace),
 			fmt.Sprintf("*.%s.svc", cfg.Namespace),
-			cfg.ControlplaneAddress,
 		},
 		IPs: []net.IP{
 			net.IPv4(127, 0, 0, 1),
-			net.ParseIP(cfg.ControlplaneAddress),
 		},
 	}
 
 	if len(cfg.Components.KarmadaAPIServer.CertSANs) > 0 {
 		appendSANsToAltNames(altNames, cfg.Components.KarmadaAPIServer.CertSANs)
+	}
+	if len(cfg.ControlplaneAddress) > 0 {
+		appendSANsToAltNames(altNames, []string{cfg.ControlplaneAddress})
 	}
 
 	return altNames, nil


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When the service type of karmada apiserver is `ClusterIP`, we will add a empty dns or IP to AltNames object. It will thorw below error:

```shell
cannot parse IP address of length 0
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

