### PR TITLE
record binding-reference-key and work-name info in binding annotations

### DIFF
--- a/pkg/util/annotation.go
+++ b/pkg/util/annotation.go
@@ -23,6 +23,18 @@ func MergeAnnotation(obj *unstructured.Unstructured, annotationKey string, annot
 	}
 }
 
+// DedupeAndMergeAnnotations merges the new annotations into exist annotations.
+func DedupeAndMergeAnnotations(existAnnotation, newAnnotation map[string]string) map[string]string {
+	if existAnnotation == nil {
+		return newAnnotation
+	}
+
+	for k, v := range newAnnotation {
+		existAnnotation[k] = v
+	}
+	return existAnnotation
+}
+
 // ReplaceAnnotation adds annotation for the given object, replace the value if key exist.
 func ReplaceAnnotation(obj *unstructured.Unstructured, annotationKey string, annotationValue string) {
 	objectAnnotation := obj.GetAnnotations()


### PR DESCRIPTION
**What type of PR is this?**  
/kind feature  
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:  
Now, we could list `work` by `binding reference key`, but the key could only be generated in code. It would make the daily operations easier if we could record the key and the work name in the annotations of `binding`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

