### PR TITLE
fix: fix dependent resources being created and deleted repeatedly when the dependent resource has a status field.

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -35,6 +35,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter"
 	"github.com/karmada-io/karmada/pkg/sharedcli/ratelimiterflag"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/eventfilter"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/keys"
@@ -303,7 +304,7 @@ func (d *ResourceDetector) OnUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	if !SpecificationChanged(unstructuredOldObj, unstructuredNewObj) {
+	if !eventfilter.SpecificationChanged(unstructuredOldObj, unstructuredNewObj) {
 		klog.V(4).Infof("Ignore update event of object (kind=%s, %s/%s) as specification no change", unstructuredOldObj.GetKind(), unstructuredOldObj.GetNamespace(), unstructuredOldObj.GetName())
 		return
 	}

--- a/pkg/util/eventfilter/eventfilter.go
+++ b/pkg/util/eventfilter/eventfilter.go
@@ -1,4 +1,4 @@
-package detector
+package eventfilter
 
 import (
 	"reflect"

--- a/pkg/util/eventfilter/eventfilter_test.go
+++ b/pkg/util/eventfilter/eventfilter_test.go
@@ -1,10 +1,10 @@
-package detector
+package eventfilter
 
 import (
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
@@ -105,7 +105,7 @@ func TestSpecificationChanged(t *testing.T) {
 				},
 				Spec: workloadv1alpha1.WorkloadSpec{
 					Replicas: pointer.Int32(3),
-					Template: v1.PodTemplateSpec{},
+					Template: corev1.PodTemplateSpec{},
 					Paused:   false,
 				},
 				Status: workloadv1alpha1.WorkloadStatus{ReadyReplicas: 3},
@@ -117,7 +117,7 @@ func TestSpecificationChanged(t *testing.T) {
 				},
 				Spec: workloadv1alpha1.WorkloadSpec{
 					Replicas: pointer.Int32(5),
-					Template: v1.PodTemplateSpec{},
+					Template: corev1.PodTemplateSpec{},
 					Paused:   false,
 				},
 				Status: workloadv1alpha1.WorkloadStatus{ReadyReplicas: 3},
@@ -133,7 +133,7 @@ func TestSpecificationChanged(t *testing.T) {
 				},
 				Spec: workloadv1alpha1.WorkloadSpec{
 					Replicas: pointer.Int32(3),
-					Template: v1.PodTemplateSpec{},
+					Template: corev1.PodTemplateSpec{},
 					Paused:   false,
 				},
 				Status: workloadv1alpha1.WorkloadStatus{ReadyReplicas: 1},
@@ -145,7 +145,7 @@ func TestSpecificationChanged(t *testing.T) {
 				},
 				Spec: workloadv1alpha1.WorkloadSpec{
 					Replicas: pointer.Int32(3),
-					Template: v1.PodTemplateSpec{},
+					Template: corev1.PodTemplateSpec{},
 					Paused:   false,
 				},
 				Status: workloadv1alpha1.WorkloadStatus{ReadyReplicas: 3},
@@ -161,7 +161,7 @@ func TestSpecificationChanged(t *testing.T) {
 				},
 				Spec: workloadv1alpha1.WorkloadSpec{
 					Replicas: pointer.Int32(3),
-					Template: v1.PodTemplateSpec{},
+					Template: corev1.PodTemplateSpec{},
 					Paused:   false,
 				},
 				Status: workloadv1alpha1.WorkloadStatus{ReadyReplicas: 1},
@@ -173,7 +173,7 @@ func TestSpecificationChanged(t *testing.T) {
 				},
 				Spec: workloadv1alpha1.WorkloadSpec{
 					Replicas: pointer.Int32(5),
-					Template: v1.PodTemplateSpec{},
+					Template: corev1.PodTemplateSpec{},
 					Paused:   false,
 				},
 				Status: workloadv1alpha1.WorkloadStatus{ReadyReplicas: 3},


### PR DESCRIPTION


**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Fix dependent resources being created and deleted repeatedly when the dependent resource has a status field.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


When dependent resources only change state, there is no need to modify dependent resources in member clusters.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: fix dependent resources being created and deleted repeatedly when the dependent resource has a status field.
```

