### PR TITLE
Automated cherry pick of #4818: Fix the bug of mcs binding losing

### DIFF
--- a/pkg/controllers/multiclusterservice/mcs_controller.go
+++ b/pkg/controllers/multiclusterservice/mcs_controller.go
@@ -409,12 +409,12 @@ func (c *MCSController) propagateService(ctx context.Context, mcs *networkingv1a
 			}
 
 			if util.GetLabelValue(bindingCopy.Labels, workv1alpha2.ResourceBindingPermanentIDLabel) == "" {
-				binding.Labels = util.DedupeAndMergeLabels(binding.Labels,
+				bindingCopy.Labels = util.DedupeAndMergeLabels(bindingCopy.Labels,
 					map[string]string{workv1alpha2.ResourceBindingPermanentIDLabel: uuid.New().String()})
 			}
 			// Just update necessary fields, especially avoid modifying Spec.Clusters which is scheduling result, if already exists.
-			bindingCopy.Annotations = binding.Annotations
-			bindingCopy.Labels = binding.Labels
+			bindingCopy.Annotations = util.DedupeAndMergeAnnotations(bindingCopy.Annotations, binding.Annotations)
+			bindingCopy.Labels = util.DedupeAndMergeLabels(bindingCopy.Labels, binding.Labels)
 			bindingCopy.OwnerReferences = binding.OwnerReferences
 			bindingCopy.Finalizers = binding.Finalizers
 			bindingCopy.Spec.Placement = binding.Spec.Placement


### PR DESCRIPTION
Cherry pick of #4818 on release-1.9.
#4818: Fix the bug of mcs binding losing
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`: Fixed the bug of mcs binding losing resourcebinding.karmada.io/permanent-id label.
```