### PR TITLE
helm: support PodDisruptionBudget for resources

### DIFF
--- a/charts/karmada/templates/karmada-agent.yaml
+++ b/charts/karmada/templates/karmada-agent.yaml
@@ -131,4 +131,21 @@ spec:
         - name: kubeconfig
           secret:
             secretName: {{ $name }}-kubeconfig
+
+{{ if .Values.agent.podDisruptionBudget }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $name }}
+  namespace: {{ include "karmada.namespace" . }}
+  labels:
+    {{- include "karmada.agent.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "karmada.agent.labels" . | nindent 6 }}
+  {{ toYaml .Values.agent.podDisruptionBudget | nindent 2 }}
+{{- end -}}
+
 {{- end }}

--- a/charts/karmada/templates/karmada-aggregated-apiserver.yaml
+++ b/charts/karmada/templates/karmada-aggregated-apiserver.yaml
@@ -124,4 +124,20 @@ spec:
   selector:
     {{- include "karmada.aggregatedApiserver.labels" . | nindent 4 }}
 
+{{ if and .Values.aggregatedApiserver .Values.aggregatedApiserver.podDisruptionBudget }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $name }}-aggregated-apiserver
+  namespace: {{ include "karmada.namespace" . }}
+  labels:
+    {{- include "karmada.aggregatedApiserver.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "karmada.aggregatedApiserver.labels" . | nindent 6 }}
+  {{ toYaml .Values.aggregatedApiserver.podDisruptionBudget | nindent 2 }}
+{{- end -}}
+
 {{- end }}

--- a/charts/karmada/templates/karmada-apiserver.yaml
+++ b/charts/karmada/templates/karmada-apiserver.yaml
@@ -170,4 +170,20 @@ spec:
   selector:
   {{- include "karmada.apiserver.labels" . | nindent 4}}
 
+{{ if .Values.apiServer.podDisruptionBudget }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $name }}-apiserver
+  namespace: {{ include "karmada.namespace" . }}
+  labels:
+    {{- include "karmada.apiserver.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "karmada.apiserver.labels" . | nindent 6}}
+  {{ toYaml .Values.apiServer.podDisruptionBudget | nindent 2 }}
+{{- end -}}
+
 {{- end }}

--- a/charts/karmada/templates/karmada-controller-manager.yaml
+++ b/charts/karmada/templates/karmada-controller-manager.yaml
@@ -75,5 +75,22 @@ spec:
           {{- include "karmada.kubeconfig.volumeMount" . | nindent 12 }}
           resources:
           {{- toYaml .Values.controllerManager.resources | nindent 12 }}
+
+{{ if .Values.controllerManager.podDisruptionBudget }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $name }}-controller-manager
+  namespace: {{ include "karmada.namespace" . }}
+  labels:
+    {{- include "karmada.cm.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "karmada.cm.labels" . | nindent 6 }}
+  {{ toYaml .Values.controllerManager.podDisruptionBudget | nindent 2 }}
+{{- end -}}
+
 ---
 {{- end }}

--- a/charts/karmada/templates/karmada-descheduler.yaml
+++ b/charts/karmada/templates/karmada-descheduler.yaml
@@ -66,4 +66,21 @@ spec:
           {{- toYaml .Values.descheduler.resources | nindent 12 }}
       volumes:
       {{- include "karmada.descheduler.kubeconfig.volume" . | nindent 8 }}
+
+{{ if .Values.descheduler.podDisruptionBudget }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $name }}-descheduler
+  namespace: {{ include "karmada.namespace" . }}
+  labels:
+    {{- include "karmada.descheduler.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "karmada.descheduler.labels" . | nindent 6}}
+  {{ toYaml .Values.descheduler.podDisruptionBudget | nindent 2 }}
+{{- end -}}
+
 {{- end }}

--- a/charts/karmada/templates/karmada-scheduler-estimator.yaml
+++ b/charts/karmada/templates/karmada-scheduler-estimator.yaml
@@ -105,4 +105,23 @@ stringData:
           user: {{ $clusterName }}-apiserver
         name: {{ $clusterName }}-apiserver
     current-context: {{ $clusterName }}-apiserver
+
+{{ if .Values.schedulerEstimator.podDisruptionBudget }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: karmada-scheduler-estimator-{{ $clusterName }}
+  namespace: {{ include "karmada.namespace" . }}
+  labels:
+    cluster: {{ $clusterName }}
+    {{- include "karmada.schedulerEstimator.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: karmada-scheduler-estimator-{{ $clusterName }}
+      {{- include "karmada.schedulerEstimator.labels" . | nindent 6 }}
+  {{ toYaml .Values.schedulerEstimator.podDisruptionBudget | nindent 2 }}
+{{- end -}}
+
 {{- end }}

--- a/charts/karmada/templates/karmada-scheduler.yaml
+++ b/charts/karmada/templates/karmada-scheduler.yaml
@@ -66,6 +66,23 @@ spec:
           {{- toYaml .Values.scheduler.resources | nindent 12 }}
       volumes:
       {{- include "karmada.kubeconfig.volume" . | nindent 8 }}
+
+{{ if .Values.scheduler.podDisruptionBudget }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $name }}-scheduler
+  namespace: {{ include "karmada.namespace" . }}
+  labels:
+    {{- include "karmada.scheduler.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "karmada.scheduler.labels" . | nindent 6 }}
+  {{ toYaml .Values.scheduler.podDisruptionBudget | nindent 2 }}
+{{- end }}
+
 ---
 
 {{- end }}

--- a/charts/karmada/templates/karmada-search.yaml
+++ b/charts/karmada/templates/karmada-search.yaml
@@ -167,4 +167,21 @@ spec:
             name: {{ $name }}-search-apiservice
         {{ include "karmada.search.kubeconfig.volume" . | nindent 8 }}
 {{- end }}
+
+{{ if .Values.search.podDisruptionBudget }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $name }}-search
+  namespace: {{ include "karmada.namespace" . }}
+  labels:
+    {{- include "karmada.search.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "karmada.search.labels" . | nindent 6 }}
+  {{ toYaml .Values.search.podDisruptionBudget | nindent 2 }}
+{{- end -}}
+
 {{- end }}

--- a/charts/karmada/templates/karmada-webhook.yaml
+++ b/charts/karmada/templates/karmada-webhook.yaml
@@ -81,4 +81,20 @@ spec:
     - port: 443
       targetPort: 8443
 
+{{ if .Values.webhook.podDisruptionBudget }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $name }}-webhook
+  namespace: {{ include "karmada.namespace" . }}
+  labels:
+    {{- include "karmada.webhook.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "karmada.webhook.labels" . | nindent 6 }}
+  {{ toYaml .Values.webhook.podDisruptionBudget | nindent 2 }}
+{{- end -}}
+
 {{- end }}

--- a/charts/karmada/templates/kube-controller-manager.yaml
+++ b/charts/karmada/templates/kube-controller-manager.yaml
@@ -88,4 +88,21 @@ spec:
           secret:
             secretName: {{ $name }}-cert
         {{- include "karmada.kubeconfig.volume" . | nindent 8 }}
+
+{{ if .Values.kubeControllerManager.podDisruptionBudget }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $name }}-kube-controller-manager
+  namespace: {{ include "karmada.namespace" . }}
+  labels:
+    {{- include "karmada.kube-cm.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "karmada.kube-cm.labels" . | nindent 6 }}
+  {{ toYaml .Values.kubeControllerManager.podDisruptionBudget | nindent 2 }}
+{{- end -}}
+
 {{- end }}

--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -19,6 +19,9 @@ global:
 ## for more details about yaml anchors and aliases.
 karmadaImageVersion: &karmadaImageVersion latest
 
+podDisruptionBudget: &podDisruptionBudget {}
+  # maxUnavailable: 20%
+
 ## @param installMode "host" and "agent" are provided
 ## "host" means install karmada in the control-cluster
 ## "agent" means install agent client in the member cluster
@@ -192,6 +195,8 @@ scheduler:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 50%
+  ## @param apiServer.podDisruptionBudget
+  podDisruptionBudget: *podDisruptionBudget
 
 ## webhook config
 webhook:
@@ -249,6 +254,8 @@ webhook:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 50%
+  ## @param apiServer.podDisruptionBudget
+  podDisruptionBudget: *podDisruptionBudget
 
 ## controller manager config
 controllerManager:
@@ -314,6 +321,8 @@ controllerManager:
   controllers: ""
   ## @param extraCommandArgs to extraCommandArgs
   extraCommandArgs: {}
+  ## @param apiServer.podDisruptionBudget
+  podDisruptionBudget: *podDisruptionBudget
 
 ## karmada apiserver config
 apiServer:
@@ -396,6 +405,8 @@ apiServer:
     rollingUpdate:
       maxUnavailable: 1
       maxSurge: 1
+  ## @param apiServer.podDisruptionBudget
+  podDisruptionBudget: *podDisruptionBudget
 
 ## karmada aggregated apiserver config
 aggregatedApiServer:
@@ -455,6 +466,8 @@ aggregatedApiServer:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 50%
+  ## @param apiServer.podDisruptionBudget
+  podDisruptionBudget: *podDisruptionBudget
 
 ## kubernetes controller manager config
 kubeControllerManager:
@@ -514,6 +527,8 @@ kubeControllerManager:
       maxUnavailable: 0
       maxSurge: 50%
   controllers: namespace,garbagecollector,serviceaccount-token,ttl-after-finished,bootstrapsigner,tokencleaner,csrapproving,csrcleaner,csrsigning
+  ## @param apiServer.podDisruptionBudget
+  podDisruptionBudget: *podDisruptionBudget
 
 ## etcd config
 etcd:
@@ -680,6 +695,8 @@ agent:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 50%
+  ## @param apiServer.podDisruptionBudget
+  podDisruptionBudget: *podDisruptionBudget
 
 ## karmada scheduler estimator
 schedulerEstimator:
@@ -758,6 +775,8 @@ schedulerEstimator:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 50%
+  ## @param apiServer.podDisruptionBudget
+  podDisruptionBudget: *podDisruptionBudget
 
 ## descheduler config
 descheduler:
@@ -817,6 +836,8 @@ descheduler:
       maxSurge: 50%
   ## @param descheduler.kubeconfig kubeconfig of the descheduler
   kubeconfig: karmada-kubeconfig
+  ## @param apiServer.podDisruptionBudget
+  podDisruptionBudget: *podDisruptionBudget
 
 ## karmada-search config
 search:
@@ -878,3 +899,5 @@ search:
   certs: karmada-cert
   ## @param search.kubeconfig kubeconfig of the search
   kubeconfig: karmada-kubeconfig
+  ## @param apiServer.podDisruptionBudget
+  podDisruptionBudget: *podDisruptionBudget


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind feature

**What this PR does / why we need it**:

Currently there's not a way to render PodDisruptionBudget for critical resources such as kube-apiserver

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
helm: support PodDisruptionBudget for resources
```

