### PR TITLE
`karmadactl`: Add the reserved label `karmada.io/system` to resources created by the `join` command

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -52,8 +52,13 @@ const (
 	// FederatedResourceQuotaNameLabel is added to Work to specify associated FederatedResourceQuota's name.
 	FederatedResourceQuotaNameLabel = "federatedresourcequota.karmada.io/name"
 
-	// ManagedByKarmadaLabel is a reserved karmada label to indicate whether resources are managed by karmada controllers.
+	// ManagedByKarmadaLabel is a reserved karmada label to indicate whether resources are member cluster resources
+	// synchronized by karmada controllers.
 	ManagedByKarmadaLabel = "karmada.io/managed"
+
+	// KarmadaSystemLabel is a reserved karmada label to indicate whether resources are system level resources
+	// managed by karmada controllers.
+	KarmadaSystemLabel = "karmada.io/system"
 
 	// EndpointSliceDispatchControllerLabelValue indicates the endpointSlice are controlled by Karmada
 	EndpointSliceDispatchControllerLabelValue = "endpointslice-dispatch-controller.karmada.io"
@@ -71,8 +76,11 @@ const (
 )
 
 const (
-	// ManagedByKarmadaLabelValue indicates that resources are managed by karmada controllers.
+	// ManagedByKarmadaLabelValue indicates that these are workloads in member cluster synchronized by karmada controllers.
 	ManagedByKarmadaLabelValue = "true"
+
+	// KarmadaSystemLabelValue indicates that resources are system level resources managed by karmada controllers.
+	KarmadaSystemLabelValue = "true"
 
 	// RetainReplicasValue is an optional value of RetainReplicasLabel, indicating retain
 	RetainReplicasValue = "true"

--- a/pkg/util/credential.go
+++ b/pkg/util/credential.go
@@ -59,7 +59,7 @@ func ObtainCredentialsFromMemberCluster(clusterKubeClient kubeclient.Interface, 
 	var err error
 	// It's necessary to set the label of namespace to make sure that the namespace is created by Karmada.
 	labels := map[string]string{
-		ManagedByKarmadaLabel: ManagedByKarmadaLabelValue,
+		KarmadaSystemLabel: KarmadaSystemLabelValue,
 	}
 	// ensure namespace where the karmada control plane credential be stored exists in cluster.
 	if _, err = EnsureNamespaceExistWithLabels(clusterKubeClient, opts.ClusterNamespace, opts.DryRun, labels); err != nil {
@@ -68,9 +68,13 @@ func ObtainCredentialsFromMemberCluster(clusterKubeClient kubeclient.Interface, 
 
 	if opts.IsKubeImpersonatorEnabled() {
 		// create a ServiceAccount for impersonation in cluster.
-		impersonationSA := &corev1.ServiceAccount{}
-		impersonationSA.Namespace = opts.ClusterNamespace
-		impersonationSA.Name = names.GenerateServiceAccountName("impersonator")
+		impersonationSA := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: opts.ClusterNamespace,
+				Name:      names.GenerateServiceAccountName("impersonator"),
+				Labels:    labels,
+			},
+		}
 		if impersonationSA, err = EnsureServiceAccountExist(clusterKubeClient, impersonationSA, opts.DryRun); err != nil {
 			return nil, nil, err
 		}
@@ -82,26 +86,38 @@ func ObtainCredentialsFromMemberCluster(clusterKubeClient kubeclient.Interface, 
 	}
 	if opts.IsKubeCredentialsEnabled() {
 		// create a ServiceAccount in cluster.
-		serviceAccountObj := &corev1.ServiceAccount{}
-		serviceAccountObj.Namespace = opts.ClusterNamespace
-		serviceAccountObj.Name = names.GenerateServiceAccountName(opts.ClusterName)
+		serviceAccountObj := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: opts.ClusterNamespace,
+				Name:      names.GenerateServiceAccountName(opts.ClusterName),
+				Labels:    labels,
+			},
+		}
 		if serviceAccountObj, err = EnsureServiceAccountExist(clusterKubeClient, serviceAccountObj, opts.DryRun); err != nil {
 			return nil, nil, err
 		}
 
 		// create a ClusterRole in cluster.
-		clusterRole := &rbacv1.ClusterRole{}
-		clusterRole.Name = names.GenerateRoleName(serviceAccountObj.Name)
-		clusterRole.Rules = ClusterPolicyRules
+		clusterRole := &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   names.GenerateRoleName(serviceAccountObj.Name),
+				Labels: labels,
+			},
+			Rules: ClusterPolicyRules,
+		}
 		if _, err = EnsureClusterRoleExist(clusterKubeClient, clusterRole, opts.DryRun); err != nil {
 			return nil, nil, err
 		}
 
 		// create a ClusterRoleBinding in cluster.
-		clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
-		clusterRoleBinding.Name = clusterRole.Name
-		clusterRoleBinding.Subjects = BuildRoleBindingSubjects(serviceAccountObj.Name, serviceAccountObj.Namespace)
-		clusterRoleBinding.RoleRef = BuildClusterRoleReference(clusterRole.Name)
+		clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   clusterRole.Name,
+				Labels: labels,
+			},
+			Subjects: BuildRoleBindingSubjects(serviceAccountObj.Name, serviceAccountObj.Namespace),
+			RoleRef:  BuildClusterRoleReference(clusterRole.Name),
+		}
 		if _, err = EnsureClusterRoleBindingExist(clusterKubeClient, clusterRoleBinding, opts.DryRun); err != nil {
 			return nil, nil, err
 		}
