### PR TITLE
Delete k8s v1.21 and v1.22 from CI Schedule Workflow.

### DIFF
--- a/.github/workflows/ci-schedule.yml
+++ b/.github/workflows/ci-schedule.yml
@@ -10,8 +10,9 @@ jobs:
     if: ${{ github.repository == 'karmada-io/karmada' }}
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
-        k8s: [ v1.21.10, v1.22.7, v1.23.4, v1.24.2, v1.25.0, v1.26.0, v1.27.3, v1.28.0 ]
+        k8s: [ v1.23.4, v1.24.2, v1.25.0, v1.26.0, v1.27.3, v1.28.0 ]
     steps:
       # Free up disk space on Ubuntu
       - name: Free Disk Space (Ubuntu)


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind failing-test

**What this PR does / why we need it**:
This PR is working for fix CI of `CI Schedule Workflow`, Now, it's always failed with kubernetes 1.21.0 and v1.22.7 of  member cluster, here is the error log:

```
 [FAILED] Timed out after 420.001s.
  Expected
      <bool>: false
  to equal
      <bool>: true
  In [It] at: /home/runner/work/karmada/karmada/test/e2e/framework/deployment.go:82 @ 12/03/23 18:24:15.332

  Full Stack Trace
    github.com/karmada-io/karmada/test/e2e/framework.WaitDeploymentPresentOnClusterFitWith({0xc00067d3e9, 0x7}, {0xc00079fd28, 0x11}, {0xc0006d3ce4, 0xc}, 0xc0009e7380)
    	/home/runner/work/karmada/karmada/test/e2e/framework/deployment.go:82 +0x62b
    github.com/karmada-io/karmada/test/e2e/framework.WaitDeploymentPresentOnClustersFitWith.func1()
    	/home/runner/work/karmada/karmada/test/e2e/framework/deployment.go:89 +0xcf
    github.com/karmada-io/karmada/test/e2e/framework.WaitDeploymentPresentOnClustersFitWith({0xc0003099c0, 0x3, 0x4}, {0xc00079fd28, 0x11}, {0xc0006d3ce4, 0xc}, 0xc0009e7380)
    	/home/runner/work/karmada/karmada/test/e2e/framework/deployment.go:87 +0x1ac
    github.com/karmada-io/karmada/test/e2e.glob..func14.1.3()
    	/home/runner/work/karmada/karmada/test/e2e/hpareplicassyncer_test.go:92 +0x28e
```

The reason is the test is using autoscaling/v2 for HorizontalPodAutoscaler, and this version is GA from kubernetes v1.23.0, so it will never succeed.
This PR just ~~let it skip the test when kubernetes version is lessthan v1.23.~~

Other change is let the CI `CI Schedule Workflow` do not fail-fast.


**Which issue(s) this PR fixes**:
Fixes #
Related:
- https://github.com/karmada-io/karmada/issues/3706

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

