### PR TITLE
Fix cannot add object use plaintext overide regardless of whether the path exists or not

### DIFF
--- a/pkg/util/overridemanager/overridemanager.go
+++ b/pkg/util/overridemanager/overridemanager.go
@@ -255,7 +255,10 @@ func applyJSONPatch(obj *unstructured.Unstructured, overrides []overrideOption) 
 		return err
 	}
 
-	patchedObjectJSONBytes, err := patch.Apply(objectJSONBytes)
+	applyOption := jsonpatch.NewApplyOptions()
+	applyOption.EnsurePathExistsOnAdd = true
+	applyOption.AllowMissingPathOnRemove = true
+	patchedObjectJSONBytes, err := patch.ApplyWithOptions(objectJSONBytes, applyOption)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/overridemanager/overridemanager_test.go
+++ b/pkg/util/overridemanager/overridemanager_test.go
@@ -87,6 +87,34 @@ func Test_overrideManagerImpl_ApplyOverridePolicies(t *testing.T) {
 												},
 											},
 										},
+										Plaintext: []policyv1alpha1.PlaintextOverrider{
+											{
+												// add on not exist path
+												Path:     "/spec/template/metadata/annotations/testAddAnnotation",
+												Operator: policyv1alpha1.OverriderOpAdd,
+												Value: apiextensionsv1.JSON{
+													Raw: []byte(`"testAddAnnotation"`),
+												},
+											},
+											{
+												// add on exist path
+												Path:     "/spec/template/metadata/labels/testAddLabel",
+												Operator: policyv1alpha1.OverriderOpAdd,
+												Value: apiextensionsv1.JSON{
+													Raw: []byte(`"testAddLabel"`),
+												},
+											},
+											{
+												// remove on not exist path
+												Path:     "/notexist",
+												Operator: policyv1alpha1.OverriderOpRemove,
+											},
+											{
+												// remove on exist path
+												Path:     "/spec/replicas",
+												Operator: policyv1alpha1.OverriderOpRemove,
+											},
+										},
 									},
 								},
 							},
@@ -119,6 +147,34 @@ func Test_overrideManagerImpl_ApplyOverridePolicies(t *testing.T) {
 									Value: map[string]string{
 										"testAddAnnotation": "testAddAnnotation",
 									},
+								},
+							},
+							Plaintext: []policyv1alpha1.PlaintextOverrider{
+								{
+									// add on not exist path
+									Path:     "/spec/template/metadata/annotations/testAddAnnotation",
+									Operator: policyv1alpha1.OverriderOpAdd,
+									Value: apiextensionsv1.JSON{
+										Raw: []byte(`"testAddAnnotation"`),
+									},
+								},
+								{
+									// add on exist path
+									Path:     "/spec/template/metadata/labels/testAddLabel",
+									Operator: policyv1alpha1.OverriderOpAdd,
+									Value: apiextensionsv1.JSON{
+										Raw: []byte(`"testAddLabel"`),
+									},
+								},
+								{
+									// remove on not exist path
+									Path:     "/notexist",
+									Operator: policyv1alpha1.OverriderOpRemove,
+								},
+								{
+									// remove on exist path
+									Path:     "/spec/replicas",
+									Operator: policyv1alpha1.OverriderOpRemove,
 								},
 							},
 						},
@@ -161,6 +217,34 @@ func Test_overrideManagerImpl_ApplyOverridePolicies(t *testing.T) {
 												},
 											},
 										},
+										Plaintext: []policyv1alpha1.PlaintextOverrider{
+											{
+												// add on not exist path
+												Path:     "/spec/template/metadata/annotations/testAddAnnotation",
+												Operator: policyv1alpha1.OverriderOpAdd,
+												Value: apiextensionsv1.JSON{
+													Raw: []byte(`"testAddAnnotation"`),
+												},
+											},
+											{
+												// add on exist path
+												Path:     "/spec/template/metadata/labels/testAddLabel",
+												Operator: policyv1alpha1.OverriderOpAdd,
+												Value: apiextensionsv1.JSON{
+													Raw: []byte(`"testAddLabel"`),
+												},
+											},
+											{
+												// remove on not exist path
+												Path:     "/notexist",
+												Operator: policyv1alpha1.OverriderOpRemove,
+											},
+											{
+												// remove on exist path
+												Path:     "/spec/replicas",
+												Operator: policyv1alpha1.OverriderOpRemove,
+											},
+										},
 									},
 								},
 							},
@@ -192,6 +276,34 @@ func Test_overrideManagerImpl_ApplyOverridePolicies(t *testing.T) {
 									Value: map[string]string{
 										"testAddAnnotation": "testAddAnnotation",
 									},
+								},
+							},
+							Plaintext: []policyv1alpha1.PlaintextOverrider{
+								{
+									// add on not exist path
+									Path:     "/spec/template/metadata/annotations/testAddAnnotation",
+									Operator: policyv1alpha1.OverriderOpAdd,
+									Value: apiextensionsv1.JSON{
+										Raw: []byte(`"testAddAnnotation"`),
+									},
+								},
+								{
+									// add on exist path
+									Path:     "/spec/template/metadata/labels/testAddLabel",
+									Operator: policyv1alpha1.OverriderOpAdd,
+									Value: apiextensionsv1.JSON{
+										Raw: []byte(`"testAddLabel"`),
+									},
+								},
+								{
+									// remove on not exist path
+									Path:     "/notexist",
+									Operator: policyv1alpha1.OverriderOpRemove,
+								},
+								{
+									// remove on exist path
+									Path:     "/spec/replicas",
+									Operator: policyv1alpha1.OverriderOpRemove,
 								},
 							},
 						},


### PR DESCRIPTION

Fix cannot add object use plaintext overide regardless of whether the path exists or not
Fix cannot remove object use plaintext overide regardless of whether the path exists or not

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #3923 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

