### PR TITLE
Add image-pull-policy field for karmada-operator

### DIFF
--- a/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
+++ b/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
@@ -96,6 +96,11 @@ spec:
                               are not queryable and should be preserved when modifying
                               objects. More info: http://kubernetes.io/docs/user-guide/annotations'
                             type: object
+                          imagePullPolicy:
+                            description: ImagePullPolicy defines the policy for pulling
+                              the container image. If not specified, it defaults to
+                              IfNotPresent.
+                            type: string
                           imageRepository:
                             description: ImageRepository sets the container registry
                               to pull images from. if not set, the ImageRepository
@@ -571,6 +576,10 @@ spec:
                         description: 'FeatureGates enabled by the user. More info:
                           https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/'
                         type: object
+                      imagePullPolicy:
+                        description: ImagePullPolicy defines the policy for pulling
+                          the container image. If not specified, it defaults to IfNotPresent.
+                        type: string
                       imageRepository:
                         description: ImageRepository sets the container registry to
                           pull images from. if not set, the ImageRepository defined
@@ -703,6 +712,10 @@ spec:
                           https://karmada.io/docs/userguide/scheduling/cluster-resources#start-to-use-cluster-resource-models
                           More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go'
                         type: object
+                      imagePullPolicy:
+                        description: ImagePullPolicy defines the policy for pulling
+                          the container image. If not specified, it defaults to IfNotPresent.
+                        type: string
                       imageRepository:
                         description: ImageRepository sets the container registry to
                           pull images from. if not set, the ImageRepository defined
@@ -832,6 +845,10 @@ spec:
                           - CustomizedClusterResourceModeling: https://karmada.io/docs/userguide/scheduling/cluster-resources#start-to-use-cluster-resource-models
                           More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go'
                         type: object
+                      imagePullPolicy:
+                        description: ImagePullPolicy defines the policy for pulling
+                          the container image. If not specified, it defaults to IfNotPresent.
+                        type: string
                       imageRepository:
                         description: ImageRepository sets the container registry to
                           pull images from. if not set, the ImageRepository defined
@@ -937,6 +954,10 @@ spec:
                           For supported flags, please see https://karmada.io/docs/reference/components/karmada-descheduler
                           for details."
                         type: object
+                      imagePullPolicy:
+                        description: ImagePullPolicy defines the policy for pulling
+                          the container image. If not specified, it defaults to IfNotPresent.
+                        type: string
                       imageRepository:
                         description: ImageRepository sets the container registry to
                           pull images from. if not set, the ImageRepository defined
@@ -1042,6 +1063,10 @@ spec:
                           configuration. \n For supported flags, please see https://karmada.io/docs/reference/components/karmada-metrics-adapter
                           for details."
                         type: object
+                      imagePullPolicy:
+                        description: ImagePullPolicy defines the policy for pulling
+                          the container image. If not specified, it defaults to IfNotPresent.
+                        type: string
                       imageRepository:
                         description: ImageRepository sets the container registry to
                           pull images from. if not set, the ImageRepository defined
@@ -1154,6 +1179,10 @@ spec:
                           https://karmada.io/docs/userguide/scheduling/cluster-resources#start-to-use-cluster-resource-models
                           More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go'
                         type: object
+                      imagePullPolicy:
+                        description: ImagePullPolicy defines the policy for pulling
+                          the container image. If not specified, it defaults to IfNotPresent.
+                        type: string
                       imageRepository:
                         description: ImageRepository sets the container registry to
                           pull images from. if not set, the ImageRepository defined
@@ -1259,6 +1288,10 @@ spec:
                           please see https://karmada.io/docs/reference/components/karmada-search
                           for details."
                         type: object
+                      imagePullPolicy:
+                        description: ImagePullPolicy defines the policy for pulling
+                          the container image. If not specified, it defaults to IfNotPresent.
+                        type: string
                       imageRepository:
                         description: ImageRepository sets the container registry to
                           pull images from. if not set, the ImageRepository defined
