### PR TITLE
Automated cherry pick of #3591: Change the length of modelSortings array for panic of index

### DIFF
--- a/pkg/modeling/modeling.go
+++ b/pkg/modeling/modeling.go
@@ -84,7 +84,7 @@ func InitSummary(resourceModels []clusterapis.ResourceModel) (ResourceSummary, e
 	}
 	rs = make(ResourceSummary, len(rsList))
 	// generate a sorted array by first priority of ResourceName
-	modelSortings = make([][]resource.Quantity, len(rsList))
+	modelSortings = make([][]resource.Quantity, len(rsName))
 	for index := 0; index < len(rsList); index++ {
 		for i, name := range rsName {
 			modelSortings[i] = append(modelSortings[i], rsList[index][name])

--- a/pkg/modeling/modeling_test.go
+++ b/pkg/modeling/modeling_test.go
@@ -96,6 +96,35 @@ func TestInitSummaryError(t *testing.T) {
 	}
 }
 
+func TestInitSummaryWithOneGrade(t *testing.T) {
+	rms := []clusterapis.ResourceModel{
+		{
+			Grade: 0,
+			Ranges: []clusterapis.ResourceModelRange{
+				{
+					Name: clusterapis.ResourceCPU,
+					Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
+					Max:  *resource.NewQuantity(1, resource.DecimalSI),
+				},
+				{
+					Name: clusterapis.ResourceMemory,
+					Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
+					Max:  *resource.NewQuantity(1024, resource.DecimalSI),
+				},
+			},
+		},
+	}
+
+	rs, err := InitSummary(rms)
+	if actualValue := len(rs); actualValue != 1 {
+		t.Errorf("Got %v expected %v", actualValue, 1)
+	}
+
+	if err != nil {
+		t.Errorf("Got %v expected %v", err, nil)
+	}
+}
+
 func TestSearchLastLessElement(t *testing.T) {
 	nums, target := []resource.Quantity{
 		*resource.NewMilliQuantity(1999, resource.DecimalSI),


### PR DESCRIPTION
Cherry pick of #3591 on release-1.3.
#3591: Change the length of modelSortings array for panic of index
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`: Fixed the panic issue in case of the grade number of resourceModel is less than the number of resources.
```