### PR TITLE
fix: reduce the number of metrics by merging entries 

### DIFF
--- a/pkg/controllers/binding/binding_controller.go
+++ b/pkg/controllers/binding/binding_controller.go
@@ -111,7 +111,7 @@ func (c *ResourceBindingController) syncBinding(binding *workv1alpha2.ResourceBi
 	}
 	start := time.Now()
 	err = ensureWork(c.Client, c.ResourceInterpreter, workload, c.OverrideManager, binding, apiextensionsv1.NamespaceScoped)
-	metrics.ObserveSyncWorkLatency(binding.ObjectMeta, err, start)
+	metrics.ObserveSyncWorkLatency(err, start)
 	if err != nil {
 		klog.Errorf("Failed to transform resourceBinding(%s/%s) to works. Error: %v.",
 			binding.GetNamespace(), binding.GetName(), err)

--- a/pkg/controllers/binding/cluster_resource_binding_controller.go
+++ b/pkg/controllers/binding/cluster_resource_binding_controller.go
@@ -111,7 +111,7 @@ func (c *ClusterResourceBindingController) syncBinding(binding *workv1alpha2.Clu
 
 	start := time.Now()
 	err = ensureWork(c.Client, c.ResourceInterpreter, workload, c.OverrideManager, binding, apiextensionsv1.ClusterScoped)
-	metrics.ObserveSyncWorkLatency(binding.ObjectMeta, err, start)
+	metrics.ObserveSyncWorkLatency(err, start)
 	if err != nil {
 		klog.Errorf("Failed to transform clusterResourceBinding(%s) to works. Error: %v.", binding.GetName(), err)
 		c.EventRecorder.Event(binding, corev1.EventTypeWarning, events.EventReasonSyncWorkFailed, err.Error())

--- a/pkg/controllers/execution/execution_controller.go
+++ b/pkg/controllers/execution/execution_controller.go
@@ -114,7 +114,7 @@ func (c *Controller) SetupWithManager(mgr controllerruntime.Manager) error {
 func (c *Controller) syncWork(clusterName string, work *workv1alpha1.Work) (controllerruntime.Result, error) {
 	start := time.Now()
 	err := c.syncToClusters(clusterName, work)
-	metrics.ObserveSyncWorkloadLatency(work.ObjectMeta, err, start)
+	metrics.ObserveSyncWorkloadLatency(err, start)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to sync work(%s) to cluster(%s): %v", work.Name, clusterName, err)
 		klog.Errorf(msg)

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -378,7 +378,7 @@ func (d *ResourceDetector) ApplyPolicy(object *unstructured.Unstructured, object
 	klog.Infof("Applying policy(%s/%s) for object: %s", policy.Namespace, policy.Name, objectKey)
 	var operationResult controllerutil.OperationResult
 	defer func() {
-		metrics.ObserveApplyPolicyAttemptAndLatency(object, policy.ObjectMeta, err, start)
+		metrics.ObserveApplyPolicyAttemptAndLatency(err, start)
 		if err != nil {
 			d.EventRecorder.Eventf(object, corev1.EventTypeWarning, events.EventReasonApplyPolicyFailed, "Apply policy(%s/%s) failed: %v", policy.Namespace, policy.Name, err)
 		} else if operationResult != controllerutil.OperationResultNone {
@@ -451,7 +451,7 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 	klog.Infof("Applying cluster policy(%s) for object: %s", policy.Name, objectKey)
 	var operationResult controllerutil.OperationResult
 	defer func() {
-		metrics.ObserveApplyPolicyAttemptAndLatency(object, policy.ObjectMeta, err, start)
+		metrics.ObserveApplyPolicyAttemptAndLatency(err, start)
 		if err != nil {
 			d.EventRecorder.Eventf(object, corev1.EventTypeWarning, events.EventReasonApplyPolicyFailed, "Apply cluster policy(%s) failed: %v", policy.Name, err)
 		} else if operationResult != controllerutil.OperationResultNone {

--- a/pkg/detector/policy.go
+++ b/pkg/detector/policy.go
@@ -53,7 +53,7 @@ func (d *ResourceDetector) propagateResource(object *unstructured.Unstructured, 
 			return fmt.Errorf("waiting for dependent overrides")
 		}
 		d.RemoveWaiting(objectKey)
-		metrics.ObserveFindMatchedPolicyLatency(object, start)
+		metrics.ObserveFindMatchedPolicyLatency(start)
 		return d.ApplyPolicy(object, objectKey, propagationPolicy)
 	}
 
@@ -70,7 +70,7 @@ func (d *ResourceDetector) propagateResource(object *unstructured.Unstructured, 
 			return fmt.Errorf("waiting for dependent overrides")
 		}
 		d.RemoveWaiting(objectKey)
-		metrics.ObserveFindMatchedPolicyLatency(object, start)
+		metrics.ObserveFindMatchedPolicyLatency(start)
 		return d.ApplyClusterPolicy(object, objectKey, clusterPolicy)
 	}
 

--- a/pkg/metrics/resource.go
+++ b/pkg/metrics/resource.go
@@ -4,8 +4,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	utilmetrics "github.com/karmada-io/karmada/pkg/util/metrics"
 )
@@ -23,51 +21,51 @@ var (
 		Name:    resourceMatchPolicyDurationMetricsName,
 		Help:    "Duration in seconds to find a matched propagation policy for the resource template.",
 		Buckets: prometheus.ExponentialBuckets(0.001, 2, 12),
-	}, []string{"apiVersion", "kind", "name", "namespace"})
+	}, []string{})
 
 	applyPolicyDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    resourceApplyPolicyDurationMetricsName,
 		Help:    "Duration in seconds to apply a propagation policy for the resource template. By the result, 'error' means a resource template failed to apply the policy. Otherwise 'success'.",
 		Buckets: prometheus.ExponentialBuckets(0.001, 2, 12),
-	}, []string{"apiVersion", "kind", "name", "namespace", "result"})
+	}, []string{"result"})
 
 	policyApplyAttempts = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: policyApplyAttemptsMetricsName,
 		Help: "Number of attempts to be applied for a propagation policy. By the result, 'error' means a resource template failed to apply the policy. Otherwise 'success'.",
