### PR TITLE
[WIP] feat/karmadactl: extra etcd support without cert.

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -56,7 +56,7 @@ jobs:
           kubectl --kubeconfig ~/.kube/karmada-host.config get pod -A -owide
 
           # would not deploy etcd when useing extra etcd.
-          KARMADA_ETCD_STS_COUNT=`kubectl --kubeconfig ~/.kube/karmada-host.config get sts -n karmada-system -l karmada.io/bootstrapping=app-defaults  -ojson | jq '.items | length'`
+          KARMADA_ETCD_STS_COUNT=`kubectl --kubeconfig ~/.kube/karmada-host.config get sts -n karmada-system -l karmada.io/bootstrapping=app-defaults,app=etcd  -ojson | jq '.items | length'`
           echo "KARMADA_ETCD_STS_COUNT:"$KARMADA_ETCD_STS_COUNT
           if [ $KARMADA_ETCD_STS_COUNT -ne 0 ];then
             exit -1

--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -50,7 +50,7 @@ jobs:
           export KUBECONFIG=${HOME}/karmada/karmada-apiserver.config
           GO111MODULE=on go install github.com/onsi/ginkgo/v2/ginkgo
           ginkgo -v --race --trace -p  --focus="[BasicPropagation] propagation testing deployment propagation testing"  ./test/e2e/
-      - name: check
+      - name: verify
         if: ${{ matrix.extraEtcdVersion != '' }} 
         run: |
           kubectl --kubeconfig ~/.kube/karmada-host.config get pod -A -owide

--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -23,7 +23,7 @@ jobs:
         # the same as the End of Life of the Kubernetes release: https://kubernetes.io/releases/
         # Please remember to update the CI Schedule Workflow when we add a new version.
         k8s: [ v1.28.0, v1.29.0, v1.30.0 ]
-        extraEtcdVersion: [ "3.5.9-0", "" ]
+        extraEtcdVersion: [ "3.5.13-0", "" ]
     env:
       KARMADA_EXTRA_ETCD_VERSION: ${{ matrix.extraEtcdVersion }}
       CLUSTER_VERSION: kindest/node:${{ matrix.k8s }}

--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -23,6 +23,10 @@ jobs:
         # the same as the End of Life of the Kubernetes release: https://kubernetes.io/releases/
         # Please remember to update the CI Schedule Workflow when we add a new version.
         k8s: [ v1.28.0, v1.29.0, v1.30.0 ]
+        extraEtcdVersion: [ "3.5.9-0", "" ]
+    env:
+      KARMADA_EXTRA_ETCD_VERSION: ${{ matrix.extraEtcdVersion }}
+      CLUSTER_VERSION: kindest/node:${{ matrix.k8s }}
     steps:
       - name: checkout code
         uses: actions/checkout@v4
@@ -39,8 +43,6 @@ jobs:
           version: "v0.22.0"
       - name: run karmadactl init test
         run: |
-          export CLUSTER_VERSION=kindest/node:${{ matrix.k8s }}
-
           # init e2e environment
           hack/cli-testing-environment.sh
 
@@ -48,6 +50,17 @@ jobs:
           export KUBECONFIG=${HOME}/karmada/karmada-apiserver.config
           GO111MODULE=on go install github.com/onsi/ginkgo/v2/ginkgo
           ginkgo -v --race --trace -p  --focus="[BasicPropagation] propagation testing deployment propagation testing"  ./test/e2e/
+      - name: check
+        if: ${{ matrix.extraEtcdVersion != '' }} 
+        run: |
+          kubectl --kubeconfig ~/.kube/karmada-host.config get pod -A -owide
+
+          # would not deploy etcd when useing extra etcd.
+          KARMADA_ETCD_STS_COUNT=`kubectl --kubeconfig ~/.kube/karmada-host.config get sts -n karmada-system -l karmada.io/bootstrapping=app-defaults  -ojson | jq '.items | length'`
+          echo "KARMADA_ETCD_STS_COUNT:"$KARMADA_ETCD_STS_COUNT
+          if [ $KARMADA_ETCD_STS_COUNT -ne 0 ];then
+            exit -1
+          fi
       - uses: chainguard-dev/actions/kind-diag@main
         # Only upload logs on failure.
         if: ${{ failure() }}

--- a/hack/cli-testing-environment.sh
+++ b/hack/cli-testing-environment.sh
@@ -80,10 +80,10 @@ kind load docker-image "${REGISTRY}/karmada-aggregated-apiserver:${VERSION}" --n
 export KARMADACTL_INIT_EXTRA_OPTS=${KARMADACTL_INIT_EXTRA_OPTS:-""}
 export KARMADA_EXTRA_ETCD_VERSION=${KARMADA_EXTRA_ETCD_VERSION:-""}
 
+# test for external etcd.
 if [ "$KARMADA_EXTRA_ETCD_VERSION" != "" ];then 
     docker run -p 2379:2379 -it -d --name etcd  registry.k8s.io/etcd:$KARMADA_EXTRA_ETCD_VERSION  etcd --data-dir /var/lib/etcd --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls http://0.0.0.0:2379
