### PR TITLE
make pull cluster to be able to register with zones

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -140,6 +140,7 @@ func run(ctx context.Context, opts *options.Options) error {
 		ProxyServerAddress: opts.ProxyServerAddress,
 		ClusterProvider:    opts.ClusterProvider,
 		ClusterRegion:      opts.ClusterRegion,
+		ClusterZones:       opts.ClusterZones,
 		DryRun:             false,
 		ControlPlaneConfig: controlPlaneRestConfig,
 		ClusterConfig:      clusterConfig,

--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -109,6 +109,9 @@ type Options struct {
 	// ClusterRegion represents the region of the cluster locate in.
 	ClusterRegion string
 
+	// ClusterZones represents the zones of the cluster locate in.
+	ClusterZones []string
+
 	// EnableClusterResourceModeling indicates if enable cluster resource modeling.
 	// The resource modeling might be used by the scheduler to make scheduling decisions
 	// in scenario of dynamic replica assignment based on cluster free resources.
@@ -189,6 +192,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, allControllers []string) {
 	fs.StringVar(&o.MetricsBindAddress, "metrics-bind-address", ":8080", "The TCP address that the controller should bind to for serving prometheus metrics(e.g. 127.0.0.1:8080, :8080). It can be set to \"0\" to disable the metrics serving.")
 	fs.StringVar(&o.ClusterProvider, "cluster-provider", "", "Provider of the joining cluster. The Karmada scheduler can use this information to spread workloads across providers for higher availability.")
 	fs.StringVar(&o.ClusterRegion, "cluster-region", "", "The region of the joining cluster. The Karmada scheduler can use this information to spread workloads across regions for higher availability.")
+	fs.StringSliceVar(&o.ClusterZones, "cluster-zones", []string{}, "The zones of the joining cluster. The Karmada scheduler can use this information to spread workloads across zones for higher availability.")
 	fs.BoolVar(&o.EnableClusterResourceModeling, "enable-cluster-resource-modeling", true, "Enable means controller would build resource modeling for each cluster by syncing Nodes and Pods resources.\n"+
 		"The resource modeling might be used by the scheduler to make scheduling decisions in scenario of dynamic replica assignment based on cluster free resources.\n"+
 		"Disable if it does not fit your cases for better performance.")

--- a/pkg/karmadactl/register/register.go
+++ b/pkg/karmadactl/register/register.go
@@ -169,6 +169,7 @@ func NewCmdRegister(parentCommand string) *cobra.Command {
 	flags.StringVar(&opts.ClusterNamespace, "cluster-namespace", options.DefaultKarmadaClusterNamespace, "Namespace in the control plane where member cluster secrets are stored.")
 	flags.StringVar(&opts.ClusterProvider, "cluster-provider", "", "Provider of the joining cluster. The Karmada scheduler can use this information to spread workloads across providers for higher availability.")
 	flags.StringVar(&opts.ClusterRegion, "cluster-region", "", "The region of the joining cluster. The Karmada scheduler can use this information to spread workloads across regions for higher availability.")
+	flags.StringSliceVar(&opts.ClusterZones, "cluster-zones", []string{}, "The zones of the joining cluster. The Karmada scheduler can use this information to spread workloads across zones for higher availability.")
 	flags.BoolVar(&opts.EnableCertRotation, "enable-cert-rotation", false, "Enable means controller would rotate certificate for karmada-agent when the certificate is about to expire.")
 	flags.StringVar(&opts.CACertPath, "ca-cert-path", CACertPath, "The path to the SSL certificate authority used to secure communications between member cluster and karmada-control-plane.")
 	flags.StringVar(&opts.BootstrapToken.Token, "token", "", "For token-based discovery, the token used to validate cluster information fetched from the API server.")
@@ -206,6 +207,9 @@ type CommandRegisterOption struct {
 
 	// ClusterRegion represents the region of the cluster locate in.
 	ClusterRegion string
+
+	// ClusterZones represents the zones of the cluster locate in.
+	ClusterZones []string
 
 	// EnableCertRotation indicates if enable certificate rotation for karmada-agent.
 	EnableCertRotation bool
@@ -668,6 +672,7 @@ func (o *CommandRegisterOption) makeKarmadaAgentDeployment() *appsv1.Deployment 
 					fmt.Sprintf("--cluster-api-endpoint=%s", o.memberClusterEndpoint),
 					fmt.Sprintf("--cluster-provider=%s", o.ClusterProvider),
 					fmt.Sprintf("--cluster-region=%s", o.ClusterRegion),
+					fmt.Sprintf("--cluster-zones=%s", strings.Join(o.ClusterZones, ",")),
 					fmt.Sprintf("--controllers=%s", strings.Join(controllers, ",")),
 					"--cluster-status-update-frequency=10s",
 					"--bind-address=0.0.0.0",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
User want to registry cluster in pull mode with region as well as zones field

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: Introduced `--cluster-zones` flag to `register` command to declare cluster zones during registering a cluster.
`karmada-agent`: Introduced `--cluster-zones` flag to declare cluster zones during registering a cluster.
```

