### PR TITLE
make DeepEqual judgments more efficient

### DIFF
--- a/pkg/util/cluster.go
+++ b/pkg/util/cluster.go
@@ -143,21 +143,22 @@ func CreateOrUpdateClusterObject(controlPlaneClient karmadaclientset.Interface, 
 		return nil, err
 	}
 	if exist {
-		if reflect.DeepEqual(cluster.Spec, clusterObj.Spec) {
+		clusterCopy := cluster.DeepCopy()
+		mutate(cluster)
+		if reflect.DeepEqual(clusterCopy.Spec, cluster.Spec) {
 			klog.Warningf("Cluster(%s) already exist and newest", clusterObj.Name)
 			return cluster, nil
 		}
-		mutate(cluster)
+
 		cluster, err = updateCluster(controlPlaneClient, cluster)
 		if err != nil {
-			klog.Warningf("Failed to create cluster(%s). error: %v", clusterObj.Name, err)
+			klog.Warningf("Failed to update cluster(%s). error: %v", clusterObj.Name, err)
 			return nil, err
 		}
 		return cluster, nil
 	}
 
 	mutate(clusterObj)
-
 	if cluster, err = createCluster(controlPlaneClient, clusterObj); err != nil {
 		klog.Warningf("Failed to create cluster(%s). error: %v", clusterObj.Name, err)
 		return nil, err


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Function `CreateOrUpdateClusterObject` is used to create cluster object in karmada control plane, or update it if it has been existed. 
https://github.com/karmada-io/karmada/blob/da7689f715aa7c8424a6e14d99be8536f5f1f77a/pkg/util/cluster.go#L145-L151
`reflect.DeepEqual(cluster.Spec, clusterObj.Spec)` It doesn't make sense to compare the `cluster` to the `clusterobj`, it should be the `cluster` to the `mutate(cluster)` in order to correctly determine if an update is needed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

