### PR TITLE
Enhanced forced deletion on karmadactl unjoin

### DIFF
--- a/pkg/karmadactl/unregister/unregister.go
+++ b/pkg/karmadactl/unregister/unregister.go
@@ -130,6 +130,9 @@ type CommandUnregisterOption struct {
 	// ControlPlaneClient control plane client set
 	ControlPlaneClient karmadaclientset.Interface
 
+	// ControlPlaneKubeClient control plane kube client set
+	ControlPlaneKubeClient kubeclient.Interface
+
 	// MemberClusterClient member cluster client set
 	MemberClusterClient kubeclient.Interface
 }
@@ -223,6 +226,10 @@ func (j *CommandUnregisterOption) buildKarmadaClientSetFromFile() error {
 	if err != nil {
 		return fmt.Errorf("failed to build karmada control plane clientset: %w", err)
 	}
+	j.ControlPlaneKubeClient, err = register.ToClientSet(karmadaCfg)
+	if err != nil {
+		return fmt.Errorf("failed to build kube control plane clientset: %w", err)
+	}
 	return nil
 }
 
@@ -248,7 +255,14 @@ func (j *CommandUnregisterOption) buildKarmadaClientSetFromAgent() error {
 	}
 
 	j.ControlPlaneClient, err = register.ToKarmadaClient(karmadaCfg)
