### PR TITLE
Delete redundant deepcopy

### DIFF
--- a/pkg/controllers/execution/execution_controller.go
+++ b/pkg/controllers/execution/execution_controller.go
@@ -273,8 +273,7 @@ func (c *Controller) updateAppliedCondition(work *workv1alpha1.Work, status meta
 		}
 		updated := &workv1alpha1.Work{}
 		if err = c.Get(context.TODO(), client.ObjectKey{Namespace: work.Namespace, Name: work.Name}, updated); err == nil {
-			// make a copy, so we don't mutate the shared cache
-			work = updated.DeepCopy()
+			work = updated
 		} else {
 			klog.Errorf("Failed to get updated work %s/%s: %v", work.Namespace, work.Name, err)
 		}

--- a/pkg/controllers/federatedresourcequota/federated_resource_quota_status_controller.go
+++ b/pkg/controllers/federatedresourcequota/federated_resource_quota_status_controller.go
@@ -153,8 +153,7 @@ func (c *StatusController) collectQuotaStatus(quota *policyv1alpha1.FederatedRes
 
 		updated := &policyv1alpha1.FederatedResourceQuota{}
 		if err = c.Get(context.TODO(), client.ObjectKey{Namespace: quota.Namespace, Name: quota.Name}, updated); err == nil {
-			// make a copy, so we don't mutate the shared cache
-			quota = updated.DeepCopy()
+			quota = updated
 		} else {
 			klog.Errorf("Failed to get updated  federatedResourceQuota(%s): %v", klog.KObj(quota).String(), err)
 		}

--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -269,8 +269,7 @@ func (c *ClusterStatusController) updateStatusIfNeeded(cluster *clusterv1alpha1.
 
 			updated := &clusterv1alpha1.Cluster{}
 			if err = c.Get(context.TODO(), client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Name}, updated); err == nil {
-				// make a copy, so we don't mutate the shared cache
-				cluster = updated.DeepCopy()
+				cluster = updated
 			} else {
 				klog.Errorf("Failed to get updated cluster %s: %v", cluster.Name, err)
 			}

--- a/pkg/controllers/status/work_status_controller.go
+++ b/pkg/controllers/status/work_status_controller.go
@@ -336,8 +336,7 @@ func (c *WorkStatusController) reflectStatus(work *workv1alpha1.Work, clusterObj
 
 		updated := &workv1alpha1.Work{}
 		if err = c.Get(context.TODO(), client.ObjectKey{Namespace: workCopy.Namespace, Name: workCopy.Name}, updated); err == nil {
-			//make a copy, so we don't mutate the shared cache
-			workCopy = updated.DeepCopy()
+			workCopy = updated
 		} else {
 			klog.Errorf("Failed to get updated work %s/%s: %v", workCopy.Namespace, workCopy.Name, err)
 		}

--- a/pkg/dependenciesdistributor/dependencies_distributor.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor.go
@@ -441,8 +441,7 @@ func (d *DependenciesDistributor) recordDependenciesForIndependentBinding(bindin
 
 		updated := &workv1alpha2.ResourceBinding{}
 		if err = d.Client.Get(context.TODO(), client.ObjectKey{Namespace: binding.Namespace, Name: binding.Name}, updated); err == nil {
-			//make a copy, so we don't mutate the shared cache
-			binding = updated.DeepCopy()
+			binding = updated
 		} else {
 			klog.Errorf("Failed to get updated binding %s/%s: %v", binding.Namespace, binding.Name, err)
 		}

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -1137,8 +1137,7 @@ func (d *ResourceDetector) CleanupResourceBindingLabels(rb *workv1alpha2.Resourc
 
 		updated := &workv1alpha2.ResourceBinding{}
 		if err = d.Client.Get(context.TODO(), client.ObjectKey{Namespace: rb.GetNamespace(), Name: rb.GetName()}, updated); err == nil {
-			//make a copy, so we don't mutate the shared cache
-			rb = updated.DeepCopy()
+			rb = updated
 		} else {
 			klog.Errorf("Failed to get updated resource binding %s/%s: %v", rb.GetNamespace(), rb.GetName(), err)
 		}
@@ -1162,8 +1161,7 @@ func (d *ResourceDetector) CleanupClusterResourceBindingLabels(crb *workv1alpha2
 
 		updated := &workv1alpha2.ClusterResourceBinding{}
 		if err = d.Client.Get(context.TODO(), client.ObjectKey{Name: crb.GetName()}, updated); err == nil {
-			//make a copy, so we don't mutate the shared cache
-			crb = updated.DeepCopy()
+			crb = updated
 		} else {
 			klog.Errorf("Failed to get updated cluster resource binding %s: %v", crb.GetName(), err)
 		}

--- a/pkg/util/helper/workstatus.go
+++ b/pkg/util/helper/workstatus.go
@@ -79,8 +79,7 @@ func AggregateResourceBindingWorkStatus(
 
 		updated := &workv1alpha2.ResourceBinding{}
 		if err = c.Get(context.TODO(), client.ObjectKey{Namespace: binding.Namespace, Name: binding.Name}, updated); err == nil {
-			// make a copy, so we don't mutate the shared cache
-			binding = updated.DeepCopy()
+			binding = updated
 		} else {
 			klog.Errorf("Failed to get updated binding %s/%s: %v", binding.Namespace, binding.Name, err)
 		}
@@ -138,8 +137,7 @@ func AggregateClusterResourceBindingWorkStatus(
 
 		updated := &workv1alpha2.ClusterResourceBinding{}
 		if err = c.Get(context.TODO(), client.ObjectKey{Name: binding.Name}, updated); err == nil {
-			// make a copy, so we don't mutate the shared cache
-			binding = updated.DeepCopy()
+			binding = updated
 		} else {
 			klog.Errorf("Failed to get updated binding %s/%s: %v", binding.Namespace, binding.Name, err)
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The resource object which get from controller is a brand new memory. There will be not any risk of mutating the cache.
See https://github.com/karmada-io/karmada/pull/3538#issuecomment-1549124143 and [controller-runtime examples](https://github.com/kubernetes-sigs/controller-runtime/blob/main/examples/builtins/controller.go). 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None
