### PR TITLE
fix: when the PP is deleted, the propagationpolicy.karmada.io/name label in the resource template's labels is not removed.

### DIFF
--- a/pkg/detector/policy.go
+++ b/pkg/detector/policy.go
@@ -89,6 +89,10 @@ func (d *ResourceDetector) propagateResource(object *unstructured.Unstructured, 
 func (d *ResourceDetector) getAndApplyPolicy(object *unstructured.Unstructured, objectKey keys.ClusterWideKey, policyNamespace, policyName string) error {
 	policyObject, err := d.propagationPolicyLister.ByNamespace(policyNamespace).Get(policyName)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.V(4).Infof("PropagationPolicy(%s/%s) has been removed.", policyNamespace, policyName)
+			return d.HandlePropagationPolicyDeletion(policyNamespace, policyName)
+		}
 		klog.Errorf("Failed to get claimed policy(%s/%s),: %v", policyNamespace, policyName, err)
 		return err
 	}
@@ -122,6 +126,11 @@ func (d *ResourceDetector) getAndApplyPolicy(object *unstructured.Unstructured, 
 func (d *ResourceDetector) getAndApplyClusterPolicy(object *unstructured.Unstructured, objectKey keys.ClusterWideKey, policyName string) error {
 	policyObject, err := d.clusterPropagationPolicyLister.Get(policyName)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.V(4).Infof("ClusterPropagationPolicy(%s) has been removed.", policyName)
+			return d.HandleClusterPropagationPolicyDeletion(policyName)
+		}
+
 		klog.Errorf("Failed to get claimed policy(%s),: %v", policyName, err)
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: chaunceyjiang <chaunceyjiang@gmail.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Fixed a boundary case where the `propagationpolicy.karmada.io/name` in the label of the resource template would not be removed when deleting PP.

**Which issue(s) this PR fixes**:
Fixes #3847 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`:  Fixed a boundary case where the `propagationpolicy.karmada.io/name` in the label of the resource template would not be removed after deleting PP.
```

