### PR TITLE
karmadactl init with external etcd

### DIFF
--- a/pkg/karmadactl/addons/search/manifests.go
+++ b/pkg/karmadactl/addons/search/manifests.go
@@ -48,7 +48,8 @@ spec:
             - --audit-log-path=-
             - --feature-gates=APIPriorityAndFairness=false
             - --audit-log-maxage=0
-            - --audit-log-maxbackup=0
+            - --audit-log-maxbackup=0{{- if .KeyPrefix }}
+            - --etcd-prefix={{ .KeyPrefix }}{{- end }}
           livenessProbe:
             httpGet:
               path: /livez
@@ -126,6 +127,7 @@ type DeploymentReplace struct {
 	Replicas   *int32
 	Image      string
 	ETCDSevers string
+	KeyPrefix  string
 }
 
 // ServiceReplace is a struct to help to concrete

--- a/pkg/karmadactl/addons/search/search.go
+++ b/pkg/karmadactl/addons/search/search.go
@@ -3,7 +3,6 @@ package search
 import (
 	"context"
 	"fmt"
-	"k8s.io/client-go/kubernetes"
 	"strings"
 	"time"
 
@@ -12,6 +11,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kuberuntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"

--- a/pkg/karmadactl/addons/search/search.go
+++ b/pkg/karmadactl/addons/search/search.go
@@ -3,6 +3,7 @@ package search
 import (
 	"context"
 	"fmt"
+	"k8s.io/client-go/kubernetes"
 	"strings"
 	"time"
 
@@ -28,6 +29,8 @@ const (
 
 	// etcdStatefulSetAndServiceName define etcd statefulSet and serviceName installed by init command
 	etcdStatefulSetAndServiceName = "etcd"
+	// karmadaAPIServerDeploymentAndServiceName defines the name of karmada-apiserver deployment and service installed by init command
+	karmadaAPIServerDeploymentAndServiceName = "karmada-apiserver"
 
 	// etcdContainerClientPort define etcd pod installed by init command
 	etcdContainerClientPort = 2379
@@ -134,7 +137,7 @@ func installComponentsOnHostCluster(opts *addoninit.CommandAddonsEnableOption) e
 		return fmt.Errorf("create karmada search service error: %v", err)
 	}
 
-	etcdServers, err := etcdServers(opts)
+	etcdServers, keyPrefix, err := etcdServers(opts)
 	if err != nil {
 		return err
 	}
@@ -146,6 +149,7 @@ func installComponentsOnHostCluster(opts *addoninit.CommandAddonsEnableOption) e
 		Namespace:  opts.Namespace,
 		Replicas:   &opts.KarmadaSearchReplicas,
 		ETCDSevers: etcdServers,
+		KeyPrefix:  keyPrefix,
 		Image:      addoninit.KarmadaSearchImage(opts),
 	})
 	if err != nil {
@@ -212,10 +216,51 @@ func installComponentsOnKarmadaControlPlane(opts *addoninit.CommandAddonsEnableO
 	return nil
 }
 
-func etcdServers(opts *addoninit.CommandAddonsEnableOption) (string, error) {
-	sts, err := opts.KubeClientSet.AppsV1().StatefulSets(opts.Namespace).Get(context.TODO(), etcdStatefulSetAndServiceName, metav1.GetOptions{})
+const (
+	etcdServerArgPrefix          = "--etcd-servers="
+	etcdServerArgPrefixLength    = len(etcdServerArgPrefix)
+	etcdKeyPrefixArgPrefix       = "--etcd-prefix="
+	etcdKeyPrefixArgPrefixLength = len(etcdKeyPrefixArgPrefix)
+)
+
+func getExternalEtcdServerConfig(ctx context.Context, host kubernetes.Interface, namespace string) (servers, prefix string, err error) {
+	var apiserver *appsv1.Deployment
+	if apiserver, err = host.AppsV1().Deployments(namespace).Get(
+		ctx, karmadaAPIServerDeploymentAndServiceName, metav1.GetOptions{}); err != nil {
+		return
+	}
+	// should be only one container, but it may be injected others by mutating webhook of host cluster,
+	// anyway, a for can handle all cases.
+	for _, container := range apiserver.Spec.Template.Spec.Containers {
+		if container.Name == karmadaAPIServerDeploymentAndServiceName {
+			for _, cmd := range container.Command {
+				if strings.HasPrefix(etcdServerArgPrefix, cmd) {
+					servers = cmd[etcdServerArgPrefixLength:]
+				} else if strings.HasPrefix(etcdKeyPrefixArgPrefix, cmd) {
+					prefix = cmd[etcdKeyPrefixArgPrefixLength:]
+				}
+				if servers != "" && prefix != "" {
+					break
+				}
+			}
+			return
+		}
+	}
+	return
+}
+
+func etcdServers(opts *addoninit.CommandAddonsEnableOption) (string, string, error) {
+	ctx := context.TODO()
+	sts, err := opts.KubeClientSet.AppsV1().StatefulSets(opts.Namespace).Get(ctx, etcdStatefulSetAndServiceName, metav1.GetOptions{})
 	if err != nil {
-		return "", err
+		if apierrors.IsNotFound(err) {
+			if servers, prefix, cfgErr := getExternalEtcdServerConfig(ctx, opts.KubeClientSet, opts.Namespace); cfgErr != nil {
+				return "", "", cfgErr
+			} else if servers != "" {
+				return servers, prefix, nil
+			}
+		}
+		return "", "", err
 	}
 
 	etcdReplicas := *sts.Spec.Replicas
@@ -225,5 +270,5 @@ func etcdServers(opts *addoninit.CommandAddonsEnableOption) (string, error) {
 		etcdServers += fmt.Sprintf("https://%s-%v.%s.%s.svc.%s:%v", etcdStatefulSetAndServiceName, v, etcdStatefulSetAndServiceName, opts.Namespace, opts.HostClusterDomain, etcdContainerClientPort) + ","
 	}
 
-	return strings.TrimRight(etcdServers, ","), nil
+	return strings.TrimRight(etcdServers, ","), "", nil
 }

--- a/pkg/karmadactl/addons/search/search.go
+++ b/pkg/karmadactl/addons/search/search.go
@@ -234,9 +234,9 @@ func getExternalEtcdServerConfig(ctx context.Context, host kubernetes.Interface,
 	for _, container := range apiserver.Spec.Template.Spec.Containers {
 		if container.Name == karmadaAPIServerDeploymentAndServiceName {
 			for _, cmd := range container.Command {
-				if strings.HasPrefix(etcdServerArgPrefix, cmd) {
+				if strings.HasPrefix(cmd, etcdServerArgPrefix) {
 					servers = cmd[etcdServerArgPrefixLength:]
-				} else if strings.HasPrefix(etcdKeyPrefixArgPrefix, cmd) {
+				} else if strings.HasPrefix(cmd, etcdKeyPrefixArgPrefix) {
 					prefix = cmd[etcdKeyPrefixArgPrefixLength:]
 				}
 				if servers != "" && prefix != "" {

--- a/pkg/karmadactl/cmdinit/cert/cert.go
+++ b/pkg/karmadactl/cmdinit/cert/cert.go
@@ -285,6 +285,10 @@ func GenCerts(pkiPath string, etcdServerCertCfg, etcdClientCertCfg, karmadaCertC
 		return err
 	}
 
+	if etcdServerCertCfg == nil && etcdClientCertCfg == nil {
+		// use external etcd
+		return nil
+	}
 	return genEtcdCerts(pkiPath, etcdServerCertCfg, etcdClientCertCfg)
 }
 

--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -122,6 +122,11 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 	flags.StringVarP(&opts.EtcdHostDataPath, "etcd-data", "", "/var/lib/karmada-etcd", "etcd data path,valid in hostPath mode.")
 	flags.StringVarP(&opts.EtcdNodeSelectorLabels, "etcd-node-selector-labels", "", "", "etcd pod select the labels of the node. valid in hostPath mode ( e.g. --etcd-node-selector-labels karmada.io/etcd=true)")
 	flags.StringVarP(&opts.EtcdPersistentVolumeSize, "etcd-pvc-size", "", "5Gi", "etcd data path,valid in pvc mode.")
+	flags.StringVar(&opts.ExternalEtcdCACertPath, "external-etcd-ca-cert-path", "", "The path of CA certificate of the external etcd cluster in pem format.")
+	flags.StringVar(&opts.ExternalEtcdClientCertPath, "external-etcd-client-cert-path", "", "The path of client side certificate to the external etcd cluster in pem format.")
+	flags.StringVar(&opts.ExternalEtcdClientKeyPath, "external-etcd-client-key-path", "", "The path of client side private key to the external etcd cluster in pem format.")
+	flags.StringVar(&opts.ExternalEtcdServers, "external-etcd-servers", "", "The server urls of external etcd cluster, to be used by kube-apiserver through --etcd-servers.")
+	flags.StringVar(&opts.ExternalEtcdKeyPrefix, "external-etcd-key-prefix", "", "The key prefix to be configured to kube-apiserver through --etcd-prefix.")
 	// karmada
 	flags.StringVar(&opts.CRDs, "crds", kubernetes.DefaultCrdURL, "Karmada crds resource.(local file e.g. --crds /root/crds.tar.gz)")
 	flags.StringVarP(&opts.KarmadaAPIServerAdvertiseAddress, "karmada-apiserver-advertise-address", "", "", "The IP address the Karmada API Server will advertise it's listening on. If not set, the address on the master node will be used.")

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -155,7 +155,7 @@ type CommandInitOption struct {
 	WaitComponentReadyTimeout          int
 }
 
-func (i *CommandInitOption) validateBundledEtcd(parentCommand string) error {
+func (i *CommandInitOption) validateLocalEtcd(parentCommand string) error {
 	if i.EtcdStorageMode == etcdStorageModeHostPath && i.EtcdHostDataPath == "" {
 		return fmt.Errorf("when etcd storage mode is hostPath, dataPath is not empty. See '%s init --help'", parentCommand)
 	}
@@ -213,7 +213,7 @@ func (i *CommandInitOption) Validate(parentCommand string) error {
 	if i.isExternalEtcdProvided() {
 		return i.validateExternalEtcd(parentCommand)
 	} else {
-		return i.validateBundledEtcd(parentCommand)
+		return i.validateLocalEtcd(parentCommand)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind feature

**What this PR does / why we need it**:

Users may have existing etcd cluster which is under well maintenance by a team, so it's better to use such etcd cluster, rather than setup new one. (a poor one, maybe)

**Which issue(s) this PR fixes**:
Fixes #3897

**Special notes for your reviewer**:

~~**NOT** tested yet, for review only, if this pr is worth to go on finishing, I will continue.~~

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: The `init` now can setup production ready HA control plane by using an external HA etcd cluster.
```

