### PR TITLE
Support Karmada installed by helm to use karmadactl register

### DIFF
--- a/charts/karmada/templates/_helpers.tpl
+++ b/charts/karmada/templates/_helpers.tpl
@@ -93,6 +93,15 @@ app: {{- include "karmada.name" .}}-kube-controller-manager
   mountPath: /etc/kubeconfig
 {{- end -}}
 
+{{- define "karmada.kubeconfig.caData" -}}
+{{- if eq .Values.certs.mode "auto" }}
+certificate-authority-data: {{ print "{{ ca_crt }}" }}
+{{- end }}
+{{- if eq .Values.certs.mode "custom" }}
+certificate-authority-data: {{ b64enc .Values.certs.custom.caCrt }}
+{{- end }}
+{{- end -}}
+
 {{- define "karmada.cm.labels" -}}
 {{ $name :=  include "karmada.name" . }}
 {{- if .Values.controllerManager.labels -}}

--- a/charts/karmada/templates/_karmada_bootstrap_token_configuration.tpl
+++ b/charts/karmada/templates/_karmada_bootstrap_token_configuration.tpl
@@ -1,0 +1,202 @@
+{{- define "karmada.bootstrapToken.configuration" -}}
+{{- $name := include "karmada.name" . -}}
+{{- $namespace := include "karmada.namespace" . -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-info
+  namespace: kube-public
+data:
+  kubeconfig: |
+    apiVersion: v1
+    clusters:
+    - cluster:
+        {{- include "karmada.kubeconfig.caData" . | nindent 8 }}
+        server: https://{{ $name }}-apiserver.{{ $namespace }}.svc.{{ .Values.clusterDomain }}:5443
+    kind: Config
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: karmada:bootstrap-signer-clusterinfo
+  namespace: kube-public
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - cluster-info
+  resources:
+  - configmaps
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: karmada:bootstrap-signer-clusterinfo
+  namespace: kube-public
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: karmada:bootstrap-signer-clusterinfo
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:anonymous
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: karmada:agent-bootstrap
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:node-bootstrapper
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:bootstrappers:karmada:default-cluster-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: karmada:agent-autoapprove-bootstrap
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:certificates.k8s.io:certificatesigningrequests:nodeclient
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:bootstrappers:karmada:default-cluster-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: karmada:agent-autoapprove-certificate-rotation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:certificates.k8s.io:certificatesigningrequests:selfnodeclient
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:karmada:agent
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - cluster.karmada.io
+  resources:
+  - clusters
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - cluster.karmada.io
+  resources:
+  - clusters/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - work.karmada.io
+  resources:
+  - works
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - work.karmada.io
+  resources:
+  - works/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - config.karmada.io
+  resources:
+  - resourceinterpreterwebhookconfigurations
+  - resourceinterpretercustomizations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:karmada:agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:karmada:agent
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
+{{- end -}}

--- a/charts/karmada/templates/_karmada_cluster_proxy_admin_rbac.tpl
+++ b/charts/karmada/templates/_karmada_cluster_proxy_admin_rbac.tpl
@@ -1,6 +1,6 @@
 {{- define "karmada.proxyRbac" -}}
 {{- $name := include "karmada.name" . -}}
-
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/karmada/templates/karmada-apiserver.yaml
+++ b/charts/karmada/templates/karmada-apiserver.yaml
@@ -38,7 +38,6 @@ spec:
             - --authorization-mode=Node,RBAC
             - --client-ca-file=/etc/kubernetes/pki/server-ca.crt
             - --disable-admission-plugins=StorageObjectInUseProtection,ServiceAccount
-            - --enable-admission-plugins=NodeRestriction
             - --enable-bootstrap-token-auth=true
             {{- if eq .Values.etcd.mode "external" }}
             - --etcd-cafile=/etc/etcd/pki/ca.crt

--- a/charts/karmada/templates/post-install-job.yaml
+++ b/charts/karmada/templates/post-install-job.yaml
@@ -16,6 +16,8 @@ data:
     {{- include "karmada.apiservice" . | nindent 4 }}
   {{- print "cluster-proxy-admin-rbac.yaml: " | nindent 2 }} |-
     {{- include "karmada.proxyRbac" . | nindent 4 }}
+  {{- print "bootstrap-token-configuration.yaml: " | nindent 2 }} |-
+    {{- include "karmada.bootstrapToken.configuration" . | nindent 4 }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/karmada/templates/pre-install-job.yaml
+++ b/charts/karmada/templates/pre-install-job.yaml
@@ -86,6 +86,8 @@ data:
         {{- include "karmada.apiservice" . | nindent 8 }}
       {{- print "cluster-proxy-admin-rbac.yaml: " | nindent 6 }} |-
         {{- include "karmada.proxyRbac" . | nindent 8 }}
+      {{- print "bootstrap-token-configuration.yaml: " | nindent 6 }} |-
+        {{- include "karmada.bootstrapToken.configuration" . | nindent 8 }}
   crds-configmaps.yaml: |-
     apiVersion: v1
     kind: ConfigMap

--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -505,7 +505,7 @@ kubeControllerManager:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 50%
-  controllers: namespace,garbagecollector,serviceaccount-token,ttl-after-finished,bootstrapsigner,csrapproving,csrcleaner,csrsigning
+  controllers: namespace,garbagecollector,serviceaccount-token,ttl-after-finished,bootstrapsigner,tokencleaner,csrapproving,csrcleaner,csrsigning
 
 ## etcd config
 etcd:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Support Karmada installed by helm to use karmadactl register.

**Which issue(s) this PR fixes**:
Part of #3280 

**Special notes for your reviewer**:

The usage is that:

1. We need to specify a hostIP in a cert signed by `CA` in `charts/karmada/values.yaml` to provide external service. Like below, `10.10.103.67` is a hostIP.

```yaml
## karmada certificate config
certs:
  ## @param certs.mode "auto" and "custom" are provided
  ## "auto" means auto generate certificate
  ## "custom" means use user certificate
  mode: auto
  auto:
    ## @param certs.auto.expiry expiry of the certificate
    expiry: 43800h
    ## @param certs.auto.hosts hosts of the certificate
    hosts: [
      "kubernetes.default.svc",
      "*.etcd.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}",
      "*.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}",
      "*.{{ .Release.Namespace }}.svc",
      "localhost",
      "127.0.0.1",
      "10.10.103.67"  # add a hostIP
    ]
```

2. Executing `helm install karmada -n karmada-system --create-namespace --dependency-update ./charts/karmada`
3. Update the Service `kubectl edit svc -n karmada-system   karmada-apiserver`, type is `NodePort`, `nodePort: 32443`
```
spec:
  clusterIP: 10.110.146.229
  externalTrafficPolicy: Cluster
  ports:
  - name: karmada-apiserver
    nodePort: 32443
    port: 5443
    protocol: TCP
    targetPort: 5443
  selector:
    app: karmada-apiserver
  sessionAffinity: None
  type: NodePort
```

4. `kubectl get secret -n karmada-system karmada-kubeconfig -o jsonpath={.data.kubeconfig} | base64 -d > /etc/karmada/karamda-apiserver.config`, and update the `server` to `server: https://10.10.103.67:32443`
5. Change the `cluster-info` ConfigMap in `kube-public` namespace, `kubectl --kubeconfig /etc/karmada/karmada-apiserver.config edit cm -n kube-public cluster-info`, and update the `server` to `server: https://10.10.103.67:32443`
6. Create a token
```
[root@master67 ~]# karmadactl --kubeconfig /etc/karmada/karmada-apiserver.config token create --print-register-command
karmadactl register 10.10.103.67:32443 --token 1tk5q6.16rus1rn7xypmcsu --discovery-token-ca-cert-hash sha256:ac79e69d81083393155bfce2580aa5f40936ca4d636c60907ac22e9fa7adc468
```
7. Execute the register command at a member cluster
```
[root@master68 ~]# karmadactl register 10.10.103.67:32443 --token 1tk5q6.16rus1rn7xypmcsu --discovery-token-ca-cert-hash sha256:ac79e69d81083393155bfce2580aa5f40936ca4d636c60907ac22e9fa7adc468
[preflight] Running pre-flight checks
......
```


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Support Karmada installed by helm to use karmadactl register
```

