### PR TITLE
ci: fix schedule ci workflow failure

### DIFF
--- a/.github/workflows/ci-schedule-compatibility.yaml
+++ b/.github/workflows/ci-schedule-compatibility.yaml
@@ -11,6 +11,9 @@ jobs:
     if: ${{ github.repository == 'karmada-io/karmada' }}
     runs-on: ubuntu-22.04
     strategy:
+      # max-parallel limits the max number of jobs running at the same time.
+      # We set it to 5 to avoid too many jobs running at the same time, causing the CI to fail because of resource limitations.
+      max-parallel: 5
       fail-fast: false
       matrix:
         kubeapiserver-version: [ v1.23.4, v1.24.2, v1.25.0, v1.26.0, v1.27.3, v1.28.0, v1.29.0 ]
@@ -51,8 +54,12 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: setup e2e test environment
-        run: |
-          hack/local-up-karmada.sh
+        uses: nick-fields/retry@v2.9.0
+        with:
+          max_attempts: 3
+          timeout_minutes: 20
+          command: |
+            hack/local-up-karmada.sh
       - name: change kube-apiserver and kube-controller-manager version
         run: |
           # Update images

--- a/.github/workflows/ci-schedule.yml
+++ b/.github/workflows/ci-schedule.yml
@@ -10,6 +10,9 @@ jobs:
     if: ${{ github.repository == 'karmada-io/karmada' }}
     runs-on: ubuntu-22.04
     strategy:
+      # max-parallel limits the max number of jobs running at the same time.
+      # We set it to 5 to avoid too many jobs running at the same time, causing the CI to fail because of resource limitations.
+      max-parallel: 5
       fail-fast: false
       matrix:
         k8s: [ v1.23.4, v1.24.2, v1.25.0, v1.26.0, v1.27.3, v1.28.0, v1.29.0 ]
@@ -38,7 +41,10 @@ jobs:
         with:
           go-version: 1.20.11
       - name: setup e2e test environment
-        run: |
+        uses: nick-fields/retry@v2.9.0
+        max_attempts: 3
+        timeout_minutes: 20
+        command: |
           export CLUSTER_VERSION=kindest/node:${{ matrix.k8s }}
           hack/local-up-karmada.sh
       - name: run e2e


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Now `https://github.com/karmada-io/karmada/actions/workflows/ci-schedule.yml` and `https://github.com/karmada-io/karmada/actions/workflows/ci-schedule-compatibility.yaml` both failed almost, there are different errors(cluster creation timeout and e2e case failed).

The problem could be github resource limitations, I limit the concurrency to 2 and test it: https://github.com/jwcesign/karmada/actions/runs/6468715625/job/17561283243


**Which issue(s) this PR fixes**:
Part of #4111 

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

