### PR TITLE
adjust the Priority of General and Accurate Estimator of Karmada Scheduler

### DIFF
--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -100,7 +100,8 @@ func NewDescheduler(karmadaClient karmadaclientset.Interface, kubeClient kuberne
 		ReconcileFunc: desched.reconcileEstimatorConnection,
 	}
 	desched.schedulerEstimatorWorker = util.NewAsyncWorker(schedulerEstimatorWorkerOptions)
-	schedulerEstimator := estimatorclient.NewSchedulerEstimator(desched.schedulerEstimatorCache, opts.SchedulerEstimatorTimeout.Duration)
+	schedulerEstimator := estimatorclient.NewSchedulerEstimator(desched.schedulerEstimatorCache,
+		opts.SchedulerEstimatorTimeout.Duration, estimatorclient.Accurate)
 	estimatorclient.RegisterSchedulerEstimator(schedulerEstimator)
 	deschedulerWorkerOptions := util.Options{
 		Name:          "descheduler",

--- a/pkg/descheduler/descheduler_test.go
+++ b/pkg/descheduler/descheduler_test.go
@@ -485,7 +485,7 @@ func TestDescheduler_worker(t *testing.T) {
 				unschedulableThreshold:  5 * time.Minute,
 				eventRecorder:           record.NewFakeRecorder(1024),
 			}
-			schedulerEstimator := estimatorclient.NewSchedulerEstimator(desched.schedulerEstimatorCache, 5*time.Second)
+			schedulerEstimator := estimatorclient.NewSchedulerEstimator(desched.schedulerEstimatorCache, 5*time.Second, estimatorclient.Accurate)
 			estimatorclient.RegisterSchedulerEstimator(schedulerEstimator)
 
 			for _, c := range tt.args.unschedulable {

--- a/pkg/estimator/client/general.go
+++ b/pkg/estimator/client/general.go
@@ -32,15 +32,17 @@ import (
 
 // GeneralEstimator is the default replica estimator.
 func init() {
-	replicaEstimators["general-estimator"] = NewGeneralEstimator()
+	registerReplicaEstimator("general-estimator", NewGeneralEstimator(General))
 }
 
 // GeneralEstimator is a normal estimator in terms of cluster ResourceSummary.
-type GeneralEstimator struct{}
+type GeneralEstimator struct {
+	priority EstimatorPriority
+}
 
 // NewGeneralEstimator builds a new GeneralEstimator.
-func NewGeneralEstimator() *GeneralEstimator {
-	return &GeneralEstimator{}
+func NewGeneralEstimator(priority EstimatorPriority) *GeneralEstimator {
+	return &GeneralEstimator{priority: priority}
 }
 
 // MaxAvailableReplicas estimates the maximum replicas that can be applied to the target cluster by cluster ResourceSummary.
@@ -51,6 +53,11 @@ func (ge *GeneralEstimator) MaxAvailableReplicas(_ context.Context, clusters []*
 		availableTargetClusters[i] = workv1alpha2.TargetCluster{Name: cluster.Name, Replicas: maxReplicas}
 	}
 	return availableTargetClusters, nil
+}
+
+// Priority provides the priority of this estimator.
+func (ge *GeneralEstimator) Priority() EstimatorPriority {
+	return ge.priority
 }
 
 func (ge *GeneralEstimator) maxAvailableReplicas(cluster *clusterv1alpha1.Cluster, replicaRequirements *workv1alpha2.ReplicaRequirements) int32 {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -262,7 +262,8 @@ func NewScheduler(dynamicClient dynamic.Interface, karmadaClient karmadaclientse
 			ReconcileFunc: sched.reconcileEstimatorConnection,
 		}
 		sched.schedulerEstimatorWorker = util.NewAsyncWorker(schedulerEstimatorWorkerOptions)
-		schedulerEstimator := estimatorclient.NewSchedulerEstimator(sched.schedulerEstimatorCache, options.schedulerEstimatorTimeout.Duration)
+		schedulerEstimator := estimatorclient.NewSchedulerEstimator(sched.schedulerEstimatorCache,
+			options.schedulerEstimatorTimeout.Duration, estimatorclient.Accurate)
 		estimatorclient.RegisterSchedulerEstimator(schedulerEstimator)
 	}
 	sched.enableEmptyWorkloadPropagation = options.enableEmptyWorkloadPropagation

--- a/vendor/github.com/emirpasic/gods/maps/maps.go
+++ b/vendor/github.com/emirpasic/gods/maps/maps.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2015, Emir Pasic. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package maps provides an abstract Map interface.
+//
+// In computer science, an associative array, map, symbol table, or dictionary is an abstract data type composed of a collection of (key, value) pairs, such that each possible key appears just once in the collection.
+//
+// Operations associated with this data type allow:
+// - the addition of a pair to the collection
+// - the removal of a pair from the collection
+// - the modification of an existing pair
+// - the lookup of a value associated with a particular key
+//
+// Reference: https://en.wikipedia.org/wiki/Associative_array
+package maps
+
+import "github.com/emirpasic/gods/containers"
+
+// Map interface that all maps implement
+type Map interface {
+	Put(key interface{}, value interface{})
+	Get(key interface{}) (value interface{}, found bool)
+	Remove(key interface{})
+	Keys() []interface{}
+
+	containers.Container
+	// Empty() bool
+	// Size() int
+	// Clear()
+	// Values() []interface{}
+	// String() string
+}
+
+// BidiMap interface that all bidirectional maps implement (extends the Map interface)
+type BidiMap interface {
+	GetKey(value interface{}) (key interface{}, found bool)
+
+	Map
+}

--- a/vendor/github.com/emirpasic/gods/maps/treemap/enumerable.go
+++ b/vendor/github.com/emirpasic/gods/maps/treemap/enumerable.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2015, Emir Pasic. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package treemap
+
+import (
+	"github.com/emirpasic/gods/containers"
+	rbt "github.com/emirpasic/gods/trees/redblacktree"
+)
+
+// Assert Enumerable implementation
+var _ containers.EnumerableWithKey = (*Map)(nil)
+
+// Each calls the given function once for each element, passing that element's key and value.
+func (m *Map) Each(f func(key interface{}, value interface{})) {
+	iterator := m.Iterator()
+	for iterator.Next() {
+		f(iterator.Key(), iterator.Value())
+	}
+}
+
+// Map invokes the given function once for each element and returns a container
+// containing the values returned by the given function as key/value pairs.
+func (m *Map) Map(f func(key1 interface{}, value1 interface{}) (interface{}, interface{})) *Map {
+	newMap := &Map{tree: rbt.NewWith(m.tree.Comparator)}
+	iterator := m.Iterator()
+	for iterator.Next() {
+		key2, value2 := f(iterator.Key(), iterator.Value())
+		newMap.Put(key2, value2)
+	}
+	return newMap
+}
+
+// Select returns a new container containing all elements for which the given function returns a true value.
+func (m *Map) Select(f func(key interface{}, value interface{}) bool) *Map {
+	newMap := &Map{tree: rbt.NewWith(m.tree.Comparator)}
+	iterator := m.Iterator()
+	for iterator.Next() {
+		if f(iterator.Key(), iterator.Value()) {
+			newMap.Put(iterator.Key(), iterator.Value())
+		}
+	}
+	return newMap
+}
+
+// Any passes each element of the container to the given function and
+// returns true if the function ever returns true for any element.
+func (m *Map) Any(f func(key interface{}, value interface{}) bool) bool {
+	iterator := m.Iterator()
+	for iterator.Next() {
+		if f(iterator.Key(), iterator.Value()) {
+			return true
+		}
+	}
+	return false
+}
+
+// All passes each element of the container to the given function and
+// returns true if the function returns true for all elements.
+func (m *Map) All(f func(key interface{}, value interface{}) bool) bool {
+	iterator := m.Iterator()
+	for iterator.Next() {
+		if !f(iterator.Key(), iterator.Value()) {
+			return false
+		}
+	}
+	return true
+}
+
+// Find passes each element of the container to the given function and returns
+// the first (key,value) for which the function is true or nil,nil otherwise if no element
+// matches the criteria.
+func (m *Map) Find(f func(key interface{}, value interface{}) bool) (interface{}, interface{}) {
+	iterator := m.Iterator()
+	for iterator.Next() {
+		if f(iterator.Key(), iterator.Value()) {
+			return iterator.Key(), iterator.Value()
+		}
+	}
+	return nil, nil
+}

--- a/vendor/github.com/emirpasic/gods/maps/treemap/iterator.go
+++ b/vendor/github.com/emirpasic/gods/maps/treemap/iterator.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2015, Emir Pasic. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package treemap
+
+import (
+	"github.com/emirpasic/gods/containers"
+	rbt "github.com/emirpasic/gods/trees/redblacktree"
+)
+
+// Assert Iterator implementation
+var _ containers.ReverseIteratorWithKey = (*Iterator)(nil)
+
+// Iterator holding the iterator's state
+type Iterator struct {
+	iterator rbt.Iterator
+}
+
+// Iterator returns a stateful iterator whose elements are key/value pairs.
+func (m *Map) Iterator() Iterator {
+	return Iterator{iterator: m.tree.Iterator()}
+}
+
+// Next moves the iterator to the next element and returns true if there was a next element in the container.
+// If Next() returns true, then next element's key and value can be retrieved by Key() and Value().
+// If Next() was called for the first time, then it will point the iterator to the first element if it exists.
+// Modifies the state of the iterator.
+func (iterator *Iterator) Next() bool {
+	return iterator.iterator.Next()
+}
+
+// Prev moves the iterator to the previous element and returns true if there was a previous element in the container.
+// If Prev() returns true, then previous element's key and value can be retrieved by Key() and Value().
+// Modifies the state of the iterator.
+func (iterator *Iterator) Prev() bool {
+	return iterator.iterator.Prev()
+}
+
+// Value returns the current element's value.
+// Does not modify the state of the iterator.
+func (iterator *Iterator) Value() interface{} {
+	return iterator.iterator.Value()
+}
+
+// Key returns the current element's key.
+// Does not modify the state of the iterator.
+func (iterator *Iterator) Key() interface{} {
+	return iterator.iterator.Key()
+}
+
+// Begin resets the iterator to its initial state (one-before-first)
+// Call Next() to fetch the first element if any.
+func (iterator *Iterator) Begin() {
+	iterator.iterator.Begin()
+}
+
+// End moves the iterator past the last element (one-past-the-end).
+// Call Prev() to fetch the last element if any.
+func (iterator *Iterator) End() {
+	iterator.iterator.End()
+}
+
+// First moves the iterator to the first element and returns true if there was a first element in the container.
+// If First() returns true, then first element's key and value can be retrieved by Key() and Value().
+// Modifies the state of the iterator
+func (iterator *Iterator) First() bool {
+	return iterator.iterator.First()
+}
+
+// Last moves the iterator to the last element and returns true if there was a last element in the container.
+// If Last() returns true, then last element's key and value can be retrieved by Key() and Value().
+// Modifies the state of the iterator.
+func (iterator *Iterator) Last() bool {
+	return iterator.iterator.Last()
+}
+
+// NextTo moves the iterator to the next element from current position that satisfies the condition given by the
+// passed function, and returns true if there was a next element in the container.
+// If NextTo() returns true, then next element's key and value can be retrieved by Key() and Value().
+// Modifies the state of the iterator.
+func (iterator *Iterator) NextTo(f func(key interface{}, value interface{}) bool) bool {
+	for iterator.Next() {
+		key, value := iterator.Key(), iterator.Value()
+		if f(key, value) {
+			return true
+		}
+	}
+	return false
+}
+
+// PrevTo moves the iterator to the previous element from current position that satisfies the condition given by the
+// passed function, and returns true if there was a next element in the container.
+// If PrevTo() returns true, then next element's key and value can be retrieved by Key() and Value().
+// Modifies the state of the iterator.
+func (iterator *Iterator) PrevTo(f func(key interface{}, value interface{}) bool) bool {
+	for iterator.Prev() {
+		key, value := iterator.Key(), iterator.Value()
+		if f(key, value) {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/emirpasic/gods/maps/treemap/serialization.go
+++ b/vendor/github.com/emirpasic/gods/maps/treemap/serialization.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2015, Emir Pasic. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package treemap
+
+import (
+	"github.com/emirpasic/gods/containers"
+)
+
+// Assert Serialization implementation
+var _ containers.JSONSerializer = (*Map)(nil)
+var _ containers.JSONDeserializer = (*Map)(nil)
+
+// ToJSON outputs the JSON representation of the map.
+func (m *Map) ToJSON() ([]byte, error) {
+	return m.tree.ToJSON()
+}
+
+// FromJSON populates the map from the input JSON representation.
+func (m *Map) FromJSON(data []byte) error {
+	return m.tree.FromJSON(data)
+}
+
+// UnmarshalJSON @implements json.Unmarshaler
+func (m *Map) UnmarshalJSON(bytes []byte) error {
+	return m.FromJSON(bytes)
+}
+
+// MarshalJSON @implements json.Marshaler
+func (m *Map) MarshalJSON() ([]byte, error) {
+	return m.ToJSON()
+}

--- a/vendor/github.com/emirpasic/gods/maps/treemap/treemap.go
+++ b/vendor/github.com/emirpasic/gods/maps/treemap/treemap.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2015, Emir Pasic. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package treemap implements a map backed by red-black tree.
+//
+// Elements are ordered by key in the map.
+//
+// Structure is not thread safe.
+//
+// Reference: http://en.wikipedia.org/wiki/Associative_array
+package treemap
+
+import (
+	"fmt"
+	"github.com/emirpasic/gods/maps"
+	rbt "github.com/emirpasic/gods/trees/redblacktree"
+	"github.com/emirpasic/gods/utils"
+	"strings"
+)
+
+// Assert Map implementation
+var _ maps.Map = (*Map)(nil)
+
+// Map holds the elements in a red-black tree
+type Map struct {
+	tree *rbt.Tree
+}
+
+// NewWith instantiates a tree map with the custom comparator.
+func NewWith(comparator utils.Comparator) *Map {
+	return &Map{tree: rbt.NewWith(comparator)}
+}
+
+// NewWithIntComparator instantiates a tree map with the IntComparator, i.e. keys are of type int.
+func NewWithIntComparator() *Map {
+	return &Map{tree: rbt.NewWithIntComparator()}
+}
+
+// NewWithStringComparator instantiates a tree map with the StringComparator, i.e. keys are of type string.
+func NewWithStringComparator() *Map {
+	return &Map{tree: rbt.NewWithStringComparator()}
+}
+
+// Put inserts key-value pair into the map.
+// Key should adhere to the comparator's type assertion, otherwise method panics.
+func (m *Map) Put(key interface{}, value interface{}) {
+	m.tree.Put(key, value)
+}
+
+// Get searches the element in the map by key and returns its value or nil if key is not found in tree.
+// Second return parameter is true if key was found, otherwise false.
+// Key should adhere to the comparator's type assertion, otherwise method panics.
+func (m *Map) Get(key interface{}) (value interface{}, found bool) {
+	return m.tree.Get(key)
+}
+
+// Remove removes the element from the map by key.
+// Key should adhere to the comparator's type assertion, otherwise method panics.
+func (m *Map) Remove(key interface{}) {
+	m.tree.Remove(key)
+}
+
+// Empty returns true if map does not contain any elements
+func (m *Map) Empty() bool {
+	return m.tree.Empty()
+}
+
+// Size returns number of elements in the map.
+func (m *Map) Size() int {
+	return m.tree.Size()
+}
+
+// Keys returns all keys in-order
+func (m *Map) Keys() []interface{} {
+	return m.tree.Keys()
+}
+
+// Values returns all values in-order based on the key.
+func (m *Map) Values() []interface{} {
+	return m.tree.Values()
+}
+
+// Clear removes all elements from the map.
+func (m *Map) Clear() {
+	m.tree.Clear()
+}
+
+// Min returns the minimum key and its value from the tree map.
+// Returns nil, nil if map is empty.
+func (m *Map) Min() (key interface{}, value interface{}) {
+	if node := m.tree.Left(); node != nil {
+		return node.Key, node.Value
+	}
+	return nil, nil
+}
+
+// Max returns the maximum key and its value from the tree map.
+// Returns nil, nil if map is empty.
+func (m *Map) Max() (key interface{}, value interface{}) {
+	if node := m.tree.Right(); node != nil {
+		return node.Key, node.Value
+	}
+	return nil, nil
+}
+
+// Floor finds the floor key-value pair for the input key.
+// In case that no floor is found, then both returned values will be nil.
+// It's generally enough to check the first value (key) for nil, which determines if floor was found.
+//
+// Floor key is defined as the largest key that is smaller than or equal to the given key.
+// A floor key may not be found, either because the map is empty, or because
+// all keys in the map are larger than the given key.
+//
+// Key should adhere to the comparator's type assertion, otherwise method panics.
+func (m *Map) Floor(key interface{}) (foundKey interface{}, foundValue interface{}) {
+	node, found := m.tree.Floor(key)
+	if found {
+		return node.Key, node.Value
+	}
+	return nil, nil
+}
+
+// Ceiling finds the ceiling key-value pair for the input key.
+// In case that no ceiling is found, then both returned values will be nil.
+// It's generally enough to check the first value (key) for nil, which determines if ceiling was found.
+//
+// Ceiling key is defined as the smallest key that is larger than or equal to the given key.
+// A ceiling key may not be found, either because the map is empty, or because
+// all keys in the map are smaller than the given key.
+//
+// Key should adhere to the comparator's type assertion, otherwise method panics.
+func (m *Map) Ceiling(key interface{}) (foundKey interface{}, foundValue interface{}) {
+	node, found := m.tree.Ceiling(key)
+	if found {
+		return node.Key, node.Value
+	}
+	return nil, nil
+}
+
+// String returns a string representation of container
+func (m *Map) String() string {
+	str := "TreeMap\nmap["
+	it := m.Iterator()
+	for it.Next() {
+		str += fmt.Sprintf("%v:%v ", it.Key(), it.Value())
+	}
+	return strings.TrimRight(str, " ") + "]"
+
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -68,6 +68,8 @@ github.com/emicklei/go-restful/v3/log
 # github.com/emirpasic/gods v1.18.1
 ## explicit; go 1.2
 github.com/emirpasic/gods/containers
+github.com/emirpasic/gods/maps
+github.com/emirpasic/gods/maps/treemap
 github.com/emirpasic/gods/trees
 github.com/emirpasic/gods/trees/redblacktree
 github.com/emirpasic/gods/utils


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

 If the accurate estimator is enabled and `karmada-scheduler-estimator` components also are enabled, the accurate estimator should be prior to `ResourceModeling` rather than using the minumal value of them.

**Which issue(s) this PR fixes**:

Fixes #3333

**Special notes for your reviewer**:

CC @lonelyCZ @whitewindmills 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
introduced priority to schedule estimator so that higher-priority estimator can override the result given by lower-priority.
```

