### PR TITLE
feat: support install karmada search with operator

### DIFF
--- a/operator/pkg/apis/operator/v1alpha1/defaults.go
+++ b/operator/pkg/apis/operator/v1alpha1/defaults.go
@@ -40,6 +40,7 @@ var (
 	karmadaWebhookImageRepository             = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, constants.KarmadaWebhook)
 	karmadaDeschedulerImageRepository         = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, constants.KarmadaDescheduler)
 	KarmadaMetricsAdapterImageRepository      = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, constants.KarmadaMetricsAdapter)
+	karmadaSearchImageRepository              = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, constants.KarmadaSearch)
 )
 
 func init() {
@@ -87,7 +88,7 @@ func setDefaultsKarmadaComponents(obj *Karmada) {
 	setDefaultsKarmadaScheduler(obj.Spec.Components)
 	setDefaultsKarmadaWebhook(obj.Spec.Components)
 	setDefaultsKarmadaMetricsAdapter(obj.Spec.Components)
-
+	setDefaultsKarmadaSearch(obj.Spec.Components)
 	// set addon defaults
 	setDefaultsKarmadaDescheduler(obj.Spec.Components)
 }
@@ -240,6 +241,23 @@ func setDefaultsKarmadaWebhook(obj *KarmadaComponents) {
 	}
 	if webhook.Replicas == nil {
 		webhook.Replicas = pointer.Int32(1)
+	}
+}
+
+func setDefaultsKarmadaSearch(obj *KarmadaComponents) {
+	if obj.KarmadaSearch == nil {
+		return
+	}
+
+	search := obj.KarmadaSearch
+	if len(search.Image.ImageRepository) == 0 {
+		search.Image.ImageRepository = karmadaSearchImageRepository
+	}
+	if len(search.Image.ImageTag) == 0 {
+		search.Image.ImageTag = DefaultKarmadaImageVersion
+	}
+	if search.Replicas == nil {
+		search.Replicas = pointer.Int32(1)
 	}
 }
 

