### PR TITLE
Fix interactive checks in one-click installations

### DIFF
--- a/hack/install-cli.sh
+++ b/hack/install-cli.sh
@@ -241,9 +241,9 @@ setup_binary() {
 
   local CMD_MOVE="mv -i \"${TMP_DIR}/${INSTALL_CLI_TYPE}\" \"${INSTALL_LOCATION}\""
   if [[ -w "${INSTALL_LOCATION}" ]]; then
-    eval "${CMD_MOVE}"
+    eval "${CMD_MOVE} < /dev/tty"
   else
-    eval "sudo ${CMD_MOVE}"
+    eval "sudo ${CMD_MOVE} < /dev/tty"
   fi
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
The interactive doesn't work in the one click installation during a repeated installation/upgrade scenario.
Possible reason is that the pipe (|) transfers the standard input of the script to the output of the pipe, which causes some commands that require user interaction (such as mv) to not work properly. If need it to be interactive, redirect the standard input of the mv command to /dev/tty.

**Which issue(s) this PR fixes**:
Fixes #4091

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

