### PR TITLE
bump alpine to 3.18.5 to address CVE concerns

### DIFF
--- a/cluster/images/Dockerfile
+++ b/cluster/images/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.18.3
+FROM alpine:3.18.5
 
 ARG BINARY
 

--- a/cluster/images/buildx.Dockerfile
+++ b/cluster/images/buildx.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.18.3
+FROM alpine:3.18.5
 
 ARG BINARY
 ARG TARGETPLATFORM

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -114,7 +114,7 @@ func init() {
 	karmadaRelease = releaseVer.ReleaseVersion()
 
 	DefaultCrdURL = fmt.Sprintf("https://github.com/karmada-io/karmada/releases/download/%s/crds.tar.gz", releaseVer.ReleaseVersion())
-	DefaultInitImage = "docker.io/alpine:3.15.1"
+	DefaultInitImage = "docker.io/alpine:3.18.5"
 	DefaultKarmadaSchedulerImage = fmt.Sprintf("docker.io/karmada/karmada-scheduler:%s", releaseVer.ReleaseVersion())
 	DefaultKarmadaControllerManagerImage = fmt.Sprintf("docker.io/karmada/karmada-controller-manager:%s", releaseVer.ReleaseVersion())
 	DefualtKarmadaWebhookImage = fmt.Sprintf("docker.io/karmada/karmada-webhook:%s", releaseVer.ReleaseVersion())
@@ -665,7 +665,7 @@ func (i *CommandInitOption) kubeControllerManagerImage() string {
 // get etcd-init image
 func (i *CommandInitOption) etcdInitImage() string {
 	if i.ImageRegistry != "" && i.EtcdInitImage == DefaultInitImage {
-		return i.ImageRegistry + "/alpine:3.15.1"
+		return i.ImageRegistry + "/alpine:3.18.5"
 	}
 	return i.EtcdInitImage
 }

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
@@ -379,7 +379,7 @@ func TestEtcdInitImage(t *testing.T) {
 				ImageRegistry: "my-registry",
 				EtcdInitImage: DefaultInitImage,
 			},
-			expected: "my-registry/alpine:3.15.1",
+			expected: "my-registry/alpine:3.18.5",
 		},
 		{
 			name: "EtcdInitImage is set to a non-default value",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
bump alpine to 3.18.5 to address CVE-2023-5363
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
```bash
➜  karmada git:(master) ✗ trivy image --format table  docker.io/karmada/karmada-operator:new 
2023-12-06T10:42:09.997+0800    INFO    Need to update DB
2023-12-06T10:42:09.997+0800    INFO    DB Repository: ghcr.io/aquasecurity/trivy-db
2023-12-06T10:42:09.997+0800    INFO    Downloading DB...
41.17 MiB / 41.17 MiB [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 1.89 MiB p/s 22s
2023-12-06T10:42:33.531+0800    INFO    Vulnerability scanning is enabled
2023-12-06T10:42:33.531+0800    INFO    Secret scanning is enabled
2023-12-06T10:42:33.531+0800    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-12-06T10:42:33.531+0800    INFO    Please see also https://aquasecurity.github.io/trivy/v0.45/docs/scanner/secret/#recommendation for faster secret detection
2023-12-06T10:42:36.627+0800    INFO    Detected OS: alpine
2023-12-06T10:42:36.627+0800    INFO    Detecting Alpine vulnerabilities...
2023-12-06T10:42:36.629+0800    INFO    Number of language-specific files: 1
2023-12-06T10:42:36.629+0800    INFO    Detecting gobinary vulnerabilities...

docker.io/karmada/karmada-operator:new (alpine 3.18.5)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
The base image `alpine` now has been promoted from `alpine:3.18.3` to `alpine:3.18.5`
```

