### PR TITLE
Automated cherry pick of #4344: correct the license in the lifted directory

### DIFF
--- a/pkg/util/lifted/deployment_test.go
+++ b/pkg/util/lifted/deployment_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Karmada Authors.
+Copyright 2015 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/util/lifted/federatedhpa.go
+++ b/pkg/util/lifted/federatedhpa.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Karmada Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/util/lifted/federatedhpa_test.go
+++ b/pkg/util/lifted/federatedhpa_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Karmada Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/util/lifted/lua_oslib_safe.go
+++ b/pkg/util/lifted/lua_oslib_safe.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Karmada Authors.
+Copyright 2019 The Argo Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/util/lifted/validatingfhpa.go
+++ b/pkg/util/lifted/validatingfhpa.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Karmada Authors.
+Copyright 2016 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/util/lifted/validatingmci_test.go
+++ b/pkg/util/lifted/validatingmci_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Karmada Authors.
+Copyright 2014 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Cherry pick of #4344 on release-1.8.
#4344: correct the license in the lifted directory
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
NONE
```