### PR TITLE
Automated cherry pick of #3874: use ClusterCacheSyncTimeout for resources on fed control

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -196,6 +196,7 @@ func run(ctx context.Context, opts *options.Options) error {
 				workv1alpha1.SchemeGroupVersion.WithKind("Work").GroupKind().String():       opts.ConcurrentWorkSyncs,
 				clusterv1alpha1.SchemeGroupVersion.WithKind("Cluster").GroupKind().String(): opts.ConcurrentClusterSyncs,
 			},
+			CacheSyncTimeout: opts.ClusterCacheSyncTimeout.Duration,
 		},
 		NewCache: cache.BuilderWithOptions(cache.Options{
 			DefaultTransform: fedinformer.StripUnusedFields,

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -148,6 +148,7 @@ func Run(ctx context.Context, opts *options.Options) error {
 				clusterv1alpha1.SchemeGroupVersion.WithKind("Cluster").GroupKind().String():               opts.ConcurrentClusterSyncs,
 				schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}.GroupKind().String(): opts.ConcurrentNamespaceSyncs,
 			},
+			CacheSyncTimeout: opts.ClusterCacheSyncTimeout.Duration,
 		},
 		NewCache: cache.BuilderWithOptions(cache.Options{
 			DefaultTransform: fedinformer.StripUnusedFields,
@@ -583,6 +584,7 @@ func startFederatedHorizontalPodAutoscalerController(ctx controllerscontext.Cont
 		ClusterScaleClientSetFunc:         util.NewClusterScaleClientSet,
 		TypedInformerManager:              typedmanager.GetInstance(),
 		RateLimiterOptions:                ctx.Opts.RateLimiterOptions,
+		ClusterCacheSyncTimeout:           ctx.Opts.ClusterCacheSyncTimeout,
 	}
 	if err = federatedHPAController.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err

--- a/pkg/controllers/federatedhpa/federatedhpa_controller.go
+++ b/pkg/controllers/federatedhpa/federatedhpa_controller.go
@@ -68,6 +68,7 @@ type FederatedHPAController struct {
 	RESTMapper                meta.RESTMapper
 	EventRecorder             record.EventRecorder
 	TypedInformerManager      typedmanager.MultiClusterInformerManager
+	ClusterCacheSyncTimeout   metav1.Duration
 
 	monitor monitor.Monitor
 
@@ -544,7 +545,7 @@ func (c *FederatedHPAController) buildPodInformerForCluster(clusterScaleClient *
 	c.TypedInformerManager.Start(clusterScaleClient.ClusterName)
 
 	if err := func() error {
-		synced := c.TypedInformerManager.WaitForCacheSyncWithTimeout(clusterScaleClient.ClusterName, util.CacheSyncTimeout)
+		synced := c.TypedInformerManager.WaitForCacheSyncWithTimeout(clusterScaleClient.ClusterName, c.ClusterCacheSyncTimeout.Duration)
 		if synced == nil {
 			return fmt.Errorf("no informerFactory for cluster %s exist", clusterScaleClient.ClusterName)
 		}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -159,5 +159,5 @@ const (
 
 const (
 	// CacheSyncTimeout refers to the time limit set on waiting for cache to sync
-	CacheSyncTimeout = 30 * time.Second
+	CacheSyncTimeout = 2 * time.Minute
 )


### PR DESCRIPTION
Cherry pick of #3874 on release-1.6.
#3874: use ClusterCacheSyncTimeout for resources on fed control
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
```