### PR TITLE
fix: When suppression and graciously Tasks coexist in the GracefulEvictionTask queue,  the graciously task cannot work.

### DIFF
--- a/pkg/controllers/gracefuleviction/evictiontask_test.go
+++ b/pkg/controllers/gracefuleviction/evictiontask_test.go
@@ -569,7 +569,46 @@ func Test_nextRetry(t *testing.T) {
 				timeout: timeout,
 				timeNow: timeNow.Time,
 			},
-			want: timeout / 10,
+			want: time.Minute * 10,
+		},
+		{
+			name: "suppression and graciously tasks co-exist",
+			args: args{
+				task: []workv1alpha2.GracefulEvictionTask{
+					{
+						FromCluster:       "member1",
+						CreationTimestamp: metav1.Time{Time: timeNow.Add(time.Minute * -60)},
+						SuppressDeletion:  pointer.Bool(true),
+					},
+					{
+						FromCluster:       "member2",
+						CreationTimestamp: metav1.Time{Time: timeNow.Add(time.Minute * -5)},
+					},
+				},
+				timeout: timeout,
+				timeNow: timeNow.Time,
+			},
+			want: time.Minute * 15,
+		},
+		{
+			name: "only suppression tasks",
+			args: args{
+				task: []workv1alpha2.GracefulEvictionTask{
+					{
+						FromCluster:       "member1",
+						CreationTimestamp: metav1.Time{Time: timeNow.Add(time.Minute * -60)},
+						SuppressDeletion:  pointer.Bool(true),
+					},
+					{
+						FromCluster:       "member2",
+						CreationTimestamp: metav1.Time{Time: timeNow.Add(time.Minute * -5)},
+						SuppressDeletion:  pointer.Bool(true),
+					},
+				},
+				timeout: timeout,
+				timeNow: timeNow.Time,
+			},
+			want: 0,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Signed-off-by: chaunceyjiang <chaunceyjiang@gmail.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When susspresion and graciously Tasks coexist in the GracefulEvictionTask queue, the graciously task cannot work.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Once the PurgeMode of Applicationfailover is set to Never, graceful eviction does not work.

Because the `retryInterval` is always less than 0.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

