### PR TITLE
cleanup: enable revive(range/error-naming) checking

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,6 +74,8 @@ linters-settings:
       - name: error-return
       - name: receiver-naming
       - name: increment-decrement
+      - name: range
+      - name: error-naming
   staticcheck:
     checks:
       - all


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
cleanup: enable revive (range/error-naming) checking.

- `range`: suggests a shorter way of writing ranges that do not use the second value.
- `error-naming`: variables of type error must be named with the prefix `err` for the sake of readability, 



**Which issue(s) this PR fixes**:
Fixes part of #4490

**Special notes for your reviewer**:
```bash
> ./hack/verify-staticcheck.sh
Using golangci-lint version:
golangci-lint has version 1.52.2 built with go1.20.2 from da04413a on 2023-03-25T18:11:28Z
Congratulations!  All Go source files have passed staticcheck.

```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

