### PR TITLE
update karmada operator default karmada version

### DIFF
--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -15,7 +15,7 @@ const (
 	// EtcdDefaultVersion defines the default of the karmada etcd image tag
 	EtcdDefaultVersion = "3.5.9-0"
 	// KarmadaDefaultVersion defines the default of the karmada components image tag
-	KarmadaDefaultVersion = "v1.6.0"
+	KarmadaDefaultVersion = "v1.7.0"
 	// KubeDefaultVersion defines the default of the karmada apiserver and kubeControllerManager image tag
 	KubeDefaultVersion = "v1.25.4"
 	// KarmadaDefaultServiceSubnet defines the default of the subnet used by k8s services.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
````bash
[root@master-01 ~]# k -n test get karmada.operator.karmada.io/karmada-demo -oyaml
apiVersion: operator.karmada.io/v1alpha1
kind: Karmada
metadata:
  creationTimestamp: "2023-06-27T07:12:57Z"
  finalizers:
  - operator.karmada.io/finalizer
  generation: 2
  labels:
    operator.karmada.io/disable-cascading-deletion: "false"
  name: karmada-demo
  namespace: test
  resourceVersion: "746734041"
  uid: 423ea5fe-b848-4b5f-b51a-aaeed83b6ea7
spec:
  components:
    etcd:
      local:
        imageRepository: registry.k8s.io/etcd
        imageTag: 3.5.9-0
        replicas: 1
        resources: {}
        volumeData:
          volumeClaim:
            metadata: {}
            spec:
              accessModes:
              - ReadWriteOnce
              resources:
                requests:
                  storage: 3Gi
    karmadaAPIServer:
      imageRepository: registry.k8s.io/kube-apiserver
      imageTag: v1.25.4
      replicas: 1
      resources: {}
      serviceSubnet: 10.96.0.0/12
      serviceType: NodePort
    karmadaAggregatedAPIServer:
      imageRepository: docker.io/karmada/karmada-aggregated-apiserver
      imageTag: v1.7.0
      replicas: 1
      resources: {}
    karmadaControllerManager:
      imageRepository: docker.io/karmada/karmada-controller-manager
      imageTag: v1.7.0
      replicas: 1
      resources: {}
    karmadaScheduler:
      imageRepository: docker.io/karmada/karmada-scheduler
      imageTag: v1.7.0
      replicas: 1
      resources: {}
    karmadaWebhook:
      imageRepository: docker.io/karmada/karmada-webhook
      imageTag: v1.7.0
      replicas: 1
      resources: {}
    kubeControllerManager:
      imageRepository: registry.k8s.io/kube-controller-manager
      imageTag: v1.25.4
      replicas: 1
      resources: {}
  hostCluster:
    networking:
      dnsDomain: cluster.local


[root@master-01 ~]# k -n test get pod
NAME                                                    READY   STATUS    RESTARTS      AGE
karmada-demo-aggregated-apiserver-5544c5d8b7-gqjsf      1/1     Running   0             6m9s
karmada-demo-apiserver-d66dd9cb-sn4kw                   1/1     Running   0             9m
karmada-demo-controller-manager-6858bf649d-t67qd        1/1     Running   0             5m5s
karmada-demo-etcd-0                                     1/1     Running   0             9m16s
karmada-demo-kube-controller-manager-74575bbcdc-nf5jk   1/1     Running   2 (36s ago)   5m5s
karmada-demo-scheduler-7b7c7b5649-4tr4z                 1/1     Running   0             5m4s
karmada-demo-webhook-c646bc69d-dgxv2                    1/1     Running   0             5m4s
````

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

