### PR TITLE
feat: Fix version parse

### DIFF
--- a/pkg/karmadactl/addons/init/enable_option.go
+++ b/pkg/karmadactl/addons/init/enable_option.go
@@ -63,11 +63,11 @@ func init() {
 		klog.Infof("No default release version found. build version: %s", version.Get().String())
 		releaseVer = &version.ReleaseVersion{} // initialize to avoid panic
 	}
-	karmadaRelease = releaseVer.PatchRelease()
+	karmadaRelease = releaseVer.ReleaseVersion()
 
-	DefaultKarmadaDeschedulerImage = fmt.Sprintf("docker.io/karmada/karmada-descheduler:%s", releaseVer.PatchRelease())
-	DefaultKarmadaSchedulerEstimatorImage = fmt.Sprintf("docker.io/karmada/karmada-scheduler-estimator:%s", releaseVer.PatchRelease())
-	DefaultKarmadaSearchImage = fmt.Sprintf("docker.io/karmada/karmada-search:%s", releaseVer.PatchRelease())
+	DefaultKarmadaDeschedulerImage = fmt.Sprintf("docker.io/karmada/karmada-descheduler:%s", releaseVer.ReleaseVersion())
+	DefaultKarmadaSchedulerEstimatorImage = fmt.Sprintf("docker.io/karmada/karmada-scheduler-estimator:%s", releaseVer.ReleaseVersion())
+	DefaultKarmadaSearchImage = fmt.Sprintf("docker.io/karmada/karmada-search:%s", releaseVer.ReleaseVersion())
 }
 
 // KarmadaDeschedulerImage get karmada descheduler image

--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -149,5 +149,5 @@ func initExample(parentCommand string) string {
 		klog.Infof("No default release version found. build version: %s", version.Get().String())
 		releaseVer = &version.ReleaseVersion{}
 	}
-	return fmt.Sprintf(initExamples, parentCommand, releaseVer.FirstMinorRelease())
+	return fmt.Sprintf(initExamples, parentCommand, releaseVer.ReleaseVersion())
 }

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -75,14 +75,14 @@ func init() {
 		klog.Infof("No default release version found. build version: %s", version.Get().String())
 		releaseVer = &version.ReleaseVersion{} // initialize to avoid panic
 	}
-	karmadaRelease = releaseVer.PatchRelease()
+	karmadaRelease = releaseVer.ReleaseVersion()
 
-	DefaultCrdURL = fmt.Sprintf("https://github.com/karmada-io/karmada/releases/download/%s/crds.tar.gz", releaseVer.FirstMinorRelease())
+	DefaultCrdURL = fmt.Sprintf("https://github.com/karmada-io/karmada/releases/download/%s/crds.tar.gz", releaseVer.ReleaseVersion())
 	DefaultInitImage = "docker.io/alpine:3.15.1"
-	DefaultKarmadaSchedulerImage = fmt.Sprintf("docker.io/karmada/karmada-scheduler:%s", releaseVer.PatchRelease())
-	DefaultKarmadaControllerManagerImage = fmt.Sprintf("docker.io/karmada/karmada-controller-manager:%s", releaseVer.PatchRelease())
-	DefualtKarmadaWebhookImage = fmt.Sprintf("docker.io/karmada/karmada-webhook:%s", releaseVer.PatchRelease())
-	DefaultKarmadaAggregatedAPIServerImage = fmt.Sprintf("docker.io/karmada/karmada-aggregated-apiserver:%s", releaseVer.PatchRelease())
+	DefaultKarmadaSchedulerImage = fmt.Sprintf("docker.io/karmada/karmada-scheduler:%s", releaseVer.ReleaseVersion())
+	DefaultKarmadaControllerManagerImage = fmt.Sprintf("docker.io/karmada/karmada-controller-manager:%s", releaseVer.ReleaseVersion())
+	DefualtKarmadaWebhookImage = fmt.Sprintf("docker.io/karmada/karmada-webhook:%s", releaseVer.ReleaseVersion())
+	DefaultKarmadaAggregatedAPIServerImage = fmt.Sprintf("docker.io/karmada/karmada-aggregated-apiserver:%s", releaseVer.ReleaseVersion())
 }
 
 // CommandInitOption holds all flags options for init.

