### PR TITLE
karmadactl init add timeout flag

### DIFF
--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/cert"
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/kubernetes"
+	cmdinitoptions "github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
 	"github.com/karmada-io/karmada/pkg/karmadactl/options"
 	"github.com/karmada-io/karmada/pkg/karmadactl/util"
 	"github.com/karmada-io/karmada/pkg/version"
@@ -139,7 +140,7 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 	flags.Int32VarP(&opts.KarmadaWebhookReplicas, "karmada-webhook-replicas", "", 1, "Karmada webhook replica set")
 	flags.StringVarP(&opts.KarmadaAggregatedAPIServerImage, "karmada-aggregated-apiserver-image", "", kubernetes.DefaultKarmadaAggregatedAPIServerImage, "Karmada aggregated apiserver image")
 	flags.Int32VarP(&opts.KarmadaAggregatedAPIServerReplicas, "karmada-aggregated-apiserver-replicas", "", 1, "Karmada aggregated apiserver replica set")
-
+	flags.IntVarP(&opts.WaitComponentReadyTimeout, "wait-component-ready-timeout", "", cmdinitoptions.WaitComponentReadyTimeout, "Wait for karmada component ready timeout. 0 means wait forever")
 	return cmd
 }
 

--- a/pkg/karmadactl/cmdinit/options/global.go
+++ b/pkg/karmadactl/cmdinit/options/global.go
@@ -24,5 +24,5 @@ const (
 	// KarmadaKubeConfigName karmada kubeconfig name
 	KarmadaKubeConfigName = "karmada-apiserver.config"
 	// WaitComponentReadyTimeout wait component ready time
-	WaitComponentReadyTimeout = 30
+	WaitComponentReadyTimeout = 120
 )


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
see https://github.com/karmada-io/karmada/pull/3453
**Which issue(s) this PR fixes**:
Fixes #3406
Fixes #3611

**Special notes for your reviewer**:
/cc @lonelyCZ @XiShanYongYe-Chang 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: The `--wait-component-ready-timeout` flag has been introduced in the `init` command to specify the component installation timeout.
```

