### PR TITLE
replace work namespace/name labels with annotations

### DIFF
--- a/pkg/controllers/multiclusterservice/endpointslice_dispatch_controller.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_dispatch_controller.go
@@ -42,6 +42,7 @@ import (
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	networkingv1alpha1 "github.com/karmada-io/karmada/pkg/apis/networking/v1alpha1"
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/events"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
@@ -383,15 +384,15 @@ func (c *EndpointsliceDispatchController) ensureEndpointSliceWork(mcs *networkin
 	endpointSlice.Name = providerCluster + "-" + endpointSlice.Name
 	clusterNamespace := names.GenerateExecutionSpaceName(consumerCluster)
 	endpointSlice.Labels = map[string]string{
-		discoveryv1.LabelServiceName:    mcs.Name,
-		workv1alpha1.WorkNamespaceLabel: clusterNamespace,
-		workv1alpha1.WorkNameLabel:      work.Name,
-		util.ManagedByKarmadaLabel:      util.ManagedByKarmadaLabelValue,
-		discoveryv1.LabelManagedBy:      util.EndpointSliceDispatchControllerLabelValue,
+		discoveryv1.LabelServiceName: mcs.Name,
+		util.ManagedByKarmadaLabel:   util.ManagedByKarmadaLabelValue,
+		discoveryv1.LabelManagedBy:   util.EndpointSliceDispatchControllerLabelValue,
 	}
 	endpointSlice.Annotations = map[string]string{
 		// This annotation is used to identify the source cluster of EndpointSlice and whether the eps are the newest version
 		util.EndpointSliceProvisionClusterAnnotation: providerCluster,
+		workv1alpha2.WorkNamespaceAnnotation:         clusterNamespace,
+		workv1alpha2.WorkNameAnnotation:              work.Name,
 	}
 
 	workMeta := metav1.ObjectMeta{

--- a/pkg/controllers/namespace/namespace_sync_controller.go
+++ b/pkg/controllers/namespace/namespace_sync_controller.go
@@ -40,7 +40,7 @@ import (
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
-	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/controllers/binding"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/helper"
@@ -160,9 +160,9 @@ func (c *Controller) buildWorks(namespace *corev1.Namespace, clusters []clusterv
 				Annotations: annotations,
 			}
 
-			util.MergeLabel(clonedNamespaced, workv1alpha1.WorkNamespaceLabel, workNamespace)
-			util.MergeLabel(clonedNamespaced, workv1alpha1.WorkNameLabel, workName)
 			util.MergeLabel(clonedNamespaced, util.ManagedByKarmadaLabel, util.ManagedByKarmadaLabelValue)
+			util.MergeAnnotation(clonedNamespaced, workv1alpha2.WorkNamespaceAnnotation, workNamespace)
+			util.MergeAnnotation(clonedNamespaced, workv1alpha2.WorkNameAnnotation, workName)
 
 			if err = helper.CreateOrUpdateWork(c.Client, objectMeta, clonedNamespaced); err != nil {
 				ch <- fmt.Errorf("sync namespace(%s) to cluster(%s) failed due to: %v", clonedNamespaced.GetName(), cluster.GetName(), err)

--- a/pkg/controllers/unifiedauth/unified_auth_controller.go
+++ b/pkg/controllers/unifiedauth/unified_auth_controller.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
-	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/events"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/helper"
@@ -235,9 +235,9 @@ func (c *Controller) buildWorks(cluster *clusterv1alpha1.Cluster, obj *unstructu
 		},
 	}
 
-	util.MergeLabel(obj, workv1alpha1.WorkNamespaceLabel, workNamespace)
-	util.MergeLabel(obj, workv1alpha1.WorkNameLabel, clusterRoleBindingWorkName)
 	util.MergeLabel(obj, util.ManagedByKarmadaLabel, util.ManagedByKarmadaLabelValue)
+	util.MergeAnnotation(obj, workv1alpha2.WorkNamespaceAnnotation, workNamespace)
+	util.MergeAnnotation(obj, workv1alpha2.WorkNameAnnotation, clusterRoleBindingWorkName)
 
 	if err := helper.CreateOrUpdateWork(c.Client, objectMeta, obj); err != nil {
 		return err


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

When we create a namespace with a length of 63, the namespace will not be synchronized to the member cluster. The error reported in `karmada-controller-manager` is as follows:

```log
objectwatcher.go:102] Failed to create resource(kind=Namespace, /test12345678901234567890123456789012345678901234567890123456789) in cluster member1, err is Namespace "test12345678901234567890123456789012345678901234567890123456789" is invalid: metadata.labels: Invalid value: "test12345678901234567890123456789012345678901234567890123456789-56889cc77": must be no more than 63 characters
E0424 07:43:38.082314       1 execution_controller.go:261] Failed to create resource(/test12345678901234567890123456789012345678901234567890123456789) in the given member cluster member1, err is Namespace "test12345678901234567890123456789012345678901234567890123456789" is invalid: metadata.labels: Invalid value: "test12345678901234567890123456789012345678901234567890123456789-56889cc77": must be no more than 63 characters
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

We miss update it in the #4765

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-controller-manager: fix the error that can not propagate the namespace with a length of 63.
```

