### PR TITLE
remove insecureSkipTLSVerify in karmadactl

### DIFF
--- a/pkg/karmadactl/addons/metricsadapter/manifests.go
+++ b/pkg/karmadactl/addons/metricsadapter/manifests.go
@@ -102,7 +102,7 @@ spec:
     namespace:  {{ .Namespace }}
   group: {{ .Group }}
   version:  {{ .Version }}
-  insecureSkipTLSVerify: true
+  caBundle: {{ .CABundle }}
   groupPriorityMinimum: 100
   versionPriority: 200
 `
@@ -140,6 +140,7 @@ type AAApiServiceReplace struct {
 	Namespace string
 	Group     string
 	Version   string
+	CABundle  string
 }
 
 // AAServiceReplace is a struct to help to concrete

--- a/pkg/karmadactl/addons/search/manifests.go
+++ b/pkg/karmadactl/addons/search/manifests.go
@@ -98,7 +98,7 @@ metadata:
     app: karmada-search
     apiserver: "true"
 spec:
-  insecureSkipTLSVerify: true
+  caBundle: {{ .CABundle }}
   group: search.karmada.io
   groupPriorityMinimum: 2000
   service:
@@ -141,6 +141,7 @@ type ServiceReplace struct {
 type AAApiServiceReplace struct {
 	Name      string
 	Namespace string
+	CABundle  string
 }
 
 // AAServiceReplace is a struct to help to concrete

--- a/pkg/karmadactl/cmdinit/cert/cert.go
+++ b/pkg/karmadactl/cmdinit/cert/cert.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kube-openapi/pkg/util/sets"
 
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
+	globaloptions "github.com/karmada-io/karmada/pkg/karmadactl/options"
 )
 
 const (
@@ -249,7 +250,7 @@ func GenCerts(pkiPath string, etcdServerCertCfg, etcdClientCertCfg, karmadaCertC
 	if err != nil {
 		return err
 	}
-	if err = WriteCertAndKey(pkiPath, options.CaCertAndKeyName, caCert, caKey); err != nil {
+	if err = WriteCertAndKey(pkiPath, globaloptions.CaCertAndKeyName, caCert, caKey); err != nil {
 		return err
 	}
 

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -23,6 +23,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/karmada"
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/utils"
+	globaloptions "github.com/karmada-io/karmada/pkg/karmadactl/options"
 	"github.com/karmada-io/karmada/pkg/karmadactl/util"
 	"github.com/karmada-io/karmada/pkg/karmadactl/util/apiclient"
 	"github.com/karmada-io/karmada/pkg/version"
@@ -35,7 +36,7 @@ var (
 	}
 
 	certList = []string{
-		options.CaCertAndKeyName,
+		globaloptions.CaCertAndKeyName,
 		options.EtcdCaCertAndKeyName,
 		options.EtcdServerCertAndKeyName,
 		options.EtcdClientCertAndKeyName,
@@ -358,7 +359,7 @@ func (i *CommandInitOption) prepareCRD() error {
 func (i *CommandInitOption) createCertsSecrets() error {
 	// Create kubeconfig Secret
 	karmadaServerURL := fmt.Sprintf("https://%s.%s.svc.%s:%v", karmadaAPIServerDeploymentAndServiceName, i.Namespace, i.HostClusterDomain, karmadaAPIServerContainerPort)
-	config := utils.CreateWithCerts(karmadaServerURL, options.UserName, options.UserName, i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.CaCertAndKeyName)],
+	config := utils.CreateWithCerts(karmadaServerURL, options.UserName, options.UserName, i.CertAndKeyFileData[fmt.Sprintf("%s.crt", globaloptions.CaCertAndKeyName)],
 		i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaCertAndKeyName)], i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaCertAndKeyName)])
 	configBytes, err := clientcmd.Write(*config)
 	if err != nil {
@@ -386,7 +387,7 @@ func (i *CommandInitOption) createCertsSecrets() error {
 		karmadaCert[fmt.Sprintf("%s.crt", v)] = string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", v)])
 		karmadaCert[fmt.Sprintf("%s.key", v)] = string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", v)])
 	}
-	karmadaSecret := i.SecretFromSpec(karmadaCertsName, corev1.SecretTypeOpaque, karmadaCert)
+	karmadaSecret := i.SecretFromSpec(globaloptions.KarmadaCertsName, corev1.SecretTypeOpaque, karmadaCert)
 	if err := util.CreateOrUpdateSecret(i.KubeClientSet, karmadaSecret); err != nil {
 		return err
 	}
@@ -571,7 +572,7 @@ func (i *CommandInitOption) RunInit(parentCommand string) error {
 	}
 
 	// Create CRDs in karmada
-	caBase64 := base64.StdEncoding.EncodeToString(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.CaCertAndKeyName)])
+	caBase64 := base64.StdEncoding.EncodeToString(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", globaloptions.CaCertAndKeyName)])
 	if err := karmada.InitKarmadaResources(i.KarmadaDataPath, caBase64, i.Namespace); err != nil {
 		return err
 	}
@@ -598,7 +599,7 @@ func (i *CommandInitOption) createKarmadaConfig() error {
 		return err
 	}
 	if err := utils.WriteKubeConfigFromSpec(serverURL, options.UserName, options.ClusterName, i.KarmadaDataPath, options.KarmadaKubeConfigName,
-		i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.CaCertAndKeyName)], i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaCertAndKeyName)],
+		i.CertAndKeyFileData[fmt.Sprintf("%s.crt", globaloptions.CaCertAndKeyName)], i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaCertAndKeyName)],
 		i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaCertAndKeyName)]); err != nil {
 		return fmt.Errorf("failed to create karmada kubeconfig file. %v", err)
 	}

--- a/pkg/karmadactl/cmdinit/kubernetes/deployments.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deployments.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
+	globaloptions "github.com/karmada-io/karmada/pkg/karmadactl/options"
 )
 
 const (
@@ -21,7 +22,6 @@ const (
 
 	// KubeConfigSecretAndMountName is the secret and volume mount name of karmada kubeconfig
 	KubeConfigSecretAndMountName                                = "kubeconfig"
-	karmadaCertsName                                            = "karmada-cert"
 	karmadaCertsVolumeMountPath                                 = "/etc/karmada/pki"
 	kubeConfigContainerMountPath                                = "/etc/kubeconfig"
 	karmadaAPIServerDeploymentAndServiceName                    = "karmada-apiserver"
@@ -67,7 +67,7 @@ func (i *CommandInitOption) karmadaAPIServerContainerCommand() []string {
 		"kube-apiserver",
 		"--allow-privileged=true",
 		"--authorization-mode=Node,RBAC",
-		fmt.Sprintf("--client-ca-file=%s/%s.crt", karmadaCertsVolumeMountPath, options.CaCertAndKeyName),
+		fmt.Sprintf("--client-ca-file=%s/%s.crt", karmadaCertsVolumeMountPath, globaloptions.CaCertAndKeyName),
 		"--enable-bootstrap-token-auth=true",
 		fmt.Sprintf("--etcd-cafile=%s/%s.crt", karmadaCertsVolumeMountPath, options.EtcdCaCertAndKeyName),
 		fmt.Sprintf("--etcd-certfile=%s/%s.crt", karmadaCertsVolumeMountPath, options.EtcdClientCertAndKeyName),
@@ -180,7 +180,7 @@ func (i *CommandInitOption) makeKarmadaAPIServerDeployment() *appsv1.Deployment 
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{
-						Name:      karmadaCertsName,
+						Name:      globaloptions.KarmadaCertsName,
 						ReadOnly:  true,
 						MountPath: karmadaCertsVolumeMountPath,
 					},
@@ -191,10 +191,10 @@ func (i *CommandInitOption) makeKarmadaAPIServerDeployment() *appsv1.Deployment 
 		},
 		Volumes: []corev1.Volume{
 			{
-				Name: karmadaCertsName,
+				Name: globaloptions.KarmadaCertsName,
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: karmadaCertsName,
+						SecretName: globaloptions.KarmadaCertsName,
 					},
 				},
 			},
@@ -290,17 +290,17 @@ func (i *CommandInitOption) makeKarmadaKubeControllerManagerDeployment() *appsv1
 					"--authentication-kubeconfig=/etc/kubeconfig",
 					"--authorization-kubeconfig=/etc/kubeconfig",
 					"--bind-address=0.0.0.0",
-					fmt.Sprintf("--client-ca-file=%s/%s.crt", karmadaCertsVolumeMountPath, options.CaCertAndKeyName),
+					fmt.Sprintf("--client-ca-file=%s/%s.crt", karmadaCertsVolumeMountPath, globaloptions.CaCertAndKeyName),
 					"--cluster-cidr=10.244.0.0/16",
 					fmt.Sprintf("--cluster-name=%s", options.ClusterName),
-					fmt.Sprintf("--cluster-signing-cert-file=%s/%s.crt", karmadaCertsVolumeMountPath, options.CaCertAndKeyName),
-					fmt.Sprintf("--cluster-signing-key-file=%s/%s.key", karmadaCertsVolumeMountPath, options.CaCertAndKeyName),
+					fmt.Sprintf("--cluster-signing-cert-file=%s/%s.crt", karmadaCertsVolumeMountPath, globaloptions.CaCertAndKeyName),
+					fmt.Sprintf("--cluster-signing-key-file=%s/%s.key", karmadaCertsVolumeMountPath, globaloptions.CaCertAndKeyName),
 					"--controllers=namespace,garbagecollector,serviceaccount-token,ttl-after-finished,bootstrapsigner,tokencleaner,csrapproving,csrcleaner,csrsigning,clusterrole-aggregation",
 					"--kubeconfig=/etc/kubeconfig",
 					"--leader-elect=true",
 					fmt.Sprintf("--leader-elect-resource-namespace=%s", i.Namespace),
 					"--node-cidr-mask-size=24",
-					fmt.Sprintf("--root-ca-file=%s/%s.crt", karmadaCertsVolumeMountPath, options.CaCertAndKeyName),
+					fmt.Sprintf("--root-ca-file=%s/%s.crt", karmadaCertsVolumeMountPath, globaloptions.CaCertAndKeyName),
 					fmt.Sprintf("--service-account-private-key-file=%s/%s.key", karmadaCertsVolumeMountPath, options.KarmadaCertAndKeyName),
 					fmt.Sprintf("--service-cluster-ip-range=%s", serviceClusterIP),
 					"--use-service-account-credentials=true",
@@ -322,7 +322,7 @@ func (i *CommandInitOption) makeKarmadaKubeControllerManagerDeployment() *appsv1
 						SubPath:   KubeConfigSecretAndMountName,
 					},
 					{
-						Name:      karmadaCertsName,
+						Name:      globaloptions.KarmadaCertsName,
 						ReadOnly:  true,
 						MountPath: karmadaCertsVolumeMountPath,
 					},
@@ -339,10 +339,10 @@ func (i *CommandInitOption) makeKarmadaKubeControllerManagerDeployment() *appsv1
 				},
 			},
 			{
-				Name: karmadaCertsName,
+				Name: globaloptions.KarmadaCertsName,
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: karmadaCertsName,
+						SecretName: globaloptions.KarmadaCertsName,
 					},
 				},
 			},
@@ -840,7 +840,7 @@ func (i *CommandInitOption) makeKarmadaAggregatedAPIServerDeployment() *appsv1.D
 						SubPath:   KubeConfigSecretAndMountName,
 					},
 					{
-						Name:      karmadaCertsName,
+						Name:      globaloptions.KarmadaCertsName,
 						ReadOnly:  true,
 						MountPath: karmadaCertsVolumeMountPath,
 					},
@@ -864,10 +864,10 @@ func (i *CommandInitOption) makeKarmadaAggregatedAPIServerDeployment() *appsv1.D
 				},
 			},
 			{
-				Name: karmadaCertsName,
+				Name: globaloptions.KarmadaCertsName,
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: karmadaCertsName,
+						SecretName: globaloptions.KarmadaCertsName,
 					},
 				},
 			},

--- a/pkg/karmadactl/cmdinit/options/global.go
+++ b/pkg/karmadactl/cmdinit/options/global.go
@@ -1,8 +1,6 @@
 package options
 
 const (
-	// CaCertAndKeyName ca certificate key name
-	CaCertAndKeyName = "ca"
 	// EtcdCaCertAndKeyName etcd ca certificate key name
 	EtcdCaCertAndKeyName = "etcd-ca"
 	// EtcdServerCertAndKeyName etcd server certificate key name

--- a/pkg/karmadactl/options/global.go
+++ b/pkg/karmadactl/options/global.go
@@ -16,6 +16,13 @@ const DefaultHostClusterDomain = "cluster.local"
 // DefaultKarmadactlCommandDuration defines the default timeout for karmadactl execute
 const DefaultKarmadactlCommandDuration = 60 * time.Second
 
+const (
+	// KarmadaCertsName the secret name of karmada certs
+	KarmadaCertsName = "karmada-cert"
+	// CaCertAndKeyName ca certificate cert/key name in karmada certs secret
+	CaCertAndKeyName = "ca"
+)
+
 // DefaultConfigFlags It composes the set of values necessary for obtaining a REST client config with default values set.
 var DefaultConfigFlags = genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag().WithDiscoveryBurst(300).WithDiscoveryQPS(50.0)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

Backupground: insecureSkipTLSVerify=true means prohibit clientside from verifing the cert of serverside, this is an unsafe configuration, we can avoid unnecessary unsafe configurations.

This PR mainly aims to remove insecureSkipTLSVerify in `karmadactl`.

**Which issue(s) this PR fixes**:

part of #4024

**Special notes for your reviewer**:

You can test by following bash script:

```bash
# clean old clusters and config
kind delete clusters --all; rm -rf ~/.karmada/; rm -rf ~/.kube/*.config; rm -rf /etc/karmada
# please replace to your own local karmada repo path
cd /root/home/gopath/src/github.com/karmada

# parpare cluster
hack/create-cluster.sh karmada-host ~/.kube/karmada.config
export KUBECONFIG=~/.kube/karmada.config

# install
make karmadactl
_output/bin/linux/amd64/karmadactl init
_output/bin/linux/amd64/karmadactl addons enable karmada-search
_output/bin/linux/amd64/karmadactl addons enable karmada-metrics-adapter

# verify
export KUBECONFIG=~/.kube/karmada.config:/etc/karmada/karmada-apiserver.config
kubectl --context karmada-host get po -A 
kubectl --context karmada-apiserver get apiservice
kubectl --context karmada-apiserver describe apiservice v1alpha1.cluster.karmada.io
kubectl --context karmada-apiserver describe apiservice v1alpha1.search.karmada.io
kubectl --context karmada-apiserver describe apiservice v1beta1.custom.metrics.k8s.io
```

Test result：
![image](https://github.com/karmada-io/karmada/assets/30589999/eda176a4-4289-4145-8ab9-111c2cd640e2)

![image](https://github.com/karmada-io/karmada/assets/30589999/4fbd1dc0-3414-495e-b538-bff28085e85d)

![image](https://github.com/karmada-io/karmada/assets/30589999/9ef79d4e-16cf-4a3b-9d3f-3955b70f8bf9)

![image](https://github.com/karmada-io/karmada/assets/30589999/5fa45cc9-0f07-4e7f-8666-2f0f4dbc16a5)

![image](https://github.com/karmada-io/karmada/assets/30589999/1db71e7d-739c-439e-badd-cc86fb3485bb)


**Does this PR introduce a user-facing change?**:

```release-note
none
```

