### PR TITLE
feat: upgrade karmada chart dependency

### DIFF
--- a/charts/karmada/Chart.lock
+++ b/charts/karmada/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.17.1
-digest: sha256:91bdebcf473f5da3c018dd74f25fab166d4faaa6be86d492f5caa50fc63f93fb
-generated: "2022-09-11T14:03:55.938069+08:00"
+  version: 2.19.1
+digest: sha256:0a730717cb8d4d2c481be801923c643b0b9c5087b48bb2f4bc6f5d35ea90c849
+generated: "2024-04-12T20:38:01.015548+08:00"

--- a/charts/karmada/Chart.yaml
+++ b/charts/karmada/Chart.yaml
@@ -32,7 +32,7 @@ appVersion: latest
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
-    version: 1.x.x
+    version: 2.x.x
 
 # This is karmada maintainers
 maintainers:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
upgrade `bitnami/common` dependency in karmada chart
**Which issue(s) this PR fixes**:
no related issue, but as part of another pr https://github.com/karmada-io/karmada/pull/4785
in this pr, we combine all image secrets together, this is reduce similar code like :
```
{{/*
Return the proper Docker Image Registry Secret Names
*/}}
{{- define "karmada.agent.imagePullSecrets" -}}
{{ include "common.images.pullSecrets" (dict "images" (list .Values.agent.image) "global" .Values.global) }}
{{- end -}}
```
but this is introduce another problem, `bitnami/common@1.x.x` will not handle duplicate secret names in chart,  after upgrade it to `bitnami/common@2.x.x`, it will use `uniq` to remove duplicate secret names in chart.

more details can refer 👉: https://github.com/bitnami/charts/commit/ddfea70831875639cb298a555ad6dd5e68f059e4

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
upgrade `bitnami/common` dependency in karmada chart from `1.x.x` to `2.x.x`
```

