### PR TITLE
ci: fix uploading chart assests multiple times

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,6 @@ jobs:
         files: |
           _output/release/${{ matrix.target }}-${{ matrix.os }}-${{ matrix.arch }}.tgz
           _output/release/${{ matrix.target }}-${{ matrix.os }}-${{ matrix.arch }}.tgz.sha256
-          _output/charts/karmada-chart-${{ github.ref_name }}.tgz
-          _output/charts/karmada-chart-${{ github.ref_name }}.tgz.sha256
   release-crds-assests:
     name: release crds
     runs-on: ubuntu-22.04
@@ -62,6 +60,22 @@ jobs:
       with:
         files: |
           crds.tar.gz
+  release-charts:
+    name: Release charts
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Making helm charts
+      env:
+        VERSION: ${{ github.ref_name }}
+      run: make package-chart
+    - name: Uploading assets...
+      if: ${{ !env.ACT }}
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          _output/charts/karmada-chart-${{ github.ref_name }}.tgz
+          _output/charts/karmada-chart-${{ github.ref_name }}.tgz.sha256
   update-krew-index:
     needs: release-assests
     name: Update krew-index


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
With the old workflow, it will generate the charts multiple times: https://github.com/karmada-io/karmada/actions/runs/6621950672/job/17987099745
![image](https://github.com/karmada-io/karmada/assets/19745536/d439df5c-dd6d-4a60-aa9b-95c6e9e5f03c)

Which is not necessary. So let's change it and only generate it one time and upload it.

**Which issue(s) this PR fixes**:
Fixes #none

**Special notes for your reviewer**:

Test result: https://github.com/jwcesign/karmada/actions/runs/6626074810/job/17998272299

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

