### PR TITLE
fix panic when printing log when lastSuccessfulTime of cronjob is nil

### DIFF
--- a/pkg/resourceinterpreter/default/native/aggregatestatus.go
+++ b/pkg/resourceinterpreter/default/native/aggregatestatus.go
@@ -214,8 +214,8 @@ func aggregateCronJobStatus(object *unstructured.Unstructured, aggregatedStatusI
 		if err = json.Unmarshal(item.Status.Raw, temp); err != nil {
 			return nil, err
 		}
-		klog.V(3).Infof("Grab cronJob(%s/%s) status from cluster(%s), active: %+v, lastScheduleTime: %s, lastSuccessfulTime: %s",
-			cronjob.Namespace, cronjob.Name, item.ClusterName, temp.Active, temp.LastScheduleTime.String(), temp.LastSuccessfulTime.String())
+		klog.V(3).Infof("Grab cronJob(%s/%s) status from cluster(%s), active: %+v, lastScheduleTime: %+v, lastSuccessfulTime: %+v",
+			cronjob.Namespace, cronjob.Name, item.ClusterName, temp.Active, temp.LastScheduleTime, temp.LastSuccessfulTime)
 		newStatus.Active = append(newStatus.Active, temp.Active...)
 		if newStatus.LastScheduleTime == nil {
 			newStatus.LastScheduleTime = temp.LastScheduleTime

--- a/pkg/resourceinterpreter/default/native/aggregatestatus_test.go
+++ b/pkg/resourceinterpreter/default/native/aggregatestatus_test.go
@@ -995,7 +995,7 @@ func Test_aggregateCronJobStatus(t *testing.T) {
 			},
 		},
 		"lastScheduleTime":   "2023-02-08T07:16:00Z",
-		"lastSuccessfulTime": "2023-02-08T07:15:00Z",
+		"lastSuccessfulTime": nil,
 	})
 	cronjobStatusRaw2, _ := helper.BuildStatusRawExtension(map[string]interface{}{
 		"active": []corev1.ObjectReference{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

fix aggregateCronJobStatus panic

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

When job is not successful even once, `lastSuccessfulTime` will always be`nil`. Printing logs at this time will cause a panic.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: fix panic when printing log when lastSuccessfulTime of cronjob is nil.
```

