### PR TITLE
cleanup: do not reconcile when the resoruce generation doesn't change

### DIFF
--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_controller.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_controller.go
@@ -27,6 +27,7 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	autoscalingv1alpha1 "github.com/karmada-io/karmada/pkg/apis/autoscaling/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/metrics"
@@ -116,6 +117,7 @@ func (c *CronFHPAController) SetupWithManager(mgr controllerruntime.Manager) err
 	return controllerruntime.NewControllerManagedBy(mgr).
 		For(&autoscalingv1alpha1.CronFederatedHPA{}).
 		WithOptions(controller.Options{RateLimiter: ratelimiterflag.DefaultControllerRateLimiter(c.RateLimiterOptions)}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(c)
 }
 

--- a/pkg/controllers/federatedhpa/federatedhpa_controller.go
+++ b/pkg/controllers/federatedhpa/federatedhpa_controller.go
@@ -28,6 +28,7 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	autoscalingv1alpha1 "github.com/karmada-io/karmada/pkg/apis/autoscaling/v1alpha1"
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
@@ -112,6 +113,7 @@ func (c *FederatedHPAController) SetupWithManager(mgr controllerruntime.Manager)
 	return controllerruntime.NewControllerManagedBy(mgr).
 		For(&autoscalingv1alpha1.FederatedHPA{}).
 		WithOptions(controller.Options{RateLimiter: ratelimiterflag.DefaultControllerRateLimiter(c.RateLimiterOptions)}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(c)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Having only one CronFederatedHPA/FederatedHPA, it will be reconciled even if the status is updated, which is unnecessary.

![image](https://github.com/karmada-io/karmada/assets/19745536/a211794d-0ce3-49d2-9bdf-097d29d2514e)

**Which issue(s) this PR fixes**:
Fixes #none

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

