### PR TITLE
ci: upload trivy scan results to GitHub Security tab

### DIFF
--- a/.github/workflows/ci-image-scanning.yaml
+++ b/.github/workflows/ci-image-scanning.yaml
@@ -33,7 +33,11 @@ jobs:
         uses: aquasecurity/trivy-action@0.12.0
         with:
           image-ref: 'docker.io/karmada/${{ matrix.target }}:latest'
-          format: 'table'
+          format: 'sarif'
           ignore-unfixed: true
           vuln-type: 'os,library'
-          exit-code: '1'
+          output: 'trivy-results.sarif'
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'          


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:
When the code is merged into the ```master``` branch, ```trivy``` will scan images for vulnerabilities. This PR uploads trivy scan results to GitHub Security tab for easy viewing and analysis.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
