### PR TITLE
Secret resource name and key name for karmada-agent's kubeconfig in helm chart should be "karmada-kubeconfig" 

### DIFF
--- a/charts/karmada/templates/karmada-agent.yaml
+++ b/charts/karmada/templates/karmada-agent.yaml
@@ -33,7 +33,7 @@ subjects:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $name }}-kubeconfig
+  name: karmada-kubeconfig
   namespace: {{ include "karmada.namespace" . }}
 stringData:
   karmada-kubeconfig: |-
@@ -130,7 +130,7 @@ spec:
       volumes:
         - name: kubeconfig
           secret:
-            secretName: {{ $name }}-kubeconfig
+            secretName: karmada-kubeconfig
 
 {{ if .Values.agent.podDisruptionBudget }}
 ---


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Secret resource name and its key name of kubeconfig for karama-agent to connect karmada-control plane is expected as `karmada-kubeconfig`. It is hardcoded in:

- `karmadactl register`: 
  - https://github.com/karmada-io/karmada/blob/d508417a1e9b6be048a181ae89adbb94e1b08fbb/pkg/karmadactl/register/register.go#L94-L95
- `CertRotationController`: 
  - https://github.com/karmada-io/karmada/blob/d508417a1e9b6be048a181ae89adbb94e1b08fbb/pkg/controllers/certificate/cert_rotation_controller.go#L59-L60
  - Moreover, key in the Secret resource is also hardcoded as `karmada-kubeconfig`.
    - https://github.com/karmada-io/karmada/blob/d508417a1e9b6be048a181ae89adbb94e1b08fbb/pkg/controllers/certificate/cert_rotation_controller.go#L266-L282

Thus, Secret resource for agent's kubeconfig in member cluster should be:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: karmada-kubeconfig
  # namespace can be specified in 
  # karmada-agent's --karmada-kubeconfig-namespace flag
  namespace: karmada-system 
data:
  karmada-kubeconfig: ...
```

However, in helm chart, the secret name and its key name is dependent to helm release name which user can specified: https://github.com/karmada-io/karmada/blob/823aeb3175891a5fc968218298c38c190437c35f/charts/karmada/templates/karmada-agent.yaml#L33-L39

This inconsistency causes `CertRotationController` can't work in agent when installed by Helm and user activated `CertRotationController` controller manually.

```console
# 1. Install agent to member cluster by Helm
$ helm --kubeconfig=member upgrade -i karmada-agent \
    karmada-charts/karmada --version=1.7.1 \
    --create-namespace --namespace karmada-system \
    --set installMode=agent \
    --set agent.clusterName=member \
    --set agent.kubeconfig.caCrt="$kamadaCa" \
    --set agent.kubeconfig.crt="$karamadaAgentClientCrt" \
    --set agent.kubeconfig.key="$karamadaAgentClientKey" \
    --set agent.kubeconfig.server=https://${karmada_controlplane_ip}:${karmada_controlplane_port}

# 2. Secret name is karmada-agent-kubeconfig
#    and its key is kubeconfig
$ kubectl --kubeconfig=member -n karmada-system get secret
NAME                                  TYPE                 DATA   AGE
karmada-agent-kubeconfig              Opaque               1      7m10s
$ kubectl --kubeconfig=member -n karmada-system get secret karmada-agent-kubeconfig -o yaml
apiVersion: v1
data:
  kubeconfig: ...



# 3. Enable "certRotation" controller in agent manually
$ kubectl --kubeconfig=kubeconfig/$c -n karmada-system patch deployment/karmada-agent --type='json' -p="[
  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--controllers=*"},
  {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--controllers=certRotation"},
]"


# 4. BUG: cert_rotation_controller can't find kubeconfig secret resource.
$ kubectl --context=kind-karmada-workload-1 logs -n karmada-system karmada-agent-bf669478-fp48k | grep cert_rotation_controller
I0123 09:54:27.243156       1 cert_rotation_controller.go:74] Rotating the certificate of karmada-agent for the member cluster: karmada-workload-1
E0123 09:54:27.244557       1 cert_rotation_controller.go:101] failed to get karmada kubeconfig secret: secrets "karmada-kubeconfig" not found
```

Therefore, This PR fixes

- Secret resource name for karmada-agent's kubeconfig
- and its key name

in Helm chart.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

