### PR TITLE
fix test env timeout of APIServer compatibility

### DIFF
--- a/.github/workflows/ci-schedule-compatibility.yaml
+++ b/.github/workflows/ci-schedule-compatibility.yaml
@@ -11,6 +11,7 @@ jobs:
     if: ${{ github.repository == 'karmada-io/karmada' }}
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         kubeapiserver-version: [ v1.21.10, v1.22.7, v1.23.4, v1.24.2, v1.25.0, v1.26.0, v1.27.3, v1.28.0 ]
         karmada-version: [ release-1.5, release-1.6, release-1.7 ]
@@ -53,7 +54,8 @@ jobs:
       - name: setup e2e test environment
         run: |
           hack/local-up-karmada.sh
-
+      - name: change kube-apiserver and kube-controller-manager version
+        run: |
           # Update images
           kubectl --kubeconfig=${HOME}/.kube/karmada.config --context=karmada-host \
             set image deployment/karmada-apiserver -nkarmada-system \


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind failing-test

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of #4111

**Special notes for your reviewer**:

this PR have two change:
- let workflow of `APIServer compatibility` do not fail-fast
- split the step of setup `e2e test environment` to fix timeout

Since the workflow is scheduled to trigger, I will trigger it immediately in my repo.

https://github.com/liangyuanpeng/karmada/actions/runs/6864906349
This workflow is working for reproduce to problem of setup e2e test env timeout.
The error log say:
```shell
...
Waiting for running............................................................................................................................................................................................................................................................................................................
Error:  Timeout waiting for condition running
Error: Process completed with exit code 1.
```

And this workflow is working for fix poblem of timeout. https://github.com/liangyuanpeng/karmada/actions/runs/6865184671

There are  some job is failed due to the propagation `Job` failed when the `karmada-apiserver` version great then v1.27
PR  https://github.com/karmada-io/karmada/pull/4160 will be fix it.

```shell
...
[FAILED] in [It] - /home/runner/work/karmada/karmada/test/e2e/resource_test.go:380 @ 11/15/23 02:07:12.449
  STEP: Removing PropagationPolicy(karmadatest-9fblz/job-t2h9r) @ 11/15/23 02:07:12.449
  STEP: Removing Job(karmadatest-9fblz/job-t2h9r) @ 11/15/23 02:07:12.453
  << Timeline

  [FAILED] Timed out after 300.000s.
  Expected
      <bool>: false
  to equal
      <bool>: true
  In [It] at: /home/runner/work/karmada/karmada/test/e2e/resource_test.go:380 @ 11/15/23 02:07:12.449

  Full Stack Trace
    github.com/karmada-io/karmada/test/e2e.glob..func30.6.3.1()
    	/home/runner/work/karmada/karmada/test/e2e/resource_test.go:380 +0x450
    github.com/karmada-io/karmada/test/e2e.glob..func30.6.3()
    	/home/runner/work/karmada/karmada/test/e2e/resource_test.go:366 +0x94
------------------------------
[SynchronizedAfterSuite] PASSED [0.009 seconds]
[SynchronizedAfterSuite] 
/home/runner/work/karmada/karmada/test/e2e/suite_test.go:137
------------------------------
• [INTERRUPTED] [15.937 seconds]
propagation with label and group constraints testing Job propagation testing [It] Job propagation with label and group constraints testing
/home/runner/work/karmada/karmada/test/e2e/scheduling_test.go:285

  Captured StdOut/StdErr Output >>
  MaxGroups= 1, MinGroups= 1
  target clusters in cluster resource binding are [member1]
  I1115 02:07:01.831005   50198 job.go:47] Waiting for job(karmadatest-nd4cz/job-wsc2q) synced on cluster(member1)
  << Captured StdOut/StdErr Output

  Timeline >>
  STEP: Creating PropagationPolicy(karmadatest-nd4cz/job-wsc2q) @ 11/15/23 02:06:56.786
  STEP: Creating Job(karmadatest-nd4cz/job-wsc2q) @ 11/15/23 02:06:56.806
  STEP: Get job(job-wsc2q) @ 11/15/23 02:06:56.812
  STEP: collect the target clusters in resource binding @ 11/15/23 02:06:56.817
  STEP: check if the scheduled condition is true @ 11/15/23 02:07:01.825
  STEP: check if job present on right clusters @ 11/15/23 02:07:01.83
  [INTERRUPTED] in [It] - /home/runner/work/karmada/karmada/test/e2e/scheduling_test.go:285 @ 11/15/23 02:07:12.698
  STEP: Removing Job(karmadatest-nd4cz/job-wsc2q) @ 11/15/23 02:07:12.7
  STEP: Removing PropagationPolicy(karmadatest-nd4cz/job-wsc2q) @ 11/15/23 02:07:12.71
  << Timeline

  [INTERRUPTED] Interrupted by Other Ginkgo Process
  In [It] at: /home/runner/work/karmada/karmada/test/e2e/scheduling_test.go:285 @ 11/15/23 02:07:12.698

  Full Stack Trace
------------------------------
• [INTERRUPTED] [297.406 seconds]
[JobReplicaScheduling] JobReplicaSchedulingStrategy testing ReplicaSchedulingType is Divided, ReplicaDivisionPreference is Weighted, WeightPreference isn't nil, spec.completions isn`t nil. [It] job replicas divided and weighted testing
...
```

![image](https://github.com/karmada-io/karmada/assets/28711504/06397d47-0ab7-4ad0-baf2-3c65bc98c8db)







**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

