### PR TITLE
Automated cherry pick of #3739: fix: when application failover is enabled but propagateDeps

### DIFF
--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -22,6 +22,9 @@ const LabelValueMaxLength int = 63
 func ValidatePropagationSpec(spec policyv1alpha1.PropagationSpec) field.ErrorList {
 	var allErrs field.ErrorList
 	allErrs = append(allErrs, ValidatePlacement(spec.Placement, field.NewPath("spec").Child("placement"))...)
+	if spec.Failover != nil && spec.Failover.Application != nil && !spec.PropagateDeps {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("propagateDeps"), spec.PropagateDeps, "application failover is set, propagateDeps must be true"))
+	}
 	allErrs = append(allErrs, ValidateFailover(spec.Failover, field.NewPath("spec").Child("failover"))...)
 	return allErrs
 }


### PR DESCRIPTION
Cherry pick of #3739 on release-1.6.
#3739: fix: when application failover is enabled but propagateDeps
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note

`karmada-webhook`: When application failover is enabled, users are prevented from setting propagateDeps to `false`.
```