### PR TITLE
Pin plural name for all APIs to avoid unexpected change

### DIFF
--- a/charts/karmada/_crds/bases/config/config.karmada.io_resourceinterpretercustomizations.yaml
+++ b/charts/karmada/_crds/bases/config/config.karmada.io_resourceinterpretercustomizations.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: config.karmada.io
   names:
+    categories:
+    - karmada-io
     kind: ResourceInterpreterCustomization
     listKind: ResourceInterpreterCustomizationList
     plural: resourceinterpretercustomizations

--- a/charts/karmada/_crds/bases/config/config.karmada.io_resourceinterpreterwebhookconfigurations.yaml
+++ b/charts/karmada/_crds/bases/config/config.karmada.io_resourceinterpreterwebhookconfigurations.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: config.karmada.io
   names:
+    categories:
+    - karmada-io
     kind: ResourceInterpreterWebhookConfiguration
     listKind: ResourceInterpreterWebhookConfigurationList
     plural: resourceinterpreterwebhookconfigurations

--- a/charts/karmada/_crds/bases/remedy/remedy.karmada.io_remedies.yaml
+++ b/charts/karmada/_crds/bases/remedy/remedy.karmada.io_remedies.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: remedy.karmada.io
   names:
+    categories:
+    - karmada-io
     kind: Remedy
     listKind: RemedyList
     plural: remedies

--- a/pkg/apis/autoscaling/v1alpha1/cronfederatedhpa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/cronfederatedhpa_types.go
@@ -21,7 +21,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:shortName=cronfhpa,categories={karmada-io}
+// +kubebuilder:resource:path=cronfederatedhpas,scope=Namespaced,shortName=cronfhpa,categories={karmada-io}
 // +kubebuilder:printcolumn:JSONPath=`.spec.scaleTargetRef.kind`,name=`REFERENCE-KIND`,type=string
 // +kubebuilder:printcolumn:JSONPath=`.spec.scaleTargetRef.name`,name=`REFERENCE-NAME`,type=string
 // +kubebuilder:printcolumn:JSONPath=`.metadata.creationTimestamp`,name=`AGE`,type=date

--- a/pkg/apis/autoscaling/v1alpha1/federatedhpa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/federatedhpa_types.go
@@ -24,7 +24,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:shortName=fhpa,categories={karmada-io}
+// +kubebuilder:resource:path=federatedhpas,scope=Namespaced,shortName=fhpa,categories={karmada-io}
 // +kubebuilder:printcolumn:JSONPath=`.spec.scaleTargetRef.kind`,name=`REFERENCE-KIND`,type=string
 // +kubebuilder:printcolumn:JSONPath=`.spec.scaleTargetRef.name`,name=`REFERENCE-NAME`,type=string
 // +kubebuilder:printcolumn:JSONPath=`.spec.minReplicas`,name=`MINPODS`,type=integer

