### PR TITLE
Automated cherry pick of #3123: Avoid multiple executions after rlock in concurrent scenarios

### DIFF
--- a/pkg/util/fedinformer/genericmanager/multi-cluster-manager.go
+++ b/pkg/util/fedinformer/genericmanager/multi-cluster-manager.go
@@ -85,13 +85,14 @@ func (m *multiClusterInformerManagerImpl) getManager(cluster string) (SingleClus
 }
 
 func (m *multiClusterInformerManagerImpl) ForCluster(cluster string, client dynamic.Interface, defaultResync time.Duration) SingleClusterInformerManager {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
 	// If informer manager already exist, just return
-	if manager, exist := m.getManager(cluster); exist {
+	if manager, exist := m.managers[cluster]; exist {
 		return manager
 	}
 
-	m.lock.Lock()
-	defer m.lock.Unlock()
 	manager := NewSingleClusterInformerManager(client, defaultResync, m.stopCh)
 	m.managers[cluster] = manager
 	return manager

--- a/pkg/util/fedinformer/typedmanager/multi-cluster-manager.go
+++ b/pkg/util/fedinformer/typedmanager/multi-cluster-manager.go
@@ -94,13 +94,14 @@ func (m *multiClusterInformerManagerImpl) getManager(cluster string) (SingleClus
 }
 
 func (m *multiClusterInformerManagerImpl) ForCluster(cluster string, client kubernetes.Interface, defaultResync time.Duration) SingleClusterInformerManager {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
 	// If informer manager already exist, just return
-	if manager, exist := m.getManager(cluster); exist {
+	if manager, exist := m.managers[cluster]; exist {
 		return manager
 	}
 
-	m.lock.Lock()
-	defer m.lock.Unlock()
 	manager := NewSingleClusterInformerManager(client, defaultResync, m.stopCh, m.transformFuncs)
 	m.managers[cluster] = manager
 	return manager


### PR DESCRIPTION
Cherry pick of #3123 on release-1.4.
#3123: Avoid multiple executions after rlock in concurrent scenarios
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
NONE
```
#3763 