### PR TITLE
Setup operator API owners

### DIFF
--- a/operator/pkg/apis/OWNERS
+++ b/operator/pkg/apis/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+- calvin0327
+- lonelyCZ
+- Poor12
+approvers:
+- RainbowMango
+options:
+  no_parent_owners: true


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR added me to the list of Karmada Operator APIs, the option [no_parent_owners](https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md#owners) ensures I won't be missed from review of API changes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

Assigning operator owners:
/assign @calvin0327 @lonelyCZ @Poor12 
