### PR TITLE
Add image-pull-policy flag for karmada init cmd

### DIFF
--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/util/templates"
 
@@ -114,6 +115,7 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 	}
 	flags := cmd.Flags()
 	flags.StringVarP(&opts.ImageRegistry, "private-image-registry", "", "", "Private image registry where pull images from. If set, all required images will be downloaded from it, it would be useful in offline installation scenarios.  In addition, you still can use --kube-image-registry to specify the registry for Kubernetes's images.")
+	flags.StringVarP(&opts.ImagePullPolicy, "image-pull-policy", "", string(corev1.PullIfNotPresent), "The image pull policy for all Karmada components container. One of Always, Never, IfNotPresent. Defaults to IfNotPresent.")
 	flags.StringSliceVar(&opts.PullSecrets, "image-pull-secrets", nil, "Image pull secrets are used to pull images from the private registry, could be secret list separated by comma (e.g '--image-pull-secrets PullSecret1,PullSecret2', the secrets should be pre-settled in the namespace declared by '--namespace')")
 	// kube image registry
 	flags.StringVarP(&opts.KubeImageMirrorCountry, "kube-image-mirror-country", "", "", "Country code of the kube image registry to be used. For Chinese mainland users, set it to cn")

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -124,6 +124,7 @@ func init() {
 // CommandInitOption holds all flags options for init.
 type CommandInitOption struct {
 	ImageRegistry                      string
+	ImagePullPolicy                    string
 	KubeImageRegistry                  string
 	KubeImageMirrorCountry             string
 	KubeImageTag                       string
@@ -218,13 +219,18 @@ func (i *CommandInitOption) isExternalEtcdProvided() bool {
 }
 
 // Validate Check that there are enough flags to run the command.
-//
-//nolint:gocyclo
 func (i *CommandInitOption) Validate(parentCommand string) error {
 	if i.KarmadaAPIServerAdvertiseAddress != "" {
 		if netutils.ParseIPSloppy(i.KarmadaAPIServerAdvertiseAddress) == nil {
 			return fmt.Errorf("karmada apiserver advertise address is not valid")
 		}
+	}
+
+	switch i.ImagePullPolicy {
+	case string(corev1.PullAlways), string(corev1.PullIfNotPresent), string(corev1.PullNever):
+		// continue
+	default:
+		return fmt.Errorf("invalid image pull policy: %s", i.ImagePullPolicy)
 	}
 
 	if i.isExternalEtcdProvided() {

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -75,6 +76,7 @@ func TestCommandInitOption_Validate(t *testing.T) {
 			name: "Invalid KarmadaAPIServerAdvertiseAddress",
 			opt: CommandInitOption{
 				KarmadaAPIServerAdvertiseAddress: "111",
+				ImagePullPolicy:                  string(corev1.PullIfNotPresent),
 			},
 			wantErr:  true,
 			errorMsg: "CommandInitOption.Validate() does not return err when KarmadaAPIServerAdvertiseAddress is wrong",
@@ -85,6 +87,7 @@ func TestCommandInitOption_Validate(t *testing.T) {
 				KarmadaAPIServerAdvertiseAddress: "192.0.2.1",
 				EtcdStorageMode:                  etcdStorageModeHostPath,
 				EtcdHostDataPath:                 "",
+				ImagePullPolicy:                  string(corev1.PullIfNotPresent),
 			},
 			wantErr:  true,
 			errorMsg: "CommandInitOption.Validate() does not return err when EtcdHostDataPath is empty",
@@ -96,6 +99,7 @@ func TestCommandInitOption_Validate(t *testing.T) {
 				EtcdStorageMode:                  etcdStorageModeHostPath,
 				EtcdHostDataPath:                 "/data",
 				EtcdNodeSelectorLabels:           "key",
+				ImagePullPolicy:                  string(corev1.PullIfNotPresent),
 			},
 			wantErr:  true,
 			errorMsg: "CommandInitOption.Validate() does not return err when EtcdNodeSelectorLabels is %v",
@@ -108,6 +112,7 @@ func TestCommandInitOption_Validate(t *testing.T) {
 				EtcdHostDataPath:                 "/data",
 				EtcdNodeSelectorLabels:           "key=value",
 				EtcdReplicas:                     2,
+				ImagePullPolicy:                  string(corev1.PullIfNotPresent),
 			},
 			wantErr:  true,
 			errorMsg: "CommandInitOption.Validate() does not return err when EtcdReplicas is %v",
@@ -121,6 +126,7 @@ func TestCommandInitOption_Validate(t *testing.T) {
 				EtcdNodeSelectorLabels:           "key=value",
 				EtcdReplicas:                     1,
 				StorageClassesName:               "",
+				ImagePullPolicy:                  string(corev1.PullIfNotPresent),
 			},
 			wantErr:  true,
 			errorMsg: "CommandInitOption.Validate() does not return err when StorageClassesName is empty",
@@ -130,6 +136,7 @@ func TestCommandInitOption_Validate(t *testing.T) {
 			opt: CommandInitOption{
 				KarmadaAPIServerAdvertiseAddress: "192.0.2.1",
 				EtcdStorageMode:                  "unknown",
+				ImagePullPolicy:                  string(corev1.PullIfNotPresent),
 			},
 			wantErr:  true,
 			errorMsg: "CommandInitOption.Validate() does not return err when EtcdStorageMode is unknown",
@@ -139,6 +146,7 @@ func TestCommandInitOption_Validate(t *testing.T) {
 			opt: CommandInitOption{
 				KarmadaAPIServerAdvertiseAddress: "192.0.2.1",
 				EtcdStorageMode:                  etcdStorageModeEmptyDir,
+				ImagePullPolicy:                  string(corev1.PullIfNotPresent),
 			},
 			wantErr:  false,
 			errorMsg: "CommandInitOption.Validate() returns err when EtcdStorageMode is emptyDir",
@@ -148,16 +156,27 @@ func TestCommandInitOption_Validate(t *testing.T) {
 			opt: CommandInitOption{
 				KarmadaAPIServerAdvertiseAddress: "192.0.2.1",
 				EtcdStorageMode:                  "",
+				ImagePullPolicy:                  string(corev1.PullIfNotPresent),
 			},
 			wantErr:  false,
 			errorMsg: "CommandInitOption.Validate() returns err when EtcdStorageMode is empty",
+		},
+		{
+			name: "Invalid ImagePullPolicy",
+			opt: CommandInitOption{
+				KarmadaAPIServerAdvertiseAddress: "192.0.2.1",
+				EtcdStorageMode:                  "",
+				ImagePullPolicy:                  "NotExistImagePullPolicy",
+			},
+			wantErr:  true,
+			errorMsg: "CommandInitOption.Validate() returns err when invalid ImagePullPolicy",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := tt.opt.Validate("parentCommand"); (err != nil) != tt.wantErr {
-				t.Errorf(tt.errorMsg)
+				t.Errorf("%s err = %v, want %v", tt.name, err.Error(), tt.errorMsg)
 			}
 		})
 	}

--- a/pkg/karmadactl/cmdinit/kubernetes/deployments.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deployments.go
@@ -444,8 +444,9 @@ func (i *CommandInitOption) makeKarmadaSchedulerDeployment() *appsv1.Deployment 
 		},
 		Containers: []corev1.Container{
 			{
-				Name:  schedulerDeploymentNameAndServiceAccountName,
-				Image: i.karmadaSchedulerImage(),
+				Name:            schedulerDeploymentNameAndServiceAccountName,
+				Image:           i.karmadaSchedulerImage(),
+				ImagePullPolicy: corev1.PullPolicy(i.ImagePullPolicy),
 				Command: []string{
 					"/bin/karmada-scheduler",
 					"--kubeconfig=/etc/kubeconfig",
@@ -559,8 +560,9 @@ func (i *CommandInitOption) makeKarmadaControllerManagerDeployment() *appsv1.Dep
 		},
 		Containers: []corev1.Container{
 			{
-				Name:  controllerManagerDeploymentAndServiceName,
-				Image: i.karmadaControllerManagerImage(),
+				Name:            controllerManagerDeploymentAndServiceName,
+				Image:           i.karmadaControllerManagerImage(),
+				ImagePullPolicy: corev1.PullPolicy(i.ImagePullPolicy),
 				Command: []string{
 					"/bin/karmada-controller-manager",
 					"--kubeconfig=/etc/kubeconfig",
@@ -677,8 +679,9 @@ func (i *CommandInitOption) makeKarmadaWebhookDeployment() *appsv1.Deployment {
 		AutomountServiceAccountToken: pointer.Bool(false),
 		Containers: []corev1.Container{
 			{
-				Name:  webhookDeploymentAndServiceAccountAndServiceName,
-				Image: i.karmadaWebhookImage(),
+				Name:            webhookDeploymentAndServiceAccountAndServiceName,
+				Image:           i.karmadaWebhookImage(),
+				ImagePullPolicy: corev1.PullPolicy(i.ImagePullPolicy),
 				Command: []string{
 					"/bin/karmada-webhook",
 					"--kubeconfig=/etc/kubeconfig",
@@ -847,9 +850,10 @@ func (i *CommandInitOption) makeKarmadaAggregatedAPIServerDeployment() *appsv1.D
 		AutomountServiceAccountToken: pointer.Bool(false),
 		Containers: []corev1.Container{
 			{
-				Name:    karmadaAggregatedAPIServerDeploymentAndServiceName,
-				Image:   i.karmadaAggregatedAPIServerImage(),
-				Command: command,
+				Name:            karmadaAggregatedAPIServerDeploymentAndServiceName,
+				Image:           i.karmadaAggregatedAPIServerImage(),
+				ImagePullPolicy: corev1.PullPolicy(i.ImagePullPolicy),
+				Command:         command,
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      KubeConfigSecretAndMountName,


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

#4789 

**Which issue(s) this PR fixes**:
Part of #4789 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: Introduced `--image-pull-policy` flag to the `init` command, which will be used to specify the image pull policy of all components.
```

