### PR TITLE
Automated cherry pick of #4144: fix: cannot access ResourceRegistry with its singularName

### DIFF
--- a/pkg/registry/search/storage/resourceregistry.go
+++ b/pkg/registry/search/storage/resourceregistry.go
@@ -30,7 +30,6 @@ func NewResourceRegistryStorage(scheme *runtime.Scheme, optsGetter generic.RESTO
 		PredicateFunc: searchregistry.MatchResourceRegistry,
 		// NOTE: plural name and singular name of the resource must be all lowercase.
 		DefaultQualifiedResource:  searchapis.Resource("resourceregistries"),
-		SingularQualifiedResource: searchapis.Resource("resourceregistry"),
 
 		CreateStrategy:      strategy,
 		UpdateStrategy:      strategy,

--- a/pkg/registry/search/storage/resourceregistry.go
+++ b/pkg/registry/search/storage/resourceregistry.go
@@ -25,14 +25,17 @@ func NewResourceRegistryStorage(scheme *runtime.Scheme, optsGetter generic.RESTO
 	strategy := searchregistry.NewStrategy(scheme)
 
 	store := &genericregistry.Store{
-		NewFunc:                  func() runtime.Object { return &searchapis.ResourceRegistry{} },
-		NewListFunc:              func() runtime.Object { return &searchapis.ResourceRegistryList{} },
-		PredicateFunc:            searchregistry.MatchResourceRegistry,
-		DefaultQualifiedResource: searchapis.Resource("resourceRegistries"),
+		NewFunc:       func() runtime.Object { return &searchapis.ResourceRegistry{} },
+		NewListFunc:   func() runtime.Object { return &searchapis.ResourceRegistryList{} },
+		PredicateFunc: searchregistry.MatchResourceRegistry,
+		// NOTE: plural name and singular name of the resource must be all lowercase.
+		DefaultQualifiedResource:  searchapis.Resource("resourceregistries"),
+		SingularQualifiedResource: searchapis.Resource("resourceregistry"),
 
-		CreateStrategy: strategy,
-		UpdateStrategy: strategy,
-		DeleteStrategy: strategy,
+		CreateStrategy:      strategy,
+		UpdateStrategy:      strategy,
+		DeleteStrategy:      strategy,
+		ResetFieldsStrategy: strategy,
 
 		// TODO: define table converter that exposes more than name/creation timestamp
 		TableConvertor: rest.NewDefaultTableConvertor(searchapis.Resource("resourceRegistries")),


### PR DESCRIPTION
Cherry pick of #4144 on release-1.6.
#4144: fix: cannot access ResourceRegistry with its singularName
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-search`:  fix cannot access ResourceRegistry with its singularName.
```