### PR TITLE
Introduce a validation webhook to prohibit WorkloadRebalancer from being modified

### DIFF
--- a/artifacts/deploy/webhook-configuration.yaml
+++ b/artifacts/deploy/webhook-configuration.yaml
@@ -268,3 +268,17 @@ webhooks:
     sideEffects: None
     admissionReviewVersions: [ "v1" ]
     timeoutSeconds: 3
+  - name: workloadrebalancer.karmada.io
+    rules:
+      - operations: [ "UPDATE" ]
+        apiGroups: [ "apps.karmada.io" ]
+        apiVersions: [ "*" ]
+        resources: [ "workloadrebalancers" ]
+        scope: "Cluster"
+    clientConfig:
+      url: https://karmada-webhook.karmada-system.svc:443/validate-workloadrebalancer
+      caBundle: {{caBundle}}
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: [ "v1" ]
+    timeoutSeconds: 3

--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -54,6 +54,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/webhook/resourcedeletionprotection"
 	"github.com/karmada-io/karmada/pkg/webhook/resourceinterpretercustomization"
 	"github.com/karmada-io/karmada/pkg/webhook/work"
+	"github.com/karmada-io/karmada/pkg/webhook/workloadrebalancer"
 )
 
 // NewWebhookCommand creates a *cobra.Command object with default parameters
@@ -176,6 +177,7 @@ func Run(ctx context.Context, opts *options.Options) error {
 	hookServer.Register("/mutate-multiclusterservice", &webhook.Admission{Handler: &multiclusterservice.MutatingAdmission{Decoder: decoder}})
 	hookServer.Register("/mutate-federatedhpa", &webhook.Admission{Handler: &federatedhpa.MutatingAdmission{Decoder: decoder}})
 	hookServer.Register("/validate-resourcedeletionprotection", &webhook.Admission{Handler: &resourcedeletionprotection.ValidatingAdmission{Decoder: decoder}})
+	hookServer.Register("/validate-workloadrebalancer", &webhook.Admission{Handler: &workloadrebalancer.ValidatingAdmission{Decoder: decoder}})
 	hookServer.WebhookMux().Handle("/readyz/", http.StripPrefix("/readyz/", &healthz.Handler{}))
 
 	// blocks until the context is done.

--- a/pkg/webhook/workloadrebalancer/validating.go
+++ b/pkg/webhook/workloadrebalancer/validating.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloadrebalancer
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	appsv1alpha1 "github.com/karmada-io/karmada/pkg/apis/apps/v1alpha1"
+)
+
+// ValidatingAdmission validates WorkloadRebalancer object when creating/updating/deleting.
+type ValidatingAdmission struct {
+	Decoder *admission.Decoder
+}
+
+// Check if our ValidatingAdmission implements necessary interface
+var _ admission.Handler = &ValidatingAdmission{}
+
+// Handle implements admission.Handler interface.
+// It yields a response to an AdmissionRequest.
+func (v *ValidatingAdmission) Handle(_ context.Context, req admission.Request) admission.Response {
+	rebalancer := &appsv1alpha1.WorkloadRebalancer{}
+
+	err := v.Decoder.Decode(req, rebalancer)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	klog.V(2).Infof("Validating WorkloadRebalancer(%s) for request: %s", rebalancer.Name, req.Operation)
+
+	if req.Operation == admissionv1.Update {
+		oldRebalancer := &appsv1alpha1.WorkloadRebalancer{}
+		err = v.Decoder.DecodeRaw(req.OldObject, oldRebalancer)
+		if err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		if !reflect.DeepEqual(rebalancer.Spec, oldRebalancer.Spec) {
+			err = fmt.Errorf("the spec field should not be modified")
+			klog.Error(err)
+			return admission.Denied(err.Error())
+		}
+	}
+
+	return admission.Allowed("")
+}


### PR DESCRIPTION
**DO NOT MERGE** until the following PR have been merged (this PR needs a rebasing) :

* #4841


**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Introduce a validation webhook to prohibit WorkloadRebalancer from being modified, the final effect is like:

```shell
$ kubectl --context karmada-apiserver edit wr demo
error: workloadrebalancers.apps.karmada.io "demo" could not be patched: admission webhook "workloadrebalancer.karmada.io" denied the request: the spec field should not be modified
You can run `kubectl replace -f /tmp/kubectl-edit-vdiqj.yaml` to try this update again.
$
$ kubectl --context karmada-apiserver replace -f demo2.yaml     
Error from server (Forbidden): error when replacing "demo2.yaml": admission webhook "workloadrebalancer.karmada.io" denied the request: the spec field should not be modified
```

**Which issue(s) this PR fixes**:

Fixes part of #4840

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

