### PR TITLE
feat: When a resource is created for the first time, it should also be considred as a modification.

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -340,17 +340,15 @@ func (d *ResourceDetector) OnUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
+	if !eventfilter.SpecificationChanged(unstructuredOldObj, unstructuredNewObj) {
+		klog.V(4).Infof("Ignore update event of object (kind=%s, %s/%s) as specification no change", unstructuredOldObj.GetKind(), unstructuredOldObj.GetNamespace(), unstructuredOldObj.GetName())
+		return
+	}
 	newRuntimeObj, ok := newObj.(runtime.Object)
 	if !ok {
 		klog.Errorf("Failed to assert newObj as runtime.Object")
 		return
 	}
-
-	if !eventfilter.SpecificationChanged(unstructuredOldObj, unstructuredNewObj) {
-		klog.V(4).Infof("Ignore update event of object (kind=%s, %s/%s) as specification no change", unstructuredOldObj.GetKind(), unstructuredOldObj.GetNamespace(), unstructuredOldObj.GetName())
-		return
-	}
-
 	resourceChangeByKarmada := eventfilter.ResourceChangeByKarmada(unstructuredOldObj, unstructuredNewObj)
 
 	resourceItem := ResourceItem{

--- a/pkg/detector/policy.go
+++ b/pkg/detector/policy.go
@@ -69,7 +69,7 @@ func (d *ResourceDetector) propagateResource(object *unstructured.Unstructured,
 		}
 		d.RemoveWaiting(objectKey)
 		metrics.ObserveFindMatchedPolicyLatency(start)
-		return d.ApplyPolicy(object, objectKey, resourceChangeByKarmada, propagationPolicy)
+		return d.ApplyPolicy(object, objectKey, false, propagationPolicy)
 	}
 
 	// 4. reaching here means there is no appropriate PropagationPolicy, attempt to match a ClusterPropagationPolicy.
@@ -86,7 +86,7 @@ func (d *ResourceDetector) propagateResource(object *unstructured.Unstructured,
 		}
 		d.RemoveWaiting(objectKey)
 		metrics.ObserveFindMatchedPolicyLatency(start)
-		return d.ApplyClusterPolicy(object, objectKey, resourceChangeByKarmada, clusterPolicy)
+		return d.ApplyClusterPolicy(object, objectKey, false, clusterPolicy)
 	}
 
 	if d.isWaiting(objectKey) {


### PR DESCRIPTION

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

If the first creation is not considered as a modification, then resources like GatewayClass, IPPool can never be propagated to member clusters. Because once they are created, they will never be modified.




**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: When a resource is created for the first time, it should also be considred as a modification.
```

