### PR TITLE
karmada operator: implement installing karmada descheduler

### DIFF
--- a/operator/pkg/apis/operator/v1alpha1/defaults.go
+++ b/operator/pkg/apis/operator/v1alpha1/defaults.go
@@ -18,6 +18,7 @@ var (
 	karmadaControllerManagerImageRepository   = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, constants.KarmadaControllerManager)
 	karmadaSchedulerImageRepository           = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, constants.KarmadaScheduler)
 	karmadaWebhookImageRepository             = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, constants.KarmadaWebhook)
+	karmadaDeschedulerImageRepository         = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, constants.KarmadaDescheduler)
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -54,6 +55,9 @@ func setDefaultsKarmadaComponents(obj *Karmada) {
 	setDefaultsKarmadaControllerManager(obj.Spec.Components)
 	setDefaultsKarmadaScheduler(obj.Spec.Components)
 	setDefaultsKarmadaWebhook(obj.Spec.Components)
+
+	// set addon defaults
+	setDefaultsKarmadaDescheduler(obj.Spec.Components)
 }
 
 func setDefaultsHostCluster(obj *Karmada) {
@@ -204,5 +208,22 @@ func setDefaultsKarmadaWebhook(obj *KarmadaComponents) {
 	}
 	if webhook.Replicas == nil {
 		webhook.Replicas = pointer.Int32(1)
+	}
+}
+
+func setDefaultsKarmadaDescheduler(obj *KarmadaComponents) {
+	if obj.KarmadaDescheduler == nil {
+		return
+	}
+
+	descheduler := obj.KarmadaDescheduler
+	if len(descheduler.Image.ImageRepository) == 0 {
+		descheduler.Image.ImageRepository = karmadaDeschedulerImageRepository
+	}
+	if len(descheduler.Image.ImageTag) == 0 {
+		descheduler.Image.ImageTag = constants.KarmadaDefaultVersion
+	}
+	if descheduler.Replicas == nil {
+		descheduler.Replicas = pointer.Int32(1)
 	}
 }

