### PR TITLE
support config karmada components resources

### DIFF
--- a/operator/pkg/controller/karmada/planner.go
+++ b/operator/pkg/controller/karmada/planner.go
@@ -88,6 +88,7 @@ func (p *Planner) Execute() error {
 		return err
 	}
 	if err := p.job.Run(); err != nil {
+		klog.ErrorS(err, "failed to executed the workflow", "workflow", p.action, "karmada", klog.KObj(p.karmada))
 		return p.runJobErr(err)
 	}
 	if err := p.afterRunJob(); err != nil {

--- a/operator/pkg/controlplane/apiserver/apiserver.go
+++ b/operator/pkg/controlplane/apiserver/apiserver.go
@@ -59,7 +59,7 @@ func installKarmadaAPIServer(client clientset.Interface, cfg *operatorv1alpha1.K
 		return fmt.Errorf("error when decoding karmadaApiserver deployment: %w", err)
 	}
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
-		WithExtraArgs(cfg.ExtraArgs).ForDeployment(apiserverDeployment)
+		WithExtraArgs(cfg.ExtraArgs).WithResources(cfg.Resources).ForDeployment(apiserverDeployment)
 
 	if err := apiclient.CreateOrUpdateDeployment(client, apiserverDeployment); err != nil {
 		return fmt.Errorf("error when creating deployment for %s, err: %w", apiserverDeployment.Name, err)
@@ -117,7 +117,7 @@ func installKarmadaAggregatedAPIServer(client clientset.Interface, cfg *operator
 	}
 
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
-		WithExtraArgs(cfg.ExtraArgs).WithFeatureGates(featureGates).ForDeployment(aggregatedAPIServerDeployment)
+		WithExtraArgs(cfg.ExtraArgs).WithFeatureGates(featureGates).WithResources(cfg.Resources).ForDeployment(aggregatedAPIServerDeployment)
 
 	if err := apiclient.CreateOrUpdateDeployment(client, aggregatedAPIServerDeployment); err != nil {
 		return fmt.Errorf("error when creating deployment for %s, err: %w", aggregatedAPIServerDeployment.Name, err)

--- a/operator/pkg/controlplane/controlplane.go
+++ b/operator/pkg/controlplane/controlplane.go
@@ -89,7 +89,7 @@ func getKubeControllerManagerManifest(name, namespace string, cfg *operatorv1alp
 	}
 
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).
-		WithLabels(cfg.Labels).WithExtraArgs(cfg.ExtraArgs).ForDeployment(kcm)
+		WithLabels(cfg.Labels).WithExtraArgs(cfg.ExtraArgs).WithResources(cfg.Resources).ForDeployment(kcm)
 	return kcm, nil
 }
 
@@ -116,7 +116,7 @@ func getKarmadaControllerManagerManifest(name, namespace string, featureGates ma
 	}
 
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
-		WithExtraArgs(cfg.ExtraArgs).WithFeatureGates(featureGates).ForDeployment(kcm)
+		WithExtraArgs(cfg.ExtraArgs).WithFeatureGates(featureGates).WithResources(cfg.Resources).ForDeployment(kcm)
 	return kcm, nil
 }
 
@@ -143,7 +143,7 @@ func getKarmadaSchedulerManifest(name, namespace string, featureGates map[string
 	}
 
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
-		WithExtraArgs(cfg.ExtraArgs).WithFeatureGates(featureGates).ForDeployment(scheduler)
+		WithExtraArgs(cfg.ExtraArgs).WithFeatureGates(featureGates).WithResources(cfg.Resources).ForDeployment(scheduler)
 	return scheduler, nil
 }
 
@@ -170,7 +170,7 @@ func getKarmadaDeschedulerManifest(name, namespace string, featureGates map[stri
 	}
 
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
-		WithExtraArgs(cfg.ExtraArgs).WithFeatureGates(featureGates).ForDeployment(descheduler)
+		WithExtraArgs(cfg.ExtraArgs).WithFeatureGates(featureGates).WithResources(cfg.Resources).ForDeployment(descheduler)
 
 	return descheduler, nil
 }

