### PR TITLE
when controller return error is non-nil not need to set Result.Requeue 

### DIFF
--- a/pkg/controllers/applicationfailover/crb_application_failover_controller.go
+++ b/pkg/controllers/applicationfailover/crb_application_failover_controller.go
@@ -71,7 +71,7 @@ func (c *CRBApplicationFailoverController) Reconcile(ctx context.Context, req co
 			c.workloadUnhealthyMap.delete(req.NamespacedName)
 			return controllerruntime.Result{}, nil
 		}
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	if !c.clusterResourceBindingFilter(binding) {
@@ -81,7 +81,7 @@ func (c *CRBApplicationFailoverController) Reconcile(ctx context.Context, req co
 
 	retryDuration, err := c.syncBinding(binding)
 	if err != nil {
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 	if retryDuration > 0 {
 		klog.V(4).Infof("Retry to check health status of the workload after %v minutes.", retryDuration.Minutes())

--- a/pkg/controllers/applicationfailover/rb_application_failover_controller.go
+++ b/pkg/controllers/applicationfailover/rb_application_failover_controller.go
@@ -71,7 +71,7 @@ func (c *RBApplicationFailoverController) Reconcile(ctx context.Context, req con
 			c.workloadUnhealthyMap.delete(req.NamespacedName)
 			return controllerruntime.Result{}, nil
 		}
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	if !c.bindingFilter(binding) {
@@ -81,7 +81,7 @@ func (c *RBApplicationFailoverController) Reconcile(ctx context.Context, req con
 
 	retryDuration, err := c.syncBinding(binding)
 	if err != nil {
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 	if retryDuration > 0 {
 		klog.V(4).Infof("Retry to check health status of the workload after %v minutes.", retryDuration.Minutes())

--- a/pkg/controllers/binding/binding_controller_test.go
+++ b/pkg/controllers/binding/binding_controller_test.go
@@ -111,7 +111,7 @@ func TestResourceBindingController_Reconcile(t *testing.T) {
 		},
 		{
 			name:    "RB found without deleting",
-			want:    controllerruntime.Result{Requeue: true},
+			want:    controllerruntime.Result{},
 			wantErr: true,
 			rb: &workv1alpha2.ResourceBinding{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/certificate/cert_rotation_controller.go
+++ b/pkg/controllers/certificate/cert_rotation_controller.go
@@ -98,7 +98,7 @@ func (c *CertRotationController) Reconcile(ctx context.Context, req controllerru
 			return controllerruntime.Result{}, nil
 		}
 
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	if !cluster.DeletionTimestamp.IsZero() {
@@ -109,18 +109,18 @@ func (c *CertRotationController) Reconcile(ctx context.Context, req controllerru
 	c.ClusterClient, err = c.ClusterClientSetFunc(cluster.Name, c.Client, c.ClusterClientOption)
 	if err != nil {
 		klog.Errorf("Failed to create a ClusterClient for the given member cluster: %s, err is: %v", cluster.Name, err)
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	secret, err := c.ClusterClient.KubeClient.CoreV1().Secrets(c.KarmadaKubeconfigNamespace).Get(ctx, KarmadaKubeconfigName, metav1.GetOptions{})
 	if err != nil {
 		klog.Errorf("failed to get karmada kubeconfig secret: %v", err)
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	if err = c.syncCertRotation(secret); err != nil {
 		klog.Errorf("Failed to rotate the certificate of karmada-agent for the given member cluster: %s, err is: %v", cluster.Name, err)
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	return controllerruntime.Result{RequeueAfter: c.CertRotationCheckingInterval}, nil

--- a/pkg/controllers/cluster/taint_manager.go
+++ b/pkg/controllers/cluster/taint_manager.go
@@ -67,7 +67,7 @@ func (tc *NoExecuteTaintManager) Reconcile(ctx context.Context, req reconcile.Re
 		if apierrors.IsNotFound(err) {
 			return controllerruntime.Result{}, nil
 		}
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	// Check whether the target cluster has no execute taints.
@@ -85,7 +85,7 @@ func (tc *NoExecuteTaintManager) syncCluster(ctx context.Context, cluster *clust
 		Selector: fields.OneTermEqualSelector(rbClusterKeyIndex, cluster.Name),
 	}); err != nil {
 		klog.ErrorS(err, "Failed to list ResourceBindings", "cluster", cluster.Name)
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 	for i := range rbList.Items {
 		key, err := keys.FederatedKeyFunc(cluster.Name, &rbList.Items[i])
@@ -102,7 +102,7 @@ func (tc *NoExecuteTaintManager) syncCluster(ctx context.Context, cluster *clust
 		Selector: fields.OneTermEqualSelector(crbClusterKeyIndex, cluster.Name),
 	}); err != nil {
 		klog.ErrorS(err, "Failed to list ClusterResourceBindings", "cluster", cluster.Name)
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 	for i := range crbList.Items {
 		key, err := keys.FederatedKeyFunc(cluster.Name, &crbList.Items[i])

--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_controller.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_controller.go
@@ -64,7 +64,7 @@ func (c *CronFHPAController) Reconcile(ctx context.Context, req controllerruntim
 		}
 
 		klog.Errorf("Fail to get CronFederatedHPA(%s):%v", req.NamespacedName, err)
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	//  If this CronFederatedHPA is deleting, stop all related cron executors
@@ -92,7 +92,7 @@ func (c *CronFHPAController) Reconcile(ctx context.Context, req controllerruntim
 	newRuleSets := sets.New[string]()
 	for _, rule := range cronFHPA.Spec.Rules {
 		if err = c.processCronRule(cronFHPA, rule); err != nil {
-			return controllerruntime.Result{Requeue: true}, err
+			return controllerruntime.Result{}, err
 		}
 		newRuleSets.Insert(rule.Name)
 	}
@@ -104,7 +104,7 @@ func (c *CronFHPAController) Reconcile(ctx context.Context, req controllerruntim
 		}
 		c.CronHandler.StopRuleExecutor(req.NamespacedName.String(), name)
 		if err = c.removeCronFHPAHistory(cronFHPA, name); err != nil {
-			return controllerruntime.Result{Requeue: true}, err
+			return controllerruntime.Result{}, err
 		}
 	}
 

--- a/pkg/controllers/federatedresourcequota/federated_resource_quota_status_controller.go
+++ b/pkg/controllers/federatedresourcequota/federated_resource_quota_status_controller.go
@@ -70,7 +70,7 @@ func (c *StatusController) Reconcile(ctx context.Context, req controllerruntime.
 		if apierrors.IsNotFound(err) {
 			return controllerruntime.Result{}, nil
 		}
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	if !quota.DeletionTimestamp.IsZero() {
@@ -80,7 +80,7 @@ func (c *StatusController) Reconcile(ctx context.Context, req controllerruntime.
 	if err := c.collectQuotaStatus(quota); err != nil {
 		klog.Errorf("Failed to collect status from works to federatedResourceQuota(%s), error: %v", req.NamespacedName.String(), err)
 		c.EventRecorder.Eventf(quota, corev1.EventTypeWarning, events.EventReasonCollectFederatedResourceQuotaStatusFailed, err.Error())
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 	c.EventRecorder.Eventf(quota, corev1.EventTypeNormal, events.EventReasonCollectFederatedResourceQuotaStatusSucceed, "Collect status of FederatedResourceQuota(%s) succeed.", req.NamespacedName.String())
 	return controllerruntime.Result{}, nil

--- a/pkg/controllers/federatedresourcequota/federated_resource_quota_sync_controller.go
+++ b/pkg/controllers/federatedresourcequota/federated_resource_quota_sync_controller.go
@@ -67,23 +67,23 @@ func (c *SyncController) Reconcile(ctx context.Context, req controllerruntime.Re
 			klog.V(4).Infof("Begin to cleanup works created by federatedResourceQuota(%s)", req.NamespacedName.String())
 			if err = c.cleanUpWorks(req.Namespace, req.Name); err != nil {
 				klog.Errorf("Failed to cleanup works created by federatedResourceQuota(%s)", req.NamespacedName.String())
-				return controllerruntime.Result{Requeue: true}, err
+				return controllerruntime.Result{}, err
 			}
 			return controllerruntime.Result{}, nil
 		}
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	clusterList := &clusterv1alpha1.ClusterList{}
 	if err := c.Client.List(ctx, clusterList); err != nil {
 		klog.Errorf("Failed to list clusters, error: %v", err)
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	if err := c.buildWorks(quota, clusterList.Items); err != nil {
 		klog.Errorf("Failed to build works for federatedResourceQuota(%s), error: %v", req.NamespacedName.String(), err)
 		c.EventRecorder.Eventf(quota, corev1.EventTypeWarning, events.EventReasonSyncFederatedResourceQuotaFailed, err.Error())
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 	c.EventRecorder.Eventf(quota, corev1.EventTypeNormal, events.EventReasonSyncFederatedResourceQuotaSucceed, "Sync works for FederatedResourceQuota(%s) succeed.", req.NamespacedName.String())
 

--- a/pkg/controllers/gracefuleviction/crb_graceful_eviction_controller.go
+++ b/pkg/controllers/gracefuleviction/crb_graceful_eviction_controller.go
@@ -59,7 +59,7 @@ func (c *CRBGracefulEvictionController) Reconcile(ctx context.Context, req contr
 		if apierrors.IsNotFound(err) {
 			return controllerruntime.Result{}, nil
 		}
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	if !binding.DeletionTimestamp.IsZero() {
@@ -68,7 +68,7 @@ func (c *CRBGracefulEvictionController) Reconcile(ctx context.Context, req contr
 
 	retryDuration, err := c.syncBinding(binding)
 	if err != nil {
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 	if retryDuration > 0 {
 		klog.V(4).Infof("Retry to evict task after %v minutes.", retryDuration.Minutes())

--- a/pkg/controllers/gracefuleviction/rb_graceful_eviction_controller.go
+++ b/pkg/controllers/gracefuleviction/rb_graceful_eviction_controller.go
@@ -59,7 +59,7 @@ func (c *RBGracefulEvictionController) Reconcile(ctx context.Context, req contro
 		if apierrors.IsNotFound(err) {
 			return controllerruntime.Result{}, nil
 		}
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	if !binding.DeletionTimestamp.IsZero() {
@@ -68,7 +68,7 @@ func (c *RBGracefulEvictionController) Reconcile(ctx context.Context, req contro
 
 	retryDuration, err := c.syncBinding(binding)
 	if err != nil {
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 	if retryDuration > 0 {
 		klog.V(4).Infof("Retry to evict task after %v minutes.", retryDuration.Minutes())

--- a/pkg/controllers/mcs/service_import_controller.go
+++ b/pkg/controllers/mcs/service_import_controller.go
@@ -54,7 +54,7 @@ func (c *ServiceImportController) Reconcile(ctx context.Context, req controllerr
 			return c.deleteDerivedService(req.NamespacedName)
 		}
 
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	if !svcImport.DeletionTimestamp.IsZero() || svcImport.Spec.Type != mcsv1alpha1.ClusterSetIP {
@@ -63,7 +63,7 @@ func (c *ServiceImportController) Reconcile(ctx context.Context, req controllerr
 
 	if err := c.deriveServiceFromServiceImport(svcImport); err != nil {
 		c.EventRecorder.Eventf(svcImport, corev1.EventTypeWarning, events.EventReasonSyncDerivedServiceFailed, err.Error())
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 	c.EventRecorder.Eventf(svcImport, corev1.EventTypeNormal, events.EventReasonSyncDerivedServiceSucceed, "Sync derived service for serviceImport(%s) succeed.", svcImport.Name)
 	return controllerruntime.Result{}, nil
@@ -86,13 +86,13 @@ func (c *ServiceImportController) deleteDerivedService(svcImport types.Namespace
 			return controllerruntime.Result{}, nil
 		}
 
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	err = c.Client.Delete(context.TODO(), derivedSvc)
 	if err != nil && !apierrors.IsNotFound(err) {
 		klog.Errorf("Delete derived service(%s) failed, Error: %v", derivedSvcNamespacedName, err)
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	return controllerruntime.Result{}, nil

--- a/pkg/controllers/multiclusterservice/endpointslice_collect_controller.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_collect_controller.go
@@ -86,7 +86,7 @@ func (c *EndpointSliceCollectController) Reconcile(ctx context.Context, req cont
 		if apierrors.IsNotFound(err) {
 			return controllerruntime.Result{}, nil
 		}
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	if !helper.IsWorkContains(work.Spec.Workload.Manifests, multiClusterServiceGVK) {
@@ -101,15 +101,15 @@ func (c *EndpointSliceCollectController) Reconcile(ctx context.Context, req cont
 	clusterName, err := names.GetClusterName(work.Namespace)
 	if err != nil {
 		klog.Errorf("Failed to get cluster name for work %s/%s", work.Namespace, work.Name)
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	if err = c.buildResourceInformers(clusterName); err != nil {
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	if err = c.collectTargetEndpointSlice(work, clusterName); err != nil {
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	return controllerruntime.Result{}, nil

--- a/pkg/controllers/multiclusterservice/endpointslice_dispatch_controller.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_dispatch_controller.go
@@ -69,7 +69,7 @@ func (c *EndpointsliceDispatchController) Reconcile(ctx context.Context, req con
 		if apierrors.IsNotFound(err) {
 			return controllerruntime.Result{}, nil
 		}
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	if !helper.IsWorkContains(work.Spec.Workload.Manifests, util.EndpointSliceGVK) {
@@ -80,7 +80,7 @@ func (c *EndpointsliceDispatchController) Reconcile(ctx context.Context, req con
 	if !work.DeletionTimestamp.IsZero() || mcsName == "" {
 		if err := c.cleanupEndpointSliceFromConsumerClusters(ctx, work); err != nil {
 			klog.Errorf("Failed to cleanup EndpointSlice from consumer clusters for work %s/%s:%v", work.Namespace, work.Name, err)
-			return controllerruntime.Result{Requeue: true}, err
+			return controllerruntime.Result{}, err
 		}
 		return controllerruntime.Result{}, nil
 	}
@@ -92,7 +92,7 @@ func (c *EndpointsliceDispatchController) Reconcile(ctx context.Context, req con
 			klog.Warningf("MultiClusterService %s/%s is not found", mcsNS, mcsName)
 			return controllerruntime.Result{}, nil
 		}
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	var err error
@@ -107,11 +107,11 @@ func (c *EndpointsliceDispatchController) Reconcile(ctx context.Context, req con
 	}()
 
 	if err = c.cleanOrphanDispatchedEndpointSlice(ctx, mcs); err != nil {
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	if err = c.dispatchEndpointSlice(ctx, work.DeepCopy(), mcs); err != nil {
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	return controllerruntime.Result{}, nil

--- a/pkg/controllers/namespace/namespace_sync_controller.go
+++ b/pkg/controllers/namespace/namespace_sync_controller.go
@@ -77,7 +77,7 @@ func (c *Controller) Reconcile(ctx context.Context, req controllerruntime.Reques
 			return controllerruntime.Result{}, nil
 		}
 
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	if !namespace.DeletionTimestamp.IsZero() {
@@ -95,13 +95,13 @@ func (c *Controller) Reconcile(ctx context.Context, req controllerruntime.Reques
 	clusterList := &clusterv1alpha1.ClusterList{}
 	if err := c.Client.List(ctx, clusterList); err != nil {
 		klog.Errorf("Failed to list clusters, error: %v", err)
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	err := c.buildWorks(namespace, clusterList.Items)
 	if err != nil {
 		klog.Errorf("Failed to build work for namespace %s. Error: %v.", namespace.GetName(), err)
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	return controllerruntime.Result{}, nil

--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -143,7 +143,7 @@ func (c *ClusterStatusController) Reconcile(ctx context.Context, req controllerr
 			return controllerruntime.Result{}, nil
 		}
 
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	// start syncing status only when the finalizer is present on the given Cluster to
@@ -213,7 +213,7 @@ func (c *ClusterStatusController) syncClusterStatus(cluster *clusterv1alpha1.Clu
 
 		err := c.setCurrentClusterStatus(clusterClient, cluster, &currentClusterStatus)
 		if err != nil {
-			return controllerruntime.Result{Requeue: true}, err
+			return controllerruntime.Result{}, err
 		}
 	}
 
@@ -293,7 +293,7 @@ func (c *ClusterStatusController) updateStatusIfNeeded(cluster *clusterv1alpha1.
 		})
 		if err != nil {
 			klog.Errorf("Failed to update health status of the member cluster: %v, err is : %v", cluster.Name, err)
-			return controllerruntime.Result{Requeue: true}, err
+			return controllerruntime.Result{}, err
 		}
 	}
 

--- a/pkg/controllers/status/cluster_status_controller_test.go
+++ b/pkg/controllers/status/cluster_status_controller_test.go
@@ -979,7 +979,7 @@ func TestClusterStatusController_updateStatusIfNeeded(t *testing.T) {
 		}
 
 		actual, err := c.updateStatusIfNeeded(cluster, currentClusterStatus)
-		expect := controllerruntime.Result{Requeue: true}
+		expect := controllerruntime.Result{}
 		assert.Equal(t, expect, actual)
 		assert.NotEmpty(t, err, "updateStatusIfNeeded doesn't return error")
 	})

--- a/pkg/controllers/status/crb_status_controller.go
+++ b/pkg/controllers/status/crb_status_controller.go
@@ -67,7 +67,7 @@ func (c *CRBStatusController) Reconcile(ctx context.Context, req controllerrunti
 			return controllerruntime.Result{}, nil
 		}
 
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	// The crb is being deleted, in which case we stop processing.
@@ -77,7 +77,7 @@ func (c *CRBStatusController) Reconcile(ctx context.Context, req controllerrunti
 
 	err := c.syncBindingStatus(binding)
 	if err != nil {
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 	return controllerruntime.Result{}, nil
 }

--- a/pkg/controllers/status/rb_status_controller.go
+++ b/pkg/controllers/status/rb_status_controller.go
@@ -67,7 +67,7 @@ func (c *RBStatusController) Reconcile(ctx context.Context, req controllerruntim
 			return controllerruntime.Result{}, nil
 		}
 
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	// The rb is being deleted, in which case we stop processing.
@@ -77,7 +77,7 @@ func (c *RBStatusController) Reconcile(ctx context.Context, req controllerruntim
 
 	err := c.syncBindingStatus(binding)
 	if err != nil {
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 	return controllerruntime.Result{}, nil
 }

--- a/pkg/controllers/status/work_status_controller.go
+++ b/pkg/controllers/status/work_status_controller.go
@@ -88,7 +88,7 @@ func (c *WorkStatusController) Reconcile(ctx context.Context, req controllerrunt
 			return controllerruntime.Result{}, nil
 		}
 
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	if !work.DeletionTimestamp.IsZero() {
@@ -102,18 +102,18 @@ func (c *WorkStatusController) Reconcile(ctx context.Context, req controllerrunt
 	clusterName, err := names.GetClusterName(work.GetNamespace())
 	if err != nil {
 		klog.Errorf("Failed to get member cluster name by %s. Error: %v.", work.GetNamespace(), err)
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	cluster, err := util.GetCluster(c.Client, clusterName)
 	if err != nil {
 		klog.Errorf("Failed to the get given member cluster %s", clusterName)
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	if !util.IsClusterReady(&cluster.Status) {
 		klog.Errorf("Stop sync work(%s/%s) for cluster(%s) as cluster not ready.", work.Namespace, work.Name, cluster.Name)
-		return controllerruntime.Result{Requeue: true}, fmt.Errorf("cluster(%s) not ready", cluster.Name)
+		return controllerruntime.Result{}, fmt.Errorf("cluster(%s) not ready", cluster.Name)
 	}
 
 	return c.buildResourceInformers(cluster, work)
@@ -125,7 +125,7 @@ func (c *WorkStatusController) buildResourceInformers(cluster *clusterv1alpha1.C
 	err := c.registerInformersAndStart(cluster, work)
 	if err != nil {
 		klog.Errorf("Failed to register informer for Work %s/%s. Error: %v.", work.GetNamespace(), work.GetName(), err)
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 	return controllerruntime.Result{}, nil
 }

--- a/pkg/controllers/status/work_status_controller_test.go
+++ b/pkg/controllers/status/work_status_controller_test.go
@@ -235,7 +235,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 				},
 			},
 			ns:        "karmada-cluster",
-			expectRes: controllerruntime.Result{Requeue: true},
+			expectRes: controllerruntime.Result{},
 			existErr:  true,
 		},
 		{
@@ -263,7 +263,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 				},
 			},
 			ns:        "karmada-es-cluster",
-			expectRes: controllerruntime.Result{Requeue: true},
+			expectRes: controllerruntime.Result{},
 			existErr:  true,
 		},
 		{
@@ -291,7 +291,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 				},
 			},
 			ns:        "karmada-es-cluster",
-			expectRes: controllerruntime.Result{Requeue: true},
+			expectRes: controllerruntime.Result{},
 			existErr:  true,
 		},
 	}

--- a/pkg/controllers/unifiedauth/unified_auth_controller.go
+++ b/pkg/controllers/unifiedauth/unified_auth_controller.go
@@ -73,7 +73,7 @@ func (c *Controller) Reconcile(ctx context.Context, req controllerruntime.Reques
 			return controllerruntime.Result{}, nil
 		}
 
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 
 	if !cluster.DeletionTimestamp.IsZero() {
@@ -91,7 +91,7 @@ func (c *Controller) Reconcile(ctx context.Context, req controllerruntime.Reques
 	if err != nil {
 		klog.Errorf("Failed to sync impersonation config for cluster %s. Error: %v.", cluster.Name, err)
 		c.EventRecorder.Eventf(cluster, corev1.EventTypeWarning, events.EventReasonSyncImpersonationConfigFailed, err.Error())
-		return controllerruntime.Result{Requeue: true}, err
+		return controllerruntime.Result{}, err
 	}
 	c.EventRecorder.Eventf(cluster, corev1.EventTypeNormal, events.EventReasonSyncImpersonationConfigSucceed, "Sync impersonation config succeed.")
 


### PR DESCRIPTION
Signed-off-by: huangyanfeng <huangyanfeng1992@gmail.com>

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

The Controller will requeue the Request to be processed again if an error is non-nil or Result.Requeue is true, an error is non-nil has higher priority. Therefore, there is no need to set Result.Requeue to true when the error is non-nil.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