@@ -1364,6 +1397,10 @@ spec:
                           please see https://karmada.io/docs/reference/components/karmada-webhook
                           for details."
                         type: object
+                      imagePullPolicy:
+                        description: ImagePullPolicy defines the policy for pulling
+                          the container image. If not specified, it defaults to IfNotPresent.
+                        type: string
                       imageRepository:
                         description: ImageRepository sets the container registry to
                           pull images from. if not set, the ImageRepository defined
@@ -1512,6 +1549,10 @@ spec:
                         description: 'FeatureGates enabled by the user. More info:
                           https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/'
                         type: object
+                      imagePullPolicy:
+                        description: ImagePullPolicy defines the policy for pulling
+                          the container image. If not specified, it defaults to IfNotPresent.
+                        type: string
                       imageRepository:
                         description: ImageRepository sets the container registry to
                           pull images from. if not set, the ImageRepository defined

--- a/operator/config/crds/operator.karmada.io_karmadas.yaml
+++ b/operator/config/crds/operator.karmada.io_karmadas.yaml
@@ -96,6 +96,11 @@ spec:
                               are not queryable and should be preserved when modifying
                               objects. More info: http://kubernetes.io/docs/user-guide/annotations'
                             type: object
+                          imagePullPolicy:
+                            description: ImagePullPolicy defines the policy for pulling
+                              the container image. If not specified, it defaults to
+                              IfNotPresent.
+                            type: string
                           imageRepository:
                             description: ImageRepository sets the container registry
                               to pull images from. if not set, the ImageRepository
@@ -571,6 +576,10 @@ spec:
                         description: 'FeatureGates enabled by the user. More info:
                           https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/'
                         type: object
+                      imagePullPolicy:
+                        description: ImagePullPolicy defines the policy for pulling
+                          the container image. If not specified, it defaults to IfNotPresent.
+                        type: string
                       imageRepository:
                         description: ImageRepository sets the container registry to
                           pull images from. if not set, the ImageRepository defined
@@ -703,6 +712,10 @@ spec:
                           https://karmada.io/docs/userguide/scheduling/cluster-resources#start-to-use-cluster-resource-models
                           More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go'
                         type: object
+                      imagePullPolicy:
+                        description: ImagePullPolicy defines the policy for pulling
+                          the container image. If not specified, it defaults to IfNotPresent.
+                        type: string
                       imageRepository:
                         description: ImageRepository sets the container registry to
                           pull images from. if not set, the ImageRepository defined
@@ -832,6 +845,10 @@ spec:
                           - CustomizedClusterResourceModeling: https://karmada.io/docs/userguide/scheduling/cluster-resources#start-to-use-cluster-resource-models
                           More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go'
                         type: object
+                      imagePullPolicy:
+                        description: ImagePullPolicy defines the policy for pulling
+                          the container image. If not specified, it defaults to IfNotPresent.
+                        type: string
                       imageRepository:
                         description: ImageRepository sets the container registry to
                           pull images from. if not set, the ImageRepository defined
@@ -937,6 +954,10 @@ spec:
                           For supported flags, please see https://karmada.io/docs/reference/components/karmada-descheduler
                           for details."
                         type: object
+                      imagePullPolicy:
+                        description: ImagePullPolicy defines the policy for pulling
+                          the container image. If not specified, it defaults to IfNotPresent.
+                        type: string
                       imageRepository:
                         description: ImageRepository sets the container registry to
                           pull images from. if not set, the ImageRepository defined
@@ -1042,6 +1063,10 @@ spec:
                           configuration. \n For supported flags, please see https://karmada.io/docs/reference/components/karmada-metrics-adapter
                           for details."
                         type: object
+                      imagePullPolicy:
+                        description: ImagePullPolicy defines the policy for pulling
+                          the container image. If not specified, it defaults to IfNotPresent.
+                        type: string
                       imageRepository:
                         description: ImageRepository sets the container registry to
                           pull images from. if not set, the ImageRepository defined
@@ -1154,6 +1179,10 @@ spec:
                           https://karmada.io/docs/userguide/scheduling/cluster-resources#start-to-use-cluster-resource-models
                           More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go'
                         type: object
