### PR TITLE
fix incorrect forType in clusterResourceBinding status controller

### DIFF
--- a/pkg/controllers/status/common.go
+++ b/pkg/controllers/status/common.go
@@ -37,7 +37,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/restmapper"
 )
 
-var rbPredicateFn = builder.WithPredicates(predicate.Funcs{
+var bindingPredicateFn = builder.WithPredicates(predicate.Funcs{
 	CreateFunc: func(e event.CreateEvent) bool { return false },
 	UpdateFunc: func(e event.UpdateEvent) bool {
 		var oldResourceVersion, newResourceVersion string

--- a/pkg/controllers/status/crb_status_controller.go
+++ b/pkg/controllers/status/crb_status_controller.go
@@ -102,7 +102,7 @@ func (c *CRBStatusController) SetupWithManager(mgr controllerruntime.Manager) er
 		})
 
 	return controllerruntime.NewControllerManagedBy(mgr).Named("clusterResourceBinding_status_controller").
-		For(&workv1alpha2.ResourceBinding{}, rbPredicateFn).
+		For(&workv1alpha2.ClusterResourceBinding{}, bindingPredicateFn).
 		Watches(&workv1alpha1.Work{}, handler.EnqueueRequestsFromMapFunc(workMapFunc), workPredicateFn).
 		WithOptions(controller.Options{RateLimiter: ratelimiterflag.DefaultControllerRateLimiter(c.RateLimiterOptions)}).
 		Complete(c)

--- a/pkg/controllers/status/rb_status_controller.go
+++ b/pkg/controllers/status/rb_status_controller.go
@@ -104,7 +104,7 @@ func (c *RBStatusController) SetupWithManager(mgr controllerruntime.Manager) err
 		})
 
 	return controllerruntime.NewControllerManagedBy(mgr).Named("resourceBinding_status_controller").
-		For(&workv1alpha2.ResourceBinding{}, rbPredicateFn).
+		For(&workv1alpha2.ResourceBinding{}, bindingPredicateFn).
 		Watches(&workv1alpha1.Work{}, handler.EnqueueRequestsFromMapFunc(workMapFunc), workPredicateFn).
 		WithOptions(controller.Options{RateLimiter: ratelimiterflag.DefaultControllerRateLimiter(c.RateLimiterOptions)}).
 		Complete(c)


### PR DESCRIPTION
**What type of PR is this?**  
/kind bug  

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:  
Fix the incorrect `forType` declared in `clusterresourcebinding-status controller`  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:  

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: fix incorrect `forType` in `cluster-resource-binding-status controller` from `ResouceBinding` to `ClusterResourceBinding` 
```

