### PR TITLE
Remove label of job for kubernetes 1.27

### DIFF
--- a/pkg/resourceinterpreter/default/native/prune/prune.go
+++ b/pkg/resourceinterpreter/default/native/prune/prune.go
@@ -98,9 +98,12 @@ func removeGenerateSelectorOfJob(workload *unstructured.Unstructured) error {
 		return err
 	}
 	if exist {
-		if util.GetLabelValue(matchLabels, "controller-uid") != "" {
-			delete(matchLabels, "controller-uid")
-		}
+		delete(matchLabels, "controller-uid")
+		// The label 'batch.kubernetes.io/controller-uid' was introduced at Kubernetes v1.27, which intend to replace
+		// the previous label "controller-uid"(without batch.kubernetes.io prefix).
+		// See https://github.com/kubernetes/kubernetes/pull/114930 for more details.
+		delete(matchLabels, batchv1.ControllerUidLabel)
+
 		err = unstructured.SetNestedStringMap(workload.Object, matchLabels, "spec", "selector", "matchLabels")
 		if err != nil {
 			return err
@@ -112,13 +115,13 @@ func removeGenerateSelectorOfJob(workload *unstructured.Unstructured) error {
 		return err
 	}
 	if exist {
-		if util.GetLabelValue(templateLabels, "controller-uid") != "" {
-			delete(templateLabels, "controller-uid")
-		}
-
-		if util.GetLabelValue(templateLabels, "job-name") != "" {
-			delete(templateLabels, "job-name")
-		}
+		delete(templateLabels, "controller-uid")
+		delete(templateLabels, "job-name")
+		// The label 'batch.kubernetes.io/controller-uid' and 'batch.kubernetes.io/job-name' were introduced at
+		// Kubernetes v1.27, which intend to replace the previous labels 'controller-uid' and 'job-name' respectively.
+		// See https://github.com/kubernetes/kubernetes/pull/114930 for more details.
+		delete(templateLabels, batchv1.ControllerUidLabel)
+		delete(templateLabels, batchv1.JobNameLabel)
 
 		err = unstructured.SetNestedStringMap(workload.Object, templateLabels, "spec", "template", "metadata", "labels")
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind cleanup

**What this PR does / why we need it**:
Since kubernetes 1.27,  `batch.kubernetes.io/job-name` and `batch.kubernetes.io/controller-uid` labels are added for job pods. It's add the prefix of `batch.kubernetes.io` for label.

This PR will resolve the problem of https://github.com/karmada-io/karmada/pull/4108#issuecomment-1752688150

And Aggregated Status of RB:

```yaml
Status:
  Aggregated Status:
    Applied Message:  Failed to apply all manifests (0/1): Job.batch "tools-n25m5" is invalid: [spec.template.metadata.labels[batch.kubernetes.io/controller-uid]: Invalid value: map[string]string{"app":"tools", "batch.kubernetes.io/controller-uid":"0325fbba-6129-43e9-89f4-c363d580dc76", "batch.kubernetes.io/job-name":"tools-n25m5", "controller-uid":"7a4480b7-66cf-42f4-8f94-0b83f66da3c3", "job-name":"tools-n25m5"}: must be '7a4480b7-66cf-42f4-8f94-0b83f66da3c3', spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"batch.kubernetes.io/controller-uid":"0325fbba-6129-43e9-89f4-c363d580dc76"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: `selector` not auto-generated]
```

So karmada need to remove label for prefix with batch.kubernetes.io.

**Which issue(s) this PR fixes**:
Fixes #

Related:
- https://github.com/karmada-io/karmada/pull/4108
- https://github.com/kubernetes/kubernetes/pull/114930

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Prune job label for kubernetes 1.27,prefix with `batch.kubernetes.io/`
```