--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -55,6 +55,8 @@ const (
 	KarmadaScheduler = "karmada-scheduler"
 	// KarmadaWebhook defines the name of the karmada-webhook component
 	KarmadaWebhook = "karmada-webhook"
+	// KarmadaSearch defines the name of the karmada-search component
+	KarmadaSearch = "karmada-search"
 	// KarmadaDescheduler defines the name of the karmada-descheduler component
 	KarmadaDescheduler = "karmada-descheduler"
 	// KarmadaMetricsAdapter defines the name of the karmada-metrics-adapter component
@@ -111,6 +113,8 @@ const (
 	KarmadaSchedulerComponent = "KarmadaScheduler"
 	// KarmadaWebhookComponent defines the name of the karmada-webhook component
 	KarmadaWebhookComponent = "KarmadaWebhook"
+	// KarmadaSearchComponent defines the name of the karmada-search component
+	KarmadaSearchComponent = "KarmadaSearch"
 	// KarmadaDeschedulerComponent defines the name of the karmada-descheduler component
 	KarmadaDeschedulerComponent = "KarmadaDescheduler"
 	// KarmadaMetricsAdapterComponent defines the name of the karmada-metrics-adapter component
@@ -132,5 +136,10 @@ var (
 		{Group: "metrics.k8s.io", Version: "v1beta1"},
 		{Group: "custom.metrics.k8s.io", Version: "v1beta1"},
 		{Group: "custom.metrics.k8s.io", Version: "v1beta2"},
+	}
+
+	// KarmadaSearchAPIServices defines the GroupVersions of all karmada-search APIServices
+	KarmadaSearchAPIServices = []schema.GroupVersion{
+		{Group: "search.karmada.io", Version: "v1alpha1"},
 	}
 )

--- a/operator/pkg/controlplane/search/mainfests.go
+++ b/operator/pkg/controlplane/search/mainfests.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2023 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package search
+
+const (
+	// KarmadaSearchDeployment is karmada search deployment manifest
+	KarmadaSearchDeployment = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .DeploymentName }}
+  namespace: {{ .Namespace }}
+  labels:
+    karmada-app: karmada-search
+    apiserver: "true"
+spec:
+  selector:
+    matchLabels:
+      karmada-app: karmada-search
+      apiserver: "true"
+  replicas: {{ .Replicas }}
+  template:
+    metadata:
+      labels:
+        karmada-app: karmada-search
+        apiserver: "true"
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: karmada-search
+          image: {{ .Image }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: k8s-certs
+              mountPath: /etc/karmada/pki
+              readOnly: true
+            - name: kubeconfig
+              subPath: kubeconfig
+              mountPath: /etc/kubeconfig
+          command:
+            - /bin/karmada-search
+            - --kubeconfig=/etc/kubeconfig
+            - --authentication-kubeconfig=/etc/kubeconfig
+            - --authorization-kubeconfig=/etc/kubeconfig
+            - --etcd-servers=https://{{ .EtcdClientService }}.{{ .Namespace }}.svc.cluster.local:{{ .EtcdListenClientPort }}
+            - --etcd-cafile=/etc/karmada/pki/etcd-ca.crt
+            - --etcd-certfile=/etc/karmada/pki/etcd-client.crt
+            - --etcd-keyfile=/etc/karmada/pki/etcd-client.key
+            - --tls-cert-file=/etc/karmada/pki/karmada.crt
+            - --tls-private-key-file=/etc/karmada/pki/karmada.key
+            - --tls-min-version=VersionTLS13
+            - --audit-log-path=-
+            - --feature-gates=APIPriorityAndFairness=false
+            - --audit-log-maxage=0
+            - --audit-log-maxbackup=0
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 443
+              scheme: HTTPS
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+      volumes:
+        - name: k8s-certs
+          secret:
+            secretName: {{ .KarmadaCertsSecret }}
+        - name: kubeconfig
+          secret:
+            secretName: {{ .KubeconfigSecret }}
+`
+
+	// KarmadaSearchService is karmada-search service manifest
+	KarmadaSearchService = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .ServiceName }}
+  namespace: {{ .Namespace }}
+  labels:
+    karmada-app: karmada-search
+    apiserver: "true"
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 443
+  selector:
+    karmada-app: karmada-search
+`
+)

