### PR TITLE
[WIP][operator] feat: ClusterDomain for karmada instance

### DIFF
--- a/operator/pkg/controlplane/apiserver/apiserver.go
+++ b/operator/pkg/controlplane/apiserver/apiserver.go
@@ -37,6 +37,7 @@ func installKarmadaAPIServer(client clientset.Interface, cfg *operatorv1alpha1.K
 	apiserverDeploymentBytes, err := util.ParseTemplate(KarmadaApiserverDeployment, struct {
 		DeploymentName, Namespace, Image, EtcdClientService string
 		ServiceSubnet, KarmadaCertsSecret, EtcdCertsSecret  string
+		DnsDomain string
 		Replicas                                            *int32
 		EtcdListenClientPort                                int32
 	}{
@@ -49,6 +50,7 @@ func installKarmadaAPIServer(client clientset.Interface, cfg *operatorv1alpha1.K
 		EtcdCertsSecret:      util.EtcdCertSecretName(name),
 		Replicas:             cfg.Replicas,
 		EtcdListenClientPort: constants.EtcdListenClientPort,
+		DnsDomain: "cluster.local",
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing karmadaApiserver deployment template: %w", err)

--- a/operator/pkg/controlplane/apiserver/mainfests.go
+++ b/operator/pkg/controlplane/apiserver/mainfests.go
@@ -164,7 +164,7 @@ spec:
         - --etcd-cafile=/etc/etcd/pki/etcd-ca.crt
         - --etcd-certfile=/etc/etcd/pki/etcd-client.crt
         - --etcd-keyfile=/etc/etcd/pki/etcd-client.key
-        - --etcd-servers=https://{{ .EtcdClientService }}.{{ .Namespace }}.svc.cluster.local:{{ .EtcdListenClientPort }}
+        - --etcd-servers=https://{{ .EtcdClientService }}.{{ .Namespace }}.svc.{{ .DnsDomain }}:{{ .EtcdListenClientPort }}
         - --tls-cert-file=/etc/karmada/pki/karmada.crt
         - --tls-private-key-file=/etc/karmada/pki/karmada.key
         - --audit-log-path=-

--- a/operator/pkg/controlplane/apiserver/mainfests.go
+++ b/operator/pkg/controlplane/apiserver/mainfests.go
@@ -37,7 +37,7 @@ spec:
         - --etcd-cafile=/etc/etcd/pki/etcd-ca.crt
         - --etcd-certfile=/etc/etcd/pki/etcd-client.crt
         - --etcd-keyfile=/etc/etcd/pki/etcd-client.key
-        - --etcd-servers=https://{{ .EtcdClientService }}.{{ .Namespace }}.svc.cluster.local:{{ .EtcdListenClientPort }}
+        - --etcd-servers=https://{{ .EtcdClientService }}.{{ .Namespace }}.svc.{{ .DnsDomain }}:{{ .EtcdListenClientPort }}
         - --bind-address=0.0.0.0
         - --kubelet-client-certificate=/etc/karmada/pki/karmada.crt
         - --kubelet-client-key=/etc/karmada/pki/karmada.key


### PR DESCRIPTION
**What type of PR is this?**

/kind feature




**What this PR does / why we need it**:

Now, karmada clusterdomain have not used, it should be use with kube-apiserver and karmada AggregatedAPIServer if i understand correctly.
/cc @calvin0327 for confirm that.

```yaml
...
  hostCluster:
    networking:
      dnsDomain: cluster.local
```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