+                      imagePullPolicy:
+                        description: ImagePullPolicy defines the policy for pulling
+                          the container image. If not specified, it defaults to IfNotPresent.
+                        type: string
                       imageRepository:
                         description: ImageRepository sets the container registry to
                           pull images from. if not set, the ImageRepository defined
@@ -1259,6 +1288,10 @@ spec:
                           please see https://karmada.io/docs/reference/components/karmada-search
                           for details."
                         type: object
+                      imagePullPolicy:
+                        description: ImagePullPolicy defines the policy for pulling
+                          the container image. If not specified, it defaults to IfNotPresent.
+                        type: string
                       imageRepository:
                         description: ImageRepository sets the container registry to
                           pull images from. if not set, the ImageRepository defined
@@ -1364,6 +1397,10 @@ spec:
                           please see https://karmada.io/docs/reference/components/karmada-webhook
                           for details."
                         type: object
+                      imagePullPolicy:
+                        description: ImagePullPolicy defines the policy for pulling
+                          the container image. If not specified, it defaults to IfNotPresent.
+                        type: string
                       imageRepository:
                         description: ImageRepository sets the container registry to
                           pull images from. if not set, the ImageRepository defined
@@ -1512,6 +1549,10 @@ spec:
                         description: 'FeatureGates enabled by the user. More info:
                           https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/'
                         type: object
+                      imagePullPolicy:
+                        description: ImagePullPolicy defines the policy for pulling
+                          the container image. If not specified, it defaults to IfNotPresent.
+                        type: string
                       imageRepository:
                         description: ImageRepository sets the container registry to
                           pull images from. if not set, the ImageRepository defined

