### PR TITLE
make hook-delete-policy in helm job configurable

### DIFF
--- a/charts/karmada/templates/post-delete-job.yaml
+++ b/charts/karmada/templates/post-delete-job.yaml
@@ -14,7 +14,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": {{ .Values.postDeleteJob.hookDeletePolicy }}
 spec:
   parallelism: 1
   completions: 1

--- a/charts/karmada/templates/post-install-job.yaml
+++ b/charts/karmada/templates/post-install-job.yaml
@@ -17,7 +17,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": {{ .Values.postInstallJob.hookDeletePolicy }}
 spec:
   parallelism: 1
   completions: 1

--- a/charts/karmada/templates/pre-install-job.yaml
+++ b/charts/karmada/templates/pre-install-job.yaml
@@ -307,7 +307,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "3"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": {{ .Values.preInstallJob.hookDeletePolicy }}
   {{- if "karmada.preInstallJob.labels" }}
   labels:
     {{- include "karmada.preInstallJob.labels" . | nindent 4 }}

--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -79,16 +79,22 @@ kubectl:
 preInstallJob:
   tolerations: []
   nodeSelector: {}
+  ## Define policies that determine when to delete corresponding hook resources: before-hook-creation,hook-succeeded,hook-failed
+  hookDeletePolicy: "hook-succeeded"
 
 ## post-install job config
 postInstallJob:
   tolerations: []
   nodeSelector: {}
+  ## Define policies that determine when to delete corresponding hook resources: before-hook-creation,hook-succeeded,hook-failed
+  hookDeletePolicy: "hook-succeeded"
 
 ## post-delete job config
 postDeleteJob:
   tolerations: []
   nodeSelector: {}
+  ## Define policies that determine when to delete corresponding hook resources: before-hook-creation,hook-succeeded,hook-failed
+  hookDeletePolicy: "hook-succeeded"
 
 ## karmada certificate config
 certs:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Could we also make "helm.sh/hook-delete-policy": hook-succeeded configurable in [post-install-job.yaml](https://github.com/karmada-io/karmada/blob/master/charts/karmada/templates/post-install-job.yaml#L20C5-L20C33). We want to keep the job pod for debugging issues if post-install job fails

**Which issue(s) this PR fixes**:

Fixes part of #4368

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

