### PR TITLE
fix: return 400(StatusBadRequest) http code when the validation failed

### DIFF
--- a/pkg/webhook/clusteroverridepolicy/validating.go
+++ b/pkg/webhook/clusteroverridepolicy/validating.go
@@ -32,7 +32,7 @@ func (v *ValidatingAdmission) Handle(_ context.Context, req admission.Request) a
 
 	if errs := validation.ValidateOverrideSpec(&policy.Spec); len(errs) != 0 {
 		klog.Error(errs)
-		return admission.Denied(errs.ToAggregate().Error())
+		return admission.Errored(http.StatusBadRequest, errs.ToAggregate())
 	}
 
 	return admission.Allowed("")

--- a/pkg/webhook/clusterpropagationpolicy/validating.go
+++ b/pkg/webhook/clusterpropagationpolicy/validating.go
@@ -42,14 +42,14 @@ func (v *ValidatingAdmission) Handle(_ context.Context, req admission.Request) a
 		if policy.Spec.SchedulerName != oldPolicy.Spec.SchedulerName {
 			err = fmt.Errorf("the schedulerName should not be updated")
 			klog.Error(err)
-			return admission.Denied(err.Error())
+			return admission.Errored(http.StatusBadRequest, err)
 		}
 	}
 
 	errs := validation.ValidatePropagationSpec(policy.Spec)
 	if len(errs) != 0 {
 		klog.Error(errs)
-		return admission.Denied(errs.ToAggregate().Error())
+		return admission.Errored(http.StatusBadRequest, errs.ToAggregate())
 	}
 	return admission.Allowed("")
 }

--- a/pkg/webhook/configuration/validating.go
+++ b/pkg/webhook/configuration/validating.go
@@ -48,7 +48,7 @@ func (v *ValidatingAdmission) Handle(_ context.Context, req admission.Request) a
 
 	if len(allErrors) != 0 {
 		klog.Error(allErrors.ToAggregate())
-		return admission.Denied(allErrors.ToAggregate().Error())
+		return admission.Errored(http.StatusBadRequest, allErrors.ToAggregate())
 	}
 
 	return admission.Allowed("")

--- a/pkg/webhook/cronfederatedhpa/validation.go
+++ b/pkg/webhook/cronfederatedhpa/validation.go
@@ -58,7 +58,7 @@ func (v *ValidatingAdmission) Handle(_ context.Context, req admission.Request) a
 	errs = append(errs, validateCronFederatedHPASpec(&cronFHPA.Spec, field.NewPath("spec"))...)
 
 	if len(errs) != 0 {
-		return admission.Denied(errs.ToAggregate().Error())
+		return admission.Errored(http.StatusBadRequest, errs.ToAggregate())
 	}
 	return admission.Allowed("")
 }

--- a/pkg/webhook/federatedhpa/validation.go
+++ b/pkg/webhook/federatedhpa/validation.go
@@ -32,7 +32,7 @@ func (v *ValidatingAdmission) Handle(_ context.Context, req admission.Request) a
 
 	if errs := lifted.ValidateFederatedHPA(fhpa); len(errs) != 0 {
 		klog.Errorf("%v", errs)
-		return admission.Denied(errs.ToAggregate().Error())
+		return admission.Errored(http.StatusBadRequest, errs.ToAggregate())
 	}
 
 	return admission.Allowed("")

--- a/pkg/webhook/federatedresourcequota/validating.go
+++ b/pkg/webhook/federatedresourcequota/validating.go
@@ -37,7 +37,7 @@ func (v *ValidatingAdmission) Handle(_ context.Context, req admission.Request) a
 
 	if errs := validateFederatedResourceQuota(quota); len(errs) != 0 {
 		klog.Errorf("%v", errs)
-		return admission.Denied(errs.ToAggregate().Error())
+		return admission.Errored(http.StatusBadRequest, errs.ToAggregate())
 	}
 
 	return admission.Allowed("")

