### PR TITLE
Add kubernetes v1.29.0 to CI

### DIFF
--- a/.github/workflows/ci-schedule-compatibility.yaml
+++ b/.github/workflows/ci-schedule-compatibility.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubeapiserver-version: [ v1.21.10, v1.22.7, v1.23.4, v1.24.2, v1.25.0, v1.26.0, v1.27.3, v1.28.0 ]
+        kubeapiserver-version: [ v1.21.10, v1.22.7, v1.23.4, v1.24.2, v1.25.0, v1.26.0, v1.27.3, v1.28.0, v1.29.0 ]
         karmada-version: [ release-1.6, release-1.7, release-1.8 ]
 
         include:

--- a/.github/workflows/ci-schedule.yml
+++ b/.github/workflows/ci-schedule.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s: [ v1.23.4, v1.24.2, v1.25.0, v1.26.0, v1.27.3, v1.28.0 ]
+        k8s: [ v1.23.4, v1.24.2, v1.25.0, v1.26.0, v1.27.3, v1.28.0, v1.29.0 ]
     steps:
       # Free up disk space on Ubuntu
       - name: Free Disk Space (Ubuntu)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         # Here support the latest three minor releases of Kubernetes, this can be considered to be roughly
         # the same as the End of Life of the Kubernetes release: https://kubernetes.io/releases/
         # Please remember to update the CI Schedule Workflow when we add a new version.
-        k8s: [ v1.26.0, v1.27.3, v1.28.0 ]
+        k8s: [ v1.27.3, v1.28.0, v1.29.0 ]
     steps:
       # Free up disk space on Ubuntu
       - name: Free Disk Space (Ubuntu)

--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -18,7 +18,7 @@ jobs:
         # Here support the latest three minor releases of Kubernetes, this can be considered to be roughly
         # the same as the End of Life of the Kubernetes release: https://kubernetes.io/releases/
         # Please remember to update the CI Schedule Workflow when we add a new version.
-        k8s: [ v1.26.0, v1.27.3, v1.28.0 ]
+        k8s: [ v1.27.3, v1.28.0, v1.29.0 ]
     steps:
       - name: checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/lint-chart.yaml
+++ b/.github/workflows/lint-chart.yaml
@@ -3,9 +3,9 @@ name: Chart Lint
 
 env:
   HELM_VERSION: v3.11.2
-  KIND_VERSION: v0.14.0
-  KIND_NODE_IMAGE: kindest/node:v1.27.3
-  K8S_VERSION: v1.26.4
+  KIND_VERSION: v0.20.0
+  KIND_NODE_IMAGE: kindest/node:v1.29.0
+  K8S_VERSION: v1.29.0
 
 on:
   push:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/hold

**What this PR does / why we need it**:

kubernetes 1.29 has been released, but there may be no need to rush to add 1.29 to CI. This is currently a placeholder.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

