### PR TITLE
stop update krew for release 1.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,11 +42,3 @@ jobs:
           _output/release/${{ matrix.target }}-${{ matrix.os }}-${{ matrix.arch }}.tgz.sha256
           _output/charts/karmada-chart-${{ github.ref_name }}.tgz
           _output/charts/karmada-chart-${{ github.ref_name }}.tgz.sha256
-  update-krew-index:
-    needs: release-assests
-    name: Update krew-index
-    runs-on: ubuntu-22.04
-    steps:
-    - uses: actions/checkout@v3
-    - name: Update new version in krew-index
-      uses: rajatjindal/krew-release-bot@v0.0.40


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Remove [update-krew-index](https://github.com/karmada-io/karmada/blob/11fac252b618dd26de530293e60b9faab9872507/.github/workflows/release.yml#L39-L46) from branch release-1.6.

**Which issue(s) this PR fixes**:
Fixes #4019

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

