### PR TITLE
Implement proxy headers of cluster API

### DIFF
--- a/pkg/util/membercluster_client.go
+++ b/pkg/util/membercluster_client.go
@@ -201,6 +201,10 @@ func BuildClusterConfig(clusterName string,
 			return nil, err
 		}
 		clusterConfig.Proxy = http.ProxyURL(proxy)
+
+		if len(cluster.Spec.ProxyHeader) != 0 {
+			clusterConfig.Wrap(NewProxyHeaderRoundTripperWrapperConstructor(clusterConfig.WrapTransport, cluster.Spec.ProxyHeader))
+		}
 	}
 
 	return clusterConfig, nil

--- a/pkg/util/round_trippers.go
+++ b/pkg/util/round_trippers.go
@@ -1,0 +1,51 @@
+package util
+
+import (
+	"net/http"
+	"net/textproto"
+	"strings"
+
+	"k8s.io/client-go/transport"
+)
+
+type proxyHeaderRoundTripper struct {
+	proxyHeaders http.Header
+	roundTripper http.RoundTripper
+}
+
+var _ http.RoundTripper = &proxyHeaderRoundTripper{}
+
+// NewProxyHeaderRoundTripperWrapperConstructor returns a RoundTripper wrapper that's usable within restConfig.WrapTransport.
+func NewProxyHeaderRoundTripperWrapperConstructor(wt transport.WrapperFunc, headers map[string]string) transport.WrapperFunc {
+	return func(rt http.RoundTripper) http.RoundTripper {
+		if wt != nil {
+			rt = wt(rt)
+		}
+		return &proxyHeaderRoundTripper{
+			proxyHeaders: parseProxyHeaders(headers),
+			roundTripper: rt,
+		}
+	}
+}
+
+// RoundTrip implements the http.RoundTripper interface.
+func (r *proxyHeaderRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if tr, ok := r.roundTripper.(*http.Transport); ok {
+		tr = tr.Clone()
+		tr.ProxyConnectHeader = r.proxyHeaders
+		return tr.RoundTrip(req)
+	}
+	return r.roundTripper.RoundTrip(req)
+}
+
+func parseProxyHeaders(headers map[string]string) http.Header {
+	if len(headers) == 0 {
+		return nil
+	}
+
+	proxyHeaders := make(http.Header)
+	for key, values := range headers {
+		proxyHeaders[textproto.CanonicalMIMEHeaderKey(key)] = strings.Split(values, ",")
+	}
+	return proxyHeaders
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Since we have add proxy headers in cluster API, I'd like to implement proxy headers of cluster API.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```
`karmada-controller-manager`: implement proxy header of cluster API
```

