### PR TITLE
execute InterpretHealth even if statusRaw is nil

### DIFF
--- a/pkg/controllers/status/work_status_controller.go
+++ b/pkg/controllers/status/work_status_controller.go
@@ -312,10 +312,6 @@ func (c *WorkStatusController) reflectStatus(work *workv1alpha1.Work, clusterObj
 	}
 	c.EventRecorder.Eventf(work, corev1.EventTypeNormal, events.EventReasonReflectStatusSucceed, "Reflect status for object(%s/%s/%s) succeed.", clusterObj.GetKind(), clusterObj.GetNamespace(), clusterObj.GetName())
 
-	if statusRaw == nil {
-		return nil
-	}
-
 	var resourceHealth workv1alpha1.ResourceHealth
 	// When an unregistered resource kind is requested with the ResourceInterpreter,
 	// the interpreter will return an error, we treat its health status as Unknown.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

continue to execute InterpretHealth even if statusRaw is nil, otherwise, the graceful eviction controller could not parse the service's health status, the EvictionTask will be kept for 10min, details described in https://github.com/karmada-io/karmada/issues/4430

**Which issue(s) this PR fixes**:

Fixes #4430

**Special notes for your reviewer**:

Test Report：

```yaml
status:
  aggregatedStatus:
  - applied: true
    clusterName: member1
    health: Healthy
  - applied: true
    clusterName: member2
    health: Healthy
  - applied: true
    clusterName: member3
    health: Healthy
  conditions:
  - lastTransitionTime: "2023-12-20T07:52:02Z"
    message: Binding has been scheduled successfully.
    reason: Success
    status: "True"
    type: Scheduled
  - lastTransitionTime: "2023-12-20T07:52:05Z"
    message: All works have been successfully applied
    reason: FullyAppliedSuccess
    status: "True"
    type: FullyApplied
```

![image](https://github.com/karmada-io/karmada/assets/30589999/da13c980-1a87-4847-9277-aed8a4dae729)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
continue to execute InterpretHealth even if statusRaw is nil when reflectStatus 
```

