### PR TITLE
Replace engineerd/setup-kind with helm/kind-action

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.21.8
-      - uses: engineerd/setup-kind@v0.5.0
+      - uses: helm/kind-action@v1.9.0
         with:
           version: "v0.20.0"
       - name: run karmadactl init test


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR updates the `engineerd/setup-kind` to eliminate the warnings. 
See #4669 for more details.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

