### PR TITLE
add cfg.Namespace.svc to apiServerAltNames in operator installation mode

### DIFF
--- a/operator/pkg/certs/certs.go
+++ b/operator/pkg/certs/certs.go
@@ -481,6 +481,17 @@ func apiServerAltNamesMutator(cfg *AltNamesMutatorConfig) (*certutil.AltNames, e
 		},
 	}
 
+	// When deploying a karmada under a namespace other than 'karmada-system', like 'test', there are two scenarios below：
+	// 1.When karmada-apiserver access APIService, the cert of 'karmada-demo-aggregated-apiserver' will be verified to see
+	// if its altNames contains 'karmada-demo-aggregated-apiserver.karmada-system.svc';
+	// 2.When karmada-apiserver access webhook, the cert of 'karmada-demo-webhook' will be verified to see
+	// if its altNames contains 'karmada-demo-webhook.test.svc'.
+	// Therefore, the certificate's altNames should contain both 'karmada-system.svc.cluster.local' and 'test.svc.cluster.local'.
+	if cfg.Namespace != constants.KarmadaSystemNamespace {
+		appendSANsToAltNames(altNames, []string{fmt.Sprintf("*.%s.svc.cluster.local", cfg.Namespace),
+			fmt.Sprintf("*.%s.svc", cfg.Namespace)})
+	}
+
 	if len(cfg.Components.KarmadaAPIServer.CertSANs) > 0 {
 		appendSANsToAltNames(altNames, cfg.Components.KarmadaAPIServer.CertSANs)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When the client accesses the server, the client will verify whether the altNames of the server's certificate contains the server's domain name. If not, the verification will fail. 
Operator installation scenario, if karmada is installed in a namespace other than 'karmada-system', like 'test', there are two scenarios below：
- When karmada-apiserver access APIService, like v1alpha1.cluster.karmada.io, the cert of 'karmada-demo-aggregated-apiserver' will be verified to see if its altNames contains 'karmada-system/karmada-demo-aggregated-apiserver'
- When karmada-apiserver access webhook, like validatingwebhookconfigurations, the cert of 'karmada-demo-webhook' will be verified to see if its altNames contains 'karmada-demo-webhook.test.svc'

Therefore, the certificate's altNames should contain 'karmada-system.svc.cluster.local' and 'test.svc.cluster.local'



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
1. Follow the [tutorial](https://github.com/karmada-io/karmada/blob/master/operator/README.md) to install karmada
2. deploy a svc
```yaml
apiVersion: v1
kind: Service
metadata:
  name: my-service
spec:
  type: LoadBalancer
  selector:
    foo: bar
  ports:
    - protocol: TCP
      port: 80
      targetPort: 9376
```
3. deploy a pp 
```yaml
apiVersion: policy.karmada.io/v1alpha1
kind: PropagationPolicy
metadata:
  name: foo
spec:
  resourceSelectors:
    - apiVersion: v1
      kind: Service
  placement:
    clusterAffinity:
      clusterNames:
        - member1
```
4. check the result
```bash
➜  karmada git:(master) ✗ kubectl --kubeconfig $HOME/.kube/member.config --context member1 get svc -A
NAMESPACE     NAME         TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)                  AGE
default       kubernetes   ClusterIP      100.236.0.1      <none>        443/TCP                  5m13s
default       my-service   LoadBalancer   100.236.164.14   <pending>     80:30696/TCP             69s
kube-system   kube-dns     ClusterIP      100.236.0.10     <none>        53/UDP,53/TCP,9153/TCP   5m11s
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

