### PR TITLE
feat: clean the endpointslice if the current cluster is not in the mcs consumption clusters

### DIFF
--- a/pkg/controllers/multiclusterservice/endpointslice_collect_controller.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_collect_controller.go
@@ -140,6 +140,11 @@ func (c *EndpointSliceCollectController) cleanWorkWithMCSDelete(work *workv1alph
 		if !helper.IsWorkContains(work.Spec.Workload.Manifests, endpointSliceGVK) {
 			continue
 		}
+		// We only care about the EndpointSlice work in provision clusters
+		if util.GetAnnotationValue(work.Annotations, util.EndpointSliceProvisionClusterAnnotation) != "" {
+			continue
+		}
+
 		if err := c.Delete(context.TODO(), work.DeepCopy()); err != nil {
 			klog.Errorf("Failed to delete work(%s/%s), Error: %v", work.Namespace, work.Name, err)
 			errs = append(errs, err)
@@ -334,7 +339,7 @@ func (c *EndpointSliceCollectController) handleEndpointSliceEvent(endpointSliceK
 		return err
 	}
 
-	if util.GetLabelValue(endpointSliceObj.GetLabels(), discoveryv1.LabelManagedBy) == util.EndpointSliceControllerLabelValue {
+	if util.GetLabelValue(endpointSliceObj.GetLabels(), discoveryv1.LabelManagedBy) == util.EndpointSliceDispatchControllerLabelValue {
 		return nil
 	}
 
@@ -393,7 +398,7 @@ func (c *EndpointSliceCollectController) collectTargetEndpointSlice(work *workv1
 			klog.Errorf("Failed to convert object to EndpointSlice, error: %v", err)
 			return err
 		}
-		if util.GetLabelValue(eps.GetLabels(), discoveryv1.LabelManagedBy) == util.EndpointSliceControllerLabelValue {
+		if util.GetLabelValue(eps.GetLabels(), discoveryv1.LabelManagedBy) == util.EndpointSliceDispatchControllerLabelValue {
 			continue
 		}
 		epsUnstructured, err := helper.ToUnstructured(eps)

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -51,8 +51,8 @@ const (
 	// ManagedByKarmadaLabelValue indicates that resources are managed by karmada controllers.
 	ManagedByKarmadaLabelValue = "true"
 
-	// EndpointSliceControllerLabelValue indicates the endpointSlice are controlled by karmada-mcs-endpointslice-controller
-	EndpointSliceControllerLabelValue = "karmada-mcs-endpointslice-controller"
+	// EndpointSliceDispatchControllerLabelValue indicates the endpointSlice are controlled by Karmada
+	EndpointSliceDispatchControllerLabelValue = "endpointslice-dispatch-controller.karmada.io"
 
 	// RetainReplicasLabel is a reserved label to indicate whether the replicas should be retained. e.g:
 	// resourcetemplate.karmada.io/retain-replicas: true   // with value `true` indicates retain

--- a/pkg/util/helper/mcs.go
+++ b/pkg/util/helper/mcs.go
@@ -118,3 +118,16 @@ func GetProvisionClusters(client client.Client, mcs *networkingv1alpha1.MultiClu
 	}
 	return provisionClusters, nil
 }
+
+func GetConsumptionClustres(client client.Client, mcs *networkingv1alpha1.MultiClusterService) (sets.Set[string], error) {
+	consumptionClusters := sets.New[string](mcs.Spec.ServiceConsumptionClusters...)
+	if len(consumptionClusters) == 0 {
+		var err error
+		consumptionClusters, err = util.GetClusterSet(client)
+		if err != nil {
+			klog.Errorf("Failed to get cluster set, Error: %v", err)
+			return nil, err
+		}
+	}
+	return consumptionClusters, nil
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Firstly, member1 and member2 are in the consumption clusters set,
Then, the consumption clusters set changes to member1.
We should clean the endpointslice dispatched to member2 before.

**Which issue(s) this PR fixes**:
Fixes #none

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

