### PR TITLE
grant clusterrole admin with karamda resource permission

### DIFF
--- a/artifacts/deploy/admin-clusterrole-aggregation.yaml
+++ b/artifacts/deploy/admin-clusterrole-aggregation.yaml
@@ -1,0 +1,149 @@
+# This configuration is used to grant the admin clusterrole read
+# and write permissions for Karmada resources.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    # refer to https://kubernetes.io/docs/reference/access-authn-authz/rbac/#auto-reconciliation
+    # and https://kubernetes.io/docs/reference/access-authn-authz/rbac/#kubectl-auth-reconcile
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    # refer to https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+    kubernetes.io/bootstrapping: rbac-defaults
+    # used to aggregate rules to view clusterrole
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: karmada-view
+rules:
+  - apiGroups:
+      - "autoscaling.karmada.io"
+    resources:
+      - cronfederatedhpas
+      - cronfederatedhpas/status
+      - federatedhpas
+      - federatedhpas/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "multicluster.x-k8s.io"
+    resources:
+      - serviceexports
+      - serviceexports/status
+      - serviceimports
+      - serviceimports/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "networking.karmada.io"
+    resources:
+      - multiclusteringresses
+      - multiclusteringresses/status
+      - multiclusterservices
+      - multiclusterservices/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "policy.karmada.io"
+    resources:
+      - overridepolicies
+      - propagationpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "work.karmada.io"
+    resources:
+      - resourcebindings
+      - resourcebindings/status
+      - works
+      - works/status
+    verbs:
+      - get
+      - list
+      - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    # refer to https://kubernetes.io/docs/reference/access-authn-authz/rbac/#auto-reconciliation
+    # and https://kubernetes.io/docs/reference/access-authn-authz/rbac/#kubectl-auth-reconcile
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    # refer to https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+    kubernetes.io/bootstrapping: rbac-defaults
+    # used to aggregate rules to view clusterrole
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: karmada-edit
+rules:
+  - apiGroups:
+      - "autoscaling.karmada.io"
+    resources:
+      - cronfederatedhpas
+      - cronfederatedhpas/status
+      - federatedhpas
+      - federatedhpas/status
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+  - apiGroups:
+      - "multicluster.x-k8s.io"
+    resources:
+      - serviceexports
+      - serviceexports/status
+      - serviceimports
+      - serviceimports/status
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+  - apiGroups:
+      - "networking.karmada.io"
+    resources:
+      - multiclusteringresses
+      - multiclusteringresses/status
+      - multiclusterservices
+      - multiclusterservices/status
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+  - apiGroups:
+      - "policy.karmada.io"
+    resources:
+      - overridepolicies
+      - propagationpolicies
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+  - apiGroups:
+      - "work.karmada.io"
+    resources:
+      - resourcebindings
+      - resourcebindings/status
+      - works
+      - works/status
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update

--- a/artifacts/deploy/kube-controller-manager.yaml
+++ b/artifacts/deploy/kube-controller-manager.yaml
@@ -43,7 +43,7 @@ spec:
             - --cluster-name=karmada
             - --cluster-signing-cert-file=/etc/karmada/pki/ca.crt
             - --cluster-signing-key-file=/etc/karmada/pki/ca.key
-            - --controllers=namespace,garbagecollector,serviceaccount-token,ttl-after-finished,bootstrapsigner,tokencleaner,csrapproving,csrcleaner,csrsigning
+            - --controllers=namespace,garbagecollector,serviceaccount-token,ttl-after-finished,bootstrapsigner,tokencleaner,csrapproving,csrcleaner,csrsigning,clusterrole-aggregation
             - --kubeconfig=/etc/kubeconfig
             - --leader-elect=true
             - --node-cidr-mask-size=24

--- a/hack/deploy-karmada.sh
+++ b/hack/deploy-karmada.sh
@@ -268,6 +268,9 @@ kubectl --context="karmada-apiserver" apply -f "${REPO_ROOT}/artifacts/deploy/ka
 # make sure apiservice for karmada metrics adapter is Available
 util::wait_apiservice_ready "karmada-apiserver" "${KARMADA_METRICS_ADAPTER_LABEL}"
 
+# grant the admin clusterrole read and write permissions for Karmada resources
+kubectl --context="karmada-apiserver" apply -f "${REPO_ROOT}/artifacts/deploy/admin-clusterrole-aggregation.yaml"
+
 # deploy cluster proxy rbac for admin
 kubectl --context="karmada-apiserver" apply -f "${REPO_ROOT}/artifacts/deploy/cluster-proxy-admin-rbac.yaml"
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

`admin` is a built-in ClusterRole in Kubernetes. It collects rules from other clusterRoles through aggregation method. This logic is managed by the `clusterrole-aggregation-controller` in kube-controller-manager, so we need to enable this controller.

In addition, we also need to grant `admin` the permissions to handle Karmada resources, including read and write access.

**Which issue(s) this PR fixes**:
Part of #3916 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-kube-controller-manager: grant admin clusterrole with karamda resource permission
```

