### PR TITLE
add wildcard support to `ResourceSelectors`

### DIFF
--- a/pkg/util/selector.go
+++ b/pkg/util/selector.go
@@ -33,9 +33,9 @@ func ResourceMatches(resource *unstructured.Unstructured, rs policyv1alpha1.Reso
 
 // ResourceSelectorPriority tells the priority between the specific resource and the selector.
 func ResourceSelectorPriority(resource *unstructured.Unstructured, rs policyv1alpha1.ResourceSelector) ImplicitPriority {
-	if resource.GetAPIVersion() != rs.APIVersion ||
-		resource.GetKind() != rs.Kind ||
-		(len(rs.Namespace) > 0 && resource.GetNamespace() != rs.Namespace) {
+	if (resource.GetAPIVersion() != rs.APIVersion && rs.APIVersion != "*") ||
+		(resource.GetKind() != rs.Kind && rs.Kind != "*") ||
+		(len(rs.Namespace) > 0 && resource.GetNamespace() != rs.Namespace && rs.Namespace != "*") {
 		return PriorityMisMatch
 	}
 

--- a/pkg/util/selector_test.go
+++ b/pkg/util/selector_test.go
@@ -170,6 +170,17 @@ func TestResourceSelectorPriority(t *testing.T) {
 			want: PriorityMatchName,
 		},
 		{
+			name: "wildcard namespace matched",
+			args: args{
+				rs: policyv1alpha1.ResourceSelector{
+					APIVersion: "*",
+					Kind:       "*",
+					Namespace:  "*",
+				},
+			},
+			want: PriorityMatchAll,
+		},
+		{
 			name: "[case 1] name not matched",
 			args: args{
 				rs: policyv1alpha1.ResourceSelector{


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind feature

**What this PR does / why we need it**: 

Currently a `ClusterPropagationPolicy` is able to propagate both namespaced and cluster-wide resources to member clusters. However, there is not currently a way to say "I would like for all resources, both namespaced and cluster-wide, to be propagated according to this `ClusterPropagationPolicy`, regardless of their `APIVersion` or `Kind`, and in all `Namespaces` (except for the system-reserved namespaces)."

With this change, a wildcard feature is added to allow a `ClusterPropagationPolicy` to do just that. By Providing a "*" for any combination of the `APIVersion`, `Kind` and `Namespace`, a `ClusterPropagationPolicy` can be made to match on a wider array of 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Adds a wildcard parsing feature to the ResourceSelector, allowing more flexible matching behavior.
```

