### PR TITLE
When maxgroup is not set, ignore this field

### DIFF
--- a/pkg/scheduler/core/spreadconstraint/select_clusters_by_cluster.go
+++ b/pkg/scheduler/core/spreadconstraint/select_clusters_by_cluster.go
@@ -30,9 +30,9 @@ func selectBestClustersByCluster(spreadConstraint policyv1alpha1.SpreadConstrain
 		return nil, fmt.Errorf("the number of feasible clusters is less than spreadConstraint.MinGroups")
 	}
 
-	needCnt := spreadConstraint.MaxGroups
-	if totalClusterCnt < spreadConstraint.MaxGroups {
-		needCnt = totalClusterCnt
+	needCnt := totalClusterCnt
+	if spreadConstraint.MaxGroups != 0 && spreadConstraint.MaxGroups < totalClusterCnt {
+		needCnt = spreadConstraint.MaxGroups
 	}
 
 	var clusterInfos []ClusterDetailInfo

--- a/pkg/scheduler/core/spreadconstraint/select_clusters_by_region.go
+++ b/pkg/scheduler/core/spreadconstraint/select_clusters_by_region.go
@@ -48,7 +48,7 @@ func selectBestClustersByRegion(spreadConstraintMap map[policyv1alpha1.SpreadFie
 	}
 
 	needCnt := len(candidateClusters) + len(clusters)
-	if needCnt > spreadConstraintMap[policyv1alpha1.SpreadByFieldCluster].MaxGroups {
+	if spreadConstraintMap[policyv1alpha1.SpreadByFieldCluster].MaxGroups != 0 && needCnt > spreadConstraintMap[policyv1alpha1.SpreadByFieldCluster].MaxGroups {
 		needCnt = spreadConstraintMap[policyv1alpha1.SpreadByFieldCluster].MaxGroups
 	}
 

--- a/pkg/scheduler/core/spreadconstraint/select_groups.go
+++ b/pkg/scheduler/core/spreadconstraint/select_groups.go
@@ -161,9 +161,11 @@ func findFeasiblePaths(groups []*GroupInfo, minConstraint, maxConstraint, target
 	rootPath := new(dfsPath)
 	var dfsFunc func(int, int)
 	dfsFunc = func(sum, begin int) {
-		if sum >= target && rootPath.length() >= minConstraint && rootPath.length() <= maxConstraint {
-			paths = append(paths, rootPath.next())
-			return
+		if sum >= target && rootPath.length() >= minConstraint {
+			if maxConstraint == 0 || rootPath.length() <= maxConstraint {
+				paths = append(paths, rootPath.next())
+				return
+			}
 		}
 
 		// pruning makes DFS faster


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
SpreadConstraints represents a list of the scheduling constraints. SpreadConstraint.MinGroups defaults to 1, but SpreadConstraint.MaxGroups defaults to 0. This will result in scheduling failure when SpreadConstraint.MaxGroups is not set.
How to reproduce
- install karmada with `local-up-karmada.sh`
- kubectl apply the following yaml
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  labels:
    app: nginx
spec:
  replicas: 2
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - image: nginx
        name: nginx
        resources:
          requests:
            cpu: 0.1
            memory: 10Mi
---
apiVersion: policy.karmada.io/v1alpha1
kind: PropagationPolicy
metadata:
  name: nginx
spec:
  resourceSelectors:
    - apiVersion: apps/v1
      kind: Deployment
      name: nginx
  placement:
    spreadConstraints:
      - spreadByField: cluster
    clusterAffinities:
      - affinityName: local-clusters
        clusterNames:
          - member1
          - member2
      - affinityName: cloud-clusters
        clusterNames:
          - member2
```
- view the logs of Karmada-scheduler
```shell
(base) ➜  karmada git:(revive) ✗ kh logs -f karmada-scheduler-58b454779b-8pb8d -nkarmada-system
I0206 08:44:51.157656       1 general.go:77] cluster member1 has max available replicas: 10 according to cluster resource models
I0206 08:44:51.157674       1 general.go:77] cluster member2 has max available replicas: 10 according to cluster resource models
I0206 08:44:51.159535       1 util.go:99] Target cluster calculated by estimators (available cluster && maxAvailableReplicas): [{member1 10} {member2 10}]
I0206 08:44:51.159580       1 generic_scheduler.go:101] Selected clusters: []
E0206 08:44:51.159632       1 scheduler.go:518] failed to schedule ResourceBinding(default/nginx-deployment) with clusterAffiliates index(0): failed to assign replicas: no clusters available to schedule
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-scheduler: fix the issue of scheduling failure caused by the default value of SpreadConstraint.MaxGroups being 0.
```

