### PR TITLE
schedulerOptions add support for RateLimiterOptions

### DIFF
--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -14,6 +14,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/scheduler"
 	frameworkplugins "github.com/karmada-io/karmada/pkg/scheduler/framework/plugins"
 	"github.com/karmada-io/karmada/pkg/sharedcli/profileflag"
+	"github.com/karmada-io/karmada/pkg/sharedcli/ratelimiterflag"
 	"github.com/karmada-io/karmada/pkg/util"
 )
 
@@ -68,6 +69,9 @@ type Options struct {
 	// SchedulerName represents the name of the scheduler.
 	// default is "default-scheduler".
 	SchedulerName string
+
+	// RateLimiterOpts contains the options for rate limiter.
+	RateLimiterOpts ratelimiterflag.Options
 }
 
 // NewOptions builds an default scheduler options.
@@ -111,4 +115,5 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.SchedulerName, "scheduler-name", scheduler.DefaultScheduler, "SchedulerName represents the name of the scheduler. default is 'default-scheduler'.")
 	features.FeatureGate.AddFlag(fs)
 	o.ProfileOpts.AddFlags(fs)
+	o.RateLimiterOpts.AddFlags(fs)
 }

--- a/cmd/scheduler/app/scheduler.go
+++ b/cmd/scheduler/app/scheduler.go
@@ -159,6 +159,7 @@ func run(opts *options.Options, stopChan <-chan struct{}, registryOptions ...Opt
 		scheduler.WithEnableEmptyWorkloadPropagation(opts.EnableEmptyWorkloadPropagation),
 		scheduler.WithEnableSchedulerPlugin(opts.Plugins),
 		scheduler.WithSchedulerName(opts.SchedulerName),
+		scheduler.WithRateLimiterOptions(opts.RateLimiterOpts),
 	)
 	if err != nil {
 		return fmt.Errorf("couldn't create scheduler: %w", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

schedulerOptions add support for RateLimiterOptions

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-scheduler`: Introduced rate limiter options including: `--rate-limiter-base-delay`, `--rate-limiter-max-delay`, `--rate-limiter-qps`, and `--rate-limiter-bucket-size`, the default value not changed compared to previous version.
```

