### PR TITLE
fix: resourceregistry is incompatible in the upgrade scenario

### DIFF
--- a/pkg/registry/search/storage/resourceregistry.go
+++ b/pkg/registry/search/storage/resourceregistry.go
@@ -25,11 +25,11 @@ func NewResourceRegistryStorage(scheme *runtime.Scheme, optsGetter generic.RESTO
 	strategy := searchregistry.NewStrategy(scheme)
 
 	store := &genericregistry.Store{
-		NewFunc:       func() runtime.Object { return &searchapis.ResourceRegistry{} },
-		NewListFunc:   func() runtime.Object { return &searchapis.ResourceRegistryList{} },
-		PredicateFunc: searchregistry.MatchResourceRegistry,
-		// NOTE: plural name and singular name of the resource must be all lowercase.
-		DefaultQualifiedResource:  searchapis.Resource("resourceregistries"),
+		NewFunc:                  func() runtime.Object { return &searchapis.ResourceRegistry{} },
+		NewListFunc:              func() runtime.Object { return &searchapis.ResourceRegistryList{} },
+		PredicateFunc:            searchregistry.MatchResourceRegistry,
+		DefaultQualifiedResource: searchapis.Resource("resourceRegistries"),
+		// NOTE: singular name of the resource must be all lowercase.
 		SingularQualifiedResource: searchapis.Resource("resourceregistry"),
 
 		CreateStrategy:      strategy,


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Referring to #4144, there is a problem in the upgrade scenario of resource ```resourceregistry```.  We need to solve it, otherwise the relevant data will be lost after the upgrade.

**Which issue(s) this PR fixes**:
Refer to #4141

**Special notes for your reviewer**:
none
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

