### PR TITLE
federatedhpa supports the same pod name in multiple clusters

### DIFF
--- a/pkg/controllers/federatedhpa/federatedhpa_controller.go
+++ b/pkg/controllers/federatedhpa/federatedhpa_controller.go
@@ -540,7 +540,7 @@ func (c *FHPAController) scaleForTargetCluster(clusters []string, hpa *autoscali
 			klog.Errorf("Failed to get podList for cluster %s.", cluster)
 			continue
 		}
-
+		completePodQuerySourceClusterAnnotations(podList, cluster)
 		multiClusterPodList = append(multiClusterPodList, podList...)
 	}
 
@@ -549,6 +549,18 @@ func (c *FHPAController) scaleForTargetCluster(clusters []string, hpa *autoscali
 	}
 
 	return multiClusterScale, multiClusterPodList, nil
+}
+
+func completePodQuerySourceClusterAnnotations(podList []*corev1.Pod, cluster string) {
+	for _, pod := range podList {
+		if pod.Annotations == nil {
+			pod.Annotations = map[string]string{autoscalingv1alpha1.QuerySourceAnnotationKey: cluster}
+			continue
+		}
+		if pod.Annotations[autoscalingv1alpha1.QuerySourceAnnotationKey] == "" {
+			pod.Annotations[autoscalingv1alpha1.QuerySourceAnnotationKey] = cluster
+		}
+	}
 }
 
 // buildPodInformerForCluster builds informer manager for cluster if it doesn't exist, then constructs informers for pod and start it. If the informer manager exist, return it.

--- a/pkg/controllers/federatedhpa/metrics/client.go
+++ b/pkg/controllers/federatedhpa/metrics/client.go
@@ -33,7 +33,9 @@ import (
 	customclient "k8s.io/metrics/pkg/client/custom_metrics"
 	externalclient "k8s.io/metrics/pkg/client/external_metrics"
 
+	autoscalingv1alpha1 "github.com/karmada-io/karmada/pkg/apis/autoscaling/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/metrics"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 const (
@@ -101,7 +103,7 @@ func getContainerMetrics(rawMetrics []metricsapi.PodMetrics, resource corev1.Res
 			if c.Name == container {
 				containerFound = true
 				if val, resFound := c.Usage[resource]; resFound {
-					res[m.Name] = PodMetric{
+					res[names.ClusteredKey(m.Annotations[autoscalingv1alpha1.QuerySourceAnnotationKey], m.Name)] = PodMetric{
 						Timestamp: m.Timestamp.Time,
 						Window:    m.Window.Duration,
 						Value:     val.MilliValue(),
@@ -132,7 +134,7 @@ func getPodMetrics(rawMetrics []metricsapi.PodMetrics, resource corev1.ResourceN
 			podSum += resValue.MilliValue()
 		}
 		if !missing {
-			res[m.Name] = PodMetric{
+			res[names.ClusteredKey(m.Annotations[autoscalingv1alpha1.QuerySourceAnnotationKey], m.Name)] = PodMetric{
 				Timestamp: m.Timestamp.Time,
 				Window:    m.Window.Duration,
 				Value:     podSum,

--- a/pkg/util/names/names.go
+++ b/pkg/util/names/names.go
@@ -181,3 +181,11 @@ func NamespacedKey(namespace, name string) string {
 	}
 	return namespace + "/" + name
 }
+
+// ClusteredKey generates key with cluster and name.
+func ClusteredKey(cluster, name string) string {
+	if cluster == "" {
+		return name
+	}
+	return cluster + "/" + name
+}

--- a/pkg/util/names/names_test.go
+++ b/pkg/util/names/names_test.go
@@ -438,3 +438,31 @@ func TestGeneratePolicyName(t *testing.T) {
 		}
 	}
 }
+
+func TestClusteredKey(t *testing.T) {
+	tests := []struct {
+		testName string
+		cluster  string
+		name     string
+		expected string
+	}{
+		{
+			testName: "clusteredKey without cluster",
+			cluster:  "",
+			name:     "foo",
+			expected: "foo",
+		},
+		{
+			testName: "clusteredKey with cluster",
+			cluster:  "member1",
+			name:     "foo",
+			expected: "member1/foo",
+		},
+	}
+	for _, test := range tests {
+		got := ClusteredKey(test.cluster, test.name)
+		if got != test.expected {
+			t.Errorf("Test %s failed: expected %v, but got %v", test.testName, test.expected, got)
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When multiple clusters have pods with the same name, metricsadapter query through podName will fail. The relevant code is as follows：
https://github.com/karmada-io/karmada/blob/e857d1f95efbd7c0fff64fdb4ce57ca1f9f97920/pkg/metricsadapter/provider/resourcemetrics.go#L465-L468

When fhpa calculates the replicas, it will also regard podName as the key value of the map, which is globally unique in multiple clusters. When multiple clusters have pods with the same name, the value of the pod with the same name will be overwritten in the map.


**Which issue(s) this PR fixes**:
Fixes #4257 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
‘federatedhpa’： supports the same pod name in multiple clusters
```