### PR TITLE
feat: Add script to deploy k8s metrics-server in member cluster

### DIFF
--- a/hack/deploy-k8s-metrics-server.sh
+++ b/hack/deploy-k8s-metrics-server.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+_tmp=$(mktemp -d)
+
+function usage() {
+  echo "This script will deploy metrics-server in member clusters."
+  echo "Usage: hack/deploy-k8s-metrics-server.sh <MEMBER_CLUSTER_KUBECONFIG> <MEMBER_CLUSTER_NAME>"
+  echo "Example: hack/deploy-k8s-metrics-server.sh ~/.kube/members.config member1"
+}
+
+cleanup() {
+  rm -rf "${_tmp}"
+}
+trap "cleanup" EXIT SIGINT
+
+if [[ $# -ne 2 ]]; then
+  usage
+  exit 1
+fi
+
+# check kube config file existence
+if [[ ! -f "${1}" ]]; then
+  echo -e "ERROR: failed to get kubernetes config file: '${1}', not existed.\n"
+  usage
+  exit 1
+fi
+MEMBER_CLUSTER_KUBECONFIG=$1
+
+# check context existence
+if ! kubectl config get-contexts "${2}" --kubeconfig="${MEMBER_CLUSTER_KUBECONFIG}" > /dev/null 2>&1;
+then
+  echo -e "ERROR: failed to get context: '${2}' not in ${MEMBER_CLUSTER_KUBECONFIG}. \n"
+  usage
+  exit 1
+fi
+MEMBER_CLUSTER_NAME=$2
+
+# get deploy yaml
+wget https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.6.3/components.yaml -O "${_tmp}/components.yaml"
+sed -i'' -e 's/args:/args:\n        - --kubelet-insecure-tls=true/' "${_tmp}/components.yaml"
+
+# deploy metrics-server in member cluster
+kubectl --kubeconfig="${MEMBER_CLUSTER_KUBECONFIG}" --context="${MEMBER_CLUSTER_NAME}" apply -f "${_tmp}/components.yaml"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When using FederatedHPA, `metrics-server` needs to be installed in member clusters.
So we provider a script to install `metrics-server` in member cluster conveniently.


**Which issue(s) this PR fixes**:
Fixes #none

**Special notes for your reviewer**:
Testing report:
```sh
root@karmada [02:38:05 PM] [~/workspace/git/karmada] [install-script *]
-> # k get pods -A
NAMESPACE            NAME                                            READY   STATUS    RESTARTS   AGE
karmada-system       karmada-agent-648c99647-qvkf5                   1/1     Running   0          3d23h
karmada-system       karmada-agent-648c99647-tfw2m                   1/1     Running   0          3d23h
kube-system          coredns-787d4945fb-9pfm2                        1/1     Running   0          3d23h
kube-system          coredns-787d4945fb-mx9w5                        1/1     Running   0          3d23h
kube-system          etcd-member3-control-plane                      1/1     Running   0          3d23h
kube-system          kindnet-8r4qt                                   1/1     Running   0          3d23h
kube-system          kube-apiserver-member3-control-plane            1/1     Running   0          3d23h
kube-system          kube-controller-manager-member3-control-plane   1/1     Running   0          3d23h
kube-system          kube-proxy-z8xsc                                1/1     Running   0          3d23h
kube-system          kube-scheduler-member3-control-plane            1/1     Running   0          3d23h
local-path-storage   local-path-provisioner-c8855d4bb-mzmth          1/1     Running   0          3d23h
root@karmada [02:38:07 PM] [~/workspace/git/karmada] [install-script *]
-> # hack/deploy-k8s-metrics-server.sh $HOME/.kube/members.config member3
--2023-06-13 14:38:12--  https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.6.3/components.yaml
Resolving github.com (github.com)... 20.205.243.166
Connecting to github.com (github.com)|20.205.243.166|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/92132038/22f5d9ae-42db-4bae-86a2-771cc0477b2e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYA                           X4CSVEH53A%2F20230613%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230613T063733Z&X-Amz-Expires=300&X-Amz-Signature=1aa531ae8177e671bf001d8025628a05a24a3e5da6af41ce2baae51eac19592e&X-Amz-Signed                           Headers=host&actor_id=0&key_id=0&repo_id=92132038&response-content-disposition=attachment%3B%20filename%3Dcomponents.yaml&response-content-type=application%2Foctet-stream [following]
--2023-06-13 14:38:12--  https://objects.githubusercontent.com/github-production-release-asset-2e65be/92132038/22f5d9ae-42db-4bae-86a2-771cc0477b2e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Creden                           tial=AKIAIWNJYAX4CSVEH53A%2F20230613%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230613T063733Z&X-Amz-Expires=300&X-Amz-Signature=1aa531ae8177e671bf001d8025628a05a24a3e5da6af41ce2baae51eac1959                           2e&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=92132038&response-content-disposition=attachment%3B%20filename%3Dcomponents.yaml&response-content-type=application%2Foctet-stream
Resolving objects.githubusercontent.com (objects.githubusercontent.com)... 185.199.111.133, 185.199.108.133, 185.199.109.133, ...
Connecting to objects.githubusercontent.com (objects.githubusercontent.com)|185.199.111.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 4186 (4.1K) [application/octet-stream]
Saving to: ‘/tmp/tmp.TfHvwzb8c8/components.yaml’

/tmp/tmp.TfHvwzb8c8/components.yaml              100%[=======================================================================================================>]   4.09K  --.-KB/s    in 0s

2023-06-13 14:38:12 (58.9 MB/s) - ‘/tmp/tmp.TfHvwzb8c8/components.yaml’ saved [4186/4186]

serviceaccount/metrics-server created
clusterrole.rbac.authorization.k8s.io/system:aggregated-metrics-reader created
clusterrole.rbac.authorization.k8s.io/system:metrics-server created
rolebinding.rbac.authorization.k8s.io/metrics-server-auth-reader created
clusterrolebinding.rbac.authorization.k8s.io/metrics-server:system:auth-delegator created
clusterrolebinding.rbac.authorization.k8s.io/system:metrics-server created
service/metrics-server created
deployment.apps/metrics-server created
apiservice.apiregistration.k8s.io/v1beta1.metrics.k8s.io created
root@karmada [02:38:13 PM] [~/workspace/git/karmada] [install-script *]
-> # k get pods -A
NAMESPACE            NAME                                            READY   STATUS    RESTARTS   AGE
karmada-system       karmada-agent-648c99647-qvkf5                   1/1     Running   0          3d23h
karmada-system       karmada-agent-648c99647-tfw2m                   1/1     Running   0          3d23h
kube-system          coredns-787d4945fb-9pfm2                        1/1     Running   0          3d23h
kube-system          coredns-787d4945fb-mx9w5                        1/1     Running   0          3d23h
kube-system          etcd-member3-control-plane                      1/1     Running   0          3d23h
kube-system          kindnet-8r4qt                                   1/1     Running   0          3d23h
kube-system          kube-apiserver-member3-control-plane            1/1     Running   0          3d23h
kube-system          kube-controller-manager-member3-control-plane   1/1     Running   0          3d23h
kube-system          kube-proxy-z8xsc                                1/1     Running   0          3d23h
kube-system          kube-scheduler-member3-control-plane            1/1     Running   0          3d23h
kube-system          metrics-server-5c84698c5d-jhkcz                 0/1     Running   0          7s
local-path-storage   local-path-provisioner-c8855d4bb-mzmth          1/1     Running   0          3d23h


```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

