### PR TITLE
Fix misjudgment when updating attached binding

### DIFF
--- a/pkg/dependenciesdistributor/dependencies_distributor.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor.go
@@ -534,6 +534,7 @@ func (d *DependenciesDistributor) createOrUpdateAttachedBinding(attachedBinding 
 			klog.Errorf("Failed to update resource binding(%s/%s): %v", existBinding.Namespace, existBinding.Name, err)
 			return err
 		}
+		return nil
 	}
 
 	if !apierrors.IsNotFound(err) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Fix misjudgment when updating attached binding.
![image](https://github.com/karmada-io/karmada/assets/89241565/7bf32cf4-21b1-44e9-bc25-6c3b859e58b1)

We should return `nil` after successfully updating attached binding.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

