### PR TITLE
add http limit for the Slowloris attack

### DIFF
--- a/cmd/descheduler/app/descheduler.go
+++ b/cmd/descheduler/app/descheduler.go
@@ -43,6 +43,22 @@ const (
 	// References:
 	// - https://en.wikipedia.org/wiki/Slowloris_(computer_security)
 	ReadHeaderTimeout = 32 * time.Second
+	// WriteTimeout is the amount of time allowed to write the
+	// request data.
+	// HTTP timeouts are necessary to expire inactive connections
+	// and failing to do so might make the application vulnerable
+	// to attacks like slowloris which work by sending data very slow,
+	// which in case of no timeout will keep the connection active
+	// eventually leading to a denial-of-service (DoS) attack.
+	WriteTimeout = 5 * time.Minute
+	// ReadTimeout is the amount of time allowed to read
+	// response data.
+	// HTTP timeouts are necessary to expire inactive connections
+	// and failing to do so might make the application vulnerable
+	// to attacks like slowloris which work by sending data very slow,
+	// which in case of no timeout will keep the connection active
+	// eventually leading to a denial-of-service (DoS) attack.
+	ReadTimeout = 5 * time.Minute
 )
 
 // NewDeschedulerCommand creates a *cobra.Command object with default parameters
@@ -174,6 +190,8 @@ func serveHealthzAndMetrics(address string) {
 		Addr:              address,
 		Handler:           mux,
 		ReadHeaderTimeout: ReadHeaderTimeout,
+		WriteTimeout:      WriteTimeout,
+		ReadTimeout:       ReadTimeout,
 	}
 	if err := httpServer.ListenAndServe(); err != nil {
 		klog.Errorf("Failed to serve healthz and metrics: %v", err)

--- a/cmd/scheduler-estimator/app/scheduler-estimator.go
+++ b/cmd/scheduler-estimator/app/scheduler-estimator.go
@@ -40,6 +40,22 @@ const (
 	// References:
 	// - https://en.wikipedia.org/wiki/Slowloris_(computer_security)
 	ReadHeaderTimeout = 32 * time.Second
+	// WriteTimeout is the amount of time allowed to write the
+	// request data.
+	// HTTP timeouts are necessary to expire inactive connections
+	// and failing to do so might make the application vulnerable
+	// to attacks like slowloris which work by sending data very slow,
+	// which in case of no timeout will keep the connection active
+	// eventually leading to a denial-of-service (DoS) attack.
+	WriteTimeout = 5 * time.Minute
+	// ReadTimeout is the amount of time allowed to read
+	// response data.
+	// HTTP timeouts are necessary to expire inactive connections
+	// and failing to do so might make the application vulnerable
+	// to attacks like slowloris which work by sending data very slow,
+	// which in case of no timeout will keep the connection active
+	// eventually leading to a denial-of-service (DoS) attack.
+	ReadTimeout = 5 * time.Minute
 )
 
 // NewSchedulerEstimatorCommand creates a *cobra.Command object with default parameters
@@ -121,6 +137,8 @@ func serveHealthzAndMetrics(address string) {
 		Addr:              address,
 		Handler:           mux,
 		ReadHeaderTimeout: ReadHeaderTimeout,
+		WriteTimeout:      WriteTimeout,
+		ReadTimeout:       ReadTimeout,
 	}
 	if err := httpServer.ListenAndServe(); err != nil {
 		klog.Errorf("Failed to serve healthz and metrics: %v", err)

--- a/cmd/scheduler/app/scheduler.go
+++ b/cmd/scheduler/app/scheduler.go
@@ -45,6 +45,22 @@ const (
 	// References:
 	// - https://en.wikipedia.org/wiki/Slowloris_(computer_security)
 	ReadHeaderTimeout = 32 * time.Second
+	// WriteTimeout is the amount of time allowed to write the
+	// request data.
+	// HTTP timeouts are necessary to expire inactive connections
+	// and failing to do so might make the application vulnerable
+	// to attacks like slowloris which work by sending data very slow,
+	// which in case of no timeout will keep the connection active
+	// eventually leading to a denial-of-service (DoS) attack.
+	WriteTimeout = 5 * time.Minute
+	// ReadTimeout is the amount of time allowed to read
+	// response data.
+	// HTTP timeouts are necessary to expire inactive connections
+	// and failing to do so might make the application vulnerable
+	// to attacks like slowloris which work by sending data very slow,
+	// which in case of no timeout will keep the connection active
+	// eventually leading to a denial-of-service (DoS) attack.
+	ReadTimeout = 5 * time.Minute
 )
 
 // Option configures a framework.Registry.
@@ -207,6 +223,8 @@ func serveHealthzAndMetrics(address string) {
 		Addr:              address,
 		Handler:           mux,
 		ReadHeaderTimeout: ReadHeaderTimeout,
+		WriteTimeout:      WriteTimeout,
+		ReadTimeout:       ReadTimeout,
 	}
 	if err := httpServer.ListenAndServe(); err != nil {
 		klog.Errorf("Failed to serve healthz and metrics: %v", err)

--- a/pkg/sharedcli/profileflag/profileflag.go
+++ b/pkg/sharedcli/profileflag/profileflag.go
@@ -21,6 +21,22 @@ const (
 	// References:
 	// - https://en.wikipedia.org/wiki/Slowloris_(computer_security)
 	ReadHeaderTimeout = 32 * time.Second
+	// WriteTimeout is the amount of time allowed to write the
+	// request data.
+	// HTTP timeouts are necessary to expire inactive connections
+	// and failing to do so might make the application vulnerable
+	// to attacks like slowloris which work by sending data very slow,
+	// which in case of no timeout will keep the connection active
+	// eventually leading to a denial-of-service (DoS) attack.
+	WriteTimeout = 5 * time.Minute
+	// ReadTimeout is the amount of time allowed to read
+	// response data.
+	// HTTP timeouts are necessary to expire inactive connections
+	// and failing to do so might make the application vulnerable
+	// to attacks like slowloris which work by sending data very slow,
+	// which in case of no timeout will keep the connection active
+	// eventually leading to a denial-of-service (DoS) attack.
+	ReadTimeout = 5 * time.Minute
 )
 
 // Options are options for pprof.
@@ -57,6 +73,8 @@ func ListenAndServe(opts Options) {
 				Addr:              opts.ProfilingBindAddress,
 				Handler:           mux,
 				ReadHeaderTimeout: ReadHeaderTimeout,
+				WriteTimeout:      WriteTimeout,
+				ReadTimeout:       ReadTimeout,
 			}
 			if err := httpServer.ListenAndServe(); err != nil {
 				klog.Errorf("Failed to enable profiling: %v", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Avoid slow http attack.

**Which issue(s) this PR fixes**:
Fixes #3945 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```
Security: Sets an upper bound for all components on the lifetime of idle keep-alive connections and time to read the headers of incoming requests.
```

@RainbowMango @XiShanYongYe-Chang PTAL

