### PR TITLE
create cluster script support MacOS

### DIFF
--- a/hack/create-cluster.sh
+++ b/hack/create-cluster.sh
@@ -13,8 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script only fits for Linux, macOS adaptation will come soon
-
+# This script works for both linux and macOS.
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -70,7 +69,7 @@ fi
 function rand() {
     min=$1
     max=$(($2-$min+1))
-    num=$(date +%s%N)
+    num=$(date +%s)
     echo $(($num%$max+$min))
 }
 
@@ -96,7 +95,8 @@ cp -rf "${REPO_ROOT}"/artifacts/kindClusterConfig/general-config.yaml "${TEMP_PA
 sed -i'' -e "s#{{pod_cidr}}#${POD_CIDR}#g" "${TEMP_PATH}"/"${CLUSTER_NAME}"-config.yaml
 sed -i'' -e "s#{{service_cidr}}#${SERVICE_CIDR}#g" "${TEMP_PATH}"/"${CLUSTER_NAME}"-config.yaml
 
-kind_log="$(mktemp --suffix=-kind.log)"
+mkdir -p /tmp/kind-log/
+kind_log="/tmp/kind-log/$(date +%s)"
 echo "Creating cluster \"${CLUSTER_NAME}\" ..."
 kind create cluster --name "${CLUSTER_NAME}" --kubeconfig="${KUBECONFIG}" --image="${CLUSTER_VERSION}" --config="${TEMP_PATH}"/"${CLUSTER_NAME}"-config.yaml > ${kind_log} 2>&1 || (
   echo "Creating cluster ${CLUSTER_NAME} failed, see detail log in ${kind_log}."


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

improvement of create-cluster.sh script, so that it can support MacOS

* MacOS not support `mktemp --suffix`
* In `date +%s%N` command, not support `%N` format

**Which issue(s) this PR fixes**:

Fixes #4294

**Special notes for your reviewer**:

CC @chaunceyjiang

Test Report：

```shell
$ hack/create-cluster.sh member4  ~/.kube/member4.config
Creating cluster "member4" ...
Context "kind-member4" renamed to "member4".
Cluster "kind-member4" set.
cluster "member4" is created successfully!
You can now use your cluster with:
kubectl cluster-info --context member4 --kubeconfig /Users/chaosi/.kube/member4.config
```

**Does this PR introduce a user-facing change?**:

```release-note
none
```

