### PR TITLE
Automated cherry pick of #4598: bump alpine to 3.19.1 to address CVE concerns

### DIFF
--- a/cluster/images/Dockerfile
+++ b/cluster/images/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.18.5
+FROM alpine:3.19.1
 
 ARG BINARY
 

--- a/cluster/images/buildx.Dockerfile
+++ b/cluster/images/buildx.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.18.5
+FROM alpine:3.19.1
 
 ARG BINARY
 ARG TARGETPLATFORM

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -114,7 +114,7 @@ func init() {
 	karmadaRelease = releaseVer.ReleaseVersion()
 
 	DefaultCrdURL = fmt.Sprintf("https://github.com/karmada-io/karmada/releases/download/%s/crds.tar.gz", releaseVer.ReleaseVersion())
-	DefaultInitImage = "docker.io/alpine:3.18.5"
+	DefaultInitImage = "docker.io/alpine:3.19.1"
 	DefaultKarmadaSchedulerImage = fmt.Sprintf("docker.io/karmada/karmada-scheduler:%s", releaseVer.ReleaseVersion())
 	DefaultKarmadaControllerManagerImage = fmt.Sprintf("docker.io/karmada/karmada-controller-manager:%s", releaseVer.ReleaseVersion())
 	DefualtKarmadaWebhookImage = fmt.Sprintf("docker.io/karmada/karmada-webhook:%s", releaseVer.ReleaseVersion())
@@ -665,7 +665,7 @@ func (i *CommandInitOption) kubeControllerManagerImage() string {
 // get etcd-init image
 func (i *CommandInitOption) etcdInitImage() string {
 	if i.ImageRegistry != "" && i.EtcdInitImage == DefaultInitImage {
-		return i.ImageRegistry + "/alpine:3.18.5"
+		return i.ImageRegistry + "/alpine:3.19.1"
 	}
 	return i.EtcdInitImage
 }

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
@@ -379,7 +379,7 @@ func TestEtcdInitImage(t *testing.T) {
 				ImageRegistry: "my-registry",
 				EtcdInitImage: DefaultInitImage,
 			},
-			expected: "my-registry/alpine:3.18.5",
+			expected: "my-registry/alpine:3.19.1",
 		},
 		{
 			name: "EtcdInitImage is set to a non-default value",


### PR DESCRIPTION
Cherry pick of #4598 on release-1.8.
#4598: bump alpine to 3.19.1 to address CVE concerns
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
```