### PR TITLE
feat: Change the port of MCS to required.

### DIFF
--- a/charts/karmada/_crds/bases/networking/networking.karmada.io_multiclusterservices.yaml
+++ b/charts/karmada/_crds/bases/networking/networking.karmada.io_multiclusterservices.yaml
@@ -61,6 +61,8 @@ spec:
                       description: Port specifies the exposed service port.
                       format: int32
                       type: integer
+                  required:
+                  - port
                   type: object
                 type: array
               range:

--- a/docs/proposals/networking/multiclusterservice.md
+++ b/docs/proposals/networking/multiclusterservice.md
@@ -128,8 +128,8 @@ type ExposurePort struct {
 	Name string `json:"name,omitempty"`
 
 	// Port specifies the exposed service port.
-	// +optional
-	Port int32 `json:"port,omitempty"`
+	// +required
+	Port int32 `json:"port"`
 }
 
 // ExposureRange describes a list of clusters where the service is exposed.
@@ -174,7 +174,7 @@ spec:
    ports:
    - port: 80
    types:
-   - LoadBalance
+   - LoadBalancer
 ```
 
 ![image](statics/service-exposure.png)

--- a/pkg/apis/networking/v1alpha1/service_types.go
+++ b/pkg/apis/networking/v1alpha1/service_types.go
@@ -72,8 +72,8 @@ type ExposurePort struct {
 	Name string `json:"name,omitempty"`
 
 	// Port specifies the exposed service port.
-	// +optional
-	Port int32 `json:"port,omitempty"`
+	// +required
+	Port int32 `json:"port"`
 }
 
 // ExposureRange describes a list of clusters where the service is exposed.

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -2641,11 +2641,13 @@ func schema_pkg_apis_networking_v1alpha1_ExposurePort(ref common.ReferenceCallba
 					"port": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Port specifies the exposed service port.",
+							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
 					},
 				},
+				Required: []string{"port"},
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
clarify the meaning when the port of MCS is empty
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

https://github.com/kubernetes-sigs/mcs-api/blob/master/pkg/apis/v1alpha1/serviceimport.go#L108-L109

The port of `ServiceImport` is a required field, but the port of MCS is optional.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

