### PR TITLE
Automated cherry pick of #3505: fix:search http response add content-type header

### DIFF
--- a/pkg/registry/search/storage/cache.go
+++ b/pkg/registry/search/storage/cache.go
@@ -40,7 +40,7 @@ func (r *SearchREST) newCacheHandler(info *genericrequest.RequestInfo, responder
 
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		enc := json.NewEncoder(rw)
-
+		rw.Header().Set("Content-Type", "application/json")
 		opts := metainternalversion.ListOptions{}
 		if err := searchscheme.ParameterCodec.DecodeParameters(req.URL.Query(), metav1.SchemeGroupVersion, &opts); err != nil {
 			rw.WriteHeader(http.StatusBadRequest)


### PR DESCRIPTION
Cherry pick of #3505 on release-1.3.
#3505: fix:search http response add content-type header
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
karmada-search: http response add content-type header
```