### PR TITLE
remove insecureSkipTLSVerify in operator

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -410,9 +410,8 @@ func generateClusterInControllerPlane(opts util.ClusterRegisterOption) (*cluster
 			cluster.Spec.Region = opts.ClusterRegion
 		}
 
-		if opts.ClusterConfig.TLSClientConfig.Insecure {
-			cluster.Spec.InsecureSkipTLSVerification = true
-		}
+		cluster.Spec.InsecureSkipTLSVerification = opts.ClusterConfig.TLSClientConfig.Insecure
+
 		if opts.ClusterConfig.Proxy != nil {
 			url, err := opts.ClusterConfig.Proxy(nil)
 			if err != nil {

--- a/operator/pkg/controlplane/metricsadapter/mainfests.go
+++ b/operator/pkg/controlplane/metricsadapter/mainfests.go
@@ -35,6 +35,8 @@ spec:
         - --authentication-kubeconfig=/etc/karmada/kubeconfig
         - --authorization-kubeconfig=/etc/karmada/kubeconfig
         - --client-ca-file=/etc/karmada/pki/ca.crt
+        - --tls-cert-file=/etc/karmada/pki/karmada.crt
+        - --tls-private-key-file=/etc/karmada/pki/karmada.key
         - --audit-log-path=-
         - --audit-log-maxage=0
         - --audit-log-maxbackup=0

--- a/operator/pkg/karmadaresource/apiservice/manifest.go
+++ b/operator/pkg/karmadaresource/apiservice/manifest.go
@@ -13,7 +13,7 @@ metadata:
 spec:
   group: cluster.karmada.io
   groupPriorityMinimum: 2000
-  insecureSkipTLSVerify: true
+  caBundle: {{ .CABundle }}
   service:
     name: {{ .ServiceName }}
     namespace: {{ .Namespace }}
@@ -45,7 +45,7 @@ spec:
     namespace: {{ .Namespace }}
   group: {{ .Group }}
   version: {{ .Version }}
-  insecureSkipTLSVerify: true
+  caBundle: {{ .CABundle }}
   groupPriorityMinimum: 100
   versionPriority: 200
 `

--- a/operator/pkg/tasks/init/component.go
+++ b/operator/pkg/tasks/init/component.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"time"
@@ -185,7 +186,13 @@ func runDeployMetricAdapterAPIService(r workflow.RunData) error {
 		return err
 	}
 
-	err = apiservice.EnsureMetricsAdapterAPIService(client, data.KarmadaClient(), data.GetName(), data.GetNamespace())
+	cert := data.GetCert(constants.CaCertAndKeyName)
+	if len(cert.CertData()) == 0 {
+		return errors.New("unexpected empty ca cert data for aggregatedAPIService")
+	}
+	caBase64 := base64.StdEncoding.EncodeToString(cert.CertData())
+
+	err = apiservice.EnsureMetricsAdapterAPIService(client, data.KarmadaClient(), data.GetName(), data.GetNamespace(), caBase64)
 	if err != nil {
 		return fmt.Errorf("failed to apply karmada-metrics-adapter APIService resource to karmada controlplane, err: %w", err)
 	}

--- a/operator/pkg/tasks/init/karmadaresource.go
+++ b/operator/pkg/tasks/init/karmadaresource.go
@@ -194,7 +194,13 @@ func runAPIService(r workflow.RunData) error {
 		return err
 	}
 
-	err = apiservice.EnsureAggregatedAPIService(client, data.KarmadaClient(), data.GetName(), data.GetNamespace())
+	cert := data.GetCert(constants.CaCertAndKeyName)
+	if len(cert.CertData()) == 0 {
+		return errors.New("unexpected empty ca cert data for aggregatedAPIService")
+	}
+	caBase64 := base64.StdEncoding.EncodeToString(cert.CertData())
+
+	err = apiservice.EnsureAggregatedAPIService(client, data.KarmadaClient(), data.GetName(), data.GetNamespace(), caBase64)
 	if err != nil {
 		return fmt.Errorf("failed to apply aggregated APIService resource to karmada controlplane, err: %w", err)
 	}

--- a/pkg/karmadactl/join/join.go
+++ b/pkg/karmadactl/join/join.go
@@ -255,9 +255,7 @@ func generateClusterInControllerPlane(opts util.ClusterRegisterOption) (*cluster
 		clusterObj.Spec.Region = opts.ClusterRegion
 	}
 
-	if opts.ClusterConfig.TLSClientConfig.Insecure {
-		clusterObj.Spec.InsecureSkipTLSVerification = true
-	}
+	clusterObj.Spec.InsecureSkipTLSVerification = opts.ClusterConfig.TLSClientConfig.Insecure
 
 	if opts.ClusterConfig.Proxy != nil {
 		url, err := opts.ClusterConfig.Proxy(nil)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Backupground: insecureSkipTLSVerify=true means prohibit clientside from verifing the cert of serverside, this is an unsafe configuration, we can avoid unnecessary unsafe configurations.

This PR mainly aims to remove insecureSkipTLSVerify in `Operator`.

**Which issue(s) this PR fixes**:

part of #4024

**Special notes for your reviewer**:

You can test by following bash script:

```bash
# clean old clusters and config
kind delete clusters --all; rm -rf ~/.karmada/; rm -rf ~/.kube/*.config; rm -rf /etc/karmada
# please replace to your own local karmada repo path
cd /root/home/gopath/src/github.com/karmada

# parpare cluster
hack/create-cluster.sh karmada-host ~/.kube/karmada-host.config
export KUBECONFIG=~/.kube/karmada-host.config

# build operator image
export VERSION="latest"
export REGISTRY="docker.io/karmada"
make image-karmada-operator GOOS="linux" --directory=.
kind load docker-image docker.io/karmada/karmada-operator:latest --name karmada-host

# install (3 steps)

helm install karmada-operator -n karmada-system  --create-namespace --dependency-update ./charts/karmada-operator --debug

kubectl apply -f operator/config/crds/

## be careful that the default karmada.yaml has some syntax error, manually fix it
kubectl apply -f  operator/config/samples/karmada.yaml

# generate karmada-config
kubectl get secret -n karmada-system karmada-admin-config -o jsonpath={.data.kubeconfig} | base64 -d > ~/.kube/karmada-apiserver.config

# verify
export KUBECONFIG=~/.kube/karmada-host.config
kubectl get pod -A 
export KUBECONFIG=~/.kube/karmada-apiserver.config
kubectl get apiservice
kubectl describe apiservice v1alpha1.cluster.karmada.io
kubectl describe apiservice v1beta1.custom.metrics.k8s.io
```

Test result：

![image](https://github.com/karmada-io/karmada/assets/30589999/335264b5-065f-4ebd-a5af-22061aadd4ae)
![image](https://github.com/karmada-io/karmada/assets/30589999/edd5a2ff-f297-4cb7-aee6-928798ed9a7a)
![image](https://github.com/karmada-io/karmada/assets/30589999/c3d8163e-09c9-45e5-aef0-71525daf0faa)
![image](https://github.com/karmada-io/karmada/assets/30589999/d6035452-5890-4eeb-9808-3ce3ec8e8c79)


**Does this PR introduce a user-facing change?**:

```release-note
none
```

