### PR TITLE
Deprecate key labels of rb/crb

### DIFF
--- a/pkg/apis/work/v1alpha1/well_known_constants.go
+++ b/pkg/apis/work/v1alpha1/well_known_constants.go
@@ -17,15 +17,6 @@ limitations under the License.
 package v1alpha1
 
 const (
-	// ResourceBindingNamespaceLabel is added to objects to specify associated ResourceBinding's namespace.
-	ResourceBindingNamespaceLabel = "resourcebinding.karmada.io/namespace"
-
-	// ResourceBindingNameLabel is added to objects to specify associated ResourceBinding's name.
-	ResourceBindingNameLabel = "resourcebinding.karmada.io/name"
-
-	// ClusterResourceBindingLabel is added to objects to specify associated ClusterResourceBinding.
-	ClusterResourceBindingLabel = "clusterresourcebinding.karmada.io/name"
-
 	// WorkNamespaceLabel is added to objects to specify associated Work's namespace.
 	WorkNamespaceLabel = "work.karmada.io/namespace"
 

--- a/pkg/apis/work/v1alpha2/well_known_constants.go
+++ b/pkg/apis/work/v1alpha2/well_known_constants.go
@@ -40,16 +40,6 @@ const (
 	// WorkNameAnnotation is added to objects to specify associated Work's name.
 	WorkNameAnnotation = "work.karmada.io/name"
 
-	// ResourceBindingReferenceKey is the key of ResourceBinding object.
-	// It is usually a unique hash value of ResourceBinding object's namespace and name, intended to be added to the Work object.
-	// It will be used to retrieve all Works objects that derived from a specific ResourceBinding object.
-	ResourceBindingReferenceKey = "resourcebinding.karmada.io/key"
-
-	// ClusterResourceBindingReferenceKey is the key of ClusterResourceBinding object.
-	// It is usually a unique hash value of ClusterResourceBinding object's namespace and name, intended to be added to the Work object.
-	// It will be used to retrieve all Works objects that derived by a specific ClusterResourceBinding object.
-	ClusterResourceBindingReferenceKey = "clusterresourcebinding.karmada.io/key"
-
 	// ResourceBindingNamespaceAnnotationKey is added to object to describe the associated ResourceBinding's namespace.
 	// It is added to:
 	// - Work object: describes the namespace of ResourceBinding which the Work derived from.

--- a/pkg/controllers/binding/binding_controller.go
+++ b/pkg/controllers/binding/binding_controller.go
@@ -82,7 +82,7 @@ func (c *ResourceBindingController) Reconcile(ctx context.Context, req controlle
 
 	if !binding.DeletionTimestamp.IsZero() {
 		klog.V(4).Infof("Begin to delete works owned by binding(%s).", req.NamespacedName.String())
-		if err := helper.DeleteWorkByRBNamespaceAndName(c.Client, req.Namespace, req.Name); err != nil {
+		if err := helper.DeleteWorks(c.Client, req.Namespace, req.Name, binding.Labels[workv1alpha2.ResourceBindingPermanentIDLabel]); err != nil {
 			klog.Errorf("Failed to delete works related to %s/%s: %v", binding.GetNamespace(), binding.GetName(), err)
 			return controllerruntime.Result{}, err
 		}
@@ -143,7 +143,8 @@ func (c *ResourceBindingController) syncBinding(binding *workv1alpha2.ResourceBi
 }
 
 func (c *ResourceBindingController) removeOrphanWorks(binding *workv1alpha2.ResourceBinding) error {
-	works, err := helper.FindOrphanWorks(c.Client, binding.Namespace, binding.Name, helper.ObtainBindingSpecExistingClusters(binding.Spec))
+	works, err := helper.FindOrphanWorks(c.Client, binding.Namespace, binding.Name,
+		binding.Labels[workv1alpha2.ResourceBindingPermanentIDLabel], helper.ObtainBindingSpecExistingClusters(binding.Spec))
 	if err != nil {
 		klog.Errorf("Failed to find orphan works by resourceBinding(%s/%s). Error: %v.",
 			binding.GetNamespace(), binding.GetName(), err)

--- a/pkg/controllers/binding/cluster_resource_binding_controller.go
+++ b/pkg/controllers/binding/cluster_resource_binding_controller.go
@@ -82,7 +82,7 @@ func (c *ClusterResourceBindingController) Reconcile(ctx context.Context, req co
 
 	if !clusterResourceBinding.DeletionTimestamp.IsZero() {
 		klog.V(4).Infof("Begin to delete works owned by binding(%s).", req.NamespacedName.String())
-		if err := helper.DeleteWorkByCRBName(c.Client, req.Name); err != nil {
+		if err := helper.DeleteWorks(c.Client, "", req.Name, clusterResourceBinding.Labels[workv1alpha2.ClusterResourceBindingPermanentIDLabel]); err != nil {
 			klog.Errorf("Failed to delete works related to %s: %v", clusterResourceBinding.GetName(), err)
 			return controllerruntime.Result{}, err
 		}
@@ -142,7 +142,7 @@ func (c *ClusterResourceBindingController) syncBinding(binding *workv1alpha2.Clu
 }
 
 func (c *ClusterResourceBindingController) removeOrphanWorks(binding *workv1alpha2.ClusterResourceBinding) error {
-	works, err := helper.FindOrphanWorks(c.Client, "", binding.Name, helper.ObtainBindingSpecExistingClusters(binding.Spec))
+	works, err := helper.FindOrphanWorks(c.Client, "", binding.Name, binding.Labels[workv1alpha2.ClusterResourceBindingPermanentIDLabel], helper.ObtainBindingSpecExistingClusters(binding.Spec))
 	if err != nil {
 		klog.Errorf("Failed to find orphan works by ClusterResourceBinding(%s). Error: %v.", binding.GetName(), err)
 		c.EventRecorder.Event(binding, corev1.EventTypeWarning, events.EventReasonCleanupWorkFailed, err.Error())

--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -157,17 +157,11 @@ func mergeLabel(workload *unstructured.Unstructured, binding metav1.Object, scop
 	util.MergeLabel(workload, util.ManagedByKarmadaLabel, util.ManagedByKarmadaLabelValue)
 	if scope == apiextensionsv1.NamespaceScoped {
 		bindingID := util.GetLabelValue(binding.GetLabels(), workv1alpha2.ResourceBindingPermanentIDLabel)
-		util.MergeLabel(workload, workv1alpha2.ResourceBindingReferenceKey, names.GenerateBindingReferenceKey(binding.GetNamespace(), binding.GetName()))
 		util.MergeLabel(workload, workv1alpha2.ResourceBindingPermanentIDLabel, bindingID)
-
-		workLabel[workv1alpha2.ResourceBindingReferenceKey] = names.GenerateBindingReferenceKey(binding.GetNamespace(), binding.GetName())
 		workLabel[workv1alpha2.ResourceBindingPermanentIDLabel] = bindingID
 	} else {
 		bindingID := util.GetLabelValue(binding.GetLabels(), workv1alpha2.ClusterResourceBindingPermanentIDLabel)
-		util.MergeLabel(workload, workv1alpha2.ClusterResourceBindingReferenceKey, names.GenerateBindingReferenceKey("", binding.GetName()))
 		util.MergeLabel(workload, workv1alpha2.ClusterResourceBindingPermanentIDLabel, bindingID)
-
-		workLabel[workv1alpha2.ClusterResourceBindingReferenceKey] = names.GenerateBindingReferenceKey("", binding.GetName())
 		workLabel[workv1alpha2.ClusterResourceBindingPermanentIDLabel] = bindingID
 	}
 	return workLabel
@@ -234,7 +228,7 @@ func mergeConflictResolution(workload *unstructured.Unstructured, conflictResolu
 		return annotations
 	} else if conflictResolutionInRT != "" {
 		// ignore its value and add logs if conflictResolutionInRT is neither abort nor overwrite.
-		klog.Warningf("ignore the invalid conflict-resolution annotation in ResourceTemplate %s/%s/%s: %s",
+		klog.Warningf("Ignore the invalid conflict-resolution annotation in ResourceTemplate %s/%s/%s: %s",
 			workload.GetKind(), workload.GetNamespace(), workload.GetName(), conflictResolutionInRT)
 	}
 

--- a/pkg/controllers/binding/common_test.go
+++ b/pkg/controllers/binding/common_test.go
@@ -26,7 +26,6 @@ import (
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
-	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 func Test_mergeTargetClusters(t *testing.T) {
@@ -136,7 +135,6 @@ func Test_mergeLabel(t *testing.T) {
 			scope: v1.NamespaceScoped,
 			want: map[string]string{
 				workv1alpha2.ResourceBindingPermanentIDLabel: rbID,
-				workv1alpha2.ResourceBindingReferenceKey:     names.GenerateBindingReferenceKey(namespace, bindingName),
 			},
 		},
 		{
@@ -161,13 +159,21 @@ func Test_mergeLabel(t *testing.T) {
 			scope: v1.ClusterScoped,
 			want: map[string]string{
 				workv1alpha2.ClusterResourceBindingPermanentIDLabel: rbID,
-				workv1alpha2.ClusterResourceBindingReferenceKey:     names.GenerateBindingReferenceKey("", bindingName),
 			},
 		},
 	}
+
+	checker := func(got, want map[string]string) bool {
+		for key, val := range want {
+			if got[key] != val {
+				return false
+			}
+		}
+		return true
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := mergeLabel(tt.workload, tt.binding, tt.scope); !reflect.DeepEqual(got, tt.want) {
+			if got := mergeLabel(tt.workload, tt.binding, tt.scope); !checker(got, tt.want) {
 				t.Errorf("mergeLabel() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/dependenciesdistributor/dependencies_distributor.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor.go
@@ -522,10 +522,6 @@ func (d *DependenciesDistributor) createOrUpdateAttachedBinding(attachedBinding 
 	key := client.ObjectKeyFromObject(attachedBinding)
 	err := d.Client.Get(context.TODO(), key, existBinding)
 	if err == nil {
-		if util.GetLabelValue(existBinding.Labels, workv1alpha2.ResourceBindingPermanentIDLabel) == "" {
-			existBinding.Labels = util.DedupeAndMergeLabels(existBinding.Labels,
-				map[string]string{workv1alpha2.ResourceBindingPermanentIDLabel: uuid.New().String()})
-		}
 		existBinding.Spec.RequiredBy = mergeBindingSnapshot(existBinding.Spec.RequiredBy, attachedBinding.Spec.RequiredBy)
 		existBinding.Labels = util.DedupeAndMergeLabels(existBinding.Labels, attachedBinding.Labels)
 		existBinding.Spec.Resource = attachedBinding.Spec.Resource

--- a/pkg/util/helper/binding.go
+++ b/pkg/util/helper/binding.go
@@ -194,9 +194,9 @@ func ObtainBindingSpecExistingClusters(bindingSpec workv1alpha2.ResourceBindingS
 
 // FindOrphanWorks retrieves all works that labeled with current binding(ResourceBinding or ClusterResourceBinding) objects,
 // then pick the works that not meet current binding declaration.
-func FindOrphanWorks(c client.Client, bindingNamespace, bindingName string, expectClusters sets.Set[string]) ([]workv1alpha1.Work, error) {
+func FindOrphanWorks(c client.Client, bindingNamespace, bindingName, bindingID string, expectClusters sets.Set[string]) ([]workv1alpha1.Work, error) {
 	var needJudgeWorks []workv1alpha1.Work
-	workList, err := GetWorksByBindingNamespaceName(c, bindingNamespace, bindingName)
+	workList, err := GetWorksByBindingID(c, bindingID, bindingNamespace != "")
 	if err != nil {
 		klog.Errorf("Failed to get works by binding object (%s/%s): %v", bindingNamespace, bindingName, err)
 		return nil, err
@@ -344,21 +344,11 @@ func GetResourceBindings(c client.Client, ls labels.Set) (*workv1alpha2.Resource
 	return bindings, c.List(context.TODO(), bindings, listOpt)
 }
 
-// DeleteWorkByRBNamespaceAndName will delete all Work objects by ResourceBinding namespace and name.
-func DeleteWorkByRBNamespaceAndName(c client.Client, namespace, name string) error {
-	return DeleteWorks(c, namespace, name)
-}
-
-// DeleteWorkByCRBName will delete all Work objects by ClusterResourceBinding name.
-func DeleteWorkByCRBName(c client.Client, name string) error {
-	return DeleteWorks(c, "", name)
-}
-
 // DeleteWorks will delete all Work objects by labels.
-func DeleteWorks(c client.Client, namespace, name string) error {
-	workList, err := GetWorksByBindingNamespaceName(c, namespace, name)
+func DeleteWorks(c client.Client, namespace, name, bindingID string) error {
+	workList, err := GetWorksByBindingID(c, bindingID, namespace != "")
 	if err != nil {
-		klog.Errorf("Failed to get works by ResourceBinding(%s/%s) : %v", namespace, name, err)
+		klog.Errorf("Failed to get works by (Cluster)ResourceBinding(%s/%s) : %v", namespace, name, err)
 		return err
 	}
 

--- a/pkg/util/helper/binding_test.go
+++ b/pkg/util/helper/binding_test.go
@@ -410,6 +410,7 @@ func TestFindOrphanWorks(t *testing.T) {
 		c                client.Client
 		bindingNamespace string
 		bindingName      string
+		bindingID        string
 		expectClusters   sets.Set[string]
 	}
 	tests := []struct {
@@ -428,17 +429,14 @@ func TestFindOrphanWorks(t *testing.T) {
 							Namespace:       "wrong format",
 							ResourceVersion: "999",
 							Labels: map[string]string{
-								workv1alpha2.ResourceBindingReferenceKey: names.GenerateBindingReferenceKey("default", "binding"),
-							},
-							Annotations: map[string]string{
-								workv1alpha2.ResourceBindingNamespaceAnnotationKey: "default",
-								workv1alpha2.ResourceBindingNameAnnotationKey:      "binding",
+								workv1alpha2.ResourceBindingPermanentIDLabel: "3617252f-b1bb-43b0-98a1-c7de833c472c",
 							},
 						},
 					},
 				).Build(),
 				bindingNamespace: "default",
 				bindingName:      "binding",
+				bindingID:        "3617252f-b1bb-43b0-98a1-c7de833c472c",
 				expectClusters:   sets.New("clusterx"),
 			},
 			want:    nil,
@@ -454,11 +452,7 @@ func TestFindOrphanWorks(t *testing.T) {
 							Namespace:       names.ExecutionSpacePrefix + "cluster1",
 							ResourceVersion: "999",
 							Labels: map[string]string{
-								workv1alpha2.ResourceBindingReferenceKey: names.GenerateBindingReferenceKey("default", "binding"),
-							},
-							Annotations: map[string]string{
-								workv1alpha2.ResourceBindingNamespaceAnnotationKey: "default",
-								workv1alpha2.ResourceBindingNameAnnotationKey:      "binding",
+								workv1alpha2.ResourceBindingPermanentIDLabel: "3617252f-b1bb-43b0-98a1-c7de833c472c",
 							},
 						},
 					},
@@ -476,31 +470,18 @@ func TestFindOrphanWorks(t *testing.T) {
 					},
 					&workv1alpha1.Work{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:            "not-selected-because-of-annotation",
-							Namespace:       names.ExecutionSpacePrefix + "cluster1",
-							ResourceVersion: "999",
-							Labels: map[string]string{
-								workv1alpha2.ResourceBindingReferenceKey: names.GenerateBindingReferenceKey("default", "binding"),
-							},
-						},
-					},
-					&workv1alpha1.Work{
-						ObjectMeta: metav1.ObjectMeta{
 							Name:            "not-selected-because-of-cluster",
 							Namespace:       names.ExecutionSpacePrefix + "clusterx",
 							ResourceVersion: "999",
 							Labels: map[string]string{
-								workv1alpha2.ResourceBindingReferenceKey: names.GenerateBindingReferenceKey("default", "binding"),
-							},
-							Annotations: map[string]string{
-								workv1alpha2.ResourceBindingNamespaceAnnotationKey: "default",
-								workv1alpha2.ResourceBindingNameAnnotationKey:      "binding",
+								workv1alpha2.ResourceBindingPermanentIDLabel: "3617252f-b1bb-43b0-98a1-c7de833c472c",
 							},
 						},
 					},
 				).Build(),
 				bindingNamespace: "default",
 				bindingName:      "binding",
+				bindingID:        "3617252f-b1bb-43b0-98a1-c7de833c472c",
 				expectClusters:   sets.New("clusterx"),
 			},
 			want: []workv1alpha1.Work{
@@ -510,11 +491,7 @@ func TestFindOrphanWorks(t *testing.T) {
 						Namespace:       names.ExecutionSpacePrefix + "cluster1",
 						ResourceVersion: "999",
 						Labels: map[string]string{
-							workv1alpha2.ResourceBindingReferenceKey: names.GenerateBindingReferenceKey("default", "binding"),
-						},
-						Annotations: map[string]string{
-							workv1alpha2.ResourceBindingNamespaceAnnotationKey: "default",
-							workv1alpha2.ResourceBindingNameAnnotationKey:      "binding",
+							workv1alpha2.ResourceBindingPermanentIDLabel: "3617252f-b1bb-43b0-98a1-c7de833c472c",
 						},
 					},
 				},
@@ -531,10 +508,7 @@ func TestFindOrphanWorks(t *testing.T) {
 							Namespace:       names.ExecutionSpacePrefix + "cluster1",
 							ResourceVersion: "999",
 							Labels: map[string]string{
-								workv1alpha2.ClusterResourceBindingReferenceKey: names.GenerateBindingReferenceKey("", "binding"),
-							},
-							Annotations: map[string]string{
-								workv1alpha2.ClusterResourceBindingAnnotationKey: "binding",
+								workv1alpha2.ClusterResourceBindingPermanentIDLabel: "3617252f-b1bb-43b0-98a1-c7de833c472c",
 							},
 						},
 					},
@@ -544,19 +518,6 @@ func TestFindOrphanWorks(t *testing.T) {
 							Namespace:       names.ExecutionSpacePrefix + "cluster1",
 							ResourceVersion: "999",
 							Labels:          map[string]string{},
-							Annotations: map[string]string{
-								workv1alpha2.ClusterResourceBindingAnnotationKey: "binding",
-							},
-						},
-					},
-					&workv1alpha1.Work{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:            "not-selected-because-of-annotation",
-							Namespace:       names.ExecutionSpacePrefix + "cluster1",
-							ResourceVersion: "999",
-							Labels: map[string]string{
-								workv1alpha2.ClusterResourceBindingReferenceKey: names.GenerateBindingReferenceKey("", "binding"),
-							},
 						},
 					},
 					&workv1alpha1.Work{
@@ -565,16 +526,14 @@ func TestFindOrphanWorks(t *testing.T) {
 							Namespace:       names.ExecutionSpacePrefix + "clusterx",
 							ResourceVersion: "999",
 							Labels: map[string]string{
-								workv1alpha2.ClusterResourceBindingReferenceKey: names.GenerateBindingReferenceKey("", "binding"),
-							},
-							Annotations: map[string]string{
-								workv1alpha2.ClusterResourceBindingAnnotationKey: "binding",
+								workv1alpha2.ClusterResourceBindingPermanentIDLabel: "3617252f-b1bb-43b0-98a1-c7de833c472c",
 							},
 						},
 					},
 				).Build(),
 				bindingNamespace: "",
 				bindingName:      "binding",
+				bindingID:        "3617252f-b1bb-43b0-98a1-c7de833c472c",
 				expectClusters:   sets.New("clusterx"),
 			},
 			want: []workv1alpha1.Work{
@@ -584,10 +543,7 @@ func TestFindOrphanWorks(t *testing.T) {
 						Namespace:       names.ExecutionSpacePrefix + "cluster1",
 						ResourceVersion: "999",
 						Labels: map[string]string{
-							workv1alpha2.ClusterResourceBindingReferenceKey: names.GenerateBindingReferenceKey("", "binding"),
-						},
-						Annotations: map[string]string{
-							workv1alpha2.ClusterResourceBindingAnnotationKey: "binding",
+							workv1alpha2.ClusterResourceBindingPermanentIDLabel: "3617252f-b1bb-43b0-98a1-c7de833c472c",
 						},
 					},
 				},
@@ -597,7 +553,7 @@ func TestFindOrphanWorks(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := FindOrphanWorks(tt.args.c, tt.args.bindingNamespace, tt.args.bindingName, tt.args.expectClusters)
+			got, err := FindOrphanWorks(tt.args.c, tt.args.bindingNamespace, tt.args.bindingName, tt.args.bindingID, tt.args.expectClusters)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FindOrphanWorks() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1020,6 +976,7 @@ func TestDeleteWorkByRBNamespaceAndName(t *testing.T) {
 		c         client.Client
 		namespace string
 		name      string
+		bindingID string
 	}
 	tests := []struct {
 		name    string
@@ -1033,19 +990,20 @@ func TestDeleteWorkByRBNamespaceAndName(t *testing.T) {
 				c:         fake.NewClientBuilder().WithScheme(gclient.NewSchema()).Build(),
 				namespace: "default",
 				name:      "foo",
+				bindingID: "3617252f-b1bb-43b0-98a1-c7de833c472c",
 			},
 			want:    nil,
 			wantErr: false,
 		},
 		{
-			name: "delete",
+			name: "delete rb's work",
 			args: args{
 				c: fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(
 					&workv1alpha1.Work{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "w1", Namespace: names.ExecutionSpacePrefix + "cluster",
 							Labels: map[string]string{
-								workv1alpha2.ResourceBindingReferenceKey: names.GenerateBindingReferenceKey("default", "foo"),
+								workv1alpha2.ResourceBindingPermanentIDLabel: "3617252f-b1bb-43b0-98a1-c7de833c472c",
 							},
 							Annotations: map[string]string{
 								workv1alpha2.ResourceBindingNameAnnotationKey:      "foo",
@@ -1056,48 +1014,20 @@ func TestDeleteWorkByRBNamespaceAndName(t *testing.T) {
 				).Build(),
 				namespace: "default",
 				name:      "foo",
+				bindingID: "3617252f-b1bb-43b0-98a1-c7de833c472c",
 			},
 			want:    []workv1alpha1.Work{},
 			wantErr: false,
 		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := DeleteWorkByRBNamespaceAndName(tt.args.c, tt.args.namespace, tt.args.name); (err != nil) != tt.wantErr {
-				t.Errorf("DeleteWorkByRBNamespaceAndName() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			list := &workv1alpha1.WorkList{}
-			if err := tt.args.c.List(context.TODO(), list); err != nil {
-				t.Error(err)
-				return
-			}
-			if got := list.Items; !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("DeleteWorkByRBNamespaceAndName() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestDeleteWorkByCRBName(t *testing.T) {
-	type args struct {
-		c    client.Client
-		name string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    []workv1alpha1.Work
-		wantErr bool
-	}{
 		{
-			name: "delete",
+			name: "delete crb's work",
 			args: args{
 				c: fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(
 					&workv1alpha1.Work{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "w1", Namespace: names.ExecutionSpacePrefix + "cluster",
 							Labels: map[string]string{
-								workv1alpha2.ClusterResourceBindingReferenceKey: names.GenerateBindingReferenceKey("", "foo"),
+								workv1alpha2.ClusterResourceBindingPermanentIDLabel: "3617252f-b1bb-43b0-98a1-c7de833c472c",
 							},
 							Annotations: map[string]string{
 								workv1alpha2.ClusterResourceBindingAnnotationKey: "foo",
@@ -1105,7 +1035,8 @@ func TestDeleteWorkByCRBName(t *testing.T) {
 						},
 					},
 				).Build(),
-				name: "foo",
+				name:      "foo",
+				bindingID: "3617252f-b1bb-43b0-98a1-c7de833c472c",
 			},
 			want:    []workv1alpha1.Work{},
 			wantErr: false,
@@ -1113,8 +1044,8 @@ func TestDeleteWorkByCRBName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := DeleteWorkByCRBName(tt.args.c, tt.args.name); (err != nil) != tt.wantErr {
-				t.Errorf("DeleteWorkByRBNamespaceAndName() error = %v, wantErr %v", err, tt.wantErr)
+			if err := DeleteWorks(tt.args.c, tt.args.namespace, tt.args.name, tt.args.bindingID); (err != nil) != tt.wantErr {
+				t.Errorf("DeleteWorks() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			list := &workv1alpha1.WorkList{}
 			if err := tt.args.c.List(context.TODO(), list); err != nil {
@@ -1122,7 +1053,7 @@ func TestDeleteWorkByCRBName(t *testing.T) {
 				return
 			}
 			if got := list.Items; !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("DeleteWorkByRBNamespaceAndName() got = %v, want %v", got, tt.want)
+				t.Errorf("DeleteWorks() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/util/helper/workstatus.go
+++ b/pkg/util/helper/workstatus.go
@@ -61,7 +61,7 @@ func AggregateResourceBindingWorkStatus(
 	resourceTemplate *unstructured.Unstructured,
 	eventRecorder record.EventRecorder,
 ) error {
-	workList, err := GetWorksByBindingNamespaceName(c, binding.Namespace, binding.Name)
+	workList, err := GetWorksByBindingID(c, binding.Labels[workv1alpha2.ResourceBindingPermanentIDLabel], true)
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func AggregateClusterResourceBindingWorkStatus(
 	resourceTemplate *unstructured.Unstructured,
 	eventRecorder record.EventRecorder,
 ) error {
-	workList, err := GetWorksByBindingNamespaceName(c, "", binding.Name)
+	workList, err := GetWorksByBindingID(c, binding.Labels[workv1alpha2.ClusterResourceBindingPermanentIDLabel], false)
 	if err != nil {
 		return err
 	}
@@ -249,7 +249,7 @@ func assembleWorkStatus(works []workv1alpha1.Work, workload *unstructured.Unstru
 	return statuses, nil
 }
 
-// GetManifestIndex get the index of clusterObj in manifest list, if not exist return -1.
+// GetManifestIndex gets the index of clusterObj in manifest list, if not exist return -1.
 func GetManifestIndex(manifests []workv1alpha1.Manifest, clusterObj *unstructured.Unstructured) (int, error) {
 	for index, rawManifest := range manifests {
 		manifest := &unstructured.Unstructured{}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
```
resourcebinding.karmada.io/key -> resourcebinding.karmada.io/permanent-id
clusterresourcebinding.karmada.io/key -> clusterresourcebinding.karmada.io/permanent-id
```

**Which issue(s) this PR fixes**:
part of https://github.com/karmada-io/karmada/issues/4711

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: The labels `resourcebinding.karmada.io/key` and `clusterresourcebinding.karmada.io/key` has been deprecated and not be populated in Work objects(replaced by `resourcebinding.karmada.io/permanent-id` and `clusterresourcebinding.karmada.io/permanent-id` respectively).
```

