### PR TITLE
register cluster install karmada-agent should set leader-elect-resouce-namespace

### DIFF
--- a/pkg/karmadactl/register/register.go
+++ b/pkg/karmadactl/register/register.go
@@ -695,6 +695,7 @@ func (o *CommandRegisterOption) makeKarmadaAgentDeployment() *appsv1.Deployment 
 					fmt.Sprintf("--cluster-zones=%s", strings.Join(o.ClusterZones, ",")),
 					fmt.Sprintf("--controllers=%s", strings.Join(controllers, ",")),
 					fmt.Sprintf("--proxy-server-address=%s", o.ProxyServerAddress),
+					fmt.Sprintf("--leader-elect-resource-namespace=%s", o.Namespace),
 					"--cluster-status-update-frequency=10s",
 					"--bind-address=0.0.0.0",
 					"--secure-port=10357",


### PR DESCRIPTION

**What type of PR is this?**

/kind bug


<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

karmada agent deployment namespace and leader-elect-resouce-namespace should be consistent

now we install karmada agent in a new namespace, but leader-elect-resouce-namespace is karmada-system

![image](https://github.com/karmada-io/karmada/assets/89568107/d8e18f9b-5eb0-46b5-ae94-08d140838405)



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

`karmadactl`:  Register cluster install karmada-agent should set leader-elect-resouce-namespace

```