--- a/operator/pkg/controlplane/search/search.go
+++ b/operator/pkg/controlplane/search/search.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2023 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package search
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	kuberuntime "k8s.io/apimachinery/pkg/runtime"
+	clientset "k8s.io/client-go/kubernetes"
+	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+
+	operatorv1alpha1 "github.com/karmada-io/karmada/operator/pkg/apis/operator/v1alpha1"
+	"github.com/karmada-io/karmada/operator/pkg/constants"
+	"github.com/karmada-io/karmada/operator/pkg/util"
+	"github.com/karmada-io/karmada/operator/pkg/util/apiclient"
+	"github.com/karmada-io/karmada/operator/pkg/util/patcher"
+)
+
+// EnsureKarmadaSearch creates karmada search deployment and service resource.
+func EnsureKarmadaSearch(client clientset.Interface, cfg *operatorv1alpha1.KarmadaSearch, name, namespace string, featureGates map[string]bool) error {
+	if err := installKarmadaSearch(client, cfg, name, namespace, featureGates); err != nil {
+		return err
+	}
+
+	return createKarmadaSearchService(client, name, namespace)
+}
+
+func installKarmadaSearch(client clientset.Interface, cfg *operatorv1alpha1.KarmadaSearch, name, namespace string, featureGates map[string]bool) error {
+	searchDeploymentSetBytes, err := util.ParseTemplate(KarmadaSearchDeployment, struct {
+		DeploymentName, Namespace, Image, KarmadaCertsSecret string
+		KubeconfigSecret, EtcdClientService                  string
+		Replicas                                             *int32
+		EtcdListenClientPort                                 int32
+	}{
+		DeploymentName:       util.KarmadaSearchName(name),
+		Namespace:            namespace,
+		Image:                cfg.Image.Name(),
+		KarmadaCertsSecret:   util.KarmadaCertSecretName(name),
+		Replicas:             cfg.Replicas,
+		KubeconfigSecret:     util.AdminKubeconfigSecretName(name),
+		EtcdClientService:    util.KarmadaEtcdClientName(name),
+		EtcdListenClientPort: constants.EtcdListenClientPort,
+	})
+	if err != nil {
+		return fmt.Errorf("error when parsing KarmadaSearch Deployment template: %w", err)
+	}
+
+	searchDeployment := &appsv1.Deployment{}
+	if err := kuberuntime.DecodeInto(clientsetscheme.Codecs.UniversalDecoder(), searchDeploymentSetBytes, searchDeployment); err != nil {
+		return fmt.Errorf("err when decoding KarmadaSearch Deployment: %w", err)
+	}
+
+	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
+		WithExtraArgs(cfg.ExtraArgs).WithResources(cfg.Resources).ForDeployment(searchDeployment)
+
+	if err := apiclient.CreateOrUpdateDeployment(client, searchDeployment); err != nil {
+		return fmt.Errorf("error when creating deployment for %s, err: %w", searchDeployment.Name, err)
+	}
+	return nil
+}
+
+func createKarmadaSearchService(client clientset.Interface, name, namespace string) error {
+	searchServiceSetBytes, err := util.ParseTemplate(KarmadaSearchService, struct {
+		ServiceName, Namespace string
+	}{
+		ServiceName: util.KarmadaSearchName(name),
+		Namespace:   namespace,
+	})
+	if err != nil {
+		return fmt.Errorf("error when parsing KarmadaSearch Service template: %w", err)
+	}
+
+	searchService := &corev1.Service{}
+	if err := kuberuntime.DecodeInto(clientsetscheme.Codecs.UniversalDecoder(), searchServiceSetBytes, searchService); err != nil {
+		return fmt.Errorf("err when decoding KarmadaSearch Service: %w", err)
+	}
+
+	if err := apiclient.CreateOrUpdateService(client, searchService); err != nil {
+		return fmt.Errorf("err when creating service for %s, err: %w", searchService.Name, err)
+	}
+	return nil
+}

--- a/operator/pkg/karmadaresource/apiservice/manifest.go
+++ b/operator/pkg/karmadaresource/apiservice/manifest.go
@@ -77,4 +77,36 @@ spec:
   type: ExternalName
   externalName: {{ .HostClusterServiceName }}.{{ .HostClusterNamespace }}.svc
 `
+
+	// KarmadaSearchAPIService is karmada-search APIService manifest
+	KarmadaSearchAPIService = `
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.search.karmada.io
+  labels:
+    app: karmada-search
+    apiserver: "true"
+spec:
+  caBundle: {{ .CABundle }}
+  group: search.karmada.io
+  groupPriorityMinimum: 2000
+  service:
+    name: {{ .ServiceName }}
+    namespace: {{ .Namespace }}
+  version: v1alpha1
+  versionPriority: 10
+`
+
+	// KarmadaSearchService is karmada-search service manifest
+	KarmadaSearchService = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .ServiceName }}
+  namespace: {{ .Namespace }}
+spec:
+  type: ExternalName
+  externalName: {{ .HostClusterServiceName }}.{{ .HostClusterNamespace }}.svc
+`
 )

