### PR TITLE
Use SetOut and/or SetErr instead SetOutput

### DIFF
--- a/pkg/karmadactl/options/options.go
+++ b/pkg/karmadactl/options/options.go
@@ -34,7 +34,8 @@ func NewCmdOptions(parentCommand string, out io.Writer) *cobra.Command {
 	// function call will fall back to stderr.
 	//
 	// See https://github.com/kubernetes/kubernetes/pull/46394 for details.
-	cmd.SetOutput(out)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
 
 	templates.UseOptionsTemplates(cmd)
 	return cmd


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The SetOutput will be Deprecated

https://github.com/kubernetes/kubernetes/blob/75889ecec5d30cbe1dcb6636d5334b21b4378e9c/staging/src/k8s.io/kubectl/pkg/cmd/options/options.go#L51C1-L52C17


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

