### PR TITLE
fix: reschedule the replicas of the disappear clusters in PP

### DIFF
--- a/pkg/scheduler/core/assignment_test.go
+++ b/pkg/scheduler/core/assignment_test.go
@@ -580,8 +580,8 @@ func Test_dynamicScale(t *testing.T) {
 			},
 			want: []workv1alpha2.TargetCluster{
 				{Name: ClusterMember1, Replicas: 7},
-				{Name: ClusterMember2, Replicas: 8},
-				{Name: ClusterMember4, Replicas: 9},
+				{Name: ClusterMember3, Replicas: 6},
+				{Name: ClusterMember4, Replicas: 11},
 			},
 			wantErr: false,
 		},
@@ -784,6 +784,37 @@ func Test_dynamicScaleUp(t *testing.T) {
 				ReplicaScheduling: aggregatedStrategy,
 			},
 			wantErr: true,
+		},
+		{
+			name: "replica 12, dynamic weight 3:3, with cluster3 disappeared and cluster2 appeared",
+			candidates: []*clusterv1alpha1.Cluster{
+				helper.NewClusterWithResource(ClusterMember1, corev1.ResourceList{
+					corev1.ResourcePods: *resource.NewQuantity(3, resource.DecimalSI),
+				}, util.EmptyResource().ResourceList(), util.EmptyResource().ResourceList()),
+				helper.NewClusterWithResource(ClusterMember2, corev1.ResourceList{
+					corev1.ResourcePods: *resource.NewQuantity(3, resource.DecimalSI),
+				}, util.EmptyResource().ResourceList(), util.EmptyResource().ResourceList()),
+			},
+			object: &workv1alpha2.ResourceBindingSpec{
+				ReplicaRequirements: &workv1alpha2.ReplicaRequirements{
+					ResourceRequest: util.EmptyResource().ResourceList(),
+				},
+				Clusters: []workv1alpha2.TargetCluster{
+					{Name: ClusterMember1, Replicas: 6},
+					{Name: ClusterMember3, Replicas: 6},
+				},
+				Replicas: 12,
+			},
+			placement: &policyv1alpha1.Placement{
+				ReplicaScheduling: dynamicWeightStrategy,
+			},
+			wants: [][]workv1alpha2.TargetCluster{
+				{
+					{Name: ClusterMember1, Replicas: 9},
+					{Name: ClusterMember2, Replicas: 3},
+				},
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Please see https://github.com/karmada-io/karmada/issues/4560

**Which issue(s) this PR fixes**:
Fixes #4560

Please note：
As described in: https://github.com/karmada-io/karmada/issues/4560#issuecomment-1911303202
Due to the changes in the score plugin, the scheduling results of instance counts may oscillate among multiple clusters.

We should find a better way to fix this in the future.

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-scheduler`: reschedule the replicas of the disappear clusters in PP/CPP.
```

