### PR TITLE
Updated Golang version from v1.20.4 to v1.20.6

### DIFF
--- a/.github/workflows/ci-schedule.yml
+++ b/.github/workflows/ci-schedule.yml
@@ -22,7 +22,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.6
       - name: setup e2e test environment
         run: |
           export CLUSTER_VERSION=kindest/node:${{ matrix.k8s }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.6
       - name: vendor
         run: hack/verify-vendor.sh
       - name: lint
@@ -41,7 +41,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.6
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
@@ -73,7 +73,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.6
       - name: compile
         run: make all
   test:
@@ -88,7 +88,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.6
       - name: make test
         run: make test
       - name: Upload coverage to Codecov
@@ -125,7 +125,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.6
       - name: setup e2e test environment
         run: |
           export CLUSTER_VERSION=kindest/node:${{ matrix.k8s }}

--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.6
       - uses: engineerd/setup-kind@v0.5.0
         with:
           version: "v0.17.0"

--- a/.github/workflows/dockerhub-latest-image.yml
+++ b/.github/workflows/dockerhub-latest-image.yml
@@ -38,7 +38,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.6
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.0.3
         with:

--- a/.github/workflows/dockerhub-released-image.yml
+++ b/.github/workflows/dockerhub-released-image.yml
@@ -34,7 +34,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.6
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.0.3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.4
+        go-version: 1.20.6
     - name: Making and packaging
       env:
         GOOS: ${{ matrix.os }}

--- a/.github/workflows/swr-latest-image.yml
+++ b/.github/workflows/swr-latest-image.yml
@@ -22,7 +22,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.6
       - name: build images
         env:
           REGISTRY: ${{secrets.SWR_REGISTRY}}

--- a/.github/workflows/swr-released-image.yml
+++ b/.github/workflows/swr-released-image.yml
@@ -19,7 +19,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.6
       - name: build images
         env:
           REGISTRY: ${{secrets.SWR_REGISTRY}}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
This PR updates the default Go version for CI and release bots to v1.20.6.s

**Which issue(s) this PR fixes**:
Fixes #3864 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Karmada(v1.7) is now built with Go1.20.6.
```

