### PR TITLE
Feat: Add karmada resource clusterrole for helm install

### DIFF
--- a/charts/karmada/templates/karmada-resource-clusterrole.yaml
+++ b/charts/karmada/templates/karmada-resource-clusterrole.yaml
@@ -1,0 +1,149 @@
+# This configuration is used to grant the admin clusterrole read
+# and write permissions for Karmada resources.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    # refer to https://kubernetes.io/docs/reference/access-authn-authz/rbac/#auto-reconciliation
+    # and https://kubernetes.io/docs/reference/access-authn-authz/rbac/#kubectl-auth-reconcile
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    # refer to https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+    kubernetes.io/bootstrapping: rbac-defaults
+    # used to aggregate rules to view clusterrole
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: karmada-view
+rules:
+  - apiGroups:
+      - "autoscaling.karmada.io"
+    resources:
+      - cronfederatedhpas
+      - cronfederatedhpas/status
+      - federatedhpas
+      - federatedhpas/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "multicluster.x-k8s.io"
+    resources:
+      - serviceexports
+      - serviceexports/status
+      - serviceimports
+      - serviceimports/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "networking.karmada.io"
+    resources:
+      - multiclusteringresses
+      - multiclusteringresses/status
+      - multiclusterservices
+      - multiclusterservices/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "policy.karmada.io"
+    resources:
+      - overridepolicies
+      - propagationpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "work.karmada.io"
+    resources:
+      - resourcebindings
+      - resourcebindings/status
+      - works
+      - works/status
+    verbs:
+      - get
+      - list
+      - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    # refer to https://kubernetes.io/docs/reference/access-authn-authz/rbac/#auto-reconciliation
+    # and https://kubernetes.io/docs/reference/access-authn-authz/rbac/#kubectl-auth-reconcile
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    # refer to https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+    kubernetes.io/bootstrapping: rbac-defaults
+    # used to aggregate rules to view clusterrole
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: karmada-edit
+rules:
+  - apiGroups:
+      - "autoscaling.karmada.io"
+    resources:
+      - cronfederatedhpas
+      - cronfederatedhpas/status
+      - federatedhpas
+      - federatedhpas/status
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+  - apiGroups:
+      - "multicluster.x-k8s.io"
+    resources:
+      - serviceexports
+      - serviceexports/status
+      - serviceimports
+      - serviceimports/status
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+  - apiGroups:
+      - "networking.karmada.io"
+    resources:
+      - multiclusteringresses
+      - multiclusteringresses/status
+      - multiclusterservices
+      - multiclusterservices/status
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+  - apiGroups:
+      - "policy.karmada.io"
+    resources:
+      - overridepolicies
+      - propagationpolicies
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+  - apiGroups:
+      - "work.karmada.io"
+    resources:
+      - resourcebindings
+      - resourcebindings/status
+      - works
+      - works/status
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
add admin clusterrole for karmada resources when helm install
**Which issue(s) this PR fixes**:
Part of https://github.com/karmada-io/karmada/issues/3916

**Special notes for your reviewer**:
Test:
install by helm, and create the clusterroles
<img width="888" alt="image" src="https://github.com/karmada-io/karmada/assets/19872346/909d1eb2-496d-4b1d-8fed-955659dfde23">

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
add admin clusterrole for karmada resources when helm install

```

