### PR TITLE
cleanup: Adapt metrics-adapter deploying script to more generic scenario

### DIFF
--- a/hack/deploy-metrics-adapter.sh
+++ b/hack/deploy-metrics-adapter.sh
@@ -7,11 +7,11 @@ REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${REPO_ROOT}"/hack/util.sh
 function usage() {
   echo "This script will deploy karmada-metrics-adapter on host cluster"
-  echo "Usage: hack/deploy-metrics-adapter.sh  <HOST_CLUSTER_KUBECONFIG> <HOST_CLUSTER_NAME>>"
-  echo "Example: hack/deploy-metrics-adapter.sh ~/.kube/config karmada-host"
+  echo "Usage: hack/deploy-metrics-adapter.sh  <HOST_CLUSTER_KUBECONFIG> <HOST_CONTEXT_NAME> <KARMADA_APISERVER_KUBECONFIG> <KARMADA_APISERVER_CONTEXT_NAME>"
+  echo "Example: hack/deploy-metrics-adapter.sh ~/.kube/karmada.config karmada-host ~/.kube/karmada.config karmada-apiserver"
 }
 
-if [[ $# -ne 2 ]]; then
+if [[ $# -ne 4 ]]; then
   usage
   exit 1
 fi
@@ -31,7 +31,24 @@ then
   usage
   exit 1
 fi
-HOST_CLUSTER_NAME=$2
+HOST_CONTEXT_NAME=$2
+
+# check kube config file existence
+if [[ ! -f "${3}" ]]; then
+  echo -e "ERROR: failed to get kubernetes config file: '${3}', not existed.\n"
+  usage
+  exit 1
+fi
+KARMADA_APISERVER_KUBECONFIG=$3
+
+# check context existence
+if ! kubectl config get-contexts "${4}" --kubeconfig="${KARMADA_APISERVER_KUBECONFIG}" > /dev/null 2>&1;
+then
+  echo -e "ERROR: failed to get context: '${4}' not in ${KARMADA_APISERVER_KUBECONFIG}. \n"
+  usage
+  exit 1
+fi
+KARMADA_APISERVER_CONTEXT_NAME=$4
 
 # install metrics adapter to host cluster
 if [ -n "${KUBECONFIG+x}" ];then
@@ -42,16 +59,18 @@ export KUBECONFIG=$HOST_CLUSTER_KUBECONFIG
 echo "using kubeconfig: "$KUBECONFIG
 
 # deploy karmada-metrics-adapter
-kubectl --context="${HOST_CLUSTER_NAME}" apply -f "${REPO_ROOT}/artifacts/deploy/karmada-metrics-adapter.yaml"
+kubectl --context="${HOST_CONTEXT_NAME}" apply -f "${REPO_ROOT}/artifacts/deploy/karmada-metrics-adapter.yaml"
 
 # make sure that karmada-metrics-adapter is ready
-util::wait_pod_ready "${HOST_CLUSTER_NAME}" "${KARMADA_METRICS_ADAPTER_LABEL}" "${KARMADA_SYSTEM_NAMESPACE}"
+util::wait_pod_ready "${HOST_CONTEXT_NAME}" "${KARMADA_METRICS_ADAPTER_LABEL}" "${KARMADA_SYSTEM_NAMESPACE}"
+
+export KUBECONFIG=$KARMADA_APISERVER_KUBECONFIG
 
 # deploy karmada-metrics-adapter-apiservice
-kubectl --context="karmada-apiserver" apply -f "${REPO_ROOT}/artifacts/deploy/karmada-metrics-adapter-apiservice.yaml"
+kubectl --context="${KARMADA_APISERVER_CONTEXT_NAME}" apply -f "${REPO_ROOT}/artifacts/deploy/karmada-metrics-adapter-apiservice.yaml"
 
 # make sure that karmada-metrics-adapter-apiservice is ready
-util::wait_apiservice_ready "karmada-apiserver" "${KARMADA_METRICS_ADAPTER_LABEL}"
+util::wait_apiservice_ready "${KARMADA_APISERVER_CONTEXT_NAME}" "${KARMADA_METRICS_ADAPTER_LABEL}"
 
 # recover the kubeconfig before installing metrics adapter if necessary
 if [ -n "${CURR_KUBECONFIG+x}" ];then


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When karmada kubeconfig is different from host kubeconfig, this script can't deploy the metrics-adapter.

**Which issue(s) this PR fixes**:
Fixes #none

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