-	return err
+	if err != nil {
+		return fmt.Errorf("failed to build karmada control plane clientset: %w", err)
+	}
+	j.ControlPlaneKubeClient, err = register.ToClientSet(karmadaCfg)
+	if err != nil {
+		return fmt.Errorf("failed to build kube control plane clientset: %w", err)
+	}
+	return nil
 }
 
 func (j *CommandUnregisterOption) getKarmadaAgentConfig(agent *appsv1.Deployment) (*clientcmdapi.Config, error) {
@@ -305,7 +319,8 @@ func (j *CommandUnregisterOption) RunUnregisterCluster() error {
 	}
 
 	// 1. delete the cluster object from the Karmada control plane
-	if err := cmdutil.DeleteClusterObject(j.ControlPlaneClient, j.ClusterName, j.Wait, j.DryRun); err != nil {
+	//TODO: add flag --force to implement force deletion.
+	if err := cmdutil.DeleteClusterObject(j.ControlPlaneKubeClient, j.ControlPlaneClient, j.ClusterName, j.Wait, j.DryRun, false); err != nil {
 		klog.Errorf("Failed to delete cluster object. cluster name: %s, error: %v", j.ClusterName, err)
 		return err
 	}

--- a/pkg/karmadactl/util/cluster.go
+++ b/pkg/karmadactl/util/cluster.go
@@ -21,17 +21,22 @@ import (
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
+	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 // DeleteClusterObject deletes the cluster object from the Karmada control plane.
-func DeleteClusterObject(controlPlaneKarmadaClient karmadaclientset.Interface, clusterName string,
-	timeout time.Duration, dryRun bool) error {
+func DeleteClusterObject(controlPlaneKubeClient kubeclient.Interface, controlPlaneKarmadaClient karmadaclientset.Interface, clusterName string,
+	timeout time.Duration, dryRun bool, forceDeletion bool) error {
 	if dryRun {
 		return nil
 	}
@@ -45,7 +50,8 @@ func DeleteClusterObject(controlPlaneKarmadaClient karmadaclientset.Interface, c
 		return err
 	}
 
-	// make sure the given cluster object has been deleted
+	// make sure the given cluster object has been deleted.
+	// If the operation times out and `forceDeletion` is true, then force deletion begins, which involves sequentially deleting the `work`, `executionSpace`, and `cluster` finalizers.
 	err = wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, timeout, false, func(context.Context) (done bool, err error) {
 		_, err = controlPlaneKarmadaClient.ClusterV1alpha1().Clusters().Get(context.TODO(), clusterName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
@@ -58,10 +64,88 @@ func DeleteClusterObject(controlPlaneKarmadaClient karmadaclientset.Interface, c
 		klog.Infof("Waiting for the cluster object %s to be deleted", clusterName)
 		return false, nil
 	})
-	if err != nil {
-		klog.Errorf("Failed to delete cluster object. cluster name: %s, error: %v", clusterName, err)
-		return err
+
+	// If the Cluster object not be deleted within the timeout period, it is likely due to the resources in the member
+	// cluster can not be cleaned up. With the option force deletion, we will try to clean up the Cluster object by
+	// removing the finalizers from related resources. This behavior may result in some resources remain in the member
+	// clusters.
+	if err != nil && forceDeletion {
+		klog.Warningf("Deleting the cluster object timed out. cluster name: %s, error: %v", clusterName, err)
+		klog.Infof("Start forced deletion. cluster name: %s", clusterName)
+		executionSpaceName := names.GenerateExecutionSpaceName(clusterName)
+		err = removeWorkFinalizer(executionSpaceName, controlPlaneKarmadaClient)
+		if err != nil {
+			klog.Errorf("Force deletion. Failed to remove the finalizer of Work, error: %v", err)
+		}
+
+		err = removeExecutionSpaceFinalizer(executionSpaceName, controlPlaneKubeClient)
+		if err != nil {
+			klog.Errorf("Force deletion. Failed to remove the finalizer of Namespace(%s), error: %v", executionSpaceName, err)
+		}
+
+		err = removeClusterFinalizer(clusterName, controlPlaneKarmadaClient)
+		if err != nil {
+			klog.Errorf("Force deletion. Failed to remove the finalizer of Cluster(%s), error: %v", clusterName, err)
+		}
+
+		klog.Infof("Forced deletion is complete.")
+		return nil
 	}
 
+	return err
+}
+
+// removeWorkFinalizer removes the finalizer of works in the executionSpace.
+func removeWorkFinalizer(executionSpaceName string, controlPlaneKarmadaClient karmadaclientset.Interface) error {
+	list, err := controlPlaneKarmadaClient.WorkV1alpha1().Works(executionSpaceName).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list work in executionSpace %s", executionSpaceName)
+	}
+
+	for i := range list.Items {
+		work := &list.Items[i]
+		if !controllerutil.ContainsFinalizer(work, util.ExecutionControllerFinalizer) {
+			continue
+		}
+		controllerutil.RemoveFinalizer(work, util.ExecutionControllerFinalizer)
+		_, err = controlPlaneKarmadaClient.WorkV1alpha1().Works(executionSpaceName).Update(context.TODO(), work, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to remove the finalizer of work(%s/%s)", executionSpaceName, work.GetName())
+		}
+	}
 	return nil
+}
+
+// removeExecutionSpaceFinalizer removes the finalizer of executionSpace.
+func removeExecutionSpaceFinalizer(executionSpaceName string, controlPlaneKubeClient kubeclient.Interface) error {
+	executionSpace, err := controlPlaneKubeClient.CoreV1().Namespaces().Get(context.TODO(), executionSpaceName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get Namespace(%s)", executionSpaceName)
+	}
+
+	if !controllerutil.ContainsFinalizer(executionSpace, string(corev1.FinalizerKubernetes)) {
+		return nil
+	}
+
+	controllerutil.RemoveFinalizer(executionSpace, "kubernetes")
+	_, err = controlPlaneKubeClient.CoreV1().Namespaces().Update(context.TODO(), executionSpace, metav1.UpdateOptions{})
+
+	return err
+}
+
+// removeClusterFinalizer removes the finalizer of cluster object.
+func removeClusterFinalizer(clusterName string, controlPlaneKarmadaClient karmadaclientset.Interface) error {
+	cluster, err := controlPlaneKarmadaClient.ClusterV1alpha1().Clusters().Get(context.TODO(), clusterName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get Cluster(%s)", clusterName)
+	}
+
+	if !controllerutil.ContainsFinalizer(cluster, util.ClusterControllerFinalizer) {
+		return nil
+	}
+
+	controllerutil.RemoveFinalizer(cluster, util.ClusterControllerFinalizer)
+	_, err = controlPlaneKarmadaClient.ClusterV1alpha1().Clusters().Update(context.TODO(), cluster, metav1.UpdateOptions{})
+
+	return err
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When karmadactl unjoin a member cluster, the unjoin may fail all the time because the resource deletion of the member cluster fails. By enhancing the forced deletion on karmadactl unjoin, if the resource deletion of the member cluster fails also force unjoin
**Which issue(s) this PR fixes**:
Fixes #4431

**Special notes for your reviewer**:
1. delete clusterRole of member1
```shell
➜  karmada git:(master) km1 delete clusterrole karmada-controller-manager:karmada-member1 
clusterrole.rbac.authorization.k8s.io "karmada-controller-manager:karmada-member1" deleted
```
2. karmadactl unjoin member1
```shell
➜  karmada git:(master) karmadactl unjoin member1 --cluster-kubeconfig=/root/.kube/members.config
I1219 15:56:28.602959   54698 unjoin.go:264] Waiting for the cluster object member1 to be deleted
...
I1219 15:57:27.605630   54698 unjoin.go:264] Waiting for the cluster object member1 to be deleted
E1219 15:57:27.605651   54698 unjoin.go:268] Failed to delete cluster object. cluster name: member1, error: timed out waiting for the condition
E1219 15:57:27.605675   54698 unjoin.go:191] Failed to delete cluster object. cluster name: member1, error: timed out waiting for the condition
error: timed out waiting for the condition
```
3. karmadactl unjoin member1 --force
```shell
➜  karmada git:(master) karmadactl unjoin member1 --cluster-kubeconfig=/root/.kube/members.config --force
I1219 15:57:48.816159   54808 unjoin.go:264] Waiting for the cluster object member1 to be deleted
...
I1219 15:58:47.822262   54808 unjoin.go:264] Waiting for the cluster object member1 to be deleted
E1219 15:58:47.822290   54808 unjoin.go:268] Failed to delete cluster object. cluster name: member1, error: timed out waiting for the condition
E1219 15:58:47.822305   54808 unjoin.go:191] Failed to delete cluster object. cluster name: member1, error: timed out waiting for the condition
I1219 15:58:47.822310   54808 unjoin.go:193] Start forced deletion by remove work finalizer. cluster name: member1
I1219 15:58:47.847819   54808 unjoin.go:200] Succeeded to remove work's finalizer. After confirming the success of the unjoin, manually delete remaining resources on the cluster member1.
➜  karmada git:(master) ka get cluster
NAME      VERSION   MODE   READY   AGE
member2   v1.27.3   Push   True    4h3m
member3   v1.27.3   Pull   True    4h3m
```
4. rejoin
```shell
➜  karmada git:(master) karmadactl join member1 --cluster-kubeconfig=/root/.kube/members.config             
cluster(member1) is joined successfully
➜  karmada git:(master) ka get cluster
NAME      VERSION   MODE   READY   AGE
member1   v1.27.3   Push   True    5s
member2   v1.27.3   Push   True    4h15m
member3   v1.27.3   Pull   True    4h15m
```
**Does this PR introduce a user-facing change?**:

```release-note
`karmadactl`: The `--force` option of `unjoin` command now try to clean up resources propagated in member clusters.
```