--- a/operator/pkg/controlplane/etcd/etcd.go
+++ b/operator/pkg/controlplane/etcd/etcd.go
@@ -72,7 +72,7 @@ func installKarmadaEtcd(client clientset.Interface, name, namespace string, cfg 
 	}
 
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
-		WithVolumeData(cfg.VolumeData).ForStatefulSet(etcdStatefulSet)
+		WithVolumeData(cfg.VolumeData).WithResources(cfg.Resources).ForStatefulSet(etcdStatefulSet)
 
 	if err := apiclient.CreateOrUpdateStatefulSet(client, etcdStatefulSet); err != nil {
 		return fmt.Errorf("error when creating Etcd statefulset, err: %w", err)

--- a/operator/pkg/controlplane/metricsadapter/metricsadapter.go
+++ b/operator/pkg/controlplane/metricsadapter/metricsadapter.go
@@ -46,7 +46,7 @@ func installKarmadaMetricAdapter(client clientset.Interface, cfg *operatorv1alph
 		return fmt.Errorf("err when decoding KarmadaMetricAdapter Deployment: %w", err)
 	}
 
-	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).ForDeployment(metricAdapter)
+	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).WithResources(cfg.Resources).ForDeployment(metricAdapter)
 
 	if err := apiclient.CreateOrUpdateDeployment(client, metricAdapter); err != nil {
 		return fmt.Errorf("error when creating deployment for %s, err: %w", metricAdapter.Name, err)

--- a/operator/pkg/controlplane/webhook/webhook.go
+++ b/operator/pkg/controlplane/webhook/webhook.go
@@ -47,7 +47,7 @@ func installKarmadaWebhook(client clientset.Interface, cfg *operatorv1alpha1.Kar
 	}
 
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
-		WithExtraArgs(cfg.ExtraArgs).ForDeployment(webhookDeployment)
+		WithExtraArgs(cfg.ExtraArgs).WithResources(cfg.Resources).ForDeployment(webhookDeployment)
 
 	if err := apiclient.CreateOrUpdateDeployment(client, webhookDeployment); err != nil {
 		return fmt.Errorf("error when creating deployment for %s, err: %w", webhookDeployment.Name, err)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

The karmada operator does not support users to explicitly set the resource scale of each component. But resource planning will be different in different scenarios, so we can provide explicit configuration

**Which issue(s) this PR fixes**:
from https://github.com/karmada-io/karmada/pull/3732#discussion_r1301425856

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-operator`: Support config required resources for each Karmada component.
```

Test Results

karmada instance yaml with resources config
```yaml
apiVersion: operator.karmada.io/v1alpha1
kind: Karmada
metadata:
  name: karmada-demo
  namespace: test
spec:
  components:
    etcd:
      local:
        imageRepository: k8s.m.daocloud.io/etcd
        imageTag: 3.5.9-0
        replicas: 1
        resources:
          requests:
            cpu: 216m
    karmadaMetricsAdapter:
      resources:
        requests:
          cpu: 111m
    karmadaAPIServer:
      imageRepository: k8s.m.daocloud.io/kube-apiserver
      imageTag: v1.25.4
      replicas: 1
      serviceType: NodePort
      serviceSubnet: 10.96.0.0/12
      resources:
        requests:
          cpu: 276m
    karmadaAggregatedAPIServer:
      imageRepository: docker.io/karmada/karmada-aggregated-apiserver
      imageTag: v1.6.0
      replicas: 1
      resources:
        requests:
          cpu: 279m
    karmadaControllerManager:
      imageRepository: docker.io/karmada/karmada-controller-manager
      imageTag: v1.6.0
      replicas: 1
      resources:
        requests:
          cpu: 290m
    karmadaScheduler:
      imageRepository: docker.io/karmada/karmada-scheduler
      imageTag: v1.6.0
      replicas: 1
      resources:
        requests:
          cpu: 370m
    karmadaWebhook:
      imageRepository: docker.io/karmada/karmada-webhook
      imageTag: v1.6.0
      replicas: 1
      resources:
        requests:
          cpu: 470m
    kubeControllerManager:
      imageRepository: k8s.m.daocloud.io/kube-controller-manager
      imageTag: v1.25.4
      replicas: 1
      resources:
        requests:
          cpu: 550m
```

actual effect

```bash
➜  karmada git:(support-config-karmada-component-resources) ✗ kubectl get karmada -n test
NAME            READY   AGE
karmada-demo   True    27m


➜  karmada git:(support-config-karmada-component-resources) ✗ kubectl get po -n test  -w
NAME                                                     READY   STATUS    RESTARTS   AGE
karmada-demo-aggregated-apiserver-f4b494875-5xwkf       1/1     Running   0          24m
karmada-demo-apiserver-579bd4875f-26bpn                 1/1     Running   0          25m
karmada-demo1-controller-manager-5f5fb98c4-448lc         1/1     Running   0          24m
karmada-demo-etcd-0                                     1/1     Running   0          25m
karmada-demo-kube-controller-manager-5b8bfdd9fd-psbq7   1/1     Running   0          24m
karmada-demo-metrics-adapter-98dbbdc79-4djc5            1/1     Running   0          24m
karmada-demo-metrics-adapter-98dbbdc79-xbhwq            1/1     Running   0          24m
karmada-demo-scheduler-bf6fc95c5-tz2q6                  1/1     Running   0          24m
karmada-demo-webhook-84d87598d6-xtlmq                   1/1     Running   0          24m

# grep the resources(The number is consistent with the number of karmada instance components)

➜  karmada git:(support-config-karmada-component-resources) ✗ kubectl get po -n test  -o yaml | grep -A 2 resources
      resources:
        requests:
          cpu: 279m
--
      resources:
        requests:
          cpu: 276m
--
      resources:
        requests:
          cpu: 290m
--
      resources:
        requests:
          cpu: 216m
--
      resources:
        requests:
          cpu: 550m
--
      resources:
        requests:
          cpu: 111m
--
      resources:
        requests:
          cpu: 111m
--
      resources:
        requests:
          cpu: 370m
--
      resources:
        requests:
          cpu: 470m

```

