### PR TITLE
feat: prevent updates to mcs.types or when multiple types are involved.

### DIFF
--- a/pkg/webhook/multiclusterservice/validating_test.go
+++ b/pkg/webhook/multiclusterservice/validating_test.go
@@ -51,7 +51,6 @@ func TestValidateMultiClusterServiceSpec(t *testing.T) {
 					},
 					Types: []networkingv1alpha1.ExposureType{
 						networkingv1alpha1.ExposureTypeLoadBalancer,
-						networkingv1alpha1.ExposureTypeCrossCluster,
 					},
 					ProviderClusters: []networkingv1alpha1.ClusterSelector{
 						{Name: "member1"},
@@ -64,6 +63,39 @@ func TestValidateMultiClusterServiceSpec(t *testing.T) {
 				},
 			},
 			expectedErr: field.ErrorList{},
+		},
+		{
+			name: "multiple exposure type mcs",
+			mcs: &networkingv1alpha1.MultiClusterService{
+				Spec: networkingv1alpha1.MultiClusterServiceSpec{
+					Ports: []networkingv1alpha1.ExposurePort{
+						{
+							Name: "foo",
+							Port: 16312,
+						},
+						{
+							Name: "bar",
+							Port: 16313,
+						},
+					},
+					Types: []networkingv1alpha1.ExposureType{
+						networkingv1alpha1.ExposureTypeLoadBalancer,
+						networkingv1alpha1.ExposureTypeCrossCluster,
+					},
+					ProviderClusters: []networkingv1alpha1.ClusterSelector{
+						{Name: "member1"},
+						{Name: "member2"},
+					},
+					ConsumerClusters: []networkingv1alpha1.ClusterSelector{
+						{Name: "member1"},
+						{Name: "member2"},
+					},
+				},
+			},
+			expectedErr: field.ErrorList{field.Invalid(specFld.Child("types"), []networkingv1alpha1.ExposureType{
+				networkingv1alpha1.ExposureTypeLoadBalancer,
+				networkingv1alpha1.ExposureTypeCrossCluster,
+			}, "MultiClusterService types should not contain more than one type")},
 		},
 		{
 			name: "duplicated svc name",


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Currently, the north-south traffic routing is implemented through ServiceImport/ServiceExport by collecting EndpointSlice from member clusters to Karmada control plane for Work resources. 

The east-west MCS will also collect EndpointSlice for Work, and both sides will jointly manage the overlay of Work operations.

If both types are configured at the same time, when the north-south Work is overlaid (mcs label is deleted), the east-west MCS cannot synchronize the provider cluster's endpointslice to consumer clusters.

This PR temporarily prohibits mixed configuration and will resolve related conflict issues in future updates.

**Which issue(s) this PR fixes**:
Part of https://github.com/karmada-io/karmada/issues/4292

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-webhook`: prevent updates to mcs.types or when multiple types are involved.
```

