### PR TITLE
[release-1.5] Bump Golang to v1.19.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.19.13
       - name: vendor
         run: hack/verify-vendor.sh
       - name: lint
@@ -37,7 +37,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.19.13
       - name: Install Protoc
         # TODO(@RainbowMango): Update the action version to adopt Node16
         # track issue: https://github.com/arduino/setup-protoc/issues/59
@@ -71,7 +71,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.19.13
       - name: compile
         run: make all
   test:
@@ -84,7 +84,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.19.13
       - name: make test
         run: make test
       - name: Upload coverage to Codecov
@@ -131,7 +131,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.19.13
       - name: setup e2e test environment
         run: |
           export CLUSTER_VERSION=kindest/node:${{ matrix.k8s }}

--- a/.github/workflows/dockerhub-latest-image.yml
+++ b/.github/workflows/dockerhub-latest-image.yml
@@ -34,7 +34,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.19.13
       - name: install QEMU
         uses: docker/setup-qemu-action@v2
       - name: install Buildx

--- a/.github/workflows/dockerhub-released-image.yml
+++ b/.github/workflows/dockerhub-released-image.yml
@@ -30,7 +30,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.19.13
       - name: install QEMU
         uses: docker/setup-qemu-action@v2
       - name: install Buildx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19.5
+        go-version: 1.19.13
     - name: Making and packaging
       env:
         GOOS: ${{ matrix.os }}

--- a/.github/workflows/swr-latest-image.yml
+++ b/.github/workflows/swr-latest-image.yml
@@ -22,7 +22,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.19.13
       - name: build images
         env:
           REGISTRY: ${{secrets.SWR_REGISTRY}}

--- a/.github/workflows/swr-released-image.yml
+++ b/.github/workflows/swr-released-image.yml
@@ -19,7 +19,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.19.13
       - name: build images
         env:
           REGISTRY: ${{secrets.SWR_REGISTRY}}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Bump Golang version from v1.19.5 to v1.19.13 to address potential security concerns.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

See Golang v1.19 release notes [here](https://go.dev/doc/devel/release#go1.19).

We will tag a new patch release for release-1.5, and it might be the last patch release as Karmada maintains the last 3 minor releases.

**Does this PR introduce a user-facing change?**:
```release-note
Karmada is now built with Go1.19.13. 
```

