### PR TITLE
fix: local-up-karmada.sh delete all kind cluster, this will delete user kind clusters

### DIFF
--- a/hack/local-up-karmada.sh
+++ b/hack/local-up-karmada.sh
@@ -62,6 +62,7 @@ MEMBER_CLUSTER_2_TMP_CONFIG="${KUBECONFIG_PATH}/${MEMBER_TMP_CONFIG_PREFIX}-${ME
 PULL_MODE_CLUSTER_TMP_CONFIG="${KUBECONFIG_PATH}/${MEMBER_TMP_CONFIG_PREFIX}-${PULL_MODE_CLUSTER_NAME}.config"
 HOST_IPADDRESS=${1:-}
 
+
 CLUSTER_VERSION=${CLUSTER_VERSION:-"${DEFAULT_CLUSTER_VERSION}"}
 KIND_LOG_FILE=${KIND_LOG_FILE:-"/tmp/karmada"}
 
@@ -112,7 +113,7 @@ echo -e "Preparing kindClusterConfig in path: ${TEMP_PATH}"
 cp -rf "${REPO_ROOT}"/artifacts/kindClusterConfig/member1.yaml "${TEMP_PATH}"/member1.yaml
 cp -rf "${REPO_ROOT}"/artifacts/kindClusterConfig/member2.yaml "${TEMP_PATH}"/member2.yaml
 
-util::delete_all_clusters "${MAIN_KUBECONFIG}" "${MEMBER_CLUSTER_KUBECONFIG}" "${KIND_LOG_FILE}"
+util::delete_all_clusters "${MAIN_KUBECONFIG}" "${MEMBER_CLUSTER_KUBECONFIG}" "${KIND_LOG_FILE}" "${HOST_CLUSTER_NAME}" "${MEMBER_CLUSTER_1_NAME}" "${MEMBER_CLUSTER_2_NAME}" "${PULL_MODE_CLUSTER_NAME}"
 
 if [[ -n "${HOST_IPADDRESS}" ]]; then # If bind the port of clusters(karmada-host, member1 and member2) to the host IP
   util::verify_ip_address "${HOST_IPADDRESS}"

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -452,12 +452,16 @@ function util::delete_all_clusters() {
   local main_config=${1}
   local member_config=${2}
   local log_path=${3}
+  local host_cluster_name=${4}
+  local member1_name=${5}
+  local member2_name=${6}
 
   local log_file="${log_path}"/delete-all-clusters.log
   rm -rf ${log_file}
   mkdir -p ${log_path}
 
-  kind delete clusters --all >> "${log_file}" 2>&1
+  # only delete karmada create clusters
+  kind delete clusters "${host_cluster_name}" "${member1_name}" "${member2_name}" >> "${log_file}" 2>&1
   rm -f "${main_config}"
   rm -f "${member_config}"
 


### PR DESCRIPTION
hack/local-up-karmada.sh should not delete user kind clusters, it can only delete clusters that karmada create
/assign @mrlihanbo

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind bug

**What this PR does / why we need it**:

it delete user clusters, that will make users lost important data

**Which issue(s) this PR fixes**:
Fixes #

util::delete_all_clusters function

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

