### PR TITLE
fix: when application failover is enabled but propagateDeps is set to false, the failover has no effect

### DIFF
--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -22,6 +22,9 @@ const LabelValueMaxLength int = 63
 func ValidatePropagationSpec(spec policyv1alpha1.PropagationSpec) field.ErrorList {
 	var allErrs field.ErrorList
 	allErrs = append(allErrs, ValidatePlacement(spec.Placement, field.NewPath("spec").Child("placement"))...)
+	if spec.Failover != nil && spec.Failover.Application != nil && !spec.PropagateDeps {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("propagateDeps"), spec.PropagateDeps, "application failover is set, propagateDeps must be true"))
+	}
 	allErrs = append(allErrs, ValidateFailover(spec.Failover, field.NewPath("spec").Child("failover"))...)
 	return allErrs
 }


### PR DESCRIPTION
Signed-off-by: chaunceyjiang <chaunceyjiang@gmail.com>

**What type of PR is this?**

/kind bug 

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/karmada/issues/3738

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-webhook`: When application failover is enabled, users are prevented from setting propagateDeps to `false`.
```

