### PR TITLE
Automated cherry pick of #4340: add forType in binding status controller to inherit

### DIFF
--- a/pkg/controllers/status/common.go
+++ b/pkg/controllers/status/common.go
@@ -21,6 +21,15 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/restmapper"
 )
 
+// Fake predicate for inheriting concurrency of `forType` from global options.
+// Matching the feature in later version.
+var bindingPredicateFn = builder.WithPredicates(predicate.Funcs{
+	CreateFunc:  func(event.CreateEvent) bool { return false },
+	UpdateFunc:  func(event.UpdateEvent) bool { return false },
+	DeleteFunc:  func(event.DeleteEvent) bool { return false },
+	GenericFunc: func(event.GenericEvent) bool { return false },
+})
+
 var workPredicateFn = builder.WithPredicates(predicate.Funcs{
 	CreateFunc: func(e event.CreateEvent) bool { return false },
 	UpdateFunc: func(e event.UpdateEvent) bool {

--- a/pkg/controllers/status/crb_status_controller.go
+++ b/pkg/controllers/status/crb_status_controller.go
@@ -87,6 +87,7 @@ func (c *CRBStatusController) SetupWithManager(mgr controllerruntime.Manager) er
 		})
 
 	return controllerruntime.NewControllerManagedBy(mgr).Named("clusterResourceBinding_status_controller").
+		For(&workv1alpha2.ClusterResourceBinding{}, bindingPredicateFn).
 		Watches(&source.Kind{Type: &workv1alpha1.Work{}}, handler.EnqueueRequestsFromMapFunc(workMapFunc), workPredicateFn).
 		WithOptions(controller.Options{RateLimiter: ratelimiterflag.DefaultControllerRateLimiter(c.RateLimiterOptions)}).
 		Complete(c)

--- a/pkg/controllers/status/rb_status_controller.go
+++ b/pkg/controllers/status/rb_status_controller.go
@@ -89,6 +89,7 @@ func (c *RBStatusController) SetupWithManager(mgr controllerruntime.Manager) err
 		})
 
 	return controllerruntime.NewControllerManagedBy(mgr).Named("resourceBinding_status_controller").
+		For(&workv1alpha2.ResourceBinding{}, bindingPredicateFn).
 		Watches(&source.Kind{Type: &workv1alpha1.Work{}}, handler.EnqueueRequestsFromMapFunc(workMapFunc), workPredicateFn).
 		WithOptions(controller.Options{RateLimiter: ratelimiterflag.DefaultControllerRateLimiter(c.RateLimiterOptions)}).
 		Complete(c)


### PR DESCRIPTION
Cherry pick of #4340 on release-1.6.
#4340: add forType in binding status controller to inherit
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controllr-manager`: concurrency of `binding-status controller` inherit from the concurrency of `binding` declared in global options
```