### PR TITLE
Automated cherry pick of #4181: set MinVersion to VersionTLS13 for tlsconfig in

### DIFF
--- a/pkg/karmadactl/cmdinit/kubernetes/deployments.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deployments.go
@@ -90,6 +90,7 @@ func (i *CommandInitOption) karmadaAPIServerContainerCommand() []string {
 		"--requestheader-username-headers=X-Remote-User",
 		fmt.Sprintf("--tls-cert-file=%s/%s.crt", karmadaCertsVolumeMountPath, options.ApiserverCertAndKeyName),
 		fmt.Sprintf("--tls-private-key-file=%s/%s.key", karmadaCertsVolumeMountPath, options.ApiserverCertAndKeyName),
+		"--tls-min-version=VersionTLS13",
 	}
 }
 
@@ -811,6 +812,7 @@ func (i *CommandInitOption) makeKarmadaAggregatedAPIServerDeployment() *appsv1.D
 					fmt.Sprintf("--etcd-keyfile=%s/%s.key", karmadaCertsVolumeMountPath, options.EtcdClientCertAndKeyName),
 					fmt.Sprintf("--tls-cert-file=%s/%s.crt", karmadaCertsVolumeMountPath, options.KarmadaCertAndKeyName),
 					fmt.Sprintf("--tls-private-key-file=%s/%s.key", karmadaCertsVolumeMountPath, options.KarmadaCertAndKeyName),
+					"--tls-min-version=VersionTLS13",
 					"--audit-log-path=-",
 					"--feature-gates=APIPriorityAndFairness=false",
 					"--audit-log-maxage=0",


### PR DESCRIPTION
Cherry pick of #4181 on release-1.6.
#4181: set MinVersion to VersionTLS13 for tlsconfig in
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmadactl`: The `karmada-apiserver` and `karmada-aggregated-apiserver` installed by the `init` command will take `--tls-min-version=VersionTLS13` by default.
```