### PR TITLE
Fix DeepEqual in federated-resource-quota-status-controller;

### DIFF
--- a/pkg/controllers/federatedresourcequota/federated_resource_quota_status_controller.go
+++ b/pkg/controllers/federatedresourcequota/federated_resource_quota_status_controller.go
@@ -139,7 +139,7 @@ func (c *StatusController) collectQuotaStatus(quota *policyv1alpha1.FederatedRes
 	quotaStatus.AggregatedStatus = aggregatedStatuses
 	quotaStatus.OverallUsed = calculateUsed(aggregatedStatuses)
 
-	if reflect.DeepEqual(quota.Status, quotaStatus) {
+	if reflect.DeepEqual(quota.Status, *quotaStatus) {
 		klog.V(4).Infof("New quotaStatus are equal with old federatedResourceQuota(%s) status, no update required.", klog.KObj(quota).String())
 		return nil
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

fix an issue where DeepEqual becomes invalid in federated-resource-quota-status-controller

**Which issue(s) this PR fixes**:

Fixes #3519

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

