### PR TITLE
fix: helm podDisruptionBudget for controller-manager

### DIFF
--- a/charts/karmada/templates/karmada-controller-manager.yaml
+++ b/charts/karmada/templates/karmada-controller-manager.yaml
@@ -92,5 +92,4 @@ spec:
   {{ toYaml .Values.controllerManager.podDisruptionBudget | nindent 2 }}
 {{- end -}}
 
----
 {{- end }}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

before
```
---
# Source: karmada/templates/karmada-controller-manager.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: karmada-controller-manager
  namespace: karmada-system
  labels:

    app: karmada-controller-manager
spec:
  selector:
    matchLabels:

      app: karmada-controller-manager

  maxUnavailable: 20%---  # <--- this is the issue
---
```

after:
```yaml
---
# Source: karmada/templates/karmada-controller-manager.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: karmada-controller-manager
  namespace: karmada-system
  labels:

    app: karmada-controller-manager
spec:
  selector:
    matchLabels:

      app: karmada-controller-manager

  maxUnavailable: 20%
---
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
fixed helm render of podDisruptionBudget in controller-manager
```

