### PR TITLE
skip recreating resources that is not supposed to be propagated

### DIFF
--- a/pkg/controllers/status/work_status_controller.go
+++ b/pkg/controllers/status/work_status_controller.go
@@ -276,6 +276,10 @@ func (c *WorkStatusController) handleDeleteEvent(key keys.FederatedKey) error {
 		return nil
 	}
 
+	if util.GetLabelValue(work.Labels, util.PropagationInstruction) == util.PropagationInstructionSuppressed {
+		return nil
+	}
+
 	return c.recreateResourceIfNeeded(work, key)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
1.K8s create multiple endpointslice for one service.
2.Karmada collects these endpointslice to control plane as work.
3.K8s delete some endpointslice.
4.Karmad work_status_controller.go will detect this and recreate it.

We expect the endpointslice will be deleted correctly.

**Which issue(s) this PR fixes**:
Fixes #none

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Fixed the issue that always trying to re-create resources that should not be propagated.
```

