### PR TITLE
ignoring codecov errors in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           token: ${{secrets.CODECOV_UPLOAD_TOKEN}}
           files: ./_output/coverage/coverage_pkg.txt,./_output/coverage/coverage_cmd.txt,./_output/coverage/coverage_examples.txt
           flags: unittests
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
   e2e:
     name: e2e test


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does**:
It simply ignores codecov errors and does not let ci tests fail in case.

**Which issue(s) this PR fixes**:
Fixes #3674 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

