### PR TITLE
karmada-operator: add karmada apiserver kubeconfig to karmada status

### DIFF
--- a/operator/pkg/controlplane/apiserver/mainfests.go
+++ b/operator/pkg/controlplane/apiserver/mainfests.go
@@ -158,9 +158,9 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
         - /bin/karmada-aggregated-apiserver
-        - --kubeconfig=/etc/karmada/config
-        - --authentication-kubeconfig=/etc/karmada/config
-        - --authorization-kubeconfig=/etc/karmada/config
+        - --kubeconfig=/etc/karmada/kubeconfig
+        - --authentication-kubeconfig=/etc/karmada/kubeconfig
+        - --authorization-kubeconfig=/etc/karmada/kubeconfig
         - --etcd-cafile=/etc/etcd/pki/etcd-ca.crt
         - --etcd-certfile=/etc/etcd/pki/etcd-client.crt
         - --etcd-keyfile=/etc/etcd/pki/etcd-client.key
@@ -172,9 +172,9 @@ spec:
         - --audit-log-maxage=0
         - --audit-log-maxbackup=0
         volumeMounts:
-        - mountPath: /etc/karmada/config
+        - mountPath: /etc/karmada/kubeconfig
           name: kubeconfig
-          subPath: config
+          subPath: kubeconfig
         - mountPath: /etc/etcd/pki
           name: etcd-cert
           readOnly: true

--- a/operator/pkg/controlplane/manifests.go
+++ b/operator/pkg/controlplane/manifests.go
@@ -39,9 +39,9 @@ spec:
         command:
         - kube-controller-manager
         - --allocate-node-cidrs=true
-        - --kubeconfig=/etc/karmada/config
-        - --authentication-kubeconfig=/etc/karmada/config
-        - --authorization-kubeconfig=/etc/karmada/config
+        - --kubeconfig=/etc/karmada/kubeconfig
+        - --authentication-kubeconfig=/etc/karmada/kubeconfig
+        - --authorization-kubeconfig=/etc/karmada/kubeconfig
         - --bind-address=0.0.0.0
         - --client-ca-file=/etc/karmada/pki/ca.crt
         - --cluster-cidr=10.244.0.0/16
@@ -71,8 +71,8 @@ spec:
           mountPath: /etc/karmada/pki
           readOnly: true
         - name: kubeconfig
-          mountPath: /etc/karmada/config
-          subPath: config
+          mountPath: /etc/karmada/kubeconfig
+          subPath: kubeconfig
       volumes:
         - name: karmada-certs
           secret:
@@ -111,7 +111,7 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
         - /bin/karmada-controller-manager
-        - --kubeconfig=/etc/karmada/config
+        - --kubeconfig=/etc/karmada/kubeconfig
         - --bind-address=0.0.0.0
         - --cluster-status-update-frequency=10s
         - --secure-port=10357
@@ -129,8 +129,8 @@ spec:
           timeoutSeconds: 5
         volumeMounts:
         - name: kubeconfig
-          subPath: config
-          mountPath: /etc/karmada/config
+          subPath: kubeconfig
+          mountPath: /etc/karmada/kubeconfig
       volumes:
       - name: kubeconfig
         secret:
@@ -167,7 +167,7 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
         - /bin/karmada-scheduler
-        - --kubeconfig=/etc/karmada/config
+        - --kubeconfig=/etc/karmada/kubeconfig
         - --bind-address=0.0.0.0
         - --secure-port=10351
         - --enable-scheduler-estimator=true
@@ -184,8 +184,8 @@ spec:
           timeoutSeconds: 5
         volumeMounts:
         - name: kubeconfig
-          subPath: config
-          mountPath: /etc/karmada/config
+          subPath: kubeconfig
+          mountPath: /etc/karmada/kubeconfig
       volumes:
         - name: kubeconfig
           secret:
@@ -222,7 +222,7 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
         - /bin/karmada-descheduler
-        - --kubeconfig=/etc/karmada/config
+        - --kubeconfig=/etc/karmada/kubeconfig
         - --bind-address=0.0.0.0
         - --leader-elect-resource-namespace={{ .SystemNamespace }}
         - --v=4
@@ -237,8 +237,8 @@ spec:
           timeoutSeconds: 5
         volumeMounts:
         - name: kubeconfig
-          subPath: config
-          mountPath: /etc/karmada/config
+          subPath: kubeconfig
+          mountPath: /etc/karmada/kubeconfig
       volumes:
         - name: kubeconfig
           secret:

