### PR TITLE
CI: add image scanning

### DIFF
--- a/.github/workflows/ci-image-scanning.yaml
+++ b/.github/workflows/ci-image-scanning.yaml
@@ -1,0 +1,39 @@
+name: image-scanning
+on:
+  push: 
+jobs:
+  use-trivy-to-scan-image:
+    name: image-scanning
+    if: ${{ github.repository == 'karmada-io/karmada' }}
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - karmada-controller-manager
+          - karmada-scheduler
+          - karmada-descheduler
+          - karmada-webhook
+          - karmada-agent
+          - karmada-scheduler-estimator
+          - karmada-interpreter-webhook-example
+          - karmada-aggregated-apiserver
+          - karmada-search
+          - karmada-operator
+          - karmada-metrics-adapter
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: Build an image from Dockerfile
+        run: |
+          export VERSION="latest"
+          export REGISTRY="docker.io/karmada"
+          make image-${{ matrix.target }}
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.12.0
+        with:
+          image-ref: 'docker.io/karmada/${{ matrix.target }}:latest'
+          format: 'table'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          exit-code: '1'


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Runs Trivy as GitHub action to scan Docker container image for vulnerabilities. 

We talked about this task at [Community Meeting 2023-01-17](https://docs.google.com/document/d/1y6YLVC-v7cmVAdbjedoyR5WL0-q45DBRXTvz5_I7bkA/edit?pli=1#heading=h.yrs5d1w97tdg).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Please see https://github.com/zhzhuang-zju/karmada/actions/runs/6530626808/job/17730271059 for more specific effects.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

