### PR TITLE
karmada operator: add conditions to karmada cr

### DIFF
--- a/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
+++ b/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
@@ -16,8 +16,8 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.controlPlaneReady
-      name: Status
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age

--- a/operator/config/crds/operator.karmada.io_karmadas.yaml
+++ b/operator/config/crds/operator.karmada.io_karmadas.yaml
@@ -16,8 +16,8 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.controlPlaneReady
-      name: Status
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age

--- a/operator/pkg/apis/operator/v1alpha1/helper.go
+++ b/operator/pkg/apis/operator/v1alpha1/helper.go
@@ -2,9 +2,48 @@ package v1alpha1
 
 import (
 	"fmt"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Name returns the image name.
 func (image *Image) Name() string {
 	return fmt.Sprintf("%s:%s", image.ImageRepository, image.ImageTag)
+}
+
+func KarmadaInProgressing(karmada *Karmada, conditionType ConditionType, message string) {
+	karmada.Status.Conditions = []metav1.Condition{}
+	newCondition := metav1.Condition{
+		Type:    string(conditionType),
+		Status:  metav1.ConditionFalse,
+		Reason:  "Progressing",
+		Message: message,
+	}
+
+	apimeta.SetStatusCondition(&karmada.Status.Conditions, newCondition)
+}
+
+func KarmadaCompleted(karmada *Karmada, conditionType ConditionType, message string) {
+	karmada.Status.Conditions = []metav1.Condition{}
+	newCondition := metav1.Condition{
+		Type:    string(conditionType),
+		Status:  metav1.ConditionTrue,
+		Reason:  "Completed",
+		Message: message,
+	}
+
+	apimeta.SetStatusCondition(&karmada.Status.Conditions, newCondition)
+}
+
+func KarmadaFailed(karmada *Karmada, conditionType ConditionType, message string) {
+	karmada.Status.Conditions = []metav1.Condition{}
+	newCondition := metav1.Condition{
+		Type:    string(conditionType),
+		Status:  metav1.ConditionFalse,
+		Reason:  "Failed",
+		Message: message,
+	}
+
+	apimeta.SetStatusCondition(&karmada.Status.Conditions, newCondition)
 }

--- a/operator/pkg/apis/operator/v1alpha1/type.go
+++ b/operator/pkg/apis/operator/v1alpha1/type.go
@@ -25,7 +25,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
 // +kubebuilder:path=karmadas,scope=Namespaced,categories={karmada-io}
-// +kubebuilder:printcolumn:JSONPath=`.status.controlPlaneReady`,name="Status",type=string
+// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Ready")].status`,name="Ready",type=string
 // +kubebuilder:printcolumn:JSONPath=`.metadata.creationTimestamp`,name="Age",type=date
 
 // Karmada enables declarative installation of karmada.
@@ -557,10 +557,6 @@ type HostCluster struct {
 type ConditionType string
 
 const (
-	// Unknown represent a condition type the karmada not be reconciled by operator
-	// or unpredictable condition.
-	Unknown ConditionType = "Unknown"
-
 	// Ready represent a condition type the all installation process to karmada have completed.
 	Ready ConditionType = "Ready"
 )

--- a/operator/pkg/controller/karmada/controller.go
+++ b/operator/pkg/controller/karmada/controller.go
@@ -59,8 +59,8 @@ func (ctrl *Controller) Reconcile(ctx context.Context, req controllerruntime.Req
 
 	// The object is being deleted
 	if !karmada.DeletionTimestamp.IsZero() {
-		value, isExist := karmada.Labels[DisableCascadingDeletionLabel]
-		if !isExist || value == strconv.FormatBool(false) {
+		val, ok := karmada.Labels[DisableCascadingDeletionLabel]
+		if !ok || val == strconv.FormatBool(false) {
 			if err := ctrl.syncKarmada(karmada); err != nil {
 				return controllerruntime.Result{}, err
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
In init and deinit, we need more informations to observe the karmada current status.

here is test result:

```shell
kubectl get karmada -n test
NAME           READY   AGE
karmada-demo   False   27m
```

the cr status message:

<img width="650" alt="image" src="https://github.com/karmada-io/karmada/assets/45745657/b8cd0ba1-776f-4b23-aee1-cab96cbd7450">



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

