### PR TITLE
add chart lint ci step for karmada-operaoter chart

### DIFF
--- a/.github/workflows/lint-chart.yaml
+++ b/.github/workflows/lint-chart.yaml
@@ -11,7 +11,7 @@ on:
   push:
   pull_request:
     paths:
-      - "charts/karmada/**"
+      - "charts/**"
 
 jobs:
   chart-lint-test:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
In this pr https://github.com/karmada-io/karmada/pull/3524, the chart karmada-operaoter is introduced and the chart lint ci step is missing


**Which issue(s) this PR fixes**:
Fixes #3579 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