--- a/operator/pkg/apis/operator/v1alpha1/defaults.go
+++ b/operator/pkg/apis/operator/v1alpha1/defaults.go
@@ -126,7 +126,9 @@ func setDefaultsEtcd(obj *KarmadaComponents) {
 		if len(obj.Etcd.Local.Image.ImageTag) == 0 {
 			obj.Etcd.Local.Image.ImageTag = constants.EtcdDefaultVersion
 		}
-
+		if len(obj.Etcd.Local.ImagePullPolicy) == 0 {
+			obj.Etcd.Local.ImagePullPolicy = corev1.PullIfNotPresent
+		}
 		if obj.Etcd.Local.VolumeData == nil {
 			obj.Etcd.Local.VolumeData = &VolumeData{}
 		}
@@ -147,6 +149,9 @@ func setDefaultsKarmadaAPIServer(obj *KarmadaComponents) {
 	}
 	if len(apiserver.Image.ImageTag) == 0 {
 		apiserver.Image.ImageTag = constants.KubeDefaultVersion
+	}
+	if len(apiserver.ImagePullPolicy) == 0 {
+		apiserver.ImagePullPolicy = corev1.PullIfNotPresent
 	}
 	if apiserver.Replicas == nil {
 		apiserver.Replicas = pointer.Int32(1)
@@ -171,6 +176,9 @@ func setDefaultsKarmadaAggregatedAPIServer(obj *KarmadaComponents) {
 	if len(aggregated.Image.ImageTag) == 0 {
 		aggregated.Image.ImageTag = DefaultKarmadaImageVersion
 	}
+	if len(aggregated.ImagePullPolicy) == 0 {
+		aggregated.ImagePullPolicy = corev1.PullIfNotPresent
+	}
 	if aggregated.Replicas == nil {
 		aggregated.Replicas = pointer.Int32(1)
 	}
@@ -187,6 +195,9 @@ func setDefaultsKubeControllerManager(obj *KarmadaComponents) {
 	}
 	if len(kubeControllerManager.Image.ImageTag) == 0 {
 		kubeControllerManager.Image.ImageTag = constants.KubeDefaultVersion
+	}
+	if len(kubeControllerManager.ImagePullPolicy) == 0 {
+		kubeControllerManager.ImagePullPolicy = corev1.PullIfNotPresent
 	}
 	if kubeControllerManager.Replicas == nil {
 		kubeControllerManager.Replicas = pointer.Int32(1)
@@ -205,6 +216,9 @@ func setDefaultsKarmadaControllerManager(obj *KarmadaComponents) {
 	if len(karmadaControllerManager.Image.ImageTag) == 0 {
 		karmadaControllerManager.Image.ImageTag = DefaultKarmadaImageVersion
 	}
+	if len(karmadaControllerManager.ImagePullPolicy) == 0 {
+		karmadaControllerManager.ImagePullPolicy = corev1.PullIfNotPresent
+	}
 	if karmadaControllerManager.Replicas == nil {
 		karmadaControllerManager.Replicas = pointer.Int32(1)
 	}
@@ -221,6 +235,9 @@ func setDefaultsKarmadaScheduler(obj *KarmadaComponents) {
 	}
 	if len(scheduler.Image.ImageTag) == 0 {
 		scheduler.Image.ImageTag = DefaultKarmadaImageVersion
+	}
+	if len(scheduler.ImagePullPolicy) == 0 {
+		scheduler.ImagePullPolicy = corev1.PullIfNotPresent
 	}
 	if scheduler.Replicas == nil {
 		scheduler.Replicas = pointer.Int32(1)
@@ -239,6 +256,9 @@ func setDefaultsKarmadaWebhook(obj *KarmadaComponents) {
 	if len(webhook.Image.ImageTag) == 0 {
 		webhook.Image.ImageTag = DefaultKarmadaImageVersion
 	}
+	if len(webhook.ImagePullPolicy) == 0 {
+		webhook.ImagePullPolicy = corev1.PullIfNotPresent
+	}
 	if webhook.Replicas == nil {
 		webhook.Replicas = pointer.Int32(1)
 	}
@@ -255,6 +275,9 @@ func setDefaultsKarmadaSearch(obj *KarmadaComponents) {
 	}
 	if len(search.Image.ImageTag) == 0 {
 		search.Image.ImageTag = DefaultKarmadaImageVersion
+	}
+	if len(search.ImagePullPolicy) == 0 {
+		search.ImagePullPolicy = corev1.PullIfNotPresent
 	}
 	if search.Replicas == nil {
 		search.Replicas = pointer.Int32(1)
@@ -273,6 +296,9 @@ func setDefaultsKarmadaDescheduler(obj *KarmadaComponents) {
 	if len(descheduler.Image.ImageTag) == 0 {
 		descheduler.Image.ImageTag = DefaultKarmadaImageVersion
 	}
+	if len(descheduler.ImagePullPolicy) == 0 {
+		descheduler.ImagePullPolicy = corev1.PullIfNotPresent
+	}
 	if descheduler.Replicas == nil {
 		descheduler.Replicas = pointer.Int32(1)
 	}
@@ -290,7 +316,9 @@ func setDefaultsKarmadaMetricsAdapter(obj *KarmadaComponents) {
 	if len(metricsAdapter.Image.ImageTag) == 0 {
 		metricsAdapter.Image.ImageTag = DefaultKarmadaImageVersion
 	}
-
+	if len(metricsAdapter.ImagePullPolicy) == 0 {
+		metricsAdapter.ImagePullPolicy = corev1.PullIfNotPresent
+	}
 	if metricsAdapter.Replicas == nil {
 		metricsAdapter.Replicas = pointer.Int32(2)
 	}

--- a/operator/pkg/apis/operator/v1alpha1/type.go
+++ b/operator/pkg/apis/operator/v1alpha1/type.go
@@ -524,6 +524,11 @@ type CommonSettings struct {
 	// Image allows to customize the image used for the component.
 	Image `json:",inline"`
 
+	// ImagePullPolicy defines the policy for pulling the container image.
+	// If not specified, it defaults to IfNotPresent.
+	// +optional
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
+
 	// Number of desired pods. This is a pointer to distinguish between explicit
 	// zero and not specified. Defaults to 1.
 	// +optional

--- a/operator/pkg/controlplane/apiserver/apiserver.go
+++ b/operator/pkg/controlplane/apiserver/apiserver.go
@@ -52,14 +52,15 @@ func EnsureKarmadaAggregatedAPIServer(client clientset.Interface, cfg *operatorv
 
 func installKarmadaAPIServer(client clientset.Interface, cfg *operatorv1alpha1.KarmadaAPIServer, name, namespace string, _ map[string]bool) error {
 	apiserverDeploymentBytes, err := util.ParseTemplate(KarmadaApiserverDeployment, struct {
-		DeploymentName, Namespace, Image, EtcdClientService string
-		ServiceSubnet, KarmadaCertsSecret, EtcdCertsSecret  string
-		Replicas                                            *int32
-		EtcdListenClientPort                                int32
+		DeploymentName, Namespace, Image, ImagePullPolicy, EtcdClientService string
+		ServiceSubnet, KarmadaCertsSecret, EtcdCertsSecret                   string
+		Replicas                                                             *int32
+		EtcdListenClientPort                                                 int32
 	}{
 		DeploymentName:       util.KarmadaAPIServerName(name),
 		Namespace:            namespace,
 		Image:                cfg.Image.Name(),
+		ImagePullPolicy:      string(cfg.ImagePullPolicy),
 		EtcdClientService:    util.KarmadaEtcdClientName(name),
 		ServiceSubnet:        *cfg.ServiceSubnet,
 		KarmadaCertsSecret:   util.KarmadaCertSecretName(name),
@@ -112,14 +113,15 @@ func createKarmadaAPIServerService(client clientset.Interface, cfg *operatorv1al
 
 func installKarmadaAggregatedAPIServer(client clientset.Interface, cfg *operatorv1alpha1.KarmadaAggregatedAPIServer, name, namespace string, featureGates map[string]bool) error {
 	aggregatedAPIServerDeploymentBytes, err := util.ParseTemplate(KarmadaAggregatedAPIServerDeployment, struct {
-		DeploymentName, Namespace, Image, EtcdClientService   string
-		KubeconfigSecret, KarmadaCertsSecret, EtcdCertsSecret string
-		Replicas                                              *int32
-		EtcdListenClientPort                                  int32
+		DeploymentName, Namespace, Image, ImagePullPolicy, EtcdClientService string
+		KubeconfigSecret, KarmadaCertsSecret, EtcdCertsSecret                string
+		Replicas                                                             *int32
+		EtcdListenClientPort                                                 int32
 	}{
 		DeploymentName:       util.KarmadaAggregatedAPIServerName(name),
 		Namespace:            namespace,
 		Image:                cfg.Image.Name(),
+		ImagePullPolicy:      string(cfg.ImagePullPolicy),
 		EtcdClientService:    util.KarmadaEtcdClientName(name),
 		KubeconfigSecret:     util.AdminKubeconfigSecretName(name),
 		KarmadaCertsSecret:   util.KarmadaCertSecretName(name),

--- a/operator/pkg/controlplane/apiserver/mainfests.go
+++ b/operator/pkg/controlplane/apiserver/mainfests.go
@@ -41,7 +41,7 @@ spec:
       containers:
       - name: kube-apiserver
         image: {{ .Image }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .ImagePullPolicy }}
         command:
         - kube-apiserver
         - --allow-privileged=true
@@ -173,7 +173,7 @@ spec:
       containers:
       - name: karmada-aggregated-apiserver
         image: {{ .Image }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .ImagePullPolicy }}
         command:
         - /bin/karmada-aggregated-apiserver
         - --kubeconfig=/etc/karmada/kubeconfig

--- a/operator/pkg/controlplane/controlplane.go
+++ b/operator/pkg/controlplane/controlplane.go
@@ -84,13 +84,14 @@ func getComponentManifests(name, namespace string, featureGates map[string]bool,
 
 func getKubeControllerManagerManifest(name, namespace string, cfg *operatorv1alpha1.KubeControllerManager) (*appsv1.Deployment, error) {
 	kubeControllerManagerBytes, err := util.ParseTemplate(KubeControllerManagerDeployment, struct {
-		DeploymentName, Namespace, Image     string
-		KarmadaCertsSecret, KubeconfigSecret string
-		Replicas                             *int32
+		DeploymentName, Namespace, Image, ImagePullPolicy string
+		KarmadaCertsSecret, KubeconfigSecret              string
+		Replicas                                          *int32
 	}{
 		DeploymentName:     util.KubeControllerManagerName(name),
 		Namespace:          namespace,
 		Image:              cfg.Image.Name(),
+		ImagePullPolicy:    string(cfg.ImagePullPolicy),
 		KarmadaCertsSecret: util.KarmadaCertSecretName(name),
 		KubeconfigSecret:   util.AdminKubeconfigSecretName(name),
 		Replicas:           cfg.Replicas,
@@ -113,12 +114,13 @@ func getKarmadaControllerManagerManifest(name, namespace string, featureGates ma
 	karmadaControllerManagerBytes, err := util.ParseTemplate(KamradaControllerManagerDeployment, struct {
 		Replicas                                   *int32
 		DeploymentName, Namespace, SystemNamespace string
-		Image, KubeconfigSecret                    string
+		Image, ImagePullPolicy, KubeconfigSecret   string
 	}{
 		DeploymentName:   util.KarmadaControllerManagerName(name),
 		Namespace:        namespace,
 		SystemNamespace:  constants.KarmadaSystemNamespace,
 		Image:            cfg.Image.Name(),
+		ImagePullPolicy:  string(cfg.ImagePullPolicy),
 		KubeconfigSecret: util.AdminKubeconfigSecretName(name),
 		Replicas:         cfg.Replicas,
 	})
@@ -140,12 +142,13 @@ func getKarmadaSchedulerManifest(name, namespace string, featureGates map[string
 	karmadaSchedulerBytes, err := util.ParseTemplate(KarmadaSchedulerDeployment, struct {
 		Replicas                                   *int32
 		DeploymentName, Namespace, SystemNamespace string
-		Image, KubeconfigSecret                    string
+		Image, ImagePullPolicy, KubeconfigSecret   string
 	}{
 		DeploymentName:   util.KarmadaSchedulerName(name),
 		Namespace:        namespace,
 		SystemNamespace:  constants.KarmadaSystemNamespace,
 		Image:            cfg.Image.Name(),
+		ImagePullPolicy:  string(cfg.ImagePullPolicy),
 		KubeconfigSecret: util.AdminKubeconfigSecretName(name),
 		Replicas:         cfg.Replicas,
 	})
@@ -167,12 +170,13 @@ func getKarmadaDeschedulerManifest(name, namespace string, featureGates map[stri
 	karmadaDeschedulerBytes, err := util.ParseTemplate(KarmadaDeschedulerDeployment, struct {
 		Replicas                                   *int32
 		DeploymentName, Namespace, SystemNamespace string
-		Image, KubeconfigSecret                    string
+		Image, ImagePullPolicy, KubeconfigSecret   string
 	}{
 		DeploymentName:   util.KarmadaDeschedulerName(name),
 		Namespace:        namespace,
 		SystemNamespace:  constants.KarmadaSystemNamespace,
 		Image:            cfg.Image.Name(),
+		ImagePullPolicy:  string(cfg.ImagePullPolicy),
 		KubeconfigSecret: util.AdminKubeconfigSecretName(name),
 		Replicas:         cfg.Replicas,
 	})

--- a/operator/pkg/controlplane/etcd/etcd.go
+++ b/operator/pkg/controlplane/etcd/etcd.go
@@ -62,14 +62,15 @@ func installKarmadaEtcd(client clientset.Interface, name, namespace string, cfg 
 	}
 
 	etcdStatefulSetBytes, err := util.ParseTemplate(KarmadaEtcdStatefulSet, struct {
-		StatefulSetName, Namespace, Image, EtcdClientService string
-		CertsSecretName, EtcdPeerServiceName                 string
-		InitialCluster, EtcdDataVolumeName, EtcdCipherSuites string
-		Replicas, EtcdListenClientPort, EtcdListenPeerPort   int32
+		StatefulSetName, Namespace, Image, ImagePullPolicy, EtcdClientService string
+		CertsSecretName, EtcdPeerServiceName                                  string
+		InitialCluster, EtcdDataVolumeName, EtcdCipherSuites                  string
+		Replicas, EtcdListenClientPort, EtcdListenPeerPort                    int32
 	}{
 		StatefulSetName:      util.KarmadaEtcdName(name),
 		Namespace:            namespace,
 		Image:                cfg.Image.Name(),
+		ImagePullPolicy:      string(cfg.ImagePullPolicy),
 		EtcdClientService:    util.KarmadaEtcdClientName(name),
 		CertsSecretName:      util.EtcdCertSecretName(name),
 		EtcdPeerServiceName:  util.KarmadaEtcdName(name),

--- a/operator/pkg/controlplane/etcd/mainfests.go
+++ b/operator/pkg/controlplane/etcd/mainfests.go
@@ -45,7 +45,7 @@ spec:
       containers:
       - name: etcd
         image: {{ .Image }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .ImagePullPolicy }}
         command:
         - /usr/local/bin/etcd
         - --name=$(KARMADA_ETCD_NAME)

--- a/operator/pkg/controlplane/manifests.go
+++ b/operator/pkg/controlplane/manifests.go
@@ -51,7 +51,7 @@ spec:
       containers:
       - name: kube-controller-manager
         image: {{ .Image }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .ImagePullPolicy }}
         command:
         - kube-controller-manager
         - --allocate-node-cidrs=true
@@ -124,7 +124,7 @@ spec:
       containers:
       - name: karmada-controller-manager
         image: {{ .Image }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .ImagePullPolicy }}
         command:
         - /bin/karmada-controller-manager
         - --kubeconfig=/etc/karmada/kubeconfig
@@ -180,7 +180,7 @@ spec:
       containers:
       - name: karmada-scheduler
         image: {{ .Image }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .ImagePullPolicy }}
         command:
         - /bin/karmada-scheduler
         - --kubeconfig=/etc/karmada/kubeconfig
@@ -235,7 +235,7 @@ spec:
       containers:
       - name: karmada-descheduler
         image: {{ .Image }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .ImagePullPolicy }}
         command:
         - /bin/karmada-descheduler
         - --kubeconfig=/etc/karmada/kubeconfig

--- a/operator/pkg/controlplane/metricsadapter/mainfests.go
+++ b/operator/pkg/controlplane/metricsadapter/mainfests.go
@@ -44,7 +44,7 @@ spec:
       containers:
       - name: karmada-metrics-adapter
         image: {{ .Image }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .ImagePullPolicy }}
         command:
         - /bin/karmada-metrics-adapter
         - --kubeconfig=/etc/karmada/kubeconfig

--- a/operator/pkg/controlplane/metricsadapter/metricsadapter.go
+++ b/operator/pkg/controlplane/metricsadapter/metricsadapter.go
@@ -42,13 +42,14 @@ func EnsureKarmadaMetricAdapter(client clientset.Interface, cfg *operatorv1alpha
 
 func installKarmadaMetricAdapter(client clientset.Interface, cfg *operatorv1alpha1.KarmadaMetricsAdapter, name, namespace string) error {
 	metricAdapterBytes, err := util.ParseTemplate(KarmadaMetricsAdapterDeployment, struct {
-		DeploymentName, Namespace, Image     string
-		KubeconfigSecret, KarmadaCertsSecret string
-		Replicas                             *int32
+		DeploymentName, Namespace, Image, ImagePullPolicy string
+		KubeconfigSecret, KarmadaCertsSecret              string
+		Replicas                                          *int32
 	}{
 		DeploymentName:     util.KarmadaMetricsAdapterName(name),
 		Namespace:          namespace,
 		Image:              cfg.Image.Name(),
+		ImagePullPolicy:    string(cfg.ImagePullPolicy),
 		Replicas:           cfg.Replicas,
 		KubeconfigSecret:   util.AdminKubeconfigSecretName(name),
 		KarmadaCertsSecret: util.KarmadaCertSecretName(name),

--- a/operator/pkg/controlplane/search/mainfests.go
+++ b/operator/pkg/controlplane/search/mainfests.go
@@ -44,7 +44,7 @@ spec:
       containers:
         - name: karmada-search
           image: {{ .Image }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .ImagePullPolicy }}
           volumeMounts:
             - name: k8s-certs
               mountPath: /etc/karmada/pki

--- a/operator/pkg/controlplane/search/search.go
+++ b/operator/pkg/controlplane/search/search.go
@@ -43,14 +43,15 @@ func EnsureKarmadaSearch(client clientset.Interface, cfg *operatorv1alpha1.Karma
 
 func installKarmadaSearch(client clientset.Interface, cfg *operatorv1alpha1.KarmadaSearch, name, namespace string, _ map[string]bool) error {
 	searchDeploymentSetBytes, err := util.ParseTemplate(KarmadaSearchDeployment, struct {
-		DeploymentName, Namespace, Image, KarmadaCertsSecret string
-		KubeconfigSecret, EtcdClientService                  string
-		Replicas                                             *int32
-		EtcdListenClientPort                                 int32
+		DeploymentName, Namespace, Image, ImagePullPolicy, KarmadaCertsSecret string
+		KubeconfigSecret, EtcdClientService                                   string
+		Replicas                                                              *int32
+		EtcdListenClientPort                                                  int32
 	}{
 		DeploymentName:       util.KarmadaSearchName(name),
 		Namespace:            namespace,
 		Image:                cfg.Image.Name(),
+		ImagePullPolicy:      string(cfg.ImagePullPolicy),
 		KarmadaCertsSecret:   util.KarmadaCertSecretName(name),
 		Replicas:             cfg.Replicas,
 		KubeconfigSecret:     util.AdminKubeconfigSecretName(name),

--- a/operator/pkg/controlplane/webhook/mainfests.go
+++ b/operator/pkg/controlplane/webhook/mainfests.go
@@ -44,7 +44,7 @@ spec:
       containers:
       - name: karmada-webhook
         image: {{ .Image }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .ImagePullPolicy }}
         command:
         - /bin/karmada-webhook
         - --kubeconfig=/etc/karmada/kubeconfig

--- a/operator/pkg/controlplane/webhook/webhook.go
+++ b/operator/pkg/controlplane/webhook/webhook.go
@@ -42,13 +42,14 @@ func EnsureKarmadaWebhook(client clientset.Interface, cfg *operatorv1alpha1.Karm
 
 func installKarmadaWebhook(client clientset.Interface, cfg *operatorv1alpha1.KarmadaWebhook, name, namespace string, _ map[string]bool) error {
 	webhookDeploymentSetBytes, err := util.ParseTemplate(KarmadaWebhookDeployment, struct {
-		DeploymentName, Namespace, Image     string
-		KubeconfigSecret, WebhookCertsSecret string
-		Replicas                             *int32
+		DeploymentName, Namespace, Image, ImagePullPolicy string
+		KubeconfigSecret, WebhookCertsSecret              string
+		Replicas                                          *int32
 	}{
 		DeploymentName:     util.KarmadaWebhookName(name),
 		Namespace:          namespace,
 		Image:              cfg.Image.Name(),
+		ImagePullPolicy:    string(cfg.ImagePullPolicy),
 		Replicas:           cfg.Replicas,
 		KubeconfigSecret:   util.AdminKubeconfigSecretName(name),
 		WebhookCertsSecret: util.WebhookCertSecretName(name),


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
https://github.com/karmada-io/karmada/issues/4789

**Which issue(s) this PR fixes**:
Part of https://github.com/karmada-io/karmada/issues/4789

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Allow the user to specify `imagePullPolicy` in Karmada CR when installing via karmada-operator.
```

