### PR TITLE
reduce unnecessary object update in workstatus_controller

### DIFF
--- a/pkg/util/lifted/objectwatcher.go
+++ b/pkg/util/lifted/objectwatcher.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -80,12 +81,19 @@ func objectMetaObjEquivalent(a, b metav1.Object) bool {
 	if a.GetNamespace() != b.GetNamespace() {
 		return false
 	}
-	aLabels := a.GetLabels()
 	// ignore the labels which are added by Karmada itself rather than user
+	aLabels := a.GetLabels()
+	delete(aLabels, policyv1alpha1.PropagationPolicyNamespaceLabel)
+	delete(aLabels, policyv1alpha1.PropagationPolicyNamespaceLabel)
+	delete(aLabels, policyv1alpha1.ClusterPropagationPolicyLabel)
 	bLabels := b.GetLabels()
 	delete(bLabels, policyv1alpha1.PropagationPolicyNamespaceLabel)
 	delete(bLabels, policyv1alpha1.PropagationPolicyNamespaceLabel)
 	delete(bLabels, policyv1alpha1.ClusterPropagationPolicyLabel)
+	delete(bLabels, workv1alpha2.ResourceBindingReferenceKey)
+	delete(bLabels, workv1alpha2.ClusterResourceBindingReferenceKey)
+	delete(bLabels, workv1alpha2.WorkNamespaceLabel)
+	delete(bLabels, workv1alpha2.WorkNameLabel)
 	if !reflect.DeepEqual(aLabels, bLabels) && (len(aLabels) != 0 || len(bLabels) != 0) {
 		return false
 	}

--- a/pkg/util/lifted/objectwatcher.go
+++ b/pkg/util/lifted/objectwatcher.go
@@ -27,6 +27,7 @@ import (
 	"reflect"
 	"strings"
 
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -80,7 +81,11 @@ func objectMetaObjEquivalent(a, b metav1.Object) bool {
 		return false
 	}
 	aLabels := a.GetLabels()
+	// ignore the labels which are added by Karmada itself rather than user
 	bLabels := b.GetLabels()
+	delete(bLabels, policyv1alpha1.PropagationPolicyNamespaceLabel)
+	delete(bLabels, policyv1alpha1.PropagationPolicyNamespaceLabel)
+	delete(bLabels, policyv1alpha1.ClusterPropagationPolicyLabel)
 	if !reflect.DeepEqual(aLabels, bLabels) && (len(aLabels) != 0 || len(bLabels) != 0) {
 		return false
 	}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
 The cluster object status change on member cluster triggers workstatus_controller. Then in function syncWorkStatus(), workstatus_controller checks if the object on Karmada control plane and member cluster are equal.
However the equivalent logic provided by function ObjectNeedsUpdate() always return true in case like below, which results in unneccessary ObjectWatcher.Update action from workstatus_controller.

Object in Karmada control plane like
```
metadata:
  creationTimestamp: "2023-07-10T05:58:42Z"
  generation: 1
  labels:
    clusterpropagationpolicy.karmada.io/name: xyz-propagation
```

Object in member cluster like 
```
metadata:
  labels:
    clusterpropagationpolicy.karmada.io/name: xyz-propagation
    clusterresourcebinding.karmada.io/key: 778949d7dc
    work.karmada.io/name: xyz-qii5l2vmpor7w7z06jnk-778949d7dc
    work.karmada.io/namespace: karmada-es-cluster170
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
In this PR, we solve the issue by ignoring all known Karmada labels of objects in both Karmada control plane and member cluster.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

