### PR TITLE
use ClusterCacheSyncTimeout for resources on fed control plane as well

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -197,6 +197,7 @@ func run(ctx context.Context, opts *options.Options) error {
 				workv1alpha1.SchemeGroupVersion.WithKind("Work").GroupKind().String():       opts.ConcurrentWorkSyncs,
 				clusterv1alpha1.SchemeGroupVersion.WithKind("Cluster").GroupKind().String(): opts.ConcurrentClusterSyncs,
 			},
+			CacheSyncTimeout: opts.ClusterCacheSyncTimeout.Duration,
 		},
 		NewCache: func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
 			opts.DefaultTransform = fedinformer.StripUnusedFields

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -150,6 +150,7 @@ func Run(ctx context.Context, opts *options.Options) error {
 				clusterv1alpha1.SchemeGroupVersion.WithKind("Cluster").GroupKind().String():               opts.ConcurrentClusterSyncs,
 				schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}.GroupKind().String(): opts.ConcurrentNamespaceSyncs,
 			},
+			CacheSyncTimeout: opts.ClusterCacheSyncTimeout.Duration,
 		},
 		NewCache: func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
 			opts.DefaultTransform = fedinformer.StripUnusedFields
@@ -588,6 +589,7 @@ func startFederatedHorizontalPodAutoscalerController(ctx controllerscontext.Cont
 		ClusterScaleClientSetFunc:         util.NewClusterScaleClientSet,
 		TypedInformerManager:              typedmanager.GetInstance(),
 		RateLimiterOptions:                ctx.Opts.RateLimiterOptions,
+		ClusterCacheSyncTimeout:           ctx.Opts.ClusterCacheSyncTimeout,
 	}
 	if err = federatedHPAController.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err

--- a/pkg/controllers/federatedhpa/federatedhpa_controller.go
+++ b/pkg/controllers/federatedhpa/federatedhpa_controller.go
@@ -68,6 +68,7 @@ type FederatedHPAController struct {
 	RESTMapper                meta.RESTMapper
 	EventRecorder             record.EventRecorder
 	TypedInformerManager      typedmanager.MultiClusterInformerManager
+	ClusterCacheSyncTimeout   metav1.Duration
 
 	monitor monitor.Monitor
 
@@ -544,7 +545,7 @@ func (c *FederatedHPAController) buildPodInformerForCluster(clusterScaleClient *
 	c.TypedInformerManager.Start(clusterScaleClient.ClusterName)
 
 	if err := func() error {
-		synced := c.TypedInformerManager.WaitForCacheSyncWithTimeout(clusterScaleClient.ClusterName, util.CacheSyncTimeout)
+		synced := c.TypedInformerManager.WaitForCacheSyncWithTimeout(clusterScaleClient.ClusterName, c.ClusterCacheSyncTimeout.Duration)
 		if synced == nil {
 			return fmt.Errorf("no informerFactory for cluster %s exist", clusterScaleClient.ClusterName)
 		}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -159,5 +159,5 @@ const (
 
 const (
 	// CacheSyncTimeout refers to the time limit set on waiting for cache to sync
-	CacheSyncTimeout = 30 * time.Second
+	CacheSyncTimeout = 2 * time.Minute
 )


### PR DESCRIPTION
**What type of PR is this?**  
/kind feature  
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:  
Now, the default timeout for waiting cache syncing in `controller-runtime` is 2 minutes. If we have a lot resources on the fed control plane, the default timeout might be reached and the process would return with an error like:  
```
E0801 06:15:22.538099       1 controllermanager.go:154] controller manager exits unexpectedly: [failed to wait for build-resource-informers for work caches to sync: timed out waiting for cache to be synced, failed waiting for all runnables to end within grace period of 30s: context deadline exceeded
```  
And the `karmada-controller-manager` would be hard to restart successfully.  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:  
The log printed above is from `karmada-controller-manager v1.3.1`, but it still exists in the latest version.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: The `--cluster-cache-sync-timeout` flag is now used to specify the sync timeout of the control plane cache in addition to the member cluster's cache. The default value has been increased to 2 minutes.
```

