### PR TITLE
helm: index 1.7.1

### DIFF
--- a/charts/index.yaml
+++ b/charts/index.yaml
@@ -3,6 +3,28 @@ entries:
   karmada:
   - apiVersion: v2
     appVersion: v1.1.0
+    created: "2023-10-25T16:55:42.896904-04:00"
+    dependencies:
+    - name: common
+      repository: https://charts.bitnami.com/bitnami
+      version: 1.x.x
+    description: A Helm chart for karmada
+    digest: cd63fc86a70a5c288d1e41204adef4774faabf99539fbab08d761842ca9092af
+    kubeVersion: '>= 1.16.0-0'
+    maintainers:
+    - email: jrkeen@hotmail.com
+      name: jrkeen
+    - email: jackson.cloudnative@gmail.com
+      name: pidb
+    - email: shentiecheng@huawei.com
+      name: Poor12
+    name: karmada
+    type: application
+    urls:
+    - https://github.com/karmada-io/karmada/releases/download/v1.7.1/karmada-chart-v1.7.1.tgz
+    version: v1.7.1
+  - apiVersion: v2
+    appVersion: v1.1.0
     created: "2023-09-14T18:29:27.744549-04:00"
     dependencies:
     - name: common
@@ -175,4 +197,4 @@ entries:
     urls:
     - https://github.com/karmada-io/karmada/releases/download/v1.2.0/karmada-chart-v1.2.0.tgz
     version: v1.2.0
-generated: "2023-09-14T18:29:27.739005-04:00"
+generated: "2023-10-25T16:55:42.883421-04:00"


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature

**What this PR does / why we need it**:
publishes 1.7.1 helm release

I am able to pull 1.7.1
```

Error: accumulating resources: accumulation err='accumulating resources from '../base/': '/Users/amir.alavi/workspace/k8s-clusterset/kustomize/base' must resolve to a file': recursed accumulation of path '/Users/amir.alavi/workspace/k8s-clusterset/kustomize/base': Error: chart "karmada" version "v1.7.1" not found in https://raw.githubusercontent.com/karmada-io/karmada/master/charts repository
: unable to run: ...
```

**Which issue(s) this PR fixes**:
Follow up to https://github.com/karmada-io/karmada/releases/tag/v1.7.1

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`Helm chart`: Added helm index for 1.7.1 release.
```

