### PR TITLE
karmada-metrics-adapter: reduce memory usage

### DIFF
--- a/pkg/metricsadapter/adapter.go
+++ b/pkg/metricsadapter/adapter.go
@@ -34,7 +34,7 @@ type MetricsAdapter struct {
 func NewMetricsAdapter(controller *MetricsController, customMetricsAdapterServerOptions *options.CustomMetricsAdapterServerOptions) *MetricsAdapter {
 	adapter := &MetricsAdapter{}
 	adapter.CustomMetricsAdapterServerOptions = customMetricsAdapterServerOptions
-	adapter.ResourceMetricsProvider = provider.NewResourceMetricsProvider(controller.ClusterLister, controller.InformerManager)
+	adapter.ResourceMetricsProvider = provider.NewResourceMetricsProvider(controller.ClusterLister, controller.TypedInformerManager, controller.InformerManager)
 	customProvider := provider.MakeCustomMetricsProvider(controller.ClusterLister, controller.MultiClusterDiscovery)
 	externalProvider := provider.MakeExternalMetricsProvider()
 	adapter.WithCustomMetrics(customProvider)


### PR DESCRIPTION
When there is a large amount of pod usage in the member cluster, metrics-adapter will consume a lot of memory. The reason is that it caches all the information of all pods in the cluster. However, we don't need all this information, so we trim some of the information to reduce memory usage.

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:



The core idea of this PR is to use `TransformFunc` to trim the fields that pod and node need to buffer. Currently, it only retains fields such as `name`, `namespace`, `labels`, etc. Other fields are not needed, so we do not need to cache them.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-metrics-adapter: reduce memory usage
```

