### PR TITLE
add scan-image-vuln.sh to do image-scanning with trivy

### DIFF
--- a/hack/scan-image-vuln.sh
+++ b/hack/scan-image-vuln.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Copyright 2024 The Karmada Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script starts a images scanning with trivy
+# This script depends on utils in: ${REPO_ROOT}/hack/util.sh
+# 1. used to locally scan Karmada component images vulnerabilities with trivy
+# 2. Used to scan specified image with trivy
+
+function usage() {
+    echo "Usage:"
+    echo "    hack/scan-image-vuln.sh [-i imageRef] [-r registry] [-v version] [-s skip-image-generation] [-h]"
+    echo "Examples:"
+    echo "    # starts a images scanning with specific image provided"
+    echo "    hack/scan-image-vuln.sh -i docker.io/karmada/karmada-controller-manager:v1.8.0"
+    echo "    # scan Karmada component images with trivy and images will be automatically generated, imageRef='docker.io/karmada/{imageName}:latest'"
+    echo "    hack/scan-image-vuln.sh"
+    echo "    # scan Karmada component images with trivy and images generation will be skipped, imageRef='docker.io/karmada/{imageName}:latest'"
+    echo "    hack/scan-image-vuln.sh -s"
+    echo "    # scan Karmada component images with trivy and provide specific image's registry or version"
+    echo "    hack/scan-image-vuln.sh -r foo # imageRef='foo/{imageName}:latest'"
+    echo "    hack/scan-image-vuln.sh -s -v v1.8.0 # imageRef='docker.io/karmada/{imageName}:v1.8.0'"
+    echo "Args:"
+    echo "    i imageRef: starts a images scanning with specific image provided, if not provided, local Karmada images will be scanned"
+    echo "    r registry: registry of images"
+    echo "    v version: version of images"
+    echo "    s skip-image-generation: whether to skip image generation"
+    echo "    h: print help information"
+}
+
+SKIP_IMAGE_GENERAION="false"
+IMAGEREF=""
+
+while getopts 'h:si:r:v:' OPT; do
+    case $OPT in
+        h)
+          usage
+          exit 0
+          ;;
+        s)
+        	SKIP_IMAGE_GENERAION="true";;
+        i)
+        	IMAGEREF=${OPTARG};;
+       	r)
+       		REGISTRY=${OPTARG};;
+        v)
+        	VERSION=${OPTARG};;
+        ?)
+          usage
+          exit 1
+          ;;
+    esac
+done
+
+source "hack/util.sh"
+
+echo -n "Preparing: 'trivy' existence check - "
+if util::cmd_exist trivy ; then
+	echo "pass"
+else
+	echo "start installing trivy"
+	curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.48.1
+fi
+
+if [ ${IMAGEREF} ];then
+	echo "---------------------------- the image scanning result of Image <<${IMAGEREF}>> ----------------------------"
+  trivy image --format table --ignore-unfixed --vuln-type os,library --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL -q ${IMAGEREF}
+  exit 0
+fi
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd "${REPO_ROOT}"
+export VERSION=${VERSION:-"latest"}
+export REGISTRY=${REGISTRY:-"docker.io/karmada"}
+IMAGE_ARRAR=(
+	karmada-controller-manager
+  karmada-scheduler
+  karmada-descheduler
+  karmada-webhook
+  karmada-agent
+  karmada-scheduler-estimator
+  karmada-interpreter-webhook-example
+  karmada-aggregated-apiserver
+  karmada-search
+  karmada-operator
+  karmada-metrics-adapter
+)
+if [ ${SKIP_IMAGE_GENERAION} == "false" ]; then
+	echo "start generating image"
+	make images GOOS="linux" --directory=.
+fi
+
+echo "start image scan"
+for image in ${IMAGE_ARRAR[@]}
+do
+  imageRef="$REGISTRY/$image:$VERSION"
+  echo "---------------------------- the image scanning result of Image <<$imageRef>> ----------------------------"
+  trivy image --format table --ignore-unfixed --vuln-type os,library --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL -q $imageRef
+done


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Sometimes, we eliminate image vulnerabilities by upgrading dependencies. We can use this script to confirm locally whether the vulnerability has been completely eliminated.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
```shell
(base) ➜  karmada git:(crypt) ✗ hack/verify-vuln.sh false CVE-2023-45142,CVE-2023-45333
Preparing: 'trivy' existence check - pass
start image scan
2024-01-02T16:19:00.464+0800    INFO    Vulnerability scanning is enabled
2024-01-02T16:19:00.465+0800    INFO    Secret scanning is enabled
2024-01-02T16:19:00.465+0800    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-01-02T16:19:00.465+0800    INFO    Please see also https://aquasecurity.github.io/trivy/v0.48/docs/scanner/secret/#recommendation for faster secret detection
2024-01-02T16:19:00.470+0800    INFO    Detected OS: alpine
2024-01-02T16:19:00.470+0800    INFO    Detecting Alpine vulnerabilities...
2024-01-02T16:19:00.471+0800    INFO    Number of language-specific files: 1
2024-01-02T16:19:00.471+0800    INFO    Detecting gobinary vulnerabilities...
Image docker.io/karmada/karmada-controller-manager:latest has a security vulnerability CVE-2023-45142, detail
│                           Library                            │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                            Title                            │
│ go.opentelemetry.io/contrib/instrumentation/net/http/otelht- │ CVE-2023-45142 │          │        │ v0.35.1           │ 0.44.0        │ opentelemetry: DoS vulnerability in otelhttp                │

(base) ➜  karmada git:(crypt) ✗ hack/verify-vuln.sh false CVE-2023-453333
Preparing: 'trivy' existence check - pass
start image scan
2024-01-02T16:17:50.774+0800    INFO    Vulnerability scanning is enabled
2024-01-02T16:17:50.774+0800    INFO    Secret scanning is enabled
2024-01-02T16:17:50.774+0800    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-01-02T16:17:50.774+0800    INFO    Please see also https://aquasecurity.github.io/trivy/v0.48/docs/scanner/secret/#recommendation for faster secret detection
2024-01-02T16:17:50.780+0800    INFO    Detected OS: alpine
...
Congratulations! All images have not been scanned for security vulnerabilities CVE-2023-453333.

```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

