### PR TITLE
Upgrade a7ul/tar-action to v1.1.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       run: |
         mv ./charts/karmada/_crds ./charts/karmada/crds
     - name: Tar the crds
-      uses: a7ul/tar-action@v1.1.0
+      uses: a7ul/tar-action@v1.1.3
       with:
         command: c
         cwd: ./charts/karmada/


### PR DESCRIPTION
**What type of PR is this?**

/kind deprecation


**What this PR does / why we need it**:

This PR updates the version of a7ul/tar-action used in our GitHub Actions workflow from v1.1.0 to v1.1.3. The update is needed to address two deprecation warnings. The first is regarding the use of Node.js 12 which is being deprecated and will default to Node.js 16. The second concerns the deprecation of the set-output command. Both of these issues are handled in v1.1.3 of a7ul/tar-action.

**Which issue(s) this PR fixes**:

Fixes #3871

**Special notes for your reviewer**:

This change has no impact on the functionality of our workflows. It's a minor version update to stay aligned with the best practices and remove deprecation warnings.

**Does this PR introduce a user-facing change?**:

None
```release-note
Updated a7ul/tar-action from v1.1.0 to v1.1.3 in GitHub Actions workflow to address deprecation warnings.
```

