### PR TITLE
[release-1.6] Bump Golang to go1.20.12

### DIFF
--- a/.github/workflows/ci-schedule.yml
+++ b/.github/workflows/ci-schedule.yml
@@ -22,7 +22,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.12
       - name: setup e2e test environment
         run: |
           export CLUSTER_VERSION=kindest/node:${{ matrix.k8s }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.12
       - name: vendor
         run: hack/verify-vendor.sh
       - name: lint
@@ -41,7 +41,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.12
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
@@ -73,7 +73,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.12
       - name: compile
         run: make all
   test:
@@ -86,7 +86,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.12
       - name: make test
         run: make test
       - name: Upload coverage to Codecov
@@ -136,7 +136,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.12
       - name: setup e2e test environment
         run: |
           export CLUSTER_VERSION=kindest/node:${{ matrix.k8s }}

--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.12
       - uses: engineerd/setup-kind@v0.5.0
         with:
           version: "v0.17.0"

--- a/.github/workflows/dockerhub-latest-image.yml
+++ b/.github/workflows/dockerhub-latest-image.yml
@@ -36,7 +36,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.12
       - name: install QEMU
         uses: docker/setup-qemu-action@v2
       - name: install Buildx

--- a/.github/workflows/dockerhub-released-image.yml
+++ b/.github/workflows/dockerhub-released-image.yml
@@ -32,7 +32,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.12
       - name: install QEMU
         uses: docker/setup-qemu-action@v2
       - name: install Buildx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.4
+        go-version: 1.20.12
     - name: Making and packaging
       env:
         GOOS: ${{ matrix.os }}

--- a/.github/workflows/swr-latest-image.yml
+++ b/.github/workflows/swr-latest-image.yml
@@ -22,7 +22,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.12
       - name: build images
         env:
           REGISTRY: ${{secrets.SWR_REGISTRY}}

--- a/.github/workflows/swr-released-image.yml
+++ b/.github/workflows/swr-released-image.yml
@@ -19,7 +19,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.12
       - name: build images
         env:
           REGISTRY: ${{secrets.SWR_REGISTRY}}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Bump Golang version from v1.20.4 to v1.20.12 to address potential security concerns.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

See Golang v1.20 release notes [here](https://go.dev/doc/devel/release#go1.20).

**Does this PR introduce a user-facing change?**:
```release-note
Karmada is now built with Go1.20.12. 
```

