### PR TITLE
retain for hpa controlled Deployment resource (labels method)

### DIFF
--- a/artifacts/deploy/karmada-controller-manager.yaml
+++ b/artifacts/deploy/karmada-controller-manager.yaml
@@ -30,6 +30,7 @@ spec:
             - --cluster-status-update-frequency=10s
             - --secure-port=10357
             - --failover-eviction-timeout=30s
+            - --controllers=*,hpaReplicasSyncer
             - --feature-gates=PropagationPolicyPreemption=true
             - --v=4
           livenessProbe:

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -602,9 +602,10 @@ func startHPAReplicasSyncerController(ctx controllerscontext.Context) (enabled b
 	}
 
 	hpaReplicasSyncer := hpareplicassyncer.HPAReplicasSyncer{
-		Client:      ctx.Mgr.GetClient(),
-		RESTMapper:  ctx.Mgr.GetRESTMapper(),
-		ScaleClient: scaleClient,
+		Client:        ctx.Mgr.GetClient(),
+		DynamicClient: ctx.DynamicClientSet,
+		RESTMapper:    ctx.Mgr.GetRESTMapper(),
+		ScaleClient:   scaleClient,
 	}
 	err = hpaReplicasSyncer.SetupWithManager(ctx.Mgr)
 	if err != nil {

--- a/pkg/controllers/hpareplicassyncer/hpa_replicas_syncer_predicate.go
+++ b/pkg/controllers/hpareplicassyncer/hpa_replicas_syncer_predicate.go
@@ -1,0 +1,77 @@
+package hpareplicassyncer
+
+import (
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+)
+
+var _ predicate.Predicate = &HPAReplicasSyncer{}
+
+func (r *HPAReplicasSyncer) Create(e event.CreateEvent) bool {
+	hpa, ok := e.Object.(*autoscalingv2.HorizontalPodAutoscaler)
+	if !ok {
+		klog.Errorf("create predicates in hpa controller called, but obj is not hpa type")
+		return false
+	}
+
+	// if hpa exist and has been propagated, add label to its scale ref resource
+	if hasBeenPropagated(hpa) {
+		r.scaleRefWorker.Add(labelEvent{addLabelEvent, hpa})
+	}
+
+	return false
+}
+
+func (r *HPAReplicasSyncer) Update(e event.UpdateEvent) bool {
+	oldHPA, ok := e.ObjectOld.(*autoscalingv2.HorizontalPodAutoscaler)
+	if !ok {
+		klog.Errorf("update predicates in hpa controller called, but old obj is not hpa type")
+		return false
+	}
+
+	newHPA, ok := e.ObjectNew.(*autoscalingv2.HorizontalPodAutoscaler)
+	if !ok {
+		klog.Errorf("update predicates in hpa controller called, but new obj is not hpa type")
+		return false
+	}
+
+	// hpa scale ref changed, remove old hpa label and add to new hpa
+	if oldHPA.Spec.ScaleTargetRef.String() != newHPA.Spec.ScaleTargetRef.String() {
+		// if scale ref has label, remove label, otherwise skip
+		r.scaleRefWorker.Add(labelEvent{deleteLabelEvent, oldHPA})
+	}
+
+	// if new hpa exist and has been propagated, add label to its scale ref resource
+	if hasBeenPropagated(newHPA) {
+		r.scaleRefWorker.Add(labelEvent{addLabelEvent, newHPA})
+	}
+
+	return oldHPA.Status.CurrentReplicas != newHPA.Status.CurrentReplicas
+}
+
+func (r *HPAReplicasSyncer) Delete(e event.DeleteEvent) bool {
+	hpa, ok := e.Object.(*autoscalingv2.HorizontalPodAutoscaler)
+	if !ok {
+		klog.Errorf("delete predicates in hpa controller called, but obj is not hpa type")
+		return false
+	}
+
+	// if scale ref has label, remove label, otherwise skip
+	r.scaleRefWorker.Add(labelEvent{deleteLabelEvent, hpa})
+
+	return false
+}
+
+func (r *HPAReplicasSyncer) Generic(e event.GenericEvent) bool {
+	return false
+}
+
+func hasBeenPropagated(hpa *autoscalingv2.HorizontalPodAutoscaler) bool {
+	_, ppExist := hpa.GetLabels()[policyv1alpha1.PropagationPolicyUIDLabel]
+	_, cppExist := hpa.GetLabels()[policyv1alpha1.ClusterPropagationPolicyUIDLabel]
+	return ppExist || cppExist
+}

--- a/pkg/controllers/hpareplicassyncer/hpa_scale_ref_worker.go
+++ b/pkg/controllers/hpareplicassyncer/hpa_scale_ref_worker.go
@@ -1,0 +1,137 @@
+package hpareplicassyncer
+
+import (
+	"context"
+	"fmt"
+
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+
+	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/helper"
+)
+
+type labelEventKind int
+
+const (
+	// addLabelEvent refer to addding util.RetainReplicasLabel to resource scaled by HPA
+	addLabelEvent labelEventKind = iota
+	// deleteLabelEvent refer to deleting util.RetainReplicasLabel from resource scaled by HPA
+	deleteLabelEvent
+)
+
+type labelEvent struct {
+	kind labelEventKind
+	hpa  *autoscalingv2.HorizontalPodAutoscaler
+}
+
+func (r *HPAReplicasSyncer) reconcileScaleRef(key util.QueueKey) (err error) {
+	event, ok := key.(labelEvent)
+	if !ok {
+		klog.Errorf("Found invalid key when reconciling hpa scale ref: %+v", key)
+		return nil
+	}
+
+	switch event.kind {
+	case addLabelEvent:
+		err = r.addHPALabelToScaleRef(context.TODO(), event.hpa)
+	case deleteLabelEvent:
+		err = r.deleteHPALabelFromScaleRef(context.TODO(), event.hpa)
+	default:
+		klog.Errorf("Found invalid key when reconciling hpa scale ref: %+v", key)
+		return nil
+	}
+
+	if err != nil {
+		klog.Errorf("reconcile scale ref failed: %+v", err)
+	}
+	return err
+}
+
+func (r *HPAReplicasSyncer) addHPALabelToScaleRef(ctx context.Context, hpa *autoscalingv2.HorizontalPodAutoscaler) error {
+	targetGVK := schema.FromAPIVersionAndKind(hpa.Spec.ScaleTargetRef.APIVersion, hpa.Spec.ScaleTargetRef.Kind)
+	mapping, err := r.RESTMapper.RESTMapping(targetGVK.GroupKind(), targetGVK.Version)
+	if err != nil {
+		return fmt.Errorf("unable to recognize scale ref resource, %s/%v, err: %+v", hpa.Namespace, hpa.Spec.ScaleTargetRef, err)
+	}
+
+	scaleRef, err := r.DynamicClient.Resource(mapping.Resource).Namespace(hpa.Namespace).Get(ctx, hpa.Spec.ScaleTargetRef.Name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.Infof("scale ref resource is not found (%s/%v), skip processing", hpa.Namespace, hpa.Spec.ScaleTargetRef)
+			return nil
+		}
+		return fmt.Errorf("failed to find scale ref resource (%s/%v), err: %+v", hpa.Namespace, hpa.Spec.ScaleTargetRef, err)
+	}
+
+	// use patch is better than update, when modification occur after get, patch can still success while update can not
+	newScaleRef := scaleRef.DeepCopy()
+	util.MergeLabel(newScaleRef, util.RetainReplicasLabel, util.RetainReplicasValue)
+	patchBytes, err := helper.GenMergePatch(scaleRef, newScaleRef)
+	if err != nil {
+		return fmt.Errorf("failed to gen merge patch (%s/%v), err: %+v", hpa.Namespace, hpa.Spec.ScaleTargetRef, err)
+	}
+	if len(patchBytes) == 0 {
+		klog.Infof("hpa labels already exist, skip adding (%s/%v)", hpa.Namespace, hpa.Spec.ScaleTargetRef)
+		return nil
+	}
+
+	_, err = r.DynamicClient.Resource(mapping.Resource).Namespace(newScaleRef.GetNamespace()).
+		Patch(ctx, newScaleRef.GetName(), types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.Infof("scale ref resource is not found (%s/%v), skip processing", hpa.Namespace, hpa.Spec.ScaleTargetRef)
+			return nil
+		}
+		return fmt.Errorf("failed to patch scale ref resource (%s/%v), err: %+v", hpa.Namespace, hpa.Spec.ScaleTargetRef, err)
+	}
+
+	klog.Infof("add hpa labels to %s/%v success", hpa.Namespace, hpa.Spec.ScaleTargetRef)
+	return nil
+}
+
+func (r *HPAReplicasSyncer) deleteHPALabelFromScaleRef(ctx context.Context, hpa *autoscalingv2.HorizontalPodAutoscaler) error {
+	targetGVK := schema.FromAPIVersionAndKind(hpa.Spec.ScaleTargetRef.APIVersion, hpa.Spec.ScaleTargetRef.Kind)
+	mapping, err := r.RESTMapper.RESTMapping(targetGVK.GroupKind(), targetGVK.Version)
+	if err != nil {
+		return fmt.Errorf("unable to recognize scale ref resource, %s/%v, err: %+v", hpa.Namespace, hpa.Spec.ScaleTargetRef, err)
+	}
+
+	scaleRef, err := r.DynamicClient.Resource(mapping.Resource).Namespace(hpa.Namespace).Get(ctx, hpa.Spec.ScaleTargetRef.Name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.Infof("scale ref resource is not found (%s/%v), skip processing", hpa.Namespace, hpa.Spec.ScaleTargetRef)
+			return nil
+		}
+		return fmt.Errorf("failed to find scale ref resource (%s/%v), err: %+v", hpa.Namespace, hpa.Spec.ScaleTargetRef, err)
+	}
+
+	// use patch is better than update, when modification occur after get, patch can still success while update can not
+	newScaleRef := scaleRef.DeepCopy()
+	util.RemoveLabels(newScaleRef, util.RetainReplicasLabel)
+	patchBytes, err := helper.GenMergePatch(scaleRef, newScaleRef)
+	if err != nil {
+		return fmt.Errorf("failed to gen merge patch (%s/%v), err: %+v", hpa.Namespace, hpa.Spec.ScaleTargetRef, err)
+	}
+	if len(patchBytes) == 0 {
+		klog.Infof("hpa labels not exist, skip deleting (%s/%v)", hpa.Namespace, hpa.Spec.ScaleTargetRef)
+		return nil
+	}
+
+	_, err = r.DynamicClient.Resource(mapping.Resource).Namespace(newScaleRef.GetNamespace()).
+		Patch(ctx, newScaleRef.GetName(), types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.Infof("scale ref resource is not found (%s/%v), skip processing", hpa.Namespace, hpa.Spec.ScaleTargetRef)
+			return nil
+		}
+		return fmt.Errorf("failed to patch scale ref resource (%s/%v), err: %+v", hpa.Namespace, hpa.Spec.ScaleTargetRef, err)
+	}
+
+	klog.Infof("delete hpa labels from %s/%+v success", hpa.Namespace, hpa.Spec.ScaleTargetRef)
+	return nil
+}

