### PR TITLE
remove insecureSkipTLSVerify in helm chart

### DIFF
--- a/charts/karmada/templates/_helpers.tpl
+++ b/charts/karmada/templates/_helpers.tpl
@@ -213,6 +213,15 @@ app: {{$name}}
 {{- end }}
 {{- end -}}
 
+{{- define "karmada.apiserver.caBundle" -}}
+{{- if eq .Values.certs.mode "auto" }}
+caBundle: {{ print "{{ ca_crt }}" }}
+{{- end }}
+{{- if eq .Values.certs.mode "custom" }}
+caBundle: {{ b64enc .Values.certs.custom.caCrt }}
+{{- end }}
+{{- end -}}
+
 {{- define "karmada.webhook.caBundle" -}}
 {{- if eq .Values.certs.mode "auto" }}
 caBundle: {{ print "{{ ca_crt }}" }}

--- a/charts/karmada/templates/_karmada_apiservice.tpl
+++ b/charts/karmada/templates/_karmada_apiservice.tpl
@@ -11,7 +11,7 @@ metadata:
     app: {{ $name }}-aggregated-apiserver
     apiserver: "true"
 spec:
-  insecureSkipTLSVerify: true
+  {{- include "karmada.apiserver.caBundle" . | nindent 2 }}
   group: cluster.karmada.io
   groupPriorityMinimum: 2000
   service:
@@ -39,7 +39,7 @@ metadata:
     app: {{ $name }}-search
     apiserver: "true"
 spec:
-  insecureSkipTLSVerify: true
+  {{- include "karmada.apiserver.caBundle" . | nindent 2 }}
   group: search.karmada.io
   groupPriorityMinimum: 2000
   service:

--- a/charts/karmada/templates/pre-install-job.yaml
+++ b/charts/karmada/templates/pre-install-job.yaml
@@ -212,7 +212,6 @@ data:
         clusters:
           - cluster:
               certificate-authority-data: {{ print "{{ ca_crt }}" }}
-              insecure-skip-tls-verify: false
               server: https://{{ $name }}-apiserver.{{ $namespace }}.svc.{{ .Values.clusterDomain }}:5443
             name: {{ $name }}-apiserver
         users:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

**Backupground:** `insecureSkipTLSVerify=true` means prohibit clientside from verifing the cert of serverside, this is an unsafe configuration, we can avoid unnecessary unsafe configurations.

This PR mainly aims to remove `insecureSkipTLSVerify` in helm chart.

**Which issue(s) this PR fixes**:

part of #4024

**Special notes for your reviewer**:

You can test `helm install` by following bash script:

```bash
#!/bin/bash

# clean old clusters and config
kind delete clusters --all; rm -r ~/.karmada/; rm ~/.kube/*.config; rm -r /etc/karmada
# please replace to your own local karmada repo path
cd /root/home/gopath/src/github.com/karmada
# create a Kind cluster
hack/create-cluster.sh karmada-host ~/.kube/karmada.config

export KUBECONFIG=~/.kube/karmada.config:~/.kube/karmada-apiserver.config

# pull images in advance and avoid duplicate downloads when each installation
for img in `cat charts/karmada/values.yaml | grep -C 1 'repository:' | sed 's/*karmadaImageVersion/latest/g' | awk -F ':' '{print $2}' | sed 's/\"//g' | xargs -n3 | awk '{print $1"/"$2":"$3}'`; do docker pull $img; kind load docker-image $img --name karmada-host; done

kubectl get pods -o wide -A

# helm install
helm install karmada -n karmada-system --create-namespace --dependency-update --set components={"descheduler"} ./charts/karmada --debug

# export karmada-apiserver kubeconfig
kubectl get secret -n karmada-system karmada-kubeconfig -o jsonpath={.data.kubeconfig} | base64 -d > ~/.kube/karmada-apiserver.config
```

Test result：
![image](https://github.com/karmada-io/karmada/assets/30589999/a30bf9f5-77a6-4c33-8737-65ac81fec211)
![image](https://github.com/karmada-io/karmada/assets/30589999/9456039e-93e8-42d5-b7cd-4b3d1b3e4d84)
![image](https://github.com/karmada-io/karmada/assets/30589999/87cef758-fa81-47c8-9103-b0753b9259cf)


**Does this PR introduce a user-facing change?**:

```release-note
none
```

