### PR TITLE
Automated cherry pick of #3966: fix addAnnotationWithClusterName crash

### DIFF
--- a/pkg/registry/search/storage/cache.go
+++ b/pkg/registry/search/storage/cache.go
@@ -119,7 +119,7 @@ func (r *SearchREST) getObjectItemsFromClusters(
 					objGVR, namespace, name, cluster.Name, err)
 				continue
 			}
-			items = append(items, addAnnotationWithClusterName([]runtime.Object{resourceObject}, cluster.Name)...)
+			items = append(items, addAnnotationWithClusterName([]runtime.Object{resourceObject.DeepCopyObject()}, cluster.Name)...)
 		} else {
 			var resourceObjects []runtime.Object
 			if len(namespace) > 0 {
@@ -132,7 +132,13 @@ func (r *SearchREST) getObjectItemsFromClusters(
 					objGVR, cluster.Name, err)
 				continue
 			}
-			items = append(items, addAnnotationWithClusterName(resourceObjects, cluster.Name)...)
+
+			cloneObjects := make([]runtime.Object, len(resourceObjects))
+			for i := range resourceObjects {
+				cloneObjects[i] = resourceObjects[i].DeepCopyObject()
+			}
+
+			items = append(items, addAnnotationWithClusterName(cloneObjects, cluster.Name)...)
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #3966 on release-1.6.
#3966: fix addAnnotationWithClusterName crash
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-search`: Fixed a panic due to concurrent mutating objects in the informer cache.
```