### PR TITLE
Remove print in test

### DIFF
--- a/pkg/util/helper/taint_test.go
+++ b/pkg/util/helper/taint_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package helper
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -541,7 +540,6 @@ func TestGetMinTolerationTime(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := GetMinTolerationTime(tt.noExecuteTaints, tt.usedTolerantion)
-			fmt.Printf("%+v", result)
 			if result > 0 {
 				if result > (tt.wantResult+1)*time.Second || result < (tt.wantResult-1)*time.Second {
 					t.Errorf("GetMinTolerationTime() = %v, want %v", result, tt.wantResult)


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

This `fmt.Print` causes an unexpected line in stdout for test run output JSON, which causes an error for future possible go test tools. And we don't use it anyway, so I think it's better to remove it.

```console
{"Time":"2024-04-19T23:11:03.422137+07:00","Action":"output","Package":"command-line-arguments","Test":"TestGetMinTolerationTime/no_noExecuteTaints","Output":"-1ns"}
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

