### PR TITLE
fix addAnnotationWithClusterName crash

### DIFF
--- a/pkg/registry/search/storage/cache.go
+++ b/pkg/registry/search/storage/cache.go
@@ -119,7 +119,7 @@ func (r *SearchREST) getObjectItemsFromClusters(
 					objGVR, namespace, name, cluster.Name, err)
 				continue
 			}
-			items = append(items, addAnnotationWithClusterName([]runtime.Object{resourceObject}, cluster.Name)...)
+			items = append(items, addAnnotationWithClusterName([]runtime.Object{resourceObject.DeepCopyObject()}, cluster.Name)...)
 		} else {
 			var resourceObjects []runtime.Object
 			if len(namespace) > 0 {
@@ -132,7 +132,13 @@ func (r *SearchREST) getObjectItemsFromClusters(
 					objGVR, cluster.Name, err)
 				continue
 			}
-			items = append(items, addAnnotationWithClusterName(resourceObjects, cluster.Name)...)
+
+			cloneObjects := make([]runtime.Object, len(resourceObjects))
+			for i := range resourceObjects {
+				cloneObjects[i] = resourceObjects[i].DeepCopyObject()
+			}
+
+			items = append(items, addAnnotationWithClusterName(cloneObjects, cluster.Name)...)
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #3960

**Special notes for your reviewer**:

When listing from an  Infromer, it returns reference of objects in `cache`.
https://github.com/karmada-io/karmada/blob/48a37ab5b1f535eaa2c70e3b6ca52909fa78372e/vendor/k8s.io/client-go/tools/cache/thread_safe_store.go#L245-L253

When two or more search requests come at the same time, and all requests list objects from informer and add cluster annotation into the same objecs, it raises crash.
https://github.com/karmada-io/karmada/blob/5763248181ed3a90684b36b4d5d2ffea2c68d987/pkg/registry/search/storage/cache.go#L141

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-search`: Fixed a panic due to concurrent mutating objects in the informer cache.
```

