### PR TITLE
Support accept content type as=Table into karmada-search.

### DIFF
--- a/pkg/search/proxy/framework/plugins/cache/cache.go
+++ b/pkg/search/proxy/framework/plugins/cache/cache.go
@@ -108,6 +108,7 @@ func (c *Cache) Connect(_ context.Context, request framework.ProxyRequest) (http
 		Convertor:        runtime.NewScheme(),
 		Subresource:      requestInfo.Subresource,
 		MetaGroupVersion: metav1.SchemeGroupVersion,
+		TableConvertor:   r.tableConvertor,
 	}
 
 	var h http.Handler


### PR DESCRIPTION
if accept set application/json;as=Table;g=meta.k8s.io;v=v1beta1.
scope not support TableConvertor will return code 406.
Signed-off-by: niuyueyang <719415781@qq.com>

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
support accept content type as=Table into karmada-search.

```

