### PR TITLE
[release-1.8] Bump Golang to v1.20.12

### DIFF
--- a/.github/workflows/ci-schedule-compatibility.yaml
+++ b/.github/workflows/ci-schedule-compatibility.yaml
@@ -18,13 +18,13 @@ jobs:
 
         include:
         - karmada-version: release-1.5
-          go-version: 1.19.5
+          go-version: 1.19.13
 
         - karmada-version: release-1.6
-          go-version: 1.20.5
+          go-version: 1.20.12
 
         - karmada-version: release-1.7
-          go-version: 1.20.6
+          go-version: 1.20.12
 
     steps:
       # Free up disk space on Ubuntu

--- a/.github/workflows/ci-schedule.yml
+++ b/.github/workflows/ci-schedule.yml
@@ -35,7 +35,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.11
+          go-version: 1.20.12
       - name: setup e2e test environment
         run: |
           export CLUSTER_VERSION=kindest/node:${{ matrix.k8s }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.11
+          go-version: 1.20.12
       - name: verify license
         run: hack/verify-license.sh
       - name: vendor
@@ -43,7 +43,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.11
+          go-version: 1.20.12
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
@@ -75,7 +75,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.11
+          go-version: 1.20.12
       - name: compile
         run: make all
   test:
@@ -90,7 +90,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.11
+          go-version: 1.20.12
       - name: make test
         run: make test
       - name: Upload coverage to Codecov
@@ -140,7 +140,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.11
+          go-version: 1.20.12
       - name: setup e2e test environment
         run: |
           export CLUSTER_VERSION=kindest/node:${{ matrix.k8s }}

--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.11
+          go-version: 1.20.12
       - uses: engineerd/setup-kind@v0.5.0
         with:
           version: "v0.20.0"

--- a/.github/workflows/dockerhub-latest-image.yml
+++ b/.github/workflows/dockerhub-latest-image.yml
@@ -38,7 +38,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.11
+          go-version: 1.20.12
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.1.1
         with:

--- a/.github/workflows/dockerhub-released-image.yml
+++ b/.github/workflows/dockerhub-released-image.yml
@@ -34,7 +34,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.11
+          go-version: 1.20.12
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.1.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.11
+        go-version: 1.20.12
     - name: Making and packaging
       env:
         GOOS: ${{ matrix.os }}

--- a/.github/workflows/swr-latest-image.yml
+++ b/.github/workflows/swr-latest-image.yml
@@ -22,7 +22,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.11
+          go-version: 1.20.12
       - name: build images
         env:
           REGISTRY: ${{secrets.SWR_REGISTRY}}

--- a/.github/workflows/swr-released-image.yml
+++ b/.github/workflows/swr-released-image.yml
@@ -19,7 +19,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.11
+          go-version: 1.20.12
       - name: build images
         env:
           REGISTRY: ${{secrets.SWR_REGISTRY}}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Bump Golang version from v1.20.11 to v1.20.12 to address potential security concerns.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

See Golang v1.20 release notes [here](https://go.dev/doc/devel/release#go1.20).

**Does this PR introduce a user-facing change?**:
```release-note
Karmada is now built with Go1.20.12. 
```