--- a/pkg/karmadactl/register/register.go
+++ b/pkg/karmadactl/register/register.go
@@ -174,7 +174,7 @@ func NewCmdRegister(parentCommand string) *cobra.Command {
 	flags.StringSliceVar(&opts.BootstrapToken.CACertHashes, "discovery-token-ca-cert-hash", []string{}, "For token-based discovery, validate that the root CA public key matches this hash (format: \"<type>:<value>\").")
 	flags.BoolVar(&opts.BootstrapToken.UnsafeSkipCAVerification, "discovery-token-unsafe-skip-ca-verification", false, "For token-based discovery, allow joining without --discovery-token-ca-cert-hash pinning.")
 	flags.DurationVar(&opts.Timeout, "discovery-timeout", DefaultDiscoveryTimeout, "The timeout to discovery karmada apiserver client.")
-	flags.StringVar(&opts.KarmadaAgentImage, "karmada-agent-image", fmt.Sprintf("docker.io/karmada/karmada-agent:%s", releaseVer.PatchRelease()), "Karmada agent image.")
+	flags.StringVar(&opts.KarmadaAgentImage, "karmada-agent-image", fmt.Sprintf("docker.io/karmada/karmada-agent:%s", releaseVer.ReleaseVersion()), "Karmada agent image.")
 	flags.Int32Var(&opts.KarmadaAgentReplicas, "karmada-agent-replicas", 1, "Karmada agent replicas.")
 	flags.Int32Var(&opts.CertExpirationSeconds, "cert-expiration-seconds", DefaultCertExpirationSeconds, "The expiration time of certificate.")
 	flags.BoolVar(&opts.DryRun, "dry-run", false, "Run the command in dry-run mode, without making any server requests.")

--- a/pkg/version/release_test.go
+++ b/pkg/version/release_test.go
@@ -4,37 +4,27 @@ import "testing"
 
 func TestReleaseVersion(t *testing.T) {
 	tests := []struct {
-		name                    string
-		gitVersion              string
-		expectFirstMinorRelease string
-		expectPatchRelease      string
-		expectError             bool
+		name                 string
+		gitVersion           string
+		expectReleaseVersion string
+		expectError          bool
 	}{
 		{
-			name:                    "first minor release",
-			gitVersion:              "v1.1.0",
-			expectFirstMinorRelease: "v1.1.0",
-			expectPatchRelease:      "v1.1.0",
-			expectError:             false,
-		},
-		{
-			name:                    "subsequent minor release",
-			gitVersion:              "v1.1.1",
-			expectFirstMinorRelease: "v1.1.0",
-			expectPatchRelease:      "v1.1.1",
-			expectError:             false,
-		},
-		{
-			name:                    "normal git version",
-			gitVersion:              "v1.1.1-6-gf20c721a",
-			expectFirstMinorRelease: "v1.1.0",
-			expectPatchRelease:      "v1.1.1",
-			expectError:             false,
+			name:                 "normal git version",
+			gitVersion:           "v1.1.1-6-gf20c721a",
+			expectReleaseVersion: "v1.1.1",
+			expectError:          false,
 		},
 		{
 			name:        "abnormal version",
 			gitVersion:  "vx.y.z-6-gf20c721a",
 			expectError: true,
+		},
+		{
+			name:                 "prerelease alpha version",
+			gitVersion:           "v1.7.0-alpha.1-3-gf20c721a",
+			expectReleaseVersion: "v1.7.0-alpha.1",
+			expectError:          false,
 		},
 	}
 
@@ -54,106 +44,8 @@ func TestReleaseVersion(t *testing.T) {
 				}
 			}
 
-			if rv.FirstMinorRelease() != tc.expectFirstMinorRelease {
-				t.Fatalf("expect first minor release: %s, but got: %s", tc.expectFirstMinorRelease, rv.FirstMinorRelease())
-			}
-
-			if rv.PatchRelease() != tc.expectPatchRelease {
-				t.Fatalf("expect patch release: %s, but got: %s", tc.expectPatchRelease, rv.PatchRelease())
-			}
-		})
-	}
-}
-
-func TestReleaseVersion_FirstMinorRelease(t *testing.T) {
-	tests := []struct {
-		name        string
-		gitVersion  string
-		ignoreError bool
-		expect      string
-	}{
-		{
-			name:        "invalid version should dump nil",
-			gitVersion:  "",
-			ignoreError: true,
-			expect:      "<nil>",
-		},
-		{
-			name:        "standard semantic version",
-			gitVersion:  "v1.2.1",
-			ignoreError: false,
-			expect:      "v1.2.0",
-		},
-		{
-			name:        "standard semantic version suffixed with commits",
-			gitVersion:  "v1.2.3-12-g2e860210",
-			ignoreError: false,
-			expect:      "v1.2.0",
-		},
-	}
-
-	for i := range tests {
-		tc := tests[i]
-		t.Run(tc.name, func(t *testing.T) {
-			rv, err := ParseGitVersion(tc.gitVersion)
-			if err != nil {
-				if tc.ignoreError {
-					// initialize to avoid panic because just focus on the version inside ReleaseVersion.
-					rv = &ReleaseVersion{Version: nil}
-				} else {
-					t.Fatalf("unexpected error: %v", err)
-				}
-			}
-
-			if rv.FirstMinorRelease() != tc.expect {
-				t.Fatalf("expect first minor release: %s, but got: %s", tc.expect, rv.FirstMinorRelease())
-			}
-		})
-	}
-}
-
-func TestReleaseVersion_PatchRelease(t *testing.T) {
-	tests := []struct {
-		name        string
-		gitVersion  string
-		ignoreError bool
-		expect      string
-	}{
-		{
-			name:        "invalid version should dump nil",
-			gitVersion:  "",
-			ignoreError: true,
-			expect:      "<nil>",
-		},
-		{
-			name:        "standard semantic version",
-			gitVersion:  "v1.2.1",
-			ignoreError: false,
-			expect:      "v1.2.1",
-		},
-		{
-			name:        "standard semantic version suffixed with commits",
-			gitVersion:  "v1.2.3-12-g2e860210",
-			ignoreError: false,
-			expect:      "v1.2.3",
-		},
-	}
-
-	for i := range tests {
-		tc := tests[i]
-		t.Run(tc.name, func(t *testing.T) {
-			rv, err := ParseGitVersion(tc.gitVersion)
-			if err != nil {
-				if tc.ignoreError {
-					// initialize to avoid panic because just focus on the version inside ReleaseVersion.
-					rv = &ReleaseVersion{Version: nil}
-				} else {
-					t.Fatalf("unexpected error: %v", err)
-				}
-			}
-
-			if rv.PatchRelease() != tc.expect {
-				t.Fatalf("expect patch release: %s, but got: %s", tc.expect, rv.PatchRelease())
+			if rv.ReleaseVersion() != tc.expectReleaseVersion {
+				t.Fatalf("expect patch release: %s, but got: %s", tc.expectReleaseVersion, rv.ReleaseVersion())
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
We are now introducing a pre-release that follows the K8s release process. However, in the previous implementation, there was an issue with the image tag used during initialization. Here's an example:
```
karmadactl git version: v1.7.0-alpha.1-3-gf20c721a

Once parsed, the card will utilize version 1.7.0 and Karmada's image tag will also be set to version 1.7.0, which has not yet been released.
```

To fix this problem, we will parse `v1.7.0-alpha.1-3-gf20c721a` as `v1.7.0-alpha.1`, which is what this patch does.

But with this patch, each release should have the CRD assets, which should be done in another PR.

**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/karmada/issues/3633

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

