### PR TITLE
fix: replacement of `::` to be dns RFC 1123 compliant

### DIFF
--- a/pkg/util/names/names.go
+++ b/pkg/util/names/names.go
@@ -70,6 +70,7 @@ func GenerateBindingName(kind, name string) string {
 	// For more information about the DNS subdomain name, please refer to
 	// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names.
 	if strings.Contains(name, ":") {
+		name = strings.ReplaceAll(name, "::", ".") // `foo..bar` is not valid
 		name = strings.ReplaceAll(name, ":", ".")
 	}
 

--- a/pkg/util/names/names_test.go
+++ b/pkg/util/names/names_test.go
@@ -166,13 +166,13 @@ func TestGenerateBindingName(t *testing.T) {
 			testCase: "clusterRole kind resource",
 			kind:     "ClusterRole",
 			name:     "system::tom",
-			expect:   "system..tom-clusterrole",
+			expect:   "system.tom-clusterrole",
 		},
 		{
 			testCase: "roleBinding kind resource",
 			kind:     "RoleBinding",
 			name:     "system::tt:tom",
-			expect:   "system..tt.tom-rolebinding",
+			expect:   "system.tt.tom-rolebinding",
 		},
 		{
 			testCase: "clusterRoleBinding kind resource",


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #4681

**Special notes for your reviewer**:

This may cause issues if we have two roles:
`foo::bar`
and
`foo:bar`

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
fix creation of ResourceBinding for resources with :: in the name
```

