### PR TITLE
add short name for resourceinterpretercustomizations

### DIFF
--- a/charts/karmada/_crds/bases/config/config.karmada.io_resourceinterpretercustomizations.yaml
+++ b/charts/karmada/_crds/bases/config/config.karmada.io_resourceinterpretercustomizations.yaml
@@ -13,6 +13,8 @@ spec:
     kind: ResourceInterpreterCustomization
     listKind: ResourceInterpreterCustomizationList
     plural: resourceinterpretercustomizations
+    shortNames:
+    - ric
     singular: resourceinterpretercustomization
   scope: Cluster
   versions:

--- a/pkg/apis/config/v1alpha1/resourceinterpretercustomization_types.go
+++ b/pkg/apis/config/v1alpha1/resourceinterpretercustomization_types.go
@@ -34,7 +34,7 @@ const (
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:path=resourceinterpretercustomizations,scope="Cluster",categories={karmada-io}
+// +kubebuilder:resource:path=resourceinterpretercustomizations,scope="Cluster",shortName=ric,categories={karmada-io}
 // +kubebuilder:storageversion
 
 // ResourceInterpreterCustomization describes the configuration of a specific


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

The resource name `resourceinterpretercustomizations` is too long. When the automatic completion plug-in cannot be used in the environment, it is a headache to enter such a long name during operation and maintenance.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Add a short name for resourceinterpretercustomizations CRD resource.
```

