### PR TITLE
Cleanup the deprecated package of  k8s.io/utils/pointer.

### DIFF
--- a/examples/customresourceinterpreter/webhook/app/workloadwebhook.go
+++ b/examples/customresourceinterpreter/webhook/app/workloadwebhook.go
@@ -24,7 +24,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	workloadv1alpha1 "github.com/karmada-io/karmada/examples/customresourceinterpreter/apis/workload/v1alpha1"
 	configv1alpha1 "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1"
@@ -142,9 +142,9 @@ func (e *workloadInterpreter) responseWithExploreAggregateStatus(workload *workl
 }
 
 func (e *workloadInterpreter) responseWithExploreInterpretHealth(workload *workloadv1alpha1.Workload) interpreter.Response {
-	healthy := pointer.Bool(false)
+	healthy := ptr.To[bool](false)
 	if workload.Status.ReadyReplicas == *workload.Spec.Replicas {
-		healthy = pointer.Bool(true)
+		healthy = ptr.To[bool](true)
 	}
 
 	res := interpreter.Succeeded("")

--- a/operator/pkg/apis/operator/v1alpha1/defaults.go
+++ b/operator/pkg/apis/operator/v1alpha1/defaults.go
@@ -22,7 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/karmada-io/karmada/operator/pkg/constants"
 	"github.com/karmada-io/karmada/pkg/version"
@@ -103,7 +103,7 @@ func setDefaultsHostCluster(obj *Karmada) {
 		hc.Networking = &Networking{}
 	}
 	if hc.Networking.DNSDomain == nil {
-		hc.Networking.DNSDomain = pointer.String(constants.KarmadaDefaultDNSDomain)
+		hc.Networking.DNSDomain = ptr.To[string](constants.KarmadaDefaultDNSDomain)
 	}
 }
 
@@ -118,7 +118,7 @@ func setDefaultsEtcd(obj *KarmadaComponents) {
 		}
 
 		if obj.Etcd.Local.Replicas == nil {
-			obj.Etcd.Local.Replicas = pointer.Int32(1)
+			obj.Etcd.Local.Replicas = ptr.To[int32](1)
 		}
 		if len(obj.Etcd.Local.Image.ImageRepository) == 0 {
 			obj.Etcd.Local.Image.ImageRepository = etcdImageRepository
@@ -154,10 +154,10 @@ func setDefaultsKarmadaAPIServer(obj *KarmadaComponents) {
 		apiserver.ImagePullPolicy = corev1.PullIfNotPresent
 	}
 	if apiserver.Replicas == nil {
-		apiserver.Replicas = pointer.Int32(1)
+		apiserver.Replicas = ptr.To[int32](1)
 	}
 	if apiserver.ServiceSubnet == nil {
-		apiserver.ServiceSubnet = pointer.String(constants.KarmadaDefaultServiceSubnet)
+		apiserver.ServiceSubnet = ptr.To[string](constants.KarmadaDefaultServiceSubnet)
 	}
 	if len(apiserver.ServiceType) == 0 {
 		apiserver.ServiceType = corev1.ServiceTypeClusterIP
@@ -180,7 +180,7 @@ func setDefaultsKarmadaAggregatedAPIServer(obj *KarmadaComponents) {
 		aggregated.ImagePullPolicy = corev1.PullIfNotPresent
 	}
 	if aggregated.Replicas == nil {
-		aggregated.Replicas = pointer.Int32(1)
+		aggregated.Replicas = ptr.To[int32](1)
 	}
 }
 
@@ -200,7 +200,7 @@ func setDefaultsKubeControllerManager(obj *KarmadaComponents) {
 		kubeControllerManager.ImagePullPolicy = corev1.PullIfNotPresent
 	}
 	if kubeControllerManager.Replicas == nil {
-		kubeControllerManager.Replicas = pointer.Int32(1)
+		kubeControllerManager.Replicas = ptr.To[int32](1)
 	}
 }
 
@@ -220,7 +220,7 @@ func setDefaultsKarmadaControllerManager(obj *KarmadaComponents) {
 		karmadaControllerManager.ImagePullPolicy = corev1.PullIfNotPresent
 	}
 	if karmadaControllerManager.Replicas == nil {
-		karmadaControllerManager.Replicas = pointer.Int32(1)
+		karmadaControllerManager.Replicas = ptr.To[int32](1)
 	}
 }
 
@@ -240,7 +240,7 @@ func setDefaultsKarmadaScheduler(obj *KarmadaComponents) {
 		scheduler.ImagePullPolicy = corev1.PullIfNotPresent
 	}
 	if scheduler.Replicas == nil {
-		scheduler.Replicas = pointer.Int32(1)
+		scheduler.Replicas = ptr.To[int32](1)
 	}
 }
 
@@ -260,7 +260,7 @@ func setDefaultsKarmadaWebhook(obj *KarmadaComponents) {
 		webhook.ImagePullPolicy = corev1.PullIfNotPresent
 	}
 	if webhook.Replicas == nil {
-		webhook.Replicas = pointer.Int32(1)
+		webhook.Replicas = ptr.To[int32](1)
 	}
 }
 
@@ -280,7 +280,7 @@ func setDefaultsKarmadaSearch(obj *KarmadaComponents) {
 		search.ImagePullPolicy = corev1.PullIfNotPresent
 	}
 	if search.Replicas == nil {
-		search.Replicas = pointer.Int32(1)
+		search.Replicas = ptr.To[int32](1)
 	}
 }
 
@@ -300,7 +300,7 @@ func setDefaultsKarmadaDescheduler(obj *KarmadaComponents) {
 		descheduler.ImagePullPolicy = corev1.PullIfNotPresent
 	}
 	if descheduler.Replicas == nil {
-		descheduler.Replicas = pointer.Int32(1)
+		descheduler.Replicas = ptr.To[int32](1)
 	}
 }
 
@@ -320,6 +320,6 @@ func setDefaultsKarmadaMetricsAdapter(obj *KarmadaComponents) {
 		metricsAdapter.ImagePullPolicy = corev1.PullIfNotPresent
 	}
 	if metricsAdapter.Replicas == nil {
-		metricsAdapter.Replicas = pointer.Int32(2)
+		metricsAdapter.Replicas = ptr.To[int32](2)
 	}
 }

--- a/pkg/apis/policy/v1alpha1/propagation_helper_test.go
+++ b/pkg/apis/policy/v1alpha1/propagation_helper_test.go
@@ -19,7 +19,7 @@ package v1alpha1
 import (
 	"testing"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestPropagationPolicy_ExplicitPriority(t *testing.T) {
@@ -34,7 +34,7 @@ func TestPropagationPolicy_ExplicitPriority(t *testing.T) {
 		},
 		{
 			name:             "expected to be declared priority in pp",
-			declaredPriority: pointer.Int32(20),
+			declaredPriority: ptr.To[int32](20),
 			expectedPriority: 20,
 		},
 	}
@@ -62,7 +62,7 @@ func TestClusterPropagationPolicy_ExplicitPriority(t *testing.T) {
 		},
 		{
 			name:             "expected to be declared priority in cpp",
-			declaredPriority: pointer.Int32(20),
+			declaredPriority: ptr.To[int32](20),
 			expectedPriority: 20,
 		},
 	}

