### PR TITLE
set golang's secure cipher suites as etcd's cipher suites

### DIFF
--- a/artifacts/deploy/karmada-etcd.yaml
+++ b/artifacts/deploy/karmada-etcd.yaml
@@ -82,6 +82,10 @@ spec:
             - --trusted-ca-file=/etc/karmada/pki/etcd-ca.crt
             - --data-dir=/var/lib/etcd
             - --snapshot-count=10000
+            # Setting Golang's secure cipher suites as etcd's cipher suites.
+            # They are obtained by the return value of the function CipherSuites() under the go/src/crypto/tls/cipher_suites.go package.
+            # Consistent with the Preferred values of k8s’s default cipher suites.
+            - --cipher-suites=TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
       volumes:
         - hostPath:
             path: /var/lib/karmada-etcd

--- a/charts/karmada/templates/etcd.yaml
+++ b/charts/karmada/templates/etcd.yaml
@@ -97,6 +97,10 @@ spec:
             - --key-file=/etc/kubernetes/pki/etcd/karmada.key
             - --trusted-ca-file=/etc/kubernetes/pki/etcd/server-ca.crt
             - --data-dir=/var/lib/etcd
+            # Setting Golang's secure cipher suites as etcd's cipher suites.
+            # They are obtained by the return value of the function CipherSuites() under the go/src/crypto/tls/cipher_suites.go package.
+            # Consistent with the Preferred values of k8s’s default cipher suites.
+            - --cipher-suites=TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
       volumes:
         - name: etcd-cert
           secret:

--- a/operator/pkg/controlplane/etcd/mainfests.go
+++ b/operator/pkg/controlplane/etcd/mainfests.go
@@ -44,7 +44,8 @@ spec:
         - --key-file=/etc/karmada/pki/etcd/etcd-server.key
         - --data-dir=/var/lib/etcd
         - --snapshot-count=10000
-        - --log-level=debug
+        - --log-level=debug=
+        - --cipher-suites={{ .EtcdCipherSuites }}
         env:
         - name: KARMADA_ETCD_NAME
           valueFrom:

--- a/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/cli/flag"
 	"k8s.io/utils/pointer"
 
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
@@ -35,8 +36,9 @@ const (
 
 var (
 	// appLabels remove via Labels karmada StatefulSet Deployment
-	appLabels  = map[string]string{"karmada.io/bootstrapping": "app-defaults"}
-	etcdLabels = map[string]string{"app": etcdStatefulSetAndServiceName}
+	appLabels        = map[string]string{"karmada.io/bootstrapping": "app-defaults"}
+	etcdLabels       = map[string]string{"app": etcdStatefulSetAndServiceName}
+	etcdCipherSuites = genEtcdCipherSuites()
 )
 
 func (i *CommandInitOption) etcdVolume() (*[]corev1.Volume, *corev1.PersistentVolumeClaim) {
@@ -141,6 +143,7 @@ listen-client-urls: https://${%s}:%v,http://127.0.0.1:%v
 initial-advertise-peer-urls: http://${%s}:%v
 advertise-client-urls: https://${%s}.%s.%s.svc.%s:%v
 data-dir: %s
+cipher-suites: %s
 
 `,
 			etcdContainerConfigDataMountPath, etcdConfigName,
@@ -159,6 +162,7 @@ data-dir: %s
 			i.Namespace, i.HostClusterDomain,
 			etcdContainerClientPort,
 			etcdContainerDataVolumeMountPath,
+			etcdCipherSuites,
 		),
 	}
 
@@ -349,4 +353,13 @@ func (i *CommandInitOption) makeETCDStatefulSet() *appsv1.StatefulSet {
 	}
 
 	return etcd
+}
+
+// Setting Golang's secure cipher suites as etcd's cipher suites.
+// They are obtained by the return value of the function CipherSuites() under the go/src/crypto/tls/cipher_suites.go package.
+// Consistent with the Preferred values of k8s’s default cipher suites.
+func genEtcdCipherSuites() string {
+	cipherSuites := strings.Join(flag.PreferredTLSCipherNames(), "\",\"")
+	cipherSuites = "[\"" + cipherSuites + "\"]"
+	return cipherSuites
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
set golang's default secure cipher suites as etcd's cipher suites to fix [CVE-2016-2183](https://github.com/advisories/GHSA-w2rw-pv8p-h9c8).
**Which issue(s) this PR fixes**:
Parts of  #4191

**Special notes for your reviewer**:
none
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Fixed CVE-2016-2183 by setting golang's secure cipher suites as etcd's cipher suites
```

