### PR TITLE
Automated cherry pick of #3848: fix: When the PP is deleted, the

### DIFF
--- a/pkg/detector/policy.go
+++ b/pkg/detector/policy.go
@@ -89,6 +89,10 @@ func (d *ResourceDetector) propagateResource(object *unstructured.Unstructured, 
 func (d *ResourceDetector) getAndApplyPolicy(object *unstructured.Unstructured, objectKey keys.ClusterWideKey, policyNamespace, policyName string) error {
 	policyObject, err := d.propagationPolicyLister.ByNamespace(policyNamespace).Get(policyName)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.V(4).Infof("PropagationPolicy(%s/%s) has been removed.", policyNamespace, policyName)
+			return d.HandlePropagationPolicyDeletion(policyNamespace, policyName)
+		}
 		klog.Errorf("Failed to get claimed policy(%s/%s),: %v", policyNamespace, policyName, err)
 		return err
 	}
@@ -122,6 +126,11 @@ func (d *ResourceDetector) getAndApplyPolicy(object *unstructured.Unstructured, 
 func (d *ResourceDetector) getAndApplyClusterPolicy(object *unstructured.Unstructured, objectKey keys.ClusterWideKey, policyName string) error {
 	policyObject, err := d.clusterPropagationPolicyLister.Get(policyName)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.V(4).Infof("ClusterPropagationPolicy(%s) has been removed.", policyName)
+			return d.HandleClusterPropagationPolicyDeletion(policyName)
+		}
+
 		klog.Errorf("Failed to get claimed policy(%s),: %v", policyName, err)
 		return err
 	}


### PR DESCRIPTION
Cherry pick of #3848 on release-1.6.
#3848: fix: When the PP is deleted, the
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`:  Fixed a boundary case where the `propagationpolicy.karmada.io/name` in the label of the resource template would not be removed after deleting PP.
```