### PR TITLE
Automated cherry pick of #4198: set MinVersion to VersionTLS13 for tlsconfig

### DIFF
--- a/artifacts/deploy/karmada-aggregated-apiserver.yaml
+++ b/artifacts/deploy/karmada-aggregated-apiserver.yaml
@@ -46,6 +46,7 @@ spec:
             - --feature-gates=APIPriorityAndFairness=false
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
+            - --tls-min-version=VersionTLS13
           resources:
             requests:
               cpu: 100m

--- a/artifacts/deploy/karmada-apiserver.yaml
+++ b/artifacts/deploy/karmada-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
             - --requestheader-username-headers=X-Remote-User
             - --tls-cert-file=/etc/karmada/pki/apiserver.crt
             - --tls-private-key-file=/etc/karmada/pki/apiserver.key
+            - --tls-min-version=VersionTLS13
           name: karmada-apiserver
           image: registry.k8s.io/kube-apiserver:v1.25.4
           imagePullPolicy: IfNotPresent

--- a/artifacts/deploy/karmada-metrics-adapter.yaml
+++ b/artifacts/deploy/karmada-metrics-adapter.yaml
@@ -40,6 +40,7 @@ spec:
             - --audit-log-path=-
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
+            - --tls-min-version=VersionTLS13
           readinessProbe:
             httpGet:
               path: /readyz

--- a/artifacts/deploy/karmada-search.yaml
+++ b/artifacts/deploy/karmada-search.yaml
@@ -46,6 +46,7 @@ spec:
             - --feature-gates=APIPriorityAndFairness=false
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
+            - --tls-min-version=VersionTLS13
           livenessProbe:
             httpGet:
               path: /livez

--- a/charts/karmada/templates/karmada-aggregated-apiserver.yaml
+++ b/charts/karmada/templates/karmada-aggregated-apiserver.yaml
@@ -65,6 +65,7 @@ spec:
             - --feature-gates=APIPriorityAndFairness=false
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
+            - --tls-min-version=VersionTLS13
           resources:
             {{- toYaml .Values.aggregatedApiServer.resources | nindent 12 }}
           readinessProbe:

--- a/charts/karmada/templates/karmada-apiserver.yaml
+++ b/charts/karmada/templates/karmada-apiserver.yaml
@@ -73,6 +73,7 @@ spec:
             - --tls-private-key-file=/etc/kubernetes/pki/karmada.key
             - --max-requests-inflight={{ .Values.apiServer.maxRequestsInflight }}
             - --max-mutating-requests-inflight={{ .Values.apiServer.maxMutatingRequestsInflight }}
+            - --tls-min-version=VersionTLS13
           ports:
             - name: http
               containerPort: 5443

--- a/charts/karmada/templates/karmada-search.yaml
+++ b/charts/karmada/templates/karmada-search.yaml
@@ -78,6 +78,7 @@ spec:
             - --feature-gates=APIPriorityAndFairness=false
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
+            - --tls-min-version=VersionTLS13
           livenessProbe:
             httpGet:
               path: /livez

--- a/operator/pkg/controlplane/apiserver/mainfests.go
+++ b/operator/pkg/controlplane/apiserver/mainfests.go
@@ -59,6 +59,7 @@ spec:
         - --max-requests-inflight=1500
         - --max-mutating-requests-inflight=500
         - --v=4
+	- --tls-min-version=VersionTLS13
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -171,6 +172,7 @@ spec:
         - --feature-gates=APIPriorityAndFairness=false
         - --audit-log-maxage=0
         - --audit-log-maxbackup=0
+	- --tls-min-version=VersionTLS13
         volumeMounts:
         - mountPath: /etc/karmada/config
           name: kubeconfig

--- a/operator/pkg/controlplane/metricsadapter/mainfests.go
+++ b/operator/pkg/controlplane/metricsadapter/mainfests.go
@@ -38,6 +38,7 @@ spec:
         - --audit-log-path=-
         - --audit-log-maxage=0
         - --audit-log-maxbackup=0
+	- --tls-min-version=VersionTLS13
         volumeMounts:
         - name: kubeconfig
           subPath: config


### PR DESCRIPTION
Cherry pick of #4198 on release-1.7.
#4198: set MinVersion to VersionTLS13 for tlsconfig
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
Fixed CVE-2016-2183 by setting --tls-min-version to VersionTLS13 for tlsconfig. The fixes apply to the following components:
- karmada-apiserver
- karmada-aggregated-apiserver
- karmada-search
- karmada-metrics-adapter
```