### PR TITLE
remove unnecessary needUpdate to avoid unexpected skipping updating before cache synced

### DIFF
--- a/pkg/controllers/execution/execution_controller.go
+++ b/pkg/controllers/execution/execution_controller.go
@@ -3,7 +3,6 @@ package execution
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -379,24 +378,7 @@ func (c *Controller) updateAppliedConditionIfNeed(work *workv1alpha1.Work, statu
 		LastTransitionTime: metav1.Now(),
 	}
 
-	// needUpdateCondition judges if the Applied condition needs to update.
-	needUpdateCondition := func() bool {
-		lastWorkAppliedCondition := meta.FindStatusCondition(work.Status.Conditions, workv1alpha1.WorkApplied).DeepCopy()
-
-		if lastWorkAppliedCondition != nil {
-			lastWorkAppliedCondition.LastTransitionTime = newWorkAppliedCondition.LastTransitionTime
-
-			return !reflect.DeepEqual(newWorkAppliedCondition, *lastWorkAppliedCondition)
-		}
-
-		return true
-	}
-
 	return retry.RetryOnConflict(retry.DefaultRetry, func() (err error) {
-		if !needUpdateCondition() {
-			return nil
-		}
-
 		meta.SetStatusCondition(&work.Status.Conditions, newWorkAppliedCondition)
 		updateErr := c.Status().Update(context.TODO(), work)
 		if updateErr == nil {


### PR DESCRIPTION
**What type of PR is this?**  
/kind bug  
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:  
Consider if some error occured in `execution-controller`, it would update the condition of `work` from `true` to `false`, and requeue in a short time(5ms for first time as default now), but during this reconciling, the condition of got `work` might be still `true` because the cache of `work` might not be synced yet. If no error occurs this time, when calling `needUpdateCondition`, we would find the condition in both "old" and "new" `work status` is `true`, that would cause unexpected skipping updating `work status` with the condition is `false` in cluster in fact.  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:  
I'm sorry for bringing this in #3808 , I intended to reduce the attempts to update `work` because now there are much more chances to update `work status` than before. But it seems quite a potential risk here. Maybe we could consider about a better way later to reduce the attempts to do unnecessary updating.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