@@ -120,7 +136,7 @@ func ObtainCredentialsFromMemberCluster(clusterKubeClient kubeclient.Interface, 
 func RegisterClusterInControllerPlane(opts ClusterRegisterOption, controlPlaneKubeClient kubeclient.Interface, generateClusterInControllerPlane generateClusterInControllerPlaneFunc) error {
 	// It's necessary to set the label of namespace to make sure that the namespace is created by Karmada.
 	labels := map[string]string{
-		ManagedByKarmadaLabel: ManagedByKarmadaLabelValue,
+		KarmadaSystemLabel: KarmadaSystemLabelValue,
 	}
 	// ensure namespace where the cluster object be stored exists in control plane.
 	if _, err := EnsureNamespaceExistWithLabels(controlPlaneKubeClient, opts.ClusterNamespace, opts.DryRun, labels); err != nil {
@@ -137,6 +153,7 @@ func RegisterClusterInControllerPlane(opts ClusterRegisterOption, controlPlaneKu
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: opts.ClusterNamespace,
 				Name:      names.GenerateImpersonationSecretName(opts.ClusterName),
+				Labels:    labels,
 			},
 			Data: map[string][]byte{
 				clusterv1alpha1.SecretTokenKey: opts.ImpersonatorSecret.Data[clusterv1alpha1.SecretTokenKey],
@@ -154,6 +171,7 @@ func RegisterClusterInControllerPlane(opts ClusterRegisterOption, controlPlaneKu
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: opts.ClusterNamespace,
 				Name:      opts.ClusterName,
+				Labels:    labels,
 			},
 			Data: map[string][]byte{
 				clusterv1alpha1.SecretCADataKey: opts.Secret.Data["ca.crt"],


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature

**What this PR does / why we need it**:
Follow-up to https://github.com/karmada-io/karmada/pull/3262


Adds the well-known "karmada.io/managed" label to resources created by karmada controllers

We need a way to bypass creation of some ClusterRole/Rolebindings by our OPA Gatekeeper and we don't have a consistent label to select on. When we join a cluster via push command, it creates ClusterRole/ClusterRoleBinding that are too open (`*` and `*`) which is by default blocked by our opa-gatekeeper policies. This allows us to bypass it by the karmada managed label.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: Add the reserved label `karmada.io/system` to resources created by the `join` command.
```

