### PR TITLE
cleanup: enable revive(errorf/dot-imports) checking

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,6 +76,8 @@ linters-settings:
       - name: increment-decrement
       - name: range
       - name: error-naming
+      - name: dot-imports
+      - name: errorf
   staticcheck:
     checks:
       - all


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
cleanup: enable revive(errorf/dot-imports) checking. 
#### dot-imports:
Description: Importing with . makes the programs much harder to understand because it is unclear whether names belong to the current package or to an imported package.
#### errorf:
Description: It is possible to get a simpler program by replacing errors.New(fmt.Sprintf()) with fmt.Errorf(). This rule spots that kind of simplification opportunities.
**Which issue(s) this PR fixes**:
Parts of #4490

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

