### PR TITLE
[1.5] Automated cherry pick of #4160: Prune job label for kubernetes 1.27,prefix with

### DIFF
--- a/pkg/resourceinterpreter/defaultinterpreter/prune/prune.go
+++ b/pkg/resourceinterpreter/defaultinterpreter/prune/prune.go
@@ -98,9 +98,12 @@ func removeGenerateSelectorOfJob(workload *unstructured.Unstructured) error {
 		return err
 	}
 	if exist {
-		if util.GetLabelValue(matchLabels, "controller-uid") != "" {
-			delete(matchLabels, "controller-uid")
-		}
+		delete(matchLabels, "controller-uid")
+		// The label 'batch.kubernetes.io/controller-uid' was introduced at Kubernetes v1.27, which intend to replace
+		// the previous label "controller-uid"(without batch.kubernetes.io prefix).
+		// See https://github.com/kubernetes/kubernetes/pull/114930 for more details.
+		delete(matchLabels, "batch.kubernetes.io/controller-uid")
+
 		err = unstructured.SetNestedStringMap(workload.Object, matchLabels, "spec", "selector", "matchLabels")
 		if err != nil {
 			return err
@@ -112,13 +115,13 @@ func removeGenerateSelectorOfJob(workload *unstructured.Unstructured) error {
 		return err
 	}
 	if exist {
-		if util.GetLabelValue(templateLabels, "controller-uid") != "" {
-			delete(templateLabels, "controller-uid")
-		}
-
-		if util.GetLabelValue(templateLabels, "job-name") != "" {
-			delete(templateLabels, "job-name")
-		}
+		delete(templateLabels, "controller-uid")
+		delete(templateLabels, "job-name")
+		// The label 'batch.kubernetes.io/controller-uid' and 'batch.kubernetes.io/job-name' were introduced at
+		// Kubernetes v1.27, which intend to replace the previous labels 'controller-uid' and 'job-name' respectively.
+		// See https://github.com/kubernetes/kubernetes/pull/114930 for more details.
+		delete(templateLabels, "batch.kubernetes.io/controller-uid")
+		delete(templateLabels, "batch.kubernetes.io/job-name")
 
 		err = unstructured.SetNestedStringMap(workload.Object, templateLabels, "spec", "template", "metadata", "labels")
 		if err != nil {


### PR DESCRIPTION
Cherry pick of #4160 on release-1.5.
#4160: Prune job label for kubernetes 1.27,prefix with
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`: Pruned job labels `batch.kubernetes.io/controller-uid` and `batch.kubernetes.io/job-name` which were introduced by Kubernetes 1.27.
```