### PR TITLE
feat: Release crds.tar.gz in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,26 @@ jobs:
           _output/release/${{ matrix.target }}-${{ matrix.os }}-${{ matrix.arch }}.tgz.sha256
           _output/charts/karmada-chart-${{ github.ref_name }}.tgz
           _output/charts/karmada-chart-${{ github.ref_name }}.tgz.sha256
+  release-crds-assests:
+    name: release crds
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Rename the crds directory
+      run: |
+        mv ./charts/karmada/_crds ./charts/karmada/crds
+    - name: Tar the crds
+      uses: a7ul/tar-action@v1.1.0
+      with:
+        command: c
+        cwd: ./charts/karmada/
+        files: crds
+        outPath: crds.tar.gz
+    - name: Uploading crd assets...
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          crds.tar.gz
   update-krew-index:
     needs: release-assests
     name: Update krew-index


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Related to https://github.com/karmada-io/karmada/pull/3652

karmadactl will parse the version(the version comes from the git tag) and download the crds.tar.gz from GitHub release URL.
for example, with `v1.1.1-6-gf20c721a`, the  download URL will be `https://github.com/karmada-io/karmada/releases/download/v1.1.1/crds.tar.gz`
with `v1.7.0-alpha.1-3-gf20c721a`, the download URL will be `https://github.com/karmada-io/karmada/releases/download/v1.7.0-alpha.1/crds.tar.gz`.
This means we need to upload the crds.tar.gz for each release(no matter if it's path release, minor release, or pre-release).

**Which issue(s) this PR fixes**:
Part of https://github.com/karmada-io/karmada/issues/3633

**Special notes for your reviewer**:
Test result: https://github.com/jwcesign/karmada/releases/tag/v1.9.8

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