-    export CNODE=`hostname`
-    KARMADACTL_INIT_EXTRA_OPTS=--external-etcd-servers=http://$CNODE:2379
+    KARMADACTL_INIT_EXTRA_OPTS=--external-etcd-servers=http://hostname:2379
 fi
 
 # init Karmada control plane

--- a/hack/cli-testing-environment.sh
+++ b/hack/cli-testing-environment.sh
@@ -106,5 +106,5 @@ ${BUILD_PATH}/karmadactl --kubeconfig ${HOME}/karmada/karmada-apiserver.config  
 kubectl wait --for=condition=Ready clusters --all --timeout=800s  --kubeconfig=${HOME}/karmada/karmada-apiserver.config
 
 # enable addon of karmada-search
-karmadactl addons enable --kubeconfig ${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config --karmada-kubeconfig=${HOME}/karmada/karmada-apiserver.config karmada-search
+${BUILD_PATH}/karmadactl addons enable --kubeconfig ${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config --karmada-kubeconfig=${HOME}/karmada/karmada-apiserver.config karmada-search
 kubectl wait pods --all --for condition=ready --timeout=800s --kubeconfig ${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config

--- a/hack/cli-testing-environment.sh
+++ b/hack/cli-testing-environment.sh
@@ -107,4 +107,4 @@ kubectl wait --for=condition=Ready clusters --all --timeout=800s  --kubeconfig=$
 
 # enable addon of karmada-search
 karmadactl addons enable --kubeconfig ${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config --karmada-kubeconfig=${HOME}/karmada/karmada-apiserver.config karmada-search
-kubectl wait pods --all --for condition=ready --timeout=800s
+kubectl wait pods --all --for condition=ready --timeout=800s --kubeconfig ${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config

--- a/pkg/karmadactl/addons/search/manifests.go
+++ b/pkg/karmadactl/addons/search/manifests.go
@@ -44,9 +44,11 @@ spec:
           image: {{ .Image }}
           imagePullPolicy: IfNotPresent
           volumeMounts:
+          {{ if .EtcdSSL }}
             - name: k8s-certs
               mountPath: /etc/karmada/pki
               readOnly: true
+          {{ end }}
             - name: kubeconfig
               subPath: kubeconfig
               mountPath: /etc/kubeconfig
@@ -56,9 +58,11 @@ spec:
             - --authentication-kubeconfig=/etc/kubeconfig
             - --authorization-kubeconfig=/etc/kubeconfig
             - --etcd-servers={{ .ETCDSevers }}
+            {{ if .EtcdSSL }}
             - --etcd-cafile=/etc/karmada/pki/etcd-ca.crt
             - --etcd-certfile=/etc/karmada/pki/etcd-client.crt
             - --etcd-keyfile=/etc/karmada/pki/etcd-client.key
+            {{ end }}
             - --tls-cert-file=/etc/karmada/pki/karmada.crt
             - --tls-private-key-file=/etc/karmada/pki/karmada.key
             - --tls-min-version=VersionTLS13
@@ -144,6 +148,7 @@ type DeploymentReplace struct {
 	Image      string
 	ETCDSevers string
 	KeyPrefix  string
+	EtcdSSL    bool
 }
 
 // ServiceReplace is a struct to help to concrete

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -65,6 +65,9 @@ var (
 	emptyByteSlice                 = make([]byte, 0)
 	externalEtcdCertSpecialization = map[string]func(*CommandInitOption) ([]byte, []byte, error){
 		options.EtcdCaCertAndKeyName: func(option *CommandInitOption) (cert, key []byte, err error) {
+			if option.ExternalEtcdCACertPath == "" {
+				return emptyByteSlice, emptyByteSlice, nil
+			}
 			cert, err = os.ReadFile(option.ExternalEtcdCACertPath)
 			key = emptyByteSlice
 			return
@@ -73,6 +76,9 @@ var (
 			return emptyByteSlice, emptyByteSlice, nil
 		},
 		options.EtcdClientCertAndKeyName: func(option *CommandInitOption) (cert, key []byte, err error) {
+			if option.ExternalEtcdClientCertPath == "" {
+				return emptyByteSlice, emptyByteSlice, nil
+			}
 			if cert, err = os.ReadFile(option.ExternalEtcdClientCertPath); err != nil {
 				return
 			}
@@ -216,6 +222,10 @@ func (i *CommandInitOption) validateExternalEtcd(_ string) error {
 
 func (i *CommandInitOption) isExternalEtcdProvided() bool {
 	return i.ExternalEtcdServers != ""
+}
+
+func (i *CommandInitOption) isExternalEtcdTLS() bool {
+	return i.isExternalEtcdProvided() && (i.ExternalEtcdCACertPath != "" || i.ExternalEtcdClientCertPath != "" || i.ExternalEtcdClientKeyPath != "")
 }
 
 // Validate Check that there are enough flags to run the command.

--- a/pkg/karmadactl/cmdinit/kubernetes/deployments.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deployments.go
@@ -85,9 +85,6 @@ func (i *CommandInitOption) karmadaAPIServerContainerCommand() []string {
 		"--authorization-mode=Node,RBAC",
 		fmt.Sprintf("--client-ca-file=%s/%s.crt", karmadaCertsVolumeMountPath, globaloptions.CaCertAndKeyName),
 		"--enable-bootstrap-token-auth=true",
-		fmt.Sprintf("--etcd-cafile=%s/%s.crt", karmadaCertsVolumeMountPath, options.EtcdCaCertAndKeyName),
-		fmt.Sprintf("--etcd-certfile=%s/%s.crt", karmadaCertsVolumeMountPath, options.EtcdClientCertAndKeyName),
-		fmt.Sprintf("--etcd-keyfile=%s/%s.key", karmadaCertsVolumeMountPath, options.EtcdClientCertAndKeyName),
 		fmt.Sprintf("--etcd-servers=%s", etcdServers),
 		"--bind-address=0.0.0.0",
 		fmt.Sprintf("--kubelet-client-certificate=%s/%s.crt", karmadaCertsVolumeMountPath, options.KarmadaCertAndKeyName),
@@ -111,6 +108,11 @@ func (i *CommandInitOption) karmadaAPIServerContainerCommand() []string {
 		fmt.Sprintf("--tls-cert-file=%s/%s.crt", karmadaCertsVolumeMountPath, options.ApiserverCertAndKeyName),
 		fmt.Sprintf("--tls-private-key-file=%s/%s.key", karmadaCertsVolumeMountPath, options.ApiserverCertAndKeyName),
 		"--tls-min-version=VersionTLS13",
+	}
+	if i.isExternalEtcdTLS() || !i.isExternalEtcdProvided() {
+		command = append(command, fmt.Sprintf("--etcd-cafile=%s/%s.crt", karmadaCertsVolumeMountPath, options.EtcdCaCertAndKeyName))
+		command = append(command, fmt.Sprintf("--etcd-certfile=%s/%s.crt", karmadaCertsVolumeMountPath, options.EtcdClientCertAndKeyName))
+		command = append(command, fmt.Sprintf("--etcd-keyfile=%s/%s.key", karmadaCertsVolumeMountPath, options.EtcdClientCertAndKeyName))
 	}
 	if i.ExternalEtcdKeyPrefix != "" {
 		command = append(command, fmt.Sprintf("--etcd-prefix=%s", i.ExternalEtcdKeyPrefix))
@@ -813,15 +815,17 @@ func (i *CommandInitOption) makeKarmadaAggregatedAPIServerDeployment() *appsv1.D
 		"--authentication-kubeconfig=/etc/kubeconfig",
 		"--authorization-kubeconfig=/etc/kubeconfig",
 		fmt.Sprintf("--etcd-servers=%s", etcdServers),
-		fmt.Sprintf("--etcd-cafile=%s/%s.crt", karmadaCertsVolumeMountPath, options.EtcdCaCertAndKeyName),
-		fmt.Sprintf("--etcd-certfile=%s/%s.crt", karmadaCertsVolumeMountPath, options.EtcdClientCertAndKeyName),
-		fmt.Sprintf("--etcd-keyfile=%s/%s.key", karmadaCertsVolumeMountPath, options.EtcdClientCertAndKeyName),
 		fmt.Sprintf("--tls-cert-file=%s/%s.crt", karmadaCertsVolumeMountPath, options.KarmadaCertAndKeyName),
 		fmt.Sprintf("--tls-private-key-file=%s/%s.key", karmadaCertsVolumeMountPath, options.KarmadaCertAndKeyName),
 		"--tls-min-version=VersionTLS13",
 		"--audit-log-path=-",
 		"--audit-log-maxage=0",
 		"--audit-log-maxbackup=0",
+	}
+	if i.isExternalEtcdTLS() || !i.isExternalEtcdProvided() {
+		command = append(command, fmt.Sprintf("--etcd-cafile=%s/%s.crt", karmadaCertsVolumeMountPath, options.EtcdCaCertAndKeyName))
+		command = append(command, fmt.Sprintf("--etcd-certfile=%s/%s.crt", karmadaCertsVolumeMountPath, options.EtcdClientCertAndKeyName))
+		command = append(command, fmt.Sprintf("--etcd-keyfile=%s/%s.key", karmadaCertsVolumeMountPath, options.EtcdClientCertAndKeyName))
 	}
 	if i.ExternalEtcdKeyPrefix != "" {
 		command = append(command, fmt.Sprintf("--etcd-prefix=%s", i.ExternalEtcdKeyPrefix))


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature
**What this PR does / why we need it**:

I'm using karmadactl to deploy karmada and i will get the error when i only set the `external-etcd-servers` without certificate.

So this PR is working for support without certificate for external etcd when using karmadactl to init karmada.

I can without the certificate of etcd when I use `kubeadm` to configure external etcd,  so I want to get the same experience here.


> And what is the effect when configue external etcd whitout providing the certificates?

It will skip to deploy etcd (static pod)

doc ref:
(doc about caFile/certFile/keyFile of ExternalEtcd  is not correct, it is not required)
- https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta3/#kubeadm-k8s-io-v1beta3-ExternalEtcd
- https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#init-workflow   (step 4)


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
kramadactl: extra etcd support without cert now.
```

