### PR TITLE
bump alpine to 3.19.1 to address CVE concerns

### DIFF
--- a/cluster/images/Dockerfile
+++ b/cluster/images/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.18.5
+FROM alpine:3.19.1
 
 ARG BINARY
 

--- a/cluster/images/buildx.Dockerfile
+++ b/cluster/images/buildx.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.18.5
+FROM alpine:3.19.1
 
 ARG BINARY
 ARG TARGETPLATFORM

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -114,7 +114,7 @@ func init() {
 	karmadaRelease = releaseVer.ReleaseVersion()
 
 	DefaultCrdURL = fmt.Sprintf("https://github.com/karmada-io/karmada/releases/download/%s/crds.tar.gz", releaseVer.ReleaseVersion())
-	DefaultInitImage = "docker.io/alpine:3.18.5"
+	DefaultInitImage = "docker.io/alpine:3.19.1"
 	DefaultKarmadaSchedulerImage = fmt.Sprintf("docker.io/karmada/karmada-scheduler:%s", releaseVer.ReleaseVersion())
 	DefaultKarmadaControllerManagerImage = fmt.Sprintf("docker.io/karmada/karmada-controller-manager:%s", releaseVer.ReleaseVersion())
 	DefaultKarmadaWebhookImage = fmt.Sprintf("docker.io/karmada/karmada-webhook:%s", releaseVer.ReleaseVersion())
@@ -664,7 +664,7 @@ func (i *CommandInitOption) kubeControllerManagerImage() string {
 // get etcd-init image
 func (i *CommandInitOption) etcdInitImage() string {
 	if i.ImageRegistry != "" && i.EtcdInitImage == DefaultInitImage {
-		return i.ImageRegistry + "/alpine:3.18.5"
+		return i.ImageRegistry + "/alpine:3.19.1"
 	}
 	return i.EtcdInitImage
 }

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
@@ -379,7 +379,7 @@ func TestEtcdInitImage(t *testing.T) {
 				ImageRegistry: "my-registry",
 				EtcdInitImage: DefaultInitImage,
 			},
-			expected: "my-registry/alpine:3.18.5",
+			expected: "my-registry/alpine:3.19.1",
 		},
 		{
 			name: "EtcdInitImage is set to a non-default value",


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
bump alpine to 3.19.1 to address[CVE-2024-0727](https://avd.aquasec.com/nvd/cve-2024-0727)

**Which issue(s) this PR fixes**:
Fixes #4597

**Special notes for your reviewer**:

```sh
➜  karmada git:(image-alpine) ✗ make image-karmada-operator
set -e;\
        target=$(echo karmada-operator);\
        make $target GOOS=linux;\
        VERSION='v1.7.0-alpha.1-858-g2c5163ffb' REGISTRY="docker.io/karmada" BUILD_PLATFORMS=linux/amd64 hack/docker.sh $target
BUILD_PLATFORMS=linux/amd64 hack/build.sh karmada-operator
!!! Building karmada-operator for linux/amd64:
+ CGO_ENABLED=0
+ GOOS=linux
+ GOARCH=amd64
+ go build -ldflags '-X github.com/karmada-io/karmada/pkg/version.gitVersion=v1.7.0-alpha.1-858-g2c5163ffb -X github.com/karmada-io/karmada/pkg/version.gitCommit=2c5163ffbbe7e601107d788e27f7e51fca705f1f -X github.com/karmada-io/karmada/pkg/version.gitTreeState=dirty -X github.com/karmada-io/karmada/pkg/version.buildDate=2024-01-31T12:24:44Z ' -o _output/bin/linux/amd64/karmada-operator github.com/karmada-io/karmada/operator/cmd/operator
+ set +x
Building image for linux/amd64: docker.io/karmada/karmada-operator:v1.7.0-alpha.1-858-g2c5163ffb
+ docker build --build-arg BINARY=karmada-operator --tag docker.io/karmada/karmada-operator:v1.7.0-alpha.1-858-g2c5163ffb --file hack/../cluster/images/Dockerfile hack/../_output/bin/linux/amd64
[+] Building 34.6s (9/9) FINISHED                                                                                                                                                                                                       
 => [internal] load build definition from Dockerfile                                                                                                                                                                               0.1s
 => => transferring dockerfile: 840B                                                                                                                                                                                               0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                                                                                                    0.0s
 => [internal] load metadata for docker.io/library/alpine:3.19.1                                                                                                                                                                   0.0s
 => [1/4] FROM docker.io/library/alpine:3.19.1                                                                                                                                                                                     0.0s
 => [internal] load build context                                                                                                                                                                                                  3.0s
 => => transferring context: 60.81MB                                                                                                                                                                                               2.9s
 => [2/4] RUN apk add --no-cache ca-certificates                                                                                                                                                                                  22.8s
 => [3/4] RUN apk add --no-cache tzdata                                                                                                                                                                                           10.7s 
 => [4/4] COPY karmada-operator /bin/karmada-operator                                                                                                                                                                              0.3s 
 => exporting to image                                                                                                                                                                                                             0.5s 
 => => exporting layers                                                                                                                                                                                                            0.5s 
 => => writing image sha256:078b12de6def868c57c7c6e737b5ecf1cbc5e8a69e081031f4edc42049ff8bed                                                                                                                                       0.0s 
 => => naming to docker.io/karmada/karmada-operator:v1.7.0-alpha.1-858-g2c5163ffb                                                                                                                                                  0.0s 

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
+ set +x
➜  karmada git:(image-alpine) ✗ trivy image --format table docker.io/karmada/karmada-operator:v1.7.0-alpha.1-858-g2c5163ffb
2024-01-31T20:27:20.551+0800    INFO    Vulnerability scanning is enabled
2024-01-31T20:27:20.551+0800    INFO    Secret scanning is enabled
2024-01-31T20:27:20.551+0800    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-01-31T20:27:20.551+0800    INFO    Please see also https://aquasecurity.github.io/trivy/v0.48/docs/scanner/secret/#recommendation for faster secret detection
2024-01-31T20:27:23.075+0800    INFO    Detected OS: alpine
2024-01-31T20:27:23.075+0800    WARN    This OS version is not on the EOL list: alpine 3.19
2024-01-31T20:27:23.075+0800    INFO    Detecting Alpine vulnerabilities...
2024-01-31T20:27:23.088+0800    INFO    Number of language-specific files: 1
2024-01-31T20:27:23.088+0800    INFO    Detecting gobinary vulnerabilities...

docker.io/karmada/karmada-operator:v1.7.0-alpha.1-858-g2c5163ffb (alpine 3.19.1)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
The base image `alpine` now has been promoted from `alpine:3.18.5` to `alpine:3.19.1`
```

