### PR TITLE
Automated cherry pick of #4554: search add check member cluster api enable

### DIFF
--- a/pkg/search/controller.go
+++ b/pkg/search/controller.go
@@ -30,6 +30,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
+	"github.com/karmada-io/karmada/pkg/util/helper"
 	"github.com/karmada-io/karmada/pkg/util/restmapper"
 )
 
@@ -385,10 +386,18 @@ func (c *Controller) doCacheCluster(cluster string) error {
 
 	sci := c.InformerManager.GetSingleClusterManager(cluster)
 	for gvr := range cr.resources {
+		gvk, err := c.restMapper.KindFor(gvr)
+		if err != nil {
+			klog.Errorf("Failed to get gvk: %v", err)
+			continue
+		}
+		if !helper.IsAPIEnabled(cls.Status.APIEnablements, gvk.GroupVersion().String(), gvk.Kind) {
+			klog.Warningf("Resource %s is not enabled for cluster %s", gvr.String(), cluster)
+			continue
+		}
 		klog.Infof("Add informer for %s, %v", cluster, gvr)
 		sci.ForResource(gvr, handler)
 	}
-
 	klog.Infof("Start informer for %s", cluster)
 	sci.Start()
 	_ = sci.WaitForCacheSync()
@@ -470,7 +479,8 @@ func (c *Controller) updateCluster(oldObj, curObj interface{}) {
 		c.queue.Add(curCluster.GetName())
 	}
 
-	if !reflect.DeepEqual(curCluster.Spec, oldCluster.Spec) || !reflect.DeepEqual(curCluster.Labels, oldCluster.Labels) {
+	if !reflect.DeepEqual(curCluster.Spec, oldCluster.Spec) || !reflect.DeepEqual(curCluster.Labels, oldCluster.Labels) ||
+		!reflect.DeepEqual(curCluster.Status.APIEnablements, oldCluster.Status.APIEnablements) {
 		c.queue.Add(curCluster.GetName())
 	}
 }

--- a/pkg/search/proxy/controller.go
+++ b/pkg/search/proxy/controller.go
@@ -31,6 +31,7 @@ import (
 	pluginruntime "github.com/karmada-io/karmada/pkg/search/proxy/framework/runtime"
 	"github.com/karmada-io/karmada/pkg/search/proxy/store"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/helper"
 	"github.com/karmada-io/karmada/pkg/util/lifted"
 	"github.com/karmada-io/karmada/pkg/util/restmapper"
 )
@@ -207,6 +208,15 @@ func (ctl *Controller) reconcile(util.QueueKey) error {
 			}
 
 			for resource, multiNS := range matchedResources {
+				gvk, err := ctl.restMapper.KindFor(resource)
+				if err != nil {
+					klog.Errorf("Failed to get gvk: %v", err)
+					continue
+				}
+				if !helper.IsAPIEnabled(cluster.Status.APIEnablements, gvk.GroupVersion().String(), gvk.Kind) {
+					klog.Warningf("Resource %s is not enabled for cluster %s", resource.String(), cluster)
+					continue
+				}
 				resourcesByClusters[cluster.Name][resource] = multiNS
 			}
 		}

--- a/pkg/search/proxy/controller_test.go
+++ b/pkg/search/proxy/controller_test.go
@@ -494,9 +494,28 @@ func TestController_Connect_Error(t *testing.T) {
 
 func newCluster(name string) *clusterv1alpha1.Cluster {
 	c := &clusterv1alpha1.Cluster{}
+	clusterEnablements := []clusterv1alpha1.APIEnablement{
+		{
+			GroupVersion: "v1",
+			Resources: []clusterv1alpha1.APIResource{
+				{
+					Kind: "Pod",
+				},
+			},
+		},
+		{
+			GroupVersion: "v1",
+			Resources: []clusterv1alpha1.APIResource{
+				{
+					Kind: "Node",
+				},
+			},
+		},
+	}
 	c.Name = name
 	conditions := make([]metav1.Condition, 0, 1)
 	conditions = append(conditions, util.NewCondition(clusterv1alpha1.ClusterConditionReady, "", "", metav1.ConditionTrue))
 	c.Status.Conditions = conditions
+	c.Status.APIEnablements = clusterEnablements
 	return c
 }


### PR DESCRIPTION
Cherry pick of #4554 on release-1.7.
#4554: search add check member cluster api enable
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-search`: Add the logic of checking whether the resource API to be retrieved is installed in the cluster.
```