### PR TITLE
fix federated-hpa plain metric calc

### DIFF
--- a/pkg/controllers/federatedhpa/replica_calculator.go
+++ b/pkg/controllers/federatedhpa/replica_calculator.go
@@ -189,7 +189,7 @@ func (c *ReplicaCalculator) calcPlainMetricReplicas(metrics metricsclient.PodMet
 			for podName := range missingPods {
 				metrics[podName] = metricsclient.PodMetric{Value: targetUsage}
 			}
-		} else {
+		} else if usageRatio > 1.0 {
 			// on a scale-up, treat missing pods as using 0% of the resource request
 			for podName := range missingPods {
 				metrics[podName] = metricsclient.PodMetric{Value: 0}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Fix plain metric calculation error when usageRatio == 1.0 which I fixed in https://github.com/kubernetes/kubernetes/pull/117845

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`kamrada-controller-manager`: Fix federated-HPA plain metric calculation is incorrect when usageRatio == 1.0, keep same with resource replicas.
```

