### PR TITLE
Update golangci-lint to v1.52.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ run:
   - hack/tools/preferredimports # This code is directly lifted from the Kubernetes codebase, skip checking
   - (^|/)vendor($|/)
   - (^|/)third_party($|/)
+  - pkg/util/lifted # This code is lifted from other projects(Kubernetes, Kubefed, and so on), skip checking.
 
   # default is true. Enables skipping of directories:
   #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
@@ -59,6 +60,12 @@ linters-settings:
       - Standard
       - Default
       - Prefix(github.com/karmada-io/karmada)
+  revive:
+    rules:
+      # Disable if-return as it is too strict and not always useful.
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#if-return
+      - name: if-return
+        disabled: true
 
 issues:
   # The list of ids of default excludes to include or disable. By default it's empty.

--- a/hack/tools/swagger/lib/storage.go
+++ b/hack/tools/swagger/lib/storage.go
@@ -39,7 +39,7 @@ var _ rest.Patcher = &StatusREST{}
 var _ rest.Connecter = &ProxyREST{}
 
 // GroupVersionKind implement GroupVersionKind interface.
-func (r *StandardREST) GroupVersionKind(containingGV schema.GroupVersion) schema.GroupVersionKind {
+func (r *StandardREST) GroupVersionKind(_ schema.GroupVersion) schema.GroupVersionKind {
 	return r.cfg.gvk
 }
 
@@ -54,12 +54,12 @@ func (r *StandardREST) New() runtime.Object {
 }
 
 // Create implement Create interface.
-func (r *StandardREST) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
+func (r *StandardREST) Create(_ context.Context, _ runtime.Object, _ rest.ValidateObjectFunc, _ *metav1.CreateOptions) (runtime.Object, error) {
 	return r.New(), nil
 }
 
 // Get implement Get interface.
-func (r *StandardREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+func (r *StandardREST) Get(_ context.Context, _ string, _ *metav1.GetOptions) (runtime.Object, error) {
 	return r.New(), nil
 }
 
@@ -69,32 +69,32 @@ func (r *StandardREST) NewList() runtime.Object {
 }
 
 // List implement List interface.
-func (r *StandardREST) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
+func (r *StandardREST) List(_ context.Context, _ *metainternalversion.ListOptions) (runtime.Object, error) {
 	return r.NewList(), nil
 }
 
 // ConvertToTable implement ConvertToTable interface.
-func (r *StandardREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+func (r *StandardREST) ConvertToTable(_ context.Context, _ runtime.Object, _ runtime.Object) (*metav1.Table, error) {
 	return nil, nil
 }
 
 // Update implement Update interface.
-func (r *StandardREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+func (r *StandardREST) Update(_ context.Context, _ string, _ rest.UpdatedObjectInfo, _ rest.ValidateObjectFunc, _ rest.ValidateObjectUpdateFunc, _ bool, _ *metav1.UpdateOptions) (runtime.Object, bool, error) {
 	return r.New(), true, nil
 }
 
 // Delete implement Delete interface.
-func (r *StandardREST) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
+func (r *StandardREST) Delete(_ context.Context, _ string, _ rest.ValidateObjectFunc, _ *metav1.DeleteOptions) (runtime.Object, bool, error) {
 	return r.New(), true, nil
 }
 
 // DeleteCollection implement DeleteCollection interface.
-func (r *StandardREST) DeleteCollection(ctx context.Context, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions, listOptions *metainternalversion.ListOptions) (runtime.Object, error) {
+func (r *StandardREST) DeleteCollection(_ context.Context, _ rest.ValidateObjectFunc, _ *metav1.DeleteOptions, _ *metainternalversion.ListOptions) (runtime.Object, error) {
 	return r.NewList(), nil
 }
 
 // Watch implement Watch interface.
-func (r *StandardREST) Watch(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
+func (r *StandardREST) Watch(_ context.Context, _ *metainternalversion.ListOptions) (watch.Interface, error) {
 	return nil, nil
 }
 
@@ -105,7 +105,7 @@ func (r *StandardREST) Destroy() {
 }
 
 // GroupVersionKind implement GroupVersionKind interface.
-func (r *StatusREST) GroupVersionKind(containingGV schema.GroupVersion) schema.GroupVersionKind {
+func (r *StatusREST) GroupVersionKind(_ schema.GroupVersion) schema.GroupVersionKind {
 	return r.cfg.gvk
 }
 
@@ -115,12 +115,12 @@ func (r *StatusREST) New() runtime.Object {
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+func (r *StatusREST) Update(_ context.Context, _ string, _ rest.UpdatedObjectInfo, _ rest.ValidateObjectFunc, _ rest.ValidateObjectUpdateFunc, _ bool, _ *metav1.UpdateOptions) (runtime.Object, bool, error) {
 	return r.New(), true, nil
 }
 
 // Get retrieves the status object.
-func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+func (r *StatusREST) Get(_ context.Context, _ string, _ *metav1.GetOptions) (runtime.Object, error) {
 	return r.New(), nil
 }
 
@@ -146,7 +146,7 @@ func (r *ProxyREST) NewConnectOptions() (runtime.Object, bool, string) {
 }
 
 // Connect implement Connect interface.
-func (r *ProxyREST) Connect(ctx context.Context, id string, options runtime.Object, responder rest.Responder) (http.Handler, error) {
+func (r *ProxyREST) Connect(_ context.Context, _ string, _ runtime.Object, _ rest.Responder) (http.Handler, error) {
 	return nil, nil
 }
 

--- a/hack/verify-staticcheck.sh
+++ b/hack/verify-staticcheck.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-GOLANGCI_LINT_VER="v1.49.0"
+GOLANGCI_LINT_VER="v1.52.2"
 
 cd "${REPO_ROOT}"
 source "hack/util.sh"

--- a/pkg/karmadactl/cmdinit/cert/cert_test.go
+++ b/pkg/karmadactl/cmdinit/cert/cert_test.go
@@ -16,7 +16,7 @@ const (
 	TestCertsTmp = "./test-certs-tmp"
 )
 
-func TestGenCerts(t *testing.T) {
+func TestGenCerts(_ *testing.T) {
 	defer os.RemoveAll(TestCertsTmp)
 
 	notAfter := time.Now().Add(Duration365d * 10).UTC()

--- a/pkg/karmadactl/cmdinit/utils/examples_test.go
+++ b/pkg/karmadactl/cmdinit/utils/examples_test.go
@@ -2,6 +2,6 @@ package utils
 
 import "testing"
 
-func TestGenExamples(t *testing.T) {
+func TestGenExamples(_ *testing.T) {
 	GenExamples("/tmp", "kubectl karmada", " register")
 }

--- a/pkg/webhook/multiclusteringress/validating.go
+++ b/pkg/webhook/multiclusteringress/validating.go
@@ -25,7 +25,7 @@ var _ admission.DecoderInjector = &ValidatingAdmission{}
 
 // Handle implements admission.Handler interface.
 // It yields a response to an AdmissionRequest.
-func (v *ValidatingAdmission) Handle(ctx context.Context, req admission.Request) admission.Response {
+func (v *ValidatingAdmission) Handle(_ context.Context, req admission.Request) admission.Response {
 	mci := &networkingv1alpha1.MultiClusterIngress{}
 
 	err := v.decoder.Decode(req, mci)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR updates golangci-lint to v1.52.2 which including go1.20 support.

This PR is required by #3565.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

