### PR TITLE
remove ci todo annotation of adopt Node16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,6 @@ jobs:
         with:
           go-version: 1.20.4
       - name: Install Protoc
-        # TODO(@RainbowMango): Update the action version to adopt Node16
-        # track issue: https://github.com/arduino/setup-protoc/issues/59
         uses: arduino/setup-protoc@v1
         with:
           version: '3.x'


### PR DESCRIPTION
Signed-off-by: zishen <softwarebtg@163.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
For Node12 has been adapt to Node16, see ：https://github.com/arduino/setup-protoc/issues/59
so this comment should be removed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE