### PR TITLE
Automated cherry pick of #4352: e2e: make FederatedResourceQuota e2e as serial to avoid

### DIFF
--- a/test/e2e/federatedresourcequota_test.go
+++ b/test/e2e/federatedresourcequota_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/karmada-io/karmada/test/helper"
 )
 
-var _ = ginkgo.Describe("FederatedResourceQuota auto-provision testing", func() {
+var _ = framework.SerialDescribe("FederatedResourceQuota auto-provision testing", func() {
 	var frqNamespace, frqName string
 	var federatedResourceQuota *policyv1alpha1.FederatedResourceQuota
 	var f cmdutil.Factory
@@ -156,7 +156,7 @@ var _ = ginkgo.Describe("FederatedResourceQuota auto-provision testing", func() 
 	})
 })
 
-var _ = ginkgo.Describe("[FederatedResourceQuota] status collection testing", func() {
+var _ = framework.SerialDescribe("[FederatedResourceQuota] status collection testing", func() {
 	var frqNamespace, frqName string
 	var federatedResourceQuota *policyv1alpha1.FederatedResourceQuota
 


### PR DESCRIPTION
Cherry pick of #4352 on release-1.8.
#4352: e2e: make FederatedResourceQuota e2e as serial to avoid
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
```