### PR TITLE
retain for hpa controlled Deployment resource.

### DIFF
--- a/pkg/controllers/status/work_status_controller_test.go
+++ b/pkg/controllers/status/work_status_controller_test.go
@@ -678,8 +678,9 @@ func TestWorkStatusController_syncWorkStatus(t *testing.T) {
 }
 
 func newWorkStatusController(cluster *clusterv1alpha1.Cluster, dynamicClientSets ...*dynamicfake.FakeDynamicClient) WorkStatusController {
+	cli := fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(cluster).Build()
 	c := WorkStatusController{
-		Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(cluster).Build(),
+		Client:                      cli,
 		InformerManager:             genericmanager.GetInstance(),
 		PredicateFunc:               helper.NewClusterPredicateOnAgent("test"),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
@@ -705,7 +706,7 @@ func newWorkStatusController(cluster *clusterv1alpha1.Cluster, dynamicClientSets
 		sharedFactory := informers.NewSharedInformerFactory(controlPlaneKubeClientSet, 0)
 		serviceLister := sharedFactory.Core().V1().Services().Lister()
 
-		c.ResourceInterpreter = resourceinterpreter.NewResourceInterpreter(controlPlaneInformerManager, serviceLister)
+		c.ResourceInterpreter = resourceinterpreter.NewResourceInterpreter(controlPlaneInformerManager, cli, serviceLister)
 		c.ObjectWatcher = objectwatcher.NewObjectWatcher(c.Client, c.RESTMapper, util.NewClusterDynamicClientSetForAgent, c.ResourceInterpreter)
 
 		// Generate InformerManager

--- a/pkg/resourceinterpreter/default/native/default.go
+++ b/pkg/resourceinterpreter/default/native/default.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configv1alpha1 "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
@@ -15,6 +16,7 @@ import (
 // DefaultInterpreter contains all default operation interpreter factory
 // for interpreting common resource.
 type DefaultInterpreter struct {
+	client                  client.Client
 	replicaHandlers         map[schema.GroupVersionKind]replicaInterpreter
 	reviseReplicaHandlers   map[schema.GroupVersionKind]reviseReplicaInterpreter
 	retentionHandlers       map[schema.GroupVersionKind]retentionInterpreter
@@ -25,11 +27,12 @@ type DefaultInterpreter struct {
 }
 
 // NewDefaultInterpreter return a new DefaultInterpreter.
-func NewDefaultInterpreter() *DefaultInterpreter {
+func NewDefaultInterpreter(client client.Client) *DefaultInterpreter {
 	return &DefaultInterpreter{
+		client:                  client,
 		replicaHandlers:         getAllDefaultReplicaInterpreter(),
 		reviseReplicaHandlers:   getAllDefaultReviseReplicaInterpreter(),
-		retentionHandlers:       getAllDefaultRetentionInterpreter(),
+		retentionHandlers:       getAllDefaultRetentionInterpreter(client),
 		aggregateStatusHandlers: getAllDefaultAggregateStatusInterpreter(),
 		dependenciesHandlers:    getAllDefaultDependenciesInterpreter(),
 		reflectStatusHandlers:   getAllDefaultReflectStatusInterpreter(),

--- a/pkg/resourceinterpreter/default/native/retain_test.go
+++ b/pkg/resourceinterpreter/default/native/retain_test.go
@@ -1,0 +1,105 @@
+package native
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/karmada-io/karmada/pkg/util/gclient"
+	"github.com/karmada-io/karmada/pkg/util/helper"
+)
+
+func Test_retainDeploymentFields(t *testing.T) {
+	hpa := autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-hpa",
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				Kind:       "Deployment",
+				Name:       "nginx",
+				APIVersion: "apps/v1",
+			},
+		},
+	}
+	hpaList := &autoscalingv2.HorizontalPodAutoscalerList{Items: []autoscalingv2.HorizontalPodAutoscaler{hpa}}
+
+	cli := fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithLists(hpaList).WithIndex(&autoscalingv2.HorizontalPodAutoscaler{}, IndexKeyHPAScaleTargetRef,
+		func(object client.Object) []string {
+			hpa := object.(*autoscalingv2.HorizontalPodAutoscaler)
+			return []string{hpa.Spec.ScaleTargetRef.String()}
+		}).Build()
+	desiredNum, observedNum := int32(2), int32(4)
+
+	observedDeploy := appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nginx",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &observedNum,
+		},
+	}
+	desiredDeploy := observedDeploy
+	desiredDeploy.Spec.Replicas = &desiredNum
+
+	observed, _ := helper.ToUnstructured(&observedDeploy)
+	desired, _ := helper.ToUnstructured(&desiredDeploy)
+
+	observedDeploy2 := observedDeploy
+	observedDeploy2.Name = "nginx-2"
+	desiredDeploy2 := observedDeploy2
+	desiredDeploy2.Spec.Replicas = &desiredNum
+
+	observed2, _ := helper.ToUnstructured(&observedDeploy2)
+	desired2, _ := helper.ToUnstructured(&desiredDeploy2)
+
+	type args struct {
+		desired  *unstructured.Unstructured
+		observed *unstructured.Unstructured
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *unstructured.Unstructured
+		wantErr bool
+	}{
+		{
+			name: "deployment is control by hpa",
+			args: args{
+				desired:  desired,
+				observed: observed,
+			},
+			want:    observed,
+			wantErr: false,
+		},
+		{
+			name: "deployment is not control by hpa",
+			args: args{
+				desired:  desired2,
+				observed: observed2,
+			},
+			want:    desired2,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := retainDeploymentFields(cli)(tt.args.desired, tt.args.observed)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("retainDeploymentFields() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.Equalf(t, tt.want, got, "retainDeploymentFields(%v, %v)", tt.args.desired, tt.args.observed)
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add the Retain operation for Deployment resources, when there are relevant HPAs in effect, keep the number of replicas in the member cluster.

**Which issue(s) this PR fixes**:

part of #4058

**Special notes for your reviewer**:

Test Method：same as #4064

Test Report：

![image](https://github.com/karmada-io/karmada/assets/30589999/b5502f53-33c4-4d16-8c36-65be0dced25b)
![image](https://github.com/karmada-io/karmada/assets/30589999/75ce7607-711d-4308-b093-e21a253f9da5)


**Does this PR introduce a user-facing change?**:

```release-note

```

