### PR TITLE
Optimize the display of the hack/verify-import-aliases.sh

### DIFF
--- a/hack/tools/preferredimports/preferredimports.go
+++ b/hack/tools/preferredimports/preferredimports.go
@@ -260,7 +260,7 @@ func main() {
 	a := newAnalyzer()
 	for _, dir := range c.dirs {
 		if isTerminal {
-			fmt.Printf("\r\033[0m %-80s", dir)
+			fmt.Printf("\r\033[0m %-80s\n", dir)
 		}
 		a.collect(dir)
 	}

--- a/hack/verify-import-aliases.sh
+++ b/hack/verify-import-aliases.sh
@@ -39,3 +39,4 @@ if [[ $ret -ne 0 ]]; then
   echo "!!! Please see hack/.import-aliases for the preferred aliases for imports." >&2
   exit 1
 fi
+echo "Passed import-aliases verification."


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
```shell
(base) ➜  karmada git:(revive) ✗ hack/verify-import-aliases.sh 
checking-imports: 
 /root/home/workspace/code/karmada/test/helper                                   etoota
```
The output result of the script ```hack/verify-import-aliases.sh``` is confusing. 
Refer to https://github.com/karmada-io/karmada/blob/0aec7b58dc2a3be1063345f83383f4b366921aee/hack/tools/preferredimports/preferredimports.go#L261-L265
the reason is that there is no line break, and `\r` is added, resulting in the output results overlapping on the same line.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
```shell
(base) ➜  karmada git:(revive) ✗ hack/verify-import-aliases.sh
checking-imports: 
 /root/home/workspace/code/karmada/cmd                                           
 /root/home/workspace/code/karmada/cmd/agent
...                                              
 /root/home/workspace/code/karmada/pkg/webhook/overridepolicy                    
 /root/home/workspace/code/karmada/pkg/webhook/propagationpolicy                 
 /root/home/workspace/code/karmada/pkg/webhook/resourcedeletionprotection        
 /root/home/workspace/code/karmada/pkg/webhook/resourceinterpretercustomization  
 /root/home/workspace/code/karmada/pkg/webhook/work                              
 /root/home/workspace/code/karmada/test/e2e                                      
 /root/home/workspace/code/karmada/test/e2e/coverage_docs                        
 /root/home/workspace/code/karmada/test/e2e/framework                            
 /root/home/workspace/code/karmada/test/helper                                   

Passed import-aliases verification.
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below. 
If yes, a release note is required.
-->
```release-note
NONE
```

