### PR TITLE
Update chart-testing-action to v2.6.0 and cosigin-installer to v3.1.1

### DIFF
--- a/.github/workflows/dockerhub-latest-image.yml
+++ b/.github/workflows/dockerhub-latest-image.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           go-version: 1.20.10
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.0.3
+        uses: sigstore/cosign-installer@v3.1.1
         with:
           cosign-release: 'v1.13.1'
       - name: install QEMU

--- a/.github/workflows/dockerhub-released-image.yml
+++ b/.github/workflows/dockerhub-released-image.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           go-version: 1.20.10
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.0.3
+        uses: sigstore/cosign-installer@v3.1.1
         with:
           cosign-release: 'v1.13.1'
       - name: install QEMU

--- a/.github/workflows/lint-chart.yaml
+++ b/.github/workflows/lint-chart.yaml
@@ -44,7 +44,7 @@ jobs:
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
 
       - name: Add dependency chart repos
         run: |


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

helm chart testing action is broken, https://github.com/karmada-io/karmada/actions/runs/6706548301/job/18223260799

xref: 
- https://github.com/helm/chart-testing-action/issues/132
- https://github.com/helm/chart-testing-action/issues/133

I have try to update to v2.5.0 and it's not working. https://github.com/liangyuanpeng/karmada/actions/runs/6714930957 

And v2.6.0 can fix it.

Since we are using cosign separately, it is better to follow the notification to upgrade the installer version.

So this PR have two change:
- Update chart-testing-action to v2.6.0
- Update cosigin-installer to v3.1.1   see https://blog.sigstore.dev/cosign-releases-bucket-deprecation/


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

