### PR TITLE
Use merge strategy to avoid work.karmada.io/permanent-id changes

### DIFF
--- a/pkg/util/helper/work.go
+++ b/pkg/util/helper/work.go
@@ -78,8 +78,8 @@ func CreateOrUpdateWork(client client.Client, workMeta metav1.ObjectMeta, resour
 			}
 
 			runtimeObject.Spec = work.Spec
-			runtimeObject.Labels = work.Labels
-			runtimeObject.Annotations = work.Annotations
+			runtimeObject.Labels = util.DedupeAndMergeLabels(runtimeObject.Labels, work.Labels)
+			runtimeObject.Annotations = util.DedupeAndMergeAnnotations(runtimeObject.Annotations, work.Annotations)
 			if util.GetLabelValue(runtimeObject.Labels, workv1alpha2.WorkPermanentIDLabel) == "" {
 				runtimeObject.Labels = util.DedupeAndMergeLabels(runtimeObject.Labels, map[string]string{workv1alpha2.WorkPermanentIDLabel: uuid.New().String()})
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Since labels will be overwritten every time they are updated and created, this causes `work.karmada.io/permanent-id` to constantly change.
I add some debug logs in karmada-webhook to capture the bug:
![image](https://github.com/karmada-io/karmada/assets/89241565/66ae09c5-3ea1-4c2d-8153-dbede9fcf6f8)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-controller-manager: Fix the problem that work.karmada.io/permanent-id constantly changes with every update.
```

