### PR TITLE
Revert "fix: cannot access ResourceRegistry with its singularName"

### DIFF
--- a/pkg/registry/search/storage/resourceregistry.go
+++ b/pkg/registry/search/storage/resourceregistry.go
@@ -25,11 +25,10 @@ func NewResourceRegistryStorage(scheme *runtime.Scheme, optsGetter generic.RESTO
 	strategy := searchregistry.NewStrategy(scheme)
 
 	store := &genericregistry.Store{
-		NewFunc:       func() runtime.Object { return &searchapis.ResourceRegistry{} },
-		NewListFunc:   func() runtime.Object { return &searchapis.ResourceRegistryList{} },
-		PredicateFunc: searchregistry.MatchResourceRegistry,
-		// NOTE: plural name and singular name of the resource must be all lowercase.
-		DefaultQualifiedResource: searchapis.Resource("resourceregistries"),
+		NewFunc:                  func() runtime.Object { return &searchapis.ResourceRegistry{} },
+		NewListFunc:              func() runtime.Object { return &searchapis.ResourceRegistryList{} },
+		PredicateFunc:            searchregistry.MatchResourceRegistry,
+		DefaultQualifiedResource: searchapis.Resource("resourceRegistries"),
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,


### PR DESCRIPTION
This reverts commit fab54b30c1a9b64f4ebaeebf67b9fe3aef85ae03.

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Revert "fix: cannot access ResourceRegistry with its singularName". Branch release-1.5 itself does not have the problem described in issue #4141, and changing ```DefaultQualifiedResource: searchapis.Resource("resourceRegistries")``` to ```DefaultQualifiedResource: searchapis.Resource("resourceregistries")``` will cause incompatibility in the upgrade scenario.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
none
```

