### PR TITLE
make work name label value shorter

### DIFF
--- a/pkg/util/names/names.go
+++ b/pkg/util/names/names.go
@@ -3,6 +3,7 @@ package names
 import (
 	"fmt"
 	"hash/fnv"
+	"regexp"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -73,6 +74,74 @@ func GenerateBindingReferenceKey(namespace, name string) string {
 	return rand.SafeEncodeString(fmt.Sprint(hash.Sum32()))
 }
 
+var (
+	splitterPattern = regexp.MustCompile(`[._\-]`)
+)
+
+const (
+	maxNameLength = 52 // plus hex suffix -0123456789 goes to 63, value length limit of label is 63
+)
+
+func ShortName(name string, splitter *regexp.Regexp, maxLength int) string {
+	if len(name) <= maxLength {
+		return name
+	}
+	parts := splitter.Split(name, -1)
+	var length, index, trim int
+	for i, part := range parts {
+		if length+len(part)+i < maxLength {
+			length += len(part)
+			continue
+		}
+		if i == 0 {
+			index = i
+			break
+		}
+		for j := i; j > 0; j-- {
+			trim = maxLength - length - len(parts)
+			if trim >= 0 && len(parts[j]) > trim {
+				index = j
+				break
+			}
+			length -= len(parts[j-1])
+		}
+		if index != 0 {
+			break
+		}
+	}
+	if index == 0 {
+		return name[:maxLength]
+	}
+	buffer := new(strings.Builder)
+	if trim == 0 {
+		buffer.WriteString(parts[index][:1])
+	}
+	for _, part := range parts[index+1:] {
+		buffer.WriteString(part[:1])
+	}
+	if trim > 0 {
+		parts = append(parts[:index], parts[index][:trim])
+	} else {
+		parts = parts[:index]
+	}
+	if rest := buffer.String(); len(rest) > 0 {
+		parts = append(parts, rest)
+	}
+	return strings.Join(parts, "-")
+}
+
+// ShortNameLabelValue will truncate name to let length of name not to reach max length.
+// This method is inspired by java spring, for example there is a class full name
+// com.company.departure.business.module.abc.SomeClass, this will log as
+// ccdbma.SomeClass, keep the last part of class name, the prefix parts only keep
+// the first alphabet.
+// This method tries best to keep prefix. e.g.
+// input: lala.134-ab_abc-adfja2edklfja3rqdkfjasfa-1234567890123-a-b
+// output: lala-134-ab-abc-adfja2edklfja3rqdkfjasfa-12345678-ab
+func ShortNameLabelValue(name string) string {
+	return ShortName(name, splitterPattern, maxNameLength)
+}
+
 // GenerateWorkName will generate work name by its name and the hash of its namespace, kind and name.
 func GenerateWorkName(kind, name, namespace string) string {
 	// The name of resources, like 'Role'/'ClusterRole'/'RoleBinding'/'ClusterRoleBinding',
@@ -95,7 +164,7 @@ func GenerateWorkName(kind, name, namespace string) string {
 	}
 	hash := fnv.New32a()
 	hashutil.DeepHashObject(hash, workName)
-	return fmt.Sprintf("%s-%s", name, rand.SafeEncodeString(fmt.Sprint(hash.Sum32())))
+	return fmt.Sprintf("%s-%s", ShortNameLabelValue(name), rand.SafeEncodeString(fmt.Sprint(hash.Sum32())))
 }
 
 // GenerateServiceAccountName generates the name of a ServiceAccount.

--- a/pkg/util/names/names_test.go
+++ b/pkg/util/names/names_test.go
@@ -207,6 +207,35 @@ func TestGenerateWorkName(t *testing.T) {
 	}
 }
 
+func TestShortNameLabelValue(t *testing.T) {
+	cases := []struct {
+		description string
+		input       string
+		expect      string
+	}{{
+		description: "some common case",
+		input:       "lala.134-ab_abc-adfja2edklfja3rqdkfjasfa-1234567890123-a-b",
+		expect:      "lala-134-ab-abc-adfja2edklfja3rqdkfjasfa-12345678-ab",
+	}, {
+		description: "less common case",
+		input:       "0-1-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16-17-18-19-20-21-22-23-24",
+		expect:      "0-1-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16-17-1-122222",
+	}, {
+		description: "boundary case A",
+		input:       "0-1-2-3-4-5-6-7-8-9-0-a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p-q-r-s-t-u-v-w-x-y-z",
+		expect:      "0-1-2-3-4-5-6-7-8-9-0-a-b-c-d-efghijklmnopqrstuvwxyz",
+	}, {
+		description: "boundary case B",
+		input:       "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+		expect:      "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOP",
+	}}
+	for _, testCase := range cases {
+		if got := ShortNameLabelValue(testCase.input); got != testCase.expect {
+			t.Errorf("Test failed, name: %s, expect: %s, got: %s", testCase.description, testCase.expect, got)
+		}
+	}
+}
+
 func TestGenerateServiceAccountName(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind bug

**What this PR does / why we need it**:

Long label value may reach the length limit `63`, blocks `work` applying kubernetes resource to member cluster.
We need to short the label value, yet makes the value distinct and readable.

**Which issue(s) this PR fixes**:
Fixes #3809

**Special notes for your reviewer**:

short-name-xxxxxxxxxx, there a consistence hash suffix, so sort name together with suffix is unique, won't cause name conflict.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

