### PR TITLE
Correct DNSNames of karmada-apiserver certificate in operator installation mode

### DIFF
--- a/operator/pkg/certs/certs.go
+++ b/operator/pkg/certs/certs.go
@@ -473,8 +473,8 @@ func apiServerAltNamesMutator(cfg *AltNamesMutatorConfig) (*certutil.AltNames, e
 			"kubernetes",
 			"kubernetes.default",
 			"kubernetes.default.svc",
-			fmt.Sprintf("*.%s.svc.cluster.local", cfg.Namespace),
-			fmt.Sprintf("*.%s.svc", cfg.Namespace),
+			fmt.Sprintf("*.%s.svc.cluster.local", constants.KarmadaSystemNamespace),
+			fmt.Sprintf("*.%s.svc", constants.KarmadaSystemNamespace),
 		},
 		IPs: []net.IP{
 			net.IPv4(127, 0, 0, 1),


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Correct DNSNames of karmada-apiserver certificate in operator installation mode
**Which issue(s) this PR fixes**:
Fixes #4322

**Special notes for your reviewer**:
NONE
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

