### PR TITLE
upgrade CI ubuntu image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout code
         uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
         run: hack/verify-import-aliases.sh
   codegen:
     name: codegen
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       GOPATH: ${{ github.workspace }}
     defaults:
@@ -60,7 +60,7 @@ jobs:
   build:
     name: compile
     needs: codegen # rely on codegen successful completion
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout code
         uses: actions/checkout@v3
@@ -77,7 +77,7 @@ jobs:
   test:
     name: unit test
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout code
         uses: actions/checkout@v3
@@ -104,7 +104,7 @@ jobs:
   e2e:
     name: e2e test
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         k8s: [ v1.21.10, v1.22.7, v1.23.4, v1.24.2, v1.25.0 ]

--- a/.github/workflows/dockerhub-latest-image.yml
+++ b/.github/workflows/dockerhub-latest-image.yml
@@ -22,7 +22,7 @@ jobs:
           - karmada-interpreter-webhook-example
           - karmada-aggregated-apiserver
           - karmada-search
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/dockerhub-released-image.yml
+++ b/.github/workflows/dockerhub-released-image.yml
@@ -18,7 +18,7 @@ jobs:
           - karmada-interpreter-webhook-example
           - karmada-aggregated-apiserver
           - karmada-search
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -8,7 +8,7 @@ jobs:
     # 1. running on the forked repository would fail as missing necessary secret.
     # 2. running on the forked repository would use unnecessary GitHub Action time.
     if: ${{ github.repository == 'karmada-io/karmada' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/lint-chart.yaml
+++ b/.github/workflows/lint-chart.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   chart-lint-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ name: Build Release
 jobs:
   release-assests:
     name: release kubectl-karmada
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         target:

--- a/.github/workflows/swr-latest-image.yml
+++ b/.github/workflows/swr-latest-image.yml
@@ -10,7 +10,7 @@ jobs:
     # 1. running on the forked repository would fail as missing necessary secret.
     # 2. running on the forked repository would use unnecessary GitHub Action time.
     if: ${{ github.repository == 'karmada-io/karmada' && github.ref == 'refs/heads/master' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/swr-released-image.yml
+++ b/.github/workflows/swr-released-image.yml
@@ -10,7 +10,7 @@ jobs:
     # 1. running on the forked repository would fail as missing necessary secret.
     # 2. running on the forked repository would use unnecessary GitHub Action time.
     if: ${{ github.repository == 'karmada-io/karmada' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

We expect the Kind version to be v0.17.0, but the ubuntu image in our CI Runner now comes with kind@v0.20.0. The error mentioned above almost always occurs in ubuntu-20.04 when using kind@v0.20.0, but it runs normally on ubuntu-22.04.

Our CI logic checks whether there is a kind command and if so, it will not install it again, so we are using the kind@v0.20.0 that comes with the image by default . Therefore, the solution is either to upgrade to ubuntu-22.04 or force installation of kind@v0.17 .

https://github.com/kubernetes-sigs/kind/releases/tag/v0.20.0

![image](https://github.com/karmada-io/karmada/assets/30589999/f713745a-f9be-44cf-98f7-404322c0dc33)

**Which issue(s) this PR fixes**:

Fixes #3667 

**Special notes for your reviewer**:

@RainbowMango @XiShanYongYe-Chang 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
