### PR TITLE
fix deployment replicas syncer in case deployment status changed before label added

### DIFF
--- a/pkg/controllers/deploymentreplicassyncer/deployment_replicas_syncer_controller.go
+++ b/pkg/controllers/deploymentreplicassyncer/deployment_replicas_syncer_controller.go
@@ -57,6 +57,13 @@ var predicateFunc = predicate.Funcs{
 			return false
 		}
 
+		// if old deployment is not labeled `retain-replicas`, but new is labeled, reconcile is needed.
+		// in case of deployment status changed before `retain-replicas` labeled.
+		oldRetainReplicasLabel := util.GetLabelValue(oldObj.GetLabels(), util.RetainReplicasLabel)
+		if oldRetainReplicasLabel != util.RetainReplicasValue {
+			return true
+		}
+
 		if oldObj.Spec.Replicas == nil || newObj.Spec.Replicas == nil {
 			klog.Errorf("spec.replicas field unexpectedly become nil: %+v, %+v", oldObj.Spec.Replicas, newObj.Spec.Replicas)
 			return false


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

fix deployment replicas syncer in case deployment status changed before label added

how to produce:
  1. propagate deployment with 1 replicas to two clusters by static weight 1:1 strategy policy.
  2. propagate hpa which `minReplicas=2` to two clusters.
  
then, we may observed the following results in order:
  1. hpa scale deployment in member1 cluster from 1 to 2.
  2. deployment status change collected, its status.replicas change from 1 to 2.
  3. `hpaScaleTargetMarker` add label `retain-replicas` to deployment.
  4. get deployment and see `ready/expect=2/1`

in this case, `deploymentReplicasSyncer` didn't do anything because after `retain-replicas` labeled, the deployment's `spec` and `status` had no changes.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

bugfix for #4707

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

