### PR TITLE
set MinVersion to VersionTLS13 for tlsconfig in karmada-aggregated-apiserver

### DIFF
--- a/pkg/util/proxy/proxy.go
+++ b/pkg/util/proxy/proxy.go
@@ -76,7 +76,10 @@ func newProxyHandler(location *url.URL, proxyTransport http.RoundTripper, cluste
 		location.RawQuery = req.URL.RawQuery
 
 		upgradeDialer := NewUpgradeDialerWithConfig(UpgradeDialerWithConfig{
-			TLS:        &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			TLS: &tls.Config{
+				InsecureSkipVerify: true, //nolint:gosec
+				MinVersion:         tls.VersionTLS13,
+			},
 			Proxier:    http.ProxyURL(proxyURL),
 			PingPeriod: time.Second * 5,
 			Header:     ParseProxyHeaders(cluster.Spec.ProxyHeader),
@@ -124,7 +127,10 @@ func constructLocation(cluster *clusterapis.Cluster) (*url.URL, error) {
 
 func createProxyTransport(cluster *clusterapis.Cluster) (*http.Transport, error) {
 	var proxyDialerFn utilnet.DialFunc
-	proxyTLSClientConfig := &tls.Config{InsecureSkipVerify: true} // #nosec
+	proxyTLSClientConfig := &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec
+		MinVersion:         tls.VersionTLS13,
+	}
 	trans := utilnet.SetTransportDefaults(&http.Transport{
 		DialContext:     proxyDialerFn,
 		TLSClientConfig: proxyTLSClientConfig,


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Set MinVersion to `VersionTLS13` for tlsconfig in karmada-aggregated-apiserver, ensure that a secure encryption algorithm is used for communication with the kube-apiserver in the member cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

