### PR TITLE
Fix the bug of mcs binding losing resourcebinding.karmada.io/permanent-id label

### DIFF
--- a/pkg/controllers/multiclusterservice/mcs_controller.go
+++ b/pkg/controllers/multiclusterservice/mcs_controller.go
@@ -409,12 +409,12 @@ func (c *MCSController) propagateService(ctx context.Context, mcs *networkingv1a
 			}
 
 			if util.GetLabelValue(bindingCopy.Labels, workv1alpha2.ResourceBindingPermanentIDLabel) == "" {
-				binding.Labels = util.DedupeAndMergeLabels(binding.Labels,
+				bindingCopy.Labels = util.DedupeAndMergeLabels(bindingCopy.Labels,
 					map[string]string{workv1alpha2.ResourceBindingPermanentIDLabel: uuid.New().String()})
 			}
 			// Just update necessary fields, especially avoid modifying Spec.Clusters which is scheduling result, if already exists.
-			bindingCopy.Annotations = binding.Annotations
-			bindingCopy.Labels = binding.Labels
+			bindingCopy.Annotations = util.DedupeAndMergeAnnotations(bindingCopy.Annotations, binding.Annotations)
+			bindingCopy.Labels = util.DedupeAndMergeLabels(bindingCopy.Labels, binding.Labels)
 			bindingCopy.OwnerReferences = binding.OwnerReferences
 			bindingCopy.Finalizers = binding.Finalizers
 			bindingCopy.Spec.Placement = binding.Spec.Placement


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
The label `resourcebinding.karmada.io/permanent-id` of mcs binding may be lost when updating, the reason is similar to https://github.com/karmada-io/karmada/pull/4793.
![lx_clip1712658406437](https://github.com/karmada-io/karmada/assets/89241565/c67830fc-e3a4-41b1-983c-2396967a56c2)

### After fixing 
![image](https://github.com/karmada-io/karmada/assets/89241565/25332fa0-3dfb-4f19-b74b-c1332f3dcff3)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-controller-manager: fix the bug of mcs binding losing resourcebinding.karmada.io/permanent-id label.
```

