### PR TITLE
Automated cherry pick of #4056: uninstall metrics adapter when karmada cluster remove

### DIFF
--- a/operator/pkg/tasks/deinit/component.go
+++ b/operator/pkg/tasks/deinit/component.go
@@ -19,6 +19,7 @@ func NewRemoveComponentTask() workflow.Task {
 		Run:         runRemoveComponent,
 		RunSubTasks: true,
 		Tasks: []workflow.Task{
+			newRemoveComponentWithServiceSubTask(constants.KarmadaMetricsAdapterComponent, util.KarmadaMetricsAdapterName),
 			newRemoveComponentSubTask(constants.KarmadaDeschedulerComponent, util.KarmadaDeschedulerName),
 			newRemoveComponentSubTask(constants.KarmadaSchedulerComponent, util.KarmadaSchedulerName),
 			newRemoveComponentSubTask(constants.KarmadaControllerManagerComponent, util.KarmadaControllerManagerName),


### PR DESCRIPTION
Cherry pick of #4056 on release-1.7.
#4056: uninstall metrics adapter when karmada cluster remove
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-operator`: Fixed the issue that karmada-metrics-adapter was not removed after deleting a Karmada instance.
```