### PR TITLE
fix: cannot access ResourceRegistry with its singularName

### DIFF
--- a/pkg/registry/search/storage/resourceregistry.go
+++ b/pkg/registry/search/storage/resourceregistry.go
@@ -25,11 +25,12 @@ func NewResourceRegistryStorage(scheme *runtime.Scheme, optsGetter generic.RESTO
 	strategy := searchregistry.NewStrategy(scheme)
 
 	store := &genericregistry.Store{
-		NewFunc:                   func() runtime.Object { return &searchapis.ResourceRegistry{} },
-		NewListFunc:               func() runtime.Object { return &searchapis.ResourceRegistryList{} },
-		PredicateFunc:             searchregistry.MatchResourceRegistry,
-		DefaultQualifiedResource:  searchapis.Resource("resourceRegistries"),
-		SingularQualifiedResource: searchapis.Resource("resourceRegistry"),
+		NewFunc:       func() runtime.Object { return &searchapis.ResourceRegistry{} },
+		NewListFunc:   func() runtime.Object { return &searchapis.ResourceRegistryList{} },
+		PredicateFunc: searchregistry.MatchResourceRegistry,
+		// NOTE: plural name and singular name of the resource must be all lowercase.
+		DefaultQualifiedResource:  searchapis.Resource("resourceregistries"),
+		SingularQualifiedResource: searchapis.Resource("resourceregistry"),
 
 		CreateStrategy:      strategy,
 		UpdateStrategy:      strategy,


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Referring to #4141
we cannot access resource ```ResourceRegistry``` with its ```singularName```.

**Which issue(s) this PR fixes**:
Fixes #4141

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-search`:  fix cannot access ResourceRegistry with its singularName.
```
