### PR TITLE
fix karmada instance aggregated service externalName error

### DIFF
--- a/operator/pkg/karmadaresource/apiservice/manifest.go
+++ b/operator/pkg/karmadaresource/apiservice/manifest.go
@@ -30,7 +30,7 @@ metadata:
   namespace: {{ .Namespace }}
 spec:
   type: ExternalName
-  externalName: {{ .ServiceName }}.{{ .Namespace }}.svc
+  externalName: {{ .HostClusterServiceName }}.{{ .HostClusterNamespace }}.svc
 `
 
 	// KarmadaMetricsAdapterAPIService is karmada-metrics-adapter APIService manifest
@@ -59,6 +59,6 @@ metadata:
   namespace: {{ .Namespace }}
 spec:
   type: ExternalName
-  externalName: {{ .ServiceName }}.{{ .Namespace }}.svc
+  externalName: {{ .HostClusterServiceName }}.{{ .HostClusterNamespace }}.svc
 `
 )

--- a/operator/pkg/tasks/init/component.go
+++ b/operator/pkg/tasks/init/component.go
@@ -192,7 +192,7 @@ func runDeployMetricAdapterAPIService(r workflow.RunData) error {
 	}
 	caBase64 := base64.StdEncoding.EncodeToString(cert.CertData())
 
-	err = apiservice.EnsureMetricsAdapterAPIService(client, data.KarmadaClient(), data.GetName(), data.GetNamespace(), caBase64)
+	err = apiservice.EnsureMetricsAdapterAPIService(client, data.KarmadaClient(), data.GetName(), constants.KarmadaSystemNamespace, data.GetName(), data.GetNamespace(), caBase64)
 	if err != nil {
 		return fmt.Errorf("failed to apply karmada-metrics-adapter APIService resource to karmada controlplane, err: %w", err)
 	}

--- a/operator/pkg/tasks/init/karmadaresource.go
+++ b/operator/pkg/tasks/init/karmadaresource.go
@@ -191,7 +191,7 @@ func runAPIService(r workflow.RunData) error {
 	}
 	caBase64 := base64.StdEncoding.EncodeToString(cert.CertData())
 
-	err = apiservice.EnsureAggregatedAPIService(client, data.KarmadaClient(), data.GetName(), data.GetNamespace(), caBase64)
+	err = apiservice.EnsureAggregatedAPIService(client, data.KarmadaClient(), data.GetName(), constants.KarmadaSystemNamespace, data.GetName(), data.GetNamespace(), caBase64)
 	if err != nil {
 		return fmt.Errorf("failed to apply aggregated APIService resource to karmada controlplane, err: %w", err)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

fix the latest Karmada-operator cannot install karmada instance

**Which issue(s) this PR fixes**:
Fixes #4209

Two bugs fixed in this pr

1. Karmada instance Aggregated service is installed on the correct namespace karmada-system
2. Fix karmada instance Aggregated service externalName to the correct value, which should be the service corresponding to karmada control plane

the example instance yaml
```yaml
kubectl apply -f - <<EOF
apiVersion: operator.karmada.io/v1alpha1
kind: Karmada
metadata:
  name: karmada-demo
  namespace: test
EOF
```
the results
```bash
➜  karmada git:(master) ✗ kubectl get po -n test
NAME                                                    READY   STATUS    RESTARTS   AGE
karmada-demo-aggregated-apiserver-7bf4c5458f-zv4pz      1/1     Running   0          2m20s
karmada-demo-apiserver-65794cbd78-hmx99                 1/1     Running   0          2m41s
karmada-demo-controller-manager-69dbbcc866-nzxw6        1/1     Running   0          2m16s
karmada-demo-etcd-0                                     1/1     Running   0          2m43s
karmada-demo-kube-controller-manager-6949485b85-6d9mt   1/1     Running   0          2m16s
karmada-demo-metrics-adapter-68b67644dc-b7fmh           1/1     Running   0          2m16s
karmada-demo-metrics-adapter-68b67644dc-v9k5k           1/1     Running   0          2m16s
karmada-demo-scheduler-847795db5c-9thjs                 1/1     Running   0          2m16s
karmada-demo-webhook-766df78896-ccwkl                   1/1     Running   0          2m16s

➜  karmada git:(master) ✗ kubectl -n test  get karmada karmada-demo -o yaml | grep -C 10 'conditions'
      resources: {}
    kubeControllerManager:
      imageRepository: registry.k8s.io/kube-controller-manager
      imageTag: v1.25.4
      replicas: 1
      resources: {}
  hostCluster:
    networking:
      dnsDomain: cluster.local
status:
  conditions:
  - lastTransitionTime: "2023-11-06T11:40:52Z"
    message: karmada init job is completed
    reason: Completed
    status: "True"
    type: Ready
  secretRef:
    name: karmada-demo-admin-config
    namespace: test
```

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-operator`: Fix karmada instance aggregated service externalName and namespace error.
```

