### PR TITLE
feat: Refactor the mechanism for propagating serviceexport derived svc and eps.

### DIFF
--- a/pkg/resourceinterpreter/default/native/dependencies.go
+++ b/pkg/resourceinterpreter/default/native/dependencies.go
@@ -6,14 +6,18 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	mcsv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
 	configv1alpha1 "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/helper"
 	"github.com/karmada-io/karmada/pkg/util/lifted"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 type dependenciesInterpreter func(object *unstructured.Unstructured) ([]configv1alpha1.DependentObjectReference, error)
@@ -27,6 +31,7 @@ func getAllDefaultDependenciesInterpreter() map[schema.GroupVersionKind]dependen
 	s[appsv1.SchemeGroupVersion.WithKind(util.DaemonSetKind)] = getDaemonSetDependencies
 	s[appsv1.SchemeGroupVersion.WithKind(util.StatefulSetKind)] = getStatefulSetDependencies
 	s[networkingv1.SchemeGroupVersion.WithKind(util.IngressKind)] = getIngressDependencies
+	s[mcsv1alpha1.SchemeGroupVersion.WithKind(util.ServiceImportKind)] = getServiceImportDependencies
 	return s
 }
 
@@ -130,4 +135,31 @@ func getIngressDependencies(object *unstructured.Unstructured) ([]configv1alpha1
 		})
 	}
 	return dependentObjectRefs, nil
+}
+
+func getServiceImportDependencies(object *unstructured.Unstructured) ([]configv1alpha1.DependentObjectReference, error) {
+	svcImportObj := &mcsv1alpha1.ServiceImport{}
+	err := helper.ConvertToTypedObject(object, svcImportObj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert ServiceImport from unstructured object: %v", err)
+	}
+	derivedServiceName := names.GenerateDerivedServiceName(svcImportObj.Name)
+	return []configv1alpha1.DependentObjectReference{
+		{
+			APIVersion: "v1",
+			Kind:       util.ServiceKind,
+			Namespace:  svcImportObj.Namespace,
+			Name:       derivedServiceName,
+		},
+		{
+			APIVersion: "discovery.k8s.io/v1",
+			Kind:       util.EndpointSliceKind,
+			Namespace:  svcImportObj.Namespace,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					discoveryv1.LabelServiceName: derivedServiceName,
+				},
+			},
+		},
+	}, nil
 }

--- a/pkg/util/helper/policy_test.go
+++ b/pkg/util/helper/policy_test.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"testing"
 
-	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -177,11 +176,11 @@ func TestIsDependentClusterOverridesPresent(t *testing.T) {
 	}
 }
 
