### PR TITLE
search add check member cluster api enable

### DIFF
--- a/pkg/search/proxy/controller.go
+++ b/pkg/search/proxy/controller.go
@@ -47,6 +47,7 @@ import (
 	pluginruntime "github.com/karmada-io/karmada/pkg/search/proxy/framework/runtime"
 	"github.com/karmada-io/karmada/pkg/search/proxy/store"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/helper"
 	"github.com/karmada-io/karmada/pkg/util/lifted"
 	"github.com/karmada-io/karmada/pkg/util/restmapper"
 )
@@ -223,6 +224,15 @@ func (ctl *Controller) reconcile(util.QueueKey) error {
 			}
 
 			for resource, multiNS := range matchedResources {
+				gvk, err := ctl.restMapper.KindFor(resource)
+				if err != nil {
+					klog.Errorf("Failed to get gvk: %v", err)
+					continue
+				}
+				if !helper.IsAPIEnabled(cluster.Status.APIEnablements, gvk.GroupVersion().String(), gvk.Kind) {
+					klog.Warningf("Resource %s is not enabled for cluster %s", resource.String(), cluster)
+					continue
+				}
 				resourcesByClusters[cluster.Name][resource] = multiNS
 			}
 		}

--- a/pkg/search/proxy/controller_test.go
+++ b/pkg/search/proxy/controller_test.go
@@ -510,9 +510,28 @@ func TestController_Connect_Error(t *testing.T) {
 
 func newCluster(name string) *clusterv1alpha1.Cluster {
 	c := &clusterv1alpha1.Cluster{}
+	clusterEnablements := []clusterv1alpha1.APIEnablement{
+		{
+			GroupVersion: "v1",
+			Resources: []clusterv1alpha1.APIResource{
+				{
+					Kind: "Pod",
+				},
+			},
+		},
+		{
+			GroupVersion: "v1",
+			Resources: []clusterv1alpha1.APIResource{
+				{
+					Kind: "Node",
+				},
+			},
+		},
+	}
 	c.Name = name
 	conditions := make([]metav1.Condition, 0, 1)
 	conditions = append(conditions, util.NewCondition(clusterv1alpha1.ClusterConditionReady, "", "", metav1.ConditionTrue))
 	c.Status.Conditions = conditions
+	c.Status.APIEnablements = clusterEnablements
 	return c
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

When crd exists in the karmada control plane but does not exist in the member cluster, search will report an error.
Checks for member crd should be added

karmada version: 1.5

![image](https://github.com/karmada-io/karmada/assets/89568107/076a6393-6a1f-4a76-833e-b6c30deca4a6)



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-search`: Add the logic of checking whether the resource API to be retrieved is installed in the cluster.
```