--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -40,6 +40,8 @@ const (
 	KarmadaScheduler = "karmada-scheduler"
 	// KarmadaWebhook defines the name of the karmada-webhook component
 	KarmadaWebhook = "karmada-webhook"
+	// KarmadaDescheduler defines the name of the karmada-descheduler component
+	KarmadaDescheduler = "karmada-descheduler"
 
 	// KarmadaSystemNamespace defines the leader selection namespace for karmada components
 	KarmadaSystemNamespace = "karmada-system"
@@ -78,18 +80,20 @@ const (
 	// UserName karmada cluster user name
 	UserName = "karmada-admin"
 
-	// KarmadaAPIserverComponent defines the name of karmada apiserver component
+	// KarmadaAPIserverComponent defines the name of karmada-apiserver component
 	KarmadaAPIserverComponent = "KarmadaAPIServer"
-	// KarmadaAggregatedAPIServerComponent defines the name of karmada aggregated apiserver component
+	// KarmadaAggregatedAPIServerComponent defines the name of karmada-aggregated-apiserver component
 	KarmadaAggregatedAPIServerComponent = "KarmadaAggregatedAPIServer"
-	// KubeControllerManagerComponent defines the name of kube controller manager component
+	// KubeControllerManagerComponent defines the name of kube-controller-manager-component
 	KubeControllerManagerComponent = "KubeControllerManager"
-	// KarmadaControllerManagerComponent defines the name of karmada controller manager component
+	// KarmadaControllerManagerComponent defines the name of karmada-controller-manager component
 	KarmadaControllerManagerComponent = "KarmadaControllerManager"
-	// KarmadaSchedulerComponent defines the name of karmada scheduler component
+	// KarmadaSchedulerComponent defines the name of karmada-scheduler component
 	KarmadaSchedulerComponent = "KarmadaScheduler"
 	// KarmadaWebhookComponent defines the name of the karmada-webhook component
 	KarmadaWebhookComponent = "KarmadaWebhook"
+	// KarmadaDeschedulerComponent defines the name of the karmada-descheduler component
+	KarmadaDeschedulerComponent = "KarmadaDescheduler"
 
 	// KarmadaOperatorLabelKeyName defines a label key used by all of resources created by karmada operator
 	KarmadaOperatorLabelKeyName = "app.kubernetes.io/managed-by"

--- a/operator/pkg/tasks/deinit/component.go
+++ b/operator/pkg/tasks/deinit/component.go
@@ -19,6 +19,7 @@ func NewRemoveComponentTask() workflow.Task {
 		Run:         runRemoveComponent,
 		RunSubTasks: true,
 		Tasks: []workflow.Task{
+			newRemoveComponentSubTask(constants.KarmadaDeschedulerComponent, util.KarmadaDeschedulerName),
 			newRemoveComponentSubTask(constants.KarmadaSchedulerComponent, util.KarmadaSchedulerName),
 			newRemoveComponentSubTask(constants.KarmadaControllerManagerComponent, util.KarmadaControllerManagerName),
 			newRemoveComponentSubTask(constants.KubeControllerManagerComponent, util.KubeControllerManagerName),

--- a/operator/pkg/tasks/init/component.go
+++ b/operator/pkg/tasks/init/component.go
@@ -26,6 +26,7 @@ func NewComponentTask() workflow.Task {
 				Name: "KarmadaWebhook",
 				Run:  runKarmadaWebhook,
 			},
+			newComponentSubTask(constants.KarmadaDeschedulerComponent),
 		},
 	}
 }

--- a/operator/pkg/util/naming.go
+++ b/operator/pkg/util/naming.go
@@ -8,64 +8,69 @@ import (
 // Namefunc defines a function to generate resource name according to karmada resource name.
 type Namefunc func(karmada string) string
 
-// AdminKubeconfigSercretName return a secret name of karmada admin kubeconfig
+// AdminKubeconfigSercretName returns secret name of karmada-admin kubeconfig
 func AdminKubeconfigSercretName(karmada string) string {
 	return generateResourceName(karmada, "admin-config")
 }
 
-// KarmadaCertSecretName return a secret name of karmada certs
+// KarmadaCertSecretName returns secret name of karmada certs
 func KarmadaCertSecretName(karmada string) string {
 	return generateResourceName(karmada, "cert")
 }
 
-// EtcdCertSecretName return a secret name of etcd cert
+// EtcdCertSecretName returns secret name of etcd cert
 func EtcdCertSecretName(karmada string) string {
 	return generateResourceName(karmada, "etcd-cert")
 }
 
-// WebhookCertSecretName return secret name of karmada webhook cert
+// WebhookCertSecretName returns secret name of karmada-webhook cert
 func WebhookCertSecretName(karmada string) string {
 	return generateResourceName(karmada, "webhook-cert")
 }
 
-// KarmadaAPIServerName return secret name of karmada apiserver
+// KarmadaAPIServerName returns secret name of karmada-apiserver
 func KarmadaAPIServerName(karmada string) string {
 	return generateResourceName(karmada, "apiserver")
 }
 
-// KarmadaAggregatedAPIServerName return secret name of karmada aggregated apiserver
+// KarmadaAggregatedAPIServerName returns secret name of karmada-aggregated-apiserver
 func KarmadaAggregatedAPIServerName(karmada string) string {
 	return generateResourceName(karmada, "aggregated-apiserver")
 }
 
-// KarmadaEtcdName return karmada etcd name
+// KarmadaEtcdName returns name of karmada-etcd
 func KarmadaEtcdName(karmada string) string {
 	return generateResourceName(karmada, "etcd")
 }
 
-// KarmadaEtcdClientName return karmada etcd client name
+// KarmadaEtcdClientName returns name of karmada-etcd client
 func KarmadaEtcdClientName(karmada string) string {
 	return generateResourceName(karmada, "etcd-client")
 }
 
-// KubeControllerManagerName return name of kube controller manager name of karmada
+// KubeControllerManagerName returns name of kube-controller-manager
 func KubeControllerManagerName(karmada string) string {
 	return generateResourceName(karmada, "kube-controller-manager")
 }
 
-// KarmadaControllerManagerName return karmada controller manager name
+// KarmadaControllerManagerName returns name of karmada-controller-manager
 func KarmadaControllerManagerName(karmada string) string {
 	return generateResourceName(karmada, "controller-manager")
 }
 
-// KarmadaSchedulerName return karmada scheduler name
+// KarmadaSchedulerName returns name of karmada-scheduler
 func KarmadaSchedulerName(karmada string) string {
 	return generateResourceName(karmada, "scheduler")
 }
 
-// KarmadaWebhookName return karmada webhook name
+// KarmadaWebhookName returns name of karmada-webhook
 func KarmadaWebhookName(karmada string) string {
 	return generateResourceName(karmada, "webhook")
+}
+
+// KarmadaDeschedulerName returns name of karmada-descheduler
+func KarmadaDeschedulerName(karmada string) string {
+	return generateResourceName(karmada, "descheduler")
 }
 
 func generateResourceName(karmada, suffix string) string {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Desheduler is one of the more common components that we need to support.

Here is test results:

add configuration in CR resource:

```yaml
apiVersion: operator.karmada.io/v1alpha1
kind: Karmada
metadata:
  name: karmada-demo
  namespace: test
spec:
  components:
    KarmadaDescheduler: {}
```

these pod of karmada descheduler is running:

```shell
NAME                                                    READY   STATUS    RESTARTS   AGE
karmada-demo-aggregated-apiserver-587bc5c697-dt6wh      1/1     Running   0          65s
karmada-demo-apiserver-55968d9f8c-ffdx7                 1/1     Running   0          106s
karmada-demo-controller-manager-64455f7fd4-49q5v        1/1     Running   0          58s
karmada-demo-descheduler-6d6ffd4d55-l7vw7               1/1     Running   0          57s
karmada-demo-etcd-0                                     1/1     Running   0          3m5s
karmada-demo-kube-controller-manager-584f978bbd-5r27x   1/1     Running   0          58s
karmada-demo-scheduler-6d77b7547-4mpr5                  1/1     Running   0          58s
karmada-demo-webhook-6f5944f5d8-p8pws                   1/1     Running   0          58s
```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

