### PR TITLE
fix: fix bugs about validation of targetMinReplicas<=targetMaxReplicas and CronFederatedHPA status record

### DIFF
--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_job.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_job.go
@@ -268,7 +268,7 @@ func (c *CronFederatedHPAJob) addFailedExecutionHistory(
 
 func (c *CronFederatedHPAJob) addSuccessExecutionHistory(
 	cronFHPA *autoscalingv1alpha1.CronFederatedHPA,
-	appliedReplicas, appliedMaxReplicas, appliedMinReplicas *int32) error {
+	appliedReplicas, appliedMinReplicas, appliedMaxReplicas *int32) error {
 	_, nextExecutionTime := c.scheduler.NextRun()
 
 	// Add success history record, return false if there is no such rule

--- a/pkg/webhook/cronfederatedhpa/validation.go
+++ b/pkg/webhook/cronfederatedhpa/validation.go
@@ -16,6 +16,7 @@ package cronfederatedhpa
 import (
 	"context"
 	"fmt"
+	"math"
 	"net/http"
 	"time"
 	_ "time/tzdata"
@@ -140,11 +141,11 @@ func validateCronFederatedHPAScalingReplicas(rule autoscalingv1alpha1.CronFedera
 			errs = append(errs, field.Invalid(fldPath.Child("targetMinReplicas"), "",
 				"targetMinReplicas should be larger than 0"))
 		}
-		if pointer.Int32Deref(rule.TargetMaxReplicas, 1) <= 0 {
+		if pointer.Int32Deref(rule.TargetMaxReplicas, math.MaxInt32) <= 0 {
 			errs = append(errs, field.Invalid(fldPath.Child("targetMaxReplicas"), "",
 				"targetMaxReplicas should be larger than 0"))
 		}
-		if pointer.Int32Deref(rule.TargetMinReplicas, 1) > pointer.Int32Deref(rule.TargetMaxReplicas, 1) {
+		if pointer.Int32Deref(rule.TargetMinReplicas, 1) > pointer.Int32Deref(rule.TargetMaxReplicas, math.MaxInt32) {
 			errs = append(errs, field.Invalid(fldPath.Child("targetMinReplicas"), "",
 				"targetMaxReplicas should be larger than or equal to targetMinReplicas"))
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
1. When scaling FederatedHPA, `rule.targetMinReplicas` is 5 and `rule.targetMaxReplicas` is nil, this is valid. 
2. Record CronFederatedHPA.status history with the right `appliedMinReplicas` and `appliedMaxReplicas`

**Which issue(s) this PR fixes**:
Fixes #none

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE(This bug has been released)
```

