### PR TITLE
metrics-adapter: when different clusters have the same pod name, the annotations of different metrics have the same value

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/well_known_constants.go
+++ b/pkg/apis/autoscaling/v1alpha1/well_known_constants.go
@@ -1,0 +1,7 @@
+package v1alpha1
+
+const (
+	// QuerySourceAnnotationKey is the annotation used in karmada-metrics-adapter to
+	// record the query source cluster
+	QuerySourceAnnotationKey = "resource.karmada.io/query-from-cluster"
+)


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

when different clusters have the same pod name, the annotations of different metrics have the same value

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-metrics-adapter`: fix when different clusters have the same pod name, the annotations of different metrics have the same value
```

