### PR TITLE
rename the use of kubectl-karmada

### DIFF
--- a/cmd/kubectl-karmada/kubectl-karmada.go
+++ b/cmd/kubectl-karmada/kubectl-karmada.go
@@ -24,7 +24,7 @@ import (
 )
 
 func main() {
-	cmd := karmadactl.NewKarmadaCtlCommand("karmada", "kubectl karmada")
+	cmd := karmadactl.NewKarmadaCtlCommand("kubectl-karmada", "kubectl karmada")
 	if err := cli.RunNoErrOutput(cmd); err != nil {
 		util.CheckErr(err)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
The command `kubectl-karmada` cannot be automatically completed because `use` and it's name do not match.

`karmadactl` can do it but `kubectl-karmada` cannot.
![image](https://github.com/karmada-io/karmada/assets/89241565/ec4e8204-ef69-4184-9e02-b0de54c21f4a)

after fixing it.
![image](https://github.com/karmada-io/karmada/assets/89241565/991e5eb1-53f9-4f59-a7a5-b963ccd953f7)


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

