### PR TITLE
resourceModels supports extended resources

### DIFF
--- a/pkg/apis/cluster/mutation/mutation.go
+++ b/pkg/apis/cluster/mutation/mutation.go
@@ -84,12 +84,12 @@ func SetDefaultClusterResourceModels(cluster *clusterapis.Cluster) {
 			Grade: 0,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewQuantity(0, resource.BinarySI),
 					Max:  *resource.NewQuantity(4*GB, resource.BinarySI),
 				},
@@ -99,12 +99,12 @@ func SetDefaultClusterResourceModels(cluster *clusterapis.Cluster) {
 			Grade: 1,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewQuantity(1, resource.DecimalSI),
 					Max:  *resource.NewQuantity(2, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewQuantity(4*GB, resource.BinarySI),
 					Max:  *resource.NewQuantity(16*GB, resource.BinarySI),
 				},
@@ -114,12 +114,12 @@ func SetDefaultClusterResourceModels(cluster *clusterapis.Cluster) {
 			Grade: 2,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewQuantity(2, resource.DecimalSI),
 					Max:  *resource.NewQuantity(4, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewQuantity(16*GB, resource.BinarySI),
 					Max:  *resource.NewQuantity(32*GB, resource.BinarySI),
 				},
@@ -129,12 +129,12 @@ func SetDefaultClusterResourceModels(cluster *clusterapis.Cluster) {
 			Grade: 3,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewQuantity(4, resource.DecimalSI),
 					Max:  *resource.NewQuantity(8, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewQuantity(32*GB, resource.BinarySI),
 					Max:  *resource.NewQuantity(64*GB, resource.BinarySI),
 				},
@@ -144,12 +144,12 @@ func SetDefaultClusterResourceModels(cluster *clusterapis.Cluster) {
 			Grade: 4,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewQuantity(8, resource.DecimalSI),
 					Max:  *resource.NewQuantity(16, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewQuantity(64*GB, resource.BinarySI),
 					Max:  *resource.NewQuantity(128*GB, resource.BinarySI),
 				},
@@ -159,12 +159,12 @@ func SetDefaultClusterResourceModels(cluster *clusterapis.Cluster) {
 			Grade: 5,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewQuantity(16, resource.DecimalSI),
 					Max:  *resource.NewQuantity(32, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewQuantity(128*GB, resource.BinarySI),
 					Max:  *resource.NewQuantity(256*GB, resource.BinarySI),
 				},
@@ -174,12 +174,12 @@ func SetDefaultClusterResourceModels(cluster *clusterapis.Cluster) {
 			Grade: 6,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewQuantity(32, resource.DecimalSI),
 					Max:  *resource.NewQuantity(64, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewQuantity(256*GB, resource.BinarySI),
 					Max:  *resource.NewQuantity(512*GB, resource.BinarySI),
 				},
@@ -189,12 +189,12 @@ func SetDefaultClusterResourceModels(cluster *clusterapis.Cluster) {
 			Grade: 7,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewQuantity(64, resource.DecimalSI),
 					Max:  *resource.NewQuantity(128, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewQuantity(512*GB, resource.BinarySI),
 					Max:  *resource.NewQuantity(1024*GB, resource.BinarySI),
 				},
@@ -204,12 +204,12 @@ func SetDefaultClusterResourceModels(cluster *clusterapis.Cluster) {
 			Grade: 8,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewQuantity(128, resource.DecimalSI),
 					Max:  *resource.NewQuantity(math.MaxInt64, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewQuantity(1024*GB, resource.BinarySI),
 					Max:  *resource.NewQuantity(math.MaxInt64, resource.BinarySI),
 				},

--- a/pkg/apis/cluster/mutation/mutation_test.go
+++ b/pkg/apis/cluster/mutation/mutation_test.go
@@ -100,7 +100,7 @@ func TestStandardizeClusterResourceModels(t *testing.T) {
 					Grade: 2,
 					Ranges: []clusterapis.ResourceModelRange{
 						{
-							Name: clusterapis.ResourceCPU,
+							Name: corev1.ResourceCPU,
 							Min:  *resource.NewQuantity(2, resource.DecimalSI),
 							Max:  *resource.NewQuantity(math.MaxInt64, resource.DecimalSI),
 						},
@@ -110,7 +110,7 @@ func TestStandardizeClusterResourceModels(t *testing.T) {
 					Grade: 1,
 					Ranges: []clusterapis.ResourceModelRange{
 						{
-							Name: clusterapis.ResourceCPU,
+							Name: corev1.ResourceCPU,
 							Min:  *resource.NewQuantity(0, resource.DecimalSI),
 							Max:  *resource.NewQuantity(2, resource.DecimalSI),
 						},
@@ -122,7 +122,7 @@ func TestStandardizeClusterResourceModels(t *testing.T) {
 					Grade: 1,
 					Ranges: []clusterapis.ResourceModelRange{
 						{
-							Name: clusterapis.ResourceCPU,
+							Name: corev1.ResourceCPU,
 							Min:  *resource.NewQuantity(0, resource.DecimalSI),
 							Max:  *resource.NewQuantity(2, resource.DecimalSI),
 						},
@@ -132,7 +132,7 @@ func TestStandardizeClusterResourceModels(t *testing.T) {
 					Grade: 2,
 					Ranges: []clusterapis.ResourceModelRange{
 						{
-							Name: clusterapis.ResourceCPU,
+							Name: corev1.ResourceCPU,
 							Min:  *resource.NewQuantity(2, resource.DecimalSI),
 							Max:  *resource.NewQuantity(math.MaxInt64, resource.DecimalSI),
 						},
@@ -146,7 +146,7 @@ func TestStandardizeClusterResourceModels(t *testing.T) {
 					Grade: 1,
 					Ranges: []clusterapis.ResourceModelRange{
 						{
-							Name: clusterapis.ResourceCPU,
+							Name: corev1.ResourceCPU,
 							Min:  *resource.NewQuantity(1, resource.DecimalSI),
 							Max:  *resource.NewQuantity(math.MaxInt64, resource.DecimalSI),
 						},
@@ -158,7 +158,7 @@ func TestStandardizeClusterResourceModels(t *testing.T) {
 					Grade: 1,
 					Ranges: []clusterapis.ResourceModelRange{
 						{
-							Name: clusterapis.ResourceCPU,
+							Name: corev1.ResourceCPU,
 							Min:  *resource.NewQuantity(0, resource.DecimalSI),
 							Max:  *resource.NewQuantity(math.MaxInt64, resource.DecimalSI),
 						},
@@ -172,7 +172,7 @@ func TestStandardizeClusterResourceModels(t *testing.T) {
 					Grade: 1,
 					Ranges: []clusterapis.ResourceModelRange{
 						{
-							Name: clusterapis.ResourceCPU,
+							Name: corev1.ResourceCPU,
 							Min:  *resource.NewQuantity(0, resource.DecimalSI),
 							Max:  *resource.NewQuantity(2, resource.DecimalSI),
 						},
@@ -184,7 +184,7 @@ func TestStandardizeClusterResourceModels(t *testing.T) {
 					Grade: 1,
 					Ranges: []clusterapis.ResourceModelRange{
 						{
-							Name: clusterapis.ResourceCPU,
+							Name: corev1.ResourceCPU,
 							Min:  *resource.NewQuantity(0, resource.DecimalSI),
 							Max:  *resource.NewQuantity(math.MaxInt64, resource.DecimalSI),
 						},
@@ -222,12 +222,12 @@ func TestSetDefaultClusterResourceModels(t *testing.T) {
 					Grade: 0,
 					Ranges: []clusterapis.ResourceModelRange{
 						{
-							Name: clusterapis.ResourceCPU,
+							Name: corev1.ResourceCPU,
 							Min:  *resource.NewQuantity(0, resource.DecimalSI),
 							Max:  *resource.NewQuantity(1, resource.DecimalSI),
 						},
 						{
-							Name: clusterapis.ResourceMemory,
+							Name: corev1.ResourceMemory,
 							Min:  *resource.NewQuantity(0, resource.BinarySI),
 							Max:  *resource.NewQuantity(4*GB, resource.BinarySI),
 						},
@@ -237,12 +237,12 @@ func TestSetDefaultClusterResourceModels(t *testing.T) {
 					Grade: 1,
 					Ranges: []clusterapis.ResourceModelRange{
 						{
-							Name: clusterapis.ResourceCPU,
+							Name: corev1.ResourceCPU,
 							Min:  *resource.NewQuantity(1, resource.DecimalSI),
 							Max:  *resource.NewQuantity(2, resource.DecimalSI),
 						},
 						{
-							Name: clusterapis.ResourceMemory,
+							Name: corev1.ResourceMemory,
 							Min:  *resource.NewQuantity(4*GB, resource.BinarySI),
 							Max:  *resource.NewQuantity(16*GB, resource.BinarySI),
 						},
@@ -252,12 +252,12 @@ func TestSetDefaultClusterResourceModels(t *testing.T) {
 					Grade: 2,
 					Ranges: []clusterapis.ResourceModelRange{
 						{
-							Name: clusterapis.ResourceCPU,
+							Name: corev1.ResourceCPU,
 							Min:  *resource.NewQuantity(2, resource.DecimalSI),
 							Max:  *resource.NewQuantity(4, resource.DecimalSI),
 						},
 						{
-							Name: clusterapis.ResourceMemory,
+							Name: corev1.ResourceMemory,
 							Min:  *resource.NewQuantity(16*GB, resource.BinarySI),
 							Max:  *resource.NewQuantity(32*GB, resource.BinarySI),
 						},
@@ -267,12 +267,12 @@ func TestSetDefaultClusterResourceModels(t *testing.T) {
 					Grade: 3,
 					Ranges: []clusterapis.ResourceModelRange{
 						{
-							Name: clusterapis.ResourceCPU,
+							Name: corev1.ResourceCPU,
 							Min:  *resource.NewQuantity(4, resource.DecimalSI),
 							Max:  *resource.NewQuantity(8, resource.DecimalSI),
 						},
 						{
-							Name: clusterapis.ResourceMemory,
+							Name: corev1.ResourceMemory,
 							Min:  *resource.NewQuantity(32*GB, resource.BinarySI),
 							Max:  *resource.NewQuantity(64*GB, resource.BinarySI),
 						},
@@ -282,12 +282,12 @@ func TestSetDefaultClusterResourceModels(t *testing.T) {
 					Grade: 4,
 					Ranges: []clusterapis.ResourceModelRange{
 						{
-							Name: clusterapis.ResourceCPU,
+							Name: corev1.ResourceCPU,
 							Min:  *resource.NewQuantity(8, resource.DecimalSI),
 							Max:  *resource.NewQuantity(16, resource.DecimalSI),
 						},
 						{
-							Name: clusterapis.ResourceMemory,
+							Name: corev1.ResourceMemory,
 							Min:  *resource.NewQuantity(64*GB, resource.BinarySI),
 							Max:  *resource.NewQuantity(128*GB, resource.BinarySI),
 						},
@@ -297,12 +297,12 @@ func TestSetDefaultClusterResourceModels(t *testing.T) {
 					Grade: 5,
 					Ranges: []clusterapis.ResourceModelRange{
 						{
-							Name: clusterapis.ResourceCPU,
+							Name: corev1.ResourceCPU,
 							Min:  *resource.NewQuantity(16, resource.DecimalSI),
 							Max:  *resource.NewQuantity(32, resource.DecimalSI),
 						},
 						{
-							Name: clusterapis.ResourceMemory,
+							Name: corev1.ResourceMemory,
 							Min:  *resource.NewQuantity(128*GB, resource.BinarySI),
 							Max:  *resource.NewQuantity(256*GB, resource.BinarySI),
 						},
@@ -312,12 +312,12 @@ func TestSetDefaultClusterResourceModels(t *testing.T) {
 					Grade: 6,
 					Ranges: []clusterapis.ResourceModelRange{
 						{
-							Name: clusterapis.ResourceCPU,
+							Name: corev1.ResourceCPU,
 							Min:  *resource.NewQuantity(32, resource.DecimalSI),
 							Max:  *resource.NewQuantity(64, resource.DecimalSI),
 						},
 						{
-							Name: clusterapis.ResourceMemory,
+							Name: corev1.ResourceMemory,
 							Min:  *resource.NewQuantity(256*GB, resource.BinarySI),
 							Max:  *resource.NewQuantity(512*GB, resource.BinarySI),
 						},
@@ -327,12 +327,12 @@ func TestSetDefaultClusterResourceModels(t *testing.T) {
 					Grade: 7,
 					Ranges: []clusterapis.ResourceModelRange{
 						{
-							Name: clusterapis.ResourceCPU,
+							Name: corev1.ResourceCPU,
 							Min:  *resource.NewQuantity(64, resource.DecimalSI),
 							Max:  *resource.NewQuantity(128, resource.DecimalSI),
 						},
 						{
-							Name: clusterapis.ResourceMemory,
+							Name: corev1.ResourceMemory,
 							Min:  *resource.NewQuantity(512*GB, resource.BinarySI),
 							Max:  *resource.NewQuantity(1024*GB, resource.BinarySI),
 						},
@@ -342,12 +342,12 @@ func TestSetDefaultClusterResourceModels(t *testing.T) {
 					Grade: 8,
 					Ranges: []clusterapis.ResourceModelRange{
 						{
-							Name: clusterapis.ResourceCPU,
+							Name: corev1.ResourceCPU,
 							Min:  *resource.NewQuantity(128, resource.DecimalSI),
 							Max:  *resource.NewQuantity(math.MaxInt64, resource.DecimalSI),
 						},
 						{
-							Name: clusterapis.ResourceMemory,
+							Name: corev1.ResourceMemory,
 							Min:  *resource.NewQuantity(1024*GB, resource.BinarySI),
 							Max:  *resource.NewQuantity(math.MaxInt64, resource.BinarySI),
 						},

--- a/pkg/apis/cluster/types.go
+++ b/pkg/apis/cluster/types.go
@@ -22,26 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ResourceName is the name identifying various resources in a ResourceList.
-type ResourceName string
-
-// Resource names must be not more than 63 characters, consisting of upper- or lower-case alphanumeric characters,
-// with the -, _, and . characters allowed anywhere, except the first or last character.
-// The default convention, matching that for annotations, is to use lower-case names, with dashes, rather than
-// camel case, separating compound words.
-// Fully-qualified resource typenames are constructed from a DNS-style subdomain, followed by a slash `/` and a name.
-const (
-	// ResourceCPU in cores. (e,g. 500m = .5 cores)
-	ResourceCPU ResourceName = "cpu"
-	// ResourceMemory in bytes. (e,g. 500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
-	ResourceMemory ResourceName = "memory"
-	// ResourceStorage is volume size, in bytes (e,g. 5Gi = 5GiB = 5 * 1024 * 1024 * 1024)
-	ResourceStorage ResourceName = "storage"
-	// ResourceEphemeralStorage is local ephemeral storage, in bytes. (e,g. 500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
-	// The resource name for ResourceEphemeralStorage is alpha and it can change across releases.
-	ResourceEphemeralStorage ResourceName = "ephemeral-storage"
-)
-
 //revive:disable:exported
 
 // +genclient
@@ -233,7 +213,7 @@ type ResourceModel struct {
 type ResourceModelRange struct {
 	// Name is the name for the resource that you want to categorize.
 	// +required
-	Name ResourceName
+	Name corev1.ResourceName
 
 	// Min is the minimum amount of this resource represented by resource name.
 	// Note: The Min value of first grade(usually 0) always acts as zero.

--- a/pkg/apis/cluster/v1alpha1/types.go
+++ b/pkg/apis/cluster/v1alpha1/types.go
@@ -33,26 +33,6 @@ const (
 	ResourceNamespaceScopedCluster = false
 )
 
-// ResourceName is the name identifying various resources in a ResourceList.
-type ResourceName string
-
-// Resource names must be not more than 63 characters, consisting of upper- or lower-case alphanumeric characters,
-// with the -, _, and . characters allowed anywhere, except the first or last character.
-// The default convention, matching that for annotations, is to use lower-case names, with dashes, rather than
-// camel case, separating compound words.
-// Fully-qualified resource typenames are constructed from a DNS-style subdomain, followed by a slash `/` and a name.
-const (
-	// ResourceCPU in cores. (e,g. 500m = .5 cores)
-	ResourceCPU ResourceName = "cpu"
-	// ResourceMemory in bytes. (e,g. 500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
-	ResourceMemory ResourceName = "memory"
-	// ResourceStorage is volume size, in bytes (e,g. 5Gi = 5GiB = 5 * 1024 * 1024 * 1024)
-	ResourceStorage ResourceName = "storage"
-	// ResourceEphemeralStorage is local ephemeral storage, in bytes. (e,g. 500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
-	// The resource name for ResourceEphemeralStorage is alpha and it can change across releases.
-	ResourceEphemeralStorage ResourceName = "ephemeral-storage"
-)
-
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -245,7 +225,7 @@ type ResourceModel struct {
 type ResourceModelRange struct {
 	// Name is the name for the resource that you want to categorize.
 	// +required
-	Name ResourceName `json:"name"`
+	Name corev1.ResourceName `json:"name"`
 
 	// Min is the minimum amount of this resource represented by resource name.
 	// Note: The Min value of first grade(usually 0) always acts as zero.

--- a/pkg/apis/cluster/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/cluster/v1alpha1/zz_generated.conversion.go
@@ -460,7 +460,7 @@ func Convert_cluster_ResourceModel_To_v1alpha1_ResourceModel(in *cluster.Resourc
 }
 
 func autoConvert_v1alpha1_ResourceModelRange_To_cluster_ResourceModelRange(in *ResourceModelRange, out *cluster.ResourceModelRange, s conversion.Scope) error {
-	out.Name = cluster.ResourceName(in.Name)
+	out.Name = v1.ResourceName(in.Name)
 	out.Min = in.Min
 	out.Max = in.Max
 	return nil
@@ -472,7 +472,7 @@ func Convert_v1alpha1_ResourceModelRange_To_cluster_ResourceModelRange(in *Resou
 }
 
 func autoConvert_cluster_ResourceModelRange_To_v1alpha1_ResourceModelRange(in *cluster.ResourceModelRange, out *ResourceModelRange, s conversion.Scope) error {
-	out.Name = ResourceName(in.Name)
+	out.Name = v1.ResourceName(in.Name)
 	out.Min = in.Min
 	out.Max = in.Max
 	return nil

--- a/pkg/apis/cluster/validation/validation.go
+++ b/pkg/apis/cluster/validation/validation.go
@@ -54,8 +54,7 @@ func ValidateClusterName(name string) []string {
 }
 
 var (
-	supportedSyncModes     = sets.NewString(string(api.Pull), string(api.Push))
-	supportedResourceNames = sets.NewString(string(api.ResourceCPU), string(api.ResourceMemory), string(api.ResourceStorage), string(api.ResourceEphemeralStorage))
+	supportedSyncModes = sets.NewString(string(api.Pull), string(api.Push))
 )
 
 // ValidateCluster tests if required fields in the Cluster are set.
@@ -208,9 +207,6 @@ func ValidateClusterResourceModels(fldPath *field.Path, models []api.ResourceMod
 		}
 
 		for j, resourceModelRange := range resourceModel.Ranges {
-			if !supportedResourceNames.Has(string(resourceModelRange.Name)) {
-				return field.NotSupported(fldPath.Child("ranges").Child("name"), resourceModelRange.Name, supportedResourceNames.List())
-			}
 			if resourceModelRange.Max.Cmp(resourceModelRange.Min) <= 0 {
 				return field.Invalid(fldPath, models, "The max value of each resource must be greater than the min value")
 			}

--- a/pkg/apis/cluster/validation/validation_test.go
+++ b/pkg/apis/cluster/validation/validation_test.go
@@ -114,7 +114,7 @@ func TestValidateCluster(t *testing.T) {
 							Grade: 1,
 							Ranges: []api.ResourceModelRange{
 								{
-									Name: api.ResourceCPU,
+									Name: corev1.ResourceCPU,
 									Min:  *resource.NewQuantity(0, resource.DecimalSI),
 									Max:  *resource.NewQuantity(2, resource.DecimalSI),
 								},
@@ -124,7 +124,7 @@ func TestValidateCluster(t *testing.T) {
 							Grade: 2,
 							Ranges: []api.ResourceModelRange{
 								{
-									Name: api.ResourceCPU,
+									Name: corev1.ResourceCPU,
 									Min:  *resource.NewQuantity(2, resource.DecimalSI),
 									Max:  *resource.NewQuantity(math.MaxInt64, resource.DecimalSI),
 								},
@@ -144,7 +144,7 @@ func TestValidateCluster(t *testing.T) {
 							Grade: 1,
 							Ranges: []api.ResourceModelRange{
 								{
-									Name: api.ResourceCPU,
+									Name: corev1.ResourceCPU,
 									Min:  *resource.NewQuantity(0, resource.DecimalSI),
 									Max:  *resource.NewQuantity(2, resource.DecimalSI),
 								},
@@ -154,12 +154,12 @@ func TestValidateCluster(t *testing.T) {
 							Grade: 2,
 							Ranges: []api.ResourceModelRange{
 								{
-									Name: api.ResourceCPU,
+									Name: corev1.ResourceCPU,
 									Min:  *resource.NewQuantity(2, resource.DecimalSI),
 									Max:  *resource.NewQuantity(math.MaxInt64, resource.DecimalSI),
 								},
 								{
-									Name: api.ResourceMemory,
+									Name: corev1.ResourceMemory,
 									Min:  *resource.NewQuantity(2, resource.DecimalSI),
 									Max:  *resource.NewQuantity(math.MaxInt64, resource.DecimalSI),
 								},
@@ -179,7 +179,7 @@ func TestValidateCluster(t *testing.T) {
 							Grade: 1,
 							Ranges: []api.ResourceModelRange{
 								{
-									Name: api.ResourceCPU,
+									Name: corev1.ResourceCPU,
 									Min:  *resource.NewQuantity(2, resource.DecimalSI),
 									Max:  *resource.NewQuantity(0, resource.DecimalSI),
 								},
@@ -199,7 +199,7 @@ func TestValidateCluster(t *testing.T) {
 							Grade: 1,
 							Ranges: []api.ResourceModelRange{
 								{
-									Name: api.ResourceCPU,
+									Name: corev1.ResourceCPU,
 									Min:  *resource.NewQuantity(1, resource.DecimalSI),
 									Max:  *resource.NewQuantity(math.MaxInt64, resource.DecimalSI),
 								},
@@ -219,7 +219,7 @@ func TestValidateCluster(t *testing.T) {
 							Grade: 1,
 							Ranges: []api.ResourceModelRange{
 								{
-									Name: api.ResourceCPU,
+									Name: corev1.ResourceCPU,
 									Min:  *resource.NewQuantity(0, resource.DecimalSI),
 									Max:  *resource.NewQuantity(2, resource.DecimalSI),
 								},
@@ -239,7 +239,7 @@ func TestValidateCluster(t *testing.T) {
 							Grade: 1,
 							Ranges: []api.ResourceModelRange{
 								{
-									Name: api.ResourceCPU,
+									Name: corev1.ResourceCPU,
 									Min:  *resource.NewQuantity(0, resource.DecimalSI),
 									Max:  *resource.NewQuantity(2, resource.DecimalSI),
 								},
@@ -249,7 +249,7 @@ func TestValidateCluster(t *testing.T) {
 							Grade: 2,
 							Ranges: []api.ResourceModelRange{
 								{
-									Name: api.ResourceMemory,
+									Name: corev1.ResourceMemory,
 									Min:  *resource.NewQuantity(2, resource.DecimalSI),
 									Max:  *resource.NewQuantity(math.MaxInt64, resource.DecimalSI),
 								},
@@ -269,7 +269,7 @@ func TestValidateCluster(t *testing.T) {
 							Grade: 1,
 							Ranges: []api.ResourceModelRange{
 								{
-									Name: api.ResourceCPU,
+									Name: corev1.ResourceCPU,
 									Min:  *resource.NewQuantity(0, resource.DecimalSI),
 									Max:  *resource.NewQuantity(2, resource.DecimalSI),
 								},
@@ -279,7 +279,7 @@ func TestValidateCluster(t *testing.T) {
 							Grade: 2,
 							Ranges: []api.ResourceModelRange{
 								{
-									Name: api.ResourceCPU,
+									Name: corev1.ResourceCPU,
 									Min:  *resource.NewQuantity(1, resource.DecimalSI),
 									Max:  *resource.NewQuantity(math.MaxInt64, resource.DecimalSI),
 								},

--- a/pkg/controllers/status/cluster_status_controller_test.go
+++ b/pkg/controllers/status/cluster_status_controller_test.go
@@ -621,12 +621,12 @@ func TestGetAllocatableModelings(t *testing.T) {
 							Grade: 0,
 							Ranges: []clusterv1alpha1.ResourceModelRange{
 								{
-									Name: clusterv1alpha1.ResourceCPU,
+									Name: corev1.ResourceCPU,
 									Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 									Max:  *resource.NewQuantity(1, resource.DecimalSI),
 								},
 								{
-									Name: clusterv1alpha1.ResourceMemory,
+									Name: corev1.ResourceMemory,
 									Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 									Max:  *resource.NewQuantity(1024, resource.DecimalSI),
 								},
@@ -636,12 +636,12 @@ func TestGetAllocatableModelings(t *testing.T) {
 							Grade: 1,
 							Ranges: []clusterv1alpha1.ResourceModelRange{
 								{
-									Name: clusterv1alpha1.ResourceCPU,
+									Name: corev1.ResourceCPU,
 									Min:  *resource.NewMilliQuantity(1, resource.DecimalSI),
 									Max:  *resource.NewQuantity(2, resource.DecimalSI),
 								},
 								{
-									Name: clusterv1alpha1.ResourceMemory,
+									Name: corev1.ResourceMemory,
 									Min:  *resource.NewMilliQuantity(1024, resource.DecimalSI),
 									Max:  *resource.NewQuantity(1024*2, resource.DecimalSI),
 								},
@@ -733,12 +733,12 @@ func TestGetAllocatableModelings(t *testing.T) {
 							Grade: 0,
 							Ranges: []clusterv1alpha1.ResourceModelRange{
 								{
-									Name: clusterv1alpha1.ResourceCPU,
+									Name: corev1.ResourceCPU,
 									Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 									Max:  *resource.NewQuantity(1, resource.DecimalSI),
 								},
 								{
-									Name: clusterv1alpha1.ResourceMemory,
+									Name: corev1.ResourceMemory,
 									Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 									Max:  *resource.NewQuantity(1024, resource.DecimalSI),
 								},
@@ -748,7 +748,7 @@ func TestGetAllocatableModelings(t *testing.T) {
 							Grade: 1,
 							Ranges: []clusterv1alpha1.ResourceModelRange{
 								{
-									Name: clusterv1alpha1.ResourceCPU,
+									Name: corev1.ResourceCPU,
 									Min:  *resource.NewMilliQuantity(1, resource.DecimalSI),
 									Max:  *resource.NewQuantity(2, resource.DecimalSI),
 								},
@@ -800,12 +800,12 @@ func TestGetAllocatableModelings(t *testing.T) {
 							Grade: 0,
 							Ranges: []clusterv1alpha1.ResourceModelRange{
 								{
-									Name: clusterv1alpha1.ResourceCPU,
+									Name: corev1.ResourceCPU,
 									Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 									Max:  *resource.NewQuantity(1, resource.DecimalSI),
 								},
 								{
-									Name: clusterv1alpha1.ResourceMemory,
+									Name: corev1.ResourceMemory,
 									Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 									Max:  *resource.NewQuantity(1024, resource.DecimalSI),
 								},
@@ -815,12 +815,12 @@ func TestGetAllocatableModelings(t *testing.T) {
 							Grade: 1,
 							Ranges: []clusterv1alpha1.ResourceModelRange{
 								{
-									Name: clusterv1alpha1.ResourceCPU,
+									Name: corev1.ResourceCPU,
 									Min:  *resource.NewMilliQuantity(1, resource.DecimalSI),
 									Max:  *resource.NewQuantity(2, resource.DecimalSI),
 								},
 								{
-									Name: clusterv1alpha1.ResourceMemory,
+									Name: corev1.ResourceMemory,
 									Min:  *resource.NewMilliQuantity(1024, resource.DecimalSI),
 									Max:  *resource.NewQuantity(1024*2, resource.DecimalSI),
 								},
@@ -866,12 +866,12 @@ func TestClusterStatusController_updateStatusIfNeeded(t *testing.T) {
 						Grade: 0,
 						Ranges: []clusterv1alpha1.ResourceModelRange{
 							{
-								Name: clusterv1alpha1.ResourceCPU,
+								Name: corev1.ResourceCPU,
 								Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 								Max:  *resource.NewQuantity(1, resource.DecimalSI),
 							},
 							{
-								Name: clusterv1alpha1.ResourceMemory,
+								Name: corev1.ResourceMemory,
 								Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 								Max:  *resource.NewQuantity(1024, resource.DecimalSI),
 							},
@@ -881,12 +881,12 @@ func TestClusterStatusController_updateStatusIfNeeded(t *testing.T) {
 						Grade: 1,
 						Ranges: []clusterv1alpha1.ResourceModelRange{
 							{
-								Name: clusterv1alpha1.ResourceCPU,
+								Name: corev1.ResourceCPU,
 								Min:  *resource.NewMilliQuantity(1, resource.DecimalSI),
 								Max:  *resource.NewQuantity(2, resource.DecimalSI),
 							},
 							{
-								Name: clusterv1alpha1.ResourceMemory,
+								Name: corev1.ResourceMemory,
 								Min:  *resource.NewMilliQuantity(1024, resource.DecimalSI),
 								Max:  *resource.NewQuantity(1024*2, resource.DecimalSI),
 							},
@@ -933,12 +933,12 @@ func TestClusterStatusController_updateStatusIfNeeded(t *testing.T) {
 						Grade: 0,
 						Ranges: []clusterv1alpha1.ResourceModelRange{
 							{
-								Name: clusterv1alpha1.ResourceCPU,
+								Name: corev1.ResourceCPU,
 								Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 								Max:  *resource.NewQuantity(1, resource.DecimalSI),
 							},
 							{
-								Name: clusterv1alpha1.ResourceMemory,
+								Name: corev1.ResourceMemory,
 								Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 								Max:  *resource.NewQuantity(1024, resource.DecimalSI),
 							},
@@ -948,12 +948,12 @@ func TestClusterStatusController_updateStatusIfNeeded(t *testing.T) {
 						Grade: 1,
 						Ranges: []clusterv1alpha1.ResourceModelRange{
 							{
-								Name: clusterv1alpha1.ResourceCPU,
+								Name: corev1.ResourceCPU,
 								Min:  *resource.NewMilliQuantity(1, resource.DecimalSI),
 								Max:  *resource.NewQuantity(2, resource.DecimalSI),
 							},
 							{
-								Name: clusterv1alpha1.ResourceMemory,
+								Name: corev1.ResourceMemory,
 								Min:  *resource.NewMilliQuantity(1024, resource.DecimalSI),
 								Max:  *resource.NewQuantity(1024*2, resource.DecimalSI),
 							},
@@ -1056,12 +1056,12 @@ func TestClusterStatusController_initLeaseController(t *testing.T) {
 					Grade: 0,
 					Ranges: []clusterv1alpha1.ResourceModelRange{
 						{
-							Name: clusterv1alpha1.ResourceCPU,
+							Name: corev1.ResourceCPU,
 							Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 							Max:  *resource.NewQuantity(1, resource.DecimalSI),
 						},
 						{
-							Name: clusterv1alpha1.ResourceMemory,
+							Name: corev1.ResourceMemory,
 							Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 							Max:  *resource.NewQuantity(1024, resource.DecimalSI),
 						},
@@ -1071,12 +1071,12 @@ func TestClusterStatusController_initLeaseController(t *testing.T) {
 					Grade: 1,
 					Ranges: []clusterv1alpha1.ResourceModelRange{
 						{
-							Name: clusterv1alpha1.ResourceCPU,
+							Name: corev1.ResourceCPU,
 							Min:  *resource.NewMilliQuantity(1, resource.DecimalSI),
 							Max:  *resource.NewQuantity(2, resource.DecimalSI),
 						},
 						{
-							Name: clusterv1alpha1.ResourceMemory,
+							Name: corev1.ResourceMemory,
 							Min:  *resource.NewMilliQuantity(1024, resource.DecimalSI),
 							Max:  *resource.NewQuantity(1024*2, resource.DecimalSI),
 						},

--- a/pkg/estimator/client/general.go
+++ b/pkg/estimator/client/general.go
@@ -112,8 +112,8 @@ func getAllowedPodNumber(resourceSummary *clusterv1alpha1.ResourceSummary) int64
 	return allowedPodNumber
 }
 
-func convertToResourceModelsMinMap(models []clusterv1alpha1.ResourceModel) map[clusterv1alpha1.ResourceName][]resource.Quantity {
-	resourceModelsMinMap := make(map[clusterv1alpha1.ResourceName][]resource.Quantity)
+func convertToResourceModelsMinMap(models []clusterv1alpha1.ResourceModel) map[corev1.ResourceName][]resource.Quantity {
+	resourceModelsMinMap := make(map[corev1.ResourceName][]resource.Quantity)
 	for _, model := range models {
 		for _, resourceModelRange := range model.Ranges {
 			resourceModelsMinMap[resourceModelRange.Name] = append(resourceModelsMinMap[resourceModelRange.Name], resourceModelRange.Min)
@@ -123,7 +123,7 @@ func convertToResourceModelsMinMap(models []clusterv1alpha1.ResourceModel) map[c
 	return resourceModelsMinMap
 }
 
-func getNodeAvailableReplicas(modelIndex int, replicaRequirements *workv1alpha2.ReplicaRequirements, resourceModelsMinMap map[clusterv1alpha1.ResourceName][]resource.Quantity) int64 {
+func getNodeAvailableReplicas(modelIndex int, replicaRequirements *workv1alpha2.ReplicaRequirements, resourceModelsMinMap map[corev1.ResourceName][]resource.Quantity) int64 {
 	var maximumReplicasOneNode int64 = math.MaxInt64
 	for key, value := range replicaRequirements.ResourceRequest {
 		requestedQuantity := value.Value()
@@ -131,7 +131,7 @@ func getNodeAvailableReplicas(modelIndex int, replicaRequirements *workv1alpha2.
 			continue
 		}
 
-		availableMinBoundary := resourceModelsMinMap[clusterv1alpha1.ResourceName(key)][modelIndex]
+		availableMinBoundary := resourceModelsMinMap[key][modelIndex]
 
 		availableQuantity := availableMinBoundary.Value()
 		if key == corev1.ResourceCPU {
@@ -204,7 +204,7 @@ func getMaximumReplicasBasedOnResourceModels(cluster *clusterv1alpha1.Cluster, r
 			continue
 		}
 
-		quantityArray, ok := resourceModelsMinMap[clusterv1alpha1.ResourceName(key)]
+		quantityArray, ok := resourceModelsMinMap[key]
 		if !ok {
 			return -1, fmt.Errorf("resource model is inapplicable as missing resource: %s", string(key))
 		}

--- a/pkg/modeling/modeling.go
+++ b/pkg/modeling/modeling.go
@@ -33,7 +33,7 @@ import (
 type ResourceSummary struct {
 	RMs                       []resourceModels
 	modelSortings             [][]resource.Quantity
-	modelSortingResourceNames []clusterapis.ResourceName
+	modelSortingResourceNames []corev1.ResourceName
 }
 
 // resourceModels records the number of each allocatable resource models.
@@ -68,18 +68,15 @@ type ClusterResourceNode struct {
 	// It maybe contain cpu, memory, gpu...
 	// User can specify which parameters need to be included before the cluster starts
 	// +required
-	resourceList ResourceList
+	resourceList corev1.ResourceList
 }
-
-// ResourceList is a set of (resource name, quantity) pairs.
-type ResourceList map[clusterapis.ResourceName]resource.Quantity
 
 // InitSummary is the init function of modeling data structure
 func InitSummary(resourceModel []clusterapis.ResourceModel) (ResourceSummary, error) {
-	var rsName []clusterapis.ResourceName
-	var rsList []ResourceList
+	var rsName []corev1.ResourceName
+	var rsList []corev1.ResourceList
 	for _, rm := range resourceModel {
-		tmp := map[clusterapis.ResourceName]resource.Quantity{}
+		tmp := map[corev1.ResourceName]resource.Quantity{}
 		for _, rmItem := range rm.Ranges {
 			if len(rsName) != len(rm.Ranges) {
 				rsName = append(rsName, rmItem.Name)
@@ -108,7 +105,7 @@ func InitSummary(resourceModel []clusterapis.ResourceModel) (ResourceSummary, er
 func NewClusterResourceNode(resourceList corev1.ResourceList) ClusterResourceNode {
 	return ClusterResourceNode{
 		quantity:     1,
-		resourceList: ConvertToResourceList(resourceList),
+		resourceList: resourceList,
 	}
 }
 
@@ -232,23 +229,6 @@ func (rs *ResourceSummary) llConvertToRbt(list *list.List) *rbt.Tree {
 		root.Put(tmpCrn, tmpCrn.quantity)
 	}
 	return root
-}
-
-// ConvertToResourceList is convert from corev1.ResourceList to ResourceList
-func ConvertToResourceList(rsList corev1.ResourceList) ResourceList {
-	resourceList := ResourceList{}
-	for name, quantity := range rsList {
-		if name == corev1.ResourceCPU {
-			resourceList[clusterapis.ResourceCPU] = quantity
-		} else if name == corev1.ResourceMemory {
-			resourceList[clusterapis.ResourceMemory] = quantity
-		} else if name == corev1.ResourceStorage {
-			resourceList[clusterapis.ResourceStorage] = quantity
-		} else if name == corev1.ResourceEphemeralStorage {
-			resourceList[clusterapis.ResourceEphemeralStorage] = quantity
-		}
-	}
-	return resourceList
 }
 
 // GetNodeNumFromModel is for getting node number from the modeling

--- a/pkg/modeling/modeling_test.go
+++ b/pkg/modeling/modeling_test.go
@@ -35,12 +35,12 @@ func TestInitSummary(t *testing.T) {
 			Grade: 0,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1024, resource.DecimalSI),
 				},
@@ -50,12 +50,12 @@ func TestInitSummary(t *testing.T) {
 			Grade: 1,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewMilliQuantity(1, resource.DecimalSI),
 					Max:  *resource.NewQuantity(2, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewMilliQuantity(1024, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1024*2, resource.DecimalSI),
 				},
@@ -79,12 +79,12 @@ func TestInitSummaryError(t *testing.T) {
 			Grade: 0,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1024, resource.DecimalSI),
 				},
@@ -94,7 +94,7 @@ func TestInitSummaryError(t *testing.T) {
 			Grade: 1,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewMilliQuantity(1, resource.DecimalSI),
 					Max:  *resource.NewQuantity(2, resource.DecimalSI),
 				},
@@ -118,12 +118,12 @@ func TestInitSummaryWithOneGrade(t *testing.T) {
 			Grade: 0,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1024, resource.DecimalSI),
 				},
@@ -184,12 +184,12 @@ func TestGetIndex(t *testing.T) {
 			Grade: 0,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1024, resource.DecimalSI),
 				},
@@ -199,12 +199,12 @@ func TestGetIndex(t *testing.T) {
 			Grade: 1,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewMilliQuantity(1, resource.DecimalSI),
 					Max:  *resource.NewQuantity(2, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewMilliQuantity(1024, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1024*2, resource.DecimalSI),
 				},
@@ -219,9 +219,9 @@ func TestGetIndex(t *testing.T) {
 
 	crn := ClusterResourceNode{
 		quantity: 1,
-		resourceList: ResourceList{
-			clusterapis.ResourceCPU:    *resource.NewMilliQuantity(1, resource.DecimalSI),
-			clusterapis.ResourceMemory: *resource.NewQuantity(1024, resource.DecimalSI),
+		resourceList: corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(1, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(1024, resource.DecimalSI),
 		},
 	}
 	index := rs.getIndex(crn)
@@ -232,9 +232,9 @@ func TestGetIndex(t *testing.T) {
 
 	crn = ClusterResourceNode{
 		quantity: 1,
-		resourceList: ResourceList{
-			clusterapis.ResourceCPU:    *resource.NewMilliQuantity(20, resource.DecimalSI),
-			clusterapis.ResourceMemory: *resource.NewQuantity(1024*100, resource.DecimalSI),
+		resourceList: corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(20, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(1024*100, resource.DecimalSI),
 		},
 	}
 	index = rs.getIndex(crn)
@@ -250,12 +250,12 @@ func TestClusterResourceNodeComparator(t *testing.T) {
 			Grade: 0,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1024, resource.DecimalSI),
 				},
@@ -265,12 +265,12 @@ func TestClusterResourceNodeComparator(t *testing.T) {
 			Grade: 1,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewMilliQuantity(1, resource.DecimalSI),
 					Max:  *resource.NewQuantity(2, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewMilliQuantity(1024, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1024*2, resource.DecimalSI),
 				},
@@ -285,17 +285,17 @@ func TestClusterResourceNodeComparator(t *testing.T) {
 
 	crn1 := ClusterResourceNode{
 		quantity: 10,
-		resourceList: ResourceList{
-			clusterapis.ResourceCPU:    *resource.NewMilliQuantity(10, resource.DecimalSI),
-			clusterapis.ResourceMemory: *resource.NewQuantity(1024, resource.DecimalSI),
+		resourceList: corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(10, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(1024, resource.DecimalSI),
 		},
 	}
 
 	crn2 := ClusterResourceNode{
 		quantity: 789,
-		resourceList: ResourceList{
-			clusterapis.ResourceCPU:    *resource.NewMilliQuantity(2, resource.DecimalSI),
-			clusterapis.ResourceMemory: *resource.NewQuantity(1024, resource.DecimalSI),
+		resourceList: corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(2, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(1024, resource.DecimalSI),
 		},
 	}
 	if res := rs.clusterResourceNodeComparator(crn1, crn2); res != 1 {
@@ -304,17 +304,17 @@ func TestClusterResourceNodeComparator(t *testing.T) {
 
 	crn1 = ClusterResourceNode{
 		quantity: 10,
-		resourceList: ResourceList{
-			clusterapis.ResourceCPU:    *resource.NewMilliQuantity(6, resource.DecimalSI),
-			clusterapis.ResourceMemory: *resource.NewQuantity(1024, resource.DecimalSI),
+		resourceList: corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(6, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(1024, resource.DecimalSI),
 		},
 	}
 
 	crn2 = ClusterResourceNode{
 		quantity: 789,
-		resourceList: ResourceList{
-			clusterapis.ResourceCPU:    *resource.NewMilliQuantity(6, resource.DecimalSI),
-			clusterapis.ResourceMemory: *resource.NewQuantity(1024, resource.DecimalSI),
+		resourceList: corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(6, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(1024, resource.DecimalSI),
 		},
 	}
 	if res := rs.clusterResourceNodeComparator(crn1, crn2); res != 0 {
@@ -323,17 +323,17 @@ func TestClusterResourceNodeComparator(t *testing.T) {
 
 	crn1 = ClusterResourceNode{
 		quantity: 10,
-		resourceList: ResourceList{
-			clusterapis.ResourceCPU:    *resource.NewMilliQuantity(6, resource.DecimalSI),
-			clusterapis.ResourceMemory: *resource.NewQuantity(1024, resource.DecimalSI),
+		resourceList: corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(6, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(1024, resource.DecimalSI),
 		},
 	}
 
 	crn2 = ClusterResourceNode{
 		quantity: 789,
-		resourceList: ResourceList{
-			clusterapis.ResourceCPU:    *resource.NewMilliQuantity(6, resource.DecimalSI),
-			clusterapis.ResourceMemory: *resource.NewQuantity(1024*10, resource.DecimalSI),
+		resourceList: corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(6, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(1024*10, resource.DecimalSI),
 		},
 	}
 	if res := rs.clusterResourceNodeComparator(crn1, crn2); res != -1 {
@@ -347,12 +347,12 @@ func TestGetNodeNumFromModel(t *testing.T) {
 			Grade: 0,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1024, resource.DecimalSI),
 				},
@@ -362,12 +362,12 @@ func TestGetNodeNumFromModel(t *testing.T) {
 			Grade: 1,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewMilliQuantity(1, resource.DecimalSI),
 					Max:  *resource.NewQuantity(2, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewMilliQuantity(1024, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1024*2, resource.DecimalSI),
 				},
@@ -386,25 +386,25 @@ func TestGetNodeNumFromModel(t *testing.T) {
 
 	crn1 := ClusterResourceNode{
 		quantity: 3,
-		resourceList: ResourceList{
-			clusterapis.ResourceCPU:    *resource.NewMilliQuantity(8, resource.DecimalSI),
-			clusterapis.ResourceMemory: *resource.NewQuantity(1024*3, resource.DecimalSI),
+		resourceList: corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(8, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(1024*3, resource.DecimalSI),
 		},
 	}
 
 	crn2 := ClusterResourceNode{
 		quantity: 1,
-		resourceList: ResourceList{
-			clusterapis.ResourceCPU:    *resource.NewMilliQuantity(1, resource.DecimalSI),
-			clusterapis.ResourceMemory: *resource.NewQuantity(1024*6, resource.DecimalSI),
+		resourceList: corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(1, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(1024*6, resource.DecimalSI),
 		},
 	}
 
 	crn3 := ClusterResourceNode{
 		quantity: 2,
-		resourceList: ResourceList{
-			clusterapis.ResourceCPU:    *resource.NewMilliQuantity(1, resource.DecimalSI),
-			clusterapis.ResourceMemory: *resource.NewQuantity(1024*6, resource.DecimalSI),
+		resourceList: corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(1, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(1024*6, resource.DecimalSI),
 		},
 	}
 
@@ -428,14 +428,13 @@ func TestGetNodeNumFromModel(t *testing.T) {
 }
 
 func TestConvertToResourceList(t *testing.T) {
-	rslist := corev1.ResourceList{
+	rsl := corev1.ResourceList{
 		corev1.ResourceCPU:    *resource.NewMilliQuantity(1, resource.DecimalSI),
 		corev1.ResourceMemory: *resource.NewQuantity(1024*6, resource.DecimalSI),
 	}
-	rsl := ConvertToResourceList(rslist)
 	for name := range rsl {
-		if reflect.TypeOf(name).String() != "v1alpha1.ResourceName" {
-			t.Errorf("Got %v expected %v", reflect.TypeOf(name), "v1alpha1.ResourceName")
+		if reflect.TypeOf(name).String() != "v1.ResourceName" {
+			t.Errorf("Got %v expected %v", reflect.TypeOf(name), "v1.ResourceName")
 		}
 	}
 }
@@ -446,12 +445,12 @@ func TestLlConvertToRbt(t *testing.T) {
 			Grade: 0,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1024, resource.DecimalSI),
 				},
@@ -461,12 +460,12 @@ func TestLlConvertToRbt(t *testing.T) {
 			Grade: 1,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewMilliQuantity(1, resource.DecimalSI),
 					Max:  *resource.NewQuantity(2, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewMilliQuantity(1024, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1024*2, resource.DecimalSI),
 				},
@@ -481,49 +480,49 @@ func TestLlConvertToRbt(t *testing.T) {
 
 	crn1 := ClusterResourceNode{
 		quantity: 6,
-		resourceList: ResourceList{
-			clusterapis.ResourceCPU:    *resource.NewMilliQuantity(2, resource.DecimalSI),
-			clusterapis.ResourceMemory: *resource.NewQuantity(1024*7, resource.DecimalSI),
+		resourceList: corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(2, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(1024*7, resource.DecimalSI),
 		},
 	}
 
 	crn2 := ClusterResourceNode{
 		quantity: 5,
-		resourceList: ResourceList{
-			clusterapis.ResourceCPU:    *resource.NewMilliQuantity(6, resource.DecimalSI),
-			clusterapis.ResourceMemory: *resource.NewQuantity(1024*3, resource.DecimalSI),
+		resourceList: corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(6, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(1024*3, resource.DecimalSI),
 		},
 	}
 
 	crn3 := ClusterResourceNode{
 		quantity: 4,
-		resourceList: ResourceList{
-			clusterapis.ResourceCPU:    *resource.NewMilliQuantity(5, resource.DecimalSI),
-			clusterapis.ResourceMemory: *resource.NewQuantity(1024*8, resource.DecimalSI),
+		resourceList: corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(5, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(1024*8, resource.DecimalSI),
 		},
 	}
 
 	crn4 := ClusterResourceNode{
 		quantity: 3,
-		resourceList: ResourceList{
-			clusterapis.ResourceCPU:    *resource.NewMilliQuantity(8, resource.DecimalSI),
-			clusterapis.ResourceMemory: *resource.NewQuantity(1024*3, resource.DecimalSI),
+		resourceList: corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(8, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(1024*3, resource.DecimalSI),
 		},
 	}
 
 	crn5 := ClusterResourceNode{
 		quantity: 2,
-		resourceList: ResourceList{
-			clusterapis.ResourceCPU:    *resource.NewMilliQuantity(1, resource.DecimalSI),
-			clusterapis.ResourceMemory: *resource.NewQuantity(1024*6, resource.DecimalSI),
+		resourceList: corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(1, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(1024*6, resource.DecimalSI),
 		},
 	}
 
 	crn6 := ClusterResourceNode{
 		quantity: 1,
-		resourceList: ResourceList{
-			clusterapis.ResourceCPU:    *resource.NewMilliQuantity(2, resource.DecimalSI),
-			clusterapis.ResourceMemory: *resource.NewQuantity(1024*12, resource.DecimalSI),
+		resourceList: corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(2, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(1024*12, resource.DecimalSI),
 		},
 	}
 	mylist := list.New()
@@ -565,12 +564,12 @@ func TestRbtConvertToLl(t *testing.T) {
 			Grade: 0,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1024, resource.DecimalSI),
 				},
@@ -580,12 +579,12 @@ func TestRbtConvertToLl(t *testing.T) {
 			Grade: 1,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewMilliQuantity(1, resource.DecimalSI),
 					Max:  *resource.NewQuantity(2, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewMilliQuantity(1024, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1024*2, resource.DecimalSI),
 				},
@@ -615,12 +614,12 @@ func TestAddToResourceSummary(t *testing.T) {
 			Grade: 0,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewMilliQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1024, resource.DecimalSI),
 				},
@@ -630,12 +629,12 @@ func TestAddToResourceSummary(t *testing.T) {
 			Grade: 1,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewMilliQuantity(1, resource.DecimalSI),
 					Max:  *resource.NewQuantity(2, resource.DecimalSI),
 				},
 				{
-					Name: clusterapis.ResourceMemory,
+					Name: corev1.ResourceMemory,
 					Min:  *resource.NewMilliQuantity(1024, resource.DecimalSI),
 					Max:  *resource.NewQuantity(1024*2, resource.DecimalSI),
 				},
@@ -654,25 +653,25 @@ func TestAddToResourceSummary(t *testing.T) {
 
 	crn1 := ClusterResourceNode{
 		quantity: 3,
-		resourceList: ResourceList{
-			clusterapis.ResourceCPU:    *resource.NewMilliQuantity(8, resource.DecimalSI),
-			clusterapis.ResourceMemory: *resource.NewQuantity(1024*3, resource.DecimalSI),
+		resourceList: corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(8, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(1024*3, resource.DecimalSI),
 		},
 	}
 
 	crn2 := ClusterResourceNode{
 		quantity: 1,
-		resourceList: ResourceList{
-			clusterapis.ResourceCPU:    *resource.NewMilliQuantity(1, resource.DecimalSI),
-			clusterapis.ResourceMemory: *resource.NewQuantity(1024*6, resource.DecimalSI),
+		resourceList: corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(1, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(1024*6, resource.DecimalSI),
 		},
 	}
 
 	crn3 := ClusterResourceNode{
 		quantity: 2,
-		resourceList: ResourceList{
-			clusterapis.ResourceCPU:    *resource.NewMilliQuantity(1, resource.DecimalSI),
-			clusterapis.ResourceMemory: *resource.NewQuantity(1024*6, resource.DecimalSI),
+		resourceList: corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(1, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(1024*6, resource.DecimalSI),
 		},
 	}
 
@@ -698,9 +697,9 @@ func TestAddToResourceSummary(t *testing.T) {
 
 	crn4 := ClusterResourceNode{
 		quantity: 2,
-		resourceList: ResourceList{
-			clusterapis.ResourceCPU:    *resource.NewMilliQuantity(0, resource.DecimalSI),
-			clusterapis.ResourceMemory: *resource.NewQuantity(19, resource.DecimalSI),
+		resourceList: corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(0, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(19, resource.DecimalSI),
 		},
 	}
 

--- a/pkg/registry/cluster/strategy_test.go
+++ b/pkg/registry/cluster/strategy_test.go
@@ -90,7 +90,7 @@ func TestStrategy_PrepareForCreate(t *testing.T) {
 			Grade: 2,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewQuantity(2, resource.DecimalSI),
 					Max:  *resource.NewQuantity(math.MaxInt64, resource.DecimalSI),
 				},
@@ -100,7 +100,7 @@ func TestStrategy_PrepareForCreate(t *testing.T) {
 			Grade: 1,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(2, resource.DecimalSI),
 				},
@@ -113,7 +113,7 @@ func TestStrategy_PrepareForCreate(t *testing.T) {
 			Grade: 1,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(2, resource.DecimalSI),
 				},
@@ -123,7 +123,7 @@ func TestStrategy_PrepareForCreate(t *testing.T) {
 			Grade: 2,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewQuantity(2, resource.DecimalSI),
 					Max:  *resource.NewQuantity(math.MaxInt64, resource.DecimalSI),
 				},
@@ -180,7 +180,7 @@ func TestStrategy_PrepareForUpdate(t *testing.T) {
 			Grade: 2,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewQuantity(2, resource.DecimalSI),
 					Max:  *resource.NewQuantity(math.MaxInt64, resource.DecimalSI),
 				},
@@ -190,7 +190,7 @@ func TestStrategy_PrepareForUpdate(t *testing.T) {
 			Grade: 1,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(2, resource.DecimalSI),
 				},
@@ -203,7 +203,7 @@ func TestStrategy_PrepareForUpdate(t *testing.T) {
 			Grade: 1,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewQuantity(0, resource.DecimalSI),
 					Max:  *resource.NewQuantity(2, resource.DecimalSI),
 				},
@@ -213,7 +213,7 @@ func TestStrategy_PrepareForUpdate(t *testing.T) {
 			Grade: 2,
 			Ranges: []clusterapis.ResourceModelRange{
 				{
-					Name: clusterapis.ResourceCPU,
+					Name: corev1.ResourceCPU,
 					Min:  *resource.NewQuantity(2, resource.DecimalSI),
 					Max:  *resource.NewQuantity(math.MaxInt64, resource.DecimalSI),
 				},


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

resourceModels supports extended resources

**Which issue(s) this PR fixes**:

Fixes #4050

**Special notes for your reviewer**:

Demo：https://h3ld32xlpo.feishu.cn/wiki/Rj5mwS3TCigHY4kMKzhcqTggnlg

A perfect way to edit extension resource model in cluster object is like:

```shell
for cluster in "member1" "member2"; do
  kubectl --context karmada-apiserver patch cluster ${cluster} -n karmada-system --type='json' -p '[
      {"op": "add", "path": "/spec/resourceModels/0/ranges/-", "value": {"name": "karmada.io/gpu", "min": "0", "max": "4"}},
      {"op": "add", "path": "/spec/resourceModels/1/ranges/-", "value": {"name": "karmada.io/gpu", "min": "4", "max": "8"}},
      {"op": "add", "path": "/spec/resourceModels/2/ranges/-", "value": {"name": "karmada.io/gpu", "min": "8", "max": "12"}},
      {"op": "add", "path": "/spec/resourceModels/3/ranges/-", "value": {"name": "karmada.io/gpu", "min": "12", "max": "16"}},
      {"op": "add", "path": "/spec/resourceModels/4/ranges/-", "value": {"name": "karmada.io/gpu", "min": "16", "max": "20"}},
      {"op": "add", "path": "/spec/resourceModels/5/ranges/-", "value": {"name": "karmada.io/gpu", "min": "20", "max": "24"}},
      {"op": "add", "path": "/spec/resourceModels/6/ranges/-", "value": {"name": "karmada.io/gpu", "min": "24", "max": "28"}},
      {"op": "add", "path": "/spec/resourceModels/7/ranges/-", "value": {"name": "karmada.io/gpu", "min": "28", "max": "32"}},
      {"op": "add", "path": "/spec/resourceModels/8/ranges/-", "value": {"name": "karmada.io/gpu", "min": "32", "max": "9223372036854775807"}},
  ]'
done
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Resource models now support any arbitrary resource type and are no longer limited to `cpu`, `memory`, `storage`, and `ephemeral-storage`.
```

