### PR TITLE
make metrics-adapter chart installation optional

### DIFF
--- a/charts/karmada/templates/karmada-metrics-adapter.yaml
+++ b/charts/karmada/templates/karmada-metrics-adapter.yaml
@@ -1,11 +1,12 @@
-{{- if eq .Values.installMode "host" }}
+{{- if and (or (eq .Values.installMode "component") (eq .Values.installMode "host")) (has "metricsAdapter" .Values.components) }}
+{{ $namespace := include "karmada.namespace" .}}
 {{- $name := include "karmada.name" . -}}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $name }}-metrics-adapter
-  namespace: {{ include "karmada.namespace" . }}
+  namespace: {{ $namespace }}
   labels:
     {{- include "karmada.metricsAdapter.labels" . | nindent 4 }}
 spec:
@@ -89,7 +90,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $name }}-metrics-adapter
-  namespace: {{ include "karmada.namespace" . }}
+  namespace: {{ $namespace }}
   labels:
     {{- include "karmada.metricsAdapter.labels" . | nindent 4 }}
 spec:
@@ -106,7 +107,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ $name }}-metrics-adapter
-  namespace: {{ include "karmada.namespace" . }}
+  namespace: {{ $namespace }}
   labels:
     {{- include "karmada.metricsAdapter.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
With this change in v1.8: https://github.com/karmada-io/karmada/pull/4303, karmada-metrics-adapter is part of the helm chart when install karmada.

This change is to make karmada-metrics-adapter installation in components with host when set.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

