### PR TITLE
enable golangci-lint context-as-argument, context-keys-type and unexported-return checking

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -86,6 +86,9 @@ linters-settings:
       - name: var-naming
       - name: redefines-builtin-id
       - name: unused-parameter
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: unexported-return
   staticcheck:
     checks:
       - all


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

enable golangci-lint context-as-argument, context-keys-type and unexported-return checking

**Which issue(s) this PR fixes**:
Part of #4490

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

