### PR TITLE
Optimize clustersToNameSet after evictBinding,Avoid garbage object generation.

### DIFF
--- a/pkg/controllers/applicationfailover/common.go
+++ b/pkg/controllers/applicationfailover/common.go
@@ -101,3 +101,11 @@ func distinguishUnhealthyClustersWithOthers(aggregatedStatusItems []workv1alpha2
 
 	return unhealthyClusters, others
 }
+
+func clustersToNameSet(clusters []workv1alpha2.TargetCluster) sets.Set[string] {
+	allClusters := sets.New[string]()
+	for _, cluster := range clusters {
+		allClusters.Insert(cluster.Name)
+	}
+	return allClusters
+}

--- a/pkg/controllers/applicationfailover/rb_application_failover_controller.go
+++ b/pkg/controllers/applicationfailover/rb_application_failover_controller.go
@@ -110,11 +110,6 @@ func (c *RBApplicationFailoverController) syncBinding(binding *workv1alpha2.Reso
 	key := types.NamespacedName{Name: binding.Name, Namespace: binding.Namespace}
 	tolerationSeconds := binding.Spec.Failover.Application.DecisionConditions.TolerationSeconds
 
-	allClusters := sets.New[string]()
-	for _, cluster := range binding.Spec.Clusters {
-		allClusters.Insert(cluster.Name)
-	}
-
 	unhealthyClusters, others := distinguishUnhealthyClustersWithOthers(binding.Status.AggregatedStatus, binding.Spec)
 	duration, needEvictClusters := c.detectFailure(unhealthyClusters, tolerationSeconds, key)
 
@@ -123,6 +118,8 @@ func (c *RBApplicationFailoverController) syncBinding(binding *workv1alpha2.Reso
 		klog.Errorf("Failed to evict binding(%s/%s), err: %v.", binding.Namespace, binding.Name, err)
 		return 0, err
 	}
+
+	allClusters := clustersToNameSet(binding.Spec.Clusters)
 
 	if len(needEvictClusters) != 0 {
 		if err = c.updateBinding(binding, allClusters, needEvictClusters); err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

create   a function  for code of clustersToNameSet and move it to after `err := c.evictBinding(binding, needEvictClusters)`.

It's working for avoid garbage object generation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Optimize: clustersToNameSet after evictBinding,Avoid garbage object generation.
```

