### PR TITLE
Restrict “configmap/extension-apiserver-authentication” object from being distributed to member clusters

### DIFF
--- a/pkg/detector/detector_test.go
+++ b/pkg/detector/detector_test.go
@@ -125,3 +125,20 @@ func BenchmarkEventFilterMultiSkipNameSpaces(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkEventFilterExtensionApiserverAuthentication(b *testing.B) {
+	dt := &ResourceDetector{}
+	dt.SkippedPropagatingNamespaces = append(dt.SkippedPropagatingNamespaces, regexp.MustCompile("^kube-.*$"))
+	for i := 0; i < b.N; i++ {
+		dt.EventFilter(&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name":      "extension-apiserver-authentication",
+					"namespace": "kube-system",
+				},
+			},
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
While implementing Karmada to support the distribution of resources under the "kube-system" namespace, the "configmap/extension-apiserver-authentication" object created by kube-apiserver should not be distributed to member clusters.
**Which issue(s) this PR fixes**:
Fixes #4228

**Special notes for your reviewer**:
NONE
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Ignored `configmap/extension-apiserver-authentication` from propagation.
```

