### PR TITLE
cleanup: enable revive(package-comments) checking

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,6 +66,7 @@ linters-settings:
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#if-return
       - name: if-return
         disabled: true
+      - name: package-comments
       - name: superfluous-else
         arguments:
           - preserveScope

--- a/pkg/controllers/federatedhpa/monitor/metrics.go
+++ b/pkg/controllers/federatedhpa/monitor/metrics.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// metrics packages contains metrics which are exposed from the HPA controller.
+// Package monitor contains metrics which are exposed from the HPA controller.
 package monitor
 
 import (


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
cleanup: enable revive(package-comments) checking,  this rule warns on undocumented packages and when packages comments are detached to the package keyword.
**Which issue(s) this PR fixes**:
Parts of #4490 

**Special notes for your reviewer**:
```shell
(base) ➜  karmada git:(comment) ✗ hack/verify-staticcheck.sh
Using golangci-lint version:
golangci-lint has version 1.52.2 built with go1.20.2 from da04413a on 2023-03-25T18:11:28Z
Congratulations!  All Go source files have passed staticcheck.
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