--- a/operator/pkg/controlplane/metricsadapter/mainfests.go
+++ b/operator/pkg/controlplane/metricsadapter/mainfests.go
@@ -31,17 +31,17 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
         - /bin/karmada-metrics-adapter
-        - --kubeconfig=/etc/karmada/config
-        - --authentication-kubeconfig=/etc/karmada/config
-        - --authorization-kubeconfig=/etc/karmada/config
+        - --kubeconfig=/etc/karmada/kubeconfig
+        - --authentication-kubeconfig=/etc/karmada/kubeconfig
+        - --authorization-kubeconfig=/etc/karmada/kubeconfig
         - --client-ca-file=/etc/karmada/pki/ca.crt
         - --audit-log-path=-
         - --audit-log-maxage=0
         - --audit-log-maxbackup=0
         volumeMounts:
         - name: kubeconfig
-          subPath: config
-          mountPath: /etc/karmada/config
+          subPath: kubeconfig
+          mountPath: /etc/karmada/kubeconfig
         - name: karmada-cert
           mountPath: /etc/karmada/pki
           readOnly: true

--- a/operator/pkg/controlplane/webhook/mainfests.go
+++ b/operator/pkg/controlplane/webhook/mainfests.go
@@ -31,7 +31,7 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
         - /bin/karmada-webhook
-        - --kubeconfig=/etc/karmada/config
+        - --kubeconfig=/etc/karmada/kubeconfig
         - --bind-address=0.0.0.0
         - --default-not-ready-toleration-seconds=30
         - --default-unreachable-toleration-seconds=30
@@ -42,8 +42,8 @@ spec:
         - containerPort: 8443
         volumeMounts:
         - name: kubeconfig
-          subPath: config
-          mountPath: /etc/karmada/config
+          subPath: kubeconfig
+          mountPath: /etc/karmada/kubeconfig
         - name: cert
           mountPath: /var/serving-cert
           readOnly: true

--- a/operator/pkg/tasks/init/upload.go
+++ b/operator/pkg/tasks/init/upload.go
@@ -80,7 +80,7 @@ func runUploadAdminKubeconfig(r workflow.RunData) error {
 			Name:      util.AdminKubeconfigSecretName(data.GetName()),
 			Labels:    constants.KarmadaOperatorLabel,
 		},
-		Data: map[string][]byte{"config": configBytes},
+		Data: map[string][]byte{"kubeconfig": configBytes},
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create secret of kubeconfig, err: %w", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
We should expose the kubeconfig to access the karmada apiserver after installing karmada instance.
So, reference the secret of kubeconfig to `Karmada.Status.SecretRef`.

```shell
kubectl get karmada -n karmada-test-08 karmada-test-08       
NAME              READY   AGE
karmada-test-08   True    21m
---
kubectl get secret -n karmada-test-08 karmada-test-08-admin-config -ojsonpath='{.data.kubeconfig}' | base64 -d > karmada-apiserver.config
---
kubectl --kubeconfig karmada-apiserver.config get crds
NAME                                                         CREATED AT
clusteroverridepolicies.policy.karmada.io                    2023-07-13T07:25:59Z
clusterpropagationpolicies.policy.karmada.io                 2023-07-13T07:25:59Z
clusterresourcebindings.work.karmada.io                      2023-07-13T07:26:00Z
federatedhpas.autoscaling.karmada.io                         2023-07-13T07:25:58Z
federatedresourcequotas.policy.karmada.io                    2023-07-13T07:25:59Z
multiclusteringresses.networking.karmada.io                  2023-07-13T07:25:59Z
overridepolicies.policy.karmada.io                           2023-07-13T07:26:00Z
propagationpolicies.policy.karmada.io                        2023-07-13T07:26:00Z
resourcebindings.work.karmada.io                             2023-07-13T07:26:00Z
resourceinterpretercustomizations.config.karmada.io          2023-07-13T07:25:58Z
resourceinterpreterwebhookconfigurations.config.karmada.io   2023-07-13T07:25:58Z
serviceexports.multicluster.x-k8s.io                         2023-07-13T07:25:59Z
serviceimports.multicluster.x-k8s.io                         2023-07-13T07:25:59Z
works.work.karmada.io                                        2023-07-13T07:26:00Z
```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-operator`: Attached kubeconfig file into status(.status.secretRef) after installation. 
```

