### PR TITLE
cleanup the ci about interpreter-interpret-health test

### DIFF
--- a/test/e2e/resourceinterpreter_test.go
+++ b/test/e2e/resourceinterpreter_test.go
@@ -611,8 +611,7 @@ var _ = framework.SerialDescribe("Resource interpreter customization testing", f
 							memberDeployment = deployment
 							return true
 						})
-					memberDeployment.Status.ReadyReplicas = readyReplicas
-					framework.UpdateDeploymentStatus(clusterClient, memberDeployment)
+					framework.WaitDeploymentStatus(clusterClient, memberDeployment, readyReplicas)
 				}
 
 				CheckResult := func(result workv1alpha2.ResourceHealth) interface{} {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
It changes the test case from update the `.status.readyReplicas to 3` operation to wait the `.status.readyReplicas==3` operation, which is more reasonable.

**Which issue(s) this PR fixes**:
Part of #3640 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

