### PR TITLE
Align federated Deployment's observedGeneration semantics with its native

### DIFF
--- a/pkg/apis/work/v1alpha2/well_known_constants.go
+++ b/pkg/apis/work/v1alpha2/well_known_constants.go
@@ -60,6 +60,17 @@ const (
 
 	// BindingManagedByLabel is added to ResourceBinding to represent what kind of resource manages this Binding.
 	BindingManagedByLabel = "binding.karmada.io/managed-by"
+
+	// ResourceTemplateGenerationAnnotationKey records the generation of resource template in Karmada APIServer,
+	// It will be injected into the resource when propagating to member clusters, to denote the specific version of
+	// the resource template from which the resource is derived. It might be helpful in the following cases:
+	// 1. Facilitating observation from member clusters to ascertain if the most recent resource template has been
+	//    completely synced.
+	// 2. The annotation will be synced back to Karmada during the process of syncing resource status,
+	//    by leveraging this annotation, Karmada can infer if the most recent resource template has been completely
+	//    synced on member clusters, then generates accurate observed generation(like Deployment's .status.observedGeneration)
+	//    which might be required by the release system.
+	ResourceTemplateGenerationAnnotationKey = "resourcetemplate.karmada.io/generation"
 )
 
 // Define resource conflict resolution

--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -17,6 +17,8 @@ limitations under the License.
 package binding
 
 import (
+	"strconv"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -168,6 +170,9 @@ func mergeLabel(workload *unstructured.Unstructured, binding metav1.Object, scop
 
 func mergeAnnotations(workload *unstructured.Unstructured, binding metav1.Object, scope apiextensionsv1.ResourceScope) map[string]string {
 	annotations := make(map[string]string)
+	if workload.GetGeneration() > 0 {
+		util.MergeAnnotation(workload, workv1alpha2.ResourceTemplateGenerationAnnotationKey, strconv.FormatInt(workload.GetGeneration(), 10))
+	}
 
 	if scope == apiextensionsv1.NamespaceScoped {
 		util.MergeAnnotation(workload, workv1alpha2.ResourceBindingNamespaceAnnotationKey, binding.GetNamespace())

--- a/pkg/resourceinterpreter/default/native/reflectstatus.go
+++ b/pkg/resourceinterpreter/default/native/reflectstatus.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 
+	"github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/helper"
 )
@@ -68,12 +69,25 @@ func reflectDeploymentStatus(object *unstructured.Unstructured) (*runtime.RawExt
 		return nil, fmt.Errorf("failed to convert DeploymentStatus from map[string]interface{}: %v", err)
 	}
 
-	grabStatus := appsv1.DeploymentStatus{
-		Replicas:            deploymentStatus.Replicas,
-		UpdatedReplicas:     deploymentStatus.UpdatedReplicas,
-		ReadyReplicas:       deploymentStatus.ReadyReplicas,
-		AvailableReplicas:   deploymentStatus.AvailableReplicas,
-		UnavailableReplicas: deploymentStatus.UnavailableReplicas,
+	resourceTemplateGenerationInt := int64(0)
+	resourceTemplateGenerationStr := util.GetAnnotationValue(object.GetAnnotations(), v1alpha2.ResourceTemplateGenerationAnnotationKey)
+	err = runtime.Convert_string_To_int64(&resourceTemplateGenerationStr, &resourceTemplateGenerationInt, nil)
+	if err != nil {
+		klog.Errorf("Failed to parse Deployment(%s/%s) generation from annotation(%s:%s): %v", object.GetNamespace(), object.GetName(), v1alpha2.ResourceTemplateGenerationAnnotationKey, resourceTemplateGenerationStr, err)
+		return nil, err
+	}
+
+	grabStatus := &WrappedDeploymentStatus{
+		Generation:                 object.GetGeneration(),
+		ResourceTemplateGeneration: resourceTemplateGenerationInt,
+		DeploymentStatus: appsv1.DeploymentStatus{
+			Replicas:            deploymentStatus.Replicas,
+			UpdatedReplicas:     deploymentStatus.UpdatedReplicas,
+			ReadyReplicas:       deploymentStatus.ReadyReplicas,
+			AvailableReplicas:   deploymentStatus.AvailableReplicas,
+			UnavailableReplicas: deploymentStatus.UnavailableReplicas,
+			ObservedGeneration:  deploymentStatus.ObservedGeneration,
+		},
 	}
 
 	grabStatusRaw, err := helper.BuildStatusRawExtension(grabStatus)

--- a/pkg/resourceinterpreter/default/native/status_type.go
+++ b/pkg/resourceinterpreter/default/native/status_type.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package native
+
+import appsv1 "k8s.io/api/apps/v1"
+
+// WrappedDeploymentStatus is a wrapper for appsv1.DeploymentStatus.
+type WrappedDeploymentStatus struct {
+	appsv1.DeploymentStatus `json:",inline"`
+
+	// Generation holds the generation(.metadata.generation) of resource running on member cluster.
+	Generation int64 `json:"generation,omitempty"`
+	// ResourceTemplateGeneration holds the value of annotation resourcetemplate.karmada.io/generation grabbed
+	// from resource running on member cluster.
+	ResourceTemplateGeneration int64 `json:"resourceTemplateGeneration,omitempty"`
+}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of #4870, #5021

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-controller-manager & karmada-agent: Only make `observedGeneration=generation` for federated deployment when all members' statuses are algined with its federated resource template generation.
```

