### PR TITLE
clean ci runner disk space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,19 @@ jobs:
         # Please remember to update the CI Schedule Workflow when we add a new version.
         k8s: [ v1.25.0, v1.26.0, v1.27.3 ]
     steps:
+      # Free up disk space on Ubuntu
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed, if set to "true" but frees about 6 GB
+          tool-cache: false
+          # all of these default to true, but feel free to set to "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: false
       - name: checkout code
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

Handling or maximizing github runner out-of-disk space error.

**Which issue(s) this PR fixes**:

Fixes #4107

**Special notes for your reviewer**:

Reason：Runner is assigned `84GB` disk by default, but the system itself and pre-installed software occupy nearly 68GB, besides there about `4GB` swap. Then, when we installed Karmada by `local-up-karmada.sh` script, it occupy about 10GB, so there's really not much space left.

before install Karmada:

![a0fb20162c61a8ef3a2eb6949d3db92](https://github.com/karmada-io/karmada/assets/30589999/16a7ea6b-7102-47f8-bdd0-1073a4fb89b6)
![834ec9e507de8050bd3f37de1209f49](https://github.com/karmada-io/karmada/assets/30589999/3823449e-38c4-49ff-9b66-771df84d113b)

after install Karmada:

![98a4a89ac96f00b1a1877a9c93a7a25](https://github.com/karmada-io/karmada/assets/30589999/3b508486-7f4c-4558-8116-a0d385a72754)
![4d35805ea18df11c00f309a935aa798](https://github.com/karmada-io/karmada/assets/30589999/def4d561-bb07-49e5-8716-04463e26a9d4)


Here comes the key point, **refer to [Handling or maximizing github runner out-of-disk space error:](https://saturncloud.io/blog/github-action-ecr-optimizing-disk-space/#handling-or-maximizing-github-runner-out-of-disk-space-error)**

![image](https://github.com/karmada-io/karmada/assets/30589999/c5fd7571-33a9-4689-84d0-013adfc1ee20)

here added two steps to pipeline to free useless space：

* by `clean unnecessary files to save space` can free about `20GB` space, time cost `16s`:

![image](https://github.com/karmada-io/karmada/assets/30589999/10c0761b-3601-411e-bded-4e2c642b55a1)
![image](https://github.com/karmada-io/karmada/assets/30589999/ee918d68-d094-4c3d-b0e2-2be895ba89ea)

* by use `jlumbroso/free-disk-space@main` can free about another `20GB` space, time cost `3m7s`:

![image](https://github.com/karmada-io/karmada/assets/30589999/d10f9d20-a744-462f-a989-68066eeeabee)
![image](https://github.com/karmada-io/karmada/assets/30589999/98eef9bb-d744-453d-b080-2d9be921ae2a)

**Does this PR introduce a user-facing change?**:

```release-note
none
```

