### PR TITLE
feat: Add label on the namespace created by karmada

### DIFF
--- a/pkg/karmadactl/register/register.go
+++ b/pkg/karmadactl/register/register.go
@@ -38,6 +38,7 @@ import (
 	cmdutil "github.com/karmada-io/karmada/pkg/karmadactl/util"
 	"github.com/karmada-io/karmada/pkg/karmadactl/util/apiclient"
 	tokenutil "github.com/karmada-io/karmada/pkg/karmadactl/util/bootstraptoken"
+	"github.com/karmada-io/karmada/pkg/util"
 	karmadautil "github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/lifted/pubkeypin"
 	"github.com/karmada-io/karmada/pkg/version"
@@ -339,8 +340,12 @@ func (o *CommandRegisterOption) Run(parentCommand string) error {
 		return err
 	}
 
+	// It's necessary to set the label of namespace to make sure that the namespace is created by Karmada.
+	labels := map[string]string{
+		util.ManagedByKarmadaLabel: util.ManagedByKarmadaLabelValue,
+	}
 	// ensure namespace where the karmada-agent resources be deployed exists in the member cluster
-	if _, err := karmadautil.EnsureNamespaceExist(o.memberClusterClient, o.Namespace, o.DryRun); err != nil {
+	if _, err := karmadautil.EnsureNamespaceExistWithLabels(o.memberClusterClient, o.Namespace, o.DryRun, labels); err != nil {
 		return err
 	}
 

--- a/pkg/util/credential.go
+++ b/pkg/util/credential.go
@@ -41,8 +41,12 @@ func ObtainCredentialsFromMemberCluster(clusterKubeClient kubeclient.Interface, 
 	var impersonatorSecret *corev1.Secret
 	var clusterSecret *corev1.Secret
 	var err error
+	// It's necessary to set the label of namespace to make sure that the namespace is created by Karmada.
+	labels := map[string]string{
+		ManagedByKarmadaLabel: ManagedByKarmadaLabelValue,
+	}
 	// ensure namespace where the karmada control plane credential be stored exists in cluster.
-	if _, err = EnsureNamespaceExist(clusterKubeClient, opts.ClusterNamespace, opts.DryRun); err != nil {
+	if _, err = EnsureNamespaceExistWithLabels(clusterKubeClient, opts.ClusterNamespace, opts.DryRun, labels); err != nil {
 		return nil, nil, err
 	}
 
@@ -98,8 +102,12 @@ func ObtainCredentialsFromMemberCluster(clusterKubeClient kubeclient.Interface, 
 
 // RegisterClusterInControllerPlane represents register cluster in controller plane
 func RegisterClusterInControllerPlane(opts ClusterRegisterOption, controlPlaneKubeClient kubeclient.Interface, generateClusterInControllerPlane generateClusterInControllerPlaneFunc) error {
+	// It's necessary to set the label of namespace to make sure that the namespace is created by Karmada.
+	labels := map[string]string{
+		ManagedByKarmadaLabel: ManagedByKarmadaLabelValue,
+	}
 	// ensure namespace where the cluster object be stored exists in control plane.
-	if _, err := EnsureNamespaceExist(controlPlaneKubeClient, opts.ClusterNamespace, opts.DryRun); err != nil {
+	if _, err := EnsureNamespaceExistWithLabels(controlPlaneKubeClient, opts.ClusterNamespace, opts.DryRun, labels); err != nil {
 		return err
 	}
 

--- a/pkg/util/namespace.go
+++ b/pkg/util/namespace.go
@@ -50,8 +50,18 @@ func DeleteNamespace(client kubeclient.Interface, namespace string) error {
 // EnsureNamespaceExist makes sure that the specific namespace exist in cluster.
 // If namespace not exit, just create it.
 func EnsureNamespaceExist(client kubeclient.Interface, namespace string, dryRun bool) (*corev1.Namespace, error) {
+	return EnsureNamespaceExistWithLabels(client, namespace, dryRun, nil)
+}
+
+// EnsureNamespaceExistWithLabels makes sure that the specific namespace exist in cluster.
+// If namespace not exit, just create it with specific labels.
+func EnsureNamespaceExistWithLabels(client kubeclient.Interface, namespace string, dryRun bool, labels map[string]string) (*corev1.Namespace, error) {
 	namespaceObj := &corev1.Namespace{}
 	namespaceObj.Name = namespace
+	// Set labels for namespace.
+	if labels != nil {
+		namespaceObj.Labels = labels
+	}
 
 	if dryRun {
 		return namespaceObj, nil

--- a/pkg/util/namespace_test.go
+++ b/pkg/util/namespace_test.go
@@ -268,3 +268,92 @@ func TestEnsureNamespaceExist(t *testing.T) {
 		})
 	}
 }
+
+func TestEnsureNamespaceExistWithLabels(t *testing.T) {
+	type args struct {
+		client        *fake.Clientset
+		namespace     string
+		dryRun        bool
+		labels        map[string]string
+		reactorGet    coretesting.ReactionFunc
+		reactorCreate coretesting.ReactionFunc
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "dry run",
+			args: args{
+				client:    fake.NewSimpleClientset(),
+				namespace: "default",
+				dryRun:    true,
+				labels:    map[string]string{"testkey": "testvalue"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "namespace already exists",
+			args: args{
+				client:    fake.NewSimpleClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}),
+				namespace: "default",
+				labels:    map[string]string{"testkey": "testvalue"},
+				reactorCreate: func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, apierrors.NewAlreadyExists(schema.ParseGroupResource("namespaces"), "default")
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "check namespace exists error",
+			args: args{
+				client:    fake.NewSimpleClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}),
+				namespace: metav1.NamespaceDefault,
+				labels:    map[string]string{"testkey": "testvalue"},
+				reactorGet: func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, errors.New("failed to get namespace")
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "create namespace error",
+			args: args{
+				client:    fake.NewSimpleClientset(),
+				namespace: metav1.NamespaceDefault,
+				labels:    map[string]string{"testkey": "testvalue"},
+				reactorCreate: func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, errors.New("failed to create namespace")
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "create namespace with nil labels",
+			args: args{
+				client:    fake.NewSimpleClientset(),
+				namespace: metav1.NamespaceDefault,
+				labels:    nil,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.args.reactorGet != nil {
+				tt.args.client.PrependReactor("get", "namespaces", tt.args.reactorGet)
+			}
+
+			if tt.args.reactorCreate != nil {
+				tt.args.client.PrependReactor("create", "namespaces", tt.args.reactorCreate)
+			}
+
+			_, err := EnsureNamespaceExistWithLabels(tt.args.client, tt.args.namespace, tt.args.dryRun, tt.args.labels)
+			if (err == nil && tt.wantErr == true) || (err != nil && tt.wantErr == false) {
+				t.Errorf("EnsureNamespaceExistWithLabels() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test

kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #2862 

**Special notes for your reviewer**:
when adding a cluster to karmada, it will has a label indicating that the namespace was created by karmada to avoid accidental deletion.:
<img width="477" alt="1690297085554_55BC3EBF-9367-464a-AFF4-5A101499EB30" src="https://github.com/karmada-io/karmada/assets/56665618/0b37dcb0-9fdd-43ae-8f34-c4cd66f5b5fa">

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmadactl join/register, karmada-agent: Add labels on the namespace created by karmada.
```

