### PR TITLE
Fixe invalid kubebuilder marker, that makes pinned plural name does not work.

### DIFF
--- a/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
+++ b/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: operator.karmada.io
   names:
+    categories:
+    - karmada-io
     kind: Karmada
     listKind: KarmadaList
     plural: karmadas

--- a/operator/config/crds/operator.karmada.io_karmadas.yaml
+++ b/operator/config/crds/operator.karmada.io_karmadas.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: operator.karmada.io
   names:
+    categories:
+    - karmada-io
     kind: Karmada
     listKind: KarmadaList
     plural: karmadas

--- a/operator/pkg/apis/operator/v1alpha1/type.go
+++ b/operator/pkg/apis/operator/v1alpha1/type.go
@@ -24,7 +24,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
-// +kubebuilder:path=karmadas,scope=Namespaced,categories={karmada-io}
+// +kubebuilder:resource:path=karmadas,scope=Namespaced,categories={karmada-io}
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Ready")].status`,name="Ready",type=string
 // +kubebuilder:printcolumn:JSONPath=`.metadata.creationTimestamp`,name="Age",type=date
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

When configuring CRD naming and scope the valid marker should be the format `+kubebuilder:resource:xxx`, but the operator mistakenly marked `+kubebuilder:xxx`, which makes the mark doesn't work.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

I found this during updating the [controller-tools](https://github.com/karmada-io/karmada/blob/70afc1ad6d170bd4773b5e7a9735a4116816f814/hack/update-crdgen.sh#L22) to v0.12.0+, and I found the plural name of Operator changed to `Karmada` instead of `Karmadas`. That means the pinned plural name not work.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

