### PR TITLE
'karmadactl register' should use bootstrap endpoint for karmada-agents' kubeconfig instead of discovered cluster-info

### DIFF
--- a/pkg/karmadactl/register/register.go
+++ b/pkg/karmadactl/register/register.go
@@ -867,8 +867,15 @@ func (o *CommandRegisterOption) constructKubeConfig(bootstrapClient *kubeclient.
 		return nil, err
 	}
 
+	// Using o.BootstrapToken.APIServerEndpoint instead of the endpoint in discovered cluster-info
+	// because discivered endpoint can often be unreachable from member cluster
+	karmadaServer := karmadaClusterInfo.Server
+	if o.BootstrapToken.APIServerEndpoint != "" {
+		karmadaServer = fmt.Sprintf("https://%s", o.BootstrapToken.APIServerEndpoint)
+	}
+
 	return CreateWithCert(
-		karmadaClusterInfo.Server,
+		karmadaServer,
 		DefaultClusterName,
 		o.ClusterName,
 		karmadaClusterInfo.CertificateAuthorityData,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

`karmada register` command generates `/etc/karmada/bootstrap-karmada-agent.conf` with the endpoint in `default/cluster-info` configmap which can often be un-reachable from member clusters (`karmada-apiserver.karmada-system.svc.cluster.local` in most cases as reported in #4262 ??). 

Moreover, `karmada register` command does not provide any way to change the url. Thus, `karmada register` can NOT generate proper kubeconfig for karmada-agent. and it keeps failing to deploy karmada-agent on member clusters.

This PR make `karmada register` use the bootstrap endpoint which user passed instead of cluster-info.

**Which issue(s) this PR fixes**:

Fixes #4262 

**Special notes for your reviewer**:

Discussion: should we introduce `--apiserver-advertise-address/--apiserver-bind-port` like [`kubeadm join`](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-join/#:~:text=%2D%2Dapiserver%2Dadvertise%2Daddress%20string) instead of using bootstrap endoint??

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

