### PR TITLE
prevent CI from fast fail when just one k8s version e2e failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
     needs: build
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         # Here support the latest three minor releases of Kubernetes, this can be considered to be roughly
         # the same as the End of Life of the Kubernetes release: https://kubernetes.io/releases/

--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -13,6 +13,7 @@ jobs:
     name: init
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         # Here support the latest three minor releases of Kubernetes, this can be considered to be roughly
         # the same as the End of Life of the Kubernetes release: https://kubernetes.io/releases/


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

We now run e2e test on multi releases version of Kubernetes, if e2e test failed at just one releases version, the other e2e test will be interrupted by fast fail strategy.

It is not conducive to check the root cause of failure, so it is advised to disable fast fail strategy.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

