### PR TITLE
operator: update operator crd when upgrading chart

### DIFF
--- a/charts/karmada-operator/templates/_helpers.tpl
+++ b/charts/karmada-operator/templates/_helpers.tpl
@@ -14,8 +14,16 @@ Return the proper karmada operator image name
 {{- end -}}
 
 {{/*
-Return the proper Docker Image Registry Secret Names
+return the proper docker image registry secret names
 */}}
 {{- define "karmada.operator.imagePullSecrets" -}}
 {{ include "common.images.pullSecrets" (dict "images" (list .Values.operator.image) "global" .Values.global) }}
 {{- end -}}
+
+{{/*
+Return the proper kubectl image name
+*/}}
+{{- define "karmada.kubectl.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.kubectl.image "global" .Values.global) }}
+{{- end -}}
+

--- a/charts/karmada-operator/templates/post-hook-configmap.yaml
+++ b/charts/karmada-operator/templates/post-hook-configmap.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.installCRDs }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-post-manifests
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+data:
+  crds-configmaps.yaml: |-
+      {{ range $path, $bytes := .Files.Glob (printf "crds/*")}}
+      {{- $.Files.Get $path | nindent 8 }}
+      {{ end }}
+{{- end -}}
+

--- a/charts/karmada-operator/templates/post-hook-job.yaml
+++ b/charts/karmada-operator/templates/post-hook-job.yaml
@@ -1,0 +1,42 @@
+
+{{- if .Values.installCRDs }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-post-hook-install-crds
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "2"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      name: {{ .Release.Name }}
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    spec:
+      serviceAccountName: {{ .Release.Name }}-post-hook-job
+      restartPolicy: Never
+      containers:
+      - name: install-crds
+        image: {{ include "karmada.kubectl.image" . }}
+        imagePullPolicy: IfNotPresent
+        workingDir: /crds
+        command:
+        - /bin/sh
+        - -c
+        - |
+          bash <<'EOF'
+          set -ex
+          kubectl apply --server-side -f /crds --force-conflicts
+          EOF
+        volumeMounts:
+        - name: crds
+          mountPath: /crds
+      volumes:
+      - name: crds
+        configMap:
+          name: {{ .Release.Name }}-post-manifests
+{{- end -}}
+

--- a/charts/karmada-operator/templates/post-hook-rbac.yaml
+++ b/charts/karmada-operator/templates/post-hook-rbac.yaml
@@ -1,0 +1,36 @@
+
+{{- if .Values.installCRDs }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-post-hook-job
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ['apiextensions.k8s.io']
+    resources: ['customresourcedefinitions']
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+  - nonResourceURLs: ['*']
+    verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-post-hook-job
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    helm.sh/hook-weight: "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-post-hook-job
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-post-hook-job
+    namespace: {{ .Release.Namespace }}
+{{- end -}}
+

--- a/charts/karmada-operator/templates/post-hook-serviceacconut.yaml
+++ b/charts/karmada-operator/templates/post-hook-serviceacconut.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.installCRDs }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-post-hook-job
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+{{- end -}}
+

--- a/charts/karmada-operator/values.yaml
+++ b/charts/karmada-operator/values.yaml
@@ -11,6 +11,22 @@ global:
   ##   - myRegistryKeySecretName
   imagePullSecrets: []
 
+## @param installCRDs define flag whether to install CRD resources
+##
+installCRDs: true
+
+kubectl:
+  ## @param image.registry karmada kubectl image registry
+  ## @param image.repository karmada kubectl image repository
+  ## @param image.tag karmada kubectl image tag (immutable tags are recommended)
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/kubectl
+    tag: latest
+    ## Specify a imagePullPolicy, defaults to 'IfNotPresent'
+    pullPolicy: IfNotPresent
+
 ## operator manager config
 operator:
   ## @param operator.labels


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
the crd will not be updated when upgrading karmada operator chart.
so, we can support a way, run a job to apply crd resource after installing operator deployment.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
and i have test for this:

```bash
$ helm install karmada-operator -n karmada-system --create-namespace ./charts/karmada-operator --dependency-update
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /Users/chenwen/.kube/config
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /Users/chenwen/.kube/config
NAME: karmada-operator
LAST DEPLOYED: Mon Mar 11 15:44:35 2024
NAMESPACE: karmada-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Thank you for installing karmada-operator.

Your release is named karmada-operator.

To learn more about the release, try:

  $ helm status karmada-operator -n karmada-system
  $ helm get all karmada-operator -n karmada-system

---
$ kubectl get po -n karmada-system  -w
NAME                               READY   STATUS    RESTARTS   AGE
karmada-operator-b7cf7f467-rwc9h   0/1     Pending   0          0s
karmada-operator-b7cf7f467-rwc9h   0/1     Pending   0          0s
karmada-operator-b7cf7f467-rwc9h   0/1     ContainerCreating   0          0s
karmada-operator-post-hook-install-crds-2vkn9   0/1     Pending             0          0s
karmada-operator-post-hook-install-crds-2vkn9   0/1     Pending             0          0s
karmada-operator-post-hook-install-crds-2vkn9   0/1     ContainerCreating   0          0s
karmada-operator-b7cf7f467-rwc9h                1/1     Running             0          2s
karmada-operator-post-hook-install-crds-2vkn9   1/1     Running             0          1s
karmada-operator-post-hook-install-crds-2vkn9   0/1     Completed           0          2s
karmada-operator-post-hook-install-crds-2vkn9   0/1     Completed           0          3s
karmada-operator-post-hook-install-crds-2vkn9   0/1     Completed           0          4s
karmada-operator-post-hook-install-crds-2vkn9   0/1     Completed           0          4s
karmada-operator-post-hook-install-crds-2vkn9   0/1     Terminating         0          4s
karmada-operator-post-hook-install-crds-2vkn9   0/1     Terminating         0          4s

```


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

