### PR TITLE
feat: supports aggregating the status of a pod's initContainer

### DIFF
--- a/pkg/resourceinterpreter/default/native/aggregatestatus.go
+++ b/pkg/resourceinterpreter/default/native/aggregatestatus.go
@@ -385,6 +385,13 @@ func aggregatePodStatus(object *unstructured.Unstructured, aggregatedStatusItems
 			}
 			newStatus.ContainerStatuses = append(newStatus.ContainerStatuses, tempStatus)
 		}
+		for _, initContainerStatus := range temp.InitContainerStatuses {
+			tempStatus := corev1.ContainerStatus{
+				Ready: initContainerStatus.Ready,
+				State: initContainerStatus.State,
+			}
+			newStatus.InitContainerStatuses = append(newStatus.InitContainerStatuses, tempStatus)
+		}
 		klog.V(3).Infof("Grab pod(%s/%s) status from cluster(%s), phase: %s", pod.Namespace,
 			pod.Name, item.ClusterName, temp.Phase)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

supports aggregating the status of a pod's initContainer

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: supports aggregating the status of a pod's initContainer.
```

