### PR TITLE
implementation of Statization of Propagation Policy

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -929,7 +929,9 @@ func (d *ResourceDetector) OnPropagationPolicyUpdate(oldObj, newObj interface{})
 	// The idea of the long-term solution, perhaps PropagationPolicy could have
 	// a status, in that case we can record the observed priority(.status.observedPriority)
 	// which can be used to detect priority changes during reconcile logic.
-	if features.FeatureGate.Enabled(features.PolicyPreemption) {
+	//
+	// notes that preemption take effect only when StaticPolicy disabled.
+	if !features.FeatureGate.Enabled(features.StaticPolicy) && features.FeatureGate.Enabled(features.PolicyPreemption) {
 		var unstructuredOldObj *unstructured.Unstructured
 		var unstructuredNewObj *unstructured.Unstructured
 
@@ -1039,7 +1041,9 @@ func (d *ResourceDetector) OnClusterPropagationPolicyUpdate(oldObj, newObj inter
 	// The idea of the long-term solution, perhaps ClusterPropagationPolicy could have
 	// a status, in that case we can record the observed priority(.status.observedPriority)
 	// which can be used to detect priority changes during reconcile logic.
-	if features.FeatureGate.Enabled(features.PolicyPreemption) {
+	//
+	// notes that preemption take effect only when StaticPolicy disabled.
+	if !features.FeatureGate.Enabled(features.StaticPolicy) && features.FeatureGate.Enabled(features.PolicyPreemption) {
 		var unstructuredOldObj *unstructured.Unstructured
 		var unstructuredNewObj *unstructured.Unstructured
 
@@ -1227,21 +1231,25 @@ func (d *ResourceDetector) HandlePropagationPolicyCreationOrUpdate(policy *polic
 		return err
 	}
 
-	// When updating fields other than ResourceSelector, should first find the corresponding ResourceBinding
-	// and add the bound object to the processor's queue for reconciliation to make sure that
-	// PropagationPolicy's updates can be synchronized to ResourceBinding.
-	resourceBindings, err := d.listPPDerivedRB(policy.Namespace, policy.Name)
-	if err != nil {
-		return err
-	}
-	for _, rb := range resourceBindings.Items {
-		resourceKey, err := helper.ConstructClusterWideKey(rb.Spec.Resource)
+	// if StaticPolicy disabled, add the PP related RT to processor, otherwise just skip this step
+	if !features.FeatureGate.Enabled(features.StaticPolicy) {
+		// When updating fields other than ResourceSelector, should first find the corresponding ResourceBinding
+		// and add the bound object to the processor's queue for reconciliation to make sure that
+		// PropagationPolicy's updates can be synchronized to ResourceBinding.
+		resourceBindings, err := d.listPPDerivedRB(policy.Namespace, policy.Name)
 		if err != nil {
 			return err
 		}
-		d.Processor.Add(resourceKey)
+		for _, rb := range resourceBindings.Items {
+			resourceKey, err := helper.ConstructClusterWideKey(rb.Spec.Resource)
+			if err != nil {
+				return err
+			}
+			d.Processor.Add(resourceKey)
+		}
 	}
 
+	// check whether there are matched RT in waiting list, is so, add it to processor
 	matchedKeys := d.GetMatching(policy.Spec.ResourceSelectors)
 	klog.Infof("Matched %d resources by policy(%s/%s)", len(matchedKeys), policy.Namespace, policy.Name)
 
@@ -1259,8 +1267,8 @@ func (d *ResourceDetector) HandlePropagationPolicyCreationOrUpdate(policy *polic
 		d.Processor.Add(key)
 	}
 
-	// if preemption is enabled, handle the preemption process.
-	if preemptionEnabled(policy.Spec.Preemption) {
+	// if preemption is enabled, handle the preemption process (preemption take effect only when StaticPolicy disabled).
+	if !features.FeatureGate.Enabled(features.StaticPolicy) && preemptionEnabled(policy.Spec.Preemption) {
 		return d.handlePropagationPolicyPreemption(policy)
 	}
 
@@ -1284,32 +1292,14 @@ func (d *ResourceDetector) HandleClusterPropagationPolicyCreationOrUpdate(policy
 		return err
 	}
 
-	// When updating fields other than ResourceSelector, should first find the corresponding ResourceBinding/ClusterResourceBinding
-	// and add the bound object to the processor's queue for reconciliation to make sure that
-	// ClusterPropagationPolicy's updates can be synchronized to ResourceBinding/ClusterResourceBinding.
-	resourceBindings, err := d.listCPPDerivedRB(policy.Name)
-	if err != nil {
-		return err
-	}
-	clusterResourceBindings, err := d.listCPPDerivedCRB(policy.Name)
-	if err != nil {
-		return err
-	}
-	for _, rb := range resourceBindings.Items {
-		resourceKey, err := helper.ConstructClusterWideKey(rb.Spec.Resource)
-		if err != nil {
+	// if StaticPolicy disabled, add the PP related RT to processor, otherwise just skip this step
+	if !features.FeatureGate.Enabled(features.StaticPolicy) {
+		if err = d.addRelatedTemplateToProcessorQueue(policy); err != nil {
 			return err
 		}
-		d.Processor.Add(resourceKey)
-	}
-	for _, crb := range clusterResourceBindings.Items {
-		resourceKey, err := helper.ConstructClusterWideKey(crb.Spec.Resource)
-		if err != nil {
-			return err
-		}
-		d.Processor.Add(resourceKey)
 	}
 
+	// check whether there are matched RT in waiting list, is so, add it to processor
 	matchedKeys := d.GetMatching(policy.Spec.ResourceSelectors)
 	klog.Infof("Matched %d resources by policy(%s)", len(matchedKeys), policy.Name)
 
@@ -1327,11 +1317,40 @@ func (d *ResourceDetector) HandleClusterPropagationPolicyCreationOrUpdate(policy
 		d.Processor.Add(key)
 	}
 
-	// if preemption is enabled, handle the preemption process.
-	if preemptionEnabled(policy.Spec.Preemption) {
+	// if preemption is enabled, handle the preemption process (preemption take effect only when StaticPolicy disabled).
+	if !features.FeatureGate.Enabled(features.StaticPolicy) && preemptionEnabled(policy.Spec.Preemption) {
 		return d.handleClusterPropagationPolicyPreemption(policy)
 	}
 
+	return nil
+}
+
+// addRelatedTemplateToProcessorQueue When updating fields other than ResourceSelector, should first find the corresponding
+// ResourceBinding/ClusterResourceBinding and add the bound object to the processor's queue for reconciliation to make sure that
+// ClusterPropagationPolicy's updates can be synchronized to ResourceBinding/ClusterResourceBinding.
+func (d *ResourceDetector) addRelatedTemplateToProcessorQueue(policy *policyv1alpha1.ClusterPropagationPolicy) error {
+	resourceBindings, err := d.listCPPDerivedRB(policy.Name)
+	if err != nil {
+		return fmt.Errorf("failed to list CPP(%s) derived RB: %+v", policy.Name, err)
+	}
+	clusterResourceBindings, err := d.listCPPDerivedCRB(policy.Name)
+	if err != nil {
+		return fmt.Errorf("failed to list CPP(%s) derived CRB: %+v", policy.Name, err)
+	}
+	for _, rb := range resourceBindings.Items {
+		resourceKey, err := helper.ConstructClusterWideKey(rb.Spec.Resource)
+		if err != nil {
+			return fmt.Errorf("failed to get resource ClusterWideKey from RB(%s): %+v", rb.Name, err)
+		}
+		d.Processor.Add(resourceKey)
+	}
+	for _, crb := range clusterResourceBindings.Items {
+		resourceKey, err := helper.ConstructClusterWideKey(crb.Spec.Resource)
+		if err != nil {
+			return fmt.Errorf("failed to get resource ClusterWideKey from CRB(%s): %+v", crb.Name, err)
+		}
+		d.Processor.Add(resourceKey)
+	}
 	return nil
 }
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -37,6 +37,8 @@ const (
 
 	// PolicyPreemption indicates if high-priority PropagationPolicy/ClusterPropagationPolicy could preempt resource templates which are matched by low-priority PropagationPolicy/ClusterPropagationPolicy.
 	PolicyPreemption featuregate.Feature = "PropagationPolicyPreemption"
+
+	StaticPolicy featuregate.Feature = "StaticPolicy"
 )
 
 var (
@@ -50,6 +52,7 @@ var (
 		PropagateDeps:                     {Default: true, PreRelease: featuregate.Beta},
 		CustomizedClusterResourceModeling: {Default: true, PreRelease: featuregate.Beta},
 		PolicyPreemption:                  {Default: false, PreRelease: featuregate.Alpha},
+		StaticPolicy:                      {Default: false, PreRelease: featuregate.Alpha},
 	}
 )
 

--- a/pkg/util/eventfilter/eventfilter.go
+++ b/pkg/util/eventfilter/eventfilter.go
@@ -18,9 +18,14 @@ package eventfilter
 
 import (
 	"reflect"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/karmada-io/karmada/pkg/features"
 )
+
+const labelOrAnnoKeyPrefixByKarmada = ".karmada.io"
 
 // SpecificationChanged check if the specification of the given object change or not
 func SpecificationChanged(oldObj, newObj *unstructured.Unstructured) bool {
@@ -33,6 +38,33 @@ func SpecificationChanged(oldObj, newObj *unstructured.Unstructured) bool {
 	for _, r := range removedFields {
 		unstructured.RemoveNestedField(oldBackup.Object, r...)
 		unstructured.RemoveNestedField(newBackup.Object, r...)
+	}
+
+	// Notes: assuming StaticPolicy disabled, now we can not add this keyPrefixFilter.
+	// Because if you delete a Policy, the detector just remove the labels from RT, thus trigger the reconciliation of RT,
+	// and then the RT may be put into waiting list.
+	// If this keyPrefixFilter added when StaticPolicy disabled, it will eventually prevent the RT from putting into waiting list.
+	if features.FeatureGate.Enabled(features.StaticPolicy) {
+		for k := range oldBackup.GetLabels() {
+			if strings.Contains(k, labelOrAnnoKeyPrefixByKarmada) {
+				unstructured.RemoveNestedField(oldBackup.Object, []string{"metadata", "labels", k}...)
+			}
+		}
+		for k := range oldBackup.GetAnnotations() {
+			if strings.Contains(k, labelOrAnnoKeyPrefixByKarmada) {
+				unstructured.RemoveNestedField(oldBackup.Object, []string{"metadata", "annotations", k}...)
+			}
+		}
+		for k := range newBackup.GetLabels() {
+			if strings.Contains(k, labelOrAnnoKeyPrefixByKarmada) {
+				unstructured.RemoveNestedField(newBackup.Object, []string{"metadata", "labels", k}...)
+			}
+		}
+		for k := range newBackup.GetAnnotations() {
+			if strings.Contains(k, labelOrAnnoKeyPrefixByKarmada) {
+				unstructured.RemoveNestedField(newBackup.Object, []string{"metadata", "annotations", k}...)
+			}
+		}
 	}
 
 	return !reflect.DeepEqual(oldBackup, newBackup)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

In #4289, we propose an improvement to the Policy enforcement mechanism, called Policy staticization.
Before the introduction of this feature, modification of a Policy would immediately affect the resource templates it manages, potentially causing a huge shock to the system, which is too sensitive.

We want Policy to be just some API-based static system strategies. Modification of the Policy should not actively cause changes to the system behavior, but should be triggered by ResourceTemplate.

Just like if a ResourceTemplate has already been propagated by a Policy, don't change its states for any Policy changes, but you can re-propagate it by latest Policy when ResourceTemplate itself updated.

More details refer to https://github.com/karmada-io/karmada/issues/4288 and proposal content.

**Which issue(s) this PR fixes**:

Fixes part of #4288

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
introduces a modification to the behavior of Propagation Policy, making the Propagation Policy to be static.
```

