### PR TITLE
set MinVersion to VersionTLS13 for tlsconfig in karmada-search and karmada-metrics-adapter

### DIFF
--- a/pkg/karmadactl/addons/metricsadapter/manifests.go
+++ b/pkg/karmadactl/addons/metricsadapter/manifests.go
@@ -43,6 +43,7 @@ spec:
             - --audit-log-path=-
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
+            - --tls-min-version=VersionTLS13
           readinessProbe:
             httpGet:
               path: /readyz

--- a/pkg/karmadactl/addons/search/manifests.go
+++ b/pkg/karmadactl/addons/search/manifests.go
@@ -45,6 +45,7 @@ spec:
             - --etcd-keyfile=/etc/karmada/pki/etcd-client.key
             - --tls-cert-file=/etc/karmada/pki/karmada.crt
             - --tls-private-key-file=/etc/karmada/pki/karmada.key
+            - --tls-min-version=VersionTLS13
             - --audit-log-path=-
             - --feature-gates=APIPriorityAndFairness=false
             - --audit-log-maxage=0


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

https://github.com/karmada-io/karmada/issues/4191

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: The `karmada-search` and `karmada-metrics-adapter` installed by the `addon` command will take `--tls-min-version=VersionTLS13` by default.
```

