### PR TITLE
ci: image-scanning increases results display

### DIFF
--- a/.github/workflows/ci-image-scanning.yaml
+++ b/.github/workflows/ci-image-scanning.yaml
@@ -23,7 +23,7 @@ jobs:
           - karmada-metrics-adapter
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build an image from Dockerfile
         run: |
           export VERSION="latest"
@@ -37,6 +37,13 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           output: 'trivy-results.sarif'
+      - name: display scan results
+        uses: aquasecurity/trivy-action@0.12.0
+        with:
+          image-ref: 'docker.io/karmada/${{ matrix.target }}:latest'
+          format: 'table'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         with:


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Previously, the results of the image scan were uploaded to ```security tab```, and only those with write permissions to this repo could see it. Now, the image-scanning results will be displayed in the new workflow, and anyone with read permissions can see it.
![image](https://github.com/karmada-io/karmada/assets/81208264/f8e4c5b2-ffc3-4ae9-a42d-007b5348670f)

**Which issue(s) this PR fixes**:
Fixes #none

**Special notes for your reviewer**:
Test result: https://github.com/zhzhuang-zju/karmada/actions/runs/6637457822
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

