### PR TITLE
Automated cherry pick of #4106: clean ci runner disk space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,19 @@ jobs:
         # Please remember to update the CI Schedule Workflow when we add a new version.
         k8s: [ v1.25.0, v1.26.0, v1.27.3 ]
     steps:
+      # Free up disk space on Ubuntu
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed, if set to "true" but frees about 6 GB
+          tool-cache: false
+          # all of these default to true, but feel free to set to "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: false
       - name: checkout code
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Cherry pick of #4106 on release-1.7.
#4106: clean ci runner disk space
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
```