### PR TITLE
bump golangci-lint to v1.55.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -89,6 +89,8 @@ linters-settings:
       - name: context-as-argument
       - name: context-keys-type
       - name: unexported-return
+      - name: time-naming
+      - name: empty-block
   staticcheck:
     checks:
       - all

--- a/hack/verify-staticcheck.sh
+++ b/hack/verify-staticcheck.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-GOLANGCI_LINT_VER="v1.52.2"
+GOLANGCI_LINT_VER="v1.55.2"
 
 cd "${REPO_ROOT}"
 source "hack/util.sh"

--- a/pkg/apis/cluster/validation/validation_test.go
+++ b/pkg/apis/cluster/validation/validation_test.go
@@ -313,12 +313,13 @@ func TestValidateCluster(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		errs := ValidateCluster(&testCase.cluster)
-		if len(errs) == 0 && testCase.expectError {
+		pinedCase := testCase
+		errs := ValidateCluster(&pinedCase.cluster)
+		if len(errs) == 0 && pinedCase.expectError {
 			t.Errorf("expected failure for %q, but there were none", name)
 			return
 		}
-		if len(errs) != 0 && !testCase.expectError {
+		if len(errs) != 0 && !pinedCase.expectError {
 			t.Errorf("expected success for %q, but there were errors: %v", name, errs)
 			return
 		}

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -69,16 +69,16 @@ func TestPrintCluster(t *testing.T) {
 		},
 	}
 
-	for i, test := range tests {
-		rows, err := printCluster(&test.cluster, test.generateOptions)
+	for i := range tests {
+		rows, err := printCluster(&tests[i].cluster, tests[i].generateOptions)
 		if err != nil {
 			t.Fatal(err)
 		}
 		for i := range rows {
 			rows[i].Object.Object = nil
 		}
-		if !reflect.DeepEqual(test.expect, rows) {
-			t.Errorf("%d mismatch: %s", i, diff.ObjectReflectDiff(test.expect, rows))
+		if !reflect.DeepEqual(tests[i].expect, rows) {
+			t.Errorf("%d mismatch: %s", i, diff.ObjectReflectDiff(tests[i].expect, rows))
 		}
 	}
 }

--- a/pkg/scheduler/core/assignment.go
+++ b/pkg/scheduler/core/assignment.go
@@ -180,7 +180,7 @@ func assignByDynamicStrategy(state *assignState) ([]workv1alpha2.TargetCluster, 
 			return nil, fmt.Errorf("failed to scale up: %v", err)
 		}
 		return result, nil
-	} else {
-		return state.scheduledClusters, nil
 	}
+
+	return state.scheduledClusters, nil
 }

--- a/pkg/scheduler/core/spreadconstraint/select_clusters.go
+++ b/pkg/scheduler/core/spreadconstraint/select_clusters.go
@@ -54,9 +54,9 @@ func selectBestClustersBySpreadConstraints(spreadConstraints []policyv1alpha1.Sp
 		return selectBestClustersByRegion(spreadConstraintMap, groupClustersInfo)
 	} else if _, exist := spreadConstraintMap[policyv1alpha1.SpreadByFieldCluster]; exist {
 		return selectBestClustersByCluster(spreadConstraintMap[policyv1alpha1.SpreadByFieldCluster], groupClustersInfo, needReplicas)
-	} else {
-		return nil, fmt.Errorf("just support cluster and region spread constraint")
 	}
+
+	return nil, fmt.Errorf("just support cluster and region spread constraint")
 }
 
 func shouldIgnoreSpreadConstraint(placement *policyv1alpha1.Placement) bool {

--- a/pkg/search/proxy/store/util.go
+++ b/pkg/search/proxy/store/util.go
@@ -315,9 +315,9 @@ func (n *MultiNamespace) Single() (string, bool) {
 	if n.allNamespaces || n.namespaces.Len() != 1 {
 		return "", false
 	}
-	var ns string
-	for ns = range n.namespaces {
-	}
+
+	// reach here means there is exactly one namespace, so we can safely get it.
+	ns := sets.List(n.namespaces)[0]
 	return ns, true
 }
 

--- a/pkg/util/binding_test.go
+++ b/pkg/util/binding_test.go
@@ -76,11 +76,11 @@ func TestGetBindingClusterNames(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := GetBindingClusterNames(&tt.binding.Spec)
-			if !reflect.DeepEqual(got, tt.expected) {
-				t.Errorf("GetBindingClusterNames() = %v, want %v", got, tt.expected)
+	for i := range tests {
+		t.Run(tests[i].name, func(t *testing.T) {
+			got := GetBindingClusterNames(&tests[i].binding.Spec)
+			if !reflect.DeepEqual(got, tests[i].expected) {
+				t.Errorf("GetBindingClusterNames() = %v, want %v", got, tests[i].expected)
 			}
 		})
 	}

--- a/pkg/util/helper/workstatus.go
+++ b/pkg/util/helper/workstatus.go
@@ -229,14 +229,14 @@ func assembleWorkStatus(works []workv1alpha1.Work, workload *unstructured.Unstru
 			Health:      workv1alpha2.ResourceUnknown,
 		}
 
-		for _, manifestStatus := range work.Status.ManifestStatuses {
-			equal, err := equalIdentifier(&manifestStatus.Identifier, identifierIndex, workload)
+		for i := range work.Status.ManifestStatuses {
+			equal, err := equalIdentifier(&work.Status.ManifestStatuses[i].Identifier, identifierIndex, workload)
 			if err != nil {
 				return nil, err
 			}
 			if equal {
-				aggregatedStatus.Status = manifestStatus.Status
-				aggregatedStatus.Health = workv1alpha2.ResourceHealth(manifestStatus.Health)
+				aggregatedStatus.Status = work.Status.ManifestStatuses[i].Status
+				aggregatedStatus.Health = workv1alpha2.ResourceHealth(work.Status.ManifestStatuses[i].Health)
 				break
 			}
 		}

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -94,17 +94,17 @@ func ValidateClusterAffinities(affinities []policyv1alpha1.ClusterAffinityTerm, 
 	var allErrs field.ErrorList
 
 	affinityNames := make(map[string]bool)
-	for index, term := range affinities {
-		for _, err := range validation.IsQualifiedName(term.AffinityName) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Index(index), term.AffinityName, err))
+	for index := range affinities {
+		for _, err := range validation.IsQualifiedName(affinities[index].AffinityName) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Index(index), affinities[index].AffinityName, err))
 		}
-		if _, exist := affinityNames[term.AffinityName]; exist {
+		if _, exist := affinityNames[affinities[index].AffinityName]; exist {
 			allErrs = append(allErrs, field.Invalid(fldPath, affinities, "each affinity term in a policy must have a unique name"))
 		} else {
-			affinityNames[term.AffinityName] = true
+			affinityNames[affinities[index].AffinityName] = true
 		}
 
-		allErrs = append(allErrs, ValidateClusterAffinity(&term.ClusterAffinity, fldPath.Index(index))...)
+		allErrs = append(allErrs, ValidateClusterAffinity(&affinities[index].ClusterAffinity, fldPath.Index(index))...)
 	}
 	return allErrs
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR bumps golangci-lint from v1.52.2 to v1.55.2.

**Which issue(s) this PR fixes**:
Fixes #4490
This PR also included the left checks in #4490.

**Special notes for your reviewer**:
This PR fixed the following issues:
```bash
golangci-lint has version 1.55.2 built with go1.21.3 from e3c2265f on 2023-11-03T12:59:25Z
pkg/apis/cluster/validation/validation_test.go:316:27: G601: Implicit memory aliasing in for loop. (gosec)
		errs := ValidateCluster(&testCase.cluster)
		                        ^
pkg/scheduler/core/assignment.go:183:9: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
	} else {
		return state.scheduledClusters, nil
	}
pkg/printers/internalversion/printers_test.go:73:29: G601: Implicit memory aliasing in for loop. (gosec)
		rows, err := printCluster(&test.cluster, test.generateOptions)
		                          ^
pkg/util/binding_test.go:81:34: G601: Implicit memory aliasing in for loop. (gosec)
			got := GetBindingClusterNames(&tt.binding.Spec)
			                              ^
pkg/scheduler/core/spreadconstraint/select_clusters.go:57:9: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary) (revive)
	} else {
		return nil, fmt.Errorf("just support cluster and region spread constraint")
	}
```

and
```bash
golangci-lint has version 1.55.2 built with go1.21.3 from e3c2265f on 2023-11-03T12:59:25Z
pkg/util/helper/workstatus.go:233:34: G601: Implicit memory aliasing in for loop. (gosec)
			equal, err := equalIdentifier(&manifestStatus.Identifier, identifierIndex, workload)
pkg/util/validation/validation.go:107:53: G601: Implicit memory aliasing in for loop. (gosec)
		allErrs = append(allErrs, ValidateClusterAffinity(&term.ClusterAffinity, fldPath.Index(index))...)
```
and
```
golangci-lint has version 1.55.2 built with go1.21.3 from e3c2265f on 2023-11-03T12:59:25Z
pkg/search/proxy/store/util.go:319:2: empty-block: this block is empty, you can remove it (revive)
	for ns = range n.namespaces {
	}

```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

