### PR TITLE
feat: support wildcard `Kind` in `resourceSelectors` of `PropgationPolicy`

### DIFF
--- a/pkg/util/selector.go
+++ b/pkg/util/selector.go
@@ -43,6 +43,8 @@ const (
 	PriorityMatchLabelSelector
 	// PriorityMatchName means the Name of ResourceSelector matches the resource.
 	PriorityMatchName
+	// wildcardKind indicates that any kinds within an apiGroup can be matched for a policy
+	wildcardKind = "*"
 )
 
 // ResourceMatches tells if the specific resource matches the selector.
@@ -52,9 +54,9 @@ func ResourceMatches(resource *unstructured.Unstructured, rs policyv1alpha1.Reso
 
 // ResourceSelectorPriority tells the priority between the specific resource and the selector.
 func ResourceSelectorPriority(resource *unstructured.Unstructured, rs policyv1alpha1.ResourceSelector) ImplicitPriority {
-	if resource.GetAPIVersion() != rs.APIVersion ||
-		resource.GetKind() != rs.Kind ||
-		(len(rs.Namespace) > 0 && resource.GetNamespace() != rs.Namespace) {
+	if rs.APIVersion != resource.GetAPIVersion() ||
+		(rs.Kind != wildcardKind && rs.Kind != resource.GetKind()) ||
+		(len(rs.Namespace) > 0 && rs.Namespace != resource.GetNamespace()) {
 		return PriorityMisMatch
 	}
 

--- a/pkg/util/selector_test.go
+++ b/pkg/util/selector_test.go
@@ -294,6 +294,30 @@ func TestResourceSelectorPriority(t *testing.T) {
 			},
 			want: PriorityMisMatch,
 		},
+		{
+			name: "wildcard Kind, same apiVersion, matched",
+			args: args{
+				rs: policyv1alpha1.ResourceSelector{
+					APIVersion: resource.GetAPIVersion(),
+					Kind:       wildcardKind,
+					Name:       resource.GetName(),
+					Namespace:  resource.GetNamespace(),
+				},
+			},
+			want: PriorityMatchName,
+		},
+		{
+			name: "wildcard Kind, different apiVersion, not matched",
+			args: args{
+				rs: policyv1alpha1.ResourceSelector{
+					APIVersion: "unmatched",
+					Kind:       wildcardKind,
+					Name:       resource.GetName(),
+					Namespace:  resource.GetNamespace(),
+				},
+			},
+			want: PriorityMisMatch,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/test/e2e/propagationpolicy_test.go
+++ b/test/e2e/propagationpolicy_test.go
@@ -853,6 +853,28 @@ var _ = ginkgo.Describe("[AdvancedPropagation] propagation testing", func() {
 					return true
 				})
 		})
+
+		ginkgo.It("supports wildcard kind", func() {
+			policy.Spec.ResourceSelectors = []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: deployment01.APIVersion,
+					Kind:       "*",
+					Name:       deployment01.Name,
+				},
+				{
+					APIVersion: deployment02.APIVersion,
+					Kind:       "*",
+					Name:       deployment02.Name,
+				},
+			}
+			framework.UpdatePropagationPolicyWithSpec(karmadaClient, policy.Namespace, policy.Name, policy.Spec)
+
+			framework.WaitDeploymentPresentOnClusterFitWith(targetMember, deployment01.Namespace, deployment01.Name,
+				func(deployment *appsv1.Deployment) bool { return true })
+
+			framework.WaitDeploymentPresentOnClusterFitWith(targetMember, deployment02.Namespace, deployment02.Name,
+				func(deployment *appsv1.Deployment) bool { return true })
+		})
 	})
 
 	ginkgo.Context("Edit PropagationPolicy fields other than resourceSelectors", func() {


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind feature

**What this PR does / why we need it**:

It would be ideal for karmada to allow all `Kind` from a certain `apiGroup`. One use-case is opa-gatekeeper that treats each policy as a constraint `Kind`.

Our cluster currently has 68 constraint kinds and counting:
```
kubectl api-resources | grep constraints.gatekeeper.sh/v1beta1 | wc -l
      68
```

Adding each kind is not easily maintainable and ability to provide a wildcard kind support would reduce our overhead significantly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
feat: support wildcard `Kind` in `resourceSelectors` of `PropgationPolicy`
```

