### PR TITLE
Automated cherry pick of #4106: clean ci runner disk space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,19 @@ jobs:
       matrix:
         k8s: [ v1.21.10, v1.22.7, v1.23.4, v1.24.2, v1.25.0, v1.26.0 ]
     steps:
+      # Free up disk space on Ubuntu
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed, if set to "true" but frees about 6 GB
+          tool-cache: false
+          # all of these default to true, but feel free to set to "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: false
       - name: checkout code
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Cherry pick of #4106 on release-1.5.
#4106: clean ci runner disk space
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
```