### PR TITLE
feat: support to reflect service status

### DIFF
--- a/pkg/resourceinterpreter/default/native/reflectstatus.go
+++ b/pkg/resourceinterpreter/default/native/reflectstatus.go
@@ -78,19 +78,6 @@ func reflectDeploymentStatus(object *unstructured.Unstructured) (*runtime.RawExt
 }
 
 func reflectServiceStatus(object *unstructured.Unstructured) (*runtime.RawExtension, error) {
-	serviceType, exist, err := unstructured.NestedString(object.Object, "spec", "type")
-	if err != nil {
-		klog.Errorf("Failed to get spec.type field from %s(%s/%s)")
-	}
-	if !exist {
-		klog.Errorf("Failed to get spec.type from %s(%s/%s) which should have spec.type field.",
-			object.GetKind(), object.GetNamespace(), object.GetName())
-		return nil, nil
-	}
-	if serviceType != string(corev1.ServiceTypeLoadBalancer) {
-		return nil, nil
-	}
-
 	statusMap, exist, err := unstructured.NestedMap(object.Object, "status")
 	if err != nil {
 		klog.Errorf("Failed to get status field from %s(%s/%s), error: %v",


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Now, after propagating service(ClusterIP) to member clusters, the status in ResourceBinding is unknown, it's better reflect it even if the type is not ClusterIP.

This can fix https://github.com/karmada-io/karmada/issues/4430 temporarily

**Which issue(s) this PR fixes**:
Part of https://github.com/karmada-io/karmada/issues/4430

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manger`: Support to reflect service status.
```

