### PR TITLE
Use Patch() when binding-status controller update workload's status

### DIFF
--- a/pkg/controllers/status/common.go
+++ b/pkg/controllers/status/common.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -18,6 +19,7 @@ import (
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter"
+	"github.com/karmada-io/karmada/pkg/util/helper"
 	"github.com/karmada-io/karmada/pkg/util/restmapper"
 )
 
@@ -69,13 +71,24 @@ func updateResourceStatus(
 		klog.Errorf("Failed to aggregate status for resource(%s/%s/%s, Error: %v", gvr, resource.GetNamespace(), resource.GetName(), err)
 		return err
 	}
-	if reflect.DeepEqual(resource, newObj) {
+
+	oldStatus, _, _ := unstructured.NestedFieldNoCopy(resource.Object, "status")
+	newStatus, _, _ := unstructured.NestedFieldNoCopy(newObj.Object, "status")
+	if reflect.DeepEqual(oldStatus, newStatus) {
 		klog.V(3).Infof("Ignore update resource(%s/%s/%s) status as up to date.", gvr, resource.GetNamespace(), resource.GetName())
 		return nil
 	}
 
-	if _, err = dynamicClient.Resource(gvr).Namespace(resource.GetNamespace()).UpdateStatus(context.TODO(), newObj, metav1.UpdateOptions{}); err != nil {
-		klog.Errorf("Failed to update resource(%s/%s/%s), Error: %v", gvr, resource.GetNamespace(), resource.GetName(), err)
+	patchBytes, err := helper.GenReplaceFieldJSONPatch("/status", oldStatus, newStatus)
+	if err != nil {
+		klog.Errorf("Failed to gen patch bytes for resource(%s/%s/%s, Error: %v", gvr, resource.GetNamespace(), resource.GetName(), err)
+		return err
+	}
+
+	_, err = dynamicClient.Resource(gvr).Namespace(resource.GetNamespace()).
+		Patch(context.TODO(), resource.GetName(), types.JSONPatchType, patchBytes, metav1.PatchOptions{}, "status")
+	if err != nil {
+		klog.Error("Failed to update resource(%s/%s/%s), Error: %v", gvr, resource.GetNamespace(), resource.GetName(), err)
 		return err
 	}
 	klog.V(3).Infof("Update resource(%s/%s/%s) status successfully.", gvr, resource.GetNamespace(), resource.GetName())

--- a/pkg/util/helper/patch.go
+++ b/pkg/util/helper/patch.go
@@ -3,9 +3,27 @@ package helper
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
 )
+
+// RFC6902 JSONPatch operations
+const (
+	JSONPatchOPAdd     = "add"
+	JSONPatchOPReplace = "replace"
+	JSONPatchOPRemove  = "remove"
+	JSONPatchOPMove    = "move"
+	JSONPatchOPCopy    = "copy"
+	JSONPatchOPTest    = "test"
+)
+
+type jsonPatch struct {
+	OP    string      `json:"op"`
+	From  string      `json:"from,omitempty"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value,omitempty"`
+}
 
 // GenMergePatch will return a merge patch document capable of converting the
 // original object to the modified object.
@@ -31,4 +49,41 @@ func GenMergePatch(originalObj interface{}, modifiedObj interface{}) ([]byte, er
 	}
 
 	return patchBytes, nil
+}
+
+// GenReplaceFieldJSONPatch returns the RFC6902 JSONPatch array as []byte, which is used to simply
+// add/replace/delete certain JSON **Object** field.
+func GenReplaceFieldJSONPatch(path string, originalFieldValue, newFieldValue interface{}) ([]byte, error) {
+	if reflect.DeepEqual(originalFieldValue, newFieldValue) {
+		return []byte(`[]`), nil
+	}
+	if newFieldValue == nil {
+		return GenJSONPatch(JSONPatchOPRemove, "", path, nil)
+	}
+	// The implementation of “add” and “replace” for JSON objects is actually the same
+	// in “github.com/evanphx/json-patch/v5”, which is used by us and k8s.
+	// We implemented it here just to follow the RFC6902.
+	if originalFieldValue == nil {
+		return GenJSONPatch(JSONPatchOPAdd, "", path, newFieldValue)
+	}
+	return GenJSONPatch(JSONPatchOPReplace, "", path, newFieldValue)
+}
+
+// GenJSONPatch return JSONPatch array as []byte according to RFC6902
+func GenJSONPatch(op, from, path string, value interface{}) ([]byte, error) {
+	jp := jsonPatch{
+		OP:   op,
+		Path: path,
+	}
+	switch op {
+	case JSONPatchOPAdd, JSONPatchOPReplace, JSONPatchOPTest:
+		jp.Value = value
+	case JSONPatchOPMove, JSONPatchOPCopy:
+		jp.From = from
+	case JSONPatchOPRemove:
+	default:
+		return nil, fmt.Errorf("unrecognized JSONPatch OP: %s", op)
+	}
+
+	return json.Marshal([]jsonPatch{jp})
 }

