### PR TITLE
fix invalid helm chart

### DIFF
--- a/.github/workflows/lint-chart.yaml
+++ b/.github/workflows/lint-chart.yaml
@@ -27,6 +27,13 @@ jobs:
         with:
           version: ${{ env.HELM_VERSION }}
 
+      - name: Run chart-testing (template)
+        run: |
+          helm template --set components={"search,descheduler,schedulerEstimator"} --dependency-update ./charts/karmada --debug > /dev/null
+          helm template --set components={"search,descheduler,schedulerEstimator"},installMode=component --dependency-update ./charts/karmada --debug > /dev/null
+          helm template --set installMode=agent --dependency-update ./charts/karmada --debug > /dev/null
+          helm template --dependency-update ./charts/karmada-operator --debug > /dev/null   
+
       # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
       # yamllint (https://github.com/adrienverge/yamllint) which require Python
       - name: Set up Python

--- a/charts/karmada/templates/_helpers.tpl
+++ b/charts/karmada/templates/_helpers.tpl
@@ -273,6 +273,10 @@ app: {{- include "karmada.name" .}}-search
   secret:
     secretName: {{ .Values.search.kubeconfig }}
 {{- end -}}
+{{- end -}}
+
+{{- define "karmada.search.etcd.cert.volume" -}}
+{{ $name :=  include "karmada.name" . }}
 - name: etcd-certs
   secret:
   {{- if eq .Values.etcd.mode "internal" }}

--- a/charts/karmada/templates/karmada-search.yaml
+++ b/charts/karmada/templates/karmada-search.yaml
@@ -91,6 +91,7 @@ spec:
           {{- toYaml .Values.apiServer.resources | nindent 12 }}
       volumes:
       {{- include "karmada.search.kubeconfig.volume" . | nindent 8 }}
+      {{- include "karmada.search.etcd.cert.volume" . | nindent 8 }}
 ---
 apiVersion: v1
 kind: Service
@@ -165,7 +166,8 @@ spec:
         - name: {{ $name }}-search-apiservice
           configMap:
             name: {{ $name }}-search-apiservice
-        {{ include "karmada.search.kubeconfig.volume" . | nindent 8 }}
+        {{- include "karmada.search.kubeconfig.volume" . | nindent 8 }}
+        {{- include "karmada.search.etcd.cert.volume" . | nindent 8 }}
 {{- end }}
 
 {{ if .Values.search.podDisruptionBudget }}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

* chart file `karmada-search.yaml` is invalid
* lack of enough check method of chart file

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

before:
![image](https://github.com/karmada-io/karmada/assets/30589999/c46c46b9-3d0d-451d-bbfe-6a70b487f942)

now:
![image](https://github.com/karmada-io/karmada/assets/30589999/d06ac40e-4c24-416f-9036-c17891494215)


**Does this PR introduce a user-facing change?**:

```release-note
none
```

