### PR TITLE
Update helm index to v1.8.0 and add the karmada-operator chart

### DIFF
--- a/charts/index.yaml
+++ b/charts/index.yaml
@@ -3,6 +3,28 @@ entries:
   karmada:
   - apiVersion: v2
     appVersion: v1.1.0
+    created: "2023-11-30T11:46:45.584645-08:00"
+    dependencies:
+    - name: common
+      repository: https://charts.bitnami.com/bitnami
+      version: 1.x.x
+    description: A Helm chart for karmada
+    digest: 0f49ae9acf1d65c39c54f9272611661f9b7bf11e8c00e74ad0cc09c39d80b01e
+    kubeVersion: '>= 1.16.0-0'
+    maintainers:
+    - email: jrkeen@hotmail.com
+      name: jrkeen
+    - email: jackson.cloudnative@gmail.com
+      name: pidb
+    - email: shentiecheng@huawei.com
+      name: Poor12
+    name: karmada
+    type: application
+    urls:
+    - https://github.com/karmada-io/karmada/releases/download/v1.8.0/karmada-chart-v1.8.0.tgz
+    version: v1.8.0
+  - apiVersion: v2
+    appVersion: v1.1.0
     created: "2023-10-25T16:55:42.896904-04:00"
     dependencies:
     - name: common
@@ -46,7 +68,7 @@ entries:
     - https://github.com/karmada-io/karmada/releases/download/v1.7.0/karmada-chart-v1.7.0.tgz
     version: v1.7.0
   - apiVersion: v2
-    appVersion: latest
+    appVersion: v1.1.0
     created: "2023-08-03T16:11:27.3481878+08:00"
     dependencies:
     - name: common
@@ -69,7 +91,7 @@ entries:
     version: v1.6.2
   - apiVersion: v2
     appVersion: v1.1.0
-    created: "2023-07-06T11:15:13.538429300+08:00"
+    created: "2023-07-06T11:15:13.5384293+08:00"
     dependencies:
     - name: common
       repository: https://charts.bitnami.com/bitnami
@@ -197,4 +219,23 @@ entries:
     urls:
     - https://github.com/karmada-io/karmada/releases/download/v1.2.0/karmada-chart-v1.2.0.tgz
     version: v1.2.0
-generated: "2023-10-25T16:55:42.883421-04:00"
+  karmada-operator:
+  - apiVersion: v2
+    appVersion: v1.1.0
+    created: "2023-11-30T11:47:32.390757-08:00"
+    dependencies:
+    - name: common
+      repository: https://charts.bitnami.com/bitnami
+      version: 1.x.x
+    description: A Helm chart for karmada-operator
+    digest: 6a7a91fae8d6dc510d095d7dd780af868bc22e14b206fd054a7aefc8b7b94af1
+    kubeVersion: '>= 1.16.0-0'
+    maintainers:
+    - email: wen.chen@daocloud.io
+      name: calvin0327
+    name: karmada-operator
+    type: application
+    urls:
+    - https://github.com/karmada-io/karmada/releases/download/v1.8.0/karmada-operator-chart-v1.8.0.tgz
+    version: v1.8.0
+generated: "2023-11-30T11:47:32.388718-08:00"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
This publishes the v1.8.0 release and adds the karmada-operator chart. The karmada-operator chart was added to the release in [this PR](https://github.com/karmada-io/karmada/pull/4205)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`Helm chart`: Updated helm index for 1.8.0 release, and added the karmada-operator chart.
```

