### PR TITLE
Automated cherry pick of #4733: chore: Update sigstore/cosign-installer to v3.4.0.
#4736: chore: bump cosigin to v2.2.3.

### DIFF
--- a/.github/workflows/dockerhub-latest-image.yml
+++ b/.github/workflows/dockerhub-latest-image.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.4.0
         with:
-          cosign-release: 'v1.13.1'
+          cosign-release: 'v2.2.3'
       - name: install QEMU
         uses: docker/setup-qemu-action@v2
       - name: install Buildx

--- a/.github/workflows/dockerhub-latest-image.yml
+++ b/.github/workflows/dockerhub-latest-image.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           go-version: 1.20.12
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.1.1
+        uses: sigstore/cosign-installer@v3.4.0
         with:
           cosign-release: 'v1.13.1'
       - name: install QEMU

--- a/.github/workflows/dockerhub-released-image.yml
+++ b/.github/workflows/dockerhub-released-image.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.4.0
         with:
-          cosign-release: 'v1.13.1'
+          cosign-release: 'v2.2.3'
       - name: install QEMU
         uses: docker/setup-qemu-action@v2
       - name: install Buildx

--- a/.github/workflows/dockerhub-released-image.yml
+++ b/.github/workflows/dockerhub-released-image.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           go-version: 1.20.12
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.1.1
+        uses: sigstore/cosign-installer@v3.4.0
         with:
           cosign-release: 'v1.13.1'
       - name: install QEMU


### PR DESCRIPTION
Cherry pick of #4733 #4736 on release-1.8.
#4733: chore: Update sigstore/cosign-installer to v3.4.0.
#4736: chore: bump cosigin to v2.2.3.
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
```