### PR TITLE
fix: add missing federatedresourcequota validate config

### DIFF
--- a/charts/karmada/templates/_karmada_webhook_configuration.tpl
+++ b/charts/karmada/templates/_karmada_webhook_configuration.tpl
@@ -157,4 +157,18 @@ webhooks:
     sideEffects: None
     admissionReviewVersions: ["v1"]
     timeoutSeconds: 3
+  - name: federatedresourcequota.karmada.io
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["policy.karmada.io"]
+        apiVersions: ["*"]
+        resources: ["federatedresourcequotas"]
+        scope: "Namespaced"
+    clientConfig:
+      url: https://{{ $name }}-webhook.{{ $namespace }}.svc:443/validate-federatedresourcequota
+      {{- include "karmada.webhook.caBundle" . | nindent 6 }}
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: [ "v1" ]
+    timeoutSeconds: 3
 {{- end -}}

--- a/operator/pkg/karmadaresource/webhookconfiguration/mainfests.go
+++ b/operator/pkg/karmadaresource/webhookconfiguration/mainfests.go
@@ -161,5 +161,19 @@ webhooks:
     sideEffects: None
     admissionReviewVersions: ["v1"]
     timeoutSeconds: 3
+  - name: federatedresourcequota.karmada.io
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["policy.karmada.io"]
+        apiVersions: ["*"]
+        resources: ["federatedresourcequotas"]
+        scope: "Namespaced"
+    clientConfig:
+      url: https://{{ .Service }}.{{ .Namespace }}.svc:443/validate-federatedresourcequota
+      caBundle: {{ .CaBundle }}
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: [ "v1" ]
+    timeoutSeconds: 3
 `
 )

--- a/pkg/karmadactl/cmdinit/karmada/webhook_configuration.go
+++ b/pkg/karmadactl/cmdinit/karmada/webhook_configuration.go
@@ -172,6 +172,20 @@ webhooks:
     sideEffects: None
     admissionReviewVersions: ["v1"]
     timeoutSeconds: 3
+  - name: federatedresourcequota.karmada.io
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["policy.karmada.io"]
+        apiVersions: ["*"]
+        resources: ["federatedresourcequotas"]
+        scope: "Namespaced"
+    clientConfig:
+      url: https://karmada-webhook.%[1]s.svc:443/validate-federatedresourcequota
+      caBundle: %[2]s
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: [ "v1" ]
+    timeoutSeconds: 3
 `, systemNamespace, caBundle)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

add missing federatedresourcequota validate config

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/webhook-configuration.yaml#L156-L169

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-webhook`: add missing federatedresourcequota validate config.
```

