### PR TITLE
fix: `MultiClusterService` placement change triggering recreation of resources

### DIFF
--- a/pkg/controllers/multiclusterservice/mcs_controller.go
+++ b/pkg/controllers/multiclusterservice/mcs_controller.go
@@ -448,7 +448,8 @@ func (c *MCSController) buildResourceBinding(svc *corev1.Service, mcs *networkin
 	propagateClusters := providerClusters.Clone().Insert(consumerClusters.Clone().UnsortedList()...)
 	placement := &policyv1alpha1.Placement{
 		ClusterAffinity: &policyv1alpha1.ClusterAffinity{
-			ClusterNames: propagateClusters.UnsortedList(),
+			// always use sorted List for clusterNames to ensure that karmada-scheduler doesn't trigger a placement change
+			ClusterNames: sets.List(propagateClusters),
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/king bug

**What this PR does / why we need it**:
Karmada `MultiClusterService` uses an unsored list of clusters which can change order over time (set has no order guarantee). This should normally be ok, but karmda-scheduler does a [reflect.DeepEqual here](https://github.com/karmada-io/karmada/blob/master/pkg/scheduler/helper.go#L51) as opposed to checking the content of the list.

My first reaction was to change karmada-scheduler to not do this, but perhaps the order of clusters has a significance. But in a MultiClusterService provider/consumer, it does not have any significance as long as it's available.

Currently we get in a loop of Service updates / Endpoint deletion/recreation because karmada-scheduler keeps rescheduling as it thinks placement has changed:
```
1 scheduler.go:348] Start to schedule ResourceBinding(test/istio-mcs-test-service) as placement changed
22:12:23.207608       1 scheduler.go:348] Start to schedule ResourceBinding(test/istio-mcs-test-service) as placement changed
22:12:23.221188       1 event.go:307] "Event occurred" object="test/istio-mcs-test-service" fieldPath="" kind="ResourceBinding" apiVersion="work.karmada.io/v1alpha2" type="Normal" reason="ScheduleBindingSucceed" message="Binding has been scheduled successfully."
22:12:23.221337       1 event.go:307] "Event occurred" object="test/istio-mcs-test" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="ScheduleBindingSucceed" message="Binding has been scheduled successfully."
22:12:43.696352       1 scheduler.go:348] Start to schedule ResourceBinding(test/istio-mcs-test-service) as placement changed
22:12:43.707379       1 event.go:307] "Event occurred" object="test/istio-mcs-test-service" fieldPath="" kind="ResourceBinding" apiVersion="work.karmada.io/v1alpha2" type="Normal" reason="ScheduleBindingSucceed" message="Binding has been scheduled successfully."
22:12:43.707407       1 event.go:307] "Event occurred" object="test/istio-mcs-test" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="ScheduleBindingSucceed" message="Binding has been scheduled successfully."
22:12:53.628098       1 scheduler.go:348] Start to schedule ResourceBinding(test/istio-mcs-test-service) as placement changed
22:12:53.637153       1 event.go:307] "Event occurred" object="test/istio-mcs-test-service" fieldPath="" kind="ResourceBinding" apiVersion="work.karmada.io/v1alpha2" type="Normal" reason="ScheduleBindingSucceed" message="Binding has been scheduled successfully."
22:12:53.637178       1 event.go:307] "Event occurred" object="test/istio-mcs-test" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="ScheduleBindingSucceed" message="Binding has been scheduled successfully."
22:12:54.091134       1 scheduler.go:348] Start to schedule ResourceBinding(test/istio-mcs-test-service) as placement changed
22:12:54.103214       1 event.go:307] "Event occurred" object="test/istio-mcs-test-service" fieldPath="" kind="ResourceBinding" apiVersion="work.karmada.io/v1alpha2" type="Normal" reason="ScheduleBindingSucceed" message="Binding has been scheduled successfully."
22:12:54.103250       1 event.go:307] "Event occurred" object="test/istio-mcs-test" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="ScheduleBindingSucceed" message="Binding has been scheduled successfully."
22:13:35.800578       1 scheduler.go:348] Start to schedule ResourceBinding(test/istio-mcs-test-service) as placement changed
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Fixed the issue that `multiclusterservice-controller` generates unordered placement leading to unnecessary rescheduling.
```

