### PR TITLE
Extend Cluster API to support multiple zones

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16357,8 +16357,16 @@
           }
         },
         "zone": {
-          "description": "Zone represents the zone of the member cluster locate in.",
+          "description": "Zone represents the zone of the member cluster locate in. Deprecated: This filed was never been used by Karmada, and it will not be removed from v1alpha1 for backward compatibility, use Zones instead.",
           "type": "string"
+        },
+        "zones": {
+          "description": "Zones represents the failure zones(also called availability zones) of the member cluster. The zones are presented as a slice to support the case that cluster runs across multiple failure zones. Refer https://kubernetes.io/docs/setup/best-practices/multiple-zones/ for more details about running Kubernetes in multiple zones.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "default": ""
+          }
         }
       }
     },

--- a/pkg/apis/cluster/types.go
+++ b/pkg/apis/cluster/types.go
@@ -117,8 +117,18 @@ type ClusterSpec struct {
 	Region string
 
 	// Zone represents the zone of the member cluster locate in.
+	// Deprecated: This filed was never been used by Karmada, and it will not be
+	// removed from v1alpha1 for backward compatibility, use Zones instead.
 	// +optional
 	Zone string
+
+	// Zones represents the failure zones(also called availability zones) of the
+	// member cluster. The zones are presented as a slice to support the case
+	// that cluster runs across multiple failure zones.
+	// Refer https://kubernetes.io/docs/setup/best-practices/multiple-zones/ for
+	// more details about running Kubernetes in multiple zones.
+	// +optional
+	Zones []string `json:"zones,omitempty"`
 
 	// Taints attached to the member cluster.
 	// Taints on the cluster have the "effect" on

--- a/pkg/apis/cluster/v1alpha1/types.go
+++ b/pkg/apis/cluster/v1alpha1/types.go
@@ -129,8 +129,18 @@ type ClusterSpec struct {
 	Region string `json:"region,omitempty"`
 
 	// Zone represents the zone of the member cluster locate in.
+	// Deprecated: This filed was never been used by Karmada, and it will not be
+	// removed from v1alpha1 for backward compatibility, use Zones instead.
 	// +optional
 	Zone string `json:"zone,omitempty"`
+
+	// Zones represents the failure zones(also called availability zones) of the
+	// member cluster. The zones are presented as a slice to support the case
+	// that cluster runs across multiple failure zones.
+	// Refer https://kubernetes.io/docs/setup/best-practices/multiple-zones/ for
+	// more details about running Kubernetes in multiple zones.
+	// +optional
+	Zones []string `json:"zones,omitempty"`
 
 	// Taints attached to the member cluster.
 	// Taints on the cluster have the "effect" on

--- a/pkg/apis/cluster/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/cluster/v1alpha1/zz_generated.conversion.go
@@ -331,6 +331,7 @@ func autoConvert_v1alpha1_ClusterSpec_To_cluster_ClusterSpec(in *ClusterSpec, ou
 	out.Provider = in.Provider
 	out.Region = in.Region
 	out.Zone = in.Zone
+	out.Zones = *(*[]string)(unsafe.Pointer(&in.Zones))
 	out.Taints = *(*[]v1.Taint)(unsafe.Pointer(&in.Taints))
 	out.ResourceModels = *(*[]cluster.ResourceModel)(unsafe.Pointer(&in.ResourceModels))
 	return nil
@@ -353,6 +354,7 @@ func autoConvert_cluster_ClusterSpec_To_v1alpha1_ClusterSpec(in *cluster.Cluster
 	out.Provider = in.Provider
 	out.Region = in.Region
 	out.Zone = in.Zone
+	out.Zones = *(*[]string)(unsafe.Pointer(&in.Zones))
 	out.Taints = *(*[]v1.Taint)(unsafe.Pointer(&in.Taints))
 	out.ResourceModels = *(*[]ResourceModel)(unsafe.Pointer(&in.ResourceModels))
 	return nil

--- a/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
@@ -170,6 +170,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Zones != nil {
+		in, out := &in.Zones, &out.Zones
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Taints != nil {
 		in, out := &in.Taints, &out.Taints
 		*out = make([]v1.Taint, len(*in))

--- a/pkg/apis/cluster/zz_generated.deepcopy.go
+++ b/pkg/apis/cluster/zz_generated.deepcopy.go
@@ -170,6 +170,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Zones != nil {
+		in, out := &in.Zones, &out.Zones
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Taints != nil {
 		in, out := &in.Taints, &out.Taints
 		*out = make([]v1.Taint, len(*in))

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -1359,9 +1359,24 @@ func schema_pkg_apis_cluster_v1alpha1_ClusterSpec(ref common.ReferenceCallback) 
 					},
 					"zone": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Zone represents the zone of the member cluster locate in.",
+							Description: "Zone represents the zone of the member cluster locate in. Deprecated: This filed was never been used by Karmada, and it will not be removed from v1alpha1 for backward compatibility, use Zones instead.",
 							Type:        []string{"string"},
 							Format:      "",
+						},
+					},
+					"zones": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Zones represents the failure zones(also called availability zones) of the member cluster. The zones are presented as a slice to support the case that cluster runs across multiple failure zones. Refer https://kubernetes.io/docs/setup/best-practices/multiple-zones/ for more details about running Kubernetes in multiple zones.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
 						},
 					},
 					"taints": {


### PR DESCRIPTION
**What type of PR is this?**

/kind api-change

**What this PR does / why we need it**:

This PR extends the `Cluster` API by adding a new field `Zones` to represent zones of a member cluster.

**Which issue(s) this PR fixes**:
Fixes #3413

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
API change: Introduced a new field `Zones` to represent multiple zones of a member cluster.
```

