### PR TITLE
Delete k8s v1.21 and v1.22 from workflow of APIServer compatibility.

### DIFF
--- a/.github/workflows/ci-schedule-compatibility.yaml
+++ b/.github/workflows/ci-schedule-compatibility.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubeapiserver-version: [ v1.21.10, v1.22.7, v1.23.4, v1.24.2, v1.25.0, v1.26.0, v1.27.3, v1.28.0, v1.29.0 ]
+        kubeapiserver-version: [ v1.23.4, v1.24.2, v1.25.0, v1.26.0, v1.27.3, v1.28.0, v1.29.0 ]
         karmada-version: [ release-1.6, release-1.7, release-1.8 ]
 
         include:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Test is using autoscaling/v2 for HorizontalPodAutoscaler, and this version is GA from kubernetes v1.23.0, so it always failed.

https://github.com/karmada-io/karmada/pull/4366 have cleanup it for CI Schedule Workflow and this PR is working for `APIServer compatibility`

see workflow of APIServer compatibility :
- https://github.com/karmada-io/karmada/actions/runs/7440408040
- https://github.com/karmada-io/karmada/actions/runs/7433650631

Releated:
- https://github.com/karmada-io/karmada/issues/4111

/assign @RainbowMango 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Once this PR is merged,    Most CIs of the workflow of `APIServer compatibility` will be green, except for the last problem:  sometimes `setup e2e test environment` have failed.
See https://github.com/karmada-io/karmada/actions/runs/7372453496/job/20060795827

```shell
...
Waiting for kubeconfig file /home/runner/.kube/members.config and clusters member1 to be ready...
Waiting for running............................................................................................................................................................................................................................................................................................................
```

Not sure if it is the same issue as https://github.com/karmada-io/karmada/issues/4509




**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

