### PR TITLE
fix: Update RB once new clusters are added to trigger the propagation of service to these new clusters

### DIFF
--- a/pkg/controllers/multiclusterservice/mcs_controller.go
+++ b/pkg/controllers/multiclusterservice/mcs_controller.go
@@ -418,16 +418,7 @@ func (c *MCSController) propagateService(ctx context.Context, mcs *networkingv1a
 
 func (c *MCSController) buildResourceBinding(svc *corev1.Service, mcs *networkingv1alpha1.MultiClusterService,
 	providerClusters, consumerClusters sets.Set[string]) (*workv1alpha2.ResourceBinding, error) {
-	allClusters, err := util.GetClusterSet(c.Client)
-	if err != nil {
-		klog.Errorf("Failed to get all clusters:%v", err)
-		return nil, err
-	}
-
 	propagateClusters := providerClusters.Clone().Insert(consumerClusters.Clone().UnsortedList()...)
-	if propagateClusters.Equal(allClusters) {
-		propagateClusters = sets.Set[string]{}
-	}
 	placement := &policyv1alpha1.Placement{
 		ClusterAffinity: &policyv1alpha1.ClusterAffinity{
 			ClusterNames: propagateClusters.UnsortedList(),


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When new clusters are joined, we should propagate the service to the new clusters.

Before, if the providerClusters/consumerClusters are empty, there was no modification even new clusters are joined.
In this scenario, the scheduler will not schedule the service to the newly joined clusters.

So we should update the RB to trigger it.

**Which issue(s) this PR fixes**:
Fixes #none

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

