### PR TITLE
e2e: check whether the deployment disappears in the recovered clusters

### DIFF
--- a/test/e2e/failover_test.go
+++ b/test/e2e/failover_test.go
@@ -156,6 +156,10 @@ var _ = framework.SerialDescribe("failover testing", func() {
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				}
 			})
+
+			ginkgo.By("check whether the deployment disappears in the recovered clusters", func() {
+				framework.WaitDeploymentDisappearOnClusters(disabledClusters, deploymentNamespace, deploymentName)
+			})
 		})
 	})
 
@@ -255,6 +259,10 @@ var _ = framework.SerialDescribe("failover testing", func() {
 					err := recoverTaintedCluster(controlPlaneClient, disabledCluster, taint)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				}
+			})
+
+			ginkgo.By("check whether the deployment disappears in the recovered clusters", func() {
+				framework.WaitDeploymentDisappearOnClusters(disabledClusters, deploymentNamespace, deploymentName)
 			})
 		})
 	})


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Referring to https://github.com/karmada-io/karmada/issues/4455#issuecomment-1868693978, check whether the deployment disappears in the recovered clusters after cluster recovery.

**Which issue(s) this PR fixes**:
Fixes #4455

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

