### PR TITLE
add flag -f format to scan-image-vuln.sh

### DIFF
--- a/hack/scan-image-vuln.sh
+++ b/hack/scan-image-vuln.sh
@@ -24,7 +24,7 @@ set -o pipefail
 
 function usage() {
     echo "Usage:"
-    echo "    hack/scan-image-vuln.sh [-i imageRef] [-r registry] [-v version] [-s skip-image-generation] [-h]"
+    echo "    hack/scan-image-vuln.sh [-i imageRef] [-r registry] [-v version] [-s skip-image-generation] [-f format][-h]"
     echo "Examples:"
     echo "    # starts a images scanning with specific image provided"
     echo "    hack/scan-image-vuln.sh -i docker.io/karmada/karmada-controller-manager:v1.8.0"
@@ -40,13 +40,11 @@ function usage() {
     echo "    r registry: registry of images"
     echo "    v version: version of images"
     echo "    s skip-image-generation: whether to skip image generation"
+    echo "    f format: output format(table). must be one of ['table' 'json' 'template' 'sarif' 'cyclonedx' 'spdx' 'spdx-json' 'github' 'cosign-vuln']"
     echo "    h: print help information"
 }
 
-SKIP_IMAGE_GENERAION="false"
-IMAGEREF=""
-
-while getopts 'h:si:r:v:' OPT; do
+while getopts 'h:si:r:v:f:' OPT; do
     case $OPT in
         h)
           usage
@@ -60,12 +58,18 @@ while getopts 'h:si:r:v:' OPT; do
        		REGISTRY=${OPTARG};;
         v)
         	VERSION=${OPTARG};;
+        f)
+        	FORMAT=${OPTARG};;
         ?)
           usage
           exit 1
           ;;
     esac
 done
+
+FORMAT=${FORMAT:-"table"}
+SKIP_IMAGE_GENERAION=${SKIP_IMAGE_GENERAION:-"false"}
+IMAGEREF=${IMAGEREF:-""}
 
 source "hack/util.sh"
 
@@ -79,7 +83,7 @@ fi
 
 if [ ${IMAGEREF} ];then
 	echo "---------------------------- the image scanning result of Image <<${IMAGEREF}>> ----------------------------"
-  trivy image --format table --ignore-unfixed --vuln-type os,library --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL -q ${IMAGEREF}
+  trivy image --format ${FORMAT} --ignore-unfixed --vuln-type os,library --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL -q ${IMAGEREF}
   exit 0
 fi
 
@@ -110,5 +114,5 @@ for image in ${IMAGE_ARRAR[@]}
 do
   imageRef="$REGISTRY/$image:$VERSION"
   echo "---------------------------- the image scanning result of Image <<$imageRef>> ----------------------------"
-  trivy image --format table --ignore-unfixed --vuln-type os,library --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL -q $imageRef
+  trivy image --format ${FORMAT} --ignore-unfixed --vuln-type os,library --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL -q $imageRef
 done


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
add flag -f format to scan-image-vuln.sh
```bash
(base) ➜  karmada git:(revive) ✗ hack/scan-image-vuln.sh -s -f json 
Preparing: 'trivy' existence check - pass
start image scan
---------------------------- the image scanning result of Image <<docker.io/karmada/karmada-controller-manager:latest>> ----------------------------
{
  "SchemaVersion": 2,
  "CreatedAt": "2024-01-20T10:08:27.58630979+08:00",
  "ArtifactName": "docker.io/karmada/karmada-controller-manager:latest",
  "ArtifactType": "container_image",
  "Metadata": {
    "OS": {
      "Family": "alpine",
      "Name": "3.19.0"
    },
    "ImageID": "sha256:147eb2dcae81afe73109bd8e1efacf6fcd90aa98c8d8739cac527651e84d78d8",
    "DiffIDs": [
      "sha256:5af4f8f59b764c64c6def53f52ada809fe38d528441d08d01c206dfb3fc3b691",
      "sha256:d121d913ff4e1bb0612512dabb30534825f719e70962158ef6b2a90f987362f0",
...
```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

