### PR TITLE
api: delete the useless Scheme.AddUnversionedTypes code

### DIFF
--- a/pkg/apis/cluster/scheme/regiser.go
+++ b/pkg/apis/cluster/scheme/regiser.go
@@ -25,14 +25,4 @@ func init() {
 	// we need to add the options to empty v1
 	// TODO fix the server code to avoid this
 	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
-
-	// TODO: keep the generic API server from wanting this
-	unversioned := schema.GroupVersion{Group: "", Version: "v1"}
-	Scheme.AddUnversionedTypes(unversioned,
-		&metav1.Status{},
-		&metav1.APIVersions{},
-		&metav1.APIGroupList{},
-		&metav1.APIGroup{},
-		&metav1.APIResourceList{},
-	)
 }

--- a/pkg/apis/search/scheme/register.go
+++ b/pkg/apis/search/scheme/register.go
@@ -29,14 +29,4 @@ func init() {
 	// we need to add the options to empty v1
 	// TODO fix the server code to avoid this
 	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
-
-	// TODO: keep the generic API server from wanting this
-	unversioned := schema.GroupVersion{Group: "", Version: "v1"}
-	Scheme.AddUnversionedTypes(unversioned,
-		&metav1.Status{},
-		&metav1.APIVersions{},
-		&metav1.APIGroupList{},
-		&metav1.APIGroup{},
-		&metav1.APIResourceList{},
-	)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The `Scheme.AddUnversionedTypes` code in the init function is redundant because this part of the logic already exists in `metav1.AddToGroupVersion`.


https://github.com/karmada-io/karmada/blob/master/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/register.go#L75

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

