### PR TITLE
reduce unnecessary update when processing in the workstatus controller

### DIFF
--- a/pkg/util/lifted/objectwatcher_test.go
+++ b/pkg/util/lifted/objectwatcher_test.go
@@ -2,9 +2,13 @@ package lifted
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 )
 
 func TestObjectVersion(t *testing.T) {
@@ -41,21 +45,21 @@ func TestObjectVersion(t *testing.T) {
 
 func TestObjectMetaObjEquivalent(t *testing.T) {
 	tests := []struct {
-		name   string
-		a      *unstructured.Unstructured
-		b      *unstructured.Unstructured
-		expect bool
+		name       string
+		desiredObj *unstructured.Unstructured
+		clusterObj *unstructured.Unstructured
+		expect     bool
 	}{
 		{
 			name: "name not equal",
-			a: &unstructured.Unstructured{
+			desiredObj: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"metadata": map[string]interface{}{
 						"name": "a",
 					},
 				},
 			},
-			b: &unstructured.Unstructured{
+			clusterObj: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"metadata": map[string]interface{}{
 						"name": "b",
@@ -66,14 +70,14 @@ func TestObjectMetaObjEquivalent(t *testing.T) {
 		},
 		{
 			name: "namespace not equal",
-			a: &unstructured.Unstructured{
+			desiredObj: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"metadata": map[string]interface{}{
 						"namespace": "a",
 					},
 				},
 			},
-			b: &unstructured.Unstructured{
+			clusterObj: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"metadata": map[string]interface{}{
 						"namespace": "b",
@@ -83,40 +87,170 @@ func TestObjectMetaObjEquivalent(t *testing.T) {
 			expect: false,
 		},
 		{
-			name: "label not equal",
-			a: &unstructured.Unstructured{
+			name: "clusterObj annotations have updated item with record",
+			desiredObj: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"metadata": map[string]interface{}{
-						"labels": map[string]interface{}{"a": "b"},
+						"annotations": map[string]interface{}{
+							workv1alpha2.ManagedAnnotation: strings.Join([]string{workv1alpha2.ManagedAnnotation, workv1alpha2.ManagedLabels, "Updated"}, ","),
+							workv1alpha2.ManagedLabels:     "",
+							"Updated":                      "old",
+						},
 					},
 				},
 			},
-			b: &unstructured.Unstructured{
+			clusterObj: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"metadata": map[string]interface{}{
-						"labels": map[string]interface{}{"c": "d"},
+						"annotations": map[string]interface{}{
+							workv1alpha2.ManagedAnnotation: strings.Join([]string{workv1alpha2.ManagedAnnotation, workv1alpha2.ManagedLabels, "Updated"}, ","),
+							workv1alpha2.ManagedLabels:     "",
+							"Updated":                      "new",
+						},
 					},
 				},
 			},
 			expect: false,
 		},
 		{
-			name: "everything is the same",
-			a: &unstructured.Unstructured{
+			name: "clusterObj annotations have deleted item with record",
+			desiredObj: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"metadata": map[string]interface{}{
-						"name":      "a",
-						"namespace": "a",
-						"labels":    "a",
+						"annotations": map[string]interface{}{
+							workv1alpha2.ManagedAnnotation: strings.Join([]string{workv1alpha2.ManagedAnnotation, workv1alpha2.ManagedLabels, "Deleted"}, ","),
+							workv1alpha2.ManagedLabels:     "",
+							"Deleted":                      "true",
+						},
 					},
 				},
 			},
-			b: &unstructured.Unstructured{
+			clusterObj: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"metadata": map[string]interface{}{
-						"name":      "a",
-						"namespace": "a",
-						"labels":    "a",
+						"annotations": map[string]interface{}{
+							workv1alpha2.ManagedAnnotation: strings.Join([]string{workv1alpha2.ManagedAnnotation, workv1alpha2.ManagedLabels, "Deleted"}, ","),
+							workv1alpha2.ManagedLabels:     "",
+						},
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "clusterObj annotations have added item without record",
+			desiredObj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							workv1alpha2.ManagedAnnotation: strings.Join([]string{workv1alpha2.ManagedAnnotation, workv1alpha2.ManagedLabels}, ","),
+							workv1alpha2.ManagedLabels:     "",
+						},
+					},
+				},
+			},
+			clusterObj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							workv1alpha2.ManagedAnnotation: strings.Join([]string{workv1alpha2.ManagedAnnotation, workv1alpha2.ManagedLabels}, ","),
+							workv1alpha2.ManagedLabels:     "",
+							"Added":                        "true",
+						},
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "clusterObj labels have updated item with record",
+			desiredObj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							workv1alpha2.ManagedAnnotation: strings.Join([]string{workv1alpha2.ManagedAnnotation, workv1alpha2.ManagedLabels}, ","),
+							workv1alpha2.ManagedLabels:     "A,Updated",
+						},
+						"labels": map[string]interface{}{
+							"A":       "a",
+							"Updated": "old",
+						},
+					},
+				},
+			},
+			clusterObj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							workv1alpha2.ManagedAnnotation: strings.Join([]string{workv1alpha2.ManagedAnnotation, workv1alpha2.ManagedLabels}, ","),
+							workv1alpha2.ManagedLabels:     "A,Updated",
+						},
+						"labels": map[string]interface{}{
+							"A":       "a",
+							"Updated": "new",
+						},
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "clusterObj labels have deleted item with record",
+			desiredObj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							workv1alpha2.ManagedAnnotation: strings.Join([]string{workv1alpha2.ManagedAnnotation, workv1alpha2.ManagedLabels}, ","),
+							workv1alpha2.ManagedLabels:     "A,Deleted",
+						},
+						"labels": map[string]interface{}{
+							"A":       "a",
+							"Deleted": "true",
+						},
+					},
+				},
+			},
+			clusterObj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							workv1alpha2.ManagedAnnotation: strings.Join([]string{workv1alpha2.ManagedAnnotation, workv1alpha2.ManagedLabels}, ","),
+							workv1alpha2.ManagedLabels:     "A,Deleted",
+						},
+						"labels": map[string]interface{}{
+							"A": "a",
+						},
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "clusterObj labels have added item without record",
+			desiredObj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							workv1alpha2.ManagedAnnotation: strings.Join([]string{workv1alpha2.ManagedAnnotation, workv1alpha2.ManagedLabels}, ","),
+							workv1alpha2.ManagedLabels:     "A",
+						},
+						"labels": map[string]interface{}{
+							"A": "a",
+						},
+					},
+				},
+			},
+			clusterObj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							workv1alpha2.ManagedAnnotation: strings.Join([]string{workv1alpha2.ManagedAnnotation, workv1alpha2.ManagedLabels}, ","),
+							workv1alpha2.ManagedLabels:     "A",
+						},
+						"labels": map[string]interface{}{
+							"A":     "a",
+							"Added": "true",
+						},
 					},
 				},
 			},
