### PR TITLE
Support namespace to use regexp for resourceSelector of cpp and cop

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15943,7 +15943,7 @@
           "type": "string"
         },
         "namespace": {
-          "description": "Namespace of the target resource. Default is empty, which means inherit from the parent object scope.",
+          "description": "Namespace of the target resource. Default is empty, which means inherit from the parent object scope. Must be the same as the namespace of PropagationPolicy and OverridePolicy. Can be a regular expression in ClusterPropagationPolicy and ClusterOverridePolicy.",
           "type": "string"
         }
       }

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_clusteroverridepolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_clusteroverridepolicies.yaml
@@ -648,7 +648,10 @@ spec:
                       type: string
                     namespace:
                       description: Namespace of the target resource. Default is empty,
-                        which means inherit from the parent object scope.
+                        which means inherit from the parent object scope. Must be
+                        the same as the namespace of PropagationPolicy and OverridePolicy.
+                        Can be a regular expression in ClusterPropagationPolicy and
+                        ClusterOverridePolicy.
                       type: string
                   required:
                   - apiVersion

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_clusterpropagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_clusterpropagationpolicies.yaml
@@ -715,7 +715,10 @@ spec:
                       type: string
                     namespace:
                       description: Namespace of the target resource. Default is empty,
-                        which means inherit from the parent object scope.
+                        which means inherit from the parent object scope. Must be
+                        the same as the namespace of PropagationPolicy and OverridePolicy.
+                        Can be a regular expression in ClusterPropagationPolicy and
+                        ClusterOverridePolicy.
                       type: string
                   required:
                   - apiVersion

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_overridepolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_overridepolicies.yaml
@@ -648,7 +648,10 @@ spec:
                       type: string
                     namespace:
                       description: Namespace of the target resource. Default is empty,
-                        which means inherit from the parent object scope.
+                        which means inherit from the parent object scope. Must be
+                        the same as the namespace of PropagationPolicy and OverridePolicy.
+                        Can be a regular expression in ClusterPropagationPolicy and
+                        ClusterOverridePolicy.
                       type: string
                   required:
                   - apiVersion

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_propagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_propagationpolicies.yaml
@@ -711,7 +711,10 @@ spec:
                       type: string
                     namespace:
                       description: Namespace of the target resource. Default is empty,
-                        which means inherit from the parent object scope.
+                        which means inherit from the parent object scope. Must be
+                        the same as the namespace of PropagationPolicy and OverridePolicy.
+                        Can be a regular expression in ClusterPropagationPolicy and
+                        ClusterOverridePolicy.
                       type: string
                   required:
                   - apiVersion

--- a/pkg/apis/policy/v1alpha1/propagation_types.go
+++ b/pkg/apis/policy/v1alpha1/propagation_types.go
@@ -128,6 +128,8 @@ type ResourceSelector struct {
 
 	// Namespace of the target resource.
 	// Default is empty, which means inherit from the parent object scope.
+	// Must be the same as the namespace of PropagationPolicy and OverridePolicy.
+	// Can be a regular expression in ClusterPropagationPolicy and ClusterOverridePolicy.
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -4382,7 +4382,7 @@ func schema_pkg_apis_policy_v1alpha1_ResourceSelector(ref common.ReferenceCallba
 					},
 					"namespace": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Namespace of the target resource. Default is empty, which means inherit from the parent object scope.",
+							Description: "Namespace of the target resource. Default is empty, which means inherit from the parent object scope. Must be the same as the namespace of PropagationPolicy and OverridePolicy. Can be a regular expression in ClusterPropagationPolicy and ClusterOverridePolicy.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/util/selector_test.go
+++ b/pkg/util/selector_test.go
@@ -170,6 +170,30 @@ func TestResourceSelectorPriority(t *testing.T) {
 			want: PriorityMatchName,
 		},
 		{
+			name: "namespace matched set with regex and name matched",
+			args: args{
+				rs: policyv1alpha1.ResourceSelector{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       "test",
+					Namespace:  "defaul.",
+				},
+			},
+			want: PriorityMatchName,
+		},
+		{
+			name: "namespace unmatched set with regex and name matched",
+			args: args{
+				rs: policyv1alpha1.ResourceSelector{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       "test",
+					Namespace:  "fault",
+				},
+			},
+			want: PriorityMisMatch,
+		},
+		{
 			name: "[case 1] name not matched",
 			args: args{
 				rs: policyv1alpha1.ResourceSelector{

--- a/pkg/webhook/propagationpolicy/validating.go
+++ b/pkg/webhook/propagationpolicy/validating.go
@@ -33,6 +33,14 @@ func (v *ValidatingAdmission) Handle(_ context.Context, req admission.Request) a
 	}
 	klog.V(2).Infof("Validating PropagationPolicy(%s/%s) for request: %s", policy.Namespace, policy.Name, req.Operation)
 
+	for _, rs := range policy.Spec.ResourceSelectors {
+		if rs.Namespace != req.Namespace {
+			err = fmt.Errorf("the namespace of resourceSelector should be the same as the namespace of policy(%s/%s)", policy.Namespace, policy.Name)
+			klog.Error(err)
+			return admission.Denied(err.Error())
+		}
+	}
+
 	if req.Operation == admissionv1.Update {
 		oldPolicy := &policyv1alpha1.PropagationPolicy{}
 		err = v.decoder.DecodeRaw(req.OldObject, oldPolicy)

--- a/test/e2e/clusteroverridepolicy_test.go
+++ b/test/e2e/clusteroverridepolicy_test.go
@@ -179,3 +179,91 @@ var _ = framework.SerialDescribe("Test clusterOverridePolicy with nil resourceSe
 		})
 	})
 })