-func TestGetFollowedResourceSelectorsWhenMatchServiceImport(t *testing.T) {
+func TestCheckMatchServiceImport(t *testing.T) {
 	tests := []struct {
 		name              string
 		resourceSelectors []policyv1alpha1.ResourceSelector
-		expected          []policyv1alpha1.ResourceSelector
+		expected          bool
 	}{
 		{
 			name: " get followed resource selector",
@@ -196,78 +195,19 @@ func TestGetFollowedResourceSelectorsWhenMatchServiceImport(t *testing.T) {
 					Kind:      util.ServiceKind,
 				},
 				{
-					Name:      "foo3",
-					Namespace: "bar",
-					Kind:      util.ServiceImportKind,
+					Name:       "foo3",
+					Namespace:  "bar",
+					Kind:       util.ServiceImportKind,
+					APIVersion: "multicluster.x-k8s.io/v1alpha1",
 				},
 			},
-			expected: []policyv1alpha1.ResourceSelector{
-				{
-					APIVersion: "v1",
-					Kind:       util.ServiceKind,
-					Namespace:  "bar",
-					Name:       "derived-foo3",
-				},
-				{
-					APIVersion: "discovery.k8s.io/v1",
-					Kind:       util.EndpointSliceKind,
-					Namespace:  "bar",
-					LabelSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							discoveryv1.LabelServiceName: "derived-foo3",
-						},
-					},
-				},
-			},
+			expected: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res := GetFollowedResourceSelectorsWhenMatchServiceImport(tt.resourceSelectors)
-			if !reflect.DeepEqual(res, tt.expected) {
-				t.Errorf("expected %v, but got %v", tt.expected, res)
-			}
-		})
-	}
-}
-
-func TestGenerateResourceSelectorForServiceImport(t *testing.T) {
-	tests := []struct {
-		name      string
-		svcImport policyv1alpha1.ResourceSelector
-		expected  []policyv1alpha1.ResourceSelector
-	}{
-		{
-			name: "generate resource selector",
-			svcImport: policyv1alpha1.ResourceSelector{
-				Name:      "foo",
-				Namespace: "bar",
-			},
-			expected: []policyv1alpha1.ResourceSelector{
-				{
-					APIVersion: "v1",
-					Kind:       util.ServiceKind,
-					Namespace:  "bar",
-					Name:       "derived-foo",
-				},
-				{
-					APIVersion: "discovery.k8s.io/v1",
-					Kind:       util.EndpointSliceKind,
-					Namespace:  "bar",
-					LabelSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							discoveryv1.LabelServiceName: "derived-foo",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			res := GenerateResourceSelectorForServiceImport(tt.svcImport)
+			res := ContainsServiceImport(tt.resourceSelectors)
 			if !reflect.DeepEqual(res, tt.expected) {
 				t.Errorf("expected %v, but got %v", tt.expected, res)
 			}

--- a/pkg/webhook/clusterpropagationpolicy/mutating.go
+++ b/pkg/webhook/clusterpropagationpolicy/mutating.go
@@ -51,9 +51,8 @@ func (a *MutatingAdmission) Handle(_ context.Context, req admission.Request) adm
 		return admission.Errored(http.StatusBadRequest, fmt.Errorf("ClusterPropagationPolicy's name should be no more than %d characters", validation.LabelValueMaxLength))
 	}
 
-	addedResourceSelectors := helper.GetFollowedResourceSelectorsWhenMatchServiceImport(policy.Spec.ResourceSelectors)
-	if addedResourceSelectors != nil {
-		policy.Spec.ResourceSelectors = append(policy.Spec.ResourceSelectors, addedResourceSelectors...)
+	if helper.ContainsServiceImport(policy.Spec.ResourceSelectors) {
+		policy.Spec.PropagateDeps = true
 	}
 
 	// When ReplicaSchedulingType is Divided, set the default value of ReplicaDivisionPreference to Weighted.

--- a/pkg/webhook/propagationpolicy/mutating.go
+++ b/pkg/webhook/propagationpolicy/mutating.go
@@ -63,9 +63,8 @@ func (a *MutatingAdmission) Handle(_ context.Context, req admission.Request) adm
 	helper.AddTolerations(&policy.Spec.Placement, helper.NewNotReadyToleration(a.DefaultNotReadyTolerationSeconds),
 		helper.NewUnreachableToleration(a.DefaultUnreachableTolerationSeconds))
 
-	addedResourceSelectors := helper.GetFollowedResourceSelectorsWhenMatchServiceImport(policy.Spec.ResourceSelectors)
-	if addedResourceSelectors != nil {
-		policy.Spec.ResourceSelectors = append(policy.Spec.ResourceSelectors, addedResourceSelectors...)
+	if helper.ContainsServiceImport(policy.Spec.ResourceSelectors) {
+		policy.Spec.PropagateDeps = true
 	}
 
 	// When ReplicaSchedulingType is Divided, set the default value of ReplicaDivisionPreference to Weighted.


### PR DESCRIPTION
Signed-off-by: chaunceyjiang <chaunceyjiang@gmail.com>

/kind feature
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Added dependencies of ServiceImport to the default interpreter.
```

