### PR TITLE
Remove the execute permission from the directory

### DIFF
--- a/operator/pkg/tasks/init/crd.go
+++ b/operator/pkg/tasks/init/crd.go
@@ -86,7 +86,7 @@ func runCrdsDownload(r workflow.RunData) error {
 		return err
 	}
 	if !exist {
-		if err := os.MkdirAll(crdsDir, 0755); err != nil {
+		if err := os.MkdirAll(crdsDir, 0700); err != nil {
 			return err
 		}
 	}

--- a/operator/pkg/util/util.go
+++ b/operator/pkg/util/util.go
@@ -98,7 +98,7 @@ func Unpack(file, targetPath string) error {
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.Mkdir(targetPath+"/"+header.Name, 0755); err != nil {
+			if err := os.Mkdir(targetPath+"/"+header.Name, 0700); err != nil {
 				return err
 			}
 		case tar.TypeReg:

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -219,7 +219,7 @@ func initializeDirectory(path string) error {
 			return err
 		}
 	}
-	if err := os.MkdirAll(path, os.FileMode(0o755)); err != nil {
+	if err := os.MkdirAll(path, os.FileMode(0700)); err != nil {
 		return fmt.Errorf("failed to create directory: %s, error: %v", path, err)
 	}
 

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
@@ -34,7 +34,7 @@ func Test_initializeDirectory(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.createPathInAdvance {
-				if err := os.MkdirAll("tmp", os.FileMode(0755)); err != nil {
+				if err := os.MkdirAll("tmp", os.FileMode(0700)); err != nil {
 					t.Errorf("create test directory failed in advance:%v", err)
 				}
 			}

--- a/pkg/karmadactl/cmdinit/utils/util.go
+++ b/pkg/karmadactl/cmdinit/utils/util.go
@@ -94,7 +94,7 @@ func DeCompress(file, targetPath string) error {
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.Mkdir(targetPath+"/"+header.Name, 0755); err != nil {
+			if err := os.Mkdir(targetPath+"/"+header.Name, 0700); err != nil {
 				return err
 			}
 		case tar.TypeReg:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Reduce permissions for directories created by karmada itself.
From 755 to 700. Prevent unauthorized users from modifying content.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

@RainbowMango @whitewindmills @XiShanYongYe-Chang 

