### PR TITLE
Fix cached RESTMapper when pass no versions

### DIFF
--- a/pkg/util/restmapper/restmapper.go
+++ b/pkg/util/restmapper/restmapper.go
@@ -1,7 +1,6 @@
 package restmapper
 
 import (
-	"fmt"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -53,14 +52,10 @@ func (g *cachedRESTMapper) ResourceSingularizer(resource string) (singular strin
 }
 
 func (g *cachedRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
-	// in case of multi-versions, cachedRESTMapper don't know which is the preferred version,
+	// in case of multi-versions or no versions, cachedRESTMapper don't know which is the preferred version,
 	// so just bypass the cache and consult the underlying mapper.
-	if len(versions) > 1 {
+	if len(versions) != 1 {
 		return g.restMapper.RESTMapping(gk, versions...)
-	}
-
-	if len(versions) == 0 {
-		return nil, fmt.Errorf("expected at least one version")
 	}
 
 	gvk := gk.WithVersion(versions[0])


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Now cachedRESTMapper will do nothing but return an error when users do not pass versions parameter. But for the underlying RESTMapper, it can get the corresponding `RESTMapping` without versions. The reference code is [here](https://github.com/kubernetes/apimachinery/blob/6b1428efc73348cc1c33935f3a39ab0f2f01d23d/pkg/api/meta/restmapper.go#LL466C1-L466C1). So when no versions pass, we'd better try to consult the underlying mappers.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

