### PR TITLE
Automated cherry pick of #3777: chart: fix karmada search external etcd no volume mount

### DIFF
--- a/charts/karmada/templates/_helpers.tpl
+++ b/charts/karmada/templates/_helpers.tpl
@@ -264,6 +264,14 @@ app: {{- include "karmada.name" .}}-search
   secret:
     secretName: {{ .Values.search.kubeconfig }}
 {{- end -}}
+- name: etcd-certs
+  secret:
+  {{- if eq .Values.etcd.mode "internal" }}
+    secretName: {{ $name }}-cert
+  {{- end }}
+  {{- if eq .Values.etcd.mode "external" }}
+    secretName: {{ $name }}-external-etcd-cert
+  {{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/karmada/templates/karmada-search.yaml
+++ b/charts/karmada/templates/karmada-search.yaml
@@ -48,6 +48,9 @@ spec:
             - name: k8s-certs
               mountPath: /etc/kubernetes/pki
               readOnly: true
+            - name: etcd-certs
+              mountPath: /etc/etcd/pki
+              readOnly: true
             - name: kubeconfig-secret
               subPath: kubeconfig
               mountPath: /etc/kubeconfig
@@ -65,9 +68,9 @@ spec:
             {{- end }}
             {{- if eq .Values.etcd.mode "internal" }}
             - --etcd-servers=https://etcd-client.{{ include "karmada.namespace" . }}.svc.{{ .Values.clusterDomain }}:2379
-            - --etcd-cafile=/etc/kubernetes/pki/server-ca.crt
-            - --etcd-certfile=/etc/kubernetes/pki/karmada.crt
-            - --etcd-keyfile=/etc/kubernetes/pki/karmada.key
+            - --etcd-cafile=/etc/etcd/pki/server-ca.crt
+            - --etcd-certfile=/etc/etcd/pki/karmada.crt
+            - --etcd-keyfile=/etc/etcd/pki/karmada.key
             {{- end }}
             - --tls-cert-file=/etc/kubernetes/pki/karmada.crt
             - --tls-private-key-file=/etc/kubernetes/pki/karmada.key


### PR DESCRIPTION
Cherry pick of #3777 on release-1.5.
#3777: chart: fix karmada search external etcd no volume mount
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
Chart: Fixed the issue that `karmada-search` no ETCD secret volume mount when using external ETCD.
```