### PR TITLE
if watch search cache request accept first is protobuf,watch.go will …

### DIFF
--- a/pkg/search/proxy/store/multi_cluster_cache.go
+++ b/pkg/search/proxy/store/multi_cluster_cache.go
@@ -67,10 +67,10 @@ type cachedResourcesInfo struct {
 }
 
 var _ Store = &MultiClusterCache{}
-var scheme = runtime.NewScheme()
+var encodeScheme = runtime.NewScheme()
 
 func init() {
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(clientgoscheme.AddToScheme(encodeScheme))
 }
 
 // NewMultiClusterCache return a cache for resources from member clusters
@@ -141,7 +141,7 @@ func (c *MultiClusterCache) UpdateCache(resourcesByCluster map[string]map[schema
 		if err != nil {
 			continue
 		}
-		_, err = scheme.New(kind)
+		_, err = encodeScheme.New(kind)
 		if err != nil {
 			continue
 		}
@@ -417,7 +417,7 @@ func encodeObjectWithPb(encodePb bool, gvr schema.GroupVersionResource, e watch.
 		if ok {
 			obj = cacheObj.GetObject()
 		}
-		newObj, err := scheme.UnsafeConvertToVersion(obj, &schema.GroupVersion{
+		newObj, err := encodeScheme.UnsafeConvertToVersion(obj, &schema.GroupVersion{
 			Group:   gvr.Group,
 			Version: gvr.Version,
 		})

--- a/pkg/search/proxy/store/multi_cluster_cache.go
+++ b/pkg/search/proxy/store/multi_cluster_cache.go
@@ -25,14 +25,13 @@ import (
 	"sync"
 	"time"
 
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/dynamic"

--- a/pkg/search/proxy/store/multi_cluster_cache.go
+++ b/pkg/search/proxy/store/multi_cluster_cache.go
@@ -150,7 +150,6 @@ func (c *MultiClusterCache) UpdateCache(resourcesByCluster map[string]map[schema
 			v.encode = true
 			c.cachedResources[gvr] = v
 		}
-
 	}
 	return nil
 }

--- a/pkg/search/proxy/store/multi_cluster_cache.go
+++ b/pkg/search/proxy/store/multi_cluster_cache.go
@@ -19,12 +19,13 @@ package store
 import (
 	"context"
 	"fmt"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"math"
 	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"

--- a/pkg/search/proxy/store/multi_cluster_cache.go
+++ b/pkg/search/proxy/store/multi_cluster_cache.go
@@ -136,6 +136,11 @@ func (c *MultiClusterCache) UpdateCache(resourcesByCluster map[string]map[schema
 		}
 	}
 
+	// update cachedResource encode
+	c.updateCachedResourcesEncode()
+	return nil
+}
+func (c *MultiClusterCache) updateCachedResourcesEncode() {
 	for gvr, v := range c.cachedResources {
 		kind, err := c.restMapper.KindFor(gvr)
 		if err != nil {
@@ -151,7 +156,6 @@ func (c *MultiClusterCache) UpdateCache(resourcesByCluster map[string]map[schema
 			c.cachedResources[gvr] = v
 		}
 	}
-	return nil
 }
 
 // Stop stops the cache for multi cluster.

--- a/pkg/search/proxy/store/util.go
+++ b/pkg/search/proxy/store/util.go
@@ -184,7 +184,7 @@ func (c *multiClusterContinue) String() string {
 
 type decoratedWatcher struct {
 	watcher   watch.Interface
-	decorator func(watch.Event)
+	decorator func(watch.Event) watch.Event
 }
 
 type watchMux struct {
@@ -202,7 +202,7 @@ func newWatchMux() *watchMux {
 }
 
 // AddSource shall be called before Start
-func (w *watchMux) AddSource(watcher watch.Interface, decorator func(watch.Event)) {
+func (w *watchMux) AddSource(watcher watch.Interface, decorator func(watch.Event) watch.Event) {
 	w.sources = append(w.sources, decoratedWatcher{
 		watcher:   watcher,
 		decorator: decorator,
@@ -251,7 +251,7 @@ func (w *watchMux) Stop() {
 	}
 }
 
-func (w *watchMux) startWatchSource(source watch.Interface, decorator func(watch.Event)) {
+func (w *watchMux) startWatchSource(source watch.Interface, decorator func(watch.Event) watch.Event) {
 	defer source.Stop()
 	defer w.Stop()
 	for {
@@ -264,7 +264,7 @@ func (w *watchMux) startWatchSource(source watch.Interface, decorator func(watch
 			// sourceEvent object is cacheObject,all watcher use the same point,must deepcopy.
 			copyEvent = *sourceEvent.DeepCopy()
 			if decorator != nil {
-				decorator(copyEvent)
+				copyEvent = decorator(copyEvent)
 			}
 		case <-w.done:
 			return

--- a/pkg/search/proxy/store/util_test.go
+++ b/pkg/search/proxy/store/util_test.go
@@ -39,7 +39,7 @@ func Test_watchMux_StopBySelf(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		w := newFakeWatcher(wait.NeverStop)
-		m.AddSource(w, func(event watch.Event) {})
+		m.AddSource(w, func(event watch.Event) watch.Event { return event })
 		go func() {
 			ticker := time.NewTimer(time.Second)
 			for {
@@ -84,7 +84,7 @@ func Test_watchMux_StopBySource(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		w := newFakeWatcher(ctx.Done())
-		m.AddSource(w, func(event watch.Event) {})
+		m.AddSource(w, func(event watch.Event) watch.Event { return event })
 		go func() {
 			ticker := time.NewTimer(time.Second)
 			for {


### PR DESCRIPTION
…message does not implement the protobuf marshalling interface and cannot be encoded to a protobuf message,watcher will close. my client watch will quickly close. so provide some resource Unstructured to pbMarshal.

like pod/node

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