-	}, []string{"namespace", "name", "result"})
+	}, []string{"result"})
 
 	syncWorkDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    syncWorkDurationMetricsName,
 		Help:    "Duration in seconds to sync works for a binding object. By the result, 'error' means a binding failed to sync works. Otherwise 'success'.",
 		Buckets: prometheus.ExponentialBuckets(0.001, 2, 12),
-	}, []string{"namespace", "name", "result"})
+	}, []string{"result"})
 
 	syncWorkloadDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    syncWorkloadDurationMetricsName,
 		Help:    "Duration in seconds to sync the workload to a target cluster. By the result, 'error' means a work failed to sync workloads. Otherwise 'success'.",
 		Buckets: prometheus.ExponentialBuckets(0.001, 2, 12),
-	}, []string{"namespace", "name", "result"})
+	}, []string{"result"})
 )
 
 // ObserveFindMatchedPolicyLatency records the duration for the resource finding a matched policy.
-func ObserveFindMatchedPolicyLatency(object *unstructured.Unstructured, start time.Time) {
-	findMatchedPolicyDurationHistogram.WithLabelValues(object.GetAPIVersion(), object.GetKind(), object.GetName(), object.GetNamespace()).Observe(utilmetrics.DurationInSeconds(start))
+func ObserveFindMatchedPolicyLatency(start time.Time) {
+	findMatchedPolicyDurationHistogram.WithLabelValues().Observe(utilmetrics.DurationInSeconds(start))
 }
 
 // ObserveApplyPolicyAttemptAndLatency records the duration for the resource applying a policy and a applying attempt for the policy.
-func ObserveApplyPolicyAttemptAndLatency(object *unstructured.Unstructured, policyMetaData metav1.ObjectMeta, err error, start time.Time) {
-	applyPolicyDurationHistogram.WithLabelValues(object.GetAPIVersion(), object.GetKind(), object.GetName(), object.GetNamespace(), utilmetrics.GetResultByError(err)).Observe(utilmetrics.DurationInSeconds(start))
-	policyApplyAttempts.WithLabelValues(policyMetaData.Namespace, policyMetaData.Name, utilmetrics.GetResultByError(err)).Inc()
+func ObserveApplyPolicyAttemptAndLatency(err error, start time.Time) {
+	applyPolicyDurationHistogram.WithLabelValues(utilmetrics.GetResultByError(err)).Observe(utilmetrics.DurationInSeconds(start))
+	policyApplyAttempts.WithLabelValues(utilmetrics.GetResultByError(err)).Inc()
 }
 
 // ObserveSyncWorkLatency records the duration to sync works for a binding object.
-func ObserveSyncWorkLatency(bindingMetaData metav1.ObjectMeta, err error, start time.Time) {
-	syncWorkDurationHistogram.WithLabelValues(bindingMetaData.Namespace, bindingMetaData.Name, utilmetrics.GetResultByError(err)).Observe(utilmetrics.DurationInSeconds(start))
+func ObserveSyncWorkLatency(err error, start time.Time) {
+	syncWorkDurationHistogram.WithLabelValues(utilmetrics.GetResultByError(err)).Observe(utilmetrics.DurationInSeconds(start))
 }
 
 // ObserveSyncWorkloadLatency records the duration to sync the workload to a target cluster.
-func ObserveSyncWorkloadLatency(workMetadata metav1.ObjectMeta, err error, start time.Time) {
-	syncWorkloadDurationHistogram.WithLabelValues(workMetadata.Namespace, workMetadata.Name, utilmetrics.GetResultByError(err)).Observe(utilmetrics.DurationInSeconds(start))
+func ObserveSyncWorkloadLatency(err error, start time.Time) {
+	syncWorkloadDurationHistogram.WithLabelValues(utilmetrics.GetResultByError(err)).Observe(utilmetrics.DurationInSeconds(start))
 }
 
 // ResourceCollectors returns the collectors about resources.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
As https://github.com/karmada-io/karmada/issues/3790 described, if there are many works, the metrics query response will be too big. The root reason is:
The label contains namespace/name/apiVersion, and for different resources, the entries are separate.

To delete these labels, all the resources will use the same one, for example:
Before:
```
work_sync_workload_duration_seconds_bucket{name="nginx",namespace="karmada-es-member2",result="success",le="+Inf"} 1
work_sync_workload_duration_seconds_bucket{name="mysql",namespace="karmada-es-member2",result="success",le="+Inf"} 1
```
After:
```
work_sync_workload_duration_seconds_bucket{result="success",le="+Inf"} 2
```

Regardless of the amount of resources available, the metrics item is limited.

**Which issue(s) this PR fixes**:
Fixes #3790 

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`Instrumentation`: Removed specific labels from the following metrics of `karmada-controller-manager` to reduce the metrics count:
- resource_match_policy_duration_seconds: removed `apiVersion`/`kind`/`name`/`namespace`.
- resource_apply_policy_duration_seconds: removed `apiVersion`/`kind`/`name`/`namespace`.
- policy_apply_attempts_total: removed `namespace`/`name`.
- binding_sync_work_duration_seconds: removed `namespace`/`name`.
- work_sync_workload_duration_seconds: removed `namespace`/`name`.
```

