### PR TITLE
publish karmada operator helm chart archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,8 @@ jobs:
         files: |
           _output/charts/karmada-chart-${{ github.ref_name }}.tgz
           _output/charts/karmada-chart-${{ github.ref_name }}.tgz.sha256
+          _output/charts/karmada-operator-chart-${{ github.ref_name }}.tgz
+          _output/charts/karmada-operator-chart-${{ github.ref_name }}.tgz.sha256
   update-krew-index:
     needs: release-assests
     name: Update krew-index


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
This PR adds the operator helm chart artifacts to the release, so in a future PR the charts/index.yaml file can be updated to point to these artifacts. Users will then be able to pull the operator chart. This follows the same flow as the existing karmada helm chart.

Currently, the release workflow only pushes the chart to the docker registry, but it utilizes the same name and tag as the image artifact, which results in [this error](https://github.com/helm/helm/issues/10968)

**Which issue(s) this PR fixes**:
no existing issue to reference

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