--- a/pkg/util/helper/patch.go
+++ b/pkg/util/helper/patch.go
@@ -55,13 +55,13 @@ func GenMergePatch(originalObj interface{}, modifiedObj interface{}) ([]byte, er
 // add/replace/delete certain JSON **Object** field.
 func GenReplaceFieldJSONPatch(path string, originalFieldValue, newFieldValue interface{}) ([]byte, error) {
 	if reflect.DeepEqual(originalFieldValue, newFieldValue) {
-		return []byte(`[]`), nil
+		return nil, nil
 	}
 	if newFieldValue == nil {
 		return GenJSONPatch(JSONPatchOPRemove, "", path, nil)
 	}
-	// The implementation of “add” and “replace” for JSON objects is actually the same
-	// in “github.com/evanphx/json-patch/v5”, which is used by us and k8s.
+	// The implementation of "add" and "replace" for JSON objects is actually the same
+	// in "github.com/evanphx/json-patch/v5", which is used by Karmada and K8s.
 	// We implemented it here just to follow the RFC6902.
 	if originalFieldValue == nil {
 		return GenJSONPatch(JSONPatchOPAdd, "", path, newFieldValue)

--- a/pkg/util/helper/patch_test.go
+++ b/pkg/util/helper/patch_test.go
@@ -1,6 +1,7 @@
 package helper
 
 import (
+	"math"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -102,6 +103,160 @@ func TestGenMergePatch(t *testing.T) {
 			}
 			if string(patch) != tt.expectedPatch {
 				t.Fatalf("want patch: %s, but got :%s", tt.expectedPatch, string(patch))
+			}
+		})
+	}
+}
+
+func TestGenJSONPatch(t *testing.T) {
+	//doc := `{"field1":1,"field2":"2","field3":[3],"field4":{"a":"a"}}`
+	type args struct {
+		op    string
+		from  string
+		path  string
+		value interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "add object field",
+			args: args{
+				op:    "add",
+				path:  "/abc",
+				value: 1,
+			},
+			want:    `[{"op":"add","path":"/abc","value":1}]`,
+			wantErr: false,
+		},
+		{
+			name: "replace object field",
+			args: args{
+				op:    "replace",
+				path:  "/abc",
+				value: 1,
+			},
+			want:    `[{"op":"replace","path":"/abc","value":1}]`,
+			wantErr: false,
+		},
+		{
+			name: "remove object field, redundant args will be ignored",
+			args: args{
+				op:    "remove",
+				from:  "123",
+				path:  "/abc",
+				value: 1,
+			},
+			want:    `[{"op":"remove","path":"/abc"}]`,
+			wantErr: false,
+		},
+		{
+			name: "move object field",
+			args: args{
+				op:   "move",
+				from: "/abc",
+				path: "/123",
+			},
+			want:    `[{"op":"move","from":"/abc","path":"/123"}]`,
+			wantErr: false,
+		},
+		{
+			name: "copy object field, redundant array value will be ignored",
+			args: args{
+				op:    "copy",
+				from:  "/123",
+				path:  "/abc",
+				value: []interface{}{1, "a", false, 4.5},
+			},
+			want:    `[{"op":"copy","from":"/123","path":"/abc"}]`,
+			wantErr: false,
+		},
+		{
+			name: "replace object field, input string typed number",
+			args: args{
+				op:    "replace",
+				path:  "/abc",
+				value: "1",
+			},
+			want:    `[{"op":"replace","path":"/abc","value":"1"}]`,
+			wantErr: false,
+		},
+		{
+			name: "replace object field, input invalid type",
+			args: args{
+				op:    "replace",
+				path:  "/abc",
+				value: make(chan int),
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "replace object field, input invalid value",
+			args: args{
+				op:    "replace",
+				path:  "/abc",
+				value: math.Inf(1),
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "replace object field, input struct value",
+			args: args{
+				op:   "replace",
+				path: "/abc",
+				value: struct {
+					A string
+					B int
+					C float64
+					D bool
+				}{"a", 1, 1.2, true},
+			},
+			want:    `[{"op":"replace","path":"/abc","value":{"A":"a","B":1,"C":1.2,"D":true}}]`,
+			wantErr: false,
+		},
+		{
+			name: "test object field, input array value",
+			args: args{
+				op:    "test",
+				path:  "/abc",
+				value: []interface{}{1, "a", false, 4.5},
+			},
+			want:    `[{"op":"test","path":"/abc","value":[1,"a",false,4.5]}]`,
+			wantErr: false,
+		},
+		{
+			name: "move object field, input invalid path, but we won't verify it",
+			args: args{
+				op:   "move",
+				from: "123",
+				path: "abc",
+			},
+			want:    `[{"op":"move","from":"123","path":"abc"}]`,
+			wantErr: false,
+		},
+		{
+			name: "input invalid op",
+			args: args{
+				op:   "whatever",
+				path: "/abc",
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patchBytes, err := GenJSONPatch(tt.args.op, tt.args.from, tt.args.path, tt.args.value)
+			if tt.wantErr != (err != nil) {
+				t.Errorf("wantErr: %v, but got err: %v", tt.wantErr, err)
+			}
+			if tt.want != string(patchBytes) {
+				t.Errorf("want: %s, but got: %s", tt.want, patchBytes)
 			}
 		})
 	}


### PR DESCRIPTION
Change-Id: Ia0b5fde0b9d69f73aa6c2e3135e2590a6a503075

**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Discribed in  #4093

**Which issue(s) this PR fixes**:
Fixes #4093

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager: use Patch() instead of Update() when updating workload status because error rate is too high.`
```

