### PR TITLE
Deprecated namespace and name label for PP/CPP

### DIFF
--- a/pkg/apis/policy/v1alpha1/well_known_constants.go
+++ b/pkg/apis/policy/v1alpha1/well_known_constants.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 package v1alpha1
 
+// The well-known label key constant.
 const (
 	// PropagationPolicyPermanentIDLabel is the identifier of a PropagationPolicy object.
 	// Karmada generates a unique identifier, such as metadata.UUID, for each PropagationPolicy object.
@@ -31,22 +32,16 @@ const (
 	// In backup scenarios, when applying the backup resource manifest in a new cluster, the UUID may change.
 	ClusterPropagationPolicyPermanentIDLabel = "clusterpropagationpolicy.karmada.io/permanent-id"
 
-	// PropagationPolicyNamespaceAnnotation is added to objects to specify associated PropagationPolicy namespace.
-	PropagationPolicyNamespaceAnnotation = "propagationpolicy.karmada.io/namespace"
-
-	// PropagationPolicyNameAnnotation is added to objects to specify associated PropagationPolicy name.
-	PropagationPolicyNameAnnotation = "propagationpolicy.karmada.io/name"
-
-	// ClusterPropagationPolicyAnnotation is added to objects to specify associated ClusterPropagationPolicy name.
-	ClusterPropagationPolicyAnnotation = "clusterpropagationpolicy.karmada.io/name"
-
 	// PropagationPolicyNamespaceLabel is added to objects to specify associated PropagationPolicy namespace.
+	// Deprecated
 	PropagationPolicyNamespaceLabel = "propagationpolicy.karmada.io/namespace"
 
 	// PropagationPolicyNameLabel is added to objects to specify associated PropagationPolicy's name.
+	// Deprecated
 	PropagationPolicyNameLabel = "propagationpolicy.karmada.io/name"
 
 	// ClusterPropagationPolicyLabel is added to objects to specify associated ClusterPropagationPolicy.
+	// Deprecated
 	ClusterPropagationPolicyLabel = "clusterpropagationpolicy.karmada.io/name"
 
 	// NamespaceSkipAutoPropagationLabel is added to namespace objects to indicate if
@@ -58,4 +53,16 @@ const (
 	// NOTE: If create a ns without this label, then patch it with this label, the ns will not be
 	// synced to new member clusters, but old member clusters still have it.
 	NamespaceSkipAutoPropagationLabel = "namespace.karmada.io/skip-auto-propagation"
+)
+
+// The well-known annotation key constant.
+const (
+	// PropagationPolicyNamespaceAnnotation is added to objects to specify associated PropagationPolicy namespace.
+	PropagationPolicyNamespaceAnnotation = "propagationpolicy.karmada.io/namespace"
+
+	// PropagationPolicyNameAnnotation is added to objects to specify associated PropagationPolicy name.
+	PropagationPolicyNameAnnotation = "propagationpolicy.karmada.io/name"
+
+	// ClusterPropagationPolicyAnnotation is added to objects to specify associated ClusterPropagationPolicy name.
+	ClusterPropagationPolicyAnnotation = "clusterpropagationpolicy.karmada.io/name"
 )

--- a/pkg/controllers/federatedhpa/federatedhpa_controller.go
+++ b/pkg/controllers/federatedhpa/federatedhpa_controller.go
@@ -407,19 +407,14 @@ func (c *FHPAController) getBindingByLabel(resourceLabel map[string]string, reso
 		return nil, fmt.Errorf("Target resource has no label. ")
 	}
 
-	var policyName, policyNameSpace string
 	var selector labels.Selector
-	if _, ok := resourceLabel[policyv1alpha1.PropagationPolicyNameLabel]; ok {
-		policyName = resourceLabel[policyv1alpha1.PropagationPolicyNameLabel]
-		policyNameSpace = resourceLabel[policyv1alpha1.PropagationPolicyNamespaceLabel]
+	if _, ok := resourceLabel[policyv1alpha1.PropagationPolicyPermanentIDLabel]; ok {
 		selector = labels.SelectorFromSet(labels.Set{
-			policyv1alpha1.PropagationPolicyNameLabel:      policyName,
-			policyv1alpha1.PropagationPolicyNamespaceLabel: policyNameSpace,
+			policyv1alpha1.PropagationPolicyPermanentIDLabel: resourceLabel[policyv1alpha1.PropagationPolicyPermanentIDLabel],
 		})
-	} else if _, ok = resourceLabel[policyv1alpha1.ClusterPropagationPolicyLabel]; ok {
-		policyName = resourceLabel[policyv1alpha1.ClusterPropagationPolicyLabel]
+	} else if _, ok = resourceLabel[policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel]; ok {
 		selector = labels.SelectorFromSet(labels.Set{
-			policyv1alpha1.ClusterPropagationPolicyLabel: policyName,
+			policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel: resourceLabel[policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel],
 		})
 	} else {
 		return nil, fmt.Errorf("No label of policy found. ")

--- a/pkg/controllers/hpascaletargetmarker/hpa_scale_target_marker_predicate.go
+++ b/pkg/controllers/hpascaletargetmarker/hpa_scale_target_marker_predicate.go
@@ -91,7 +91,6 @@ func (r *HpaScaleTargetMarker) Generic(_ event.GenericEvent) bool {
 }
 
 func hasBeenPropagated(hpa *autoscalingv2.HorizontalPodAutoscaler) bool {
-	_, ppExist := hpa.GetLabels()[policyv1alpha1.PropagationPolicyNameLabel]
-	_, cppExist := hpa.GetLabels()[policyv1alpha1.ClusterPropagationPolicyLabel]
-	return ppExist || cppExist
+	_, exist := hpa.GetLabels()[policyv1alpha1.PropagationPolicyPermanentIDLabel]
+	return exist
 }

--- a/pkg/controllers/multiclusterservice/mcs_controller.go
+++ b/pkg/controllers/multiclusterservice/mcs_controller.go
@@ -496,10 +496,7 @@ func (c *MCSController) claimMultiClusterServiceForService(svc *corev1.Service, 
 	}
 
 	// cleanup the policy labels
-	delete(svcCopy.Labels, policyv1alpha1.PropagationPolicyNameLabel)
-	delete(svcCopy.Labels, policyv1alpha1.PropagationPolicyNamespaceLabel)
 	delete(svcCopy.Labels, policyv1alpha1.PropagationPolicyPermanentIDLabel)
-	delete(svcCopy.Labels, policyv1alpha1.ClusterPropagationPolicyLabel)
 	delete(svcCopy.Labels, policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel)
 
 	svcCopy.Labels[util.ResourceTemplateClaimedByLabel] = util.MultiClusterServiceKind

--- a/pkg/scheduler/event_handler.go
+++ b/pkg/scheduler/event_handler.go
@@ -107,8 +107,8 @@ func (s *Scheduler) resourceBindingEventFilter(obj interface{}) bool {
 		}
 	}
 
-	return util.GetLabelValue(accessor.GetLabels(), policyv1alpha1.PropagationPolicyNameLabel) != "" ||
-		util.GetLabelValue(accessor.GetLabels(), policyv1alpha1.ClusterPropagationPolicyLabel) != "" ||
+	return util.GetLabelValue(accessor.GetLabels(), policyv1alpha1.PropagationPolicyPermanentIDLabel) != "" ||
+		util.GetLabelValue(accessor.GetLabels(), policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel) != "" ||
 		util.GetLabelValue(accessor.GetLabels(), workv1alpha2.BindingManagedByLabel) != ""
 }
 

--- a/pkg/util/annotation.go
+++ b/pkg/util/annotation.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -124,4 +125,17 @@ func DedupeAndMergeAnnotations(existAnnotation, newAnnotation map[string]string)
 		existAnnotation[k] = v
 	}
 	return existAnnotation
+}
+
+// RemoveAnnotations removes the annotations from the given object.
+func RemoveAnnotations(obj metav1.Object, keys ...string) {
+	if len(keys) == 0 {
+		return
+	}
+
+	objAnnotations := obj.GetAnnotations()
+	for _, key := range keys {
+		delete(objAnnotations, key)
+	}
+	obj.SetAnnotations(objAnnotations)
 }

--- a/pkg/util/label.go
+++ b/pkg/util/label.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -75,7 +76,7 @@ func MergeLabel(obj *unstructured.Unstructured, labelKey string, labelValue stri
 }
 
 // RemoveLabels removes the labels from the given object.
-func RemoveLabels(obj *unstructured.Unstructured, labelKeys ...string) {
+func RemoveLabels(obj metav1.Object, labelKeys ...string) {
 	if len(labelKeys) == 0 {
 		return
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Replace the use of `namespace/name` labels in the code with `permanent-id` labels for PP/CPP, including:
  - `propagationpolicy.karmada.io/namespace`, `propagationpolicy.karmada.io/name` -> `propagationpolicy.karmada.io/permanent-id`
  - `clusterpropagationpolicy.karmada.io/name` -> `clusterpropagationpolicy.karmada.io/permanent-id`

**Which issue(s) this PR fixes**:
Part of #4711 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-controller-manager: deprecated namespace and name label for PP/CPP
```

