### PR TITLE
Automated cherry pick of #4793: Use merge strategy to avoid work.karmada.io/permanent-id

### DIFF
--- a/pkg/util/helper/work.go
+++ b/pkg/util/helper/work.go
@@ -80,8 +80,8 @@ func CreateOrUpdateWork(client client.Client, workMeta metav1.ObjectMeta, resour
 			// TODO: Delete following one line in release-1.9
 			delete(runtimeObject.Labels, workv1alpha2.WorkUIDLabel)
 			runtimeObject.Spec = work.Spec
-			runtimeObject.Labels = work.Labels
-			runtimeObject.Annotations = work.Annotations
+			runtimeObject.Labels = util.DedupeAndMergeLabels(runtimeObject.Labels, work.Labels)
+			runtimeObject.Annotations = util.DedupeAndMergeAnnotations(runtimeObject.Annotations, work.Annotations)
 			if util.GetLabelValue(runtimeObject.Labels, workv1alpha2.WorkPermanentIDLabel) == "" {
 				runtimeObject.Labels = util.DedupeAndMergeLabels(runtimeObject.Labels, map[string]string{workv1alpha2.WorkPermanentIDLabel: uuid.New().String()})
 			}


### PR DESCRIPTION
Cherry pick of #4793 on release-1.8.
#4793: Use merge strategy to avoid work.karmada.io/permanent-id
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
karmada-controller-manager: Fix the problem that work.karmada.io/permanent-id constantly changes with every update.
```