### PR TITLE
cleanup(mcs): do not overwrite the original service if the service exists

### DIFF
--- a/pkg/controllers/multiclusterservice/mcs_controller.go
+++ b/pkg/controllers/multiclusterservice/mcs_controller.go
@@ -444,7 +444,7 @@ func (c *MCSController) buildResourceBinding(svc *corev1.Service, mcs *networkin
 		},
 		Spec: workv1alpha2.ResourceBindingSpec{
 			Placement:          placement,
-			ConflictResolution: policyv1alpha1.ConflictOverwrite,
+			ConflictResolution: policyv1alpha1.ConflictAbort,
 			Resource: workv1alpha2.ObjectReference{
 				APIVersion:      svc.APIVersion,
 				Kind:            svc.Kind,


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When one service exists in the member cluster.
If users use MCS to propagate the service, Karmada may not overwrite the service.

In the future, we will introduce an API field to let users configure the behavior.

**Which issue(s) this PR fixes**:
Fixes none

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: do not overwrite the original service if the service exists
```