--- a/pkg/apis/work/v1alpha2/binding_types_helper_test.go
+++ b/pkg/apis/work/v1alpha2/binding_types_helper_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestResourceBindingSpec_TargetContains(t *testing.T) {
@@ -181,7 +181,7 @@ func TestResourceBindingSpec_GracefulEvictCluster(t *testing.T) {
 				GracefulEvictionTasks: []GracefulEvictionTask{
 					{
 						FromCluster: "m1",
-						Replicas:    pointer.Int32(1),
+						Replicas:    ptr.To[int32](1),
 						Reason:      EvictionReasonTaintUntolerated,
 						Message:     "graceful eviction",
 						Producer:    EvictionProducerTaintManager,
@@ -205,7 +205,7 @@ func TestResourceBindingSpec_GracefulEvictCluster(t *testing.T) {
 				GracefulEvictionTasks: []GracefulEvictionTask{
 					{
 						FromCluster: "m2",
-						Replicas:    pointer.Int32(2),
+						Replicas:    ptr.To[int32](2),
 						Reason:      EvictionReasonTaintUntolerated,
 						Message:     "graceful eviction",
 						Producer:    EvictionProducerTaintManager,
@@ -229,7 +229,7 @@ func TestResourceBindingSpec_GracefulEvictCluster(t *testing.T) {
 				GracefulEvictionTasks: []GracefulEvictionTask{
 					{
 						FromCluster: "m3",
-						Replicas:    pointer.Int32(3),
+						Replicas:    ptr.To[int32](3),
 						Reason:      EvictionReasonTaintUntolerated,
 						Message:     "graceful eviction",
 						Producer:    EvictionProducerTaintManager,
@@ -257,7 +257,7 @@ func TestResourceBindingSpec_GracefulEvictCluster(t *testing.T) {
 					},
 					{
 						FromCluster: "m3",
-						Replicas:    pointer.Int32(3),
+						Replicas:    ptr.To[int32](3),
 						Reason:      EvictionReasonTaintUntolerated,
 						Message:     "graceful eviction",
 						Producer:    EvictionProducerTaintManager,
@@ -277,7 +277,7 @@ func TestResourceBindingSpec_GracefulEvictCluster(t *testing.T) {
 				GracefulEvictionTasks: []GracefulEvictionTask{
 					{
 						FromCluster: "m1",
-						Replicas:    pointer.Int32(1),
+						Replicas:    ptr.To[int32](1),
 						Reason:      EvictionReasonTaintUntolerated,
 						Message:     "graceful eviction v1",
 						Producer:    EvictionProducerTaintManager,
@@ -286,7 +286,7 @@ func TestResourceBindingSpec_GracefulEvictCluster(t *testing.T) {
 			},
 			EvictEvent: GracefulEvictionTask{
 				FromCluster: "m1",
-				Replicas:    pointer.Int32(1),
+				Replicas:    ptr.To[int32](1),
 				Reason:      EvictionReasonTaintUntolerated,
 				Message:     "graceful eviction v2",
 				Producer:    EvictionProducerTaintManager,
@@ -296,7 +296,7 @@ func TestResourceBindingSpec_GracefulEvictCluster(t *testing.T) {
 				GracefulEvictionTasks: []GracefulEvictionTask{
 					{
 						FromCluster: "m1",
-						Replicas:    pointer.Int32(1),
+						Replicas:    ptr.To[int32](1),
 						Reason:      EvictionReasonTaintUntolerated,
 						Message:     "graceful eviction v1",
 						Producer:    EvictionProducerTaintManager,

--- a/pkg/controllers/applicationfailover/crb_application_failover_controller.go
+++ b/pkg/controllers/applicationfailover/crb_application_failover_controller.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -165,7 +165,7 @@ func (c *CRBApplicationFailoverController) evictBinding(binding *workv1alpha2.Cl
 			}
 		case policyv1alpha1.Never:
 			if features.FeatureGate.Enabled(features.GracefulEviction) {
-				binding.Spec.GracefulEvictCluster(cluster, workv1alpha2.NewTaskOptions(workv1alpha2.WithProducer(CRBApplicationFailoverControllerName), workv1alpha2.WithReason(workv1alpha2.EvictionReasonApplicationFailure), workv1alpha2.WithSuppressDeletion(pointer.Bool(true))))
+				binding.Spec.GracefulEvictCluster(cluster, workv1alpha2.NewTaskOptions(workv1alpha2.WithProducer(CRBApplicationFailoverControllerName), workv1alpha2.WithReason(workv1alpha2.EvictionReasonApplicationFailure), workv1alpha2.WithSuppressDeletion(ptr.To[bool](true))))
 			} else {
 				err := fmt.Errorf("GracefulEviction featureGate must be enabled when purgeMode is %s", policyv1alpha1.Never)
 				klog.Error(err)

--- a/pkg/controllers/applicationfailover/rb_application_failover_controller.go
+++ b/pkg/controllers/applicationfailover/rb_application_failover_controller.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -167,7 +167,7 @@ func (c *RBApplicationFailoverController) evictBinding(binding *workv1alpha2.Res
 		case policyv1alpha1.Never:
 			if features.FeatureGate.Enabled(features.GracefulEviction) {
 				binding.Spec.GracefulEvictCluster(cluster, workv1alpha2.NewTaskOptions(workv1alpha2.WithProducer(RBApplicationFailoverControllerName),
-					workv1alpha2.WithReason(workv1alpha2.EvictionReasonApplicationFailure), workv1alpha2.WithSuppressDeletion(pointer.Bool(true))))
+					workv1alpha2.WithReason(workv1alpha2.EvictionReasonApplicationFailure), workv1alpha2.WithSuppressDeletion(ptr.To[bool](true))))
 			} else {
 				err := fmt.Errorf("GracefulEviction featureGate must be enabled when purgeMode is %s", policyv1alpha1.Never)
 				klog.Error(err)

--- a/pkg/controllers/gracefuleviction/evictiontask_test.go
+++ b/pkg/controllers/gracefuleviction/evictiontask_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 )
@@ -143,7 +143,7 @@ func Test_assessSingleTask(t *testing.T) {
 			args: args{
 				task: workv1alpha2.GracefulEvictionTask{
 					FromCluster:        "member1",
-					GracePeriodSeconds: pointer.Int32(30),
+					GracePeriodSeconds: ptr.To[int32](30),
 					CreationTimestamp:  &metav1.Time{Time: timeNow.Add(time.Minute * -1)},
 				},
 				opt: assessmentOption{
@@ -163,7 +163,7 @@ func Test_assessSingleTask(t *testing.T) {
 			args: args{
 				task: workv1alpha2.GracefulEvictionTask{
 					FromCluster:        "member1",
-					GracePeriodSeconds: pointer.Int32(120),
+					GracePeriodSeconds: ptr.To[int32](120),
 					CreationTimestamp:  &metav1.Time{Time: timeNow.Add(time.Minute * -1)},
 				},
 				opt: assessmentOption{
@@ -178,7 +178,7 @@ func Test_assessSingleTask(t *testing.T) {
 			},
 			want: &workv1alpha2.GracefulEvictionTask{
 				FromCluster:        "member1",
-				GracePeriodSeconds: pointer.Int32(120),
+				GracePeriodSeconds: ptr.To[int32](120),
 				CreationTimestamp:  &metav1.Time{Time: timeNow.Add(time.Minute * -1)},
 			},
 		},
@@ -187,7 +187,7 @@ func Test_assessSingleTask(t *testing.T) {
 			args: args{
 				task: workv1alpha2.GracefulEvictionTask{
 					FromCluster:       "member1",
-					SuppressDeletion:  pointer.Bool(true),
+					SuppressDeletion:  ptr.To[bool](true),
 					CreationTimestamp: &metav1.Time{Time: timeNow.Add(time.Minute * -1)},
 				},
 				opt: assessmentOption{
@@ -202,7 +202,7 @@ func Test_assessSingleTask(t *testing.T) {
 			},
 			want: &workv1alpha2.GracefulEvictionTask{
 				FromCluster:       "member1",
-				SuppressDeletion:  pointer.Bool(true),
+				SuppressDeletion:  ptr.To[bool](true),
 				CreationTimestamp: &metav1.Time{Time: timeNow.Add(time.Minute * -1)},
 			},
 		},
@@ -211,7 +211,7 @@ func Test_assessSingleTask(t *testing.T) {
 			args: args{
 				task: workv1alpha2.GracefulEvictionTask{
 					FromCluster:       "member1",
-					SuppressDeletion:  pointer.Bool(false),
+					SuppressDeletion:  ptr.To[bool](false),
 					CreationTimestamp: &metav1.Time{Time: timeNow.Add(time.Minute * -1)},
 				},
 				opt: assessmentOption{
@@ -594,7 +594,7 @@ func Test_nextRetry(t *testing.T) {
 					{
 						FromCluster:       "member1",
 						CreationTimestamp: &metav1.Time{Time: timeNow.Add(time.Minute * -60)},
-						SuppressDeletion:  pointer.Bool(true),
+						SuppressDeletion:  ptr.To[bool](true),
 					},
 					{
 						FromCluster:       "member2",
@@ -613,12 +613,12 @@ func Test_nextRetry(t *testing.T) {
 					{
 						FromCluster:       "member1",
 						CreationTimestamp: &metav1.Time{Time: timeNow.Add(time.Minute * -60)},
-						SuppressDeletion:  pointer.Bool(true),
+						SuppressDeletion:  ptr.To[bool](true),
 					},
 					{
 						FromCluster:       "member2",
 						CreationTimestamp: &metav1.Time{Time: timeNow.Add(time.Minute * -5)},
-						SuppressDeletion:  pointer.Bool(true),
+						SuppressDeletion:  ptr.To[bool](true),
 					},
 				},
 				timeout: timeout,

--- a/pkg/controllers/workloadrebalancer/workloadrebalancer_controller_test.go
+++ b/pkg/controllers/workloadrebalancer/workloadrebalancer_controller_test.go
@@ -26,7 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -126,7 +126,7 @@ var (
 	ttlFinishedRebalancer = &appsv1alpha1.WorkloadRebalancer{
 		ObjectMeta: metav1.ObjectMeta{Name: "ttl-finished-rebalancer", CreationTimestamp: oneHourAgo},
 		Spec: appsv1alpha1.WorkloadRebalancerSpec{
-			TTLSecondsAfterFinished: pointer.Int32(5),
+			TTLSecondsAfterFinished: ptr.To[int32](5),
 			Workloads:               []appsv1alpha1.ObjectReference{deploy1Obj},
 		},
 		Status: appsv1alpha1.WorkloadRebalancerStatus{

--- a/pkg/karmadactl/cmdinit/kubernetes/deployments.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deployments.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
 	globaloptions "github.com/karmada-io/karmada/pkg/karmadactl/options"
@@ -182,7 +182,7 @@ func (i *CommandInitOption) makeKarmadaAPIServerDeployment() *appsv1.Deployment 
 				},
 			},
 		},
-		AutomountServiceAccountToken: pointer.Bool(false),
+		AutomountServiceAccountToken: ptr.To[bool](false),
 		Containers: []corev1.Container{
 			{
 				Name:    karmadaAPIServerDeploymentAndServiceName,
@@ -296,7 +296,7 @@ func (i *CommandInitOption) makeKarmadaKubeControllerManagerDeployment() *appsv1
 				},
 			},
 		},
-		AutomountServiceAccountToken: pointer.Bool(false),
+		AutomountServiceAccountToken: ptr.To[bool](false),
 		Containers: []corev1.Container{
 			{
 				Name:  kubeControllerManagerClusterRoleAndDeploymentAndServiceName,
@@ -484,7 +484,7 @@ func (i *CommandInitOption) makeKarmadaSchedulerDeployment() *appsv1.Deployment 
 				Operator: corev1.TolerationOpExists,
 			},
 		},
-		AutomountServiceAccountToken: pointer.Bool(false),
+		AutomountServiceAccountToken: ptr.To[bool](false),
 	}
 
 	// PodTemplateSpec
@@ -606,7 +606,7 @@ func (i *CommandInitOption) makeKarmadaControllerManagerDeployment() *appsv1.Dep
 				Operator: corev1.TolerationOpExists,
 			},
 		},
-		AutomountServiceAccountToken: pointer.Bool(false),
+		AutomountServiceAccountToken: ptr.To[bool](false),
 	}
 
 	// PodTemplateSpec
@@ -676,7 +676,7 @@ func (i *CommandInitOption) makeKarmadaWebhookDeployment() *appsv1.Deployment {
 				},
 			},
 		},
-		AutomountServiceAccountToken: pointer.Bool(false),
+		AutomountServiceAccountToken: ptr.To[bool](false),
 		Containers: []corev1.Container{
 			{
 				Name:            webhookDeploymentAndServiceAccountAndServiceName,
@@ -846,7 +846,7 @@ func (i *CommandInitOption) makeKarmadaAggregatedAPIServerDeployment() *appsv1.D
 				},
 			},
 		},
-		AutomountServiceAccountToken: pointer.Bool(false),
+		AutomountServiceAccountToken: ptr.To[bool](false),
 		Containers: []corev1.Container{
 			{
 				Name:            karmadaAggregatedAPIServerDeploymentAndServiceName,

--- a/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/component-base/cli/flag"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/utils"
@@ -255,7 +255,7 @@ func (i *CommandInitOption) makeETCDStatefulSet() *appsv1.StatefulSet {
 				},
 			},
 		},
-		AutomountServiceAccountToken: pointer.Bool(false),
+		AutomountServiceAccountToken: ptr.To[bool](false),
 		Containers: []corev1.Container{
 			{
 				Name:  etcdStatefulSetAndServiceName,

--- a/pkg/karmadactl/get/get.go
+++ b/pkg/karmadactl/get/get.go
@@ -46,7 +46,7 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/interrupt"
 	"k8s.io/kubectl/pkg/util/templates"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
 	"github.com/karmada-io/karmada/pkg/karmadactl/options"
@@ -627,7 +627,7 @@ func (g *CommandGetOptions) watch(watchObjs []WatchObj) error {
 
 	info := infos[0]
 	mapping := info.ResourceMapping()
-	outputObjects := utilpointer.Bool(!g.WatchOnly)
+	outputObjects := ptr.To[bool](!g.WatchOnly)
 
 	printer, err := g.ToPrinter(mapping, outputObjects, g.AllNamespaces, false)
 	if err != nil {

--- a/pkg/resourceinterpreter/customized/declarative/luavm/lua_test.go
+++ b/pkg/resourceinterpreter/customized/declarative/luavm/lua_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	configv1alpha1 "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
@@ -57,7 +57,7 @@ func TestGetReplicas(t *testing.T) {
 					Name:      "bar",
 				},
 				Spec: appsv1.DeploymentSpec{
-					Replicas: pointer.Int32(1),
+					Replicas: ptr.To[int32](1),
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							NodeSelector: map[string]string{"foo": "foo1"},
@@ -108,7 +108,7 @@ end`,
 					Name:      "bar",
 				},
 				Spec: appsv1.DeploymentSpec{
-					Replicas: pointer.Int32(1),
+					Replicas: ptr.To[int32](1),
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							NodeSelector: map[string]string{"foo": "foo1"},
@@ -641,7 +641,7 @@ func Test_decodeValue(t *testing.T) {
 		{
 			name: "int pointer",
 			args: args{
-				value: pointer.Int(1),
+				value: ptr.To[int](1),
 			},
 			want: lua.LNumber(1),
 		},

--- a/pkg/scheduler/core/spreadconstraint/select_clusters_by_region.go
+++ b/pkg/scheduler/core/spreadconstraint/select_clusters_by_region.go
@@ -19,7 +19,7 @@ package spreadconstraint
 import (
 	"fmt"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
@@ -57,7 +57,7 @@ func selectBestClustersByRegion(spreadConstraintMap map[policyv1alpha1.SpreadFie
 	if restCnt > 0 {
 		sortClusters(candidateClusters, func(i *ClusterDetailInfo, j *ClusterDetailInfo) *bool {
 			if i.AvailableReplicas != j.AvailableReplicas {
-				return pointer.Bool(i.AvailableReplicas > j.AvailableReplicas)
+				return ptr.To[bool](i.AvailableReplicas > j.AvailableReplicas)
 			}
 			return nil
 		})

--- a/pkg/util/eventfilter/eventfilter_test.go
+++ b/pkg/util/eventfilter/eventfilter_test.go
@@ -23,7 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	workloadv1alpha1 "github.com/karmada-io/karmada/examples/customresourceinterpreter/apis/workload/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/util/helper"
@@ -120,7 +120,7 @@ func TestSpecificationChanged(t *testing.T) {
 					ManagedFields:   []metav1.ManagedFieldsEntry{{}},
 				},
 				Spec: workloadv1alpha1.WorkloadSpec{
-					Replicas: pointer.Int32(3),
+					Replicas: ptr.To[int32](3),
 					Template: corev1.PodTemplateSpec{},
 					Paused:   false,
 				},
@@ -132,7 +132,7 @@ func TestSpecificationChanged(t *testing.T) {
 					ManagedFields:   []metav1.ManagedFieldsEntry{{}},
 				},
 				Spec: workloadv1alpha1.WorkloadSpec{
-					Replicas: pointer.Int32(5),
+					Replicas: ptr.To[int32](5),
 					Template: corev1.PodTemplateSpec{},
 					Paused:   false,
 				},
@@ -148,7 +148,7 @@ func TestSpecificationChanged(t *testing.T) {
 					ManagedFields:   []metav1.ManagedFieldsEntry{{}},
 				},
 				Spec: workloadv1alpha1.WorkloadSpec{
-					Replicas: pointer.Int32(3),
+					Replicas: ptr.To[int32](3),
 					Template: corev1.PodTemplateSpec{},
 					Paused:   false,
 				},
@@ -160,7 +160,7 @@ func TestSpecificationChanged(t *testing.T) {
 					ManagedFields:   []metav1.ManagedFieldsEntry{{}, {}},
 				},
 				Spec: workloadv1alpha1.WorkloadSpec{
-					Replicas: pointer.Int32(3),
+					Replicas: ptr.To[int32](3),
 					Template: corev1.PodTemplateSpec{},
 					Paused:   false,
 				},
@@ -176,7 +176,7 @@ func TestSpecificationChanged(t *testing.T) {
 					ManagedFields:   []metav1.ManagedFieldsEntry{{}},
 				},
 				Spec: workloadv1alpha1.WorkloadSpec{
-					Replicas: pointer.Int32(3),
+					Replicas: ptr.To[int32](3),
 					Template: corev1.PodTemplateSpec{},
 					Paused:   false,
 				},
@@ -188,7 +188,7 @@ func TestSpecificationChanged(t *testing.T) {
 					ManagedFields:   []metav1.ManagedFieldsEntry{{}, {}},
 				},
 				Spec: workloadv1alpha1.WorkloadSpec{
-					Replicas: pointer.Int32(5),
+					Replicas: ptr.To[int32](5),
 					Template: corev1.PodTemplateSpec{},
 					Paused:   false,
 				},

--- a/pkg/util/helper/mcs_test.go
+++ b/pkg/util/helper/mcs_test.go
@@ -24,7 +24,7 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -56,7 +56,7 @@ func TestCreateOrUpdateEndpointSlice(t *testing.T) {
 						Addresses: []string{"1.1.1.1"},
 					}},
 					Ports: []discoveryv1.EndpointPort{{
-						Port: pointer.Int32(80),
+						Port: ptr.To[int32](80),
 					}},
 				},
 			},
@@ -71,7 +71,7 @@ func TestCreateOrUpdateEndpointSlice(t *testing.T) {
 					Conditions: discoveryv1.EndpointConditions{},
 				}},
 				Ports: []discoveryv1.EndpointPort{{
-					Port: pointer.Int32(80),
+					Port: ptr.To[int32](80),
 				}},
 			},
 			wantErr: false,
@@ -91,7 +91,7 @@ func TestCreateOrUpdateEndpointSlice(t *testing.T) {
 						Addresses: []string{"1.1.1.1"},
 					}},
 					Ports: []discoveryv1.EndpointPort{{
-						Port: pointer.Int32(80),
+						Port: ptr.To[int32](80),
 					}},
 				},
 			},
@@ -106,7 +106,7 @@ func TestCreateOrUpdateEndpointSlice(t *testing.T) {
 					Conditions: discoveryv1.EndpointConditions{},
 				}},
 				Ports: []discoveryv1.EndpointPort{{
-					Port: pointer.Int32(80),
+					Port: ptr.To[int32](80),
 				}},
 			},
 			wantErr: false,
@@ -125,7 +125,7 @@ func TestCreateOrUpdateEndpointSlice(t *testing.T) {
 							Addresses: []string{"1.1.1.1"},
 						}},
 						Ports: []discoveryv1.EndpointPort{{
-							Port: pointer.Int32(80),
+							Port: ptr.To[int32](80),
 						}},
 					}).Build(),
 				endpointSlice: &discoveryv1.EndpointSlice{
@@ -138,7 +138,7 @@ func TestCreateOrUpdateEndpointSlice(t *testing.T) {
 						Addresses: []string{"1.1.1.1"},
 					}},
 					Ports: []discoveryv1.EndpointPort{{
-						Port: pointer.Int32(80),
+						Port: ptr.To[int32](80),
 					}},
 				},
 			},
@@ -153,7 +153,7 @@ func TestCreateOrUpdateEndpointSlice(t *testing.T) {
 					Conditions: discoveryv1.EndpointConditions{},
 				}},
 				Ports: []discoveryv1.EndpointPort{{
-					Port: pointer.Int32(80),
+					Port: ptr.To[int32](80),
 				}},
 			},
 			wantErr: false,

--- a/pkg/util/helper/policy.go
+++ b/pkg/util/helper/policy.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	mcsv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
@@ -129,6 +129,6 @@ func SetReplicaDivisionPreferenceWeighted(placement *policyv1alpha1.Placement) {
 // SetDefaultGracePeriodSeconds sets the default value of GracePeriodSeconds in ApplicationFailoverBehavior
 func SetDefaultGracePeriodSeconds(behavior *policyv1alpha1.ApplicationFailoverBehavior) {
 	if behavior.PurgeMode == policyv1alpha1.Graciously && behavior.GracePeriodSeconds == nil {
-		behavior.GracePeriodSeconds = pointer.Int32(600)
+		behavior.GracePeriodSeconds = ptr.To[int32](600)
 	}
 }

--- a/pkg/util/helper/policy_test.go
+++ b/pkg/util/helper/policy_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
@@ -377,11 +377,11 @@ func TestSetDefaultGracePeriodSeconds(t *testing.T) {
 			name: "purgeMode is graciously and gracePeriodSeconds is set",
 			behavior: &policyv1alpha1.ApplicationFailoverBehavior{
 				PurgeMode:          policyv1alpha1.Graciously,
-				GracePeriodSeconds: pointer.Int32(200),
+				GracePeriodSeconds: ptr.To[int32](200),
 			},
 			expectBehavior: &policyv1alpha1.ApplicationFailoverBehavior{
 				PurgeMode:          policyv1alpha1.Graciously,
-				GracePeriodSeconds: pointer.Int32(200),
+				GracePeriodSeconds: ptr.To[int32](200),
 			},
 		},
 		{
@@ -391,7 +391,7 @@ func TestSetDefaultGracePeriodSeconds(t *testing.T) {
 			},
 			expectBehavior: &policyv1alpha1.ApplicationFailoverBehavior{
 				PurgeMode:          policyv1alpha1.Graciously,
-				GracePeriodSeconds: pointer.Int32(600),
+				GracePeriodSeconds: ptr.To[int32](600),
 			},
 		},
 	}

--- a/pkg/util/lifted/deployment_test.go
+++ b/pkg/util/lifted/deployment_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/storage/names"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // +lifted:source=https://github.com/kubernetes/kubernetes/blob/release-1.26/pkg/controller/deployment/util/deployment_util_test.go#L40-L49
@@ -203,7 +203,7 @@ func TestListReplicaSetsByDeployment(t *testing.T) {
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					UID:        "test",
-					Controller: pointer.Bool(true),
+					Controller: ptr.To[bool](true),
 				},
 			},
 		},
@@ -307,7 +307,7 @@ func TestListPodsByRS(t *testing.T) {
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					UID:        "test",
-					Controller: pointer.Bool(true),
+					Controller: ptr.To[bool](true),
 				},
 			},
 		},
@@ -345,7 +345,7 @@ func TestListPodsByRS(t *testing.T) {
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								UID:        "test",
-								Controller: pointer.Bool(true),
+								Controller: ptr.To[bool](true),
 							},
 						},
 					},
@@ -385,7 +385,7 @@ func TestListPodsByRS(t *testing.T) {
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								UID:        "test",
-								Controller: pointer.Bool(true),
+								Controller: ptr.To[bool](true),
 							},
 						},
 					},
@@ -421,7 +421,7 @@ func TestListPodsByRS(t *testing.T) {
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								UID:        "test",
-								Controller: pointer.Bool(true),
+								Controller: ptr.To[bool](true),
 							},
 						},
 					},
@@ -551,7 +551,7 @@ func TestGetNewReplicaSet(t *testing.T) {
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					UID:        "test",
-					Controller: pointer.Bool(true),
+					Controller: ptr.To[bool](true),
 				},
 			},
 		},

--- a/pkg/util/lifted/federatedhpa.go
+++ b/pkg/util/lifted/federatedhpa.go
@@ -19,7 +19,7 @@ package lifted
 import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	autoscalingv1alpha1 "github.com/karmada-io/karmada/pkg/apis/autoscaling/v1alpha1"
 )
@@ -75,7 +75,7 @@ var (
 
 func SetDefaultsFederatedHPA(obj *autoscalingv1alpha1.FederatedHPA) {
 	if obj.Spec.MinReplicas == nil {
-		obj.Spec.MinReplicas = pointer.Int32(1)
+		obj.Spec.MinReplicas = ptr.To[int32](1)
 	}
 
 	if len(obj.Spec.Metrics) == 0 {

--- a/pkg/util/lifted/federatedhpa_test.go
+++ b/pkg/util/lifted/federatedhpa_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // This code is lifted from the Kubernetes codebase in order to avoid relying on the k8s.io/kubernetes package.
@@ -59,13 +59,13 @@ func TestGenerateScaleDownRules(t *testing.T) {
 			rateDownPodsPeriodSeconds:    2,
 			rateDownPercent:              3,
 			rateDownPercentPeriodSeconds: 4,
-			stabilizationSeconds:         utilpointer.Int32(25),
+			stabilizationSeconds:         ptr.To[int32](25),
 			selectPolicy:                 &maxPolicy,
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 1, PeriodSeconds: 2},
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 3, PeriodSeconds: 4},
 			},
-			expectedStabilization: utilpointer.Int32(25),
+			expectedStabilization: ptr.To[int32](25),
 			expectedSelectPolicy:  string(autoscalingv2.MaxChangePolicySelect),
 		},
 		{
@@ -141,7 +141,7 @@ func TestGenerateScaleUpRules(t *testing.T) {
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 4, PeriodSeconds: 15},
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 100, PeriodSeconds: 15},
 			},
-			expectedStabilization: utilpointer.Int32(0),
+			expectedStabilization: ptr.To[int32](0),
 			expectedSelectPolicy:  string(autoscalingv2.MaxChangePolicySelect),
 		},
 		{
@@ -150,13 +150,13 @@ func TestGenerateScaleUpRules(t *testing.T) {
 			rateUpPodsPeriodSeconds:    2,
 			rateUpPercent:              3,
 			rateUpPercentPeriodSeconds: 4,
-			stabilizationSeconds:       utilpointer.Int32(25),
+			stabilizationSeconds:       ptr.To[int32](25),
 			selectPolicy:               &maxPolicy,
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 1, PeriodSeconds: 2},
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 3, PeriodSeconds: 4},
 			},
-			expectedStabilization: utilpointer.Int32(25),
+			expectedStabilization: ptr.To[int32](25),
 			expectedSelectPolicy:  string(autoscalingv2.MaxChangePolicySelect),
 		},
 		{
@@ -167,7 +167,7 @@ func TestGenerateScaleUpRules(t *testing.T) {
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 1, PeriodSeconds: 2},
 			},
-			expectedStabilization: utilpointer.Int32(0),
+			expectedStabilization: ptr.To[int32](0),
 			expectedSelectPolicy:  string(autoscalingv2.MinChangePolicySelect),
 		},
 		{
@@ -177,29 +177,29 @@ func TestGenerateScaleUpRules(t *testing.T) {
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 7, PeriodSeconds: 10},
 			},
-			expectedStabilization: utilpointer.Int32(0),
+			expectedStabilization: ptr.To[int32](0),
 			expectedSelectPolicy:  string(autoscalingv2.MaxChangePolicySelect),
 		},
 		{
 			annotation:              "Pod policy and stabilization window are specified",
 			rateUpPodsPeriodSeconds: 2,
-			stabilizationSeconds:    utilpointer.Int32(25),
+			stabilizationSeconds:    ptr.To[int32](25),
 			rateUpPods:              4,
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 4, PeriodSeconds: 2},
 			},
-			expectedStabilization: utilpointer.Int32(25),
+			expectedStabilization: ptr.To[int32](25),
 			expectedSelectPolicy:  string(autoscalingv2.MaxChangePolicySelect),
 		},
 		{
 			annotation:                 "Percent policy and stabilization window are specified",
 			rateUpPercent:              7,
 			rateUpPercentPeriodSeconds: 60,
-			stabilizationSeconds:       utilpointer.Int32(25),
+			stabilizationSeconds:       ptr.To[int32](25),
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 7, PeriodSeconds: 60},
 			},
-			expectedStabilization: utilpointer.Int32(25),
+			expectedStabilization: ptr.To[int32](25),
 			expectedSelectPolicy:  string(autoscalingv2.MaxChangePolicySelect),
 		},
 	}

--- a/pkg/util/lifted/retain_test.go
+++ b/pkg/util/lifted/retain_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // +lifted:source=https://github.com/kubernetes-sigs/kubefed/blob/master/pkg/controller/sync/dispatch/retain_test.go#L91-L174
@@ -93,7 +93,7 @@ func TestRetainHealthCheckNodePortInServiceFields(t *testing.T) {
 				},
 			},
 			true,
-			pointer.Int64(1000),
+			ptr.To[int64](1000),
 		},
 	}
 	for _, test := range tests {
@@ -166,7 +166,7 @@ func TestRetainClusterIPInServiceFields(t *testing.T) {
 				},
 			},
 			true,
-			pointer.String("1.2.3.4"),
+			ptr.To("1.2.3.4"),
 		},
 	}
 	for _, test := range tests {

--- a/pkg/util/lifted/validatingmci_test.go
+++ b/pkg/util/lifted/validatingmci_test.go
@@ -25,7 +25,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	networkingv1alpha1 "github.com/karmada-io/karmada/pkg/apis/networking/v1alpha1"
 )
@@ -177,7 +177,7 @@ func TestValidateIngress(t *testing.T) {
 							Backend: networkingv1.IngressBackend{
 								Service: serviceBackend,
 								Resource: &corev1.TypedLocalObjectReference{
-									APIGroup: utilpointer.String("example.com"),
+									APIGroup: ptr.To("example.com"),
 									Kind:     "foo",
 									Name:     "bar",
 								},
@@ -200,7 +200,7 @@ func TestValidateIngress(t *testing.T) {
 							Backend: networkingv1.IngressBackend{
 								Service: serviceBackend,
 								Resource: &corev1.TypedLocalObjectReference{
-									APIGroup: utilpointer.String("example.com"),
+									APIGroup: ptr.To("example.com"),
 									Kind:     "foo",
 									Name:     "bar",
 								},
@@ -218,7 +218,7 @@ func TestValidateIngress(t *testing.T) {
 				mci.Spec.DefaultBackend = &networkingv1.IngressBackend{
 					Service: serviceBackend,
 					Resource: &corev1.TypedLocalObjectReference{
-						APIGroup: utilpointer.String("example.com"),
+						APIGroup: ptr.To("example.com"),
 						Kind:     "foo",
 						Name:     "bar",
 					},
@@ -233,7 +233,7 @@ func TestValidateIngress(t *testing.T) {
 				mci.Spec.DefaultBackend = &networkingv1.IngressBackend{
 					Service: serviceBackend,
 					Resource: &corev1.TypedLocalObjectReference{
-						APIGroup: utilpointer.String("example.com"),
+						APIGroup: ptr.To("example.com"),
 						Kind:     "foo",
 						Name:     "bar",
 					},

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -25,7 +25,7 @@ import (
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/util"
@@ -160,12 +160,12 @@ func ValidateSpreadConstraint(spreadConstraints []policyv1alpha1.SpreadConstrain
 
 		if len(constraint.SpreadByField) > 0 {
 			marked := spreadByFieldsWithErrorMark[constraint.SpreadByField]
-			if !pointer.BoolDeref(marked, true) {
+			if !ptr.Deref[bool](marked, true) {
 				allErrs = append(allErrs, field.Invalid(fldPath, spreadConstraints, fmt.Sprintf("multiple %s spread constraints are not allowed", constraint.SpreadByField)))
 				*marked = true
 			}
 			if marked == nil {
-				spreadByFieldsWithErrorMark[constraint.SpreadByField] = pointer.Bool(false)
+				spreadByFieldsWithErrorMark[constraint.SpreadByField] = ptr.To[bool](false)
 			}
 		}
 	}

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -22,7 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/util"
@@ -602,7 +602,7 @@ func TestValidateApplicationFailover(t *testing.T) {
 			name: "the tolerationSeconds is less than zero",
 			applicationFailoverBehavior: &policyv1alpha1.ApplicationFailoverBehavior{
 				DecisionConditions: policyv1alpha1.DecisionConditions{
-					TolerationSeconds: pointer.Int32(-100),
+					TolerationSeconds: ptr.To[int32](-100),
 				},
 			},
 			expectedErr: "spec.failover.application.decisionConditions.tolerationSeconds: Invalid value: -100: must be greater than or equal to 0",
@@ -611,10 +611,10 @@ func TestValidateApplicationFailover(t *testing.T) {
 			name: "the gracePeriodSeconds is declared when purgeMode is not graciously",
 			applicationFailoverBehavior: &policyv1alpha1.ApplicationFailoverBehavior{
 				DecisionConditions: policyv1alpha1.DecisionConditions{
-					TolerationSeconds: pointer.Int32(100),
+					TolerationSeconds: ptr.To[int32](100),
 				},
 				PurgeMode:          policyv1alpha1.Immediately,
-				GracePeriodSeconds: pointer.Int32(100),
+				GracePeriodSeconds: ptr.To[int32](100),
 			},
 			expectedErr: "spec.failover.application.gracePeriodSeconds: Invalid value: 100: only takes effect when purgeMode is graciously",
 		},
@@ -622,10 +622,10 @@ func TestValidateApplicationFailover(t *testing.T) {
 			name: "the gracePeriodSeconds is less than 0 when purgeMode is graciously",
 			applicationFailoverBehavior: &policyv1alpha1.ApplicationFailoverBehavior{
 				DecisionConditions: policyv1alpha1.DecisionConditions{
-					TolerationSeconds: pointer.Int32(100),
+					TolerationSeconds: ptr.To[int32](100),
 				},
 				PurgeMode:          policyv1alpha1.Graciously,
-				GracePeriodSeconds: pointer.Int32(-100),
+				GracePeriodSeconds: ptr.To[int32](-100),
 			},
 			expectedErr: "spec.failover.application.gracePeriodSeconds: Invalid value: -100: must be greater than 0",
 		},
@@ -633,7 +633,7 @@ func TestValidateApplicationFailover(t *testing.T) {
 			name: "the gracePeriodSeconds is empty when purgeMode is graciously",
 			applicationFailoverBehavior: &policyv1alpha1.ApplicationFailoverBehavior{
 				DecisionConditions: policyv1alpha1.DecisionConditions{
-					TolerationSeconds: pointer.Int32(100),
+					TolerationSeconds: ptr.To[int32](100),
 				},
 				PurgeMode: policyv1alpha1.Graciously,
 			},
@@ -643,7 +643,7 @@ func TestValidateApplicationFailover(t *testing.T) {
 			name: "application behavior is correctly declared",
 			applicationFailoverBehavior: &policyv1alpha1.ApplicationFailoverBehavior{
 				DecisionConditions: policyv1alpha1.DecisionConditions{
-					TolerationSeconds: pointer.Int32(100),
+					TolerationSeconds: ptr.To[int32](100),
 				},
 			},
 			expectedErr: "",

--- a/pkg/webhook/cronfederatedhpa/validating.go
+++ b/pkg/webhook/cronfederatedhpa/validating.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	autoscalingv1alpha1 "github.com/karmada-io/karmada/pkg/apis/autoscaling/v1alpha1"
@@ -128,15 +128,15 @@ func validateCronFederatedHPAScalingReplicas(rule autoscalingv1alpha1.CronFedera
 			errs = append(errs, field.Invalid(fldPath.Child("targetMaxReplicas"), "",
 				"targetMinReplicas and targetMaxReplicas cannot be nil at the same time if you want to scale FederatedHPA"))
 		}
-		if pointer.Int32Deref(rule.TargetMinReplicas, 1) <= 0 {
+		if ptr.Deref(rule.TargetMinReplicas, 1) <= 0 {
 			errs = append(errs, field.Invalid(fldPath.Child("targetMinReplicas"), "",
 				"targetMinReplicas should be larger than 0"))
 		}
-		if pointer.Int32Deref(rule.TargetMaxReplicas, math.MaxInt32) <= 0 {
+		if ptr.Deref(rule.TargetMaxReplicas, math.MaxInt32) <= 0 {
 			errs = append(errs, field.Invalid(fldPath.Child("targetMaxReplicas"), "",
 				"targetMaxReplicas should be larger than 0"))
 		}
-		if pointer.Int32Deref(rule.TargetMinReplicas, 1) > pointer.Int32Deref(rule.TargetMaxReplicas, math.MaxInt32) {
+		if ptr.Deref(rule.TargetMinReplicas, 1) > ptr.Deref(rule.TargetMaxReplicas, math.MaxInt32) {
 			errs = append(errs, field.Invalid(fldPath.Child("targetMinReplicas"), "",
 				"targetMaxReplicas should be larger than or equal to targetMinReplicas"))
 		}
@@ -149,7 +149,7 @@ func validateCronFederatedHPAScalingReplicas(rule autoscalingv1alpha1.CronFedera
 		errs = append(errs, field.Invalid(fldPath.Child("targetReplicas"), "", errMsg))
 	}
 	// It's allowed to scale to 0, such as remove all the replicas when weekends
-	if pointer.Int32Deref(rule.TargetReplicas, 0) < 0 {
+	if ptr.Deref(rule.TargetReplicas, 0) < 0 {
 		errs = append(errs, field.Invalid(fldPath.Child("targetReplicas"), "",
 			"targetReplicas should be larger than or equal to 0"))
 	}

--- a/pkg/webhook/cronfederatedhpa/validating_test.go
+++ b/pkg/webhook/cronfederatedhpa/validating_test.go
@@ -23,7 +23,7 @@ import (
 
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	autoscalingv1alpha1 "github.com/karmada-io/karmada/pkg/apis/autoscaling/v1alpha1"
 )
@@ -48,7 +48,7 @@ func Test_validateCronFederatedHPASpec(t *testing.T) {
 					{
 						Name:           "bar",
 						Schedule:       "0 0 13 * 5",
-						TargetReplicas: pointer.Int32(1),
+						TargetReplicas: ptr.To[int32](1),
 					},
 				},
 			},
@@ -66,9 +66,9 @@ func Test_validateCronFederatedHPASpec(t *testing.T) {
 					{
 						Name:              "foo",
 						Schedule:          "0 0 13 * 1",
-						TargetReplicas:    pointer.Int32(2),
-						TargetMinReplicas: pointer.Int32(1),
-						TargetMaxReplicas: pointer.Int32(3),
+						TargetReplicas:    ptr.To[int32](2),
+						TargetMinReplicas: ptr.To[int32](1),
+						TargetMaxReplicas: ptr.To[int32](3),
 					},
 				},
 			},
@@ -86,7 +86,7 @@ func Test_validateCronFederatedHPASpec(t *testing.T) {
 					{
 						Name:           "bar",
 						Schedule:       "0 0 13 * 5",
-						TargetReplicas: pointer.Int32(1),
+						TargetReplicas: ptr.To[int32](1),
 					},
 				},
 			},
@@ -102,7 +102,7 @@ func Test_validateCronFederatedHPASpec(t *testing.T) {
 					{
 						Name:           "bar",
 						Schedule:       "0 0 13 * 5",
-						TargetReplicas: pointer.Int32(1),
+						TargetReplicas: ptr.To[int32](1),
 					},
 				},
 			},
@@ -118,7 +118,7 @@ func Test_validateCronFederatedHPASpec(t *testing.T) {
 					{
 						Name:           "bar",
 						Schedule:       "0 0 13 * 5",
-						TargetReplicas: pointer.Int32(1),
+						TargetReplicas: ptr.To[int32](1),
 					},
 				},
 			},
@@ -135,12 +135,12 @@ func Test_validateCronFederatedHPASpec(t *testing.T) {
 					{
 						Name:           "bar",
 						Schedule:       "0 0 13 * 5",
-						TargetReplicas: pointer.Int32(1),
+						TargetReplicas: ptr.To[int32](1),
 					},
 					{
 						Name:           "bar",
 						Schedule:       "0 0 13 * 5",
-						TargetReplicas: pointer.Int32(1),
+						TargetReplicas: ptr.To[int32](1),
 					},
 				},
 			},
@@ -157,7 +157,7 @@ func Test_validateCronFederatedHPASpec(t *testing.T) {
 					{
 						Name:           "bar",
 						Schedule:       "0 0 13 *",
-						TargetReplicas: pointer.Int32(1),
+						TargetReplicas: ptr.To[int32](1),
 					},
 				},
 			},
@@ -174,8 +174,8 @@ func Test_validateCronFederatedHPASpec(t *testing.T) {
 					{
 						Name:           "bar",
 						Schedule:       "0 0 13 * 1",
-						TimeZone:       pointer.String("A/B"),
-						TargetReplicas: pointer.Int32(1),
+						TimeZone:       ptr.To("A/B"),
+						TargetReplicas: ptr.To[int32](1),
 					},
 				},
 			},
@@ -208,7 +208,7 @@ func Test_validateCronFederatedHPASpec(t *testing.T) {
 					{
 						Name:           "bar",
 						Schedule:       "0 0 13 * 1",
-						TargetReplicas: pointer.Int32(-1),
+						TargetReplicas: ptr.To[int32](-1),
 					},
 				},
 			},
@@ -226,7 +226,7 @@ func Test_validateCronFederatedHPASpec(t *testing.T) {
 					{
 						Name:           "bar",
 						Schedule:       "0 0 13 * 1",
-						TargetReplicas: pointer.Int32(-1),
+						TargetReplicas: ptr.To[int32](-1),
 					},
 				},
 			},
@@ -244,8 +244,8 @@ func Test_validateCronFederatedHPASpec(t *testing.T) {
 					{
 						Name:              "bar",
 						Schedule:          "0 0 13 * 1",
-						TargetMinReplicas: pointer.Int32(-1),
-						TargetReplicas:    pointer.Int32(1),
+						TargetMinReplicas: ptr.To[int32](-1),
+						TargetReplicas:    ptr.To[int32](1),
 					},
 				},
 			},
@@ -263,8 +263,8 @@ func Test_validateCronFederatedHPASpec(t *testing.T) {
 					{
 						Name:              "bar",
 						Schedule:          "0 0 13 * 1",
-						TargetMaxReplicas: pointer.Int32(-1),
-						TargetReplicas:    pointer.Int32(1),
+						TargetMaxReplicas: ptr.To[int32](-1),
+						TargetReplicas:    ptr.To[int32](1),
 					},
 				},
 			},
@@ -282,9 +282,9 @@ func Test_validateCronFederatedHPASpec(t *testing.T) {
 					{
 						Name:              "bar",
 						Schedule:          "0 0 13 * 1",
-						TargetMinReplicas: pointer.Int32(3),
-						TargetMaxReplicas: pointer.Int32(1),
-						TargetReplicas:    pointer.Int32(1),
+						TargetMinReplicas: ptr.To[int32](3),
+						TargetMaxReplicas: ptr.To[int32](1),
+						TargetReplicas:    ptr.To[int32](1),
 					},
 				},
 			},

--- a/test/e2e/cronfederatedhpa_test.go
+++ b/test/e2e/cronfederatedhpa_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	autoscalingv1alpha1 "github.com/karmada-io/karmada/pkg/apis/autoscaling/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
@@ -82,8 +82,8 @@ var _ = ginkgo.Describe("[CronFederatedHPA] CronFederatedHPA testing", func() {
 
 	// case 1: Scale FederatedHPA.
 	ginkgo.Context("Scale FederatedHPA", func() {
-		targetMinReplicas := pointer.Int32(2)
-		targetMaxReplicas := pointer.Int32(100)
+		targetMinReplicas := ptr.To[int32](2)
+		targetMaxReplicas := ptr.To[int32](100)
 
 		ginkgo.BeforeEach(func() {
 			// */1 * * * * means the rule will be triggered every 1 minute
@@ -112,7 +112,7 @@ var _ = ginkgo.Describe("[CronFederatedHPA] CronFederatedHPA testing", func() {
 
 	// case 2. Scale deployment.
 	ginkgo.Context("Test scale Deployment", func() {
-		targetReplicas := pointer.Int32(4)
+		targetReplicas := ptr.To[int32](4)
 
 		ginkgo.BeforeEach(func() {
 			// */1 * * * * means the rule will be executed every 1 minute
@@ -138,7 +138,7 @@ var _ = ginkgo.Describe("[CronFederatedHPA] CronFederatedHPA testing", func() {
 	ginkgo.Context("Test suspend rule in CronFederatedHPA", func() {
 		ginkgo.BeforeEach(func() {
 			// */1 * * * * means the rule will be executed every 1 minute
-			rule := helper.NewCronFederatedHPARule("scale-up", "*/1 * * * *", true, pointer.Int32(30), nil, nil)
+			rule := helper.NewCronFederatedHPARule("scale-up", "*/1 * * * *", true, ptr.To[int32](30), nil, nil)
 			cronFHPA = helper.NewCronFederatedHPAWithScalingDeployment(testNamespace, cronFHPAName, deploymentName, rule)
 		})
 
@@ -162,7 +162,7 @@ var _ = ginkgo.Describe("[CronFederatedHPA] CronFederatedHPA testing", func() {
 	// case 4. Test unsuspend rule then suspend it in CronFederatedHPA
 	ginkgo.Context("Test unsuspend rule then suspend it in CronFederatedHPA", func() {
 		rule := autoscalingv1alpha1.CronFederatedHPARule{}
-		targetReplicas := pointer.Int32(4)
+		targetReplicas := ptr.To[int32](4)
 
 		ginkgo.BeforeEach(func() {
 			// */1 * * * * means the rule will be executed every 1 minute
@@ -186,7 +186,7 @@ var _ = ginkgo.Describe("[CronFederatedHPA] CronFederatedHPA testing", func() {
 			framework.UpdateDeploymentReplicas(kubeClient, deployment, *deployment.Spec.Replicas)
 
 			// Step 4. Suspend rule
-			rule.Suspend = pointer.Bool(true)
+			rule.Suspend = ptr.To[bool](true)
 			framework.UpdateCronFederatedHPAWithRule(karmadaClient, testNamespace, cronFHPAName, []autoscalingv1alpha1.CronFederatedHPARule{rule})
 
 			// Step 5. Check the replicas, which should not be changed

--- a/test/e2e/deploymentreplicassyncer_test.go
+++ b/test/e2e/deploymentreplicassyncer_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
@@ -59,7 +59,7 @@ var _ = ginkgo.Describe("deployment replicas syncer testing", func() {
 
 		deployment = helper.NewDeployment(namespace, deploymentName)
 		hpa = helper.NewHPA(namespace, hpaName, deploymentName)
-		hpa.Spec.MinReplicas = pointer.Int32(2)
+		hpa.Spec.MinReplicas = ptr.To[int32](2)
 		policy = helper.NewPropagationPolicy(namespace, policyName, []policyv1alpha1.ResourceSelector{
 			{APIVersion: deployment.APIVersion, Kind: deployment.Kind, Name: deployment.Name},
 			{APIVersion: hpa.APIVersion, Kind: hpa.Kind, Name: hpa.Name},
@@ -85,7 +85,7 @@ var _ = ginkgo.Describe("deployment replicas syncer testing", func() {
 
 	ginkgo.Context("when policy is Duplicated schedule type", func() {
 		ginkgo.BeforeEach(func() {
-			deployment.Spec.Replicas = pointer.Int32(2)
+			deployment.Spec.Replicas = ptr.To[int32](2)
 		})
 
 		// Case 1: Deployment(replicas=2) | Policy(Duplicated, two clusters) | HPA(minReplicas=2)
@@ -119,7 +119,7 @@ var _ = ginkgo.Describe("deployment replicas syncer testing", func() {
 	ginkgo.Context("when policy is Divided schedule type, each cluster have more that one replica", func() {
 		ginkgo.BeforeEach(func() {
 			policy.Spec.Placement.ReplicaScheduling = helper.NewStaticWeightPolicyStrategy(targetClusters, []int64{1, 1})
-			deployment.Spec.Replicas = pointer.Int32(4)
+			deployment.Spec.Replicas = ptr.To[int32](4)
 		})
 
 		// Case 2: Deployment(replicas=4) | Policy(Divided, two clusters 1:1) | HPA(minReplicas=2)
@@ -153,8 +153,8 @@ var _ = ginkgo.Describe("deployment replicas syncer testing", func() {
 	ginkgo.Context("when policy is Divided schedule type, one cluster have no replica", func() {
 		ginkgo.BeforeEach(func() {
 			policy.Spec.Placement.ReplicaScheduling = helper.NewStaticWeightPolicyStrategy(targetClusters, []int64{1, 1})
-			deployment.Spec.Replicas = pointer.Int32(1)
-			hpa.Spec.MinReplicas = pointer.Int32(1)
+			deployment.Spec.Replicas = ptr.To[int32](1)
+			hpa.Spec.MinReplicas = ptr.To[int32](1)
 		})
 
 		// Case 3: Deployment(replicas=1) | Policy(Divided, two clusters 1:1) | HPA(minReplicas=1)
@@ -175,8 +175,8 @@ var _ = ginkgo.Describe("deployment replicas syncer testing", func() {
 	ginkgo.Context("when policy is Divided schedule type, remove one cluster's replicas", func() {
 		ginkgo.BeforeEach(func() {
 			policy.Spec.Placement.ReplicaScheduling = helper.NewStaticWeightPolicyStrategy(targetClusters, []int64{1, 1})
-			deployment.Spec.Replicas = pointer.Int32(2)
-			hpa.Spec.MinReplicas = pointer.Int32(1)
+			deployment.Spec.Replicas = ptr.To[int32](2)
+			hpa.Spec.MinReplicas = ptr.To[int32](1)
 		})
 
 		// Case 4: Deployment(replicas=2) | Policy(Divided, two clusters 1:1) | HPA(minReplicas=1)
@@ -200,8 +200,8 @@ var _ = ginkgo.Describe("deployment replicas syncer testing", func() {
 	ginkgo.Context("when policy is Divided schedule type, propagate 1 replica but hpa minReplicas is 2", func() {
 		ginkgo.BeforeEach(func() {
 			policy.Spec.Placement.ReplicaScheduling = helper.NewStaticWeightPolicyStrategy(targetClusters, []int64{1, 1})
-			deployment.Spec.Replicas = pointer.Int32(1)
-			hpa.Spec.MinReplicas = pointer.Int32(2)
+			deployment.Spec.Replicas = ptr.To[int32](1)
+			hpa.Spec.MinReplicas = ptr.To[int32](2)
 		})
 
 		// Case 5: Deployment(replicas=1) | Policy(Divided, two clusters 1:1) | HPA(minReplicas=2)

--- a/test/e2e/failover_test.go
+++ b/test/e2e/failover_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
@@ -196,7 +196,7 @@ var _ = framework.SerialDescribe("failover testing", func() {
 						Key:               "fail-test",
 						Effect:            corev1.TaintEffectNoExecute,
 						Operator:          corev1.TolerationOpExists,
-						TolerationSeconds: pointer.Int64(3),
+						TolerationSeconds: ptr.To[int64](3),
 					},
 				},
 				SpreadConstraints: []policyv1alpha1.SpreadConstraint{
@@ -312,10 +312,10 @@ var _ = framework.SerialDescribe("failover testing", func() {
 					Failover: &policyv1alpha1.FailoverBehavior{
 						Application: &policyv1alpha1.ApplicationFailoverBehavior{
 							DecisionConditions: policyv1alpha1.DecisionConditions{
-								TolerationSeconds: pointer.Int32(30),
+								TolerationSeconds: ptr.To[int32](30),
 							},
 							PurgeMode:          policyv1alpha1.Graciously,
-							GracePeriodSeconds: pointer.Int32(30),
+							GracePeriodSeconds: ptr.To[int32](30),
 						},
 					},
 				},
@@ -440,7 +440,7 @@ var _ = framework.SerialDescribe("failover testing", func() {
 					Failover: &policyv1alpha1.FailoverBehavior{
 						Application: &policyv1alpha1.ApplicationFailoverBehavior{
 							DecisionConditions: policyv1alpha1.DecisionConditions{
-								TolerationSeconds: pointer.Int32(30),
+								TolerationSeconds: ptr.To[int32](30),
 							},
 							PurgeMode: policyv1alpha1.Never,
 						},

--- a/test/e2e/federatedhpa_test.go
+++ b/test/e2e/federatedhpa_test.go
@@ -21,7 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	autoscalingv1alpha1 "github.com/karmada-io/karmada/pkg/apis/autoscaling/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
@@ -82,9 +82,9 @@ var _ = ginkgo.Describe("testing for FederatedHPA and metrics-adapter", func() {
 		})
 		federatedHPA = testhelper.NewFederatedHPA(namespace, federatedHPAName, deploymentName)
 		federatedHPA.Spec.MaxReplicas = 6
-		federatedHPA.Spec.Behavior.ScaleUp = &autoscalingv2.HPAScalingRules{StabilizationWindowSeconds: pointer.Int32(3)}
-		federatedHPA.Spec.Behavior.ScaleDown = &autoscalingv2.HPAScalingRules{StabilizationWindowSeconds: pointer.Int32(3)}
-		federatedHPA.Spec.Metrics[0].Resource.Target.AverageUtilization = pointer.Int32(10)
+		federatedHPA.Spec.Behavior.ScaleUp = &autoscalingv2.HPAScalingRules{StabilizationWindowSeconds: ptr.To[int32](3)}
+		federatedHPA.Spec.Behavior.ScaleDown = &autoscalingv2.HPAScalingRules{StabilizationWindowSeconds: ptr.To[int32](3)}
+		federatedHPA.Spec.Metrics[0].Resource.Target.AverageUtilization = ptr.To[int32](10)
 
 		pressureJob = testhelper.NewJob(namespace, pressureJobName)
 		pressureJob.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
@@ -141,7 +141,7 @@ var _ = ginkgo.Describe("testing for FederatedHPA and metrics-adapter", func() {
 	// 1. duplicated scheduling
 	ginkgo.Context("FederatedHPA scale Deployment in Duplicated schedule type", func() {
 		ginkgo.BeforeEach(func() {
-			deployment.Spec.Replicas = pointer.Int32(1)
+			deployment.Spec.Replicas = ptr.To[int32](1)
 		})
 
 		ginkgo.It("do scale when metrics of cpu/mem utilization up in Duplicated schedule type", func() {

--- a/test/e2e/lazy_activation_policy_test.go
+++ b/test/e2e/lazy_activation_policy_test.go
@@ -23,7 +23,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/util"
@@ -73,7 +73,7 @@ var _ = ginkgo.Describe("Lazy activation policy testing", func() {
 				ClusterNames: []string{modifiedCluster},
 			},
 		})
-		policyHigherPriority.Spec.Priority = pointer.Int32(2)
+		policyHigherPriority.Spec.Priority = ptr.To[int32](2)
 		policyHigherPriority.Spec.Preemption = policyv1alpha1.PreemptAlways
 	})
 

--- a/test/e2e/preemption_test.go
+++ b/test/e2e/preemption_test.go
@@ -21,7 +21,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	"github.com/karmada-io/karmada/test/e2e/framework"
@@ -201,7 +201,7 @@ var _ = ginkgo.Describe("[Preemption] propagation policy preemption testing", fu
 				})
 
 				ginkgo.By("Reduce the priority of the high-priority PropagationPolicy to be preempted by the low-priority PropagationPolicy", func() {
-					highPriorityPolicy.Spec.Priority = pointer.Int32(4)
+					highPriorityPolicy.Spec.Priority = ptr.To[int32](4)
 					patch := []map[string]interface{}{
 						{
 							"path":  "/spec/priority",
@@ -326,7 +326,7 @@ var _ = ginkgo.Describe("[Preemption] propagation policy preemption testing", fu
 				})
 
 				ginkgo.By("Reduce the priority of the high-priority ClusterPropagationPolicy to be preempted by the low-priority ClusterPropagationPolicy", func() {
-					highPriorityPolicy.Spec.Priority = pointer.Int32(4)
+					highPriorityPolicy.Spec.Priority = ptr.To[int32](4)
 					patch := []map[string]interface{}{
 						{
 							"path":  "/spec/priority",

--- a/test/e2e/propagationpolicy_test.go
+++ b/test/e2e/propagationpolicy_test.go
@@ -38,7 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
@@ -410,7 +410,7 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 					return true
 				})
 
-			patch := []map[string]interface{}{{"op": "replace", "path": "/spec/backoffLimit", "value": pointer.Int32(updateBackoffLimit)}}
+			patch := []map[string]interface{}{{"op": "replace", "path": "/spec/backoffLimit", "value": ptr.To[int32](updateBackoffLimit)}}
 			bytes, err := json.Marshal(patch)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			framework.UpdateJobWithPatchBytes(kubeClient, job.Namespace, job.Name, bytes, types.JSONPatchType)

--- a/test/e2e/rescheduling_test.go
+++ b/test/e2e/rescheduling_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
@@ -89,7 +89,7 @@ var _ = ginkgo.Describe("[cluster unjoined] reschedule testing", func() {
 			deploymentNamespace = testNamespace
 			deploymentName = policyName
 			deployment = testhelper.NewDeployment(deploymentNamespace, deploymentName)
-			deployment.Spec.Replicas = pointer.Int32(10)
+			deployment.Spec.Replicas = ptr.To[int32](10)
 
 			policy = testhelper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
 				{
@@ -219,7 +219,7 @@ var _ = ginkgo.Describe("[cluster joined] reschedule testing", func() {
 				deploymentNamespace = testNamespace
 				deploymentName = policyName
 				deployment = testhelper.NewDeployment(deploymentNamespace, deploymentName)
-				deployment.Spec.Replicas = pointer.Int32(1)
+				deployment.Spec.Replicas = ptr.To[int32](1)
 				// set ReplicaSchedulingType=Duplicated.
 				policy = testhelper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
 					{
@@ -275,7 +275,7 @@ var _ = ginkgo.Describe("[cluster joined] reschedule testing", func() {
 				deploymentNamespace = testNamespace
 				deploymentName = policyName
 				deployment = testhelper.NewDeployment(deploymentNamespace, deploymentName)
-				deployment.Spec.Replicas = pointer.Int32(1)
+				deployment.Spec.Replicas = ptr.To[int32](1)
 				// set clusterAffinity for Placement.
 				policy = testhelper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
 					{

--- a/test/e2e/resourceinterpreter_test.go
+++ b/test/e2e/resourceinterpreter_test.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	workloadv1alpha1 "github.com/karmada-io/karmada/examples/customresourceinterpreter/apis/workload/v1alpha1"
 	configv1alpha1 "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1"
@@ -117,7 +117,7 @@ var _ = ginkgo.Describe("Resource interpreter webhook testing", func() {
 				gomega.Eventually(func(g gomega.Gomega) error {
 					curWorkload := framework.GetWorkload(dynamicClient, workloadNamespace, workloadName)
 					// construct two values that need to be changed, and only one value is retained.
-					curWorkload.Spec.Replicas = pointer.Int32(2)
+					curWorkload.Spec.Replicas = ptr.To[int32](2)
 					curWorkload.Spec.Paused = true
 
 					newUnstructuredObj, err := helper.ToUnstructured(curWorkload)
@@ -152,7 +152,7 @@ var _ = ginkgo.Describe("Resource interpreter webhook testing", func() {
 				sumWeight += index + 1
 				staticWeightLists = append(staticWeightLists, staticWeightList)
 			}
-			workload.Spec.Replicas = pointer.Int32(int32(sumWeight))
+			workload.Spec.Replicas = ptr.To[int32](int32(sumWeight))
 			policy = testhelper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
 				{
 					APIVersion: workload.APIVersion,
@@ -696,7 +696,7 @@ var _ = framework.SerialDescribe("Resource interpreter customization testing", f
 					sumWeight += index + 1
 					staticWeightLists = append(staticWeightLists, staticWeightList)
 				}
-				deployment.Spec.Replicas = pointer.Int32(int32(sumWeight))
+				deployment.Spec.Replicas = ptr.To[int32](int32(sumWeight))
 				policy.Spec.Placement = policyv1alpha1.Placement{
 					ClusterAffinity: &policyv1alpha1.ClusterAffinity{
 						ClusterNames: framework.ClusterNames(),

--- a/test/e2e/scheduling_test.go
+++ b/test/e2e/scheduling_test.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
@@ -339,7 +339,7 @@ var _ = ginkgo.Describe("propagation with label and group constraints testing", 
 				gomega.Expect(minGroups == len(groupMatchedClusters)).ShouldNot(gomega.BeFalse())
 			})
 
-			patch := map[string]interface{}{"spec": map[string]interface{}{"parallelism": pointer.Int32(updateParallelism)}}
+			patch := map[string]interface{}{"spec": map[string]interface{}{"parallelism": ptr.To[int32](updateParallelism)}}
 			bytes, err := json.Marshal(patch)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			framework.UpdateJobWithPatchBytes(kubeClient, job.Namespace, job.Name, bytes, types.StrategicMergePatchType)

--- a/test/e2e/workloadrebalancer_test.go
+++ b/test/e2e/workloadrebalancer_test.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	appsv1alpha1 "github.com/karmada-io/karmada/pkg/apis/apps/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
@@ -136,7 +136,7 @@ var _ = framework.SerialDescribe("workload rebalancer testing", func() {
 				Key:               taint.Key,
 				Effect:            taint.Effect,
 				Operator:          corev1.TolerationOpExists,
-				TolerationSeconds: pointer.Int64(0),
+				TolerationSeconds: ptr.To[int64](0),
 			}}
 		})
 
@@ -203,7 +203,7 @@ var _ = framework.SerialDescribe("workload rebalancer testing", func() {
 				Key:               taint.Key,
 				Effect:            taint.Effect,
 				Operator:          corev1.TolerationOpExists,
-				TolerationSeconds: pointer.Int64(0),
+				TolerationSeconds: ptr.To[int64](0),
 			}}
 		})
 

--- a/test/helper/resource.go
+++ b/test/helper/resource.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	workloadv1alpha1 "github.com/karmada-io/karmada/examples/customresourceinterpreter/apis/workload/v1alpha1"
 	appsv1alpha1 "github.com/karmada-io/karmada/pkg/apis/apps/v1alpha1"
@@ -107,7 +107,7 @@ func NewCronFederatedHPARule(name, cron string, suspend bool, targetReplicas, ta
 		TargetReplicas:    targetReplicas,
 		TargetMinReplicas: targetMinReplicas,
 		TargetMaxReplicas: targetMaxReplicas,
-		Suspend:           pointer.Bool(suspend),
+		Suspend:           ptr.To[bool](suspend),
 	}
 }
 
@@ -130,10 +130,10 @@ func NewFederatedHPA(namespace, name, scaleTargetDeployment string) *autoscaling
 			},
 			Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
 				ScaleDown: &autoscalingv2.HPAScalingRules{
-					StabilizationWindowSeconds: pointer.Int32(10),
+					StabilizationWindowSeconds: ptr.To[int32](10),
 				},
 			},
-			MinReplicas: pointer.Int32(1),
+			MinReplicas: ptr.To[int32](1),
 			MaxReplicas: 1,
 			Metrics: []autoscalingv2.MetricSpec{
 				{
@@ -142,7 +142,7 @@ func NewFederatedHPA(namespace, name, scaleTargetDeployment string) *autoscaling
 						Name: corev1.ResourceCPU,
 						Target: autoscalingv2.MetricTarget{
 							Type:               autoscalingv2.UtilizationMetricType,
-							AverageUtilization: pointer.Int32(80),
+							AverageUtilization: ptr.To[int32](80),
 						},
 					},
 				},
@@ -168,7 +168,7 @@ func NewHPA(namespace, name, scaleDeployment string) *autoscalingv2.HorizontalPo
 				Name:       scaleDeployment,
 				APIVersion: "apps/v1",
 			},
-			MinReplicas: pointer.Int32(4),
+			MinReplicas: ptr.To[int32](4),
 			MaxReplicas: 6,
 			Metrics: []autoscalingv2.MetricSpec{
 				{
@@ -177,7 +177,7 @@ func NewHPA(namespace, name, scaleDeployment string) *autoscalingv2.HorizontalPo
 						Name: corev1.ResourceCPU,
 						Target: autoscalingv2.MetricTarget{
 							Type:               autoscalingv2.UtilizationMetricType,
-							AverageUtilization: pointer.Int32(80),
+							AverageUtilization: ptr.To[int32](80),
 						},
 					},
 				},
@@ -200,7 +200,7 @@ func NewDeployment(namespace string, name string) *appsv1.Deployment {
 			Name:      name,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32(3),
+			Replicas: ptr.To[int32](3),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: podLabels,
 			},
@@ -305,7 +305,7 @@ func NewStatefulSet(namespace string, name string) *appsv1.StatefulSet {
 			Name:      name,
 		},
 		Spec: appsv1.StatefulSetSpec{
-			Replicas: pointer.Int32(3),
+			Replicas: ptr.To[int32](3),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: podLabels,
 			},
@@ -518,7 +518,7 @@ func NewJob(namespace string, name string) *batchv1.Job {
 					RestartPolicy: corev1.RestartPolicyNever,
 				},
 			},
-			BackoffLimit: pointer.Int32(4),
+			BackoffLimit: ptr.To[int32](4),
 		},
 	}
 }
@@ -710,7 +710,7 @@ func NewWorkload(namespace, name string) *workloadv1alpha1.Workload {
 			Name:      name,
 		},
 		Spec: workloadv1alpha1.WorkloadSpec{
-			Replicas: pointer.Int32(3),
+			Replicas: ptr.To[int32](3),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: podLabels,
@@ -740,7 +740,7 @@ func NewDeploymentWithVolumes(namespace, deploymentName string, volumes []corev1
 			Name:      deploymentName,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32(3),
+			Replicas: ptr.To[int32](3),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: podLabels,
 			},
@@ -775,7 +775,7 @@ func NewDeploymentWithServiceAccount(namespace, deploymentName string, serviceAc
 		},
 		Spec: appsv1.DeploymentSpec{
 
-			Replicas: pointer.Int32(3),
+			Replicas: ptr.To[int32](3),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: podLabels,
 			},


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind cleanup

**What this PR does / why we need it**:

~~1. Bump k8s.io/utils to 20240102154912-e7106e64919e~~
2. cleanup the deprecated package of pointer, use `k8s.io/utils/ptr` instead.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

