### PR TITLE
Remove deprecated build constraints

### DIFF
--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -1,5 +1,4 @@
 //go:build tools
-// +build tools
 
 /*
 Copyright 2020 The Karmada Authors.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The build constraint `// +build` has been deprecated since Go 1.17 and replaced by `//go:build`.
The redundant constraint was [introduced while we using Go1.17](https://github.com/karmada-io/karmada/pull/1299/files#r803441093). Now it's time to cleanup it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Echo the [Go docs](https://pkg.go.dev/cmd/go#hdr-Build_constraints) here for reference:
> Go versions 1.16 and earlier used a different syntax for build constraints, with a "// +build" prefix. The gofmt command will add an equivalent //go:build constraint when encountering the older syntax.


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

