### PR TITLE
fix: Sync workload's status.observedGeneration if it's updated

### DIFF
--- a/pkg/controllers/status/crb_status_controller.go
+++ b/pkg/controllers/status/crb_status_controller.go
@@ -86,6 +86,7 @@ func (c *CRBStatusController) SetupWithManager(mgr controllerruntime.Manager) er
 		})
 
 	return controllerruntime.NewControllerManagedBy(mgr).Named("clusterResourceBinding_status_controller").
+		For(&workv1alpha2.ResourceBinding{}, rbPredicateFn).
 		Watches(&workv1alpha1.Work{}, handler.EnqueueRequestsFromMapFunc(workMapFunc), workPredicateFn).
 		WithOptions(controller.Options{RateLimiter: ratelimiterflag.DefaultControllerRateLimiter(c.RateLimiterOptions)}).
 		Complete(c)

--- a/pkg/controllers/status/rb_status_controller.go
+++ b/pkg/controllers/status/rb_status_controller.go
@@ -88,6 +88,7 @@ func (c *RBStatusController) SetupWithManager(mgr controllerruntime.Manager) err
 		})
 
 	return controllerruntime.NewControllerManagedBy(mgr).Named("resourceBinding_status_controller").
+		For(&workv1alpha2.ResourceBinding{}, rbPredicateFn).
 		Watches(&workv1alpha1.Work{}, handler.EnqueueRequestsFromMapFunc(workMapFunc), workPredicateFn).
 		WithOptions(controller.Options{RateLimiter: ratelimiterflag.DefaultControllerRateLimiter(c.RateLimiterOptions)}).
 		Complete(c)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Referring to #4137
When the deployment is updated in spe, we need to trigger the status update. To resolve the inconsistent generation.

**Which issue(s) this PR fixes**:
Fixes #4137

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Fixed inconsistent generation issue between `metadata.generation` and `status.observedGeneration`.
```

