### PR TITLE
implementation of Policy LazyReconcile feature

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -1124,10 +1124,14 @@ func (d *ResourceDetector) ReconcileClusterPropagationPolicy(key util.QueueKey) 
 }
 
 // HandlePropagationPolicyDeletion handles PropagationPolicy delete event.
-// After a policy is removed, the label marked on relevant resource template will be removed(which gives
+// After a policy is removed, the label marked on relevant resource template will be removed (which gives
 // the resource template a change to match another policy).
 //
 // Note: The relevant ResourceBinding will continue to exist until the resource template is gone.
+//
+// Corner Case: If the PolicyLazyReconcile feature is enabled, the specified label will also be removed.
+// However, since Karmada itself initiates this label change, the detector will ignore the update event.
+// Consequently, the resource will not perform a reconcile and will not match to other policies immediately until itself is updated.
 func (d *ResourceDetector) HandlePropagationPolicyDeletion(policyNS string, policyName string) error {
 	labelSet := labels.Set{
 		policyv1alpha1.PropagationPolicyNamespaceLabel: policyNS,
@@ -1161,10 +1165,14 @@ func (d *ResourceDetector) HandlePropagationPolicyDeletion(policyNS string, poli
 }
 
 // HandleClusterPropagationPolicyDeletion handles ClusterPropagationPolicy delete event.
-// After a policy is removed, the label marked on relevant resource template will be removed(which gives
+// After a policy is removed, the label marked on relevant resource template will be removed (which gives
 // the resource template a change to match another policy).
 //
 // Note: The relevant ClusterResourceBinding or ResourceBinding will continue to exist until the resource template is gone.
+//
+// Corner Case: If the PolicyLazyReconcile feature is enabled, the specified label will also be removed.
+// However, since Karmada itself initiates this label change, the detector will ignore the update event.
+// Consequently, the resource will not perform a reconcile and not match to other policies immediately until itself is updated.
 func (d *ResourceDetector) HandleClusterPropagationPolicyDeletion(policyName string) error {
 	var errs []error
 	labelSet := labels.Set{
@@ -1234,26 +1242,36 @@ func (d *ResourceDetector) HandleClusterPropagationPolicyDeletion(policyName str
 // from waiting list and throw the object to it's reconcile queue. If not, do nothing.
 // Finally, handle the propagation policy preemption process if preemption is enabled.
 func (d *ResourceDetector) HandlePropagationPolicyCreationOrUpdate(policy *policyv1alpha1.PropagationPolicy) error {
+	// If the Policy's ResourceSelectors change, causing certain resources to no longer match the Policy, the label marked
+	// on relevant resource template will be removed (which gives the resource template a change to match another policy).
+	//
+	// There exist a corner case that if the PolicyLazyReconcile feature is enabled, the specified label will also be removed.
+	// However, since Karmada itself initiates this label change, the detector will ignore the update event.
+	// Consequently, the resource will not perform a reconcile and not match to other policies immediately until itself is updated.
 	err := d.cleanPPUnmatchedResourceBindings(policy.Namespace, policy.Name, policy.Spec.ResourceSelectors)
 	if err != nil {
 		return err
 	}
 
-	// When updating fields other than ResourceSelector, should first find the corresponding ResourceBinding
-	// and add the bound object to the processor's queue for reconciliation to make sure that
-	// PropagationPolicy's updates can be synchronized to ResourceBinding.
-	resourceBindings, err := d.listPPDerivedRB(policy.Namespace, policy.Name)
-	if err != nil {
-		return err
-	}
-	for _, rb := range resourceBindings.Items {
-		resourceKey, err := helper.ConstructClusterWideKey(rb.Spec.Resource)
+	// if PolicyLazyReconcile disabled, add the PP related RT to processor, otherwise just skip this step
+	if !features.FeatureGate.Enabled(features.PolicyLazyReconcile) {
+		// When updating fields other than ResourceSelector, should first find the corresponding ResourceBinding
+		// and add the bound object to the processor's queue for reconciliation to make sure that
+		// PropagationPolicy's updates can be synchronized to ResourceBinding.
+		resourceBindings, err := d.listPPDerivedRB(policy.Namespace, policy.Name)
 		if err != nil {
 			return err
 		}
-		d.Processor.Add(resourceKey)
+		for _, rb := range resourceBindings.Items {
+			resourceKey, err := helper.ConstructClusterWideKey(rb.Spec.Resource)
+			if err != nil {
+				return err
+			}
+			d.Processor.Add(resourceKey)
+		}
 	}
 
+	// check whether there are matched RT in waiting list, is so, add it to processor
 	matchedKeys := d.GetMatching(policy.Spec.ResourceSelectors)
 	klog.Infof("Matched %d resources by policy(%s/%s)", len(matchedKeys), policy.Namespace, policy.Name)
 
@@ -1271,7 +1289,13 @@ func (d *ResourceDetector) HandlePropagationPolicyCreationOrUpdate(policy *polic
 		d.Processor.Add(key)
 	}
 
-	// if preemption is enabled, handle the preemption process.
+	// If preemption is enabled, handle the preemption process.
+	// If this policy succeeds in preempting resource managed by other policy, the label marked on relevant resource will be replaced,
+	// which gives the resource template a change to match to this policy.
+	//
+	// There exist a corner case that if the PolicyLazyReconcile feature is enabled, the specified label will also be replaced.
+	// However, since Karmada itself initiates this label change, the detector will ignore the update event.
+	// Consequently, the resource will not perform a reconcile and not match to this policy immediately until itself is updated.
 	if preemptionEnabled(policy.Spec.Preemption) {
 		return d.handlePropagationPolicyPreemption(policy)
 	}
@@ -1286,6 +1310,12 @@ func (d *ResourceDetector) HandlePropagationPolicyCreationOrUpdate(policy *polic
 // from waiting list and throw the object to it's reconcile queue. If not, do nothing.
 // Finally, handle the cluster propagation policy preemption process if preemption is enabled.
 func (d *ResourceDetector) HandleClusterPropagationPolicyCreationOrUpdate(policy *policyv1alpha1.ClusterPropagationPolicy) error {
+	// If the Policy's ResourceSelectors change, causing certain resources to no longer match the Policy, the label marked
+	// on relevant resource template will be removed (which gives the resource template a change to match another policy).
+	//
+	// There exist a corner case that if the PolicyLazyReconcile feature is enabled, the specified label will also be removed.
+	// However, since Karmada itself initiates this label change, the detector will ignore the update event.
+	// Consequently, the resource will not perform a reconcile and not match to other policies immediately until itself is updated.
 	err := d.cleanCPPUnmatchedResourceBindings(policy.Name, policy.Spec.ResourceSelectors)
 	if err != nil {
 		return err
@@ -1296,32 +1326,14 @@ func (d *ResourceDetector) HandleClusterPropagationPolicyCreationOrUpdate(policy
 		return err
 	}
 
-	// When updating fields other than ResourceSelector, should first find the corresponding ResourceBinding/ClusterResourceBinding
-	// and add the bound object to the processor's queue for reconciliation to make sure that
-	// ClusterPropagationPolicy's updates can be synchronized to ResourceBinding/ClusterResourceBinding.
-	resourceBindings, err := d.listCPPDerivedRB(policy.Name)
-	if err != nil {
-		return err
-	}
-	clusterResourceBindings, err := d.listCPPDerivedCRB(policy.Name)
-	if err != nil {
-		return err
-	}
-	for _, rb := range resourceBindings.Items {
-		resourceKey, err := helper.ConstructClusterWideKey(rb.Spec.Resource)
-		if err != nil {
+	// if PolicyLazyReconcile disabled, add the PP related RT to processor, otherwise just skip this step
+	if !features.FeatureGate.Enabled(features.PolicyLazyReconcile) {
+		if err = d.addRelatedTemplateToProcessorQueue(policy); err != nil {
 			return err
 		}
-		d.Processor.Add(resourceKey)
-	}
-	for _, crb := range clusterResourceBindings.Items {
-		resourceKey, err := helper.ConstructClusterWideKey(crb.Spec.Resource)
-		if err != nil {
-			return err
-		}
-		d.Processor.Add(resourceKey)
 	}
 
+	// check whether there are matched RT in waiting list, is so, add it to processor
 	matchedKeys := d.GetMatching(policy.Spec.ResourceSelectors)
 	klog.Infof("Matched %d resources by policy(%s)", len(matchedKeys), policy.Name)
 
@@ -1339,11 +1351,46 @@ func (d *ResourceDetector) HandleClusterPropagationPolicyCreationOrUpdate(policy
 		d.Processor.Add(key)
 	}
 
-	// if preemption is enabled, handle the preemption process.
+	// If preemption is enabled, handle the preemption process.
+	// If this policy succeeds in preempting resource managed by other policy, the label marked on relevant resource
+	// will be replaced, which gives the resource template a change to match to this policy.
+	//
+	// There exist a corner case that if the PolicyLazyReconcile feature is enabled, the specified label will also be replaced.
+	// However, since Karmada itself initiates this label change, the detector will ignore the update event.
+	// Consequently, the resource will not perform a reconcile and not match to this policy immediately until itself is updated.
 	if preemptionEnabled(policy.Spec.Preemption) {
 		return d.handleClusterPropagationPolicyPreemption(policy)
 	}
 
+	return nil
+}
+
+// addRelatedTemplateToProcessorQueue When updating fields other than ResourceSelector, should first find the corresponding
+// ResourceBinding/ClusterResourceBinding and add the bound object to the processor's queue for reconciliation to make sure that
+// ClusterPropagationPolicy's updates can be synchronized to ResourceBinding/ClusterResourceBinding.
+func (d *ResourceDetector) addRelatedTemplateToProcessorQueue(policy *policyv1alpha1.ClusterPropagationPolicy) error {
+	resourceBindings, err := d.listCPPDerivedRB(policy.Name)
+	if err != nil {
+		return fmt.Errorf("failed to list CPP(%s) derived RB: %+v", policy.Name, err)
+	}
+	clusterResourceBindings, err := d.listCPPDerivedCRB(policy.Name)
+	if err != nil {
+		return fmt.Errorf("failed to list CPP(%s) derived CRB: %+v", policy.Name, err)
+	}
+	for _, rb := range resourceBindings.Items {
+		resourceKey, err := helper.ConstructClusterWideKey(rb.Spec.Resource)
+		if err != nil {
+			return fmt.Errorf("failed to get resource ClusterWideKey from RB(%s): %+v", rb.Name, err)
+		}
+		d.Processor.Add(resourceKey)
+	}
+	for _, crb := range clusterResourceBindings.Items {
+		resourceKey, err := helper.ConstructClusterWideKey(crb.Spec.Resource)
+		if err != nil {
+			return fmt.Errorf("failed to get resource ClusterWideKey from CRB(%s): %+v", crb.Name, err)
+		}
+		d.Processor.Add(resourceKey)
+	}
 	return nil
 }
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -40,6 +40,10 @@ const (
 
 	// MultiClusterService indicates if enable multi-cluster service function.
 	MultiClusterService featuregate.Feature = "MultiClusterService"
+
+	// PolicyLazyReconcile indicates if enable Lazy Reconcile feature for Propagation Policy.
+	// If enabled, the effective time of policy modification will be delayed until the resource template is modified.
+	PolicyLazyReconcile featuregate.Feature = "PolicyLazyReconcile"
 )
 
 var (
@@ -54,6 +58,7 @@ var (
 		CustomizedClusterResourceModeling: {Default: true, PreRelease: featuregate.Beta},
 		PolicyPreemption:                  {Default: false, PreRelease: featuregate.Alpha},
 		MultiClusterService:               {Default: false, PreRelease: featuregate.Alpha},
+		PolicyLazyReconcile:               {Default: false, PreRelease: featuregate.Alpha},
 	}
 )
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Implementation of Policy LazyReconcile feature.

When this feature is enabled, the resource will not immediately respond to policy modifications if it has already been distributed according to the previous policy. Instead, it will only respond to the policy changes during the next update of the resource.

More info refer to #4563

**Which issue(s) this PR fixes**:

Fixes part of #4563

**Special notes for your reviewer**:

This PR depends on the #4564, it is recommended to wait until the #4564 is merged and then rebase this PR before reviewing it.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Introduced a Lazy Reconcile feature to PropagationPolicy/ClusterPropagationPolicy
```

