### PR TITLE
Update set-output command in lint-chart ci

### DIFF
--- a/.github/workflows/lint-chart.yaml
+++ b/.github/workflows/lint-chart.yaml
@@ -2,10 +2,10 @@
 name: Chart Lint
 
 env:
-  HELM_VERSION: v3.8.1
+  HELM_VERSION: v3.11.2
   KIND_VERSION: v0.14.0
   KIND_NODE_IMAGE: kindest/node:v1.26.0
-  K8S_VERSION: v1.23.4
+  K8S_VERSION: v1.26.4
 
 on:
   push:
@@ -32,13 +32,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
-          architecture: x64
+          python-version: 3.9
+          check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.2.1
-        with:
-          version: v3.6.0
+        uses: helm/chart-testing-action@v2.4.0
 
       - name: Add dependency chart repos
         run: |
@@ -49,14 +47,15 @@ jobs:
         run: |
           changed=$( ct list-changed )
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --debug --check-version-increment=false
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1.7.0
         if: steps.list-changed.outputs.changed == 'true'
         with:
           wait: 120s
@@ -65,4 +64,5 @@ jobs:
           kubectl_version: ${{ env.K8S_VERSION }}
 
       - name: Run chart-testing (install)
+        if: steps.list-changed.outputs.changed == 'true'
         run: ct install --debug --helm-extra-args "--timeout 800s"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
The `set-output` is be deprecated，we need set the variable in step to `$GITHUB_OUTPUT` env.

Ref: 
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-setting-an-output-parameter
https://github.com/helm/chart-testing-action#example-workflow


**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/karmada/issues/3752

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

