### PR TITLE
refactor: cleanup resource labels when delelte policy in detector

### DIFF
--- a/pkg/detector/helper.go
+++ b/pkg/detector/helper.go
@@ -1,0 +1,14 @@
+package detector
+
+import (
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+)
+
+var (
+	propagationPolicyRefLabels = []string{policyv1alpha1.PropagationPolicyNamespaceLabel, policyv1alpha1.PropagationPolicyNameLabel, policyv1alpha1.PropagationPolicyPermanentIDLabel}
+
+	clusterPropagationPolicyRefLabels = []string{policyv1alpha1.ClusterPropagationPolicyLabel, policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel}
+)
+
+// RemoveMapKeysFunc defines the func to remove some keys.
+type RemoveMapKeysFunc func(map[string]string) map[string]string


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

When the Policy is deleted, the labels that need to be cleaned up will change with development iterations. This modification point has a bit of code smell and requires modifications in multiple places, so some refactoring has been done.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

