### PR TITLE
chore: bump cosigin to v2.2.3.

### DIFF
--- a/.github/workflows/dockerhub-latest-image.yml
+++ b/.github/workflows/dockerhub-latest-image.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.4.0
         with:
-          cosign-release: 'v1.13.1'
+          cosign-release: 'v2.2.3'
       - name: install QEMU
         uses: docker/setup-qemu-action@v2
       - name: install Buildx

--- a/.github/workflows/dockerhub-released-image.yml
+++ b/.github/workflows/dockerhub-released-image.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.4.0
         with:
-          cosign-release: 'v1.13.1'
+          cosign-release: 'v2.2.3'
       - name: install QEMU
         uses: docker/setup-qemu-action@v2
       - name: install Buildx


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind cleanup
**What this PR does / why we need it**:

cosigin team say it will happen in 1.13.x, need to update to v1.2.3 (: 
https://github.com/sigstore/cosign-installer/issues/158#issuecomment-2010958383

The reason is cosigin team publish a new TUF trust root, see https://blog.sigstore.dev/tuf-root-update/

verifyed it at full the workflow: https://github.com/liangyuanpeng/karmada/actions/runs/8367696249/job/22910549544

CI is green.


**Which issue(s) this PR fixes**:
Fixes #4727

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Karmada images is signing with cosigin v2.2.3
```