--- a/pkg/resourceinterpreter/default/native/aggregatestatus.go
+++ b/pkg/resourceinterpreter/default/native/aggregatestatus.go
@@ -574,7 +574,8 @@ func aggregateHorizontalPodAutoscalerStatus(object *unstructured.Unstructured, a
 		if err = json.Unmarshal(item.Status.Raw, temp); err != nil {
 			return nil, err
 		}
-		klog.V(3).Infof("Grab hpa(%s/%s) status from cluster(%s), CurrentReplicas: %d", temp.CurrentReplicas)
+		klog.V(3).Infof("Grab hpa(%s/%s) status from cluster(%s), CurrentReplicas: %d, DesiredReplicas: %d",
+			hpa.Namespace, hpa.Name, item.ClusterName, temp.CurrentReplicas, temp.DesiredReplicas)
 
 		newStatus.CurrentReplicas += temp.CurrentReplicas
 		newStatus.DesiredReplicas += temp.DesiredReplicas

--- a/pkg/resourceinterpreter/default/native/retain_test.go
+++ b/pkg/resourceinterpreter/default/native/retain_test.go
@@ -1,0 +1,94 @@
+package native
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/helper"
+)
+
+func Test_retainK8sWorkloadReplicas(t *testing.T) {
+	desiredNum, observedNum := int32(2), int32(4)
+	observed, _ := helper.ToUnstructured(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nginx",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &observedNum,
+		},
+	})
+	desired, _ := helper.ToUnstructured(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nginx",
+			Labels: map[string]string{
+				util.RetainReplicasLabel: util.RetainReplicasValue,
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &desiredNum,
+		},
+	})
+	want, _ := helper.ToUnstructured(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nginx",
+			Labels: map[string]string{
+				util.RetainReplicasLabel: util.RetainReplicasValue,
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &observedNum,
+		},
+	})
+	desired2, _ := helper.ToUnstructured(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nginx",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &desiredNum,
+		},
+	})
+	type args struct {
+		desired  *unstructured.Unstructured
+		observed *unstructured.Unstructured
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *unstructured.Unstructured
+		wantErr bool
+	}{
+		{
+			name: "deployment is control by hpa",
+			args: args{
+				desired:  desired,
+				observed: observed,
+			},
+			want:    want,
+			wantErr: false,
+		},
+		{
+			name: "deployment is not control by hpa",
+			args: args{
+				desired:  desired2,
+				observed: observed,
+			},
+			want:    desired2,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := retainWorkloadReplicas(tt.args.desired, tt.args.observed)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("reflectPodDisruptionBudgetStatus() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.Equalf(t, tt.want, got, "retainDeploymentFields(%v, %v)", tt.args.desired, tt.args.observed)
+		})
+	}
+}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -28,6 +28,14 @@ const (
 
 	// ManagedByKarmadaLabelValue indicates that resources are managed by karmada controllers.
 	ManagedByKarmadaLabelValue = "true"
+
+	// RetainReplicasLabel is a reserved label to indicate whether the replicas should be retained. e.g:
+	// resourcetemplate.karmada.io/retain-replicas: true   // with value `true` indicates retain
+	// resourcetemplate.karmada.io/retain-replicas: false  // with value `false` and others, indicates not retain
+	RetainReplicasLabel = "resourcetemplate.karmada.io/retain-replicas"
+
+	// RetainReplicasValue is an optional value of RetainReplicasLabel, indicating retain
+	RetainReplicasValue = "true"
 )
 
 // Define annotations used by karmada system.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Write a controller to watch the creation of HPA. Once there is a change in HPA, It will add a label to the target resource pointed by HPA. Then we only need to check if the resource has this specific label here to determine whether we need to perform the retain operation.

**Which issue(s) this PR fixes**:

part of #4058

**Special notes for your reviewer**:

~another mthod：#4075~

we should choose just one between two.

Test Method：same as #4064

Test Report：

![image](https://github.com/karmada-io/karmada/assets/30589999/b5502f53-33c4-4d16-8c36-65be0dced25b)
![image](https://github.com/karmada-io/karmada/assets/30589999/75ce7607-711d-4308-b093-e21a253f9da5)
![image](https://github.com/karmada-io/karmada/assets/30589999/4310b551-fa27-4982-930e-a4913bacedf9)
![image](https://github.com/karmada-io/karmada/assets/30589999/2b7559c0-1c5c-440f-b2fe-49bac790c9f4)


**Does this PR introduce a user-facing change?**:

```release-note
Introduced retain operation to deployments if it is controlled by a HPA and the HPA has been propagated, which means member cluster deployments replicas will be controlled by member cluster HPA only.
```