--- a/pkg/apis/config/v1alpha1/resourceinterpretercustomization_types.go
+++ b/pkg/apis/config/v1alpha1/resourceinterpretercustomization_types.go
@@ -34,7 +34,7 @@ const (
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope="Cluster"
+// +kubebuilder:resource:path=resourceinterpretercustomizations,scope="Cluster",categories={karmada-io}
 // +kubebuilder:storageversion
 
 // ResourceInterpreterCustomization describes the configuration of a specific

--- a/pkg/apis/config/v1alpha1/resourceinterpreterwebhook_types.go
+++ b/pkg/apis/config/v1alpha1/resourceinterpreterwebhook_types.go
@@ -35,7 +35,7 @@ const (
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope="Cluster"
+// +kubebuilder:resource:path=resourceinterpreterwebhookconfigurations,scope="Cluster",categories={karmada-io}
 // +kubebuilder:storageversion
 
 // ResourceInterpreterWebhookConfiguration describes the configuration of webhooks which take the responsibility to

--- a/pkg/apis/networking/v1alpha1/ingress_types.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types.go
@@ -35,7 +35,7 @@ const (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:shortName=mci,categories={karmada-io}
+// +kubebuilder:resource:path=multiclusteringresses,scope=Namespaced,shortName=mci,categories={karmada-io}
 
 // MultiClusterIngress is a collection of rules that allow inbound connections to reach the
 // endpoints defined by a backend. The structure of MultiClusterIngress is same as Ingress,

--- a/pkg/apis/networking/v1alpha1/service_types.go
+++ b/pkg/apis/networking/v1alpha1/service_types.go
@@ -39,7 +39,7 @@ const (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:shortName=mcs,categories={karmada-io}
+// +kubebuilder:resource:path=multiclusterservices,scope=Namespaced,shortName=mcs,categories={karmada-io}
 
 // MultiClusterService is a named abstraction of multi-cluster software service.
 // The name field of MultiClusterService is the same as that of Service name.

--- a/pkg/apis/policy/v1alpha1/federatedresourcequota_types.go
+++ b/pkg/apis/policy/v1alpha1/federatedresourcequota_types.go
@@ -34,7 +34,7 @@ const (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:categories={karmada-io}
+// +kubebuilder:resource:path=federatedresourcequotas,scope=Namespaced,categories={karmada-io}
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 

--- a/pkg/apis/policy/v1alpha1/override_types.go
+++ b/pkg/apis/policy/v1alpha1/override_types.go
@@ -43,7 +43,7 @@ const (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:shortName=op,categories={karmada-io}
+// +kubebuilder:resource:path=overridepolicies,scope=Namespaced,shortName=op,categories={karmada-io}
 
 // OverridePolicy represents the policy that overrides a group of resources to one or more clusters.
 type OverridePolicy struct {
@@ -268,7 +268,7 @@ type OverridePolicyList struct {
 
 // +genclient
 // +genclient:nonNamespaced
-// +kubebuilder:resource:scope="Cluster",shortName=cop,categories={karmada-io}
+// +kubebuilder:resource:path=clusteroverridepolicies,scope="Cluster",shortName=cop,categories={karmada-io}
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ClusterOverridePolicy represents the cluster-wide policy that overrides a group of resources to one or more clusters.

--- a/pkg/apis/policy/v1alpha1/propagation_types.go
+++ b/pkg/apis/policy/v1alpha1/propagation_types.go
@@ -43,7 +43,7 @@ const (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:shortName=pp,categories={karmada-io}
+// +kubebuilder:resource:path=propagationpolicies,scope=Namespaced,shortName=pp,categories={karmada-io}
 
 // PropagationPolicy represents the policy that propagates a group of resources to one or more clusters.
 type PropagationPolicy struct {
@@ -560,7 +560,7 @@ type PropagationPolicyList struct {
 
 // +genclient
 // +genclient:nonNamespaced
-// +kubebuilder:resource:scope="Cluster",shortName=cpp,categories={karmada-io}
+// +kubebuilder:resource:path=clusterpropagationpolicies,scope="Cluster",shortName=cpp,categories={karmada-io}
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ClusterPropagationPolicy represents the cluster-wide policy that propagates a group of resources to one or more clusters.

--- a/pkg/apis/remedy/v1alpha1/remedy_types.go
+++ b/pkg/apis/remedy/v1alpha1/remedy_types.go
@@ -23,7 +23,7 @@ import (
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope="Cluster"
+// +kubebuilder:resource:path=remedies,scope="Cluster",categories={karmada-io}
 
 // Remedy represents the cluster-level management strategies based on cluster conditions.
 type Remedy struct {

--- a/pkg/apis/work/v1alpha1/binding_types.go
+++ b/pkg/apis/work/v1alpha1/binding_types.go
@@ -25,7 +25,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:shortName=rb,categories={karmada-io}
+// +kubebuilder:resource:path=resourcebindings,scope=Namespaced,shortName=rb,categories={karmada-io}
 
 // ResourceBinding represents a binding of a kubernetes resource with a propagation policy.
 type ResourceBinding struct {
@@ -135,7 +135,7 @@ type ResourceBindingList struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope="Cluster",shortName=crb,categories={karmada-io}
+// +kubebuilder:resource:path=clusterresourcebindings,scope="Cluster",shortName=crb,categories={karmada-io}
 // +kubebuilder:subresource:status
 
 // ClusterResourceBinding represents a binding of a kubernetes resource with a ClusterPropagationPolicy.
@@ -151,7 +151,6 @@ type ClusterResourceBinding struct {
 	Status ResourceBindingStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:resource:scope="Cluster"
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ClusterResourceBindingList contains a list of ClusterResourceBinding.

--- a/pkg/apis/work/v1alpha1/work_types.go
+++ b/pkg/apis/work/v1alpha1/work_types.go
@@ -35,7 +35,7 @@ const (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:categories={karmada-io},shortName=wk
+// +kubebuilder:resource:path=works,scope=Namespaced,shortName=wk,categories={karmada-io}
 // +kubebuilder:printcolumn:JSONPath=`.spec.workload.manifests[*].kind`,name="Workload-Kind",type=string
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Applied")].status`,name="Applied",type=string
 // +kubebuilder:printcolumn:JSONPath=`.metadata.creationTimestamp`,name="Age",type=date

--- a/pkg/apis/work/v1alpha2/binding_types.go
+++ b/pkg/apis/work/v1alpha2/binding_types.go
@@ -48,7 +48,7 @@ const (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:shortName=rb,categories={karmada-io}
+// +kubebuilder:resource:path=resourcebindings,scope=Namespaced,shortName=rb,categories={karmada-io}
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Scheduled")].status`,name="Scheduled",type=string
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="FullyApplied")].status`,name="FullyApplied",type=string
@@ -391,7 +391,7 @@ const (
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope="Cluster",shortName=crb,categories={karmada-io}
+// +kubebuilder:resource:path=clusterresourcebindings,scope="Cluster",shortName=crb,categories={karmada-io}
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Scheduled")].status`,name="Scheduled",type=string
@@ -411,7 +411,6 @@ type ClusterResourceBinding struct {
 	Status ResourceBindingStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:resource:scope="Cluster"
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ClusterResourceBindingList contains a list of ClusterResourceBinding.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
When the controller-tools generate the CRDs, it [guesses the plural name](https://github.com/kubernetes-sigs/controller-tools/blob/80fc62f695b13677135377f47b61c61908661f10/pkg/crd/spec.go#L66) by [github.com/gobuffalo/flect](https://github.com/gobuffalo/flect) if the plural name is not explicitly specified.

But the rule of generating plural names might change over different [github.com/gobuffalo/flect](https://github.com/gobuffalo/flect) versions. See https://github.com/kubernetes-sigs/controller-tools/pull/804#discussion_r1178098768 for an example.

So, this PR pin plural name for all APIs to avoid this unexpected change.
(We don't depend on [github.com/gobuffalo/flect](https://github.com/gobuffalo/flect), but the controller-tools reply on it. We might update controller-tools.)
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

I'm trying to update the [controller-tools](https://github.com/karmada-io/karmada/blob/70afc1ad6d170bd4773b5e7a9735a4116816f814/hack/update-crdgen.sh#L22) but found the plural name of Karmada operator changed unexpectedly(see the fix at #4777), that reminds me we'd better pin the plural name.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

