### PR TITLE
ensure resource template be un-claimed when deleting cluster policy

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -1177,6 +1177,8 @@ func (d *ResourceDetector) HandleClusterPropagationPolicyDeletion(policyName str
 				klog.Errorf("Failed to clean up label from resource(%s-%s) when cluster propagation policy(%s) removing, error: %v",
 					binding.Spec.Resource.Kind, binding.Spec.Resource.Name, policyName, err)
 				errs = append(errs, err)
+				// Skip cleaning up policy labels from ClusterResourceBinding, give a chance to do that in a retry loop.
+				continue
 			}
 
 			// Clean up the labels from the reference binding so that the karmada scheduler won't reschedule the binding.
@@ -1202,6 +1204,8 @@ func (d *ResourceDetector) HandleClusterPropagationPolicyDeletion(policyName str
 				klog.Errorf("Failed to clean up label from resource(%s-%s/%s) when cluster propagation policy(%s) removing, error: %v",
 					binding.Spec.Resource.Kind, binding.Spec.Resource.Namespace, binding.Spec.Resource.Name, policyName, err)
 				errs = append(errs, err)
+				// Skip cleaning up policy labels from ResourceBinding, give a chance to do that in a retry loop.
+				continue
 			}
 
 			// Clean up the labels from the reference binding so that the karmada scheduler won't reschedule the binding.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #4233

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Fix the bug that losing the chance to un-claim resource template in case of deleting ClusterPropagationPolicy.
```

