### PR TITLE
aggregate the HPA status from member clusters into control plane

### DIFF
--- a/pkg/resourceinterpreter/default/native/reflectstatus_test.go
+++ b/pkg/resourceinterpreter/default/native/reflectstatus_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -133,6 +135,48 @@ func Test_reflectPodDisruptionBudgetStatus(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("reflectPodDisruptionBudgetStatus() got = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func Test_reflectHorizontalPodAutoscalerStatus(t *testing.T) {
+	hpaStatus, _ := helper.ToUnstructured(&autoscalingv2.HorizontalPodAutoscaler{
+		Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+			CurrentReplicas: 2,
+			DesiredReplicas: 2,
+		},
+	})
+	grabStatus, _ := helper.BuildStatusRawExtension(autoscalingv2.HorizontalPodAutoscalerStatus{
+		CurrentReplicas: 2,
+		DesiredReplicas: 2,
+	})
+	nilHpaStatus, _ := helper.ToUnstructured(&map[string]interface{}{})
+	tests := []struct {
+		name    string
+		object  *unstructured.Unstructured
+		want    *runtime.RawExtension
+		wantErr bool
+	}{
+		{
+			name:    "reflect hap status",
+			object:  hpaStatus,
+			want:    grabStatus,
+			wantErr: false,
+		},
+		{
+			name:    "reflect nil hpa status",
+			object:  nilHpaStatus,
+			want:    nil,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := reflectHorizontalPodAutoscalerStatus(tt.object)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Test_reflectHorizontalPodAutoscalerStatus() err = %v, wantErr %v", err, tt.wantErr)
+			}
+			assert.Equalf(t, tt.want, got, "reflectHorizontalPodAutoscalerStatus(%v)", tt.object)
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

HPA status aggregation. Aggregate the HPA status from different clusters onto the control plane HPA resource template using a resource interpreter, with the involved state field being .status.currentReplicas.

**Which issue(s) this PR fixes**:

part of #4057

**Special notes for your reviewer**:

You can test it by：

```bash
kind delete clusters --all; rm -r ~/.karmada/; rm ~/.kube/*config; rm -r /etc/karmada
hack/local-up-karmada.sh
export KUBECONFIG=~/.kube/karmada.config:~/.kube/members.config

cat >/tmp/hpa.yaml<<EOF
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  labels:
    app: nginx
    horizontalpodautoscaler.karmada.io/name: nginx
spec:
  replicas: 1
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - image: nginx
        name: nginx
        resources:
          requests:
            cpu: 25m
            memory: 64Mi
          limits:
            cpu: 25m
            memory: 64Mi
---
apiVersion: v1
kind: Service
metadata:
  name: nginx-service
spec:
  ports:
  - port: 80
    targetPort: 80
    nodePort: 30080
  selector:
    app: nginx
  type: NodePort
---
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: nginx
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: nginx
  minReplicas: 1
  maxReplicas: 10
  behavior:
    scaleDown:
      stabilizationWindowSeconds: 10
    scaleUp:
      stabilizationWindowSeconds: 10
  metrics:
    - type: Resource
      resource:
        name: cpu
        target:
          type: Utilization
          averageUtilization: 10
---
apiVersion: policy.karmada.io/v1alpha1
kind: PropagationPolicy
metadata:
  name: nginx-propagation
spec:
  resourceSelectors:
    - apiVersion: apps/v1
      kind: Deployment
      name: nginx
    - apiVersion: v1
      kind: Service
      name: nginx-service
    - apiVersion: autoscaling/v2
      kind: HorizontalPodAutoscaler
      name: nginx
  placement:
    clusterAffinity:
      clusterNames:
        - member1
        - member2
        - member3
EOF
kubectl --context karmada-apiserver apply -f /tmp/hpa.yaml

# you should install hey, refer to https://github.com/rakyll/hey
member1=$(kubectl --context member1 get node member1-control-plane -o jsonpath='{.status.addresses[0].address}')
hey -c 100 -z 100m http://${member1}:30080

# verify
kubectl --context member1 get hpa nginx
kubectl --context member1 get deploy nginx
kubectl --context karmada-apiserver get hpa nginx
kubectl --context karmada-apiserver get hpa nginx -o jsonpath='{.status}'
```

**Test Report：**
![image](https://github.com/karmada-io/karmada/assets/30589999/b83a0833-3e52-4864-84c3-471b2ce9bcbe)
![image](https://github.com/karmada-io/karmada/assets/30589999/e5f99053-9563-43ff-a70b-8766ef413d00)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
none
```

