### PR TITLE
Remove redundant os preload in lua vm

### DIFF
--- a/pkg/resourceinterpreter/customized/declarative/luavm/lua.go
+++ b/pkg/resourceinterpreter/customized/declarative/luavm/lua.go
@@ -65,8 +65,6 @@ func (vm *VM) NewLuaState() (*lua.LState, error) {
 	if err != nil {
 		return nil, err
 	}
-	// preload our 'safe' version of the OS library. Allows the 'local os = require("os")' to work
-	l.PreloadModule(lua.OsLibName, lualifted.SafeOsLoader)
 	// preload kube library. Allows the 'local kube = require("kube")' to work
 	l.PreloadModule(KubeLibName, KubeLoader)
 	return l, err
@@ -326,8 +324,6 @@ func NewWithContext(ctx context.Context) (*lua.LState, error) {
 	if err != nil {
 		return nil, err
 	}
-	// preload our 'safe' version of the OS library. Allows the 'local os = require("os")' to work
-	l.PreloadModule(lua.OsLibName, lualifted.SafeOsLoader)
 	// preload kube library. Allows the 'local kube = require("kube")' to work
 	l.PreloadModule(KubeLibName, KubeLoader)
 	if ctx != nil {

--- a/pkg/util/lifted/lua/oslib_safe.go
+++ b/pkg/util/lifted/lua/oslib_safe.go
@@ -34,7 +34,7 @@ import (
 
 // OpenSafeOs open safe os
 func OpenSafeOs(L *lua.LState) int {
-	tabmod := L.RegisterModule(lua.TabLibName, osFuncs)
+	tabmod := L.RegisterModule(lua.OsLibName, osFuncs)
 	L.Push(tabmod)
 	return 1
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The os package has already been added in `setlib` (using the wrong package name), there is no need to preload the os package again.

After modification, the `os.date()` and `os.time()` functions can be called normally.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

