### PR TITLE
Automated cherry pick of #4580: if accept set

### DIFF
--- a/pkg/search/proxy/framework/plugins/cache/cache.go
+++ b/pkg/search/proxy/framework/plugins/cache/cache.go
@@ -108,6 +108,7 @@ func (c *Cache) Connect(_ context.Context, request framework.ProxyRequest) (http
 		Convertor:        runtime.NewScheme(),
 		Subresource:      requestInfo.Subresource,
 		MetaGroupVersion: metav1.SchemeGroupVersion,
+		TableConvertor:   r.tableConvertor,
 	}
 
 	var h http.Handler


### PR DESCRIPTION
Cherry pick of #4580 on release-1.8.
#4580: if accept set
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
karmada-search: support accept content type `as=Table` in the proxy global resource function.
```