@@ -126,7 +260,7 @@ func TestObjectMetaObjEquivalent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := objectMetaObjEquivalent(tt.a, tt.b)
+			actual := objectMetaObjEquivalent(tt.desiredObj, tt.clusterObj)
 			if actual != tt.expect {
 				t.Errorf("expect %v but got %v", tt.expect, actual)
 			}
@@ -147,5 +281,166 @@ func TestObjectNeedsUpdate(t *testing.T) {
 	actual := ObjectNeedsUpdate(desiredObj, clusterObj, recordedVersion)
 	if actual != true {
 		t.Errorf("expect %v, but got %v", true, actual)
+	}
+}
+
+func Test_propagateAnnotationsChanged(t *testing.T) {
+	tests := []struct {
+		name        string
+		desireMaps  map[string]string
+		clusterMaps map[string]string
+		want        bool
+	}{
+		{
+			name:       "nil desire annotations",
+			desireMaps: nil,
+			clusterMaps: map[string]string{
+				"A": "desiredObj",
+			},
+			want: false,
+		},
+		{
+			name: "nil cluster annotations",
+			desireMaps: map[string]string{
+				workv1alpha2.ManagedAnnotation: strings.Join([]string{workv1alpha2.ManagedAnnotation}, ","),
+			},
+			clusterMaps: nil,
+			want:        true,
+		},
+		{
+			name: "desire annotations have deleted item",
+			desireMaps: map[string]string{
+				workv1alpha2.ManagedAnnotation: strings.Join([]string{workv1alpha2.ManagedAnnotation}, ","),
+			},
+			clusterMaps: map[string]string{
+				workv1alpha2.ManagedAnnotation: strings.Join([]string{workv1alpha2.ManagedAnnotation, "Deleted"}, ","),
+				"Deleted":                      "deleted in the control plane",
+			},
+			want: true,
+		},
+		{
+			name: "desire annotations have item but not record in the record annotation",
+			desireMaps: map[string]string{
+				workv1alpha2.ManagedAnnotation: strings.Join([]string{workv1alpha2.ManagedAnnotation}, ","),
+				"only-exist-in-control-plane":  "true",
+			},
+			clusterMaps: map[string]string{
+				workv1alpha2.ManagedAnnotation: strings.Join([]string{workv1alpha2.ManagedAnnotation}, ","),
+			},
+			want: false,
+		},
+		{
+			name: "cluster annotations have updated item",
+			desireMaps: map[string]string{
+				workv1alpha2.ManagedAnnotation: strings.Join([]string{workv1alpha2.ManagedAnnotation, "Updated"}, ","),
+				"Updated":                      "control plane",
+			},
+			clusterMaps: map[string]string{
+				workv1alpha2.ManagedAnnotation: strings.Join([]string{workv1alpha2.ManagedAnnotation, "Updated"}, ","),
+				"Updated":                      "update in the member cluster",
+			},
+			want: true,
+		},
+		{
+			name: "cluster annotations have added item",
+			desireMaps: map[string]string{
+				workv1alpha2.ManagedAnnotation: strings.Join([]string{workv1alpha2.ManagedAnnotation, "A"}, ","),
+				"A":                            "desiredObj",
+			},
+			clusterMaps: map[string]string{
+				workv1alpha2.ManagedAnnotation: strings.Join([]string{workv1alpha2.ManagedAnnotation, "A"}, ","),
+				"A":                            "desiredObj",
+				"Added":                        "add in the member cluster",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, propagateAnnotationsChanged(tt.desireMaps, tt.clusterMaps),
+				"propagateAnnotationsChanged(%v, %v)", tt.desireMaps, tt.clusterMaps)
+		})
+	}
+}
+
+func Test_propagateLabelsChange(t *testing.T) {
+	tests := []struct {
+		name          string
+		desireLabels  map[string]string
+		clusterLabels map[string]string
+		keys          []string
+		want          bool
+	}{
+		{
+			name:         "nil desire labels",
+			desireLabels: nil,
+			clusterLabels: map[string]string{
+				"A": "desiredObj",
+			},
+			keys: nil,
+			want: false,
+		},
+		{
+			name:         "nil desire labels & nil keys",
+			desireLabels: nil,
+			clusterLabels: map[string]string{
+				"A": "desiredObj",
+			},
+			keys: nil,
+			want: false,
+		},
+		{
+			name: "desire labels have deleted item",
+			desireLabels: map[string]string{
+				"A": "desiredObj",
+			},
+			clusterLabels: map[string]string{
+				"A": "desiredObj",
+				"B": "b",
+			},
+			keys: []string{"A", "B"},
+			want: true,
+		},
+		{
+			name: "desire labels have item but not record in the record annotation",
+			desireLabels: map[string]string{
+				"A": "desiredObj",
+				"B": "b",
+			},
+			clusterLabels: map[string]string{
+				"B": "b",
+			},
+			keys: []string{"B"},
+			want: false,
+		},
+		{
+			name: "cluster labels have updated item",
+			desireLabels: map[string]string{
+				"B": "b",
+			},
+			clusterLabels: map[string]string{
+				"B": "b-update",
+			},
+			keys: []string{"B"},
+			want: true,
+		},
+		{
+			name: "cluster labels have added item",
+			desireLabels: map[string]string{
+				"B": "b",
+			},
+			clusterLabels: map[string]string{
+				"B": "b",
+				"C": "new-added",
+			},
+			keys: []string{"B"},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, propagateLabelsChange(tt.desireLabels, tt.clusterLabels, tt.keys),
+				"propagateLabelsChange(%v, %v, %v)", tt.desireLabels, tt.clusterLabels, tt.keys)
+		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

In the `workstatus-controller`, when collecting the work status, it will check if there are any changes in the resources propagated by Karmada on the member clusters. At this time, it is necessary to check for changes in annotations and labels on the resources because we allow users to add new annotations and labels to the resources. Therefore, we only need to check those annotations and labels controlled by Karmada.

**Which issue(s) this PR fixes**:
Fixes #3204 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

