### PR TITLE
always update scheduler observed generation when scheduling result being patched successfully

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -424,7 +424,7 @@ func (s *Scheduler) doScheduleClusterBinding(name string) (err error) {
 func (s *Scheduler) scheduleResourceBinding(rb *workv1alpha2.ResourceBinding) (err error) {
 	defer func() {
 		condition, ignoreErr := getConditionByError(err)
-		if updateErr := patchBindingStatusCondition(s.KarmadaClient, rb, condition); updateErr != nil {
+		if updateErr := patchBindingStatusCondition(s.KarmadaClient, rb, condition, ignoreErr); updateErr != nil {
 			// if patch error occurs, just return patch error to reconcile again.
 			err = updateErr
 			klog.Errorf("Failed to patch schedule status to ResourceBinding(%s/%s): %v", rb.Namespace, rb.Name, err)
@@ -562,7 +562,7 @@ func (s *Scheduler) patchScheduleResultForResourceBinding(oldBinding *workv1alph
 func (s *Scheduler) scheduleClusterResourceBinding(crb *workv1alpha2.ClusterResourceBinding) (err error) {
 	defer func() {
 		condition, ignoreErr := getConditionByError(err)
-		if updateErr := patchClusterBindingStatusCondition(s.KarmadaClient, crb, condition); updateErr != nil {
+		if updateErr := patchClusterBindingStatusCondition(s.KarmadaClient, crb, condition, ignoreErr); updateErr != nil {
 			// if patch error occurs, just return patch error to reconcile again.
 			err = updateErr
 			klog.Errorf("Failed to patch schedule status to ClusterResourceBinding(%s): %v", crb.Name, err)
@@ -745,14 +745,14 @@ func (s *Scheduler) establishEstimatorConnections() {
 }
 
 // patchBindingStatusCondition patches schedule status condition of ResourceBinding when necessary.
-func patchBindingStatusCondition(karmadaClient karmadaclientset.Interface, rb *workv1alpha2.ResourceBinding, newScheduledCondition metav1.Condition) error {
+func patchBindingStatusCondition(karmadaClient karmadaclientset.Interface, rb *workv1alpha2.ResourceBinding, newScheduledCondition metav1.Condition, ignoreErr bool) error {
 	klog.V(4).Infof("Begin to patch status condition to ResourceBinding(%s/%s)", rb.Namespace, rb.Name)
 
 	updateRB := rb.DeepCopy()
 	meta.SetStatusCondition(&updateRB.Status.Conditions, newScheduledCondition)
-	// Postpone setting observed generation until schedule succeed, assume scheduler will retry and
-	// will succeed eventually.
-	if newScheduledCondition.Status == metav1.ConditionTrue {
+	// If an error during scheduling could be ignored, the scheduling result would have been patched successfully.
+	// The scheduler observed generation should be updated.
+	if ignoreErr {
 		updateRB.Status.SchedulerObservedGeneration = rb.Generation
 	}
 
@@ -794,14 +794,14 @@ func patchBindingStatus(karmadaClient karmadaclientset.Interface, rb, updateRB *
 }
 
 // patchClusterBindingStatusCondition patches schedule status condition of ClusterResourceBinding when necessary
-func patchClusterBindingStatusCondition(karmadaClient karmadaclientset.Interface, crb *workv1alpha2.ClusterResourceBinding, newScheduledCondition metav1.Condition) error {
+func patchClusterBindingStatusCondition(karmadaClient karmadaclientset.Interface, crb *workv1alpha2.ClusterResourceBinding, newScheduledCondition metav1.Condition, ignoreErr bool) error {
 	klog.V(4).Infof("Begin to patch status condition to ClusterResourceBinding(%s)", crb.Name)
 
 	updateCRB := crb.DeepCopy()
 	meta.SetStatusCondition(&updateCRB.Status.Conditions, newScheduledCondition)
-	// Postpone setting observed generation until schedule succeed, assume scheduler will retry and
-	// will succeed eventually.
-	if newScheduledCondition.Status == metav1.ConditionTrue {
+	// If an error during scheduling could be ignored, the scheduling result would have been patched successfully.
+	// The scheduler observed generation should be updated.
+	if ignoreErr {
 		updateCRB.Status.SchedulerObservedGeneration = crb.Generation
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:  
/kind bug  

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**: 

**Which issue(s) this PR fixes**:
Fixes #4250 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-scheduler`: `schedulerObservedGeneration` would be always updated when scheduling result being patched successfully
```

