### PR TITLE
e2e: make FederatedResourceQuota e2e as serial to avoid affecting other e2e

### DIFF
--- a/test/e2e/federatedresourcequota_test.go
+++ b/test/e2e/federatedresourcequota_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/karmada-io/karmada/test/helper"
 )
 
-var _ = ginkgo.Describe("FederatedResourceQuota auto-provision testing", func() {
+var _ = framework.SerialDescribe("FederatedResourceQuota auto-provision testing", func() {
 	var frqNamespace, frqName string
 	var federatedResourceQuota *policyv1alpha1.FederatedResourceQuota
 	var f cmdutil.Factory
@@ -156,7 +156,7 @@ var _ = ginkgo.Describe("FederatedResourceQuota auto-provision testing", func() 
 	})
 })
 
-var _ = ginkgo.Describe("[FederatedResourceQuota] status collection testing", func() {
+var _ = framework.SerialDescribe("[FederatedResourceQuota] status collection testing", func() {
 	var frqNamespace, frqName string
 	var federatedResourceQuota *policyv1alpha1.FederatedResourceQuota
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind failing-test

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
There is e2e failure: https://github.com/karmada-io/karmada/actions/runs/7057108479/job/19210332348
The reason is:
![image](https://github.com/karmada-io/karmada/assets/19745536/c6bbd2e9-cc28-4c53-b914-63dd3129b857)

And I tried in my local env, if there is a resource quota in the ns, the pod creation(without setting resource requests will be rejected):
![image](https://github.com/karmada-io/karmada/assets/19745536/c0a13397-98d3-4a13-8154-b87dad92d754)

There are too many resource without the resource request setting: https://github.com/karmada-io/karmada/blob/61283676bb7fe72041c22fea18f476eaaff6d29a/test/helper/resource.go#L233

So, let's just make FederatedResourceQuota e2e as serial to avoid affecting other e2e.

**Which issue(s) this PR fixes**:
Fixes #none

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