--- a/pkg/webhook/multiclusteringress/validating.go
+++ b/pkg/webhook/multiclusteringress/validating.go
@@ -41,12 +41,12 @@ func (v *ValidatingAdmission) Handle(_ context.Context, req admission.Request) a
 		}
 		if errs := validateMCIUpdate(oldMci, mci); len(errs) != 0 {
 			klog.Errorf("%v", errs)
-			return admission.Denied(errs.ToAggregate().Error())
+			return admission.Errored(http.StatusBadRequest, errs.ToAggregate())
 		}
 	} else {
 		if errs := validateMCI(mci); len(errs) != 0 {
 			klog.Errorf("%v", errs)
-			return admission.Denied(errs.ToAggregate().Error())
+			return admission.Errored(http.StatusBadRequest, errs.ToAggregate())
 		}
 	}
 	return admission.Allowed("")

--- a/pkg/webhook/multiclusterservice/validating.go
+++ b/pkg/webhook/multiclusterservice/validating.go
@@ -44,12 +44,12 @@ func (v *ValidatingAdmission) Handle(ctx context.Context, req admission.Request)
 		}
 		if errs := v.validateMCSUpdate(oldMcs, mcs); len(errs) != 0 {
 			klog.Errorf("Validating MultiClusterServiceUpdate failed: %v", errs)
-			return admission.Denied(errs.ToAggregate().Error())
+			return admission.Errored(http.StatusBadRequest, errs.ToAggregate())
 		}
 	} else {
 		if errs := v.validateMCS(mcs); len(errs) != 0 {
 			klog.Errorf("Validating MultiClusterService failed: %v", errs)
-			return admission.Denied(errs.ToAggregate().Error())
+			return admission.Errored(http.StatusBadRequest, errs.ToAggregate())
 		}
 	}
 	return admission.Allowed("")

--- a/pkg/webhook/overridepolicy/validating.go
+++ b/pkg/webhook/overridepolicy/validating.go
@@ -32,7 +32,7 @@ func (v *ValidatingAdmission) Handle(_ context.Context, req admission.Request) a
 
 	if errs := validation.ValidateOverrideSpec(&policy.Spec); len(errs) != 0 {
 		klog.Error(errs)
-		return admission.Denied(errs.ToAggregate().Error())
+		return admission.Errored(http.StatusBadRequest, errs.ToAggregate())
 	}
 
 	return admission.Allowed("")

--- a/pkg/webhook/propagationpolicy/validating.go
+++ b/pkg/webhook/propagationpolicy/validating.go
@@ -42,14 +42,14 @@ func (v *ValidatingAdmission) Handle(_ context.Context, req admission.Request) a
 		if policy.Spec.SchedulerName != oldPolicy.Spec.SchedulerName {
 			err = fmt.Errorf("the schedulerName should not be updated")
 			klog.Error(err)
-			return admission.Denied(err.Error())
+			return admission.Errored(http.StatusBadRequest, err)
 		}
 	}
 
 	errs := validation.ValidatePropagationSpec(policy.Spec)
 	if len(errs) != 0 {
 		klog.Error(errs)
-		return admission.Denied(errs.ToAggregate().Error())
+		return admission.Errored(http.StatusBadRequest, errs.ToAggregate())
 	}
 	return admission.Allowed("")
 }

--- a/pkg/webhook/resourceinterpretercustomization/validating.go
+++ b/pkg/webhook/resourceinterpretercustomization/validating.go
@@ -35,7 +35,7 @@ func (v *ValidatingAdmission) Handle(ctx context.Context, req admission.Request)
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 	if err = validateResourceInterpreterCustomizations(configuration, configs); err != nil {
-		return admission.Denied(err.Error())
+		return admission.Errored(http.StatusBadRequest, err)
 	}
 	return admission.Allowed("")
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Currently, the webhook returns a 403 (forbidden) status code when validation fails. However, this is incorrect as it should only occur when there is insufficient privilege.

I have tested this with K8s and found that if the field is not correct, the expected status codes are either 400(StatusBadRequest) or 422(StatusUnprocessableEntity). Therefore, we should adhere to this rule.

There is no clear distinction between 400 and 422. In both cases, a parameter error occurs. Therefore, I have modified the relevant code to always return a response of 400.

**Which issue(s) this PR fixes**:
Fixes #none

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-webhook`: If the field validation fails, return a 400 (StatusBadRequest) HTTP code.
```

