### PR TITLE
Revert "fix: cannot access ResourceRegistry with its singularName"

### DIFF
--- a/pkg/registry/search/storage/resourceregistry.go
+++ b/pkg/registry/search/storage/resourceregistry.go
@@ -25,12 +25,11 @@ func NewResourceRegistryStorage(scheme *runtime.Scheme, optsGetter generic.RESTO
 	strategy := searchregistry.NewStrategy(scheme)
 
 	store := &genericregistry.Store{
-		NewFunc:       func() runtime.Object { return &searchapis.ResourceRegistry{} },
-		NewListFunc:   func() runtime.Object { return &searchapis.ResourceRegistryList{} },
-		PredicateFunc: searchregistry.MatchResourceRegistry,
-		// NOTE: plural name and singular name of the resource must be all lowercase.
-		DefaultQualifiedResource:  searchapis.Resource("resourceregistries"),
-		SingularQualifiedResource: searchapis.Resource("resourceregistry"),
+		NewFunc:                   func() runtime.Object { return &searchapis.ResourceRegistry{} },
+		NewListFunc:               func() runtime.Object { return &searchapis.ResourceRegistryList{} },
+		PredicateFunc:             searchregistry.MatchResourceRegistry,
+		DefaultQualifiedResource:  searchapis.Resource("resourceRegistries"),
+		SingularQualifiedResource: searchapis.Resource("resourceRegistry"),
 
 		CreateStrategy:      strategy,
 		UpdateStrategy:      strategy,


### PR DESCRIPTION
This reverts commit 57e972a9857adfc6495b3d2001fb8b76b4157a47.

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Revert "fix: cannot access ResourceRegistry with its singularName". Changing ```SingularQualifiedResource: searchapis.Resource("resourceRegistry")``` to ```SingularQualifiedResource: searchapis.Resource("resourceregistry")```  can indeed solve the problem mentioned in issue #4141, but changing ```DefaultQualifiedResource: searchapis.Resource("resourceRegistries")``` to ```DefaultQualifiedResource: searchapis.Resource("resourceregistries")``` will cause incompatibility in the upgrade scenario. The root cause has yet to be determined, so please roll back the PR first， and I will make modifications after I find the root cause. Thx!

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
none
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
none
```

