### PR TITLE
fix: karmada-operator install default version karmada

### DIFF
--- a/operator/cmd/operator/app/operator.go
+++ b/operator/cmd/operator/app/operator.go
@@ -25,6 +25,8 @@ import (
 	"github.com/karmada-io/karmada/operator/pkg/scheme"
 	"github.com/karmada-io/karmada/pkg/sharedcli"
 	"github.com/karmada-io/karmada/pkg/sharedcli/klogflag"
+	"github.com/karmada-io/karmada/pkg/version"
+	"github.com/karmada-io/karmada/pkg/version/sharedcommand"
 )
 
 // NewOperatorCommand creates a *cobra.Command object with default parameters
@@ -67,6 +69,7 @@ func NewOperatorCommand(ctx context.Context) *cobra.Command {
 	logsFlagSet := fss.FlagSet("logs")
 	klogflag.Add(logsFlagSet)
 
+	cmd.AddCommand(sharedcommand.NewCmdVersion("karmada-operator"))
 	cmd.Flags().AddFlagSet(genericFlagSet)
 	cmd.Flags().AddFlagSet(logsFlagSet)
 
@@ -77,6 +80,7 @@ func NewOperatorCommand(ctx context.Context) *cobra.Command {
 
 // Run runs the karmada-operator. This should never exit.
 func Run(ctx context.Context, o *options.Options) error {
+	klog.Infof("karmada-operator version: %s", version.Get())
 	klog.InfoS("Golang settings", "GOGC", os.Getenv("GOGC"), "GOMAXPROCS", os.Getenv("GOMAXPROCS"), "GOTRACEBACK", os.Getenv("GOTRACEBACK"))
 
 	manager, err := createControllerManager(ctx, o)

--- a/operator/pkg/apis/operator/v1alpha1/defaults.go
+++ b/operator/pkg/apis/operator/v1alpha1/defaults.go
@@ -5,12 +5,16 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 
 	"github.com/karmada-io/karmada/operator/pkg/constants"
+	"github.com/karmada-io/karmada/pkg/version"
 )
 
 var (
+	// DefaultKarmadaImageVersion defines the default of the karmada components image tag
+	DefaultKarmadaImageVersion                string
 	etcdImageRepository                       = fmt.Sprintf("%s/%s", constants.KubeDefaultRepository, constants.Etcd)
 	karmadaAPIServiceImageRepository          = fmt.Sprintf("%s/%s", constants.KubeDefaultRepository, constants.KubeAPIServer)
 	karmadaAggregatedAPIServerImageRepository = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, constants.KarmadaAggregatedAPIServer)
@@ -21,6 +25,16 @@ var (
 	karmadaDeschedulerImageRepository         = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, constants.KarmadaDescheduler)
 	KarmadaMetricsAdapterImageRepository      = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, constants.KarmadaMetricsAdapter)
 )
