### PR TITLE
enable concurrency for pp and cpp

### DIFF
--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -583,17 +583,19 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 	objectWatcher := objectwatcher.NewObjectWatcher(mgr.GetClient(), mgr.GetRESTMapper(), util.NewClusterDynamicClientSet, resourceInterpreter)
 
 	resourceDetector := &detector.ResourceDetector{
-		DiscoveryClientSet:              discoverClientSet,
-		Client:                          mgr.GetClient(),
-		InformerManager:                 controlPlaneInformerManager,
-		RESTMapper:                      mgr.GetRESTMapper(),
-		DynamicClient:                   dynamicClientSet,
-		SkippedResourceConfig:           skippedResourceConfig,
-		SkippedPropagatingNamespaces:    opts.SkippedNamespacesRegexps(),
-		ResourceInterpreter:             resourceInterpreter,
-		EventRecorder:                   mgr.GetEventRecorderFor("resource-detector"),
-		ConcurrentResourceTemplateSyncs: opts.ConcurrentResourceTemplateSyncs,
-		RateLimiterOptions:              opts.RateLimiterOpts,
+		DiscoveryClientSet:                      discoverClientSet,
+		Client:                                  mgr.GetClient(),
+		InformerManager:                         controlPlaneInformerManager,
+		RESTMapper:                              mgr.GetRESTMapper(),
+		DynamicClient:                           dynamicClientSet,
+		SkippedResourceConfig:                   skippedResourceConfig,
+		SkippedPropagatingNamespaces:            opts.SkippedNamespacesRegexps(),
+		ResourceInterpreter:                     resourceInterpreter,
+		EventRecorder:                           mgr.GetEventRecorderFor("resource-detector"),
+		ConcurrentPropagationPolicySyncs:        opts.ConcurrentPropagationPolicySyncs,
+		ConcurrentClusterPropagationPolicySyncs: opts.ConcurrentClusterPropagationPolicySyncs,
+		ConcurrentResourceTemplateSyncs:         opts.ConcurrentResourceTemplateSyncs,
+		RateLimiterOptions:                      opts.RateLimiterOpts,
 	}
 
 	if err := mgr.Add(resourceDetector); err != nil {

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -110,6 +110,10 @@ type Options struct {
 	// ConcurrentNamespaceSyncs is the number of Namespace objects that are
 	// allowed to sync concurrently.
 	ConcurrentNamespaceSyncs int
+	// ConcurrentPropagationPolicySyncs is the number of PropagationPolicy that are allowed to sync concurrently.
+	ConcurrentPropagationPolicySyncs int
+	// ConcurrentClusterPropagationPolicySyncs is the number of ClusterPropagationPolicy that are allowed to sync concurrently.
+	ConcurrentClusterPropagationPolicySyncs int
 	// ConcurrentResourceTemplateSyncs is the number of resource templates that are allowed to sync concurrently.
 	ConcurrentResourceTemplateSyncs int
 	// If set to true enables NoExecute Taints and will evict all not-tolerating
@@ -202,6 +206,8 @@ func (o *Options) AddFlags(flags *pflag.FlagSet, allControllers, disabledByDefau
 	flags.IntVar(&o.ConcurrentResourceBindingSyncs, "concurrent-resourcebinding-syncs", 5, "The number of ResourceBindings that are allowed to sync concurrently.")
 	flags.IntVar(&o.ConcurrentWorkSyncs, "concurrent-work-syncs", 5, "The number of Works that are allowed to sync concurrently.")
 	flags.IntVar(&o.ConcurrentNamespaceSyncs, "concurrent-namespace-syncs", 1, "The number of Namespaces that are allowed to sync concurrently.")
+	flags.IntVar(&o.ConcurrentPropagationPolicySyncs, "concurrent-propagation-policy-syncs", 1, "The number of PropagationPolicy that are allowed to sync concurrently.")
+	flags.IntVar(&o.ConcurrentClusterPropagationPolicySyncs, "concurrent-cluster-propagation-policy-syncs", 1, "The number of ClusterPropagationPolicy that are allowed to sync concurrently.")
 	flags.IntVar(&o.ConcurrentResourceTemplateSyncs, "concurrent-resource-template-syncs", 5, "The number of resource templates that are allowed to sync concurrently.")
 	flags.BoolVar(&o.EnableTaintManager, "enable-taint-manager", true, "If set to true enables NoExecute Taints and will evict all not-tolerating objects propagating on Clusters tainted with this kind of Taints.")
 	flags.DurationVar(&o.GracefulEvictionTimeout.Duration, "graceful-eviction-timeout", 10*time.Minute, "Specifies the timeout period waiting for the graceful-eviction-controller performs the final removal since the workload(resource) has been moved to the graceful eviction tasks.")

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -76,6 +76,10 @@ type ResourceDetector struct {
 	waitingObjects map[keys.ClusterWideKey]struct{}
 	// waitingLock is the lock for waitingObjects operation.
 	waitingLock sync.RWMutex
+	// ConcurrentPropagationPolicySyncs is the number of PropagationPolicy that are allowed to sync concurrently.
+	ConcurrentPropagationPolicySyncs int
+	// ConcurrentClusterPropagationPolicySyncs is the number of ClusterPropagationPolicy that are allowed to sync concurrently.
+	ConcurrentClusterPropagationPolicySyncs int
 	// ConcurrentResourceTemplateSyncs is the number of resource templates that are allowed to sync concurrently.
 	// Larger number means responsive resource template syncing but more CPU(and network) load.
 	ConcurrentResourceTemplateSyncs int
@@ -100,14 +104,14 @@ func (d *ResourceDetector) Start(ctx context.Context) error {
 		ReconcileFunc: d.ReconcilePropagationPolicy,
 	}
 	d.policyReconcileWorker = util.NewAsyncWorker(policyWorkerOptions)
-	d.policyReconcileWorker.Run(1, d.stopCh)
+	d.policyReconcileWorker.Run(d.ConcurrentPropagationPolicySyncs, d.stopCh)
 	clusterPolicyWorkerOptions := util.Options{
 		Name:          "clusterPropagationPolicy reconciler",
 		KeyFunc:       ClusterWideKeyFunc,
 		ReconcileFunc: d.ReconcileClusterPropagationPolicy,
 	}
 	d.clusterPolicyReconcileWorker = util.NewAsyncWorker(clusterPolicyWorkerOptions)
-	d.clusterPolicyReconcileWorker.Run(1, d.stopCh)
+	d.clusterPolicyReconcileWorker.Run(d.ConcurrentClusterPropagationPolicySyncs, d.stopCh)
 
 	// watch and enqueue PropagationPolicy changes.
 	propagationPolicyGVR := schema.GroupVersionResource{


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Recently, we encountered a slow restart issue where it took 15 minutes to clear the items in queues. We suspect that the number of workers in pp/cpp could be one of the reasons for this problem. Therefore, it would be reasonable to add a concurrency configuration for this.

Although the pp/cpp reconcile function appears to be capable of handling concurrency, the number of workers is hardcoded as `1`. Please let me know if there is any particular reason for this.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-controller-manager`: Introduced `--concurrent-propagation-policy-syncs`/`--concurrent-cluster-propagation-policy-syncs` flags to specify concurrent syncs for PropagationPolicy and ClusterPropagationPolicy.
```

