### PR TITLE
fix: fix fhpa controller panic when SelectPolicy is nil

### DIFF
--- a/pkg/controllers/federatedhpa/federatedhpa_controller.go
+++ b/pkg/controllers/federatedhpa/federatedhpa_controller.go
@@ -1270,9 +1270,9 @@ func calculateScaleUpLimitWithScalingRules(currentReplicas int32, scaleUpEvents,
 	var result int32
 	var proposed int32
 	var selectPolicyFn func(int32, int32) int32
-	if *scalingRules.SelectPolicy == autoscalingv2.DisabledPolicySelect {
+	if scalingRules.SelectPolicy != nil && *scalingRules.SelectPolicy == autoscalingv2.DisabledPolicySelect {
 		return currentReplicas // Scaling is disabled
-	} else if *scalingRules.SelectPolicy == autoscalingv2.MinChangePolicySelect {
+	} else if scalingRules.SelectPolicy != nil && *scalingRules.SelectPolicy == autoscalingv2.MinChangePolicySelect {
 		result = math.MaxInt32
 		selectPolicyFn = min // For scaling up, the lowest change ('min' policy) produces a minimum value
 	} else {
@@ -1299,9 +1299,9 @@ func calculateScaleDownLimitWithBehaviors(currentReplicas int32, scaleUpEvents, 
 	var result int32
 	var proposed int32
 	var selectPolicyFn func(int32, int32) int32
-	if *scalingRules.SelectPolicy == autoscalingv2.DisabledPolicySelect {
+	if scalingRules.SelectPolicy != nil && *scalingRules.SelectPolicy == autoscalingv2.DisabledPolicySelect {
 		return currentReplicas // Scaling is disabled
-	} else if *scalingRules.SelectPolicy == autoscalingv2.MinChangePolicySelect {
+	} else if scalingRules.SelectPolicy != nil && *scalingRules.SelectPolicy == autoscalingv2.MinChangePolicySelect {
 		result = math.MinInt32
 		selectPolicyFn = max // For scaling down, the lowest change ('min' policy) produces a maximum value
 	} else {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

To fix a nil pointer bug which panics karmada-controller-manager.

Following the FHPA guide outlined in our documentation and applying these FHPA resources in the karmada cluster can cause the karmada-controller-manager to anic.
 
```
apiVersion: autoscaling.karmada.io/v1alpha1
kind: FederatedHPA
metadata:
  name: nginx
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: nginx
  minReplicas: 1
  maxReplicas: 10
  behavior:
    scaleDown:
      stabilizationWindowSeconds: 10
    scaleUp:
      stabilizationWindowSeconds: 10
  metrics:
    - type: Resource
      resource:
        name: cpu
        target:
          type: Utilization
          averageUtilization: 10
```

here is stack trace:

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1ef074f]

goroutine 2249 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
        /home/runner/work/karmada/karmada/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:119 +0x1fa
panic({0x21f7220, 0x3d45a90})
        /opt/hostedtoolcache/go/1.20.4/x64/src/runtime/panic.go:884 +0x213
github.com/karmada-io/karmada/pkg/controllers/federatedhpa.calculateScaleDownLimitWithBehaviors(0x3?, {0x0?, 0xc004bcf6e0?, 0x13?}, {0x0?, 0x0?,xc004aec360?}, 0xc000c8c460?)
        /home/runner/work/karmada/karmada/pkg/controllers/federatedhpa/federatedhpa_controller.go:1175 +0x2f
github.com/karmada-io/karmada/pkg/controllers/federatedhpa.(*FederatedHPAController).convertDesiredReplicasWithBehaviorRate(0xc0001cd1d0, {{0xc004bcf6e0,x13}, 0xc002a83dd0, 0xc002a83e00, 0x1, 0xa, 0x2, 0x0})
        /home/runner/work/karmada/karmada/pkg/controllers/federatedhpa/federatedhpa_controller.go:1057 +0x485
github.com/karmada-io/karmada/pkg/controllers/federatedhpa.(*FederatedHPAController).normalizeDesiredReplicasWithBehaviors(0xc0001cd1d0, 0xc0038ba700,0xc004bcf6e0?, 0x0?}, 0x3dc86c0?, 0x0, 0xc8c3c0?)
        /home/runner/work/karmada/karmada/pkg/controllers/federatedhpa/federatedhpa_controller.go:872 +0x3a6
github.com/karmada-io/karmada/pkg/controllers/federatedhpa.(*FederatedHPAController).reconcileAutoscaler(0xc0001cd1d0, {0x29293e8, 0xc002a83d70},xc0038ba700)
        /home/runner/work/karmada/karmada/pkg/controllers/federatedhpa/federatedhpa_controller.go:335 +0x1834
github.com/karmada-io/karmada/pkg/controllers/federatedhpa.(*FederatedHPAController).Reconcile(0xc0001cd1d0, {0x29293e8, 0xc002a83d70}, {{{0xc000c8c3e0?,x0?}, {0xc000c8c3c0?, 0x40e1c7?}}})
        /home/runner/work/karmada/karmada/pkg/controllers/federatedhpa/federatedhpa_controller.go:155 +0x336
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x29293e8?, {0x29293e8?, 0xc002a83d70?}, {{{0xc000c8c3e0?, 0x20e6f20?},0xc000c8c3c0?, 0x0?}}})
        /home/runner/work/karmada/karmada/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:122 +0xc8
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0004e5180, {0x2929340, 0xc00042ecd0}, {0x22c22a0?, 0xc002859580?})
        /home/runner/work/karmada/karmada/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:323 +0x35f
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0004e5180, {0x2929340, 0xc00042ecd0})
        /home/runner/work/karmada/karmada/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:274 +0x1d9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
        /home/runner/work/karmada/karmada/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
        /home/runner/work/karmada/karmada/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:231 +0x587
```

karmada version: v1.6.3, still occurs in v1.7.0

**Does this PR introduce a user-facing change?**:

```
`karmada-controller-manager`: Fix panic when FederatedHPA's SelectPolicy is nil and FederatedHPA webhook is disabled.
```