+
+var _ = framework.SerialDescribe("Test clusterOverridePolicy with resourceSelectors", func() {
+	var deploymentNamespace, deploymentName string
+	var propagationPolicyNamespace, propagationPolicyName string
+	var clusterOverridePolicyName string
+	var deployment *appsv1.Deployment
+	var propagationPolicy *policyv1alpha1.PropagationPolicy
+	var clusterOverridePolicy *policyv1alpha1.ClusterOverridePolicy
+
+	ginkgo.BeforeEach(func() {
+		deploymentNamespace = testNamespace
+		deploymentName = deploymentNamePrefix + rand.String(RandomStrLength)
+		propagationPolicyNamespace = testNamespace
+		propagationPolicyName = deploymentName
+		clusterOverridePolicyName = deploymentName
+
+		deployment = testhelper.NewDeployment(deploymentNamespace, deploymentName)
+		propagationPolicy = testhelper.NewPropagationPolicy(propagationPolicyNamespace, propagationPolicyName, []policyv1alpha1.ResourceSelector{
+			{
+				APIVersion: deployment.APIVersion,
+				Kind:       deployment.Kind,
+				Name:       deployment.Name,
+			},
+		}, policyv1alpha1.Placement{
+			ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+				ClusterNames: framework.ClusterNames(),
+			},
+		})
+
+		clusterOverridePolicy = testhelper.NewClusterOverridePolicyByOverrideRules(clusterOverridePolicyName, []policyv1alpha1.ResourceSelector{
+			{
+				APIVersion: deployment.APIVersion,
+				Kind:       deployment.Kind,
+				Namespace:  "karmadatest-.*",
+				Name:       deployment.Name,
+			},
+		}, []policyv1alpha1.RuleWithCluster{
+			{
+				TargetCluster: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: framework.ClusterNames(),
+				},
+				Overriders: policyv1alpha1.Overriders{
+					ImageOverrider: []policyv1alpha1.ImageOverrider{
+						{
+							Predicate: &policyv1alpha1.ImagePredicate{
+								Path: "/spec/template/spec/containers/0/image",
+							},
+							Component: "Registry",
+							Operator:  "replace",
+							Value:     "fictional.registry.us",
+						},
+					},
+				},
+			},
+		})
+	})
+
+	ginkgo.Context("Deployment override testing", func() {
+		ginkgo.BeforeEach(func() {
+			framework.CreatePropagationPolicy(karmadaClient, propagationPolicy)
+			framework.CreateDeployment(kubeClient, deployment)
+			ginkgo.DeferCleanup(func() {
+				framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
+				framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
+			})
+		})
+
+		ginkgo.It("deployment imageOverride testing", func() {
+			ginkgo.By("Check if deployment have presented on member clusters", func() {
+				framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
+					func(deployment *appsv1.Deployment) bool {
+						return true
+					})
+			})
+
+			framework.CreateClusterOverridePolicy(karmadaClient, clusterOverridePolicy)
+
+			ginkgo.By("Check if deployment presented on member clusters have correct image value", func() {
+				framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
+					func(deployment *appsv1.Deployment) bool {
+						return deployment.Spec.Template.Spec.Containers[0].Image == "fictional.registry.us/nginx:1.19.0"
+					})
+			})
+
+			framework.RemoveClusterOverridePolicy(karmadaClient, clusterOverridePolicy.Name)
+		})
+	})
+})


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
For cpp and cop, we expect resourceSelectors can hit multiple namespaces with the similar format, otherwise we may need to edit cpp and cop when we add a new namespace.

Assume that there is a use case that all business departments are registered to Karmada uniformly and isolated through different namespaces. It is agreed to use the format of "test-xxx" uniformly. Now they have registered two departments and have a global cpp to propagate their applications. Once they add a new department, they do not want to edit the cpp because they may cause rescheduling of applications.

In that case, the following config may help.
```
spec:
    resourceSelectors:
    - apiVersion: apps/v1
      kind: Deployment
      Namespace: test-.*
      Name: test
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
ClusterPropagationPolicy/ClusterOverridePolicy: Support namespace to use regexp for resourceSelector.
karmada-webhook: validate that namespace of resourceSelector must be the same as that of pp/op.
```

