### PR TITLE
Update release badge to show latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 
 [![LICENSE](https://img.shields.io/github/license/karmada-io/karmada.svg)](/LICENSE)
-[![Releases](https://img.shields.io/github/release/karmada-io/karmada/all.svg)](https://github.com/karmada-io/karmada/releases)
+[![Releases](https://img.shields.io/github/v/release/karmada-io/karmada)](https://github.com/karmada-io/karmada/releases/latest)
 [![Slack](https://img.shields.io/badge/slack-join-brightgreen)](https://slack.cncf.io)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/5301/badge)](https://bestpractices.coreinfrastructure.org/projects/5301)
 ![build](https://github.com/karmada-io/karmada/actions/workflows/ci.yml/badge.svg)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Generates the badge as per the `latest` release instead of the alpha release.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
See the new badge at [here](https://github.com/RainbowMango/karmada/tree/pr_update_release_badge). (Before this PR gets merged.)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

