### PR TITLE
Proxy connect get cluster impersonator secret use secretLister

### DIFF
--- a/cmd/aggregated-apiserver/app/options/options.go
+++ b/cmd/aggregated-apiserver/app/options/options.go
@@ -92,8 +92,9 @@ func (o *Options) Run(ctx context.Context) error {
 	restConfig := config.GenericConfig.ClientConfig
 	restConfig.QPS, restConfig.Burst = o.KubeAPIQPS, o.KubeAPIBurst
 	kubeClientSet := kubernetes.NewForConfigOrDie(restConfig)
+	secretLister := config.GenericConfig.SharedInformerFactory.Core().V1().Secrets().Lister()
 
-	server, err := config.Complete().New(kubeClientSet)
+	server, err := config.Complete().New(kubeClientSet, secretLister)
 	if err != nil {
 		return err
 	}

--- a/pkg/registry/cluster/storage/storage.go
+++ b/pkg/registry/cluster/storage/storage.go
@@ -12,6 +12,7 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/client-go/kubernetes"
+	listcorev1 "k8s.io/client-go/listers/core/v1"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 
 	clusterapis "github.com/karmada-io/karmada/pkg/apis/cluster"
@@ -30,7 +31,7 @@ type ClusterStorage struct {
 }
 
 // NewStorage returns a ClusterStorage object that will work against clusters.
-func NewStorage(scheme *runtime.Scheme, kubeClient kubernetes.Interface, optsGetter generic.RESTOptionsGetter) (*ClusterStorage, error) {
+func NewStorage(scheme *runtime.Scheme, kubeClient kubernetes.Interface, secretLister listcorev1.SecretLister, optsGetter generic.RESTOptionsGetter) (*ClusterStorage, error) {
 	strategy := clusterregistry.NewStrategy(scheme)
 
 	store := &genericregistry.Store{
@@ -63,6 +64,7 @@ func NewStorage(scheme *runtime.Scheme, kubeClient kubernetes.Interface, optsGet
 		Status:  &StatusREST{&statusStore},
 		Proxy: &ProxyREST{
 			kubeClient:    kubeClient,
+			secretLister:  secretLister,
 			clusterGetter: clusterRest.getCluster,
 		},
 	}, nil


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

When using the proxy function provided by karmada-aggregated-apiserver to access member cluster resources. The current implementation needs to obtain the impersonator secret corresponding to the member cluster in real time each time.

In large-scale scenarios, the number of requests to karmada-apiserver will increase, and I think cached queries should be used

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-aggregated-apiserver` : Proxy connect get cluster impersonator secret use secretLister
```

