### PR TITLE
chore: verify whether docker is available by executing docker ps command

### DIFF
--- a/hack/local-up-karmada.sh
+++ b/hack/local-up-karmada.sh
@@ -75,8 +75,8 @@ fi
 util::cmd_must_exist "go"
 util::verify_go_version
 
-# Make sure docker exists
-util::cmd_must_exist "docker"
+# Make sure docker is available
+util::verify_docker
 
 # install kind and kubectl
 kind_version=v0.20.0

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -112,6 +112,13 @@ function util::cmd_must_exist {
     fi
 }
 
+function util::verify_docker {
+  if ! docker ps -q >/dev/null 2>&1; then
+      echo "Docker is not available, Please verify docker is installed and available"
+      exit 1
+  fi
+}
+
 function util::verify_go_version {
     local go_version
     IFS=" " read -ra go_version <<< "$(GOFLAGS='' go version)"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
The `./hack/local-up-karmada.sh` did not execute successfully but no error was reported when I installed docker but docker was not enabled.
```shell
~/Code/github/karmada #v1.7.2 ❯ ./hack/local-up-karmada.sh                                                                                                                                                                                  
Preparing: 'kind' existence check - passed
Preparing: 'kubectl' existence check - passed
Preparing kindClusterConfig in path: /tmp/tmp.GcYYjKiQ1p
~/Code/github/karmada #v1.7.2 ❯ docker ps
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```

So I want to make sure docker is available by running `docker ...` command instead of `command -v docker`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
None
```

