### PR TITLE
Introduced a lazy activation preference to PropagationPolicy/ClusterPropagationPolicy

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -17148,6 +17148,10 @@
         "resourceSelectors"
       ],
       "properties": {
+        "activationPreference": {
+          "description": "ActivationPreference indicates how the referencing resource template will be propagated, in case of policy changes.\n\nIf empty, the resource template will respond to policy changes immediately, in other words, any policy changes will drive the resource template to be propagated immediately as per the current propagation rules.\n\nIf the value is 'Lazy' means the policy changes will not take effect for now but defer to the resource template changes, in other words, the resource template will not be propagated as per the current propagation rules until there is an update on it. This is an experimental feature that might help in a scenario where a policy manages huge amount of resource templates, changes to a policy typically affect numerous applications simultaneously. A minor misconfiguration could lead to widespread failures. With this feature, the change can be gradually rolled out through iterative modifications of resource templates.",
+          "type": "string"
+        },
         "association": {
           "description": "Association tells if relevant resources should be selected automatically. e.g. a ConfigMap referred by a Deployment. default false. Deprecated: in favor of PropagateDeps.",
           "type": "boolean"

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_clusterpropagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_clusterpropagationpolicies.yaml
@@ -44,6 +44,25 @@ spec:
           spec:
             description: Spec represents the desired behavior of ClusterPropagationPolicy.
             properties:
+              activationPreference:
+                description: "ActivationPreference indicates how the referencing resource
+                  template will be propagated, in case of policy changes. \n If empty,
+                  the resource template will respond to policy changes immediately,
+                  in other words, any policy changes will drive the resource template
+                  to be propagated immediately as per the current propagation rules.
+                  \n If the value is 'Lazy' means the policy changes will not take
+                  effect for now but defer to the resource template changes, in other
+                  words, the resource template will not be propagated as per the current
+                  propagation rules until there is an update on it. This is an experimental
+                  feature that might help in a scenario where a policy manages huge
+                  amount of resource templates, changes to a policy typically affect
+                  numerous applications simultaneously. A minor misconfiguration could
+                  lead to widespread failures. With this feature, the change can be
+                  gradually rolled out through iterative modifications of resource
+                  templates."
+                enum:
+                - Lazy
+                type: string
               association:
                 description: 'Association tells if relevant resources should be selected
                   automatically. e.g. a ConfigMap referred by a Deployment. default

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_propagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_propagationpolicies.yaml
@@ -40,6 +40,25 @@ spec:
           spec:
             description: Spec represents the desired behavior of PropagationPolicy.
             properties:
+              activationPreference:
+                description: "ActivationPreference indicates how the referencing resource
+                  template will be propagated, in case of policy changes. \n If empty,
+                  the resource template will respond to policy changes immediately,
+                  in other words, any policy changes will drive the resource template
+                  to be propagated immediately as per the current propagation rules.
+                  \n If the value is 'Lazy' means the policy changes will not take
+                  effect for now but defer to the resource template changes, in other
+                  words, the resource template will not be propagated as per the current
+                  propagation rules until there is an update on it. This is an experimental
+                  feature that might help in a scenario where a policy manages huge
+                  amount of resource templates, changes to a policy typically affect
+                  numerous applications simultaneously. A minor misconfiguration could
+                  lead to widespread failures. With this feature, the change can be
+                  gradually rolled out through iterative modifications of resource
+                  templates."
+                enum:
+                - Lazy
+                type: string
               association:
                 description: 'Association tells if relevant resources should be selected
                   automatically. e.g. a ConfigMap referred by a Deployment. default

--- a/pkg/apis/policy/v1alpha1/propagation_types.go
+++ b/pkg/apis/policy/v1alpha1/propagation_types.go
@@ -152,6 +152,27 @@ type PropagationSpec struct {
 	// +kubebuilder:validation:Enum=Abort;Overwrite
 	// +optional
 	ConflictResolution ConflictResolution `json:"conflictResolution,omitempty"`
+
+	// ActivationPreference indicates how the referencing resource template will
+	// be propagated, in case of policy changes.
+	//
+	// If empty, the resource template will respond to policy changes
+	// immediately, in other words, any policy changes will drive the resource
+	// template to be propagated immediately as per the current propagation rules.
+	//
+	// If the value is 'Lazy' means the policy changes will not take effect for now
+	// but defer to the resource template changes, in other words, the resource
+	// template will not be propagated as per the current propagation rules until
+	// there is an update on it.
+	// This is an experimental feature that might help in a scenario where a policy
+	// manages huge amount of resource templates, changes to a policy typically
+	// affect numerous applications simultaneously. A minor misconfiguration
+	// could lead to widespread failures. With this feature, the change can be
+	// gradually rolled out through iterative modifications of resource templates.
+	//
+	// +kubebuilder:validation:Enum=Lazy
+	// +optional
+	ActivationPreference ActivationPreference `json:"activationPreference,omitempty"`
 }
 
 // ResourceSelector the resources will be selected.
@@ -516,6 +537,16 @@ const (
 
 	// ConflictAbort means that do not resolve the conflict and stop propagating.
 	ConflictAbort ConflictResolution = "Abort"
+)
+
+// ActivationPreference indicates how the referencing resource template will be propagated, in case of policy changes.
+type ActivationPreference string
+
+const (
+	// LazyActivation means the policy changes will not take effect for now but defer to the resource template changes,
+	// in other words, the resource template will not be propagated as per the current propagation rules until
+	// there is an update on it.
+	LazyActivation ActivationPreference = "Lazy"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/detector/policy.go
+++ b/pkg/detector/policy.go
@@ -36,21 +36,22 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/helper"
 )
 
-func (d *ResourceDetector) propagateResource(object *unstructured.Unstructured, objectKey keys.ClusterWideKey) error {
+func (d *ResourceDetector) propagateResource(object *unstructured.Unstructured,
+	objectKey keys.ClusterWideKey, resourceChangeByKarmada bool) error {
 	// 1. Check if the object has been claimed by a PropagationPolicy,
 	// if so, just apply it.
 	policyLabels := object.GetLabels()
 	claimedNamespace := util.GetLabelValue(policyLabels, policyv1alpha1.PropagationPolicyNamespaceLabel)
 	claimedName := util.GetLabelValue(policyLabels, policyv1alpha1.PropagationPolicyNameLabel)
 	if claimedNamespace != "" && claimedName != "" {
-		return d.getAndApplyPolicy(object, objectKey, claimedNamespace, claimedName)
+		return d.getAndApplyPolicy(object, objectKey, resourceChangeByKarmada, claimedNamespace, claimedName)
 	}
 
 	// 2. Check if the object has been claimed by a ClusterPropagationPolicy,
 	// if so, just apply it.
 	claimedName = util.GetLabelValue(policyLabels, policyv1alpha1.ClusterPropagationPolicyLabel)
 	if claimedName != "" {
-		return d.getAndApplyClusterPolicy(object, objectKey, claimedName)
+		return d.getAndApplyClusterPolicy(object, objectKey, resourceChangeByKarmada, claimedName)
 	}
 
 	// 3. attempt to match policy in its namespace.
@@ -68,7 +69,7 @@ func (d *ResourceDetector) propagateResource(object *unstructured.Unstructured, 
 		}
 		d.RemoveWaiting(objectKey)
 		metrics.ObserveFindMatchedPolicyLatency(start)
-		return d.ApplyPolicy(object, objectKey, propagationPolicy)
+		return d.ApplyPolicy(object, objectKey, resourceChangeByKarmada, propagationPolicy)
 	}
 
 	// 4. reaching here means there is no appropriate PropagationPolicy, attempt to match a ClusterPropagationPolicy.
@@ -85,7 +86,7 @@ func (d *ResourceDetector) propagateResource(object *unstructured.Unstructured, 
 		}
 		d.RemoveWaiting(objectKey)
 		metrics.ObserveFindMatchedPolicyLatency(start)
-		return d.ApplyClusterPolicy(object, objectKey, clusterPolicy)
+		return d.ApplyClusterPolicy(object, objectKey, resourceChangeByKarmada, clusterPolicy)
 	}
 
 	if d.isWaiting(objectKey) {
@@ -100,7 +101,8 @@ func (d *ResourceDetector) propagateResource(object *unstructured.Unstructured, 
 	return fmt.Errorf("no matched propagation policy")
 }
 
-func (d *ResourceDetector) getAndApplyPolicy(object *unstructured.Unstructured, objectKey keys.ClusterWideKey, policyNamespace, policyName string) error {
+func (d *ResourceDetector) getAndApplyPolicy(object *unstructured.Unstructured, objectKey keys.ClusterWideKey,
+	resourceChangeByKarmada bool, policyNamespace, policyName string) error {
 	policyObject, err := d.propagationPolicyLister.ByNamespace(policyNamespace).Get(policyName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -134,10 +136,11 @@ func (d *ResourceDetector) getAndApplyPolicy(object *unstructured.Unstructured, 
 		return fmt.Errorf("waiting for dependent overrides")
 	}
 
-	return d.ApplyPolicy(object, objectKey, matchedPropagationPolicy)
+	return d.ApplyPolicy(object, objectKey, resourceChangeByKarmada, matchedPropagationPolicy)
 }
 
-func (d *ResourceDetector) getAndApplyClusterPolicy(object *unstructured.Unstructured, objectKey keys.ClusterWideKey, policyName string) error {
+func (d *ResourceDetector) getAndApplyClusterPolicy(object *unstructured.Unstructured, objectKey keys.ClusterWideKey,
+	resourceChangeByKarmada bool, policyName string) error {
 	policyObject, err := d.clusterPropagationPolicyLister.Get(policyName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -172,7 +175,7 @@ func (d *ResourceDetector) getAndApplyClusterPolicy(object *unstructured.Unstruc
 		return fmt.Errorf("waiting for dependent overrides")
 	}
 
-	return d.ApplyClusterPolicy(object, objectKey, matchedClusterPropagationPolicy)
+	return d.ApplyClusterPolicy(object, objectKey, resourceChangeByKarmada, matchedClusterPropagationPolicy)
 }
 
 func (d *ResourceDetector) cleanPPUnmatchedResourceBindings(policyNamespace, policyName string, selectors []policyv1alpha1.ResourceSelector) error {

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -4474,6 +4474,13 @@ func schema_pkg_apis_policy_v1alpha1_PropagationSpec(ref common.ReferenceCallbac
 							Format:      "",
 						},
 					},
+					"activationPreference": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ActivationPreference indicates how the referencing resource template will be propagated, in case of policy changes.\n\nIf empty, the resource template will respond to policy changes immediately, in other words, any policy changes will drive the resource template to be propagated immediately as per the current propagation rules.\n\nIf the value is 'Lazy' means the policy changes will not take effect for now but defer to the resource template changes, in other words, the resource template will not be propagated as per the current propagation rules until there is an update on it. This is an experimental feature that might help in a scenario where a policy manages huge amount of resource templates, changes to a policy typically affect numerous applications simultaneously. A minor misconfiguration could lead to widespread failures. With this feature, the change can be gradually rolled out through iterative modifications of resource templates.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"resourceSelectors"},
 			},

--- a/pkg/util/eventfilter/eventfilter.go
+++ b/pkg/util/eventfilter/eventfilter.go
@@ -18,22 +18,87 @@ package eventfilter
 
 import (
 	"reflect"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 )
+
+// labelOrAnnoKeyPrefixByKarmada defines the key prefix used for labels or annotations used by karmada's own components.
+const labelOrAnnoKeyPrefixByKarmada = ".karmada.io"
+
+// labelsForUserWithKarmadaPrefix enumerates special cases that labels use the karmada prefix but are really only for users to use.
+var labelsForUserWithKarmadaPrefix = map[string]struct{}{
+	policyv1alpha1.NamespaceSkipAutoPropagationLabel: {},
+}
 
 // SpecificationChanged check if the specification of the given object change or not
 func SpecificationChanged(oldObj, newObj *unstructured.Unstructured) bool {
 	oldBackup := oldObj.DeepCopy()
 	newBackup := newObj.DeepCopy()
 
-	// Remove the status and some system defined mutable fields in metadata, including managedFields and resourceVersion.
-	// Refer to https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/object-meta/#ObjectMeta for more details.
+	removeIgnoredFields(oldBackup, newBackup)
+
+	return !reflect.DeepEqual(oldBackup, newBackup)
+}
+
+// ResourceChangeByKarmada check if the change of the object is modified by Karmada.
+// If oldObj deep equal to newObj after removing fields changed by Karmada, such change refers to ChangeByKarmada.
+func ResourceChangeByKarmada(oldObj, newObj *unstructured.Unstructured) bool {
+	oldBackup := oldObj.DeepCopy()
+	newBackup := newObj.DeepCopy()
+
+	removeIgnoredFields(oldBackup, newBackup)
+
+	removeFieldsChangedByKarmada(oldBackup, newBackup)
+
+	return reflect.DeepEqual(oldBackup, newBackup)
+}
+
+// removeIgnoredFields Remove the status and some system defined mutable fields in metadata, including managedFields and resourceVersion.
+// Refer to https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/object-meta/#ObjectMeta for more details.
+func removeIgnoredFields(oldBackup, newBackup *unstructured.Unstructured) {
 	removedFields := [][]string{{"status"}, {"metadata", "managedFields"}, {"metadata", "resourceVersion"}}
 	for _, r := range removedFields {
 		unstructured.RemoveNestedField(oldBackup.Object, r...)
 		unstructured.RemoveNestedField(newBackup.Object, r...)
 	}
+}
 
-	return !reflect.DeepEqual(oldBackup, newBackup)
+// removeFieldsChangedByKarmada Remove the fields modified by karmada's own components.
+func removeFieldsChangedByKarmada(oldBackup, newBackup *unstructured.Unstructured) {
+	// Remove label or annotations changed by Karmada
+	removeLabelOrAnnotationByKarmada(oldBackup)
+	removeLabelOrAnnotationByKarmada(newBackup)
+
+	// Karmada's change may result in some auto-generated fields being modified indirectly, e.g: metadata.generation
+	// They should also be removed before comparing.
+	removedFields := [][]string{{"metadata", "generation"}}
+	for _, r := range removedFields {
+		unstructured.RemoveNestedField(oldBackup.Object, r...)
+		unstructured.RemoveNestedField(newBackup.Object, r...)
+	}
+}
+
+// removeLabelOrAnnotationByKarmada remove the label or annotation modified by karmada's own components.
+func removeLabelOrAnnotationByKarmada(unstructuredObj *unstructured.Unstructured) {
+	for k := range unstructuredObj.GetLabels() {
+		_, isLabelForUser := labelsForUserWithKarmadaPrefix[k]
+		if strings.Contains(k, labelOrAnnoKeyPrefixByKarmada) && !isLabelForUser {
+			unstructured.RemoveNestedField(unstructuredObj.Object, []string{"metadata", "labels", k}...)
+		}
+	}
+	if len(unstructuredObj.GetLabels()) == 0 {
+		unstructured.RemoveNestedField(unstructuredObj.Object, []string{"metadata", "labels"}...)
+	}
+
+	for k := range unstructuredObj.GetAnnotations() {
+		if strings.Contains(k, labelOrAnnoKeyPrefixByKarmada) {
+			unstructured.RemoveNestedField(unstructuredObj.Object, []string{"metadata", "annotations", k}...)
+		}
+	}
+	if len(unstructuredObj.GetAnnotations()) == 0 {
+		unstructured.RemoveNestedField(unstructuredObj.Object, []string{"metadata", "annotations"}...)
+	}
 }

--- a/pkg/util/fedinformer/handlers.go
+++ b/pkg/util/fedinformer/handlers.go
@@ -24,7 +24,7 @@ import (
 )
 
 // NewHandlerOnAllEvents builds a ResourceEventHandler that the function 'fn' will be called on all events(add/update/delete).
-func NewHandlerOnAllEvents(fn func(runtime.Object)) cache.ResourceEventHandler {
+func NewHandlerOnAllEvents(fn func(interface{})) cache.ResourceEventHandler {
 	return &cache.ResourceEventHandlerFuncs{
 		AddFunc: func(cur interface{}) {
 			curObj := cur.(runtime.Object)

--- a/pkg/util/fedinformer/keys/keys.go
+++ b/pkg/util/fedinformer/keys/keys.go
@@ -111,6 +111,21 @@ func ClusterWideKeyFunc(obj interface{}) (ClusterWideKey, error) {
 	return key, nil
 }
 
+// ClusterWideKeyWithConfig is the object key which is a unique identifier under a cluster, combined with certain config.
+type ClusterWideKeyWithConfig struct {
+	// ClusterWideKey is the object key which is a unique identifier under a cluster, across all resources.
+	ClusterWideKey ClusterWideKey
+
+	// ResourceChangeByKarmada defines whether resource is changed by Karmada
+	ResourceChangeByKarmada bool
+}
+
+// String returns the key's printable info with format:
+// "<GroupVersion>, kind=<Kind>, <NamespaceKey>, ResourceChangeByKarmada=<ResourceChangeByKarmada>"
+func (k ClusterWideKeyWithConfig) String() string {
+	return fmt.Sprintf("%s, ResourceChangeByKarmada=%v", k.ClusterWideKey.String(), k.ResourceChangeByKarmada)
+}
+
 // FederatedKey is the object key which is a unique identifier across all clusters in federation.
 type FederatedKey struct {
 	// Cluster is the cluster name of the referencing object.

--- a/pkg/util/policy.go
+++ b/pkg/util/policy.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+
+// IsLazyActivationEnabled judge whether lazy activation preference is enabled.
+func IsLazyActivationEnabled(activationPreference policyv1alpha1.ActivationPreference) bool {
+	if activationPreference == "" {
+		return false
+	}
+	return activationPreference == policyv1alpha1.LazyActivation
+}

--- a/pkg/util/worker.go
+++ b/pkg/util/worker.go
@@ -19,7 +19,6 @@ package util
 import (
 	"time"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -39,7 +38,7 @@ type AsyncWorker interface {
 	AddAfter(item interface{}, duration time.Duration)
 
 	// Enqueue generates the key of 'obj' according to a 'KeyFunc' then adds the key as an item to queue by 'Add'.
-	Enqueue(obj runtime.Object)
+	Enqueue(obj interface{})
 
 	// Run starts a certain number of concurrent workers to reconcile the items and will never stop until 'stopChan'
 	// is closed.
@@ -90,10 +89,10 @@ func NewAsyncWorker(opt Options) AsyncWorker {
 	}
 }
 
-func (w *asyncWorker) Enqueue(obj runtime.Object) {
+func (w *asyncWorker) Enqueue(obj interface{}) {
 	key, err := w.keyFunc(obj)
 	if err != nil {
-		klog.Warningf("Failed to generate key for obj: %s", obj.GetObjectKind().GroupVersionKind())
+		klog.Warningf("Failed to generate key for obj: %+v", obj)
 		return
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Introduced a lazy activation preference to PropagationPolicy/ClusterPropagationPolicy.

ActivationPreference indicates how the referencing resource template will be propagated, in case of policy changes.

If empty, the resource template will respond to policy changes immediately, in other words, any policy changes will drive the resource template to be propagated immediately as per the current propagation rules.

If the value is 'Lazy' means the policy changes will not take effect for now but defer to the resource template changes, in other words, the resource template will not be propagated as per the current propagation rules until there is an update on it.

This is an experimental feature that might help in a scenario where a policy manages huge amount of resource templates, changes to a policy typically affect numerous applications simultaneously. A minor misconfiguration could lead to widespread failures. With this feature, the change can be gradually rolled out through iterative modifications of resource templates.

More info refer to #4563

**Which issue(s) this PR fixes**:

Fixes part of #4563

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Introduced a lazy activation preference to PropagationPolicy/ClusterPropagationPolicy.
```

