### PR TITLE
Fix: Denied pp create request for association

### DIFF
--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -25,6 +25,9 @@ func ValidatePropagationSpec(spec policyv1alpha1.PropagationSpec) field.ErrorLis
 	if spec.Failover != nil && spec.Failover.Application != nil && !spec.PropagateDeps {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("propagateDeps"), spec.PropagateDeps, "application failover is set, propagateDeps must be true"))
 	}
+	if spec.Association {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("association"), spec.PropagateDeps, "spec.association has been deprecated, use PropagateDeps instead."))
+	}
 	allErrs = append(allErrs, ValidateFailover(spec.Failover, field.NewPath("spec").Child("failover"))...)
 	return allErrs
 }

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -536,6 +536,13 @@ func TestValidatePropagationSpec(t *testing.T) {
 				}},
 			expectedErr: "the cluster spread constraint must be enabled in one of the constraints in case of SpreadByField is enabled",
 		},
+		{
+			name: "should not use field of association",
+			spec: policyv1alpha1.PropagationSpec{
+				Association: true,
+			},
+			expectedErr: "spec.association has been deprecated, use PropagateDeps instead.",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

association  is not used anymore, and it's not working now. Denied create request of pp to avoid user wrong usage  this field.

/cc @RainbowMango 

Related:
- #3679

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Denied Clusterpropagationpolicy& Propagationpolicy creqte quest for association.
```

