### PR TITLE
remove old MergeAnnotation func and rename ReplaceAnnotation to MergeAnnotation

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -780,7 +780,7 @@ func (d *ResourceDetector) ClaimClusterPolicyForObject(object *unstructured.Unst
 	util.MergeLabel(objectCopy, policyv1alpha1.ClusterPropagationPolicyLabel, policy.Name)
 	util.MergeLabel(objectCopy, policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel, policyID)
 
-	util.ReplaceAnnotation(objectCopy, policyv1alpha1.ClusterPropagationPolicyAnnotation, policy.Name)
+	util.MergeAnnotation(objectCopy, policyv1alpha1.ClusterPropagationPolicyAnnotation, policy.Name)
 	return policyID, d.Client.Update(context.TODO(), objectCopy)
 }
 

--- a/pkg/util/annotation.go
+++ b/pkg/util/annotation.go
@@ -26,21 +26,8 @@ import (
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 )
 
-// MergeAnnotation adds annotation for the given object, keep the value unchanged if key exist.
+// MergeAnnotation adds annotation for the given object, replace the value if key exist.
 func MergeAnnotation(obj *unstructured.Unstructured, annotationKey string, annotationValue string) {
-	objectAnnotation := obj.GetAnnotations()
-	if objectAnnotation == nil {
-		objectAnnotation = make(map[string]string, 1)
-	}
-
-	if _, exist := objectAnnotation[annotationKey]; !exist {
-		objectAnnotation[annotationKey] = annotationValue
-		obj.SetAnnotations(objectAnnotation)
-	}
-}
-
-// ReplaceAnnotation adds annotation for the given object, replace the value if key exist.
-func ReplaceAnnotation(obj *unstructured.Unstructured, annotationKey string, annotationValue string) {
 	objectAnnotation := obj.GetAnnotations()
 	if objectAnnotation == nil {
 		objectAnnotation = make(map[string]string, 1)

--- a/pkg/util/annotation_test.go
+++ b/pkg/util/annotation_test.go
@@ -25,118 +25,6 @@ import (
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 )
 
-func TestMergeAnnotation(t *testing.T) {
-	tests := []struct {
-		name            string
-		obj             *unstructured.Unstructured
-		annotationKey   string
-		annotationValue string
-		expected        *unstructured.Unstructured
-	}{
-		{
-			name: "nil annotations",
-			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "apps/v1",
-					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
-						"name": "demo-deployment",
-					},
-					"spec": map[string]interface{}{
-						"replicas": 2,
-					},
-				},
-			},
-			expected: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "apps/v1",
-					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
-						"name":        "demo-deployment",
-						"annotations": map[string]interface{}{"foo": "bar"},
-					},
-					"spec": map[string]interface{}{
-						"replicas": 2,
-					},
-				},
-			},
-			annotationKey:   "foo",
-			annotationValue: "bar",
-		},
-		{
-			name: "same annotationKey",
-			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "apps/v1",
-					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
-						"name":        "demo-deployment",
-						"annotations": map[string]interface{}{"foo": "bar"},
-					},
-					"spec": map[string]interface{}{
-						"replicas": 2,
-					},
-				},
-			},
-			expected: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "apps/v1",
-					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
-						"name":        "demo-deployment",
-						"annotations": map[string]interface{}{"foo": "bar"},
-					},
-					"spec": map[string]interface{}{
-						"replicas": 2,
-					},
-				},
-			},
-			annotationKey:   "foo",
-			annotationValue: "bar1",
-		},
-		{
-			name: "new labelKey",
-			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "apps/v1",
-					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
-						"name":        "demo-deployment",
-						"annotations": map[string]interface{}{"foo": "bar"},
-					},
-					"spec": map[string]interface{}{
-						"replicas": 2,
-					},
-				},
-			},
-			expected: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "apps/v1",
-					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
-						"name":        "demo-deployment",
-						"annotations": map[string]interface{}{"foo": "bar", "foo1": "bar1"},
-					},
-					"spec": map[string]interface{}{
-						"replicas": 2,
-					},
-				},
-			},
-			annotationKey:   "foo1",
-			annotationValue: "bar1",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			MergeAnnotation(tt.obj, tt.annotationKey, tt.annotationValue)
-			if !reflect.DeepEqual(tt.obj, tt.expected) {
-				t.Errorf("MergeAnnotation() = %v, want %v", tt.obj, tt.expected)
-			}
-		})
-	}
-}
-
 func TestRetainAnnotations(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -484,7 +372,7 @@ func TestRecordManagedAnnotations(t *testing.T) {
 	}
 }
 
-func TestReplaceAnnotation(t *testing.T) {
+func TestMergeAnnotation(t *testing.T) {
 	workload := unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "apps/v1",
@@ -530,9 +418,9 @@ func TestReplaceAnnotation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ReplaceAnnotation(tt.obj, tt.annotationKey, tt.annotationValue)
+			MergeAnnotation(tt.obj, tt.annotationKey, tt.annotationValue)
 			if !reflect.DeepEqual(tt.obj.GetAnnotations(), tt.want) {
-				t.Errorf("ReplaceAnnotation(), obj.GetAnnotations = %v, want %v", tt.obj.GetAnnotations(), tt.want)
+				t.Errorf("MergeAnnotation(), obj.GetAnnotations = %v, want %v", tt.obj.GetAnnotations(), tt.want)
 			}
 		})
 	}

--- a/pkg/util/helper/work.go
+++ b/pkg/util/helper/work.go
@@ -43,9 +43,9 @@ import (
 func CreateOrUpdateWork(client client.Client, workMeta metav1.ObjectMeta, resource *unstructured.Unstructured) error {
 	workload := resource.DeepCopy()
 	if conflictResolution, ok := workMeta.GetAnnotations()[workv1alpha2.ResourceConflictResolutionAnnotation]; ok {
-		util.ReplaceAnnotation(workload, workv1alpha2.ResourceConflictResolutionAnnotation, conflictResolution)
+		util.MergeAnnotation(workload, workv1alpha2.ResourceConflictResolutionAnnotation, conflictResolution)
 	}
-	util.ReplaceAnnotation(workload, workv1alpha2.ResourceTemplateUIDAnnotation, string(workload.GetUID()))
+	util.MergeAnnotation(workload, workv1alpha2.ResourceTemplateUIDAnnotation, string(workload.GetUID()))
 	util.RecordManagedAnnotations(workload)
 	workloadJSON, err := workload.MarshalJSON()
 	if err != nil {

--- a/pkg/util/label.go
+++ b/pkg/util/label.go
@@ -64,7 +64,7 @@ func RetainLabels(desired *unstructured.Unstructured, observed *unstructured.Uns
 	}
 }
 
-// MergeLabel adds label for the given object.
+// MergeLabel adds label for the given object, replace the value if key exist.
 func MergeLabel(obj *unstructured.Unstructured, labelKey string, labelValue string) {
 	labels := obj.GetLabels()
 	if labels == nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Learn from #4751, to avoid ambiguity and to be consistent with the Annotation naming convention:

https://github.com/karmada-io/karmada/blob/57c1989667d826864aa09105daa04434e2c75dd9/pkg/util/annotation.go#L29-L51


remove old MergeAnnotation func and rename ReplaceAnnotation to MergeAnnotation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