--- a/operator/pkg/tasks/deinit/component.go
+++ b/operator/pkg/tasks/deinit/component.go
@@ -41,6 +41,7 @@ func NewRemoveComponentTask() workflow.Task {
 			newRemoveComponentSubTask(constants.KarmadaControllerManagerComponent, util.KarmadaControllerManagerName),
 			newRemoveComponentSubTask(constants.KubeControllerManagerComponent, util.KubeControllerManagerName),
 			newRemoveComponentWithServiceSubTask(constants.KarmadaWebhookComponent, util.KarmadaWebhookName),
+			newRemoveComponentWithServiceSubTask(constants.KarmadaSearchComponent, util.KarmadaSearchName),
 			newRemoveComponentWithServiceSubTask(constants.KarmadaAggregatedAPIServerComponent, util.KarmadaAggregatedAPIServerName),
 			newRemoveComponentWithServiceSubTask(constants.KarmadaAPIserverComponent, util.KarmadaAPIServerName),
 			{

--- a/operator/pkg/util/naming.go
+++ b/operator/pkg/util/naming.go
@@ -54,6 +54,11 @@ func KarmadaAggregatedAPIServerName(karmada string) string {
 	return generateResourceName(karmada, "aggregated-apiserver")
 }
 
+// KarmadaSearchAPIServerName returns secret name of karmada-search
+func KarmadaSearchAPIServerName(karmada string) string {
+	return generateResourceName(karmada, "search")
+}
+
 // KarmadaEtcdName returns name of karmada-etcd
 func KarmadaEtcdName(karmada string) string {
 	return generateResourceName(karmada, "etcd")
@@ -92,6 +97,11 @@ func KarmadaDeschedulerName(karmada string) string {
 // KarmadaMetricsAdapterName returns name of karmada-metric-adapter
 func KarmadaMetricsAdapterName(karmada string) string {
 	return generateResourceName(karmada, "metrics-adapter")
+}
+
+// KarmadaSearchName returns name of karmada-search
+func KarmadaSearchName(karmada string) string {
+	return generateResourceName(karmada, "search")
 }
 
 func generateResourceName(karmada, suffix string) string {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
feat: support install karmada search with operator
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
```bash
➜  karmada git:(master) ✗ export KUBECONFIG=~/.kube/karmada-host.config     
➜  karmada git:(master) ✗ kubectl get pods -nkarmada-system -owide     
NAME                                              READY   STATUS    RESTARTS   AGE   IP           NODE                         NOMINATED NODE   READINESS GATES
karmada-aggregated-apiserver-dc9bdf584-spw5b      1/1     Running   0          13m   10.34.0.9    karmada-host-control-plane   <none>           <none>
karmada-apiserver-7dc5fc74f6-2g2h4                1/1     Running   0          14m   10.34.0.8    karmada-host-control-plane   <none>           <none>
karmada-controller-manager-6f46f5c86c-lb6b8       1/1     Running   0          13m   10.34.0.11   karmada-host-control-plane   <none>           <none>
karmada-etcd-0                                    1/1     Running   0          15m   10.34.0.7    karmada-host-control-plane   <none>           <none>
karmada-kube-controller-manager-7d5dccf75-kzcdz   1/1     Running   0          13m   10.34.0.10   karmada-host-control-plane   <none>           <none>
karmada-metrics-adapter-5cc8bf5697-725j5          1/1     Running   0          13m   10.34.0.15   karmada-host-control-plane   <none>           <none>
karmada-metrics-adapter-5cc8bf5697-95jwj          1/1     Running   0          13m   10.34.0.14   karmada-host-control-plane   <none>           <none>
karmada-operator-57fbccc759-wfjkp                 1/1     Running   0          11m   10.34.0.16   karmada-host-control-plane   <none>           <none>
karmada-scheduler-6c969b68b4-hr8hq                1/1     Running   0          13m   10.34.0.12   karmada-host-control-plane   <none>           <none>
karmada-search-85889bbff7-nmt64                   1/1     Running   0          10m   10.34.0.17   karmada-host-control-plane   <none>           <none>
karmada-webhook-589f867597-xlds7                  1/1     Running   0          13m   10.34.0.13   karmada-host-control-plane   <none>           <none>
➜  karmada git:(master) ✗ export KUBECONFIG=~/.kube/karmada-apiserver.config
➜  karmada git:(master) ✗ kubectl describe apiservice v1alpha1.search.karmada.io 
Name:         v1alpha1.search.karmada.io
Namespace:    
Labels:       apiserver=true
              app=karmada-search
Annotations:  <none>
API Version:  apiregistration.k8s.io/v1
Kind:         APIService
Metadata:
  Creation Timestamp:  2023-11-25T08:38:58Z
  Resource Version:    780
  UID:                 449e5915-6731-477b-b9e4-a701fea414e2
Spec:
  Ca Bundle:               LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM5VENDQWQyZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFTTVJBd0RnWURWUVFERXdkcllYSnQKWVdSaE1CNFhEVEl6TVRFeU5UQTRNek14TlZvWERUTXpNVEV5TWpBNE16TXhOVm93RWpFUU1BNEdBMVVFQXhNSAphMkZ5YldGa1lUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQU5FRHRNZDB6ZWVlCkZCbm1LbDlqY2FDeHMyV2doMFRLZ0g1VVh5eVMvOU9LSCs0Um5ueTBFWW1VckNMbzcrQWNxVUdPenRqUFhYV0kKMWt4MjYzcWY3UFppR2hKRzUwYnU0b3JjTXZVK25EZ3NMSkEzSGtWaVdkYVJWNjV5RFlGaXRWeUhWZ3JRTjQxNwpTRkUvYW91S0YxVE1iWW05bUZjQ2RlSzluTEQrOGpGZk56K2sxZG1hRWZ6WTE3UjZoOFpOY3FTVlNoOFVWWWtKCjN0NjlFcnhUMG02bkRhY0xWLzlYT0U0endMWHAxVVhPNUhlTlpva1g3V1I2bENZeUw3eGVwYmZ4Ukh2ZEJXSmsKMDlUNVpoNy9JQ29DOS83MTNZR0cyUzlMcmxPaE81c3pjYmtabFhlVTJmQ2hQUXZHQW9ML0ZEN0VIYVJqL1htYgpvM2wwaGM4c3Y2MENBd0VBQWFOV01GUXdEZ1lEVlIwUEFRSC9CQVFEQWdLa01BOEdBMVVkRXdFQi93UUZNQU1CCkFmOHdIUVlEVlIwT0JCWUVGRnZ2bTZxa292cnFPRTFSTmJEelhCY25qQVJtTUJJR0ExVWRFUVFMTUFtQ0IydGgKY20xaFpHRXdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBRWFzTmRFeGY4L3ZDelYzVkMvWWZlVVczaHBaTDZ0VwpBT0JBMDE0cHNsZ0dISm1rVEcwb0ZTNHE1UmNTYm03dVJhcHc3cU05NUU5bW01dWxvMDdpMDBVM0tETXcxdTlQCm53K0poNkQzSWhtbG40ZzlmVmlqclVUVUc1eHNFSEdGVXRqa3BEejIzQTNpb0lJaGMrQ0p1ajRSeVFoYkNGMDgKczk4S25FVjJEeU5TbE9BcGw3ZG0wL1F1bWpCZjJQMU95K25mYndYelJqSlBieVh4RmtyTGs0UFgxWnVNYSs5UApGNnAyL0drdG9jeDVSMkU1WmJYUXdmV1ljNGEyODFETVlZOGs5cDNIT1JBdkNTMlc4d0JGRFRWZkd2RDJGd05xCldJVGEvN1V0WExMZU91Vyt6ckYzLzZqZHNmRFRxOWZobkJCMmZrVFpIUUIrc1lMUlRFZlhSNmM9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
  Group:                   search.karmada.io
  Group Priority Minimum:  2000
  Service:
    Name:            karmada-search
    Namespace:       karmada-system
    Port:            443
  Version:           v1alpha1
  Version Priority:  10
Status:
  Conditions:
    Last Transition Time:  2023-11-25T08:39:11Z
    Message:               all checks passed
    Reason:                Passed
    Status:                True
    Type:                  Available
Events:
  Type     Reason             Age   From               Message
  ----     ------             ----  ----               -------
  Warning  ApplyPolicyFailed  11m   resource-detector  No policy match for resource
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-search`: Support install karmada-search with operator.
```

