### PR TITLE
add cluster flags for karmadactl top pod

### DIFF
--- a/pkg/karmadactl/get/get.go
+++ b/pkg/karmadactl/get/get.go
@@ -254,20 +254,7 @@ func (g *CommandGetOptions) Validate(cmd *cobra.Command) error {
 		if err != nil {
 			return err
 		}
-		clusterSet := sets.NewString()
-		for _, cluster := range clusters.Items {
-			clusterSet.Insert(cluster.Name)
-		}
-
-		var noneExistClusters []string
-		for _, cluster := range g.Clusters {
-			if !clusterSet.Has(cluster) {
-				noneExistClusters = append(noneExistClusters, cluster)
-			}
-		}
-		if len(noneExistClusters) != 0 {
-			return fmt.Errorf("clusters don't exist: " + strings.Join(noneExistClusters, ","))
-		}
+		return util.VerifyClustersExist(g.Clusters, clusters)
 	}
 	return nil
 }

--- a/pkg/karmadactl/top/top.go
+++ b/pkg/karmadactl/top/top.go
@@ -1,12 +1,20 @@
 package top
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/templates"
 	metricsapi "k8s.io/metrics/pkg/apis/metrics"
+	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
+
+	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
+	"github.com/karmada-io/karmada/pkg/karmadactl/util"
 )
 
 const (
@@ -27,7 +35,7 @@ var (
 		Metrics Server to be correctly configured and working on the member clusters.`)
 )
 
-func NewCmdTop(f cmdutil.Factory, parentCommand string, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdTop(f util.Factory, parentCommand string, streams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "top",
 		Short: "Display resource (CPU/memory) usage of member clusters",
@@ -55,4 +63,55 @@ func SupportedMetricsAPIVersionAvailable(discoveredAPIGroups *metav1.APIGroupLis
 		}
 	}
 	return false
+}
+
+func GenClusterList(clientSet karmadaclientset.Interface, clusters []string) ([]string, error) {
+	if len(clusters) != 0 {
+		return clusters, nil
+	}
+
+	clusterList, err := clientSet.ClusterV1alpha1().Clusters().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list all member clusters in control plane, err: %w", err)
+	}
+
+	for i := range clusterList.Items {
+		clusters = append(clusters, clusterList.Items[i].Name)
+	}
+	return clusters, nil
+}
+
+func GetMemberAndMetricsClientSet(f util.Factory,
+	cluster string, useProtocolBuffers bool) (*kubernetes.Clientset, *metricsclientset.Clientset, error) {
+	memberFactory, err := f.FactoryForMemberCluster(cluster)
+	if err != nil {
+		return nil, nil, err
+	}
+	clientset, err := memberFactory.KubernetesClientSet()
+	if err != nil {
+		return nil, nil, err
+	}
+	discoveryClient := clientset.DiscoveryClient
+	apiGroups, err := discoveryClient.ServerGroups()
+	if err != nil {
+		return nil, nil, err
+	}
+	metricsAPIAvailable := SupportedMetricsAPIVersionAvailable(apiGroups)
+	if !metricsAPIAvailable {
+		return nil, nil, fmt.Errorf("Metrics API not available")
+	}
+
+	config, err := memberFactory.ToRESTConfig()
+	if err != nil {
+		return nil, nil, err
+	}
+	if useProtocolBuffers {
+		config.ContentType = "application/vnd.kubernetes.protobuf"
+	}
+	metricsClient, err := metricsclientset.NewForConfig(config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return clientset, metricsClient, nil
 }

--- a/pkg/karmadactl/util/validate.go
+++ b/pkg/karmadactl/util/validate.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+)
+
+func VerifyClustersExist(input []string, clusters *clusterv1alpha1.ClusterList) error {
+	clusterSet := sets.NewString()
+	for _, cluster := range clusters.Items {
+		clusterSet.Insert(cluster.Name)
+	}
+
+	var nonExistClusters []string
+	for _, cluster := range input {
+		if !clusterSet.Has(cluster) {
+			nonExistClusters = append(nonExistClusters, cluster)
+		}
+	}
+	if len(nonExistClusters) != 0 {
+		return fmt.Errorf("clusters don't exist: " + strings.Join(nonExistClusters, ","))
+	}
+
+	return nil
+}

--- a/pkg/karmadactl/util/validate_test.go
+++ b/pkg/karmadactl/util/validate_test.go
@@ -1,0 +1,72 @@
+package util
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+)
+
+func TestVerifyWhetherClustersExist(t *testing.T) {
+	clusters := clusterv1alpha1.ClusterList{Items: []clusterv1alpha1.Cluster{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "member1"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "member2"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "member3"},
+		},
+	}}
+	tests := []struct {
+		name     string
+		input    []string
+		clusters *clusterv1alpha1.ClusterList
+		wantErr  error
+	}{
+		{
+			name:     "input is nil",
+			input:    nil,
+			clusters: &clusters,
+			wantErr:  nil,
+		},
+		{
+			name:     "not exist",
+			input:    []string{"member1", "member4"},
+			clusters: &clusters,
+			wantErr:  fmt.Errorf("clusters don't exist: member4"),
+		},
+		{
+			name:     "exist",
+			input:    []string{"member1"},
+			clusters: &clusters,
+			wantErr:  nil,
+		},
+		{
+			name:     "clusterList is empty",
+			input:    []string{"member1", "member2"},
+			clusters: &clusterv1alpha1.ClusterList{Items: make([]clusterv1alpha1.Cluster, 0)},
+			wantErr:  fmt.Errorf("clusters don't exist: member1,member2"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if isExist := VerifyClustersExist(tt.input, tt.clusters); !isErrorEqual(tt.wantErr, isExist) {
+				t.Errorf("VerifyClustersExist want: %v, actually: %v", tt.wantErr, isExist)
+			}
+		})
+	}
+}
+
+func isErrorEqual(want error, actual error) bool {
+	if want == nil && actual == nil {
+		return true
+	}
+	if want != nil && actual != nil && want.Error() == actual.Error() {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
add cluster flags for karmadactl top pod

**Which issue(s) this PR fixes**:
Fixes #4217 

**Special notes for your reviewer**:
Extracted some public methods for subsequent implementation of the ```top node``` command

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Add cluster flags to query the resource status of the cluster pod. Like
➜  karmada git:(top) ✗ karmadactl top po  -Cmember1
NAME         CLUSTER   CPU(cores)   MEMORY(bytes)   
mycurlpods   member1   0m           1Mi 
```

