### PR TITLE
Set enum value for operator in Remedy API

### DIFF
--- a/charts/karmada/_crds/bases/remedy/remedy.karmada.io_remedies.yaml
+++ b/charts/karmada/_crds/bases/remedy/remedy.karmada.io_remedies.yaml
@@ -79,6 +79,9 @@ spec:
                         operator:
                           description: Operator represents a conditionType's relationship
                             to a conditionStatus. Valid operators are Equal, NotEqual.
+                          enum:
+                          - Equal
+                          - NotEqual
                           type: string
                       required:
                       - conditionStatus

--- a/pkg/apis/remedy/v1alpha1/remedy_types.go
+++ b/pkg/apis/remedy/v1alpha1/remedy_types.go
@@ -70,6 +70,8 @@ type ClusterConditionRequirement struct {
 	ConditionType ConditionType `json:"conditionType"`
 	// Operator represents a conditionType's relationship to a conditionStatus.
 	// Valid operators are Equal, NotEqual.
+	//
+	// +kubebuilder:validation:Enum=Equal;NotEqual
 	// +required
 	Operator ClusterConditionOperator `json:"operator"`
 	// ConditionStatus specifies the ClusterStatue condition status.

--- a/pkg/scheduler/framework/testing/mock_interface.go
+++ b/pkg/scheduler/framework/testing/mock_interface.go
@@ -13,11 +13,10 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	v1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	v1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	framework "github.com/karmada-io/karmada/pkg/scheduler/framework"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockFramework is a mock of Framework interface.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Set the enum value for the `operator` field in Remedy API.

**Which issue(s) this PR fixes**:
Part of #4658 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

