### PR TITLE
Automated cherry pick of #3496: fix When EnableEmptyWorkloadPropagation flag is false zero

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -190,7 +190,11 @@ func (g *genericScheduler) assignReplicas(
 			return nil, fmt.Errorf("unsupported replica scheduling strategy, replicaSchedulingType: %s, replicaDivisionPreference: %s, "+
 				"please try another scheduling strategy", replicaSchedulingStrategy.ReplicaSchedulingType, replicaSchedulingStrategy.ReplicaDivisionPreference)
 		}
-		return assignFunc(state)
+		assignResults, err := assignFunc(state)
+		if err != nil {
+			return nil, err
+		}
+		return removeZeroReplicasCluster(assignResults), nil
 	}
 
 	// If not workload, assign all clusters without considering replicas.

--- a/pkg/scheduler/core/util.go
+++ b/pkg/scheduler/core/util.go
@@ -89,3 +89,14 @@ func attachZeroReplicasCluster(clusters []*clusterv1alpha1.Cluster, targetCluste
 	}
 	return targetClusters
 }
+
+// removeZeroReplicasCLuster remove the cluster with 0 replicas in assignResults
+func removeZeroReplicasCluster(assignResults []workv1alpha2.TargetCluster) []workv1alpha2.TargetCluster {
+	targetClusters := make([]workv1alpha2.TargetCluster, 0, len(assignResults))
+	for _, cluster := range assignResults {
+		if cluster.Replicas > 0 {
+			targetClusters = append(targetClusters, workv1alpha2.TargetCluster{Name: cluster.Name, Replicas: cluster.Replicas})
+		}
+	}
+	return targetClusters
+}

--- a/test/e2e/scheduling_test.go
+++ b/test/e2e/scheduling_test.go
@@ -537,6 +537,7 @@ var _ = ginkgo.Describe("[ReplicaScheduling] ReplicaSchedulingStrategy testing",
 	ginkgo.Context("ReplicaSchedulingType is Divided, ReplicaDivisionPreference is Weighted, WeightPreference isn't "+
 		"nil, trigger rescheduling when replicas have changed.", func() {
 		ginkgo.BeforeEach(func() {
+			sumWeight := 0
 			staticWeightLists := make([]policyv1alpha1.StaticClusterWeight, 0)
 			for index, clusterName := range framework.ClusterNames() {
 				staticWeightList := policyv1alpha1.StaticClusterWeight{
@@ -546,6 +547,7 @@ var _ = ginkgo.Describe("[ReplicaScheduling] ReplicaSchedulingStrategy testing",
 					Weight: int64(index + 1),
 				}
 				staticWeightLists = append(staticWeightLists, staticWeightList)
+				sumWeight += index + 1
 			}
 			klog.Infof("StaticWeightList of policy is %+v", staticWeightLists)
 			policy.Spec.Placement.ReplicaScheduling = &policyv1alpha1.ReplicaSchedulingStrategy{
@@ -555,6 +557,8 @@ var _ = ginkgo.Describe("[ReplicaScheduling] ReplicaSchedulingStrategy testing",
 					StaticWeightList: staticWeightLists,
 				},
 			}
+			sumReplicas := int32(sumWeight)
+			deployment.Spec.Replicas = &sumReplicas
 		})
 
 		ginkgo.It("replicas divided and weighted testing when rescheduling", func() {


### PR DESCRIPTION
Cherry pick of #3496 on release-1.5.
#3496: fix When EnableEmptyWorkloadPropagation flag is false zero
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-scheduler`: Fixed the issue that empty deployment can still be propagated to member clusters even when `--enableEmptyWorkloadPropagation` flag is false.
```