### PR TITLE
Add printcolumn for FederatedHPA

### DIFF
--- a/charts/karmada/_crds/bases/autoscaling.karmada.io_federatedhpas.yaml
+++ b/charts/karmada/_crds/bases/autoscaling.karmada.io_federatedhpas.yaml
@@ -19,7 +19,26 @@ spec:
     singular: federatedhpa
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.scaleTargetRef.kind
+      name: REFERENCE-KIND
+      type: string
+    - jsonPath: .spec.scaleTargetRef.name
+      name: REFERENCE-NAME
+      type: string
+    - jsonPath: .spec.minReplicas
+      name: MINPODS
+      type: integer
+    - jsonPath: .spec.maxReplicas
+      name: MAXPODS
+      type: integer
+    - jsonPath: .status.currentReplicas
+      name: REPLICAS
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: FederatedHPA is centralized HPA that can aggregate the metrics

--- a/pkg/apis/autoscaling/v1alpha1/federatedhpa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/federatedhpa_types.go
@@ -9,6 +9,12 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=fhpa,categories={karmada-io}
+// +kubebuilder:printcolumn:JSONPath=`.spec.scaleTargetRef.kind`,name=`REFERENCE-KIND`,type=string
+// +kubebuilder:printcolumn:JSONPath=`.spec.scaleTargetRef.name`,name=`REFERENCE-NAME`,type=string
+// +kubebuilder:printcolumn:JSONPath=`.spec.minReplicas`,name=`MINPODS`,type=integer
+// +kubebuilder:printcolumn:JSONPath=`.spec.maxReplicas`,name=`MAXPODS`,type=integer
+// +kubebuilder:printcolumn:JSONPath=`.status.currentReplicas`,name=`REPLICAS`,type=integer
+// +kubebuilder:printcolumn:JSONPath=`.metadata.creationTimestamp`,name=`AGE`,type=date
 
 // FederatedHPA is centralized HPA that can aggregate the metrics in multiple clusters.
 // When the system load increases, it will query the metrics from multiple clusters and scales up the replicas.


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
Add printcolumn for FederatedHPA
```
NAME         REFERENCE-KIND   REFERENCE-NAME   MINPODS   MAXPODS   REPLICAS   AGE
nginx-test   Deployment       nginx            1         10        1          5d1h
```
Unlike the native HPA, FederatedHPA cannot print the target utilization as the limit of CRD. As far as I know, CRD‘s print column only supports definite json path.

The native hpa is like:
```
NAME         REFERENCE          TARGETS        MINPODS   MAXPODS   REPLICAS   AGE
nginx-test   Deployment/nginx   <unknown>/10   1         10        0          3h59m
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```
api-change:  add printcolumn for `FederatedHPA`, including reference, minpods, maxpods and replicas.
```
