### PR TITLE
Add option way toget rest config of estimator schedule

### DIFF
--- a/cmd/scheduler-estimator/app/scheduler-estimator.go
+++ b/cmd/scheduler-estimator/app/scheduler-estimator.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/term"
@@ -22,6 +23,8 @@ import (
 
 	"github.com/karmada-io/karmada/cmd/scheduler-estimator/app/options"
 	"github.com/karmada-io/karmada/pkg/estimator/server"
+	ctloptions "github.com/karmada-io/karmada/pkg/karmadactl/options"
+	"github.com/karmada-io/karmada/pkg/karmadactl/util"
 	"github.com/karmada-io/karmada/pkg/sharedcli"
 	"github.com/karmada-io/karmada/pkg/sharedcli/klogflag"
 	"github.com/karmada-io/karmada/pkg/sharedcli/profileflag"
@@ -86,9 +89,23 @@ func run(ctx context.Context, opts *options.Options) error {
 
 	profileflag.ListenAndServe(opts.ProfileOpts)
 
-	restConfig, err := clientcmd.BuildConfigFromFlags(opts.Master, opts.KubeConfig)
-	if err != nil {
-		return fmt.Errorf("error building kubeconfig: %s", err.Error())
+	var restConfig *rest.Config
+	var err error
+	if opts.KubeConfig != "" {
+		restConfig, err = clientcmd.BuildConfigFromFlags(opts.Master, opts.KubeConfig)
+		if err != nil {
+			return fmt.Errorf("error building kubeconfig: %s", err.Error())
+		}
+	} else {
+		f := util.NewFactory(ctloptions.DefaultConfigFlags)
+		memberFactory, err := f.FactoryForMemberCluster(opts.ClusterName)
+		if err != nil {
+			return err
+		}
+		restConfig, err = memberFactory.ToRESTConfig()
+		if err != nil {
+			return fmt.Errorf("error building kubeconfig: %s", err.Error())
+		}
 	}
 	restConfig.QPS, restConfig.Burst = opts.ClusterAPIQPS, opts.ClusterAPIBurst
 


### PR DESCRIPTION
Get rest config from aggregate apiserver if member cluster kubeconfig not provided.

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

