### PR TITLE
Remove work label on the member cluster resource

### DIFF
--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -25,7 +25,6 @@ import (
 
 	configv1alpha1 "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
-	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter"
 	"github.com/karmada-io/karmada/pkg/util"
@@ -109,7 +108,7 @@ func ensureWork(
 			klog.Errorf("Failed to apply overrides for %s/%s/%s, err is: %v", clonedWorkload.GetKind(), clonedWorkload.GetNamespace(), clonedWorkload.GetName(), err)
 			return err
 		}
-		workLabel := mergeLabel(clonedWorkload, workNamespace, binding, scope)
+		workLabel := mergeLabel(clonedWorkload, binding, scope)
 
 		annotations := mergeAnnotations(clonedWorkload, workNamespace, binding, scope)
 		annotations = mergeConflictResolution(clonedWorkload, conflictResolutionInBinding, annotations)
@@ -153,10 +152,8 @@ func mergeTargetClusters(targetClusters []workv1alpha2.TargetCluster, requiredBy
 	return targetClusters
 }
 
-func mergeLabel(workload *unstructured.Unstructured, workNamespace string, binding metav1.Object, scope apiextensionsv1.ResourceScope) map[string]string {
+func mergeLabel(workload *unstructured.Unstructured, binding metav1.Object, scope apiextensionsv1.ResourceScope) map[string]string {
 	var workLabel = make(map[string]string)
-	util.MergeLabel(workload, workv1alpha1.WorkNamespaceLabel, workNamespace)
-	util.MergeLabel(workload, workv1alpha1.WorkNameLabel, names.GenerateWorkName(workload.GetKind(), workload.GetName(), workload.GetNamespace()))
 	util.MergeLabel(workload, util.ManagedByKarmadaLabel, util.ManagedByKarmadaLabelValue)
 	if scope == apiextensionsv1.NamespaceScoped {
 		bindingID := util.GetLabelValue(binding.GetLabels(), workv1alpha2.ResourceBindingPermanentIDLabel)

--- a/pkg/controllers/binding/common_test.go
+++ b/pkg/controllers/binding/common_test.go
@@ -106,12 +106,11 @@ func Test_mergeLabel(t *testing.T) {
 	rbID := "93162d3c-ee8e-4995-9034-05f4d5d2c2b9"
 
 	tests := []struct {
-		name          string
-		workload      *unstructured.Unstructured
-		workNamespace string
-		binding       metav1.Object
-		scope         v1.ResourceScope
-		want          map[string]string
+		name     string
+		workload *unstructured.Unstructured
+		binding  metav1.Object
+		scope    v1.ResourceScope
+		want     map[string]string
 	}{
 		{
 			name: "NamespaceScoped",
@@ -125,7 +124,6 @@ func Test_mergeLabel(t *testing.T) {
 					},
 				},
 			},
-			workNamespace: namespace,
 			binding: &workv1alpha2.ClusterResourceBinding{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      bindingName,
@@ -169,7 +167,7 @@ func Test_mergeLabel(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := mergeLabel(tt.workload, tt.workNamespace, tt.binding, tt.scope); !reflect.DeepEqual(got, tt.want) {
+			if got := mergeLabel(tt.workload, tt.binding, tt.scope); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("mergeLabel() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/controllers/execution/execution_controller.go
+++ b/pkg/controllers/execution/execution_controller.go
@@ -170,7 +170,7 @@ func (c *Controller) tryDeleteWorkload(clusterName string, work *workv1alpha1.Wo
 		}
 
 		// Avoid deleting resources that not managed by karmada.
-		if util.GetLabelValue(clusterObj.GetLabels(), workv1alpha1.WorkNameLabel) != util.GetLabelValue(workload.GetLabels(), workv1alpha1.WorkNameLabel) {
+		if util.GetLabelValue(clusterObj.GetLabels(), util.ManagedByKarmadaLabel) != util.ManagedByKarmadaLabelValue {
 			klog.Infof("Abort deleting the resource(kind=%s, %s/%s) exists in cluster %v but not managed by karmada", clusterObj.GetKind(), clusterObj.GetNamespace(), clusterObj.GetName(), clusterName)
 			return nil
 		}

--- a/pkg/controllers/federatedresourcequota/federated_resource_quota_sync_controller.go
+++ b/pkg/controllers/federatedresourcequota/federated_resource_quota_sync_controller.go
@@ -37,6 +37,7 @@ import (
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/events"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/helper"
@@ -168,9 +169,11 @@ func (c *SyncController) buildWorks(quota *policyv1alpha1.FederatedResourceQuota
 		resourceQuota.Namespace = quota.Namespace
 		resourceQuota.Name = quota.Name
 		resourceQuota.Labels = map[string]string{
-			workv1alpha1.WorkNamespaceLabel: workNamespace,
-			workv1alpha1.WorkNameLabel:      workName,
-			util.ManagedByKarmadaLabel:      util.ManagedByKarmadaLabelValue,
+			util.ManagedByKarmadaLabel: util.ManagedByKarmadaLabelValue,
+		}
+		resourceQuota.Annotations = map[string]string{
+			workv1alpha2.WorkNamespaceAnnotation: workNamespace,
+			workv1alpha2.WorkNameAnnotation:      workName,
 		}
 		resourceQuota.Spec.Hard = extractClusterHardResourceList(quota.Spec, cluster.Name)
 

--- a/pkg/controllers/status/work_status_controller_test.go
+++ b/pkg/controllers/status/work_status_controller_test.go
@@ -40,6 +40,7 @@ import (
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter"
 	"github.com/karmada-io/karmada/pkg/sharedcli/ratelimiterflag"
 	"github.com/karmada-io/karmada/pkg/util"
@@ -371,8 +372,8 @@ func TestGenerateKey(t *testing.T) {
 					"metadata": map[string]interface{}{
 						"name":      "test",
 						"namespace": "default",
-						"labels": map[string]interface{}{
-							workv1alpha1.WorkNamespaceLabel: "karmada-es-cluster",
+						"annotations": map[string]interface{}{
+							workv1alpha2.WorkNamespaceAnnotation: "karmada-es-cluster",
 						},
 					},
 				},
@@ -389,8 +390,8 @@ func TestGenerateKey(t *testing.T) {
 					"metadata": map[string]interface{}{
 						"name":      "test",
 						"namespace": "default",
-						"labels": map[string]interface{}{
-							workv1alpha1.WorkNamespaceLabel: "karmada-cluster",
+						"annotations": map[string]interface{}{
+							workv1alpha2.WorkNamespaceAnnotation: "karmada-cluster",
 						},
 					},
 				},
@@ -452,8 +453,8 @@ func TestGetClusterNameFromLabel(t *testing.T) {
 					"metadata": map[string]interface{}{
 						"name":      "test",
 						"namespace": "default",
-						"labels": map[string]interface{}{
-							workv1alpha1.WorkNamespaceLabel: "karmada-es-cluster",
+						"annotations": map[string]interface{}{
+							workv1alpha2.WorkNamespaceAnnotation: "karmada-es-cluster",
 						},
 					},
 				},
@@ -488,8 +489,8 @@ func TestGetClusterNameFromLabel(t *testing.T) {
 					"metadata": map[string]interface{}{
 						"name":      "test",
 						"namespace": "default",
-						"labels": map[string]interface{}{
-							workv1alpha1.WorkNamespaceLabel: "karmada-cluster",
+						"annotations": map[string]interface{}{
+							workv1alpha2.WorkNamespaceAnnotation: "karmada-cluster",
 						},
 					},
 				},
@@ -520,9 +521,9 @@ func newPodObj(namespace string) *unstructured.Unstructured {
 			"metadata": map[string]interface{}{
 				"name":      "pod",
 				"namespace": "default",
-				"labels": map[string]interface{}{
-					workv1alpha1.WorkNamespaceLabel: namespace,
-					workv1alpha1.WorkNameLabel:      "work-name",
+				"annotations": map[string]interface{}{
+					workv1alpha2.WorkNamespaceAnnotation: namespace,
+					workv1alpha2.WorkNameAnnotation:      "work-name",
 				},
 			},
 		},
@@ -530,16 +531,16 @@ func newPodObj(namespace string) *unstructured.Unstructured {
 	return obj
 }
 
-func newPod(workNs, workName string, wrongLabel ...bool) *corev1.Pod {
+func newPod(workNs, workName string, wrongAnnotations ...bool) *corev1.Pod {
 	var pod *corev1.Pod
-	if len(wrongLabel) > 0 && wrongLabel[0] == true {
+	if len(wrongAnnotations) > 0 && wrongAnnotations[0] == true {
 		pod = &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pod",
 				Namespace: "default",
-				Labels: map[string]string{
-					"test":                     workNs,
-					workv1alpha1.WorkNameLabel: workName,
+				Annotations: map[string]string{
+					"test":                          workNs,
+					workv1alpha2.WorkNameAnnotation: workName,
 				},
 			},
 		}
@@ -548,9 +549,9 @@ func newPod(workNs, workName string, wrongLabel ...bool) *corev1.Pod {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pod",
 				Namespace: "default",
-				Labels: map[string]string{
-					workv1alpha1.WorkNamespaceLabel: workNs,
-					workv1alpha1.WorkNameLabel:      workName,
+				Annotations: map[string]string{
+					workv1alpha2.WorkNamespaceAnnotation: workNs,
+					workv1alpha2.WorkNameAnnotation:      workName,
 				},
 			},
 		}
@@ -850,8 +851,8 @@ func TestWorkStatusController_recreateResourceIfNeeded(t *testing.T) {
 			"metadata": map[string]interface{}{
 				"name":      "pod1",
 				"namespace": "default",
-				"labels": map[string]interface{}{
-					workv1alpha1.WorkNamespaceLabel: "karmada-es-cluster",
+				"annotations": map[string]interface{}{
+					workv1alpha2.WorkNamespaceAnnotation: "karmada-es-cluster",
 				},
 			},
 		},

--- a/pkg/util/objectwatcher/objectwatcher.go
+++ b/pkg/util/objectwatcher/objectwatcher.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configv1alpha1 "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1"
-	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter"
 	"github.com/karmada-io/karmada/pkg/util"
@@ -283,7 +282,7 @@ func (o *objectWatcherImpl) NeedsUpdate(clusterName string, desiredObj, clusterO
 
 func (o *objectWatcherImpl) allowUpdate(clusterName string, desiredObj, clusterObj *unstructured.Unstructured) bool {
 	// If the existing resource is managed by Karmada, then the updating is allowed.
-	if util.GetLabelValue(desiredObj.GetLabels(), workv1alpha1.WorkNameLabel) == util.GetLabelValue(clusterObj.GetLabels(), workv1alpha1.WorkNameLabel) {
+	if util.GetLabelValue(clusterObj.GetLabels(), util.ManagedByKarmadaLabel) == util.ManagedByKarmadaLabelValue {
 		return true
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Karmada will generate the work namespace/name labels on the resources propagated to member clusters:

- work.karmada.io/namespace
- work.karmada.io/name

When the created resource name is longer than 63 characters, those labels will cause the resource to fail to be created successfully in the member cluster.

So we need to remove those labels from resources propagated to member clusters.

**Which issue(s) this PR fixes**:
Fixes #4683 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-controller-manager: remove the work namespace/name labels from resources propagated to member clusters
```