+
+func init() {
+	releaseVer, err := version.ParseGitVersion(version.Get().GitVersion)
+	if err != nil {
+		klog.Infof("No default release version found. build version: %s", version.Get().String())
+		releaseVer = &version.ReleaseVersion{} // initialize to avoid panic
+	}
+	DefaultKarmadaImageVersion = releaseVer.ReleaseVersion()
+	klog.Infof("default Karmada Image Version: %s", DefaultKarmadaImageVersion)
+}
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
@@ -138,7 +152,7 @@ func setDefaultsKarmadaAggregatedAPIServer(obj *KarmadaComponents) {
 		aggregated.Image.ImageRepository = karmadaAggregatedAPIServerImageRepository
 	}
 	if len(aggregated.Image.ImageTag) == 0 {
-		aggregated.Image.ImageTag = constants.KarmadaDefaultVersion
+		aggregated.Image.ImageTag = DefaultKarmadaImageVersion
 	}
 	if aggregated.Replicas == nil {
 		aggregated.Replicas = pointer.Int32(1)
@@ -172,7 +186,7 @@ func setDefaultsKarmadaControllerManager(obj *KarmadaComponents) {
 		karmadaControllerManager.Image.ImageRepository = karmadaControllerManagerImageRepository
 	}
 	if len(karmadaControllerManager.Image.ImageTag) == 0 {
-		karmadaControllerManager.Image.ImageTag = constants.KarmadaDefaultVersion
+		karmadaControllerManager.Image.ImageTag = DefaultKarmadaImageVersion
 	}
 	if karmadaControllerManager.Replicas == nil {
 		karmadaControllerManager.Replicas = pointer.Int32(1)
@@ -189,7 +203,7 @@ func setDefaultsKarmadaScheduler(obj *KarmadaComponents) {
 		scheduler.Image.ImageRepository = karmadaSchedulerImageRepository
 	}
 	if len(scheduler.Image.ImageTag) == 0 {
-		scheduler.Image.ImageTag = constants.KarmadaDefaultVersion
+		scheduler.Image.ImageTag = DefaultKarmadaImageVersion
 	}
 	if scheduler.Replicas == nil {
 		scheduler.Replicas = pointer.Int32(1)
@@ -206,7 +220,7 @@ func setDefaultsKarmadaWebhook(obj *KarmadaComponents) {
 		webhook.Image.ImageRepository = karmadaWebhookImageRepository
 	}
 	if len(webhook.Image.ImageTag) == 0 {
-		webhook.Image.ImageTag = constants.KarmadaDefaultVersion
+		webhook.Image.ImageTag = DefaultKarmadaImageVersion
 	}
 	if webhook.Replicas == nil {
 		webhook.Replicas = pointer.Int32(1)
@@ -223,7 +237,7 @@ func setDefaultsKarmadaDescheduler(obj *KarmadaComponents) {
 		descheduler.Image.ImageRepository = karmadaDeschedulerImageRepository
 	}
 	if len(descheduler.Image.ImageTag) == 0 {
-		descheduler.Image.ImageTag = constants.KarmadaDefaultVersion
+		descheduler.Image.ImageTag = DefaultKarmadaImageVersion
 	}
 	if descheduler.Replicas == nil {
 		descheduler.Replicas = pointer.Int32(1)
@@ -240,7 +254,7 @@ func setDefaultsKarmadaMetricsAdapter(obj *KarmadaComponents) {
 		metricsAdapter.Image.ImageRepository = KarmadaMetricsAdapterImageRepository
 	}
 	if len(metricsAdapter.Image.ImageTag) == 0 {
-		metricsAdapter.Image.ImageTag = constants.KarmadaDefaultVersion
+		metricsAdapter.Image.ImageTag = DefaultKarmadaImageVersion
 	}
 
 	if metricsAdapter.Replicas == nil {

--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -14,8 +14,6 @@ const (
 	KarmadaDefaultRepository = "docker.io/karmada"
 	// EtcdDefaultVersion defines the default of the karmada etcd image tag
 	EtcdDefaultVersion = "3.5.9-0"
-	// KarmadaDefaultVersion defines the default of the karmada components image tag
-	KarmadaDefaultVersion = "v1.7.0"
 	// KubeDefaultVersion defines the default of the karmada apiserver and kubeControllerManager image tag
 	KubeDefaultVersion = "v1.25.4"
 	// KarmadaDefaultServiceSubnet defines the default of the subnet used by k8s services.

--- a/operator/pkg/init.go
+++ b/operator/pkg/init.go
@@ -230,8 +230,8 @@ func defaultJobInitOptions() *InitOptions {
 	operatorscheme.Scheme.Default(karmada)
 
 	return &InitOptions{
-		CrdRemoteURL:   fmt.Sprintf(defaultCrdURL, constants.KarmadaDefaultVersion),
-		KarmadaVersion: constants.KarmadaDefaultVersion,
+		CrdRemoteURL:   fmt.Sprintf(defaultCrdURL, operatorv1alpha1.DefaultKarmadaImageVersion),
+		KarmadaVersion: operatorv1alpha1.DefaultKarmadaImageVersion,
 		KarmadaDataDir: constants.KarmadaDataDir,
 		Karmada:        karmada,
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

operator can judge which version karmada to install by operator itself's image version, inteaed of using fixed version in constant variable. (so, we will no longger need to manually submit PR like #3718)

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

how to test it:

```bash
#!/bin/bash

kind delete clusters --all; rm -rf ~/.karmada/; rm -rf ~/.kube/*.config; rm -rf /etc/karmada
cd path/to/karmada  # clone my submited code, and cd to your karmada repo path

hack/create-cluster.sh karmada-host ~/.kube/karmada-host.config
export KUBECONFIG=~/.kube/karmada-host.config

export VERSION="latest"
export REGISTRY="docker.io/karmada"
make image-karmada-operator GOOS="linux" --directory=.

kind load docker-image docker.io/karmada/karmada-operator:latest --name karmada-host
kind load docker-image registry.k8s.io/etcd:3.5.9-0 --name karmada-host
kind load docker-image registry.k8s.io/kube-apiserver:v1.25.4 --name karmada-host
kind load docker-image registry.k8s.io/kube-controller-manager:v1.25.4 --name karmada-host

helm install karmada-operator -n karmada-system  --create-namespace --dependency-update ./charts/karmada-operator --debug

kubectl apply -f operator/config/crds/

read -s -n1 -p "Press any key to continue ... "

cat >/tmp/karmada.yaml<<EOF
apiVersion: operator.karmada.io/v1alpha1
kind: Karmada
metadata:
  name: karmada
  namespace: karmada-system
EOF
kubectl apply -f karmada.yaml
```

test report:
![image](https://github.com/karmada-io/karmada/assets/30589999/b9adbf63-5342-4a7e-94d8-cc715482478d)
![image](https://github.com/karmada-io/karmada/assets/30589999/efddfac5-d8c5-44ea-800e-0daa3de750b1)
![image](https://github.com/karmada-io/karmada/assets/30589999/4010d791-b719-4672-a740-9b6d584e5263)


**Does this PR introduce a user-facing change?**:

```release-note
`karmada-operator`: The default installed version of Karmada now depends on the operator version.
```

