### PR TITLE
feat: Add ca to check the validation of the member clusters' server certificate

### DIFF
--- a/pkg/registry/cluster/storage/proxy_test.go
+++ b/pkg/registry/cluster/storage/proxy_test.go
@@ -62,8 +62,9 @@ func TestProxyREST_Connect(t *testing.T) {
 					return &clusterapis.Cluster{
 						ObjectMeta: metav1.ObjectMeta{Name: name},
 						Spec: clusterapis.ClusterSpec{
-							APIEndpoint:           s.URL,
-							ImpersonatorSecretRef: &clusterapis.LocalSecretReference{Namespace: "ns", Name: "secret"},
+							APIEndpoint:                 s.URL,
+							ImpersonatorSecretRef:       &clusterapis.LocalSecretReference{Namespace: "ns", Name: "secret"},
+							InsecureSkipTLSVerification: true,
 						},
 					}, nil
 				},
@@ -109,8 +110,9 @@ func TestProxyREST_Connect(t *testing.T) {
 					return &clusterapis.Cluster{
 						ObjectMeta: metav1.ObjectMeta{Name: name},
 						Spec: clusterapis.ClusterSpec{
-							APIEndpoint:           s.URL,
-							ImpersonatorSecretRef: &clusterapis.LocalSecretReference{Namespace: "ns", Name: "secret"},
+							APIEndpoint:                 s.URL,
+							ImpersonatorSecretRef:       &clusterapis.LocalSecretReference{Namespace: "ns", Name: "secret"},
+							InsecureSkipTLSVerification: true,
 						},
 					}, nil
 				},
@@ -134,8 +136,9 @@ func TestProxyREST_Connect(t *testing.T) {
 					return &clusterapis.Cluster{
 						ObjectMeta: metav1.ObjectMeta{Name: name},
 						Spec: clusterapis.ClusterSpec{
-							APIEndpoint:           s.URL,
-							ImpersonatorSecretRef: &clusterapis.LocalSecretReference{Namespace: "ns", Name: "secret"},
+							APIEndpoint:                 s.URL,
+							ImpersonatorSecretRef:       &clusterapis.LocalSecretReference{Namespace: "ns", Name: "secret"},
+							InsecureSkipTLSVerification: true,
 						},
 					}, nil
 				},

--- a/pkg/util/proxy/proxy_test.go
+++ b/pkg/util/proxy/proxy_test.go
@@ -167,8 +167,9 @@ func TestConnectCluster(t *testing.T) {
 				cluster: &clusterapis.Cluster{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cluster"},
 					Spec: clusterapis.ClusterSpec{
-						APIEndpoint:           s.URL,
-						ImpersonatorSecretRef: &clusterapis.LocalSecretReference{Namespace: "ns", Name: "secret"},
+						APIEndpoint:                 s.URL,
+						ImpersonatorSecretRef:       &clusterapis.LocalSecretReference{Namespace: "ns", Name: "secret"},
+						InsecureSkipTLSVerification: true,
 					},
 				},
 				secretGetter: func(_ context.Context, ns string, name string) (*corev1.Secret, error) {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:


**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/karmada/issues/4182

**Special notes for your reviewer**:
If I change the following line to false:
https://github.com/karmada-io/karmada/blob/3267155766f69083d211c4bc804e8bda4b18fd4d/pkg/util/proxy/proxy.go#L79

It will have the following error in `karmada-aggregated-apiserver`:
![01d9281bfb18dfd30d78ab197884c43](https://github.com/karmada-io/karmada/assets/19745536/f490b40d-a48a-47db-8bcc-c17ad196fe14)

And karmadactl couldn't list the pods in member clusters:
![d2a7ad79b3a939f7263191265be2176](https://github.com/karmada-io/karmada/assets/19745536/fa1ccbbb-ff3e-4f99-ac04-afc88c132593)

With this PR, everything works fine

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-aggregated-apiserver`: Add ca to check the validation of the member clusters' server certificate.
```

