### PR TITLE
Enable unit test for operator and upload coverage to CODECOV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           # but adding a token might increase successful uploads as per:
           # https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954
           token: ${{secrets.CODECOV_UPLOAD_TOKEN}}
-          files: ./_output/coverage/coverage_pkg.txt,./_output/coverage/coverage_cmd.txt,./_output/coverage/coverage_examples.txt
+          files: ./_output/coverage/coverage_pkg.txt,./_output/coverage/coverage_cmd.txt,./_output/coverage/coverage_examples.txt,./_output/coverage/coverage_operator.txt
           flags: unittests
           fail_ci_if_error: false
           verbose: true

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ test: install_gotest
 	$(GOTEST) --race --v ./pkg/... -coverprofile=./_output/coverage/coverage_pkg.txt -covermode=atomic
 	$(GOTEST) --race --v ./cmd/... -coverprofile=./_output/coverage/coverage_cmd.txt -covermode=atomic
 	$(GOTEST) --race --v ./examples/... -coverprofile=./_output/coverage/coverage_examples.txt -covermode=atomic
+	$(GOTEST) --race --v ./operator/... -coverprofile=./_output/coverage/coverage_operator.txt -covermode=atomic
 
 upload-images: images
 	@echo "push images to $(REGISTRY)"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR enables unit tests for `karmada-operator` related functionalities, the tests under `./operator/...` will be launched by `make test` and the coverage will be uploaded to [CodeCov](https://codecov.io/gh/karmada-io/karmada) along with the others.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

I happened to see the unit test is missing when I looked at #4130 at https://github.com/karmada-io/karmada/pull/4130#discussion_r1361937835.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

