### PR TITLE
support to set etcd pvc

### DIFF
--- a/operator/config/samples/karmada.yaml
+++ b/operator/config/samples/karmada.yaml
@@ -11,7 +11,18 @@ spec:
         imageTag: 3.5.3-0
         replicas: 1
         volumeData:
-          emptyDir: {}
+          # hostPath:
+          #   type: DirectoryOrCreate
+          #   path: /var/lib/karmada/etcd/karmada-demo
+          volumeClaim:
+            metadata:
+              name: etcd-data
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 3Gi
     karmadaAPIServer:
       imageRepository: registry.k8s.io/kube-apiserver
       imageTag: v1.25.4

--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -56,6 +56,8 @@ const (
 	EtcdListenPeerPort = 2380
 	// KarmadaAPIserverListenClientPort defines the port karmada apiserver listen on for client traffic
 	KarmadaAPIserverListenClientPort = 5443
+	// EtcdDataVolumeName defines the name to etcd data volume
+	EtcdDataVolumeName = "etcd-data"
 
 	// CertificateValidity Certificate validity period
 	CertificateValidity = time.Hour * 24 * 365

--- a/operator/pkg/controlplane/etcd/mainfests.go
+++ b/operator/pkg/controlplane/etcd/mainfests.go
@@ -71,15 +71,13 @@ spec:
           protocol: TCP
         volumeMounts:
         - mountPath: /var/lib/etcd
-          name: etcd-data
+          name: {{ .EtcdDataVolumeName }}
         - mountPath: /etc/karmada/pki/etcd
           name: etcd-cert
       volumes:
       - name: etcd-cert
         secret:
           secretName: {{ .CertsSecretName }}
-      - name: etcd-data
-        emptyDir: {}
 `
 
 	// KarmadaEtcdClientService is karmada etcd client service manifest


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
etcd data is need to restore a real disk, so we support two ways to do it: `HostPath`, `PVC`.

here is test results:
karmada yaml resource:
```yaml
apiVersion: operator.karmada.io/v1alpha1
kind: Karmada
metadata:
  name: karmada-demo
  namespace: test
spec:
  components:
    etcd:
      local:
        imageRepository: registry.k8s.io/etcd
        imageTag: 3.5.3-0
        replicas: 1
        volumeData:
          volumeClaim:
            metadata:
              name: etcd-data
            spec:
              accessModes:
                - ReadWriteOnce
              resources:
                requests:
                  storage: 3Gi
```

the etcd pod is running:

<img width="837" alt="image" src="https://github.com/karmada-io/karmada/assets/45745657/28153ad3-c4eb-44e9-b2ad-8fccbd71f14c">

<img width="938" alt="image" src="https://github.com/karmada-io/karmada/assets/45745657/2557c0a5-838d-4bf9-8647-aa5aa4214e9f">


/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
support to set etcd pvc.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

