### PR TITLE
fix libprotoc version validation error

### DIFF
--- a/hack/update-estimator-protobuf.sh
+++ b/hack/update-estimator-protobuf.sh
@@ -17,7 +17,7 @@ GO111MODULE=on go install github.com/gogo/protobuf/protoc-gen-gogo
 GO111MODULE=on go install github.com/vektra/mockery/v2
 
 #ref https://github.com/kubernetes/kubernetes/blob/master/hack/update-generated-protobuf-dockerized.sh
-if [[ -z "$(which protoc)" || "$(protoc --version)" != "libprotoc 3."* ]]; then
+if [[ -z "$(which protoc)" || $(protoc --version | sed -r "s/libprotoc ([0-9]+).*/\1/g") -lt 3 ]]; then
   echo "Generating protobuf requires protoc 3.0.0-beta1 or newer. Please download and"
   echo "install the platform appropriate Protobuf package for your OS: "
   echo


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

latest protoc version：

```bash
$ protoc --version
libprotoc 25.0
```

but we validate protoc version as:

```shell
if [[ -z "$(which protoc)" || "$(protoc --version)" != "libprotoc 3."* ]]; then
```

actually `libprotoc 25.0` is ok, so we should adjust validation as

```shell
if [[ -z "$(which protoc)" || $(protoc --version | sed -r "s/libprotoc ([0-9]+).*/\1/g") -lt 3 ]]; then
```

> if protoc not exist or its version lower than 3.x.x, we report error


**Which issue(s) this PR fixes**:
Fixes #4213

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
none
```

