### PR TITLE
specify `appProtocol` for services that use https

### DIFF
--- a/artifacts/deploy/karmada-search.yaml
+++ b/artifacts/deploy/karmada-search.yaml
@@ -77,7 +77,8 @@ metadata:
     apiserver: "true"
 spec:
   ports:
-    - port: 443
+    - appProtocol: https
+      port: 443
       protocol: TCP
       targetPort: 443
   selector:

--- a/artifacts/deploy/karmada-webhook.yaml
+++ b/artifacts/deploy/karmada-webhook.yaml
@@ -63,5 +63,7 @@ spec:
   selector:
     app: karmada-webhook
   ports:
-    - port: 443
+    - appProtocol: https
+      port: 443
+      protocol: TCP
       targetPort: 8443

--- a/charts/karmada/templates/karmada-aggregated-apiserver.yaml
+++ b/charts/karmada/templates/karmada-aggregated-apiserver.yaml
@@ -119,7 +119,8 @@ metadata:
     {{- include "karmada.aggregatedApiServer.labels" . | nindent 4 }}
 spec:
   ports:
-    - port: 443
+    - appProtocol: https
+      port: 443
       protocol: TCP
       targetPort: 443
   selector:

--- a/charts/karmada/templates/karmada-search.yaml
+++ b/charts/karmada/templates/karmada-search.yaml
@@ -103,7 +103,8 @@ metadata:
     {{- include "karmada.search.labels" . | nindent 4 }}
 spec:
   ports:
-    - port: 443
+    - appProtocol: https
+      port: 443
       protocol: TCP
       targetPort: 443
   selector:

--- a/charts/karmada/templates/karmada-webhook.yaml
+++ b/charts/karmada/templates/karmada-webhook.yaml
@@ -80,7 +80,9 @@ spec:
   selector:
     {{- include "karmada.webhook.labels" . | nindent 8 }}
   ports:
-    - port: 443
+    - appProtocol: https
+      port: 443
+      protocol: TCP
       targetPort: 8443
 
 {{ if .Values.webhook.podDisruptionBudget }}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature

**What this PR does / why we need it**:

For clusters that use istio, you must specify port name following format $name-$protocol or use appProtocol.

Istio Docs: https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
add `appProtocol` to manifests for kind service
```

