### PR TITLE
Automated cherry pick of #4193: set MinVersion to VersionTLS13 for tlsconfig in

### DIFF
--- a/pkg/karmadactl/addons/search/manifests.go
+++ b/pkg/karmadactl/addons/search/manifests.go
@@ -45,6 +45,7 @@ spec:
             - --etcd-keyfile=/etc/karmada/pki/etcd-client.key
             - --tls-cert-file=/etc/karmada/pki/karmada.crt
             - --tls-private-key-file=/etc/karmada/pki/karmada.key
+            - --tls-min-version=VersionTLS13
             - --audit-log-path=-
             - --feature-gates=APIPriorityAndFairness=false
             - --audit-log-maxage=0


### PR DESCRIPTION
Cherry pick of #4193 on release-1.5.
#4193: set MinVersion to VersionTLS13 for tlsconfig in
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmadactl`: The `karmada-search` and `karmada-metrics-adapter` installed by the `addon` command will take `--tls-min-version=VersionTLS13` by default.
```