### PR TITLE
Automated cherry pick of #4784: labels cannot be deleted via Karmada propagation

### DIFF
--- a/pkg/util/helper/work.go
+++ b/pkg/util/helper/work.go
@@ -47,6 +47,7 @@ func CreateOrUpdateWork(client client.Client, workMeta metav1.ObjectMeta, resour
 	}
 	util.ReplaceAnnotation(workload, workv1alpha2.ResourceTemplateUIDAnnotation, string(workload.GetUID()))
 	util.RecordManagedAnnotations(workload)
+	util.RecordManagedLabels(workload)
 	workloadJSON, err := workload.MarshalJSON()
 	if err != nil {
 		klog.Errorf("Failed to marshal workload(%s/%s), Error: %v", workload.GetNamespace(), workload.GetName(), err)
@@ -84,7 +85,6 @@ func CreateOrUpdateWork(client client.Client, workMeta metav1.ObjectMeta, resour
 			if util.GetLabelValue(runtimeObject.Labels, workv1alpha2.WorkPermanentIDLabel) == "" {
 				runtimeObject.Labels = util.DedupeAndMergeLabels(runtimeObject.Labels, map[string]string{workv1alpha2.WorkPermanentIDLabel: uuid.New().String()})
 			}
-			util.RecordManagedLabels(runtimeObject)
 			return nil
 		})
 		if err != nil {

--- a/pkg/util/label.go
+++ b/pkg/util/label.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 )
 
@@ -111,18 +110,18 @@ func getDeletedLabelKeys(desired, observed *unstructured.Unstructured) sets.Set[
 
 // RecordManagedLabels sets or updates the annotation(resourcetemplate.karmada.io/managed-labels)
 // to record the label keys.
-func RecordManagedLabels(w *workv1alpha1.Work) {
-	annotations := w.GetAnnotations()
+func RecordManagedLabels(object *unstructured.Unstructured) {
+	annotations := object.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string, 1)
 	}
 	var managedKeys []string
 	// record labels.
-	labels := w.GetLabels()
+	labels := object.GetLabels()
 	for key := range labels {
 		managedKeys = append(managedKeys, key)
 	}
 	sort.Strings(managedKeys)
 	annotations[workv1alpha2.ManagedLabels] = strings.Join(managedKeys, ",")
-	w.SetAnnotations(annotations)
+	object.SetAnnotations(annotations)
 }

--- a/pkg/util/label_test.go
+++ b/pkg/util/label_test.go
@@ -20,10 +20,8 @@ import (
 	"reflect"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 )
 
@@ -528,65 +526,71 @@ func TestRetainLabels(t *testing.T) {
 func TestRecordManagedLabels(t *testing.T) {
 	tests := []struct {
 		name     string
-		object   *workv1alpha1.Work
-		expected *workv1alpha1.Work
+		object   *unstructured.Unstructured
+		expected *unstructured.Unstructured
 	}{
 		{
 			name: "nil label",
-			object: &workv1alpha1.Work{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "work.karmada.io/v1alpha1",
-					Kind:       "Work",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "demo-work-1",
-					Namespace: "cluster1-ns",
-					Labels:    nil,
+			object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "demo-deployment-1",
+					},
+					"spec": map[string]interface{}{
+						"replicas": 2,
+					},
 				},
 			},
-			expected: &workv1alpha1.Work{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "work.karmada.io/v1alpha1",
-					Kind:       "Work",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "demo-work-1",
-					Namespace: "cluster1-ns",
-					Annotations: map[string]string{
-						workv1alpha2.ManagedLabels: "",
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "demo-deployment-1",
+						"annotations": map[string]interface{}{
+							workv1alpha2.ManagedLabels: "",
+						},
 					},
-					Labels: nil,
+					"spec": map[string]interface{}{
+						"replicas": 2,
+					},
 				},
 			},
 		},
 		{
 			name: "object has has labels",
-			object: &workv1alpha1.Work{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "work.karmada.io/v1alpha1",
-					Kind:       "Work",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "demo-work-1",
-					Namespace: "cluster1-ns",
-					Labels: map[string]string{
-						"foo": "bar",
+			object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "demo-deployment-1",
+						"labels": map[string]interface{}{
+							"foo": "foo",
+						},
+					},
+					"spec": map[string]interface{}{
+						"replicas": 2,
 					},
 				},
 			},
-			expected: &workv1alpha1.Work{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "work.karmada.io/v1alpha1",
-					Kind:       "Work",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "demo-work-1",
-					Namespace: "cluster1-ns",
-					Annotations: map[string]string{
-						workv1alpha2.ManagedLabels: "foo",
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "demo-deployment-1",
+						"annotations": map[string]interface{}{
+							workv1alpha2.ManagedLabels: "foo",
+						},
+						"labels": map[string]interface{}{
+							"foo": "foo",
+						},
 					},
-					Labels: map[string]string{
-						"foo": "bar",
+					"spec": map[string]interface{}{
+						"replicas": 2,
 					},
 				},
 			},


### PR DESCRIPTION
Cherry pick of #4784 on release-1.9.
#4784: labels cannot be deleted via Karmada propagation
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
karmada-controller-manager: Fix the problem that labels cannot be deleted via Karmada propagation.
```