### PR TITLE
Update controller-gen version from v0.13.0 to v0.14.0

### DIFF
--- a/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
+++ b/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: karmadas.operator.karmada.io
 spec:
   group: operator.karmada.io
@@ -29,14 +29,19 @@ spec:
         description: Karmada enables declarative installation of karmada.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -44,26 +49,28 @@ spec:
             description: Spec defines the desired behavior of the Karmada.
             properties:
               components:
-                description: Components define all of karmada components. not all
-                  of these components need to be installed.
+                description: |-
+                  Components define all of karmada components.
+                  not all of these components need to be installed.
                 properties:
                   etcd:
                     description: Etcd holds configuration for etcd.
                     properties:
                       external:
-                        description: External describes how to connect to an external
-                          etcd cluster Local and External are mutually exclusive
+                        description: |-
+                          External describes how to connect to an external etcd cluster
+                          Local and External are mutually exclusive
                         properties:
                           caData:
-                            description: CAData is an SSL Certificate Authority file
-                              used to secure etcd communication. Required if using
-                              a TLS connection.
+                            description: |-
+                              CAData is an SSL Certificate Authority file used to secure etcd communication.
+                              Required if using a TLS connection.
                             format: byte
                             type: string
                           certData:
-                            description: CertData is an SSL certification file used
-                              to secure etcd communication. Required if using a TLS
-                              connection.
+                            description: |-
+                              CertData is an SSL certification file used to secure etcd communication.
+                              Required if using a TLS connection.
                             format: byte
                             type: string
                           endpoints:
@@ -72,8 +79,9 @@ spec:
                               type: string
                             type: array
                           keyData:
-                            description: KeyData is an SSL key file used to secure
-                              etcd communication. Required if using a TLS connection.
+                            description: |-
+                              KeyData is an SSL key file used to secure etcd communication.
+                              Required if using a TLS connection.
                             format: byte
                             type: string
                         required:
@@ -83,42 +91,43 @@ spec:
                         - keyData
                         type: object
                       local:
-                        description: Local provides configuration knobs for configuring
-                          the built-in etcd instance Local and External are mutually
-                          exclusive
+                        description: |-
+                          Local provides configuration knobs for configuring the built-in etcd instance
+                          Local and External are mutually exclusive
                         properties:
                           annotations:
                             additionalProperties:
                               type: string
-                            description: 'Annotations is an unstructured key value
-                              map stored with a resource that may be set by external
-                              tools to store and retrieve arbitrary metadata. They
-                              are not queryable and should be preserved when modifying
-                              objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                            description: |-
+                              Annotations is an unstructured key value map stored with a resource that may be
+                              set by external tools to store and retrieve arbitrary metadata. They are not
+                              queryable and should be preserved when modifying objects.
+                              More info: http://kubernetes.io/docs/user-guide/annotations
                             type: object
                           imagePullPolicy:
-                            description: ImagePullPolicy defines the policy for pulling
-                              the container image. If not specified, it defaults to
-                              IfNotPresent.
+                            description: |-
+                              ImagePullPolicy defines the policy for pulling the container image.
+                              If not specified, it defaults to IfNotPresent.
                             type: string
                           imageRepository:
-                            description: ImageRepository sets the container registry
-                              to pull images from. if not set, the ImageRepository
-                              defined in KarmadaSpec will be used instead.
+                            description: |-
+                              ImageRepository sets the container registry to pull images from.
+                              if not set, the ImageRepository defined in KarmadaSpec will be used instead.
                             type: string
                           imageTag:
-                            description: ImageTag allows to specify a tag for the
-                              image. In case this value is set, operator does not
-                              change automatically the version of the above components
-                              during upgrades.
+                            description: |-
+                              ImageTag allows to specify a tag for the image.
+                              In case this value is set, operator does not change automatically the version
+                              of the above components during upgrades.
                             type: string
                           labels:
                             additionalProperties:
                               type: string
-                            description: 'Map of string keys and values that can be
-                              used to organize and categorize (scope and select) objects.
-                              May match selectors of replication controllers and services.
-                              More info: http://kubernetes.io/docs/user-guide/labels'
+                            description: |-
+                              Map of string keys and values that can be used to organize and categorize
+                              (scope and select) objects. May match selectors of replication controllers
+                              and services.
+                              More info: http://kubernetes.io/docs/user-guide/labels
                             type: object
                           peerCertSANs:
                             description: PeerCertSANs sets extra Subject Alternative
@@ -127,31 +136,36 @@ spec:
                               type: string
                             type: array
                           replicas:
-                            description: Number of desired pods. This is a pointer
-                              to distinguish between explicit zero and not specified.
-                              Defaults to 1.
+                            description: |-
+                              Number of desired pods. This is a pointer to distinguish between explicit
+                              zero and not specified. Defaults to 1.
                             format: int32
                             type: integer
                           resources:
-                            description: 'Compute Resources required by this component.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Compute Resources required by this component.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             properties:
                               claims:
-                                description: "Claims lists the names of resources,
-                                  defined in spec.resourceClaims, that are used by
-                                  this container. \n This is an alpha field and requires
-                                  enabling the DynamicResourceAllocation feature gate.
-                                  \n This field is immutable. It can only be set for
-                                  containers."
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+
+                                  This is an alpha field and requires enabling the
+                                  DynamicResourceAllocation feature gate.
+
+
+                                  This field is immutable. It can only be set for containers.
                                 items:
                                   description: ResourceClaim references one entry
                                     in PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description: Name must match the name of one
-                                        entry in pod.spec.resourceClaims of the Pod
-                                        where this field is used. It makes that resource
-                                        available inside a container.
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
                                       type: string
                                   required:
                                   - name
@@ -167,8 +181,9 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount
-                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                               requests:
                                 additionalProperties:
@@ -177,12 +192,11 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. Requests cannot exceed Limits. More info:
-                                  https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
                           serverCertSANs:
@@ -192,72 +206,74 @@ spec:
                               type: string
                             type: array
                           volumeData:
-                            description: 'VolumeData describes the settings of etcd
-                              data store. We will support 3 modes: emptyDir, hostPath,
-                              PVC. default by hostPath.'
+                            description: |-
+                              VolumeData describes the settings of etcd data store.
+                              We will support 3 modes: emptyDir, hostPath, PVC. default by hostPath.
                             properties:
                               emptyDir:
-                                description: 'EmptyDir represents a temporary directory
-                                  that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                description: |-
+                                  EmptyDir represents a temporary directory that shares a pod's lifetime.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                 properties:
                                   medium:
-                                    description: 'medium represents what type of storage
-                                      medium should back this directory. The default
-                                      is "" which means to use the node''s default
-                                      medium. Must be an empty string (default) or
-                                      Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    description: |-
+                                      medium represents what type of storage medium should back this directory.
+                                      The default is "" which means to use the node's default medium.
+                                      Must be an empty string (default) or Memory.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                     type: string
                                   sizeLimit:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: 'sizeLimit is the total amount of
-                                      local storage required for this EmptyDir volume.
-                                      The size limit is also applicable for memory
-                                      medium. The maximum usage on memory medium EmptyDir
-                                      would be the minimum value between the SizeLimit
-                                      specified here and the sum of memory limits
-                                      of all containers in a pod. The default is nil
-                                      which means that the limit is undefined. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    description: |-
+                                      sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                      The size limit is also applicable for memory medium.
+                                      The maximum usage on memory medium EmptyDir would be the minimum value between
+                                      the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                      The default is nil which means that the limit is undefined.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 type: object
                               hostPath:
-                                description: 'HostPath represents a pre-existing file
-                                  or directory on the host machine that is directly
-                                  exposed to the container. This is generally used
-                                  for system agents or other privileged things that
-                                  are allowed to see the host machine. Most containers
-                                  will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                  --- TODO(jonesdl) We need to restrict who can use
-                                  host directory mounts and who can/can not mount
-                                  host directories as read/write.'
+                                description: |-
+                                  HostPath represents a pre-existing file or directory on the host
+                                  machine that is directly exposed to the container. This is generally
+                                  used for system agents or other privileged things that are allowed
+                                  to see the host machine. Most containers will NOT need this.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                  ---
+                                  TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
+                                  mount host directories as read/write.
                                 properties:
                                   path:
-                                    description: 'path of the directory on the host.
-                                      If the path is a symlink, it will follow the
-                                      link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                    description: |-
+                                      path of the directory on the host.
+                                      If the path is a symlink, it will follow the link to the real path.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                     type: string
                                   type:
-                                    description: 'type for HostPath Volume Defaults
-                                      to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                    description: |-
+                                      type for HostPath Volume
+                                      Defaults to ""
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                     type: string
                                 required:
                                 - path
                                 type: object
                               volumeClaim:
-                                description: The specification for the PersistentVolumeClaim.
-                                  The entire content is copied unchanged into the
-                                  PVC that gets created from this template. The same
-                                  fields as in a PersistentVolumeClaim are also valid
-                                  here.
+                                description: |-
+                                  The specification for the PersistentVolumeClaim. The entire content is
+                                  copied unchanged into the PVC that gets created from this
+                                  template. The same fields as in a PersistentVolumeClaim
+                                  are also valid here.
                                 properties:
                                   metadata:
-                                    description: May contain labels and annotations
-                                      that will be copied into the PVC when creating
-                                      it. No other fields are allowed and will be
-                                      rejected during validation.
+                                    description: |-
+                                      May contain labels and annotations that will be copied into the PVC
+                                      when creating it. No other fields are allowed and will be rejected during
+                                      validation.
                                     properties:
                                       annotations:
                                         additionalProperties:
@@ -277,42 +293,35 @@ spec:
                                         type: string
                                     type: object
                                   spec:
-                                    description: The specification for the PersistentVolumeClaim.
-                                      The entire content is copied unchanged into
-                                      the PVC that gets created from this template.
-                                      The same fields as in a PersistentVolumeClaim
+                                    description: |-
+                                      The specification for the PersistentVolumeClaim. The entire content is
+                                      copied unchanged into the PVC that gets created from this
+                                      template. The same fields as in a PersistentVolumeClaim
                                       are also valid here.
                                     properties:
                                       accessModes:
-                                        description: 'accessModes contains the desired
-                                          access modes the volume should have. More
-                                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                        description: |-
+                                          accessModes contains the desired access modes the volume should have.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                         items:
                                           type: string
                                         type: array
                                       dataSource:
-                                        description: 'dataSource field can be used
-                                          to specify either: * An existing VolumeSnapshot
-                                          object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                        description: |-
+                                          dataSource field can be used to specify either:
+                                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                           * An existing PVC (PersistentVolumeClaim)
-                                          If the provisioner or an external controller
-                                          can support the specified data source, it
-                                          will create a new volume based on the contents
-                                          of the specified data source. When the AnyVolumeDataSource
-                                          feature gate is enabled, dataSource contents
-                                          will be copied to dataSourceRef, and dataSourceRef
-                                          contents will be copied to dataSource when
-                                          dataSourceRef.namespace is not specified.
-                                          If the namespace is specified, then dataSourceRef
-                                          will not be copied to dataSource.'
+                                          If the provisioner or an external controller can support the specified data source,
+                                          it will create a new volume based on the contents of the specified data source.
+                                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                         properties:
                                           apiGroup:
-                                            description: APIGroup is the group for
-                                              the resource being referenced. If APIGroup
-                                              is not specified, the specified Kind
-                                              must be in the core API group. For any
-                                              other third-party types, APIGroup is
-                                              required.
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
                                             type: string
                                           kind:
                                             description: Kind is the type of resource
@@ -328,50 +337,36 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       dataSourceRef:
-                                        description: 'dataSourceRef specifies the
-                                          object from which to populate the volume
-                                          with data, if a non-empty volume is desired.
-                                          This may be any object from a non-empty
-                                          API group (non core object) or a PersistentVolumeClaim
-                                          object. When this field is specified, volume
-                                          binding will only succeed if the type of
-                                          the specified object matches some installed
-                                          volume populator or dynamic provisioner.
-                                          This field will replace the functionality
-                                          of the dataSource field and as such if both
-                                          fields are non-empty, they must have the
-                                          same value. For backwards compatibility,
-                                          when namespace isn''t specified in dataSourceRef,
-                                          both fields (dataSource and dataSourceRef)
-                                          will be set to the same value automatically
-                                          if one of them is empty and the other is
-                                          non-empty. When namespace is specified in
-                                          dataSourceRef, dataSource isn''t set to
-                                          the same value and must be empty. There
-                                          are three important differences between
-                                          dataSource and dataSourceRef: * While dataSource
-                                          only allows two specific types of objects,
-                                          dataSourceRef allows any non-core object,
-                                          as well as PersistentVolumeClaim objects.
-                                          * While dataSource ignores disallowed values
-                                          (dropping them), dataSourceRef preserves
-                                          all values, and generates an error if a
-                                          disallowed value is specified. * While dataSource
-                                          only allows local objects, dataSourceRef
-                                          allows objects in any namespaces. (Beta)
-                                          Using this field requires the AnyVolumeDataSource
-                                          feature gate to be enabled. (Alpha) Using
-                                          the namespace field of dataSourceRef requires
-                                          the CrossNamespaceVolumeDataSource feature
-                                          gate to be enabled.'
+                                        description: |-
+                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                          volume is desired. This may be any object from a non-empty API group (non
+                                          core object) or a PersistentVolumeClaim object.
+                                          When this field is specified, volume binding will only succeed if the type of
+                                          the specified object matches some installed volume populator or dynamic
+                                          provisioner.
+                                          This field will replace the functionality of the dataSource field and as such
+                                          if both fields are non-empty, they must have the same value. For backwards
+                                          compatibility, when namespace isn't specified in dataSourceRef,
+                                          both fields (dataSource and dataSourceRef) will be set to the same
+                                          value automatically if one of them is empty and the other is non-empty.
+                                          When namespace is specified in dataSourceRef,
+                                          dataSource isn't set to the same value and must be empty.
+                                          There are three important differences between dataSource and dataSourceRef:
+                                          * While dataSource only allows two specific types of objects, dataSourceRef
+                                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                            preserves all values, and generates an error if a disallowed value is
+                                            specified.
+                                          * While dataSource only allows local objects, dataSourceRef allows objects
+                                            in any namespaces.
+                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                         properties:
                                           apiGroup:
-                                            description: APIGroup is the group for
-                                              the resource being referenced. If APIGroup
-                                              is not specified, the specified Kind
-                                              must be in the core API group. For any
-                                              other third-party types, APIGroup is
-                                              required.
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
                                             type: string
                                           kind:
                                             description: Kind is the type of resource
@@ -382,46 +377,42 @@ spec:
                                               being referenced
                                             type: string
                                           namespace:
-                                            description: Namespace is the namespace
-                                              of resource being referenced Note that
-                                              when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant
-                                              object is required in the referent namespace
-                                              to allow that namespace's owner to accept
-                                              the reference. See the ReferenceGrant
-                                              documentation for details. (Alpha) This
-                                              field requires the CrossNamespaceVolumeDataSource
-                                              feature gate to be enabled.
+                                            description: |-
+                                              Namespace is the namespace of resource being referenced
+                                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                             type: string
                                         required:
                                         - kind
                                         - name
                                         type: object
                                       resources:
-                                        description: 'resources represents the minimum
-                                          resources the volume should have. If RecoverVolumeExpansionFailure
-                                          feature is enabled users are allowed to
-                                          specify resource requirements that are lower
-                                          than previous value but must still be higher
-                                          than capacity recorded in the status field
-                                          of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                        description: |-
+                                          resources represents the minimum resources the volume should have.
+                                          If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                          that are lower than previous value but must still be higher than capacity recorded in the
+                                          status field of the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                         properties:
                                           claims:
-                                            description: "Claims lists the names of
-                                              resources, defined in spec.resourceClaims,
-                                              that are used by this container. \n
-                                              This is an alpha field and requires
-                                              enabling the DynamicResourceAllocation
-                                              feature gate. \n This field is immutable.
-                                              It can only be set for containers."
+                                            description: |-
+                                              Claims lists the names of resources, defined in spec.resourceClaims,
+                                              that are used by this container.
+
+
+                                              This is an alpha field and requires enabling the
+                                              DynamicResourceAllocation feature gate.
+
+
+                                              This field is immutable. It can only be set for containers.
                                             items:
                                               description: ResourceClaim references
                                                 one entry in PodSpec.ResourceClaims.
                                               properties:
                                                 name:
-                                                  description: Name must match the
-                                                    name of one entry in pod.spec.resourceClaims
-                                                    of the Pod where this field is
-                                                    used. It makes that resource available
+                                                  description: |-
+                                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                                    the Pod where this field is used. It makes that resource available
                                                     inside a container.
                                                   type: string
                                               required:
@@ -438,9 +429,9 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: 'Limits describes the maximum
-                                              amount of compute resources allowed.
-                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            description: |-
+                                              Limits describes the maximum amount of compute resources allowed.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                             type: object
                                           requests:
                                             additionalProperties:
@@ -449,13 +440,11 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: 'Requests describes the minimum
-                                              amount of compute resources required.
-                                              If Requests is omitted for a container,
-                                              it defaults to Limits if that is explicitly
-                                              specified, otherwise to an implementation-defined
-                                              value. Requests cannot exceed Limits.
-                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            description: |-
+                                              Requests describes the minimum amount of compute resources required.
+                                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                             type: object
                                         type: object
                                       selector:
@@ -467,29 +456,24 @@ spec:
                                               of label selector requirements. The
                                               requirements are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
                                               properties:
                                                 key:
                                                   description: key is the label key
                                                     that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
                                                     merge patch.
                                                   items:
                                                     type: string
@@ -502,25 +486,22 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       storageClassName:
-                                        description: 'storageClassName is the name
-                                          of the StorageClass required by the claim.
-                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                        description: |-
+                                          storageClassName is the name of the StorageClass required by the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                         type: string
                                       volumeMode:
-                                        description: volumeMode defines what type
-                                          of volume is required by the claim. Value
-                                          of Filesystem is implied when not included
-                                          in claim spec.
+                                        description: |-
+                                          volumeMode defines what type of volume is required by the claim.
+                                          Value of Filesystem is implied when not included in claim spec.
                                         type: string
                                       volumeName:
                                         description: volumeName is the binding reference
@@ -534,18 +515,18 @@ spec:
                         type: object
                     type: object
                   karmadaAPIServer:
-                    description: KarmadaAPIServer holds settings to kube-apiserver
-                      component. Currently, kube-apiserver is used as the apiserver
-                      of karmada. we had the same experience as k8s apiserver.
+                    description: |-
+                      KarmadaAPIServer holds settings to kube-apiserver component. Currently, kube-apiserver
+                      is used as the apiserver of karmada. we had the same experience as k8s apiserver.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                       certSANs:
                         description: CertSANs sets extra Subject Alternative Names
@@ -556,71 +537,84 @@ spec:
                       extraArgs:
                         additionalProperties:
                           type: string
-                        description: "ExtraArgs is an extra set of flags to pass to
-                          the kube-apiserver component or override. A key in this
-                          map is the flag name as it appears on the command line except
-                          without leading dash(es). \n Note: This is a temporary solution
-                          to allow for the configuration of the kube-apiserver component.
-                          In the future, we will provide a more structured way to
-                          configure the component. Once that is done, this field will
-                          be discouraged to be used. Incorrect settings on this field
-                          maybe lead to the corresponding component in an unhealthy
-                          state. Before you do it, please confirm that you understand
-                          the risks of this configuration. \n For supported flags,
-                          please see https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
-                          for details."
+                        description: |-
+                          ExtraArgs is an extra set of flags to pass to the kube-apiserver component or
+                          override. A key in this map is the flag name as it appears on the command line except
+                          without leading dash(es).
+
+
+                          Note: This is a temporary solution to allow for the configuration of the
+                          kube-apiserver component. In the future, we will provide a more structured way
+                          to configure the component. Once that is done, this field will be discouraged to be used.
+                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
+                          state. Before you do it, please confirm that you understand the risks of this configuration.
+
+
+                          For supported flags, please see
+                          https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
+                          for details.
                         type: object
                       featureGates:
                         additionalProperties:
                           type: boolean
-                        description: 'FeatureGates enabled by the user. More info:
-                          https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/'
+                        description: |-
+                          FeatureGates enabled by the user.
+                          More info: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
                         type: object
                       imagePullPolicy:
-                        description: ImagePullPolicy defines the policy for pulling
-                          the container image. If not specified, it defaults to IfNotPresent.
+                        description: |-
+                          ImagePullPolicy defines the policy for pulling the container image.
+                          If not specified, it defaults to IfNotPresent.
                         type: string
                       imageRepository:
-                        description: ImageRepository sets the container registry to
-                          pull images from. if not set, the ImageRepository defined
-                          in KarmadaSpec will be used instead.
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          if not set, the ImageRepository defined in KarmadaSpec will be used instead.
                         type: string
                       imageTag:
-                        description: ImageTag allows to specify a tag for the image.
-                          In case this value is set, operator does not change automatically
-                          the version of the above components during upgrades.
+                        description: |-
+                          ImageTag allows to specify a tag for the image.
+                          In case this value is set, operator does not change automatically the version
+                          of the above components during upgrades.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Map of string keys and values that can be used
-                          to organize and categorize (scope and select) objects. May
-                          match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
                       replicas:
-                        description: Number of desired pods. This is a pointer to
-                          distinguish between explicit zero and not specified. Defaults
-                          to 1.
+                        description: |-
+                          Number of desired pods. This is a pointer to distinguish between explicit
+                          zero and not specified. Defaults to 1.
                         format: int32
                         type: integer
                       resources:
-                        description: 'Compute Resources required by this component.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this component.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                              in spec.resourceClaims, that are used by this container.
-                              \n This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate. \n This field
-                              is immutable. It can only be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -637,8 +631,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -647,26 +642,28 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       serviceAnnotations:
                         additionalProperties:
                           type: string
-                        description: 'ServiceAnnotations is an extra set of annotations
-                          for service of karmada apiserver. more info: https://github.com/karmada-io/karmada/issues/4634'
+                        description: |-
+                          ServiceAnnotations is an extra set of annotations for service of karmada apiserver.
+                          more info: https://github.com/karmada-io/karmada/issues/4634
                         type: object
                       serviceSubnet:
                         description: ServiceSubnet is the subnet used by k8s services.
                           Defaults to "10.96.0.0/12".
                         type: string
                       serviceType:
-                        description: ServiceType represents the service type of karmada
-                          apiserver. it is ClusterIP by default.
+                        description: |-
+                          ServiceType represents the service type of karmada apiserver.
+                          it is ClusterIP by default.
                         type: string
                     type: object
                   karmadaAggregatedAPIServer:
@@ -676,11 +673,11 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                       certSANs:
                         description: CertSANs sets extra Subject Alternative Names
@@ -691,72 +688,85 @@ spec:
                       extraArgs:
                         additionalProperties:
                           type: string
-                        description: "ExtraArgs is an extra set of flags to pass to
-                          the karmada-aggregated-apiserver component or override.
-                          A key in this map is the flag name as it appears on the
-                          command line except without leading dash(es). \n Note: This
-                          is a temporary solution to allow for the configuration of
-                          the karmada-aggregated-apiserver component. In the future,
-                          we will provide a more structured way to configure the component.
-                          Once that is done, this field will be discouraged to be
-                          used. Incorrect settings on this field maybe lead to the
-                          corresponding component in an unhealthy state. Before you
-                          do it, please confirm that you understand the risks of this
-                          configuration. \n For supported flags, please see https://karmada.io/docs/reference/components/karmada-aggregated-apiserver
-                          for details."
+                        description: |-
+                          ExtraArgs is an extra set of flags to pass to the karmada-aggregated-apiserver component or
+                          override. A key in this map is the flag name as it appears on the command line except
+                          without leading dash(es).
+
+
+                          Note: This is a temporary solution to allow for the configuration of the
+                          karmada-aggregated-apiserver component. In the future, we will provide a more structured way
+                          to configure the component. Once that is done, this field will be discouraged to be used.
+                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
+                          state. Before you do it, please confirm that you understand the risks of this configuration.
+
+
+                          For supported flags, please see
+                          https://karmada.io/docs/reference/components/karmada-aggregated-apiserver
+                          for details.
                         type: object
                       featureGates:
                         additionalProperties:
                           type: boolean
-                        description: 'FeatureGates enabled by the user. - CustomizedClusterResourceModeling:
-                          https://karmada.io/docs/userguide/scheduling/cluster-resources#start-to-use-cluster-resource-models
-                          More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go'
+                        description: |-
+                          FeatureGates enabled by the user.
+                          - CustomizedClusterResourceModeling: https://karmada.io/docs/userguide/scheduling/cluster-resources#start-to-use-cluster-resource-models
+                          More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go
                         type: object
                       imagePullPolicy:
-                        description: ImagePullPolicy defines the policy for pulling
-                          the container image. If not specified, it defaults to IfNotPresent.
+                        description: |-
+                          ImagePullPolicy defines the policy for pulling the container image.
+                          If not specified, it defaults to IfNotPresent.
                         type: string
                       imageRepository:
-                        description: ImageRepository sets the container registry to
-                          pull images from. if not set, the ImageRepository defined
-                          in KarmadaSpec will be used instead.
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          if not set, the ImageRepository defined in KarmadaSpec will be used instead.
                         type: string
                       imageTag:
-                        description: ImageTag allows to specify a tag for the image.
-                          In case this value is set, operator does not change automatically
-                          the version of the above components during upgrades.
+                        description: |-
+                          ImageTag allows to specify a tag for the image.
+                          In case this value is set, operator does not change automatically the version
+                          of the above components during upgrades.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Map of string keys and values that can be used
-                          to organize and categorize (scope and select) objects. May
-                          match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
                       replicas:
-                        description: Number of desired pods. This is a pointer to
-                          distinguish between explicit zero and not specified. Defaults
-                          to 1.
+                        description: |-
+                          Number of desired pods. This is a pointer to distinguish between explicit
+                          zero and not specified. Defaults to 1.
                         format: int32
                         type: integer
                       resources:
-                        description: 'Compute Resources required by this component.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this component.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                              in spec.resourceClaims, that are used by this container.
-                              \n This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate. \n This field
-                              is immutable. It can only be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -773,8 +783,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -783,11 +794,11 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                     type: object
@@ -798,98 +809,114 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                       controllers:
-                        description: "A list of controllers to enable. '*' enables
-                          all on-by-default controllers, 'foo' enables the controller
-                          named 'foo', '-foo' disables the controller named 'foo'.
-                          \n All controllers: binding, cluster, clusterStatus, endpointSlice,
-                          execution, federatedResourceQuotaStatus, federatedResourceQuotaSync,
-                          hpa, namespace, serviceExport, serviceImport, unifiedAuth,
-                          workStatus. Disabled-by-default controllers: hpa (default
-                          [*]) Actual Supported controllers depend on the version
-                          of Karmada. See https://karmada.io/docs/administrator/configuration/configure-controllers#configure-karmada-controllers
-                          for details."
+                        description: |-
+                          A list of controllers to enable. '*' enables all on-by-default controllers,
+                          'foo' enables the controller named 'foo', '-foo' disables the controller named
+                          'foo'.
+
+
+                          All controllers: binding, cluster, clusterStatus, endpointSlice, execution,
+                          federatedResourceQuotaStatus, federatedResourceQuotaSync, hpa, namespace,
+                          serviceExport, serviceImport, unifiedAuth, workStatus.
+                          Disabled-by-default controllers: hpa (default [*])
+                          Actual Supported controllers depend on the version of Karmada. See
+                          https://karmada.io/docs/administrator/configuration/configure-controllers#configure-karmada-controllers
+                          for details.
                         items:
                           type: string
                         type: array
                       extraArgs:
                         additionalProperties:
                           type: string
-                        description: "ExtraArgs is an extra set of flags to pass to
-                          the karmada-controller-manager component or override. A
-                          key in this map is the flag name as it appears on the command
-                          line except without leading dash(es). \n Note: This is a
-                          temporary solution to allow for the configuration of the
-                          karmada-controller-manager component. In the future, we
-                          will provide a more structured way to configure the component.
-                          Once that is done, this field will be discouraged to be
-                          used. Incorrect settings on this field maybe lead to the
-                          corresponding component in an unhealthy state. Before you
-                          do it, please confirm that you understand the risks of this
-                          configuration. \n For supported flags, please see https://karmada.io/docs/reference/components/karmada-controller-manager
-                          for details."
+                        description: |-
+                          ExtraArgs is an extra set of flags to pass to the karmada-controller-manager component or
+                          override. A key in this map is the flag name as it appears on the command line except
+                          without leading dash(es).
+
+
+                          Note: This is a temporary solution to allow for the configuration of the
+                          karmada-controller-manager component. In the future, we will provide a more structured way
+                          to configure the component. Once that is done, this field will be discouraged to be used.
+                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
+                          state. Before you do it, please confirm that you understand the risks of this configuration.
+
+
+                          For supported flags, please see
+                          https://karmada.io/docs/reference/components/karmada-controller-manager
+                          for details.
                         type: object
                       featureGates:
                         additionalProperties:
                           type: boolean
-                        description: 'FeatureGates enabled by the user. - Failover:
-                          https://karmada.io/docs/userguide/failover/#failover - GracefulEviction:
-                          https://karmada.io/docs/userguide/failover/#graceful-eviction-feature
+                        description: |-
+                          FeatureGates enabled by the user.
+                          - Failover: https://karmada.io/docs/userguide/failover/#failover
+                          - GracefulEviction: https://karmada.io/docs/userguide/failover/#graceful-eviction-feature
                           - PropagateDeps: https://karmada.io/docs/userguide/scheduling/propagate-dependencies
                           - CustomizedClusterResourceModeling: https://karmada.io/docs/userguide/scheduling/cluster-resources#start-to-use-cluster-resource-models
-                          More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go'
+                          More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go
                         type: object
                       imagePullPolicy:
-                        description: ImagePullPolicy defines the policy for pulling
-                          the container image. If not specified, it defaults to IfNotPresent.
+                        description: |-
+                          ImagePullPolicy defines the policy for pulling the container image.
+                          If not specified, it defaults to IfNotPresent.
                         type: string
                       imageRepository:
-                        description: ImageRepository sets the container registry to
-                          pull images from. if not set, the ImageRepository defined
-                          in KarmadaSpec will be used instead.
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          if not set, the ImageRepository defined in KarmadaSpec will be used instead.
                         type: string
                       imageTag:
-                        description: ImageTag allows to specify a tag for the image.
-                          In case this value is set, operator does not change automatically
-                          the version of the above components during upgrades.
+                        description: |-
+                          ImageTag allows to specify a tag for the image.
+                          In case this value is set, operator does not change automatically the version
+                          of the above components during upgrades.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Map of string keys and values that can be used
-                          to organize and categorize (scope and select) objects. May
-                          match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
                       replicas:
-                        description: Number of desired pods. This is a pointer to
-                          distinguish between explicit zero and not specified. Defaults
-                          to 1.
+                        description: |-
+                          Number of desired pods. This is a pointer to distinguish between explicit
+                          zero and not specified. Defaults to 1.
                         format: int32
                         type: integer
                       resources:
-                        description: 'Compute Resources required by this component.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this component.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                              in spec.resourceClaims, that are used by this container.
-                              \n This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate. \n This field
-                              is immutable. It can only be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -906,8 +933,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -916,11 +944,11 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                     type: object
@@ -931,74 +959,86 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                       extraArgs:
                         additionalProperties:
                           type: string
-                        description: "ExtraArgs is an extra set of flags to pass to
-                          the karmada-descheduler component or override. A key in
-                          this map is the flag name as it appears on the command line
-                          except without leading dash(es). \n Note: This is a temporary
-                          solution to allow for the configuration of the karmada-descheduler
-                          component. In the future, we will provide a more structured
-                          way to configure the component. Once that is done, this
-                          field will be discouraged to be used. Incorrect settings
-                          on this field maybe lead to the corresponding component
-                          in an unhealthy state. Before you do it, please confirm
-                          that you understand the risks of this configuration. \n
-                          For supported flags, please see https://karmada.io/docs/reference/components/karmada-descheduler
-                          for details."
+                        description: |-
+                          ExtraArgs is an extra set of flags to pass to the karmada-descheduler component or override.
+                          A key in this map is the flag name as it appears on the command line except without
+                          leading dash(es).
+
+
+                          Note: This is a temporary solution to allow for the configuration of the karmada-descheduler
+                          component. In the future, we will provide a more structured way to configure the component.
+                          Once that is done, this field will be discouraged to be used.
+                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
+                          state. Before you do it, please confirm that you understand the risks of this configuration.
+
+
+                          For supported flags, please see
+                          https://karmada.io/docs/reference/components/karmada-descheduler
+                          for details.
                         type: object
                       imagePullPolicy:
-                        description: ImagePullPolicy defines the policy for pulling
-                          the container image. If not specified, it defaults to IfNotPresent.
+                        description: |-
+                          ImagePullPolicy defines the policy for pulling the container image.
+                          If not specified, it defaults to IfNotPresent.
                         type: string
                       imageRepository:
-                        description: ImageRepository sets the container registry to
-                          pull images from. if not set, the ImageRepository defined
-                          in KarmadaSpec will be used instead.
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          if not set, the ImageRepository defined in KarmadaSpec will be used instead.
                         type: string
                       imageTag:
-                        description: ImageTag allows to specify a tag for the image.
-                          In case this value is set, operator does not change automatically
-                          the version of the above components during upgrades.
+                        description: |-
+                          ImageTag allows to specify a tag for the image.
+                          In case this value is set, operator does not change automatically the version
+                          of the above components during upgrades.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Map of string keys and values that can be used
-                          to organize and categorize (scope and select) objects. May
-                          match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
                       replicas:
-                        description: Number of desired pods. This is a pointer to
-                          distinguish between explicit zero and not specified. Defaults
-                          to 1.
+                        description: |-
+                          Number of desired pods. This is a pointer to distinguish between explicit
+                          zero and not specified. Defaults to 1.
                         format: int32
                         type: integer
                       resources:
-                        description: 'Compute Resources required by this component.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this component.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                              in spec.resourceClaims, that are used by this container.
-                              \n This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate. \n This field
-                              is immutable. It can only be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -1015,8 +1055,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1025,11 +1066,11 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                     type: object
@@ -1040,74 +1081,86 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                       extraArgs:
                         additionalProperties:
                           type: string
-                        description: "ExtraArgs is an extra set of flags to pass to
-                          the karmada-metrics-adapter component or override. A key
-                          in this map is the flag name as it appears on the command
-                          line except without leading dash(es). \n Note: This is a
-                          temporary solution to allow for the configuration of the
-                          karmada-metrics-adapter component. In the future, we will
-                          provide a more structured way to configure the component.
-                          Once that is done, this field will be discouraged to be
-                          used. Incorrect settings on this field maybe lead to the
-                          corresponding component in an unhealthy state. Before you
-                          do it, please confirm that you understand the risks of this
-                          configuration. \n For supported flags, please see https://karmada.io/docs/reference/components/karmada-metrics-adapter
-                          for details."
+                        description: |-
+                          ExtraArgs is an extra set of flags to pass to the karmada-metrics-adapter component or override.
+                          A key in this map is the flag name as it appears on the command line except without
+                          leading dash(es).
+
+
+                          Note: This is a temporary solution to allow for the configuration of the karmada-metrics-adapter
+                          component. In the future, we will provide a more structured way to configure the component.
+                          Once that is done, this field will be discouraged to be used.
+                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
+                          state. Before you do it, please confirm that you understand the risks of this configuration.
+
+
+                          For supported flags, please see
+                          https://karmada.io/docs/reference/components/karmada-metrics-adapter
+                          for details.
                         type: object
                       imagePullPolicy:
-                        description: ImagePullPolicy defines the policy for pulling
-                          the container image. If not specified, it defaults to IfNotPresent.
+                        description: |-
+                          ImagePullPolicy defines the policy for pulling the container image.
+                          If not specified, it defaults to IfNotPresent.
                         type: string
                       imageRepository:
-                        description: ImageRepository sets the container registry to
-                          pull images from. if not set, the ImageRepository defined
-                          in KarmadaSpec will be used instead.
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          if not set, the ImageRepository defined in KarmadaSpec will be used instead.
                         type: string
                       imageTag:
-                        description: ImageTag allows to specify a tag for the image.
-                          In case this value is set, operator does not change automatically
-                          the version of the above components during upgrades.
+                        description: |-
+                          ImageTag allows to specify a tag for the image.
+                          In case this value is set, operator does not change automatically the version
+                          of the above components during upgrades.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Map of string keys and values that can be used
-                          to organize and categorize (scope and select) objects. May
-                          match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
                       replicas:
-                        description: Number of desired pods. This is a pointer to
-                          distinguish between explicit zero and not specified. Defaults
-                          to 1.
+                        description: |-
+                          Number of desired pods. This is a pointer to distinguish between explicit
+                          zero and not specified. Defaults to 1.
                         format: int32
                         type: integer
                       resources:
-                        description: 'Compute Resources required by this component.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this component.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                              in spec.resourceClaims, that are used by this container.
-                              \n This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate. \n This field
-                              is immutable. It can only be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -1124,8 +1177,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1134,11 +1188,11 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                     type: object
@@ -1149,81 +1203,94 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                       extraArgs:
                         additionalProperties:
                           type: string
-                        description: "ExtraArgs is an extra set of flags to pass to
-                          the karmada-scheduler component or override. A key in this
-                          map is the flag name as it appears on the command line except
-                          without leading dash(es). \n Note: This is a temporary solution
-                          to allow for the configuration of the karmada-scheduler
-                          component. In the future, we will provide a more structured
-                          way to configure the component. Once that is done, this
-                          field will be discouraged to be used. Incorrect settings
-                          on this field maybe lead to the corresponding component
-                          in an unhealthy state. Before you do it, please confirm
-                          that you understand the risks of this configuration. \n
-                          For supported flags, please see https://karmada.io/docs/reference/components/karmada-scheduler
-                          for details."
+                        description: |-
+                          ExtraArgs is an extra set of flags to pass to the karmada-scheduler component or override.
+                          A key in this map is the flag name as it appears on the command line except without
+                          leading dash(es).
+
+
+                          Note: This is a temporary solution to allow for the configuration of the karmada-scheduler
+                          component. In the future, we will provide a more structured way to configure the component.
+                          Once that is done, this field will be discouraged to be used.
+                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
+                          state. Before you do it, please confirm that you understand the risks of this configuration.
+
+
+                          For supported flags, please see
+                          https://karmada.io/docs/reference/components/karmada-scheduler
+                          for details.
                         type: object
                       featureGates:
                         additionalProperties:
                           type: boolean
-                        description: 'FeatureGates enabled by the user. - CustomizedClusterResourceModeling:
-                          https://karmada.io/docs/userguide/scheduling/cluster-resources#start-to-use-cluster-resource-models
-                          More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go'
+                        description: |-
+                          FeatureGates enabled by the user.
+                          - CustomizedClusterResourceModeling: https://karmada.io/docs/userguide/scheduling/cluster-resources#start-to-use-cluster-resource-models
+                          More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go
                         type: object
                       imagePullPolicy:
-                        description: ImagePullPolicy defines the policy for pulling
-                          the container image. If not specified, it defaults to IfNotPresent.
+                        description: |-
+                          ImagePullPolicy defines the policy for pulling the container image.
+                          If not specified, it defaults to IfNotPresent.
                         type: string
                       imageRepository:
-                        description: ImageRepository sets the container registry to
-                          pull images from. if not set, the ImageRepository defined
-                          in KarmadaSpec will be used instead.
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          if not set, the ImageRepository defined in KarmadaSpec will be used instead.
                         type: string
                       imageTag:
-                        description: ImageTag allows to specify a tag for the image.
-                          In case this value is set, operator does not change automatically
-                          the version of the above components during upgrades.
+                        description: |-
+                          ImageTag allows to specify a tag for the image.
+                          In case this value is set, operator does not change automatically the version
+                          of the above components during upgrades.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Map of string keys and values that can be used
-                          to organize and categorize (scope and select) objects. May
-                          match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
                       replicas:
-                        description: Number of desired pods. This is a pointer to
-                          distinguish between explicit zero and not specified. Defaults
-                          to 1.
+                        description: |-
+                          Number of desired pods. This is a pointer to distinguish between explicit
+                          zero and not specified. Defaults to 1.
                         format: int32
                         type: integer
                       resources:
-                        description: 'Compute Resources required by this component.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this component.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                              in spec.resourceClaims, that are used by this container.
-                              \n This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate. \n This field
-                              is immutable. It can only be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -1240,8 +1307,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1250,11 +1318,11 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                     type: object
@@ -1265,74 +1333,86 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                       extraArgs:
                         additionalProperties:
                           type: string
-                        description: "ExtraArgs is an extra set of flags to pass to
-                          the karmada-search component or override. A key in this
-                          map is the flag name as it appears on the command line except
-                          without leading dash(es). \n Note: This is a temporary solution
-                          to allow for the configuration of the karmada-search component.
-                          In the future, we will provide a more structured way to
-                          configure the component. Once that is done, this field will
-                          be discouraged to be used. Incorrect settings on this field
-                          maybe lead to the corresponding component in an unhealthy
-                          state. Before you do it, please confirm that you understand
-                          the risks of this configuration. \n For supported flags,
-                          please see https://karmada.io/docs/reference/components/karmada-search
-                          for details."
+                        description: |-
+                          ExtraArgs is an extra set of flags to pass to the karmada-search component or override.
+                          A key in this map is the flag name as it appears on the command line except without
+                          leading dash(es).
+
+
+                          Note: This is a temporary solution to allow for the configuration of the karmada-search
+                          component. In the future, we will provide a more structured way to configure the component.
+                          Once that is done, this field will be discouraged to be used.
+                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
+                          state. Before you do it, please confirm that you understand the risks of this configuration.
+
+
+                          For supported flags, please see
+                          https://karmada.io/docs/reference/components/karmada-search
+                          for details.
                         type: object
                       imagePullPolicy:
-                        description: ImagePullPolicy defines the policy for pulling
-                          the container image. If not specified, it defaults to IfNotPresent.
+                        description: |-
+                          ImagePullPolicy defines the policy for pulling the container image.
+                          If not specified, it defaults to IfNotPresent.
                         type: string
                       imageRepository:
-                        description: ImageRepository sets the container registry to
-                          pull images from. if not set, the ImageRepository defined
-                          in KarmadaSpec will be used instead.
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          if not set, the ImageRepository defined in KarmadaSpec will be used instead.
                         type: string
                       imageTag:
-                        description: ImageTag allows to specify a tag for the image.
-                          In case this value is set, operator does not change automatically
-                          the version of the above components during upgrades.
+                        description: |-
+                          ImageTag allows to specify a tag for the image.
+                          In case this value is set, operator does not change automatically the version
+                          of the above components during upgrades.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Map of string keys and values that can be used
-                          to organize and categorize (scope and select) objects. May
-                          match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
                       replicas:
-                        description: Number of desired pods. This is a pointer to
-                          distinguish between explicit zero and not specified. Defaults
-                          to 1.
+                        description: |-
+                          Number of desired pods. This is a pointer to distinguish between explicit
+                          zero and not specified. Defaults to 1.
                         format: int32
                         type: integer
                       resources:
-                        description: 'Compute Resources required by this component.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this component.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                              in spec.resourceClaims, that are used by this container.
-                              \n This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate. \n This field
-                              is immutable. It can only be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -1349,8 +1429,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1359,11 +1440,11 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                     type: object
@@ -1374,74 +1455,86 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                       extraArgs:
                         additionalProperties:
                           type: string
-                        description: "ExtraArgs is an extra set of flags to pass to
-                          the karmada-webhook component or override. A key in this
-                          map is the flag name as it appears on the command line except
-                          without leading dash(es). \n Note: This is a temporary solution
-                          to allow for the configuration of the karmada-webhook component.
-                          In the future, we will provide a more structured way to
-                          configure the component. Once that is done, this field will
-                          be discouraged to be used. Incorrect settings on this field
-                          maybe lead to the corresponding component in an unhealthy
-                          state. Before you do it, please confirm that you understand
-                          the risks of this configuration. \n For supported flags,
-                          please see https://karmada.io/docs/reference/components/karmada-webhook
-                          for details."
+                        description: |-
+                          ExtraArgs is an extra set of flags to pass to the karmada-webhook component or
+                          override. A key in this map is the flag name as it appears on the command line except
+                          without leading dash(es).
+
+
+                          Note: This is a temporary solution to allow for the configuration of the
+                          karmada-webhook component. In the future, we will provide a more structured way
+                          to configure the component. Once that is done, this field will be discouraged to be used.
+                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
+                          state. Before you do it, please confirm that you understand the risks of this configuration.
+
+
+                          For supported flags, please see
+                          https://karmada.io/docs/reference/components/karmada-webhook
+                          for details.
                         type: object
                       imagePullPolicy:
-                        description: ImagePullPolicy defines the policy for pulling
-                          the container image. If not specified, it defaults to IfNotPresent.
+                        description: |-
+                          ImagePullPolicy defines the policy for pulling the container image.
+                          If not specified, it defaults to IfNotPresent.
                         type: string
                       imageRepository:
-                        description: ImageRepository sets the container registry to
-                          pull images from. if not set, the ImageRepository defined
-                          in KarmadaSpec will be used instead.
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          if not set, the ImageRepository defined in KarmadaSpec will be used instead.
                         type: string
                       imageTag:
-                        description: ImageTag allows to specify a tag for the image.
-                          In case this value is set, operator does not change automatically
-                          the version of the above components during upgrades.
+                        description: |-
+                          ImageTag allows to specify a tag for the image.
+                          In case this value is set, operator does not change automatically the version
+                          of the above components during upgrades.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Map of string keys and values that can be used
-                          to organize and categorize (scope and select) objects. May
-                          match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
                       replicas:
-                        description: Number of desired pods. This is a pointer to
-                          distinguish between explicit zero and not specified. Defaults
-                          to 1.
+                        description: |-
+                          Number of desired pods. This is a pointer to distinguish between explicit
+                          zero and not specified. Defaults to 1.
                         format: int32
                         type: integer
                       resources:
-                        description: 'Compute Resources required by this component.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this component.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                              in spec.resourceClaims, that are used by this container.
-                              \n This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate. \n This field
-                              is immutable. It can only be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -1458,8 +1551,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1468,11 +1562,11 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                     type: object
@@ -1483,117 +1577,136 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                       controllers:
-                        description: "A list of controllers to enable. '*' enables
-                          all on-by-default controllers, 'foo' enables the controller
-                          named 'foo', '-foo' disables the controller named 'foo'.
-                          \n All controllers: attachdetach, bootstrapsigner, cloud-node-lifecycle,
-                          clusterrole-aggregation, cronjob, csrapproving, csrcleaner,
-                          csrsigning, daemonset, deployment, disruption, endpoint,
-                          endpointslice, endpointslicemirroring, ephemeral-volume,
-                          garbagecollector, horizontalpodautoscaling, job, namespace,
-                          nodeipam, nodelifecycle, persistentvolume-binder, persistentvolume-expander,
-                          podgc, pv-protection, pvc-protection, replicaset, replicationcontroller,
-                          resourcequota, root-ca-cert-publisher, route, service, serviceaccount,
-                          serviceaccount-token, statefulset, tokencleaner, ttl, ttl-after-finished
-                          Disabled-by-default controllers: bootstrapsigner, tokencleaner
-                          (default [*]) Actual Supported controllers depend on the
-                          version of Kubernetes. See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/
-                          for details. \n However, Karmada uses Kubernetes Native
-                          API definitions for federated resource template, so it doesn't
-                          need enable some resource related controllers like daemonset,
-                          deployment etc. On the other hand, Karmada leverages the
-                          capabilities of the Kubernetes controller to manage the
-                          lifecycle of the federated resource, so it needs to enable
-                          some controllers. For example, the `namespace` controller
-                          is used to manage the lifecycle of the namespace and the
-                          `garbagecollector` controller handles automatic clean-up
-                          of redundant items in your karmada. \n According to the
-                          user feedback and karmada requirements, the following controllers
-                          are enabled by default: namespace, garbagecollector, serviceaccount-token,
-                          ttl-after-finished, bootstrapsigner,csrapproving,csrcleaner,csrsigning.
-                          See https://karmada.io/docs/administrator/configuration/configure-controllers#kubernetes-controllers
-                          \n Others are disabled by default. If you want to enable
-                          or disable other controllers, you have to explicitly specify
-                          all the controllers that kube-controller-manager should
-                          enable at startup phase."
+                        description: |-
+                          A list of controllers to enable. '*' enables all on-by-default controllers,
+                          'foo' enables the controller named 'foo', '-foo' disables the controller named
+                          'foo'.
+
+
+                          All controllers: attachdetach, bootstrapsigner, cloud-node-lifecycle,
+                          clusterrole-aggregation, cronjob, csrapproving, csrcleaner, csrsigning,
+                          daemonset, deployment, disruption, endpoint, endpointslice,
+                          endpointslicemirroring, ephemeral-volume, garbagecollector,
+                          horizontalpodautoscaling, job, namespace, nodeipam, nodelifecycle,
+                          persistentvolume-binder, persistentvolume-expander, podgc, pv-protection,
+                          pvc-protection, replicaset, replicationcontroller, resourcequota,
+                          root-ca-cert-publisher, route, service, serviceaccount, serviceaccount-token,
+                          statefulset, tokencleaner, ttl, ttl-after-finished
+                          Disabled-by-default controllers: bootstrapsigner, tokencleaner (default [*])
+                          Actual Supported controllers depend on the version of Kubernetes. See
+                          https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/
+                          for details.
+
+
+                          However, Karmada uses Kubernetes Native API definitions for federated resource template,
+                          so it doesn't need enable some resource related controllers like daemonset, deployment etc.
+                          On the other hand, Karmada leverages the capabilities of the Kubernetes controller to
+                          manage the lifecycle of the federated resource, so it needs to enable some controllers.
+                          For example, the `namespace` controller is used to manage the lifecycle of the namespace
+                          and the `garbagecollector` controller handles automatic clean-up of redundant items in
+                          your karmada.
+
+
+                          According to the user feedback and karmada requirements, the following controllers are
+                          enabled by default: namespace, garbagecollector, serviceaccount-token, ttl-after-finished,
+                          bootstrapsigner,csrapproving,csrcleaner,csrsigning. See
+                          https://karmada.io/docs/administrator/configuration/configure-controllers#kubernetes-controllers
+
+
+                          Others are disabled by default. If you want to enable or disable other controllers, you
+                          have to explicitly specify all the controllers that kube-controller-manager should enable
+                          at startup phase.
                         items:
                           type: string
                         type: array
                       extraArgs:
                         additionalProperties:
                           type: string
-                        description: "ExtraArgs is an extra set of flags to pass to
-                          the kube-controller-manager component or override. A key
-                          in this map is the flag name as it appears on the command
-                          line except without leading dash(es). \n Note: This is a
-                          temporary solution to allow for the configuration of the
-                          kube-controller-manager component. In the future, we will
-                          provide a more structured way to configure the component.
-                          Once that is done, this field will be discouraged to be
-                          used. Incorrect settings on this field maybe lead to the
-                          corresponding component in an unhealthy state. Before you
-                          do it, please confirm that you understand the risks of this
-                          configuration. \n For supported flags, please see https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/
-                          for details."
+                        description: |-
+                          ExtraArgs is an extra set of flags to pass to the kube-controller-manager component or
+                          override. A key in this map is the flag name as it appears on the command line except
+                          without leading dash(es).
+
+
+                          Note: This is a temporary solution to allow for the configuration of the
+                          kube-controller-manager component. In the future, we will provide a more structured way
+                          to configure the component. Once that is done, this field will be discouraged to be used.
+                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
+                          state. Before you do it, please confirm that you understand the risks of this configuration.
+
+
+                          For supported flags, please see
+                          https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/
+                          for details.
                         type: object
                       featureGates:
                         additionalProperties:
                           type: boolean
-                        description: 'FeatureGates enabled by the user. More info:
-                          https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/'
+                        description: |-
+                          FeatureGates enabled by the user.
+                          More info: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/
                         type: object
                       imagePullPolicy:
-                        description: ImagePullPolicy defines the policy for pulling
-                          the container image. If not specified, it defaults to IfNotPresent.
+                        description: |-
+                          ImagePullPolicy defines the policy for pulling the container image.
+                          If not specified, it defaults to IfNotPresent.
                         type: string
                       imageRepository:
-                        description: ImageRepository sets the container registry to
-                          pull images from. if not set, the ImageRepository defined
-                          in KarmadaSpec will be used instead.
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          if not set, the ImageRepository defined in KarmadaSpec will be used instead.
                         type: string
                       imageTag:
-                        description: ImageTag allows to specify a tag for the image.
-                          In case this value is set, operator does not change automatically
-                          the version of the above components during upgrades.
+                        description: |-
+                          ImageTag allows to specify a tag for the image.
+                          In case this value is set, operator does not change automatically the version
+                          of the above components during upgrades.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Map of string keys and values that can be used
-                          to organize and categorize (scope and select) objects. May
-                          match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
                       replicas:
-                        description: Number of desired pods. This is a pointer to
-                          distinguish between explicit zero and not specified. Defaults
-                          to 1.
+                        description: |-
+                          Number of desired pods. This is a pointer to distinguish between explicit
+                          zero and not specified. Defaults to 1.
                         format: int32
                         type: integer
                       resources:
-                        description: 'Compute Resources required by this component.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this component.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                              in spec.resourceClaims, that are used by this container.
-                              \n This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate. \n This field
-                              is immutable. It can only be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -1610,8 +1723,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1620,11 +1734,11 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                     type: object
@@ -1632,21 +1746,25 @@ spec:
               featureGates:
                 additionalProperties:
                   type: boolean
-                description: 'FeatureGates enabled by the user. - Failover: https://karmada.io/docs/userguide/failover/#failover
+                description: |-
+                  FeatureGates enabled by the user.
+                  - Failover: https://karmada.io/docs/userguide/failover/#failover
                   - GracefulEviction: https://karmada.io/docs/userguide/failover/#graceful-eviction-feature
                   - PropagateDeps: https://karmada.io/docs/userguide/scheduling/propagate-dependencies
                   - CustomizedClusterResourceModeling: https://karmada.io/docs/userguide/scheduling/cluster-resources#start-to-use-cluster-resource-models
-                  More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go'
+                  More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go
                 type: object
               hostCluster:
-                description: HostCluster represents the cluster where to install the
-                  Karmada control plane. If not set, the control plane will be installed
-                  on the cluster where running the operator.
+                description: |-
+                  HostCluster represents the cluster where to install the Karmada control plane.
+                  If not set, the control plane will be installed on the cluster where
+                  running the operator.
                 properties:
                   apiEndpoint:
-                    description: APIEndpoint is the API endpoint of the cluster where
-                      deploy Karmada control plane on. This can be a hostname, hostname:port,
-                      IP or IP:port.
+                    description: |-
+                      APIEndpoint is the API endpoint of the cluster where deploy Karmada
+                      control plane on.
+                      This can be a hostname, hostname:port, IP or IP:port.
                     type: string
                   networking:
                     description: Networking holds configuration for the networking
@@ -1658,9 +1776,12 @@ spec:
                         type: string
                     type: object
                   secretRef:
-                    description: 'SecretRef represents the secret contains mandatory
-                      credentials to access the cluster. The secret should hold credentials
-                      as follows: - secret.data.token - secret.data.caBundle'
+                    description: |-
+                      SecretRef represents the secret contains mandatory credentials to
+                      access the cluster.
+                      The secret should hold credentials as follows:
+                      - secret.data.token
+                      - secret.data.caBundle
                     properties:
                       name:
                         description: Name is the name of resource being referenced.
@@ -1672,14 +1793,17 @@ spec:
                     type: object
                 type: object
               privateRegistry:
-                description: PrivateRegistry is the global image registry. If set,
-                  the operator will pull all required images from it, no matter the
-                  image is maintained by Karmada or Kubernetes. It will be useful
-                  for offline installation to specify an accessible registry.
+                description: |-
+                  PrivateRegistry is the global image registry.
+                  If set, the operator will pull all required images from it, no matter
+                  the image is maintained by Karmada or Kubernetes.
+                  It will be useful for offline installation to specify an accessible registry.
                 properties:
                   registry:
-                    description: 'Registry is the image registry hostname, like: -
-                      docker.io - fictional.registry.example'
+                    description: |-
+                      Registry is the image registry hostname, like:
+                      - docker.io
+                      - fictional.registry.example
                     type: string
                 required:
                 - registry
@@ -1693,42 +1817,42 @@ spec:
                   of a karmada's current state.
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -1742,11 +1866,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/charts/karmada/_crds/bases/apps/apps.karmada.io_workloadrebalancers.yaml
+++ b/charts/karmada/_crds/bases/apps/apps.karmada.io_workloadrebalancers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: workloadrebalancers.apps.karmada.io
 spec:
   group: apps.karmada.io
@@ -21,14 +21,19 @@ spec:
           of a job which can enforces a resource rebalance.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -37,7 +42,8 @@ spec:
               of WorkloadRebalancer.
             properties:
               workloads:
-                description: Workloads used to specify the list of expected resource.
+                description: |-
+                  Workloads used to specify the list of expected resource.
                   Nil or empty list is not allowed.
                 items:
                   description: ObjectReference the expected resource.
@@ -53,8 +59,9 @@ spec:
                       description: Name of the target resource.
                       type: string
                     namespace:
-                      description: Namespace of the target resource. Default is empty,
-                        which means it is a non-namespacescoped resource.
+                      description: |-
+                        Namespace of the target resource.
+                        Default is empty, which means it is a non-namespacescoped resource.
                       type: string
                   required:
                   - apiVersion
@@ -96,8 +103,9 @@ spec:
                           description: Name of the target resource.
                           type: string
                         namespace:
-                          description: Namespace of the target resource. Default is
-                            empty, which means it is a non-namespacescoped resource.
+                          description: |-
+                            Namespace of the target resource.
+                            Default is empty, which means it is a non-namespacescoped resource.
                           type: string
                       required:
                       - apiVersion

--- a/charts/karmada/_crds/bases/autoscaling/autoscaling.karmada.io_cronfederatedhpas.yaml
+++ b/charts/karmada/_crds/bases/autoscaling/autoscaling.karmada.io_cronfederatedhpas.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: cronfederatedhpas.autoscaling.karmada.io
 spec:
   group: autoscaling.karmada.io
@@ -31,19 +31,25 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: CronFederatedHPA represents a collection of repeating schedule
-          to scale replica number of a specific workload. It can scale any resource
-          implementing the scale subresource as well as FederatedHPA.
+        description: |-
+          CronFederatedHPA represents a collection of repeating schedule to scale
+          replica number of a specific workload. It can scale any resource implementing
+          the scale subresource as well as FederatedHPA.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -51,79 +57,92 @@ spec:
             description: Spec is the specification of the CronFederatedHPA.
             properties:
               rules:
-                description: Rules contains a collection of schedules that declares
-                  when and how the referencing target resource should be scaled.
+                description: |-
+                  Rules contains a collection of schedules that declares when and how
+                  the referencing target resource should be scaled.
                 items:
                   description: CronFederatedHPARule declares a schedule as well as
                     scale actions.
                   properties:
                     failedHistoryLimit:
                       default: 3
-                      description: FailedHistoryLimit represents the count of failed
-                        execution items for each rule. The value must be a positive
-                        integer. It defaults to 3.
+                      description: |-
+                        FailedHistoryLimit represents the count of failed execution items for
+                        each rule.
+                        The value must be a positive integer. It defaults to 3.
                       format: int32
                       maximum: 32
                       minimum: 0
                       type: integer
                     name:
-                      description: "Name of the rule. Each rule in a CronFederatedHPA
-                        must have a unique name. \n Note: the name will be used as
-                        an identifier to record its execution history. Changing the
-                        name will be considered as deleting the old rule and adding
-                        a new rule, that means the original execution history will
-                        be discarded."
+                      description: |-
+                        Name of the rule.
+                        Each rule in a CronFederatedHPA must have a unique name.
+
+
+                        Note: the name will be used as an identifier to record its execution
+                        history. Changing the name will be considered as deleting the old rule
+                        and adding a new rule, that means the original execution history will be
+                        discarded.
                       maxLength: 32
                       minLength: 1
                       type: string
                     schedule:
-                      description: Schedule is the cron expression that represents
-                        a periodical time. The syntax follows https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-syntax.
+                      description: |-
+                        Schedule is the cron expression that represents a periodical time.
+                        The syntax follows https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-syntax.
                       type: string
                     successfulHistoryLimit:
                       default: 3
-                      description: SuccessfulHistoryLimit represents the count of
-                        successful execution items for each rule. The value must be
-                        a positive integer. It defaults to 3.
+                      description: |-
+                        SuccessfulHistoryLimit represents the count of successful execution items
+                        for each rule.
+                        The value must be a positive integer. It defaults to 3.
                       format: int32
                       maximum: 32
                       minimum: 1
                       type: integer
                     suspend:
                       default: false
-                      description: Suspend tells the controller to suspend subsequent
-                        executions. Defaults to false.
+                      description: |-
+                        Suspend tells the controller to suspend subsequent executions.
+                        Defaults to false.
                       type: boolean
                     targetMaxReplicas:
-                      description: TargetMaxReplicas is the target MaxReplicas to
-                        be set for FederatedHPA. Only needed when referencing resource
-                        is FederatedHPA. TargetMinReplicas and TargetMaxReplicas can
-                        be specified together or either one can be specified alone.
-                        nil means the MaxReplicas(.spec.maxReplicas) of the referencing
-                        FederatedHPA will not be updated.
+                      description: |-
+                        TargetMaxReplicas is the target MaxReplicas to be set for FederatedHPA.
+                        Only needed when referencing resource is FederatedHPA.
+                        TargetMinReplicas and TargetMaxReplicas can be specified together or
+                        either one can be specified alone.
+                        nil means the MaxReplicas(.spec.maxReplicas) of the referencing FederatedHPA
+                        will not be updated.
                       format: int32
                       type: integer
                     targetMinReplicas:
-                      description: TargetMinReplicas is the target MinReplicas to
-                        be set for FederatedHPA. Only needed when referencing resource
-                        is FederatedHPA. TargetMinReplicas and TargetMaxReplicas can
-                        be specified together or either one can be specified alone.
-                        nil means the MinReplicas(.spec.minReplicas) of the referencing
-                        FederatedHPA will not be updated.
+                      description: |-
+                        TargetMinReplicas is the target MinReplicas to be set for FederatedHPA.
+                        Only needed when referencing resource is FederatedHPA.
+                        TargetMinReplicas and TargetMaxReplicas can be specified together or
+                        either one can be specified alone.
+                        nil means the MinReplicas(.spec.minReplicas) of the referencing FederatedHPA
+                        will not be updated.
                       format: int32
                       type: integer
                     targetReplicas:
-                      description: TargetReplicas is the target replicas to be scaled
-                        for resources referencing by ScaleTargetRef of this CronFederatedHPA.
+                      description: |-
+                        TargetReplicas is the target replicas to be scaled for resources
+                        referencing by ScaleTargetRef of this CronFederatedHPA.
                         Only needed when referencing resource is not FederatedHPA.
                       format: int32
                       type: integer
                     timeZone:
-                      description: TimeZone for the giving schedule. If not specified,
-                        this will default to the time zone of the karmada-controller-manager
-                        process. Invalid TimeZone will be rejected when applying by
-                        karmada-webhook. see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-                        for the all timezones.
+                      description: |-
+                        TimeZone for the giving schedule.
+                        If not specified, this will default to the time zone of the
+                        karmada-controller-manager process.
+                        Invalid TimeZone will be rejected when applying by karmada-webhook.
+                        see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for the
+                        all timezones.
                       type: string
                   required:
                   - name
@@ -131,7 +150,8 @@ spec:
                   type: object
                 type: array
               scaleTargetRef:
-                description: ScaleTargetRef points to the target resource to scale.
+                description: |-
+                  ScaleTargetRef points to the target resource to scale.
                   Target resource could be any resource that implementing the scale
                   subresource like Deployment, or FederatedHPA.
                 properties:
@@ -168,10 +188,10 @@ spec:
                         description: FailedExecution records a failed execution.
                         properties:
                           executionTime:
-                            description: ExecutionTime is the actual execution time
-                              of CronFederatedHPARule. Tasks may not always be executed
-                              at ScheduleTime. ExecutionTime is used to evaluate the
-                              efficiency of the controller's execution.
+                            description: |-
+                              ExecutionTime is the actual execution time of CronFederatedHPARule.
+                              Tasks may not always be executed at ScheduleTime. ExecutionTime is used
+                              to evaluate the efficiency of the controller's execution.
                             format: date-time
                             type: string
                           message:
@@ -190,7 +210,8 @@ spec:
                         type: object
                       type: array
                     nextExecutionTime:
-                      description: NextExecutionTime is the next time to execute.
+                      description: |-
+                        NextExecutionTime is the next time to execute.
                         Nil means the rule has been suspended.
                       format: date-time
                       type: string
@@ -203,28 +224,28 @@ spec:
                         description: SuccessfulExecution records a successful execution.
                         properties:
                           appliedMaxReplicas:
-                            description: AppliedMaxReplicas is the MaxReplicas have
-                              been applied. It is required if .spec.rules[*].targetMaxReplicas
-                              is not empty.
+                            description: |-
+                              AppliedMaxReplicas is the MaxReplicas have been applied.
+                              It is required if .spec.rules[*].targetMaxReplicas is not empty.
                             format: int32
                             type: integer
                           appliedMinReplicas:
-                            description: AppliedMinReplicas is the MinReplicas have
-                              been applied. It is required if .spec.rules[*].targetMinReplicas
-                              is not empty.
+                            description: |-
+                              AppliedMinReplicas is the MinReplicas have been applied.
+                              It is required if .spec.rules[*].targetMinReplicas is not empty.
                             format: int32
                             type: integer
                           appliedReplicas:
-                            description: AppliedReplicas is the replicas have been
-                              applied. It is required if .spec.rules[*].targetReplicas
-                              is not empty.
+                            description: |-
+                              AppliedReplicas is the replicas have been applied.
+                              It is required if .spec.rules[*].targetReplicas is not empty.
                             format: int32
                             type: integer
                           executionTime:
-                            description: ExecutionTime is the actual execution time
-                              of CronFederatedHPARule. Tasks may not always be executed
-                              at ScheduleTime. ExecutionTime is used to evaluate the
-                              efficiency of the controller's execution.
+                            description: |-
+                              ExecutionTime is the actual execution time of CronFederatedHPARule.
+                              Tasks may not always be executed at ScheduleTime. ExecutionTime is used
+                              to evaluate the efficiency of the controller's execution.
                             format: date-time
                             type: string
                           scheduleTime:

--- a/charts/karmada/_crds/bases/autoscaling/autoscaling.karmada.io_federatedhpas.yaml
+++ b/charts/karmada/_crds/bases/autoscaling/autoscaling.karmada.io_federatedhpas.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: federatedhpas.autoscaling.karmada.io
 spec:
   group: autoscaling.karmada.io
@@ -40,22 +40,26 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: FederatedHPA is centralized HPA that can aggregate the metrics
-          in multiple clusters. When the system load increases, it will query the
-          metrics from multiple clusters and scales up the replicas. When the system
-          load decreases, it will query the metrics from multiple clusters and scales
-          down the replicas. After the replicas are scaled up/down, karmada-scheduler
-          will schedule the replicas based on the policy.
+        description: |-
+          FederatedHPA is centralized HPA that can aggregate the metrics in multiple clusters.
+          When the system load increases, it will query the metrics from multiple clusters and scales up the replicas.
+          When the system load decreases, it will query the metrics from multiple clusters and scales down the replicas.
+          After the replicas are scaled up/down, karmada-scheduler will schedule the replicas based on the policy.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -63,40 +67,39 @@ spec:
             description: Spec is the specification of the FederatedHPA.
             properties:
               behavior:
-                description: Behavior configures the scaling behavior of the target
+                description: |-
+                  Behavior configures the scaling behavior of the target
                   in both Up and Down directions (scaleUp and scaleDown fields respectively).
-                  If not set, the default HPAScalingRules for scale up and scale down
-                  are used.
+                  If not set, the default HPAScalingRules for scale up and scale down are used.
                 properties:
                   scaleDown:
-                    description: scaleDown is scaling policy for scaling Down. If
-                      not set, the default value is to allow to scale down to minReplicas
-                      pods, with a 300 second stabilization window (i.e., the highest
-                      recommendation for the last 300sec is used).
+                    description: |-
+                      scaleDown is scaling policy for scaling Down.
+                      If not set, the default value is to allow to scale down to minReplicas pods, with a
+                      300 second stabilization window (i.e., the highest recommendation for
+                      the last 300sec is used).
                     properties:
                       policies:
-                        description: policies is a list of potential scaling polices
-                          which can be used during scaling. At least one policy must
-                          be specified, otherwise the HPAScalingRules will be discarded
-                          as invalid
+                        description: |-
+                          policies is a list of potential scaling polices which can be used during scaling.
+                          At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
                         items:
                           description: HPAScalingPolicy is a single policy which must
                             hold true for a specified past interval.
                           properties:
                             periodSeconds:
-                              description: periodSeconds specifies the window of time
-                                for which the policy should hold true. PeriodSeconds
-                                must be greater than zero and less than or equal to
-                                1800 (30 min).
+                              description: |-
+                                periodSeconds specifies the window of time for which the policy should hold true.
+                                PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
                               format: int32
                               type: integer
                             type:
                               description: type is used to specify the scaling policy.
                               type: string
                             value:
-                              description: value contains the amount of change which
-                                is permitted by the policy. It must be greater than
-                                zero
+                              description: |-
+                                value contains the amount of change which is permitted by the policy.
+                                It must be greater than zero
                               format: int32
                               type: integer
                           required:
@@ -107,50 +110,50 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       selectPolicy:
-                        description: selectPolicy is used to specify which policy
-                          should be used. If not set, the default value Max is used.
+                        description: |-
+                          selectPolicy is used to specify which policy should be used.
+                          If not set, the default value Max is used.
                         type: string
                       stabilizationWindowSeconds:
-                        description: 'stabilizationWindowSeconds is the number of
-                          seconds for which past recommendations should be considered
-                          while scaling up or scaling down. StabilizationWindowSeconds
-                          must be greater than or equal to zero and less than or equal
-                          to 3600 (one hour). If not set, use the default values:
-                          - For scale up: 0 (i.e. no stabilization is done). - For
-                          scale down: 300 (i.e. the stabilization window is 300 seconds
-                          long).'
+                        description: |-
+                          stabilizationWindowSeconds is the number of seconds for which past recommendations should be
+                          considered while scaling up or scaling down.
+                          StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).
+                          If not set, use the default values:
+                          - For scale up: 0 (i.e. no stabilization is done).
+                          - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
                         format: int32
                         type: integer
                     type: object
                   scaleUp:
-                    description: 'scaleUp is scaling policy for scaling Up. If not
-                      set, the default value is the higher of: * increase no more
-                      than 4 pods per 60 seconds * double the number of pods per 60
-                      seconds No stabilization is used.'
+                    description: |-
+                      scaleUp is scaling policy for scaling Up.
+                      If not set, the default value is the higher of:
+                        * increase no more than 4 pods per 60 seconds
+                        * double the number of pods per 60 seconds
+                      No stabilization is used.
                     properties:
                       policies:
-                        description: policies is a list of potential scaling polices
-                          which can be used during scaling. At least one policy must
-                          be specified, otherwise the HPAScalingRules will be discarded
-                          as invalid
+                        description: |-
+                          policies is a list of potential scaling polices which can be used during scaling.
+                          At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
                         items:
                           description: HPAScalingPolicy is a single policy which must
                             hold true for a specified past interval.
                           properties:
                             periodSeconds:
-                              description: periodSeconds specifies the window of time
-                                for which the policy should hold true. PeriodSeconds
-                                must be greater than zero and less than or equal to
-                                1800 (30 min).
+                              description: |-
+                                periodSeconds specifies the window of time for which the policy should hold true.
+                                PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
                               format: int32
                               type: integer
                             type:
                               description: type is used to specify the scaling policy.
                               type: string
                             value:
-                              description: value contains the amount of change which
-                                is permitted by the policy. It must be greater than
-                                zero
+                              description: |-
+                                value contains the amount of change which is permitted by the policy.
+                                It must be greater than zero
                               format: int32
                               type: integer
                           required:
@@ -161,51 +164,52 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       selectPolicy:
-                        description: selectPolicy is used to specify which policy
-                          should be used. If not set, the default value Max is used.
+                        description: |-
+                          selectPolicy is used to specify which policy should be used.
+                          If not set, the default value Max is used.
                         type: string
                       stabilizationWindowSeconds:
-                        description: 'stabilizationWindowSeconds is the number of
-                          seconds for which past recommendations should be considered
-                          while scaling up or scaling down. StabilizationWindowSeconds
-                          must be greater than or equal to zero and less than or equal
-                          to 3600 (one hour). If not set, use the default values:
-                          - For scale up: 0 (i.e. no stabilization is done). - For
-                          scale down: 300 (i.e. the stabilization window is 300 seconds
-                          long).'
+                        description: |-
+                          stabilizationWindowSeconds is the number of seconds for which past recommendations should be
+                          considered while scaling up or scaling down.
+                          StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).
+                          If not set, use the default values:
+                          - For scale up: 0 (i.e. no stabilization is done).
+                          - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
                         format: int32
                         type: integer
                     type: object
                 type: object
               maxReplicas:
-                description: MaxReplicas is the upper limit for the number of replicas
-                  to which the autoscaler can scale up. It cannot be less that minReplicas.
+                description: |-
+                  MaxReplicas is the upper limit for the number of replicas to which the
+                  autoscaler can scale up.
+                  It cannot be less that minReplicas.
                 format: int32
                 type: integer
               metrics:
-                description: Metrics contains the specifications for which to use
-                  to calculate the desired replica count (the maximum replica count
-                  across all metrics will be used). The desired replica count is calculated
-                  multiplying the ratio between the target value and the current value
-                  by the current number of pods. Ergo, metrics used must decrease
-                  as the pod count is increased, and vice-versa. See the individual
-                  metric source types for more information about how each type of
-                  metric must respond. If not set, the default metric will be set
-                  to 80% average CPU utilization.
+                description: |-
+                  Metrics contains the specifications for which to use to calculate the
+                  desired replica count (the maximum replica count across all metrics will
+                  be used). The desired replica count is calculated multiplying the
+                  ratio between the target value and the current value by the current
+                  number of pods. Ergo, metrics used must decrease as the pod count is
+                  increased, and vice-versa. See the individual metric source types for
+                  more information about how each type of metric must respond.
+                  If not set, the default metric will be set to 80% average CPU utilization.
                 items:
-                  description: MetricSpec specifies how to scale based on a single
-                    metric (only `type` and one other matching field should be set
-                    at once).
+                  description: |-
+                    MetricSpec specifies how to scale based on a single metric
+                    (only `type` and one other matching field should be set at once).
                   properties:
                     containerResource:
-                      description: containerResource refers to a resource metric (such
-                        as those specified in requests and limits) known to Kubernetes
-                        describing a single container in each pod of the current scale
-                        target (e.g. CPU or memory). Such metrics are built in to
-                        Kubernetes, and have special scaling options on top of those
+                      description: |-
+                        containerResource refers to a resource metric (such as those specified in
+                        requests and limits) known to Kubernetes describing a single container in
+                        each pod of the current scale target (e.g. CPU or memory). Such metrics are
+                        built in to Kubernetes, and have special scaling options on top of those
                         available to normal per-pod metrics using the "pods" source.
-                        This is an alpha feature and can be enabled by the HPAContainerMetrics
-                        feature flag.
+                        This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.
                       properties:
                         container:
                           description: container is the name of the container in the
@@ -219,20 +223,20 @@ spec:
                             metric
                           properties:
                             averageUtilization:
-                              description: averageUtilization is the target value
-                                of the average of the resource metric across all relevant
-                                pods, represented as a percentage of the requested
-                                value of the resource for the pods. Currently only
-                                valid for Resource metric source type
+                              description: |-
+                                averageUtilization is the target value of the average of the
+                                resource metric across all relevant pods, represented as a percentage of
+                                the requested value of the resource for the pods.
+                                Currently only valid for Resource metric source type
                               format: int32
                               type: integer
                             averageValue:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: averageValue is the target value of the
-                                average of the metric across all relevant pods (as
-                                a quantity)
+                              description: |-
+                                averageValue is the target value of the average of the
+                                metric across all relevant pods (as a quantity)
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             type:
@@ -256,11 +260,12 @@ spec:
                       - target
                       type: object
                     external:
-                      description: external refers to a global metric that is not
-                        associated with any Kubernetes object. It allows autoscaling
-                        based on information coming from components running outside
-                        of cluster (for example length of queue in cloud messaging
-                        service, or QPS from loadbalancer running outside of cluster).
+                      description: |-
+                        external refers to a global metric that is not associated
+                        with any Kubernetes object. It allows autoscaling based on information
+                        coming from components running outside of cluster
+                        (for example length of queue in cloud messaging service, or
+                        QPS from loadbalancer running outside of cluster).
                       properties:
                         metric:
                           description: metric identifies the target metric by name
@@ -270,37 +275,34 @@ spec:
                               description: name is the name of the given metric
                               type: string
                             selector:
-                              description: selector is the string-encoded form of
-                                a standard kubernetes label selector for the given
-                                metric When set, it is passed as an additional parameter
-                                to the metrics server for more specific metrics scoping.
-                                When unset, just the metricName will be used to gather
-                                metrics.
+                              description: |-
+                                selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                When unset, just the metricName will be used to gather metrics.
                               properties:
                                 matchExpressions:
                                   description: matchExpressions is a list of label
                                     selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
                                         description: key is the label key that the
                                           selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -312,12 +314,10 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
@@ -329,20 +329,20 @@ spec:
                             metric
                           properties:
                             averageUtilization:
-                              description: averageUtilization is the target value
-                                of the average of the resource metric across all relevant
-                                pods, represented as a percentage of the requested
-                                value of the resource for the pods. Currently only
-                                valid for Resource metric source type
+                              description: |-
+                                averageUtilization is the target value of the average of the
+                                resource metric across all relevant pods, represented as a percentage of
+                                the requested value of the resource for the pods.
+                                Currently only valid for Resource metric source type
                               format: int32
                               type: integer
                             averageValue:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: averageValue is the target value of the
-                                average of the metric across all relevant pods (as
-                                a quantity)
+                              description: |-
+                                averageValue is the target value of the average of the
+                                metric across all relevant pods (as a quantity)
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             type:
@@ -365,8 +365,9 @@ spec:
                       - target
                       type: object
                     object:
-                      description: object refers to a metric describing a single kubernetes
-                        object (for example, hits-per-second on an Ingress object).
+                      description: |-
+                        object refers to a metric describing a single kubernetes object
+                        (for example, hits-per-second on an Ingress object).
                       properties:
                         describedObject:
                           description: describedObject specifies the descriptions
@@ -395,37 +396,34 @@ spec:
                               description: name is the name of the given metric
                               type: string
                             selector:
-                              description: selector is the string-encoded form of
-                                a standard kubernetes label selector for the given
-                                metric When set, it is passed as an additional parameter
-                                to the metrics server for more specific metrics scoping.
-                                When unset, just the metricName will be used to gather
-                                metrics.
+                              description: |-
+                                selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                When unset, just the metricName will be used to gather metrics.
                               properties:
                                 matchExpressions:
                                   description: matchExpressions is a list of label
                                     selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
                                         description: key is the label key that the
                                           selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -437,12 +435,10 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
@@ -454,20 +450,20 @@ spec:
                             metric
                           properties:
                             averageUtilization:
-                              description: averageUtilization is the target value
-                                of the average of the resource metric across all relevant
-                                pods, represented as a percentage of the requested
-                                value of the resource for the pods. Currently only
-                                valid for Resource metric source type
+                              description: |-
+                                averageUtilization is the target value of the average of the
+                                resource metric across all relevant pods, represented as a percentage of
+                                the requested value of the resource for the pods.
+                                Currently only valid for Resource metric source type
                               format: int32
                               type: integer
                             averageValue:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: averageValue is the target value of the
-                                average of the metric across all relevant pods (as
-                                a quantity)
+                              description: |-
+                                averageValue is the target value of the average of the
+                                metric across all relevant pods (as a quantity)
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             type:
@@ -491,10 +487,10 @@ spec:
                       - target
                       type: object
                     pods:
-                      description: pods refers to a metric describing each pod in
-                        the current scale target (for example, transactions-processed-per-second).  The
-                        values will be averaged together before being compared to
-                        the target value.
+                      description: |-
+                        pods refers to a metric describing each pod in the current scale target
+                        (for example, transactions-processed-per-second).  The values will be
+                        averaged together before being compared to the target value.
                       properties:
                         metric:
                           description: metric identifies the target metric by name
@@ -504,37 +500,34 @@ spec:
                               description: name is the name of the given metric
                               type: string
                             selector:
-                              description: selector is the string-encoded form of
-                                a standard kubernetes label selector for the given
-                                metric When set, it is passed as an additional parameter
-                                to the metrics server for more specific metrics scoping.
-                                When unset, just the metricName will be used to gather
-                                metrics.
+                              description: |-
+                                selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                When unset, just the metricName will be used to gather metrics.
                               properties:
                                 matchExpressions:
                                   description: matchExpressions is a list of label
                                     selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
                                         description: key is the label key that the
                                           selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -546,12 +539,10 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
@@ -563,20 +554,20 @@ spec:
                             metric
                           properties:
                             averageUtilization:
-                              description: averageUtilization is the target value
-                                of the average of the resource metric across all relevant
-                                pods, represented as a percentage of the requested
-                                value of the resource for the pods. Currently only
-                                valid for Resource metric source type
+                              description: |-
+                                averageUtilization is the target value of the average of the
+                                resource metric across all relevant pods, represented as a percentage of
+                                the requested value of the resource for the pods.
+                                Currently only valid for Resource metric source type
                               format: int32
                               type: integer
                             averageValue:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: averageValue is the target value of the
-                                average of the metric across all relevant pods (as
-                                a quantity)
+                              description: |-
+                                averageValue is the target value of the average of the
+                                metric across all relevant pods (as a quantity)
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             type:
@@ -599,12 +590,12 @@ spec:
                       - target
                       type: object
                     resource:
-                      description: resource refers to a resource metric (such as those
-                        specified in requests and limits) known to Kubernetes describing
-                        each pod in the current scale target (e.g. CPU or memory).
-                        Such metrics are built in to Kubernetes, and have special
-                        scaling options on top of those available to normal per-pod
-                        metrics using the "pods" source.
+                      description: |-
+                        resource refers to a resource metric (such as those specified in
+                        requests and limits) known to Kubernetes describing each pod in the
+                        current scale target (e.g. CPU or memory). Such metrics are built in to
+                        Kubernetes, and have special scaling options on top of those available
+                        to normal per-pod metrics using the "pods" source.
                       properties:
                         name:
                           description: name is the name of the resource in question.
@@ -614,20 +605,20 @@ spec:
                             metric
                           properties:
                             averageUtilization:
-                              description: averageUtilization is the target value
-                                of the average of the resource metric across all relevant
-                                pods, represented as a percentage of the requested
-                                value of the resource for the pods. Currently only
-                                valid for Resource metric source type
+                              description: |-
+                                averageUtilization is the target value of the average of the
+                                resource metric across all relevant pods, represented as a percentage of
+                                the requested value of the resource for the pods.
+                                Currently only valid for Resource metric source type
                               format: int32
                               type: integer
                             averageValue:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: averageValue is the target value of the
-                                average of the metric across all relevant pods (as
-                                a quantity)
+                              description: |-
+                                averageValue is the target value of the average of the
+                                metric across all relevant pods (as a quantity)
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             type:
@@ -650,25 +641,28 @@ spec:
                       - target
                       type: object
                     type:
-                      description: 'type is the type of metric source.  It should
-                        be one of "ContainerResource", "External", "Object", "Pods"
-                        or "Resource", each mapping to a matching field in the object.
+                      description: |-
+                        type is the type of metric source.  It should be one of "ContainerResource", "External",
+                        "Object", "Pods" or "Resource", each mapping to a matching field in the object.
                         Note: "ContainerResource" type is available on when the feature-gate
-                        HPAContainerMetrics is enabled'
+                        HPAContainerMetrics is enabled
                       type: string
                   required:
                   - type
                   type: object
                 type: array
               minReplicas:
-                description: MinReplicas is the lower limit for the number of replicas
-                  to which the autoscaler can scale down. It defaults to 1 pod.
+                description: |-
+                  MinReplicas is the lower limit for the number of replicas to which the
+                  autoscaler can scale down.
+                  It defaults to 1 pod.
                 format: int32
                 type: integer
               scaleTargetRef:
-                description: ScaleTargetRef points to the target resource to scale,
-                  and is used to the pods for which metrics should be collected, as
-                  well as to actually change the replica count.
+                description: |-
+                  ScaleTargetRef points to the target resource to scale, and is used to
+                  the pods for which metrics should be collected, as well as to actually
+                  change the replica count.
                 properties:
                   apiVersion:
                     description: apiVersion is the API version of the referent
@@ -691,21 +685,24 @@ spec:
             description: Status is the current status of the FederatedHPA.
             properties:
               conditions:
-                description: conditions is the set of conditions required for this
-                  autoscaler to scale its target, and indicates whether or not those
-                  conditions are met.
+                description: |-
+                  conditions is the set of conditions required for this autoscaler to scale its target,
+                  and indicates whether or not those conditions are met.
                 items:
-                  description: HorizontalPodAutoscalerCondition describes the state
-                    of a HorizontalPodAutoscaler at a certain point.
+                  description: |-
+                    HorizontalPodAutoscalerCondition describes the state of
+                    a HorizontalPodAutoscaler at a certain point.
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from
+                        one status to another
                       format: date-time
                       type: string
                     message:
-                      description: message is a human-readable explanation containing
-                        details about the transition
+                      description: |-
+                        message is a human-readable explanation containing details about
+                        the transition
                       type: string
                     reason:
                       description: reason is the reason for the condition's last transition.
@@ -733,13 +730,12 @@ spec:
                     metric.
                   properties:
                     containerResource:
-                      description: container resource refers to a resource metric
-                        (such as those specified in requests and limits) known to
-                        Kubernetes describing a single container in each pod in the
-                        current scale target (e.g. CPU or memory). Such metrics are
-                        built in to Kubernetes, and have special scaling options on
-                        top of those available to normal per-pod metrics using the
-                        "pods" source.
+                      description: |-
+                        container resource refers to a resource metric (such as those specified in
+                        requests and limits) known to Kubernetes describing a single container in each pod in the
+                        current scale target (e.g. CPU or memory). Such metrics are built in to
+                        Kubernetes, and have special scaling options on top of those available
+                        to normal per-pod metrics using the "pods" source.
                       properties:
                         container:
                           description: container is the name of the container in the
@@ -750,9 +746,9 @@ spec:
                             given metric
                           properties:
                             averageUtilization:
-                              description: currentAverageUtilization is the current
-                                value of the average of the resource metric across
-                                all relevant pods, represented as a percentage of
+                              description: |-
+                                currentAverageUtilization is the current value of the average of the
+                                resource metric across all relevant pods, represented as a percentage of
                                 the requested value of the resource for the pods.
                               format: int32
                               type: integer
@@ -760,9 +756,9 @@ spec:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: averageValue is the current value of the
-                                average of the metric across all relevant pods (as
-                                a quantity)
+                              description: |-
+                                averageValue is the current value of the average of the
+                                metric across all relevant pods (as a quantity)
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             value:
@@ -783,20 +779,21 @@ spec:
                       - name
                       type: object
                     external:
-                      description: external refers to a global metric that is not
-                        associated with any Kubernetes object. It allows autoscaling
-                        based on information coming from components running outside
-                        of cluster (for example length of queue in cloud messaging
-                        service, or QPS from loadbalancer running outside of cluster).
+                      description: |-
+                        external refers to a global metric that is not associated
+                        with any Kubernetes object. It allows autoscaling based on information
+                        coming from components running outside of cluster
+                        (for example length of queue in cloud messaging service, or
+                        QPS from loadbalancer running outside of cluster).
                       properties:
                         current:
                           description: current contains the current value for the
                             given metric
                           properties:
                             averageUtilization:
-                              description: currentAverageUtilization is the current
-                                value of the average of the resource metric across
-                                all relevant pods, represented as a percentage of
+                              description: |-
+                                currentAverageUtilization is the current value of the average of the
+                                resource metric across all relevant pods, represented as a percentage of
                                 the requested value of the resource for the pods.
                               format: int32
                               type: integer
@@ -804,9 +801,9 @@ spec:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: averageValue is the current value of the
-                                average of the metric across all relevant pods (as
-                                a quantity)
+                              description: |-
+                                averageValue is the current value of the average of the
+                                metric across all relevant pods (as a quantity)
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             value:
@@ -826,37 +823,34 @@ spec:
                               description: name is the name of the given metric
                               type: string
                             selector:
-                              description: selector is the string-encoded form of
-                                a standard kubernetes label selector for the given
-                                metric When set, it is passed as an additional parameter
-                                to the metrics server for more specific metrics scoping.
-                                When unset, just the metricName will be used to gather
-                                metrics.
+                              description: |-
+                                selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                When unset, just the metricName will be used to gather metrics.
                               properties:
                                 matchExpressions:
                                   description: matchExpressions is a list of label
                                     selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
                                         description: key is the label key that the
                                           selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -868,12 +862,10 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
@@ -885,17 +877,18 @@ spec:
                       - metric
                       type: object
                     object:
-                      description: object refers to a metric describing a single kubernetes
-                        object (for example, hits-per-second on an Ingress object).
+                      description: |-
+                        object refers to a metric describing a single kubernetes object
+                        (for example, hits-per-second on an Ingress object).
                       properties:
                         current:
                           description: current contains the current value for the
                             given metric
                           properties:
                             averageUtilization:
-                              description: currentAverageUtilization is the current
-                                value of the average of the resource metric across
-                                all relevant pods, represented as a percentage of
+                              description: |-
+                                currentAverageUtilization is the current value of the average of the
+                                resource metric across all relevant pods, represented as a percentage of
                                 the requested value of the resource for the pods.
                               format: int32
                               type: integer
@@ -903,9 +896,9 @@ spec:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: averageValue is the current value of the
-                                average of the metric across all relevant pods (as
-                                a quantity)
+                              description: |-
+                                averageValue is the current value of the average of the
+                                metric across all relevant pods (as a quantity)
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             value:
@@ -944,37 +937,34 @@ spec:
                               description: name is the name of the given metric
                               type: string
                             selector:
-                              description: selector is the string-encoded form of
-                                a standard kubernetes label selector for the given
-                                metric When set, it is passed as an additional parameter
-                                to the metrics server for more specific metrics scoping.
-                                When unset, just the metricName will be used to gather
-                                metrics.
+                              description: |-
+                                selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                When unset, just the metricName will be used to gather metrics.
                               properties:
                                 matchExpressions:
                                   description: matchExpressions is a list of label
                                     selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
                                         description: key is the label key that the
                                           selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -986,12 +976,10 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
@@ -1004,19 +992,19 @@ spec:
                       - metric
                       type: object
                     pods:
-                      description: pods refers to a metric describing each pod in
-                        the current scale target (for example, transactions-processed-per-second).  The
-                        values will be averaged together before being compared to
-                        the target value.
+                      description: |-
+                        pods refers to a metric describing each pod in the current scale target
+                        (for example, transactions-processed-per-second).  The values will be
+                        averaged together before being compared to the target value.
                       properties:
                         current:
                           description: current contains the current value for the
                             given metric
                           properties:
                             averageUtilization:
-                              description: currentAverageUtilization is the current
-                                value of the average of the resource metric across
-                                all relevant pods, represented as a percentage of
+                              description: |-
+                                currentAverageUtilization is the current value of the average of the
+                                resource metric across all relevant pods, represented as a percentage of
                                 the requested value of the resource for the pods.
                               format: int32
                               type: integer
@@ -1024,9 +1012,9 @@ spec:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: averageValue is the current value of the
-                                average of the metric across all relevant pods (as
-                                a quantity)
+                              description: |-
+                                averageValue is the current value of the average of the
+                                metric across all relevant pods (as a quantity)
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             value:
@@ -1046,37 +1034,34 @@ spec:
                               description: name is the name of the given metric
                               type: string
                             selector:
-                              description: selector is the string-encoded form of
-                                a standard kubernetes label selector for the given
-                                metric When set, it is passed as an additional parameter
-                                to the metrics server for more specific metrics scoping.
-                                When unset, just the metricName will be used to gather
-                                metrics.
+                              description: |-
+                                selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                When unset, just the metricName will be used to gather metrics.
                               properties:
                                 matchExpressions:
                                   description: matchExpressions is a list of label
                                     selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
                                         description: key is the label key that the
                                           selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -1088,12 +1073,10 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
@@ -1105,21 +1088,21 @@ spec:
                       - metric
                       type: object
                     resource:
-                      description: resource refers to a resource metric (such as those
-                        specified in requests and limits) known to Kubernetes describing
-                        each pod in the current scale target (e.g. CPU or memory).
-                        Such metrics are built in to Kubernetes, and have special
-                        scaling options on top of those available to normal per-pod
-                        metrics using the "pods" source.
+                      description: |-
+                        resource refers to a resource metric (such as those specified in
+                        requests and limits) known to Kubernetes describing each pod in the
+                        current scale target (e.g. CPU or memory). Such metrics are built in to
+                        Kubernetes, and have special scaling options on top of those available
+                        to normal per-pod metrics using the "pods" source.
                       properties:
                         current:
                           description: current contains the current value for the
                             given metric
                           properties:
                             averageUtilization:
-                              description: currentAverageUtilization is the current
-                                value of the average of the resource metric across
-                                all relevant pods, represented as a percentage of
+                              description: |-
+                                currentAverageUtilization is the current value of the average of the
+                                resource metric across all relevant pods, represented as a percentage of
                                 the requested value of the resource for the pods.
                               format: int32
                               type: integer
@@ -1127,9 +1110,9 @@ spec:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: averageValue is the current value of the
-                                average of the metric across all relevant pods (as
-                                a quantity)
+                              description: |-
+                                averageValue is the current value of the average of the
+                                metric across all relevant pods (as a quantity)
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             value:
@@ -1149,11 +1132,11 @@ spec:
                       - name
                       type: object
                     type:
-                      description: 'type is the type of metric source.  It will be
-                        one of "ContainerResource", "External", "Object", "Pods" or
-                        "Resource", each corresponds to a matching field in the object.
+                      description: |-
+                        type is the type of metric source.  It will be one of "ContainerResource", "External",
+                        "Object", "Pods" or "Resource", each corresponds to a matching field in the object.
                         Note: "ContainerResource" type is available on when the feature-gate
-                        HPAContainerMetrics is enabled'
+                        HPAContainerMetrics is enabled
                       type: string
                   required:
                   - type
@@ -1161,19 +1144,21 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               currentReplicas:
-                description: currentReplicas is current number of replicas of pods
-                  managed by this autoscaler, as last seen by the autoscaler.
+                description: |-
+                  currentReplicas is current number of replicas of pods managed by this autoscaler,
+                  as last seen by the autoscaler.
                 format: int32
                 type: integer
               desiredReplicas:
-                description: desiredReplicas is the desired number of replicas of
-                  pods managed by this autoscaler, as last calculated by the autoscaler.
+                description: |-
+                  desiredReplicas is the desired number of replicas of pods managed by this autoscaler,
+                  as last calculated by the autoscaler.
                 format: int32
                 type: integer
               lastScaleTime:
-                description: lastScaleTime is the last time the HorizontalPodAutoscaler
-                  scaled the number of pods, used by the autoscaler to control how
-                  often the number of pods is changed.
+                description: |-
+                  lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods,
+                  used by the autoscaler to control how often the number of pods is changed.
                 format: date-time
                 type: string
               observedGeneration:

--- a/charts/karmada/_crds/bases/config/config.karmada.io_resourceinterpretercustomizations.yaml
+++ b/charts/karmada/_crds/bases/config/config.karmada.io_resourceinterpretercustomizations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: resourceinterpretercustomizations.config.karmada.io
 spec:
   group: config.karmada.io
@@ -19,19 +19,26 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ResourceInterpreterCustomization describes the configuration
-          of a specific resource for Karmada to get the structure. It has higher precedence
-          than the default interpreter and the interpreter webhook.
+        description: |-
+          ResourceInterpreterCustomization describes the configuration of a specific
+          resource for Karmada to get the structure.
+          It has higher precedence than the default interpreter and the interpreter
+          webhook.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -42,181 +49,298 @@ spec:
                 description: Customizations describe the interpretation rules.
                 properties:
                   dependencyInterpretation:
-                    description: 'DependencyInterpretation describes the rules for
-                      Karmada to analyze the dependent resources. Karmada provides
-                      built-in rules for several standard Kubernetes types, see: https://karmada.io/docs/userguide/globalview/customizing-resource-interpreter/#interpretdependency
-                      If DependencyInterpretation is set, the built-in rules will
-                      be ignored.'
+                    description: |-
+                      DependencyInterpretation describes the rules for Karmada to analyze the
+                      dependent resources.
+                      Karmada provides built-in rules for several standard Kubernetes types, see:
+                      https://karmada.io/docs/userguide/globalview/customizing-resource-interpreter/#interpretdependency
+                      If DependencyInterpretation is set, the built-in rules will be ignored.
                     properties:
                       luaScript:
-                        description: "LuaScript holds the Lua script that is used
-                          to interpret the dependencies of a specific resource. The
-                          script should implement a function as follows: \n ``` luaScript:
-                          > function GetDependencies(desiredObj) dependencies = {}
-                          if desiredObj.spec.serviceAccountName ~= nil and desiredObj.spec.serviceAccountName
-                          ~= \"default\" then dependency = {} dependency.apiVersion
-                          = \"v1\" dependency.kind = \"ServiceAccount\" dependency.name
-                          = desiredObj.spec.serviceAccountName dependency.namespace
-                          = desiredObj.namespace dependencies[1] = {} dependencies[1]
-                          = dependency end return dependencies end ``` \n The content
-                          of the LuaScript needs to be a whole function including
-                          both declaration and implementation. \n The parameters will
-                          be supplied by the system: - desiredObj: the object represents
-                          the configuration to be applied to the member cluster. \n
-                          The returned value should be expressed by a slice of DependentObjectReference."
+                        description: |-
+                          LuaScript holds the Lua script that is used to interpret the dependencies of
+                          a specific resource.
+                          The script should implement a function as follows:
+
+
+                          ```
+                            luaScript: >
+                                function GetDependencies(desiredObj)
+                                    dependencies = {}
+                                    if desiredObj.spec.serviceAccountName ~= nil and desiredObj.spec.serviceAccountName ~= "default" then
+                                        dependency = {}
+                                        dependency.apiVersion = "v1"
+                                        dependency.kind = "ServiceAccount"
+                                        dependency.name = desiredObj.spec.serviceAccountName
+                                        dependency.namespace = desiredObj.namespace
+                                        dependencies[1] = {}
+                                        dependencies[1] = dependency
+                                    end
+                                    return dependencies
+                                end
+                          ```
+
+
+                          The content of the LuaScript needs to be a whole function including both
+                          declaration and implementation.
+
+
+                          The parameters will be supplied by the system:
+                            - desiredObj: the object represents the configuration to be applied
+                                to the member cluster.
+
+
+                          The returned value should be expressed by a slice of DependentObjectReference.
                         type: string
                     required:
                     - luaScript
                     type: object
                   healthInterpretation:
-                    description: HealthInterpretation describes the health assessment
-                      rules by which Karmada can assess the health state of the resource
-                      type.
+                    description: |-
+                      HealthInterpretation describes the health assessment rules by which Karmada
+                      can assess the health state of the resource type.
                     properties:
                       luaScript:
-                        description: "LuaScript holds the Lua script that is used
-                          to assess the health state of a specific resource. The script
-                          should implement a function as follows: \n ``` luaScript:
-                          > function InterpretHealth(observedObj) if observedObj.status.readyReplicas
-                          == observedObj.spec.replicas then return true end end ```
-                          \n The content of the LuaScript needs to be a whole function
-                          including both declaration and implementation. \n The parameters
-                          will be supplied by the system: - observedObj: the object
-                          represents the configuration that is observed from a specific
-                          member cluster. \n The returned boolean value indicates
-                          the health status."
+                        description: |-
+                          LuaScript holds the Lua script that is used to assess the health state of
+                          a specific resource.
+                          The script should implement a function as follows:
+
+
+                          ```
+                            luaScript: >
+                                function InterpretHealth(observedObj)
+                                    if observedObj.status.readyReplicas == observedObj.spec.replicas then
+                                        return true
+                                    end
+                                end
+                          ```
+
+
+                          The content of the LuaScript needs to be a whole function including both
+                          declaration and implementation.
+
+
+                          The parameters will be supplied by the system:
+                            - observedObj: the object represents the configuration that is observed
+                                from a specific member cluster.
+
+
+                          The returned boolean value indicates the health status.
                         type: string
                     required:
                     - luaScript
                     type: object
                   replicaResource:
-                    description: ReplicaResource describes the rules for Karmada to
-                      discover the resource's replica as well as resource requirements.
-                      It would be useful for those CRD resources that declare workload
-                      types like Deployment. It is usually not needed for Kubernetes
-                      native resources(Deployment, Job) as Karmada knows how to discover
-                      info from them. But if it is set, the built-in discovery rules
-                      will be ignored.
+                    description: |-
+                      ReplicaResource describes the rules for Karmada to discover the resource's
+                      replica as well as resource requirements.
+                      It would be useful for those CRD resources that declare workload types like
+                      Deployment.
+                      It is usually not needed for Kubernetes native resources(Deployment, Job) as
+                      Karmada knows how to discover info from them. But if it is set, the built-in
+                      discovery rules will be ignored.
                     properties:
                       luaScript:
-                        description: "LuaScript holds the Lua script that is used
-                          to discover the resource's replica as well as resource requirements
-                          \n The script should implement a function as follows: \n
-                          ``` luaScript: > function GetReplicas(desiredObj) replica
-                          = desiredObj.spec.replicas requirement = {} requirement.nodeClaim
-                          = {} requirement.nodeClaim.nodeSelector = desiredObj.spec.template.spec.nodeSelector
-                          requirement.nodeClaim.tolerations = desiredObj.spec.template.spec.tolerations
-                          requirement.resourceRequest = desiredObj.spec.template.spec.containers[1].resources.limits
-                          return replica, requirement end ``` \n The content of the
-                          LuaScript needs to be a whole function including both declaration
-                          and implementation. \n The parameters will be supplied by
-                          the system: - desiredObj: the object represents the configuration
-                          to be applied to the member cluster. \n The function expects
-                          two return values: - replica: the declared replica number
-                          - requirement: the resource required by each replica expressed
-                          with a ResourceBindingSpec.ReplicaRequirements. The returned
-                          values will be set into a ResourceBinding or ClusterResourceBinding."
+                        description: |-
+                          LuaScript holds the Lua script that is used to discover the resource's
+                          replica as well as resource requirements
+
+
+                          The script should implement a function as follows:
+
+
+                          ```
+                            luaScript: >
+                                function GetReplicas(desiredObj)
+                                    replica = desiredObj.spec.replicas
+                                    requirement = {}
+                                    requirement.nodeClaim = {}
+                                    requirement.nodeClaim.nodeSelector = desiredObj.spec.template.spec.nodeSelector
+                                    requirement.nodeClaim.tolerations = desiredObj.spec.template.spec.tolerations
+                                    requirement.resourceRequest = desiredObj.spec.template.spec.containers[1].resources.limits
+                                    return replica, requirement
+                                end
+                          ```
+
+
+                          The content of the LuaScript needs to be a whole function including both
+                          declaration and implementation.
+
+
+                          The parameters will be supplied by the system:
+                            - desiredObj: the object represents the configuration to be applied
+                                to the member cluster.
+
+
+                          The function expects two return values:
+                            - replica: the declared replica number
+                            - requirement: the resource required by each replica expressed with a
+                                ResourceBindingSpec.ReplicaRequirements.
+                          The returned values will be set into a ResourceBinding or ClusterResourceBinding.
                         type: string
                     required:
                     - luaScript
                     type: object
                   replicaRevision:
-                    description: ReplicaRevision describes the rules for Karmada to
-                      revise the resource's replica. It would be useful for those
-                      CRD resources that declare workload types like Deployment. It
-                      is usually not needed for Kubernetes native resources(Deployment,
-                      Job) as Karmada knows how to revise replicas for them. But if
-                      it is set, the built-in revision rules will be ignored.
+                    description: |-
+                      ReplicaRevision describes the rules for Karmada to revise the resource's replica.
+                      It would be useful for those CRD resources that declare workload types like
+                      Deployment.
+                      It is usually not needed for Kubernetes native resources(Deployment, Job) as
+                      Karmada knows how to revise replicas for them. But if it is set, the built-in
+                      revision rules will be ignored.
                     properties:
                       luaScript:
-                        description: "LuaScript holds the Lua script that is used
-                          to revise replicas in the desired specification. The script
-                          should implement a function as follows: \n ``` luaScript:
-                          > function ReviseReplica(desiredObj, desiredReplica) desiredObj.spec.replicas
-                          = desiredReplica return desiredObj end ``` \n The content
-                          of the LuaScript needs to be a whole function including
-                          both declaration and implementation. \n The parameters will
-                          be supplied by the system: - desiredObj: the object represents
-                          the configuration to be applied to the member cluster. -
-                          desiredReplica: the replica number should be applied with.
-                          \n The returned object should be a revised configuration
-                          which will be applied to member cluster eventually."
+                        description: |-
+                          LuaScript holds the Lua script that is used to revise replicas in the desired specification.
+                          The script should implement a function as follows:
+
+
+                          ```
+                            luaScript: >
+                                function ReviseReplica(desiredObj, desiredReplica)
+                                    desiredObj.spec.replicas = desiredReplica
+                                    return desiredObj
+                                end
+                          ```
+
+
+                          The content of the LuaScript needs to be a whole function including both
+                          declaration and implementation.
+
+
+                          The parameters will be supplied by the system:
+                            - desiredObj: the object represents the configuration to be applied
+                                to the member cluster.
+                            - desiredReplica: the replica number should be applied with.
+
+
+                          The returned object should be a revised configuration which will be
+                          applied to member cluster eventually.
                         type: string
                     required:
                     - luaScript
                     type: object
                   retention:
-                    description: Retention describes the desired behavior that Karmada
-                      should react on the changes made by member cluster components.
-                      This avoids system running into a meaningless loop that Karmada
-                      resource controller and the member cluster component continually
-                      applying opposite values of a field. For example, the "replicas"
-                      of Deployment might be changed by the HPA controller on member
-                      cluster. In this case, Karmada should retain the "replicas"
+                    description: |-
+                      Retention describes the desired behavior that Karmada should react on
+                      the changes made by member cluster components. This avoids system
+                      running into a meaningless loop that Karmada resource controller and
+                      the member cluster component continually applying opposite values of a field.
+                      For example, the "replicas" of Deployment might be changed by the HPA
+                      controller on member cluster. In this case, Karmada should retain the "replicas"
                       and not try to change it.
                     properties:
                       luaScript:
-                        description: "LuaScript holds the Lua script that is used
-                          to retain runtime values to the desired specification. \n
-                          The script should implement a function as follows: \n ```
-                          luaScript: > function Retain(desiredObj, observedObj) desiredObj.spec.fieldFoo
-                          = observedObj.spec.fieldFoo return desiredObj end ``` \n
-                          The content of the LuaScript needs to be a whole function
-                          including both declaration and implementation. \n The parameters
-                          will be supplied by the system: - desiredObj: the object
-                          represents the configuration to be applied to the member
-                          cluster. - observedObj: the object represents the configuration
-                          that is observed from a specific member cluster. \n The
-                          returned object should be a retained configuration which
-                          will be applied to member cluster eventually."
+                        description: |-
+                          LuaScript holds the Lua script that is used to retain runtime values
+                          to the desired specification.
+
+
+                          The script should implement a function as follows:
+
+
+                          ```
+                            luaScript: >
+                                function Retain(desiredObj, observedObj)
+                                    desiredObj.spec.fieldFoo = observedObj.spec.fieldFoo
+                                    return desiredObj
+                                end
+                          ```
+
+
+                          The content of the LuaScript needs to be a whole function including both
+                          declaration and implementation.
+
+
+                          The parameters will be supplied by the system:
+                            - desiredObj: the object represents the configuration to be applied
+                                to the member cluster.
+                            - observedObj: the object represents the configuration that is observed
+                                from a specific member cluster.
+
+
+                          The returned object should be a retained configuration which will be
+                          applied to member cluster eventually.
                         type: string
                     required:
                     - luaScript
                     type: object
                   statusAggregation:
-                    description: 'StatusAggregation describes the rules for Karmada
-                      to aggregate status collected from member clusters to resource
-                      template. Karmada provides built-in rules for several standard
-                      Kubernetes types, see: https://karmada.io/docs/userguide/globalview/customizing-resource-interpreter/#aggregatestatus
-                      If StatusAggregation is set, the built-in rules will be ignored.'
+                    description: |-
+                      StatusAggregation describes the rules for Karmada to aggregate status
+                      collected from member clusters to resource template.
+                      Karmada provides built-in rules for several standard Kubernetes types, see:
+                      https://karmada.io/docs/userguide/globalview/customizing-resource-interpreter/#aggregatestatus
+                      If StatusAggregation is set, the built-in rules will be ignored.
                     properties:
                       luaScript:
-                        description: "LuaScript holds the Lua script that is used
-                          to aggregate decentralized statuses to the desired specification.
-                          The script should implement a function as follows: \n ```
-                          luaScript: > function AggregateStatus(desiredObj, statusItems)
-                          for i = 1, #statusItems do desiredObj.status.readyReplicas
-                          = desiredObj.status.readyReplicas + items[i].readyReplicas
-                          end return desiredObj end ``` \n The content of the LuaScript
-                          needs to be a whole function including both declaration
-                          and implementation. \n The parameters will be supplied by
-                          the system: - desiredObj: the object represents a resource
-                          template. - statusItems: the slice of status expressed with
-                          AggregatedStatusItem. \n The returned object should be a
-                          whole object with status aggregated."
+                        description: |-
+                          LuaScript holds the Lua script that is used to aggregate decentralized statuses
+                          to the desired specification.
+                          The script should implement a function as follows:
+
+
+                          ```
+                            luaScript: >
+                                function AggregateStatus(desiredObj, statusItems)
+                                    for i = 1, #statusItems do
+                                        desiredObj.status.readyReplicas = desiredObj.status.readyReplicas + items[i].readyReplicas
+                                    end
+                                    return desiredObj
+                                end
+                          ```
+
+
+                          The content of the LuaScript needs to be a whole function including both
+                          declaration and implementation.
+
+
+                          The parameters will be supplied by the system:
+                            - desiredObj: the object represents a resource template.
+                            - statusItems: the slice of status expressed with AggregatedStatusItem.
+
+
+                          The returned object should be a whole object with status aggregated.
                         type: string
                     required:
                     - luaScript
                     type: object
                   statusReflection:
-                    description: 'StatusReflection describes the rules for Karmada
-                      to pick the resource''s status. Karmada provides built-in rules
-                      for several standard Kubernetes types, see: https://karmada.io/docs/userguide/globalview/customizing-resource-interpreter/#interpretstatus
-                      If StatusReflection is set, the built-in rules will be ignored.'
+                    description: |-
+                      StatusReflection describes the rules for Karmada to pick the resource's status.
+                      Karmada provides built-in rules for several standard Kubernetes types, see:
+                      https://karmada.io/docs/userguide/globalview/customizing-resource-interpreter/#interpretstatus
+                      If StatusReflection is set, the built-in rules will be ignored.
                     properties:
                       luaScript:
-                        description: "LuaScript holds the Lua script that is used
-                          to get the status from the observed specification. The script
-                          should implement a function as follows: \n ``` luaScript:
-                          > function ReflectStatus(observedObj) status = {} status.readyReplicas
-                          = observedObj.status.observedObj return status end ``` \n
-                          The content of the LuaScript needs to be a whole function
-                          including both declaration and implementation. \n The parameters
-                          will be supplied by the system: - observedObj: the object
-                          represents the configuration that is observed from a specific
-                          member cluster. \n The returned status could be the whole
-                          status or part of it and will be set into both Work and
-                          ResourceBinding(ClusterResourceBinding)."
+                        description: |-
+                          LuaScript holds the Lua script that is used to get the status from the observed specification.
+                          The script should implement a function as follows:
+
+
+                          ```
+                            luaScript: >
+                                function ReflectStatus(observedObj)
+                                    status = {}
+                                    status.readyReplicas = observedObj.status.observedObj
+                                    return status
+                                end
+                          ```
+
+
+                          The content of the LuaScript needs to be a whole function including both
+                          declaration and implementation.
+
+
+                          The parameters will be supplied by the system:
+                            - observedObj: the object represents the configuration that is observed
+                                from a specific member cluster.
+
+
+                          The returned status could be the whole status or part of it and will
+                          be set into both Work and ResourceBinding(ClusterResourceBinding).
                         type: string
                     required:
                     - luaScript

--- a/charts/karmada/_crds/bases/config/config.karmada.io_resourceinterpreterwebhookconfigurations.yaml
+++ b/charts/karmada/_crds/bases/config/config.karmada.io_resourceinterpreterwebhookconfigurations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: resourceinterpreterwebhookconfigurations.config.karmada.io
 spec:
   group: config.karmada.io
@@ -19,19 +19,24 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ResourceInterpreterWebhookConfiguration describes the configuration
-          of webhooks which take the responsibility to tell karmada the details of
-          the resource object, especially for custom resources.
+        description: |-
+          ResourceInterpreterWebhookConfiguration describes the configuration of webhooks which take the responsibility to
+          tell karmada the details of the resource object, especially for custom resources.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -46,31 +51,38 @@ spec:
                   description: ClientConfig defines how to communicate with the hook.
                   properties:
                     caBundle:
-                      description: '`caBundle` is a PEM encoded CA bundle which will
-                        be used to validate the webhook''s server certificate. If
-                        unspecified, system trust roots on the apiserver are used.'
+                      description: |-
+                        `caBundle` is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
+                        If unspecified, system trust roots on the apiserver are used.
                       format: byte
                       type: string
                     service:
-                      description: "`service` is a reference to the service for this
-                        webhook. Either `service` or `url` must be specified. \n If
-                        the webhook is running within the cluster, then you should
-                        use `service`."
+                      description: |-
+                        `service` is a reference to the service for this webhook. Either
+                        `service` or `url` must be specified.
+
+
+                        If the webhook is running within the cluster, then you should use `service`.
                       properties:
                         name:
-                          description: '`name` is the name of the service. Required'
+                          description: |-
+                            `name` is the name of the service.
+                            Required
                           type: string
                         namespace:
-                          description: '`namespace` is the namespace of the service.
-                            Required'
+                          description: |-
+                            `namespace` is the namespace of the service.
+                            Required
                           type: string
                         path:
-                          description: '`path` is an optional URL path which will
-                            be sent in any request to this service.'
+                          description: |-
+                            `path` is an optional URL path which will be sent in any request to
+                            this service.
                           type: string
                         port:
-                          description: If specified, the port on the service that
-                            hosting webhook. Default to 443 for backward compatibility.
+                          description: |-
+                            If specified, the port on the service that hosting webhook.
+                            Default to 443 for backward compatibility.
                             `port` should be a valid port number (1-65535, inclusive).
                           format: int32
                           type: integer
@@ -79,36 +91,48 @@ spec:
                       - namespace
                       type: object
                     url:
-                      description: "`url` gives the location of the webhook, in standard
-                        URL form (`scheme://host:port/path`). Exactly one of `url`
-                        or `service` must be specified. \n The `host` should not refer
-                        to a service running in the cluster; use the `service` field
-                        instead. The host might be resolved via external DNS in some
-                        apiservers (e.g., `kube-apiserver` cannot resolve in-cluster
-                        DNS as that would be a layering violation). `host` may also
-                        be an IP address. \n Please note that using `localhost` or
-                        `127.0.0.1` as a `host` is risky unless you take great care
-                        to run this webhook on all hosts which run an apiserver which
-                        might need to make calls to this webhook. Such installs are
-                        likely to be non-portable, i.e., not easy to turn up in a
-                        new cluster. \n The scheme must be \"https\"; the URL must
-                        begin with \"https://\". \n A path is optional, and if present
-                        may be any string permissible in a URL. You may use the path
-                        to pass an arbitrary string to the webhook, for example, a
-                        cluster identifier. \n Attempting to use a user or basic auth
-                        e.g. \"user:password@\" is not allowed. Fragments (\"#...\")
-                        and query parameters (\"?...\") are not allowed, either."
+                      description: |-
+                        `url` gives the location of the webhook, in standard URL form
+                        (`scheme://host:port/path`). Exactly one of `url` or `service`
+                        must be specified.
+
+
+                        The `host` should not refer to a service running in the cluster; use
+                        the `service` field instead. The host might be resolved via external
+                        DNS in some apiservers (e.g., `kube-apiserver` cannot resolve
+                        in-cluster DNS as that would be a layering violation). `host` may
+                        also be an IP address.
+
+
+                        Please note that using `localhost` or `127.0.0.1` as a `host` is
+                        risky unless you take great care to run this webhook on all hosts
+                        which run an apiserver which might need to make calls to this
+                        webhook. Such installs are likely to be non-portable, i.e., not easy
+                        to turn up in a new cluster.
+
+
+                        The scheme must be "https"; the URL must begin with "https://".
+
+
+                        A path is optional, and if present may be any string permissible in
+                        a URL. You may use the path to pass an arbitrary string to the
+                        webhook, for example, a cluster identifier.
+
+
+                        Attempting to use a user or basic auth e.g. "user:password@" is not
+                        allowed. Fragments ("#...") and query parameters ("?...") are not
+                        allowed, either.
                       type: string
                   type: object
                 interpreterContextVersions:
-                  description: InterpreterContextVersions is an ordered list of preferred
-                    `ResourceInterpreterContext` versions the Webhook expects. Karmada
-                    will try to use first version in the list which it supports. If
-                    none of the versions specified in this list supported by Karmada,
-                    validation will fail for this object. If a persisted webhook configuration
-                    specifies allowed versions and does not include any versions known
-                    to the Karmada, calls to the webhook will fail and be subject
-                    to the failure policy.
+                  description: |-
+                    InterpreterContextVersions is an ordered list of preferred `ResourceInterpreterContext`
+                    versions the Webhook expects. Karmada will try to use first version in
+                    the list which it supports. If none of the versions specified in this list
+                    supported by Karmada, validation will fail for this object.
+                    If a persisted webhook configuration specifies allowed versions and does not
+                    include any versions known to the Karmada, calls to the webhook will fail
+                    and be subject to the failure policy.
                   items:
                     type: string
                   type: array
@@ -116,43 +140,50 @@ spec:
                   description: Name is the full-qualified name of the webhook.
                   type: string
                 rules:
-                  description: Rules describes what operations on what resources the
-                    webhook cares about. The webhook cares about an operation if it
-                    matches any Rule.
+                  description: |-
+                    Rules describes what operations on what resources the webhook cares about.
+                    The webhook cares about an operation if it matches any Rule.
                   items:
-                    description: RuleWithOperations is a tuple of Operations and Resources.
-                      It is recommended to make sure that all the tuple expansions
-                      are valid.
+                    description: |-
+                      RuleWithOperations is a tuple of Operations and Resources. It is recommended to make
+                      sure that all the tuple expansions are valid.
                     properties:
                       apiGroups:
-                        description: "APIGroups is the API groups the resources belong
-                          to. '*' is all groups. If '*' is present, the length of
-                          the slice must be one. For example: [\"apps\", \"batch\",
-                          \"example.io\"] means matches 3 groups. [\"*\"] means matches
-                          all group \n Note: The group could be empty, e.g the 'core'
-                          group of kubernetes, in that case use [\"\"]."
+                        description: |-
+                          APIGroups is the API groups the resources belong to. '*' is all groups.
+                          If '*' is present, the length of the slice must be one.
+                          For example:
+                           ["apps", "batch", "example.io"] means matches 3 groups.
+                           ["*"] means matches all group
+
+
+                          Note: The group could be empty, e.g the 'core' group of kubernetes, in that case use [""].
                         items:
                           type: string
                         type: array
                       apiVersions:
-                        description: 'APIVersions is the API versions the resources
-                          belong to. ''*'' is all versions. If ''*'' is present, the
-                          length of the slice must be one. For example: ["v1alpha1",
-                          "v1beta1"] means matches 2 versions. ["*"] means matches
-                          all versions.'
+                        description: |-
+                          APIVersions is the API versions the resources belong to. '*' is all versions.
+                          If '*' is present, the length of the slice must be one.
+                          For example:
+                           ["v1alpha1", "v1beta1"] means matches 2 versions.
+                           ["*"] means matches all versions.
                         items:
                           type: string
                         type: array
                       kinds:
-                        description: 'Kinds is a list of resources this rule applies
-                          to. If ''*'' is present, the length of the slice must be
-                          one. For example: ["Deployment", "Pod"] means matches Deployment
-                          and Pod. ["*"] means apply to all resources.'
+                        description: |-
+                          Kinds is a list of resources this rule applies to.
+                          If '*' is present, the length of the slice must be one.
+                          For example:
+                           ["Deployment", "Pod"] means matches Deployment and Pod.
+                           ["*"] means apply to all resources.
                         items:
                           type: string
                         type: array
                       operations:
-                        description: Operations is the operations the hook cares about.
+                        description: |-
+                          Operations is the operations the hook cares about.
                           If '*' is present, the length of the slice must be one.
                         items:
                           description: InterpreterOperation specifies an operation
@@ -167,10 +198,12 @@ spec:
                     type: object
                   type: array
                 timeoutSeconds:
-                  description: TimeoutSeconds specifies the timeout for this webhook.
-                    After the timeout passes, the webhook call will be ignored or
-                    the API call will fail based on the failure policy. The timeout
-                    value must be between 1 and 30 seconds. Default to 10 seconds.
+                  description: |-
+                    TimeoutSeconds specifies the timeout for this webhook. After the timeout passes,
+                    the webhook call will be ignored or the API call will fail based on the
+                    failure policy.
+                    The timeout value must be between 1 and 30 seconds.
+                    Default to 10 seconds.
                   format: int32
                   type: integer
               required:

--- a/charts/karmada/_crds/bases/networking/networking.karmada.io_multiclusteringresses.yaml
+++ b/charts/karmada/_crds/bases/networking/networking.karmada.io_multiclusteringresses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: multiclusteringresses.networking.karmada.io
 spec:
   group: networking.karmada.io
@@ -21,19 +21,25 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: MultiClusterIngress is a collection of rules that allow inbound
-          connections to reach the endpoints defined by a backend. The structure of
-          MultiClusterIngress is same as Ingress, indicates the Ingress in multi-clusters.
+        description: |-
+          MultiClusterIngress is a collection of rules that allow inbound connections to reach the
+          endpoints defined by a backend. The structure of MultiClusterIngress is same as Ingress,
+          indicates the Ingress in multi-clusters.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -41,23 +47,24 @@ spec:
             description: Spec is the desired state of the MultiClusterIngress.
             properties:
               defaultBackend:
-                description: defaultBackend is the backend that should handle requests
-                  that don't match any rule. If Rules are not specified, DefaultBackend
-                  must be specified. If DefaultBackend is not set, the handling of
-                  requests that do not match any of the rules will be up to the Ingress
-                  controller.
+                description: |-
+                  defaultBackend is the backend that should handle requests that don't
+                  match any rule. If Rules are not specified, DefaultBackend must be specified.
+                  If DefaultBackend is not set, the handling of requests that do not match any
+                  of the rules will be up to the Ingress controller.
                 properties:
                   resource:
-                    description: resource is an ObjectRef to another Kubernetes resource
-                      in the namespace of the Ingress object. If resource is specified,
-                      a service.Name and service.Port must not be specified. This
-                      is a mutually exclusive setting with "Service".
+                    description: |-
+                      resource is an ObjectRef to another Kubernetes resource in the namespace
+                      of the Ingress object. If resource is specified, a service.Name and
+                      service.Port must not be specified.
+                      This is a mutually exclusive setting with "Service".
                     properties:
                       apiGroup:
-                        description: APIGroup is the group for the resource being
-                          referenced. If APIGroup is not specified, the specified
-                          Kind must be in the core API group. For any other third-party
-                          types, APIGroup is required.
+                        description: |-
+                          APIGroup is the group for the resource being referenced.
+                          If APIGroup is not specified, the specified Kind must be in the core API group.
+                          For any other third-party types, APIGroup is required.
                         type: string
                       kind:
                         description: Kind is the type of resource being referenced
@@ -71,25 +78,29 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   service:
-                    description: service references a service as a backend. This is
-                      a mutually exclusive setting with "Resource".
+                    description: |-
+                      service references a service as a backend.
+                      This is a mutually exclusive setting with "Resource".
                     properties:
                       name:
-                        description: name is the referenced service. The service must
-                          exist in the same namespace as the Ingress object.
+                        description: |-
+                          name is the referenced service. The service must exist in
+                          the same namespace as the Ingress object.
                         type: string
                       port:
-                        description: port of the referenced service. A port name or
-                          port number is required for a IngressServiceBackend.
+                        description: |-
+                          port of the referenced service. A port name or port number
+                          is required for a IngressServiceBackend.
                         properties:
                           name:
-                            description: name is the name of the port on the Service.
+                            description: |-
+                              name is the name of the port on the Service.
                               This is a mutually exclusive setting with "Number".
                             type: string
                           number:
-                            description: number is the numerical port number (e.g.
-                              80) on the Service. This is a mutually exclusive setting
-                              with "Name".
+                            description: |-
+                              number is the numerical port number (e.g. 80) on the Service.
+                              This is a mutually exclusive setting with "Name".
                             format: int32
                             type: integer
                         type: object
@@ -98,86 +109,86 @@ spec:
                     type: object
                 type: object
               ingressClassName:
-                description: ingressClassName is the name of an IngressClass cluster
-                  resource. Ingress controller implementations use this field to know
-                  whether they should be serving this Ingress resource, by a transitive
-                  connection (controller -> IngressClass -> Ingress resource). Although
-                  the `kubernetes.io/ingress.class` annotation (simple constant name)
-                  was never formally defined, it was widely supported by Ingress controllers
-                  to create a direct binding between Ingress controller and Ingress
-                  resources. Newly created Ingress resources should prefer using the
-                  field. However, even though the annotation is officially deprecated,
-                  for backwards compatibility reasons, ingress controllers should
-                  still honor that annotation if present.
+                description: |-
+                  ingressClassName is the name of an IngressClass cluster resource. Ingress
+                  controller implementations use this field to know whether they should be
+                  serving this Ingress resource, by a transitive connection
+                  (controller -> IngressClass -> Ingress resource). Although the
+                  `kubernetes.io/ingress.class` annotation (simple constant name) was never
+                  formally defined, it was widely supported by Ingress controllers to create
+                  a direct binding between Ingress controller and Ingress resources. Newly
+                  created Ingress resources should prefer using the field. However, even
+                  though the annotation is officially deprecated, for backwards compatibility
+                  reasons, ingress controllers should still honor that annotation if present.
                 type: string
               rules:
-                description: rules is a list of host rules used to configure the Ingress.
-                  If unspecified, or no rule matches, all traffic is sent to the default
-                  backend.
+                description: |-
+                  rules is a list of host rules used to configure the Ingress. If unspecified,
+                  or no rule matches, all traffic is sent to the default backend.
                 items:
-                  description: IngressRule represents the rules mapping the paths
-                    under a specified host to the related backend services. Incoming
-                    requests are first evaluated for a host match, then routed to
-                    the backend associated with the matching IngressRuleValue.
+                  description: |-
+                    IngressRule represents the rules mapping the paths under a specified host to
+                    the related backend services. Incoming requests are first evaluated for a host
+                    match, then routed to the backend associated with the matching IngressRuleValue.
                   properties:
                     host:
                       description: "host is the fully qualified domain name of a network
-                        host, as defined by RFC 3986. Note the following deviations
-                        from the \"host\" part of the URI as defined in RFC 3986:
-                        1. IPs are not allowed. Currently an IngressRuleValue can
-                        only apply to the IP in the Spec of the parent Ingress. 2.
-                        The `:` delimiter is not respected because ports are not allowed.
-                        Currently the port of an Ingress is implicitly :80 for http
-                        and :443 for https. Both these may change in the future. Incoming
-                        requests are matched against the host before the IngressRuleValue.
-                        If the host is unspecified, the Ingress routes all traffic
-                        based on the specified IngressRuleValue. \n host can be \"precise\"
-                        which is a domain name without the terminating dot of a network
-                        host (e.g. \"foo.bar.com\") or \"wildcard\", which is a domain
-                        name prefixed with a single wildcard label (e.g. \"*.foo.com\").
-                        The wildcard character '*' must appear by itself as the first
-                        DNS label and matches only a single label. You cannot have
-                        a wildcard label by itself (e.g. Host == \"*\"). Requests
-                        will be matched against the Host field in the following way:
-                        1. If host is precise, the request matches this rule if the
-                        http host header is equal to Host. 2. If host is a wildcard,
-                        then the request matches this rule if the http host header
-                        is to equal to the suffix (removing the first label) of the
-                        wildcard rule."
+                        host, as defined by RFC 3986.\nNote the following deviations
+                        from the \"host\" part of the\nURI as defined in RFC 3986:\n1.
+                        IPs are not allowed. Currently an IngressRuleValue can only
+                        apply to\n   the IP in the Spec of the parent Ingress.\n2.
+                        The `:` delimiter is not respected because ports are not allowed.\n\t
+                        \ Currently the port of an Ingress is implicitly :80 for http
+                        and\n\t  :443 for https.\nBoth these may change in the future.\nIncoming
+                        requests are matched against the host before the\nIngressRuleValue.
+                        If the host is unspecified, the Ingress routes all\ntraffic
+                        based on the specified IngressRuleValue.\n\n\nhost can be
+                        \"precise\" which is a domain name without the terminating
+                        dot of\na network host (e.g. \"foo.bar.com\") or \"wildcard\",
+                        which is a domain name\nprefixed with a single wildcard label
+                        (e.g. \"*.foo.com\").\nThe wildcard character '*' must appear
+                        by itself as the first DNS label and\nmatches only a single
+                        label. You cannot have a wildcard label by itself (e.g. Host
+                        == \"*\").\nRequests will be matched against the Host field
+                        in the following way:\n1. If host is precise, the request
+                        matches this rule if the http host header is equal to Host.\n2.
+                        If host is a wildcard, then the request matches this rule
+                        if the http host header\nis to equal to the suffix (removing
+                        the first label) of the wildcard rule."
                       type: string
                     http:
-                      description: 'HTTPIngressRuleValue is a list of http selectors
-                        pointing to backends. In the example: http://<host>/<path>?<searchpart>
-                        -> backend where where parts of the url correspond to RFC
-                        3986, this resource will be used to match against everything
-                        after the last ''/'' and before the first ''?'' or ''#''.'
+                      description: |-
+                        HTTPIngressRuleValue is a list of http selectors pointing to backends.
+                        In the example: http://<host>/<path>?<searchpart> -> backend where
+                        where parts of the url correspond to RFC 3986, this resource will be used
+                        to match against everything after the last '/' and before the first '?'
+                        or '#'.
                       properties:
                         paths:
                           description: paths is a collection of paths that map requests
                             to backends.
                           items:
-                            description: HTTPIngressPath associates a path with a
-                              backend. Incoming urls matching the path are forwarded
-                              to the backend.
+                            description: |-
+                              HTTPIngressPath associates a path with a backend. Incoming urls matching the
+                              path are forwarded to the backend.
                             properties:
                               backend:
-                                description: backend defines the referenced service
-                                  endpoint to which the traffic will be forwarded
-                                  to.
+                                description: |-
+                                  backend defines the referenced service endpoint to which the traffic
+                                  will be forwarded to.
                                 properties:
                                   resource:
-                                    description: resource is an ObjectRef to another
-                                      Kubernetes resource in the namespace of the
-                                      Ingress object. If resource is specified, a
-                                      service.Name and service.Port must not be specified.
+                                    description: |-
+                                      resource is an ObjectRef to another Kubernetes resource in the namespace
+                                      of the Ingress object. If resource is specified, a service.Name and
+                                      service.Port must not be specified.
                                       This is a mutually exclusive setting with "Service".
                                     properties:
                                       apiGroup:
-                                        description: APIGroup is the group for the
-                                          resource being referenced. If APIGroup is
-                                          not specified, the specified Kind must be
-                                          in the core API group. For any other third-party
-                                          types, APIGroup is required.
+                                        description: |-
+                                          APIGroup is the group for the resource being referenced.
+                                          If APIGroup is not specified, the specified Kind must be in the core API group.
+                                          For any other third-party types, APIGroup is required.
                                         type: string
                                       kind:
                                         description: Kind is the type of resource
@@ -193,30 +204,29 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   service:
-                                    description: service references a service as a
-                                      backend. This is a mutually exclusive setting
-                                      with "Resource".
+                                    description: |-
+                                      service references a service as a backend.
+                                      This is a mutually exclusive setting with "Resource".
                                     properties:
                                       name:
-                                        description: name is the referenced service.
-                                          The service must exist in the same namespace
-                                          as the Ingress object.
+                                        description: |-
+                                          name is the referenced service. The service must exist in
+                                          the same namespace as the Ingress object.
                                         type: string
                                       port:
-                                        description: port of the referenced service.
-                                          A port name or port number is required for
-                                          a IngressServiceBackend.
+                                        description: |-
+                                          port of the referenced service. A port name or port number
+                                          is required for a IngressServiceBackend.
                                         properties:
                                           name:
-                                            description: name is the name of the port
-                                              on the Service. This is a mutually exclusive
-                                              setting with "Number".
+                                            description: |-
+                                              name is the name of the port on the Service.
+                                              This is a mutually exclusive setting with "Number".
                                             type: string
                                           number:
-                                            description: number is the numerical port
-                                              number (e.g. 80) on the Service. This
-                                              is a mutually exclusive setting with
-                                              "Name".
+                                            description: |-
+                                              number is the numerical port number (e.g. 80) on the Service.
+                                              This is a mutually exclusive setting with "Name".
                                             format: int32
                                             type: integer
                                         type: object
@@ -225,32 +235,28 @@ spec:
                                     type: object
                                 type: object
                               path:
-                                description: path is matched against the path of an
-                                  incoming request. Currently it can contain characters
-                                  disallowed from the conventional "path" part of
-                                  a URL as defined by RFC 3986. Paths must begin with
-                                  a '/' and must be present when using PathType with
-                                  value "Exact" or "Prefix".
+                                description: |-
+                                  path is matched against the path of an incoming request. Currently it can
+                                  contain characters disallowed from the conventional "path" part of a URL
+                                  as defined by RFC 3986. Paths must begin with a '/' and must be present
+                                  when using PathType with value "Exact" or "Prefix".
                                 type: string
                               pathType:
-                                description: 'pathType determines the interpretation
-                                  of the path matching. PathType can be one of the
-                                  following values: * Exact: Matches the URL path
-                                  exactly. * Prefix: Matches based on a URL path prefix
-                                  split by ''/''. Matching is done on a path element
-                                  by element basis. A path element refers is the list
-                                  of labels in the path split by the ''/'' separator.
-                                  A request is a match for path p if every p is an
-                                  element-wise prefix of p of the request path. Note
-                                  that if the last element of the path is a substring
-                                  of the last element in request path, it is not a
-                                  match (e.g. /foo/bar matches /foo/bar/baz, but does
-                                  not match /foo/barbaz). * ImplementationSpecific:
-                                  Interpretation of the Path matching is up to the
-                                  IngressClass. Implementations can treat this as
-                                  a separate PathType or treat it identically to Prefix
-                                  or Exact path types. Implementations are required
-                                  to support all path types.'
+                                description: |-
+                                  pathType determines the interpretation of the path matching. PathType can
+                                  be one of the following values:
+                                  * Exact: Matches the URL path exactly.
+                                  * Prefix: Matches based on a URL path prefix split by '/'. Matching is
+                                    done on a path element by element basis. A path element refers is the
+                                    list of labels in the path split by the '/' separator. A request is a
+                                    match for path p if every p is an element-wise prefix of p of the
+                                    request path. Note that if the last element of the path is a substring
+                                    of the last element in request path, it is not a match (e.g. /foo/bar
+                                    matches /foo/bar/baz, but does not match /foo/barbaz).
+                                  * ImplementationSpecific: Interpretation of the Path matching is up to
+                                    the IngressClass. Implementations can treat this as a separate PathType
+                                    or treat it identically to Prefix or Exact path types.
+                                  Implementations are required to support all path types.
                                 type: string
                             required:
                             - backend
@@ -265,31 +271,33 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               tls:
-                description: tls represents the TLS configuration. Currently the Ingress
-                  only supports a single TLS port, 443. If multiple members of this
-                  list specify different hosts, they will be multiplexed on the same
-                  port according to the hostname specified through the SNI TLS extension,
-                  if the ingress controller fulfilling the ingress supports SNI.
+                description: |-
+                  tls represents the TLS configuration. Currently the Ingress only supports a
+                  single TLS port, 443. If multiple members of this list specify different hosts,
+                  they will be multiplexed on the same port according to the hostname specified
+                  through the SNI TLS extension, if the ingress controller fulfilling the
+                  ingress supports SNI.
                 items:
                   description: IngressTLS describes the transport layer security associated
                     with an ingress.
                   properties:
                     hosts:
-                      description: hosts is a list of hosts included in the TLS certificate.
-                        The values in this list must match the name/s used in the
-                        tlsSecret. Defaults to the wildcard host setting for the loadbalancer
-                        controller fulfilling this Ingress, if left unspecified.
+                      description: |-
+                        hosts is a list of hosts included in the TLS certificate. The values in
+                        this list must match the name/s used in the tlsSecret. Defaults to the
+                        wildcard host setting for the loadbalancer controller fulfilling this
+                        Ingress, if left unspecified.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     secretName:
-                      description: secretName is the name of the secret used to terminate
-                        TLS traffic on port 443. Field is left optional to allow TLS
-                        routing based on SNI hostname alone. If the SNI host in a
-                        listener conflicts with the "Host" header field used by an
-                        IngressRule, the SNI host is used for termination and value
-                        of the "Host" header is used for routing.
+                      description: |-
+                        secretName is the name of the secret used to terminate TLS traffic on
+                        port 443. Field is left optional to allow TLS routing based on SNI
+                        hostname alone. If the SNI host in a listener conflicts with the "Host"
+                        header field used by an IngressRule, the SNI host is used for termination
+                        and value of the "Host" header is used for routing.
                       type: string
                   type: object
                 type: array
@@ -324,14 +332,15 @@ spec:
                               of a service port
                             properties:
                               error:
-                                description: 'error is to record the problem with
-                                  the service port The format of the error shall comply
-                                  with the following rules: - built-in error values
-                                  shall be specified in this file and those shall
-                                  use CamelCase names - cloud provider specific error
-                                  values must have names that comply with the format
-                                  foo.example.com/CamelCase. --- The regex it matches
-                                  is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
+                                description: |-
+                                  error is to record the problem with the service port
+                                  The format of the error shall comply with the following rules:
+                                  - built-in error values shall be specified in this file and those shall use
+                                    CamelCase names
+                                  - cloud provider specific error values must have names that comply with the
+                                    format foo.example.com/CamelCase.
+                                  ---
+                                  The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                                 maxLength: 316
                                 pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                                 type: string
@@ -342,8 +351,9 @@ spec:
                                 type: integer
                               protocol:
                                 default: TCP
-                                description: 'protocol is the protocol of the ingress
-                                  port. The supported values are: "TCP", "UDP", "SCTP"'
+                                description: |-
+                                  protocol is the protocol of the ingress port.
+                                  The supported values are: "TCP", "UDP", "SCTP"
                                 type: string
                             required:
                             - port
@@ -355,8 +365,9 @@ spec:
                     type: array
                 type: object
               serviceLocations:
-                description: ServiceLocations records the locations of MulticlusterIngress's
-                  backend Service resources. It will be set by the system controller.
+                description: |-
+                  ServiceLocations records the locations of MulticlusterIngress's backend
+                  Service resources. It will be set by the system controller.
                 items:
                   description: ServiceLocation records the locations of MulticlusterIngress's
                     backend Service resources.
@@ -368,19 +379,20 @@ spec:
                         type: string
                       type: array
                     name:
-                      description: name is the referenced service. The service must
-                        exist in the same namespace as the MultiClusterService object.
+                      description: |-
+                        name is the referenced service. The service must exist in
+                        the same namespace as the MultiClusterService object.
                       type: string
                   required:
                   - name
                   type: object
                 type: array
               trafficBlockClusters:
-                description: TrafficBlockClusters records the cluster name list that
-                  needs to perform traffic block. When the cloud provider implements
-                  its multicluster-cloud-provider and refreshes the service backend
-                  address to the LoadBalancer Service, it needs to filter out the
-                  backend addresses in these clusters.
+                description: |-
+                  TrafficBlockClusters records the cluster name list that needs to perform traffic block.
+                  When the cloud provider implements its multicluster-cloud-provider and refreshes
+                  the service backend address to the LoadBalancer Service, it needs to filter out
+                  the backend addresses in these clusters.
                 items:
                   type: string
                 type: array

--- a/charts/karmada/_crds/bases/networking/networking.karmada.io_multiclusterservices.yaml
+++ b/charts/karmada/_crds/bases/networking/networking.karmada.io_multiclusterservices.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: multiclusterservices.networking.karmada.io
 spec:
   group: networking.karmada.io
@@ -21,22 +21,28 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: MultiClusterService is a named abstraction of multi-cluster software
-          service. The name field of MultiClusterService is the same as that of Service
-          name. Services with the same name in different clusters are regarded as
-          the same service and are associated with the same MultiClusterService. MultiClusterService
-          can control the exposure of services to outside multiple clusters, and also
-          enable service discovery between clusters.
+        description: |-
+          MultiClusterService is a named abstraction of multi-cluster software service.
+          The name field of MultiClusterService is the same as that of Service name.
+          Services with the same name in different clusters are regarded as the same
+          service and are associated with the same MultiClusterService.
+          MultiClusterService can control the exposure of services to outside multiple
+          clusters, and also enable service discovery between clusters.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -44,9 +50,9 @@ spec:
             description: Spec is the desired state of the MultiClusterService.
             properties:
               consumerClusters:
-                description: ConsumerClusters specifies the clusters where the service
-                  will be exposed, for clients. If leave it empty, the service will
-                  be exposed to all clusters.
+                description: |-
+                  ConsumerClusters specifies the clusters where the service will be exposed, for clients.
+                  If leave it empty, the service will be exposed to all clusters.
                 items:
                   description: ClusterSelector specifies the cluster to be selected.
                   properties:
@@ -56,17 +62,18 @@ spec:
                   type: object
                 type: array
               ports:
-                description: Ports is the list of ports that are exposed by this MultiClusterService.
-                  No specified port will be filtered out during the service exposure
-                  and discovery process. All ports in the referencing service will
-                  be exposed by default.
+                description: |-
+                  Ports is the list of ports that are exposed by this MultiClusterService.
+                  No specified port will be filtered out during the service
+                  exposure and discovery process.
+                  All ports in the referencing service will be exposed by default.
                 items:
                   description: ExposurePort describes which port will be exposed.
                   properties:
                     name:
-                      description: Name is the name of the port that needs to be exposed
-                        within the service. The port name must be the same as that
-                        defined in the service.
+                      description: |-
+                        Name is the name of the port that needs to be exposed within the service.
+                        The port name must be the same as that defined in the service.
                       type: string
                     port:
                       description: Port specifies the exposed service port.
@@ -77,9 +84,10 @@ spec:
                   type: object
                 type: array
               providerClusters:
-                description: ProviderClusters specifies the clusters which will provide
-                  the service backend. If leave it empty, we will collect the backend
-                  endpoints from all clusters and sync them to the ConsumerClusters.
+                description: |-
+                  ProviderClusters specifies the clusters which will provide the service backend.
+                  If leave it empty, we will collect the backend endpoints from all clusters and sync
+                  them to the ConsumerClusters.
                 items:
                   description: ClusterSelector specifies the cluster to be selected.
                   properties:
@@ -89,11 +97,14 @@ spec:
                   type: object
                 type: array
               range:
-                description: 'Range specifies the ranges where the referencing service
-                  should be exposed. Only valid and optional in case of Types contains
-                  CrossCluster. If not set and Types contains CrossCluster, all clusters
-                  will be selected, that means the referencing service will be exposed
-                  across all registered clusters. Deprecated: in favor of ProviderClusters/ConsumerClusters.'
+                description: |-
+                  Range specifies the ranges where the referencing service should
+                  be exposed.
+                  Only valid and optional in case of Types contains CrossCluster.
+                  If not set and Types contains CrossCluster, all clusters will
+                  be selected, that means the referencing service will be exposed
+                  across all registered clusters.
+                  Deprecated: in favor of ProviderClusters/ConsumerClusters.
                 properties:
                   clusterNames:
                     description: ClusterNames is the list of clusters to be selected.
@@ -102,24 +113,26 @@ spec:
                     type: array
                 type: object
               serviceConsumptionClusters:
-                description: 'ServiceConsumptionClusters specifies the clusters where
-                  the service will be exposed, for clients. If leave it empty, the
-                  service will be exposed to all clusters. Deprecated: in favor of
-                  ProviderClusters/ConsumerClusters.'
+                description: |-
+                  ServiceConsumptionClusters specifies the clusters where the service will be exposed, for clients.
+                  If leave it empty, the service will be exposed to all clusters.
+                  Deprecated: in favor of ProviderClusters/ConsumerClusters.
                 items:
                   type: string
                 type: array
               serviceProvisionClusters:
-                description: 'ServiceProvisionClusters specifies the clusters which
-                  will provision the service backend. If leave it empty, we will collect
-                  the backend endpoints from all clusters and sync them to the ServiceConsumptionClusters.
-                  Deprecated: in favor of ProviderClusters/ConsumerClusters.'
+                description: |-
+                  ServiceProvisionClusters specifies the clusters which will provision the service backend.
+                  If leave it empty, we will collect the backend endpoints from all clusters and sync
+                  them to the ServiceConsumptionClusters.
+                  Deprecated: in favor of ProviderClusters/ConsumerClusters.
                 items:
                   type: string
                 type: array
               types:
-                description: Types specifies how to expose the service referencing
-                  by this MultiClusterService.
+                description: |-
+                  Types specifies how to expose the service referencing by this
+                  MultiClusterService.
                 items:
                   description: ExposureType describes how to expose the service.
                   type: string
@@ -134,42 +147,42 @@ spec:
                 description: Current service state
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -183,11 +196,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -203,41 +217,45 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               loadBalancer:
-                description: LoadBalancer contains the current status of the load-balancer,
+                description: |-
+                  LoadBalancer contains the current status of the load-balancer,
                   if one is present.
                 properties:
                   ingress:
-                    description: Ingress is a list containing ingress points for the
-                      load-balancer. Traffic intended for the service should be sent
-                      to these ingress points.
+                    description: |-
+                      Ingress is a list containing ingress points for the load-balancer.
+                      Traffic intended for the service should be sent to these ingress points.
                     items:
-                      description: 'LoadBalancerIngress represents the status of a
-                        load-balancer ingress point: traffic intended for the service
-                        should be sent to an ingress point.'
+                      description: |-
+                        LoadBalancerIngress represents the status of a load-balancer ingress point:
+                        traffic intended for the service should be sent to an ingress point.
                       properties:
                         hostname:
-                          description: Hostname is set for load-balancer ingress points
-                            that are DNS based (typically AWS load-balancers)
+                          description: |-
+                            Hostname is set for load-balancer ingress points that are DNS based
+                            (typically AWS load-balancers)
                           type: string
                         ip:
-                          description: IP is set for load-balancer ingress points
-                            that are IP based (typically GCE or OpenStack load-balancers)
+                          description: |-
+                            IP is set for load-balancer ingress points that are IP based
+                            (typically GCE or OpenStack load-balancers)
                           type: string
                         ports:
-                          description: Ports is a list of records of service ports
-                            If used, every port defined in the service should have
-                            an entry in it
+                          description: |-
+                            Ports is a list of records of service ports
+                            If used, every port defined in the service should have an entry in it
                           items:
                             properties:
                               error:
-                                description: 'Error is to record the problem with
-                                  the service port The format of the error shall comply
-                                  with the following rules: - built-in error values
-                                  shall be specified in this file and those shall
-                                  use CamelCase names - cloud provider specific error
-                                  values must have names that comply with the format
-                                  foo.example.com/CamelCase. --- The regex it matches
-                                  is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
+                                description: |-
+                                  Error is to record the problem with the service port
+                                  The format of the error shall comply with the following rules:
+                                  - built-in error values shall be specified in this file and those shall use
+                                    CamelCase names
+                                  - cloud provider specific error values must have names that comply with the
+                                    format foo.example.com/CamelCase.
+                                  ---
+                                  The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                                 maxLength: 316
                                 pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                                 type: string
@@ -248,9 +266,9 @@ spec:
                                 type: integer
                               protocol:
                                 default: TCP
-                                description: 'Protocol is the protocol of the service
-                                  port of which status is recorded here The supported
-                                  values are: "TCP", "UDP", "SCTP"'
+                                description: |-
+                                  Protocol is the protocol of the service port of which status is recorded here
+                                  The supported values are: "TCP", "UDP", "SCTP"
                                 type: string
                             required:
                             - port

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_clusteroverridepolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_clusteroverridepolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: clusteroverridepolicies.policy.karmada.io
 spec:
   group: policy.karmada.io
@@ -25,14 +25,19 @@ spec:
           overrides a group of resources to one or more clusters.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -67,13 +72,11 @@ spec:
                               value:
                                 additionalProperties:
                                   type: string
-                                description: Value to be applied to annotations/labels
-                                  of workload. Items in Value which will be appended
-                                  after annotations/labels when Operator is 'add'.
-                                  Items in Value which match in annotations/labels
-                                  will be deleted when Operator is 'remove'. Items
-                                  in Value which match in annotations/labels will
-                                  be replaced when Operator is 'replace'.
+                                description: |-
+                                  Value to be applied to annotations/labels of workload.
+                                  Items in Value which will be appended after annotations/labels when Operator is 'add'.
+                                  Items in Value which match in annotations/labels will be deleted when Operator is 'remove'.
+                                  Items in Value which match in annotations/labels will be replaced when Operator is 'replace'.
                                 type: object
                             required:
                             - operator
@@ -97,12 +100,11 @@ spec:
                                 - remove
                                 type: string
                               value:
-                                description: Value to be applied to command/args.
-                                  Items in Value which will be appended after command/args
-                                  when Operator is 'add'. Items in Value which match
-                                  in command/args will be deleted when Operator is
-                                  'remove'. If Value is empty, then the command/args
-                                  will remain the same.
+                                description: |-
+                                  Value to be applied to command/args.
+                                  Items in Value which will be appended after command/args when Operator is 'add'.
+                                  Items in Value which match in command/args will be deleted when Operator is 'remove'.
+                                  If Value is empty, then the command/args will remain the same.
                                 items:
                                   type: string
                                 type: array
@@ -129,12 +131,11 @@ spec:
                                 - remove
                                 type: string
                               value:
-                                description: Value to be applied to command/args.
-                                  Items in Value which will be appended after command/args
-                                  when Operator is 'add'. Items in Value which match
-                                  in command/args will be deleted when Operator is
-                                  'remove'. If Value is empty, then the command/args
-                                  will remain the same.
+                                description: |-
+                                  Value to be applied to command/args.
+                                  Items in Value which will be appended after command/args when Operator is 'add'.
+                                  Items in Value which match in command/args will be deleted when Operator is 'remove'.
+                                  If Value is empty, then the command/args will remain the same.
                                 items:
                                   type: string
                                 type: array
@@ -151,11 +152,19 @@ spec:
                               to handling image overrides.
                             properties:
                               component:
-                                description: 'Component is part of image name. Basically
-                                  we presume an image can be made of ''[registry/]repository[:tag]''.
-                                  The registry could be: - registry.k8s.io - fictional.registry.example:10443
-                                  The repository could be: - kube-apiserver - fictional/nginx
-                                  The tag cloud be: - latest - v1.19.1 - @sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c'
+                                description: |-
+                                  Component is part of image name.
+                                  Basically we presume an image can be made of '[registry/]repository[:tag]'.
+                                  The registry could be:
+                                  - registry.k8s.io
+                                  - fictional.registry.example:10443
+                                  The repository could be:
+                                  - kube-apiserver
+                                  - fictional/nginx
+                                  The tag cloud be:
+                                  - latest
+                                  - v1.19.1
+                                  - @sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c
                                 enum:
                                 - Registry
                                 - Repository
@@ -170,20 +179,22 @@ spec:
                                 - replace
                                 type: string
                               predicate:
-                                description: "Predicate filters images before applying
-                                  the rule. \n Defaults to nil, in that case, the
-                                  system will automatically detect image fields if
-                                  the resource type is Pod, ReplicaSet, Deployment,
-                                  StatefulSet, DaemonSet or Job by following rule:
-                                  - Pod: /spec/containers/<N>/image - ReplicaSet:
-                                  /spec/template/spec/containers/<N>/image - Deployment:
-                                  /spec/template/spec/containers/<N>/image - DaemonSet:
-                                  /spec/template/spec/containers/<N>/image - StatefulSet:
-                                  /spec/template/spec/containers/<N>/image - Job:
-                                  /spec/template/spec/containers/<N>/image In addition,
-                                  all images will be processed if the resource object
-                                  has more than one container. \n If not nil, only
-                                  images matches the filters will be processed."
+                                description: |-
+                                  Predicate filters images before applying the rule.
+
+
+                                  Defaults to nil, in that case, the system will automatically detect image fields if the resource type is
+                                  Pod, ReplicaSet, Deployment, StatefulSet, DaemonSet or Job by following rule:
+                                    - Pod: /spec/containers/<N>/image
+                                    - ReplicaSet: /spec/template/spec/containers/<N>/image
+                                    - Deployment: /spec/template/spec/containers/<N>/image
+                                    - DaemonSet: /spec/template/spec/containers/<N>/image
+                                    - StatefulSet: /spec/template/spec/containers/<N>/image
+                                    - Job: /spec/template/spec/containers/<N>/image
+                                  In addition, all images will be processed if the resource object has more than one container.
+
+
+                                  If not nil, only images matches the filters will be processed.
                                 properties:
                                   path:
                                     description: Path indicates the path of target
@@ -193,9 +204,10 @@ spec:
                                 - path
                                 type: object
                               value:
-                                description: Value to be applied to image. Must not
-                                  be empty when operator is 'add' or 'replace'. Defaults
-                                  to empty and ignored when operator is 'remove'.
+                                description: |-
+                                  Value to be applied to image.
+                                  Must not be empty when operator is 'add' or 'replace'.
+                                  Defaults to empty and ignored when operator is 'remove'.
                                 type: string
                             required:
                             - component
@@ -220,13 +232,11 @@ spec:
                               value:
                                 additionalProperties:
                                   type: string
-                                description: Value to be applied to annotations/labels
-                                  of workload. Items in Value which will be appended
-                                  after annotations/labels when Operator is 'add'.
-                                  Items in Value which match in annotations/labels
-                                  will be deleted when Operator is 'remove'. Items
-                                  in Value which match in annotations/labels will
-                                  be replaced when Operator is 'replace'.
+                                description: |-
+                                  Value to be applied to annotations/labels of workload.
+                                  Items in Value which will be appended after annotations/labels when Operator is 'add'.
+                                  Items in Value which match in annotations/labels will be deleted when Operator is 'remove'.
+                                  Items in Value which match in annotations/labels will be replaced when Operator is 'replace'.
                                 type: object
                             required:
                             - operator
@@ -236,14 +246,14 @@ spec:
                           description: Plaintext represents override rules defined
                             with plaintext overriders.
                           items:
-                            description: PlaintextOverrider is a simple overrider
-                              that overrides target fields according to path, operator
-                              and value.
+                            description: |-
+                              PlaintextOverrider is a simple overrider that overrides target fields
+                              according to path, operator and value.
                             properties:
                               operator:
-                                description: 'Operator indicates the operation on
-                                  target field. Available operators are: add, replace
-                                  and remove.'
+                                description: |-
+                                  Operator indicates the operation on target field.
+                                  Available operators are: add, replace and remove.
                                 enum:
                                 - add
                                 - remove
@@ -253,7 +263,8 @@ spec:
                                 description: Path indicates the path of target field
                                 type: string
                               value:
-                                description: Value to be applied to target field.
+                                description: |-
+                                  Value to be applied to target field.
                                   Must be empty when operator is Remove.
                                 x-kubernetes-preserve-unknown-fields: true
                             required:
@@ -263,9 +274,10 @@ spec:
                           type: array
                       type: object
                     targetCluster:
-                      description: TargetCluster defines restrictions on this override
-                        policy that only applies to resources propagated to the matching
-                        clusters. nil means matching all clusters.
+                      description: |-
+                        TargetCluster defines restrictions on this override policy
+                        that only applies to resources propagated to the matching clusters.
+                        nil means matching all clusters.
                       properties:
                         clusterNames:
                           description: ClusterNames is the list of clusters to be
@@ -280,38 +292,35 @@ spec:
                             type: string
                           type: array
                         fieldSelector:
-                          description: FieldSelector is a filter to select member
-                            clusters by fields. The key(field) of the match expression
-                            should be 'provider', 'region', or 'zone', and the operator
-                            of the match expression should be 'In' or 'NotIn'. If
-                            non-nil and non-empty, only the clusters match this filter
-                            will be selected.
+                          description: |-
+                            FieldSelector is a filter to select member clusters by fields.
+                            The key(field) of the match expression should be 'provider', 'region', or 'zone',
+                            and the operator of the match expression should be 'In' or 'NotIn'.
+                            If non-nil and non-empty, only the clusters match this filter will be selected.
                           properties:
                             matchExpressions:
                               description: A list of field selector requirements.
                               items:
-                                description: A node selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
+                                description: |-
+                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                  that relates the key and values.
                                 properties:
                                   key:
                                     description: The label key that the selector applies
                                       to.
                                     type: string
                                   operator:
-                                    description: Represents a key's relationship to
-                                      a set of values. Valid operators are In, NotIn,
-                                      Exists, DoesNotExist. Gt, and Lt.
+                                    description: |-
+                                      Represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: An array of string values. If the
-                                      operator is In or NotIn, the values array must
-                                      be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator
-                                      is Gt or Lt, the values array must have a single
-                                      element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      An array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                      array must have a single element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -322,16 +331,16 @@ spec:
                               type: array
                           type: object
                         labelSelector:
-                          description: LabelSelector is a filter to select member
-                            clusters by labels. If non-nil and non-empty, only the
-                            clusters match this filter will be selected.
+                          description: |-
+                            LabelSelector is a filter to select member clusters by labels.
+                            If non-nil and non-empty, only the clusters match this filter will be selected.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
                                 requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
                                   relates the key and values.
                                 properties:
                                   key:
@@ -339,17 +348,16 @@ spec:
                                       applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -361,11 +369,10 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
@@ -375,9 +382,11 @@ spec:
                   type: object
                 type: array
               overriders:
-                description: "Overriders represents the override rules that would
-                  apply on resources \n Deprecated: This filed is deprecated in v1.0
-                  and please use the OverrideRules instead."
+                description: |-
+                  Overriders represents the override rules that would apply on resources
+
+
+                  Deprecated: This filed is deprecated in v1.0 and please use the OverrideRules instead.
                 properties:
                   annotationsOverrider:
                     description: AnnotationsOverrider represents the rules dedicated
@@ -397,12 +406,11 @@ spec:
                         value:
                           additionalProperties:
                             type: string
-                          description: Value to be applied to annotations/labels of
-                            workload. Items in Value which will be appended after
-                            annotations/labels when Operator is 'add'. Items in Value
-                            which match in annotations/labels will be deleted when
-                            Operator is 'remove'. Items in Value which match in annotations/labels
-                            will be replaced when Operator is 'replace'.
+                          description: |-
+                            Value to be applied to annotations/labels of workload.
+                            Items in Value which will be appended after annotations/labels when Operator is 'add'.
+                            Items in Value which match in annotations/labels will be deleted when Operator is 'remove'.
+                            Items in Value which match in annotations/labels will be replaced when Operator is 'replace'.
                           type: object
                       required:
                       - operator
@@ -426,11 +434,11 @@ spec:
                           - remove
                           type: string
                         value:
-                          description: Value to be applied to command/args. Items
-                            in Value which will be appended after command/args when
-                            Operator is 'add'. Items in Value which match in command/args
-                            will be deleted when Operator is 'remove'. If Value is
-                            empty, then the command/args will remain the same.
+                          description: |-
+                            Value to be applied to command/args.
+                            Items in Value which will be appended after command/args when Operator is 'add'.
+                            Items in Value which match in command/args will be deleted when Operator is 'remove'.
+                            If Value is empty, then the command/args will remain the same.
                           items:
                             type: string
                           type: array
@@ -457,11 +465,11 @@ spec:
                           - remove
                           type: string
                         value:
-                          description: Value to be applied to command/args. Items
-                            in Value which will be appended after command/args when
-                            Operator is 'add'. Items in Value which match in command/args
-                            will be deleted when Operator is 'remove'. If Value is
-                            empty, then the command/args will remain the same.
+                          description: |-
+                            Value to be applied to command/args.
+                            Items in Value which will be appended after command/args when Operator is 'add'.
+                            Items in Value which match in command/args will be deleted when Operator is 'remove'.
+                            If Value is empty, then the command/args will remain the same.
                           items:
                             type: string
                           type: array
@@ -478,11 +486,19 @@ spec:
                         handling image overrides.
                       properties:
                         component:
-                          description: 'Component is part of image name. Basically
-                            we presume an image can be made of ''[registry/]repository[:tag]''.
-                            The registry could be: - registry.k8s.io - fictional.registry.example:10443
-                            The repository could be: - kube-apiserver - fictional/nginx
-                            The tag cloud be: - latest - v1.19.1 - @sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c'
+                          description: |-
+                            Component is part of image name.
+                            Basically we presume an image can be made of '[registry/]repository[:tag]'.
+                            The registry could be:
+                            - registry.k8s.io
+                            - fictional.registry.example:10443
+                            The repository could be:
+                            - kube-apiserver
+                            - fictional/nginx
+                            The tag cloud be:
+                            - latest
+                            - v1.19.1
+                            - @sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c
                           enum:
                           - Registry
                           - Repository
@@ -497,19 +513,22 @@ spec:
                           - replace
                           type: string
                         predicate:
-                          description: "Predicate filters images before applying the
-                            rule. \n Defaults to nil, in that case, the system will
-                            automatically detect image fields if the resource type
-                            is Pod, ReplicaSet, Deployment, StatefulSet, DaemonSet
-                            or Job by following rule: - Pod: /spec/containers/<N>/image
-                            - ReplicaSet: /spec/template/spec/containers/<N>/image
-                            - Deployment: /spec/template/spec/containers/<N>/image
-                            - DaemonSet: /spec/template/spec/containers/<N>/image
-                            - StatefulSet: /spec/template/spec/containers/<N>/image
-                            - Job: /spec/template/spec/containers/<N>/image In addition,
-                            all images will be processed if the resource object has
-                            more than one container. \n If not nil, only images matches
-                            the filters will be processed."
+                          description: |-
+                            Predicate filters images before applying the rule.
+
+
+                            Defaults to nil, in that case, the system will automatically detect image fields if the resource type is
+                            Pod, ReplicaSet, Deployment, StatefulSet, DaemonSet or Job by following rule:
+                              - Pod: /spec/containers/<N>/image
+                              - ReplicaSet: /spec/template/spec/containers/<N>/image
+                              - Deployment: /spec/template/spec/containers/<N>/image
+                              - DaemonSet: /spec/template/spec/containers/<N>/image
+                              - StatefulSet: /spec/template/spec/containers/<N>/image
+                              - Job: /spec/template/spec/containers/<N>/image
+                            In addition, all images will be processed if the resource object has more than one container.
+
+
+                            If not nil, only images matches the filters will be processed.
                           properties:
                             path:
                               description: Path indicates the path of target field
@@ -518,9 +537,10 @@ spec:
                           - path
                           type: object
                         value:
-                          description: Value to be applied to image. Must not be empty
-                            when operator is 'add' or 'replace'. Defaults to empty
-                            and ignored when operator is 'remove'.
+                          description: |-
+                            Value to be applied to image.
+                            Must not be empty when operator is 'add' or 'replace'.
+                            Defaults to empty and ignored when operator is 'remove'.
                           type: string
                       required:
                       - component
@@ -545,12 +565,11 @@ spec:
                         value:
                           additionalProperties:
                             type: string
-                          description: Value to be applied to annotations/labels of
-                            workload. Items in Value which will be appended after
-                            annotations/labels when Operator is 'add'. Items in Value
-                            which match in annotations/labels will be deleted when
-                            Operator is 'remove'. Items in Value which match in annotations/labels
-                            will be replaced when Operator is 'replace'.
+                          description: |-
+                            Value to be applied to annotations/labels of workload.
+                            Items in Value which will be appended after annotations/labels when Operator is 'add'.
+                            Items in Value which match in annotations/labels will be deleted when Operator is 'remove'.
+                            Items in Value which match in annotations/labels will be replaced when Operator is 'replace'.
                           type: object
                       required:
                       - operator
@@ -560,12 +579,14 @@ spec:
                     description: Plaintext represents override rules defined with
                       plaintext overriders.
                     items:
-                      description: PlaintextOverrider is a simple overrider that overrides
-                        target fields according to path, operator and value.
+                      description: |-
+                        PlaintextOverrider is a simple overrider that overrides target fields
+                        according to path, operator and value.
                       properties:
                         operator:
-                          description: 'Operator indicates the operation on target
-                            field. Available operators are: add, replace and remove.'
+                          description: |-
+                            Operator indicates the operation on target field.
+                            Available operators are: add, replace and remove.
                           enum:
                           - add
                           - remove
@@ -575,8 +596,9 @@ spec:
                           description: Path indicates the path of target field
                           type: string
                         value:
-                          description: Value to be applied to target field. Must be
-                            empty when operator is Remove.
+                          description: |-
+                            Value to be applied to target field.
+                            Must be empty when operator is Remove.
                           x-kubernetes-preserve-unknown-fields: true
                       required:
                       - operator
@@ -585,8 +607,9 @@ spec:
                     type: array
                 type: object
               resourceSelectors:
-                description: ResourceSelectors restricts resource types that this
-                  override policy applies to. nil means matching all resources.
+                description: |-
+                  ResourceSelectors restricts resource types that this override policy applies to.
+                  nil means matching all resources.
                 items:
                   description: ResourceSelector the resources will be selected.
                   properties:
@@ -598,32 +621,33 @@ spec:
                       description: Kind represents the Kind of the target resources.
                       type: string
                     labelSelector:
-                      description: A label query over a set of resources. If name
-                        is not empty, labelSelector will be ignored.
+                      description: |-
+                        A label query over a set of resources.
+                        If name is not empty, labelSelector will be ignored.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector
                             requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector
                                   applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship
-                                  to a set of values. Valid operators are In, NotIn,
-                                  Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values.
-                                  If the operator is In or NotIn, the values array
-                                  must be non-empty. If the operator is Exists or
-                                  DoesNotExist, the values array must be empty. This
-                                  array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -635,21 +659,22 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs.
-                            A single {key,value} in the matchLabels map is equivalent
-                            to an element of matchExpressions, whose key field is
-                            "key", the operator is "In", and the values array contains
-                            only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
                     name:
-                      description: Name of the target resource. Default is empty,
-                        which means selecting all resources.
+                      description: |-
+                        Name of the target resource.
+                        Default is empty, which means selecting all resources.
                       type: string
                     namespace:
-                      description: Namespace of the target resource. Default is empty,
-                        which means inherit from the parent object scope.
+                      description: |-
+                        Namespace of the target resource.
+                        Default is empty, which means inherit from the parent object scope.
                       type: string
                   required:
                   - apiVersion
@@ -657,10 +682,13 @@ spec:
                   type: object
                 type: array
               targetCluster:
-                description: "TargetCluster defines restrictions on this override
-                  policy that only applies to resources propagated to the matching
-                  clusters. nil means matching all clusters. \n Deprecated: This filed
-                  is deprecated in v1.0 and please use the OverrideRules instead."
+                description: |-
+                  TargetCluster defines restrictions on this override policy
+                  that only applies to resources propagated to the matching clusters.
+                  nil means matching all clusters.
+
+
+                  Deprecated: This filed is deprecated in v1.0 and please use the OverrideRules instead.
                 properties:
                   clusterNames:
                     description: ClusterNames is the list of clusters to be selected.
@@ -673,36 +701,35 @@ spec:
                       type: string
                     type: array
                   fieldSelector:
-                    description: FieldSelector is a filter to select member clusters
-                      by fields. The key(field) of the match expression should be
-                      'provider', 'region', or 'zone', and the operator of the match
-                      expression should be 'In' or 'NotIn'. If non-nil and non-empty,
-                      only the clusters match this filter will be selected.
+                    description: |-
+                      FieldSelector is a filter to select member clusters by fields.
+                      The key(field) of the match expression should be 'provider', 'region', or 'zone',
+                      and the operator of the match expression should be 'In' or 'NotIn'.
+                      If non-nil and non-empty, only the clusters match this filter will be selected.
                     properties:
                       matchExpressions:
                         description: A list of field selector requirements.
                         items:
-                          description: A node selector requirement is a selector that
-                            contains values, a key, and an operator that relates the
-                            key and values.
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
                           properties:
                             key:
                               description: The label key that the selector applies
                                 to.
                               type: string
                             operator:
-                              description: Represents a key's relationship to a set
-                                of values. Valid operators are In, NotIn, Exists,
-                                DoesNotExist. Gt, and Lt.
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                               type: string
                             values:
-                              description: An array of string values. If the operator
-                                is In or NotIn, the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist, the values
-                                array must be empty. If the operator is Gt or Lt,
-                                the values array must have a single element, which
-                                will be interpreted as an integer. This array is replaced
-                                during a strategic merge patch.
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
                               items:
                                 type: string
                               type: array
@@ -713,33 +740,33 @@ spec:
                         type: array
                     type: object
                   labelSelector:
-                    description: LabelSelector is a filter to select member clusters
-                      by labels. If non-nil and non-empty, only the clusters match
-                      this filter will be selected.
+                    description: |-
+                      LabelSelector is a filter to select member clusters by labels.
+                      If non-nil and non-empty, only the clusters match this filter will be selected.
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector
                           requirements. The requirements are ANDed.
                         items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
                           properties:
                             key:
                               description: key is the label key that the selector
                                 applies to.
                               type: string
                             operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
                               items:
                                 type: string
                               type: array
@@ -751,11 +778,10 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_clusterpropagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_clusterpropagationpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: clusterpropagationpolicies.policy.karmada.io
 spec:
   group: policy.karmada.io
@@ -21,22 +21,26 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: 'ClusterPropagationPolicy represents the cluster-wide policy
-          that propagates a group of resources to one or more clusters. Different
-          with PropagationPolicy that could only propagate resources in its own namespace,
-          ClusterPropagationPolicy is able to propagate cluster level resources and
-          resources in any namespace other than system reserved ones. System reserved
-          namespaces are: karmada-system, karmada-cluster, karmada-es-*.'
+        description: |-
+          ClusterPropagationPolicy represents the cluster-wide policy that propagates a group of resources to one or more clusters.
+          Different with PropagationPolicy that could only propagate resources in its own namespace, ClusterPropagationPolicy
+          is able to propagate cluster level resources and resources in any namespace other than system reserved ones.
+          System reserved namespaces are: karmada-system, karmada-cluster, karmada-es-*.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -44,97 +48,112 @@ spec:
             description: Spec represents the desired behavior of ClusterPropagationPolicy.
             properties:
               activationPreference:
-                description: "ActivationPreference indicates how the referencing resource
-                  template will be propagated, in case of policy changes. \n If empty,
-                  the resource template will respond to policy changes immediately,
-                  in other words, any policy changes will drive the resource template
-                  to be propagated immediately as per the current propagation rules.
-                  \n If the value is 'Lazy' means the policy changes will not take
-                  effect for now but defer to the resource template changes, in other
-                  words, the resource template will not be propagated as per the current
-                  propagation rules until there is an update on it. This is an experimental
-                  feature that might help in a scenario where a policy manages huge
-                  amount of resource templates, changes to a policy typically affect
-                  numerous applications simultaneously. A minor misconfiguration could
-                  lead to widespread failures. With this feature, the change can be
-                  gradually rolled out through iterative modifications of resource
-                  templates."
+                description: |-
+                  ActivationPreference indicates how the referencing resource template will
+                  be propagated, in case of policy changes.
+
+
+                  If empty, the resource template will respond to policy changes
+                  immediately, in other words, any policy changes will drive the resource
+                  template to be propagated immediately as per the current propagation rules.
+
+
+                  If the value is 'Lazy' means the policy changes will not take effect for now
+                  but defer to the resource template changes, in other words, the resource
+                  template will not be propagated as per the current propagation rules until
+                  there is an update on it.
+                  This is an experimental feature that might help in a scenario where a policy
+                  manages huge amount of resource templates, changes to a policy typically
+                  affect numerous applications simultaneously. A minor misconfiguration
+                  could lead to widespread failures. With this feature, the change can be
+                  gradually rolled out through iterative modifications of resource templates.
                 enum:
                 - Lazy
                 type: string
               association:
-                description: 'Association tells if relevant resources should be selected
-                  automatically. e.g. a ConfigMap referred by a Deployment. default
-                  false. Deprecated: in favor of PropagateDeps.'
+                description: |-
+                  Association tells if relevant resources should be selected automatically.
+                  e.g. a ConfigMap referred by a Deployment.
+                  default false.
+                  Deprecated: in favor of PropagateDeps.
                 type: boolean
               conflictResolution:
                 default: Abort
-                description: "ConflictResolution declares how potential conflict should
-                  be handled when a resource that is being propagated already exists
-                  in the target cluster. \n It defaults to \"Abort\" which means stop
-                  propagating to avoid unexpected overwrites. The \"Overwrite\" might
-                  be useful when migrating legacy cluster resources to Karmada, in
-                  which case conflict is predictable and can be instructed to Karmada
-                  take over the resource by overwriting."
+                description: |-
+                  ConflictResolution declares how potential conflict should be handled when
+                  a resource that is being propagated already exists in the target cluster.
+
+
+                  It defaults to "Abort" which means stop propagating to avoid unexpected
+                  overwrites. The "Overwrite" might be useful when migrating legacy cluster
+                  resources to Karmada, in which case conflict is predictable and can be
+                  instructed to Karmada take over the resource by overwriting.
                 enum:
                 - Abort
                 - Overwrite
                 type: string
               dependentOverrides:
-                description: "DependentOverrides represents the list of overrides(OverridePolicy)
+                description: |-
+                  DependentOverrides represents the list of overrides(OverridePolicy)
                   which must present before the current PropagationPolicy takes effect.
-                  \n It used to explicitly specify overrides which current PropagationPolicy
-                  rely on. A typical scenario is the users create OverridePolicy(ies)
-                  and resources at the same time, they want to ensure the new-created
-                  policies would be adopted. \n Note: For the overrides, OverridePolicy(ies)
-                  in current namespace and ClusterOverridePolicy(ies), which not present
-                  in this list will still be applied if they matches the resources."
+
+
+                  It used to explicitly specify overrides which current PropagationPolicy rely on.
+                  A typical scenario is the users create OverridePolicy(ies) and resources at the same time,
+                  they want to ensure the new-created policies would be adopted.
+
+
+                  Note: For the overrides, OverridePolicy(ies) in current namespace and ClusterOverridePolicy(ies),
+                  which not present in this list will still be applied if they matches the resources.
                 items:
                   type: string
                 type: array
               failover:
-                description: Failover indicates how Karmada migrates applications
-                  in case of failures. If this value is nil, failover is disabled.
+                description: |-
+                  Failover indicates how Karmada migrates applications in case of failures.
+                  If this value is nil, failover is disabled.
                 properties:
                   application:
-                    description: Application indicates failover behaviors in case
-                      of application failure. If this value is nil, failover is disabled.
-                      If set, the PropagateDeps should be true so that the dependencies
-                      could be migrated along with the application.
+                    description: |-
+                      Application indicates failover behaviors in case of application failure.
+                      If this value is nil, failover is disabled.
+                      If set, the PropagateDeps should be true so that the dependencies could
+                      be migrated along with the application.
                     properties:
                       decisionConditions:
-                        description: 'DecisionConditions indicates the decision conditions
-                          of performing the failover process. Only when all conditions
-                          are met can the failover process be performed. Currently,
-                          DecisionConditions includes several conditions: - TolerationSeconds
-                          (optional)'
+                        description: |-
+                          DecisionConditions indicates the decision conditions of performing the failover process.
+                          Only when all conditions are met can the failover process be performed.
+                          Currently, DecisionConditions includes several conditions:
+                          - TolerationSeconds (optional)
                         properties:
                           tolerationSeconds:
                             default: 300
-                            description: TolerationSeconds represents the period of
-                              time Karmada should wait after reaching the desired
-                              state before performing failover process. If not specified,
-                              Karmada will immediately perform failover process. Defaults
-                              to 300s.
+                            description: |-
+                              TolerationSeconds represents the period of time Karmada should wait
+                              after reaching the desired state before performing failover process.
+                              If not specified, Karmada will immediately perform failover process.
+                              Defaults to 300s.
                             format: int32
                             type: integer
                         type: object
                       gracePeriodSeconds:
-                        description: GracePeriodSeconds is the maximum waiting duration
-                          in seconds before application on the migrated cluster should
-                          be deleted. Required only when PurgeMode is "Graciously"
-                          and defaults to 600s. If the application on the new cluster
-                          cannot reach a Healthy state, Karmada will delete the application
-                          after GracePeriodSeconds is reached. Value must be positive
-                          integer.
+                        description: |-
+                          GracePeriodSeconds is the maximum waiting duration in seconds before
+                          application on the migrated cluster should be deleted.
+                          Required only when PurgeMode is "Graciously" and defaults to 600s.
+                          If the application on the new cluster cannot reach a Healthy state,
+                          Karmada will delete the application after GracePeriodSeconds is reached.
+                          Value must be positive integer.
                         format: int32
                         type: integer
                       purgeMode:
                         default: Graciously
-                        description: PurgeMode represents how to deal with the legacy
-                          applications on the cluster from which the application is
-                          migrated. Valid options are "Immediately", "Graciously"
-                          and "Never". Defaults to "Graciously".
+                        description: |-
+                          PurgeMode represents how to deal with the legacy applications on the
+                          cluster from which the application is migrated.
+                          Valid options are "Immediately", "Graciously" and "Never".
+                          Defaults to "Graciously".
                         type: string
                     required:
                     - decisionConditions
@@ -145,29 +164,41 @@ spec:
                   propagate resources.
                 properties:
                   clusterAffinities:
-                    description: "ClusterAffinities represents scheduling restrictions
-                      to multiple cluster groups that indicated by ClusterAffinityTerm.
-                      \n The scheduler will evaluate these groups one by one in the
-                      order they appear in the spec, the group that does not satisfy
-                      scheduling restrictions will be ignored which means all clusters
-                      in this group will not be selected unless it also belongs to
-                      the next group(a cluster could belong to multiple groups). \n
-                      If none of the groups satisfy the scheduling restrictions, then
-                      scheduling fails, which means no cluster will be selected. \n
-                      Note: 1. ClusterAffinities can not co-exist with ClusterAffinity.
-                      2. If both ClusterAffinity and ClusterAffinities are not set,
-                      any cluster can be scheduling candidates. \n Potential use case
-                      1: The private clusters in the local data center could be the
-                      main group, and the managed clusters provided by cluster providers
-                      could be the secondary group. So that the Karmada scheduler
-                      would prefer to schedule workloads to the main group and the
-                      second group will only be considered in case of the main group
-                      does not satisfy restrictions(like, lack of resources). \n Potential
-                      use case 2: For the disaster recovery scenario, the clusters
-                      could be organized to primary and backup groups, the workloads
-                      would be scheduled to primary clusters firstly, and when primary
-                      cluster fails(like data center power off), Karmada scheduler
-                      could migrate workloads to the backup clusters."
+                    description: |-
+                      ClusterAffinities represents scheduling restrictions to multiple cluster
+                      groups that indicated by ClusterAffinityTerm.
+
+
+                      The scheduler will evaluate these groups one by one in the order they
+                      appear in the spec, the group that does not satisfy scheduling restrictions
+                      will be ignored which means all clusters in this group will not be selected
+                      unless it also belongs to the next group(a cluster could belong to multiple
+                      groups).
+
+
+                      If none of the groups satisfy the scheduling restrictions, then scheduling
+                      fails, which means no cluster will be selected.
+
+
+                      Note:
+                        1. ClusterAffinities can not co-exist with ClusterAffinity.
+                        2. If both ClusterAffinity and ClusterAffinities are not set, any cluster
+                           can be scheduling candidates.
+
+
+                      Potential use case 1:
+                      The private clusters in the local data center could be the main group, and
+                      the managed clusters provided by cluster providers could be the secondary
+                      group. So that the Karmada scheduler would prefer to schedule workloads
+                      to the main group and the second group will only be considered in case of
+                      the main group does not satisfy restrictions(like, lack of resources).
+
+
+                      Potential use case 2:
+                      For the disaster recovery scenario, the clusters could be organized to
+                      primary and backup groups, the workloads would be scheduled to primary
+                      clusters firstly, and when primary cluster fails(like data center power off),
+                      Karmada scheduler could migrate workloads to the backup clusters.
                     items:
                       description: ClusterAffinityTerm selects a set of cluster.
                       properties:
@@ -189,38 +220,35 @@ spec:
                             type: string
                           type: array
                         fieldSelector:
-                          description: FieldSelector is a filter to select member
-                            clusters by fields. The key(field) of the match expression
-                            should be 'provider', 'region', or 'zone', and the operator
-                            of the match expression should be 'In' or 'NotIn'. If
-                            non-nil and non-empty, only the clusters match this filter
-                            will be selected.
+                          description: |-
+                            FieldSelector is a filter to select member clusters by fields.
+                            The key(field) of the match expression should be 'provider', 'region', or 'zone',
+                            and the operator of the match expression should be 'In' or 'NotIn'.
+                            If non-nil and non-empty, only the clusters match this filter will be selected.
                           properties:
                             matchExpressions:
                               description: A list of field selector requirements.
                               items:
-                                description: A node selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
+                                description: |-
+                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                  that relates the key and values.
                                 properties:
                                   key:
                                     description: The label key that the selector applies
                                       to.
                                     type: string
                                   operator:
-                                    description: Represents a key's relationship to
-                                      a set of values. Valid operators are In, NotIn,
-                                      Exists, DoesNotExist. Gt, and Lt.
+                                    description: |-
+                                      Represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: An array of string values. If the
-                                      operator is In or NotIn, the values array must
-                                      be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator
-                                      is Gt or Lt, the values array must have a single
-                                      element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      An array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                      array must have a single element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -231,16 +259,16 @@ spec:
                               type: array
                           type: object
                         labelSelector:
-                          description: LabelSelector is a filter to select member
-                            clusters by labels. If non-nil and non-empty, only the
-                            clusters match this filter will be selected.
+                          description: |-
+                            LabelSelector is a filter to select member clusters by labels.
+                            If non-nil and non-empty, only the clusters match this filter will be selected.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
                                 requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
                                   relates the key and values.
                                 properties:
                                   key:
@@ -248,17 +276,16 @@ spec:
                                       applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -270,11 +297,10 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
@@ -283,11 +309,12 @@ spec:
                       type: object
                     type: array
                   clusterAffinity:
-                    description: 'ClusterAffinity represents scheduling restrictions
-                      to a certain set of clusters. Note: 1. ClusterAffinity can not
-                      co-exist with ClusterAffinities. 2. If both ClusterAffinity
-                      and ClusterAffinities are not set, any cluster can be scheduling
-                      candidates.'
+                    description: |-
+                      ClusterAffinity represents scheduling restrictions to a certain set of clusters.
+                      Note:
+                        1. ClusterAffinity can not co-exist with ClusterAffinities.
+                        2. If both ClusterAffinity and ClusterAffinities are not set, any cluster
+                           can be scheduling candidates.
                     properties:
                       clusterNames:
                         description: ClusterNames is the list of clusters to be selected.
@@ -301,38 +328,35 @@ spec:
                           type: string
                         type: array
                       fieldSelector:
-                        description: FieldSelector is a filter to select member clusters
-                          by fields. The key(field) of the match expression should
-                          be 'provider', 'region', or 'zone', and the operator of
-                          the match expression should be 'In' or 'NotIn'. If non-nil
-                          and non-empty, only the clusters match this filter will
-                          be selected.
+                        description: |-
+                          FieldSelector is a filter to select member clusters by fields.
+                          The key(field) of the match expression should be 'provider', 'region', or 'zone',
+                          and the operator of the match expression should be 'In' or 'NotIn'.
+                          If non-nil and non-empty, only the clusters match this filter will be selected.
                         properties:
                           matchExpressions:
                             description: A list of field selector requirements.
                             items:
-                              description: A node selector requirement is a selector
-                                that contains values, a key, and an operator that
-                                relates the key and values.
+                              description: |-
+                                A node selector requirement is a selector that contains values, a key, and an operator
+                                that relates the key and values.
                               properties:
                                 key:
                                   description: The label key that the selector applies
                                     to.
                                   type: string
                                 operator:
-                                  description: Represents a key's relationship to
-                                    a set of values. Valid operators are In, NotIn,
-                                    Exists, DoesNotExist. Gt, and Lt.
+                                  description: |-
+                                    Represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                   type: string
                                 values:
-                                  description: An array of string values. If the operator
-                                    is In or NotIn, the values array must be non-empty.
-                                    If the operator is Exists or DoesNotExist, the
-                                    values array must be empty. If the operator is
-                                    Gt or Lt, the values array must have a single
-                                    element, which will be interpreted as an integer.
-                                    This array is replaced during a strategic merge
-                                    patch.
+                                  description: |-
+                                    An array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                    array must have a single element, which will be interpreted as an integer.
+                                    This array is replaced during a strategic merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -343,16 +367,16 @@ spec:
                             type: array
                         type: object
                       labelSelector:
-                        description: LabelSelector is a filter to select member clusters
-                          by labels. If non-nil and non-empty, only the clusters match
-                          this filter will be selected.
+                        description: |-
+                          LabelSelector is a filter to select member clusters by labels.
+                          If non-nil and non-empty, only the clusters match this filter will be selected.
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector
                               requirements. The requirements are ANDed.
                             items:
-                              description: A label selector requirement is a selector
-                                that contains values, a key, and an operator that
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
                                 relates the key and values.
                               properties:
                                 key:
@@ -360,17 +384,16 @@ spec:
                                     applies to.
                                   type: string
                                 operator:
-                                  description: operator represents a key's relationship
-                                    to a set of values. Valid operators are In, NotIn,
-                                    Exists and DoesNotExist.
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: values is an array of string values.
-                                    If the operator is In or NotIn, the values array
-                                    must be non-empty. If the operator is Exists or
-                                    DoesNotExist, the values array must be empty.
-                                    This array is replaced during a strategic merge
-                                    patch.
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -382,11 +405,10 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: matchLabels is a map of {key,value} pairs.
-                              A single {key,value} in the matchLabels map is equivalent
-                              to an element of matchExpressions, whose key field is
-                              "key", the operator is "In", and the values array contains
-                              only "value". The requirements are ANDed.
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
@@ -394,85 +416,79 @@ spec:
                   clusterTolerations:
                     description: ClusterTolerations represents the tolerations.
                     items:
-                      description: The pod this Toleration is attached to tolerates
-                        any taint that matches the triple <key,value,effect> using
-                        the matching operator <operator>.
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: Effect indicates the taint effect to match.
-                            Empty means match all taint effects. When specified, allowed
-                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: Key is the taint key that the toleration applies
-                            to. Empty means match all taint keys. If the key is empty,
-                            operator must be Exists; this combination means to match
-                            all values and all keys.
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: Operator represents a key's relationship to
-                            the value. Valid operators are Exists and Equal. Defaults
-                            to Equal. Exists is equivalent to wildcard for value,
-                            so that a pod can tolerate all taints of a particular
-                            category.
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
-                          description: TolerationSeconds represents the period of
-                            time the toleration (which must be of effect NoExecute,
-                            otherwise this field is ignored) tolerates the taint.
-                            By default, it is not set, which means tolerate the taint
-                            forever (do not evict). Zero and negative values will
-                            be treated as 0 (evict immediately) by the system.
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: Value is the taint value the toleration matches
-                            to. If the operator is Exists, the value should be empty,
-                            otherwise just a regular string.
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   replicaScheduling:
-                    description: ReplicaScheduling represents the scheduling policy
-                      on dealing with the number of replicas when propagating resources
-                      that have replicas in spec (e.g. deployments, statefulsets)
-                      to member clusters.
+                    description: |-
+                      ReplicaScheduling represents the scheduling policy on dealing with the number of replicas
+                      when propagating resources that have replicas in spec (e.g. deployments, statefulsets) to member clusters.
                     properties:
                       replicaDivisionPreference:
-                        description: ReplicaDivisionPreference determines how the
-                          replicas is divided when ReplicaSchedulingType is "Divided".
-                          Valid options are Aggregated and Weighted. "Aggregated"
-                          divides replicas into clusters as few as possible, while
-                          respecting clusters' resource availabilities during the
-                          division. "Weighted" divides replicas by weight according
-                          to WeightPreference.
+                        description: |-
+                          ReplicaDivisionPreference determines how the replicas is divided
+                          when ReplicaSchedulingType is "Divided". Valid options are Aggregated and Weighted.
+                          "Aggregated" divides replicas into clusters as few as possible,
+                          while respecting clusters' resource availabilities during the division.
+                          "Weighted" divides replicas by weight according to WeightPreference.
                         enum:
                         - Aggregated
                         - Weighted
                         type: string
                       replicaSchedulingType:
                         default: Divided
-                        description: ReplicaSchedulingType determines how the replicas
-                          is scheduled when karmada propagating a resource. Valid
-                          options are Duplicated and Divided. "Duplicated" duplicates
-                          the same replicas to each candidate member cluster from
-                          resource. "Divided" divides replicas into parts according
-                          to number of valid candidate member clusters, and exact
-                          replicas for each cluster are determined by ReplicaDivisionPreference.
+                        description: |-
+                          ReplicaSchedulingType determines how the replicas is scheduled when karmada propagating
+                          a resource. Valid options are Duplicated and Divided.
+                          "Duplicated" duplicates the same replicas to each candidate member cluster from resource.
+                          "Divided" divides replicas into parts according to number of valid candidate member
+                          clusters, and exact replicas for each cluster are determined by ReplicaDivisionPreference.
                         enum:
                         - Duplicated
                         - Divided
                         type: string
                       weightPreference:
-                        description: WeightPreference describes weight for each cluster
-                          or for each group of cluster If ReplicaDivisionPreference
-                          is set to "Weighted", and WeightPreference is not set, scheduler
-                          will weight all clusters the same.
+                        description: |-
+                          WeightPreference describes weight for each cluster or for each group of cluster
+                          If ReplicaDivisionPreference is set to "Weighted", and WeightPreference is not set, scheduler will weight all clusters the same.
                         properties:
                           dynamicWeight:
-                            description: DynamicWeight specifies the factor to generates
-                              dynamic weight list. If specified, StaticWeightList
-                              will be ignored.
+                            description: |-
+                              DynamicWeight specifies the factor to generates dynamic weight list.
+                              If specified, StaticWeightList will be ignored.
                             enum:
                             - AvailableReplicas
                             type: string
@@ -500,43 +516,35 @@ spec:
                                         type: string
                                       type: array
                                     fieldSelector:
-                                      description: FieldSelector is a filter to select
-                                        member clusters by fields. The key(field)
-                                        of the match expression should be 'provider',
-                                        'region', or 'zone', and the operator of the
-                                        match expression should be 'In' or 'NotIn'.
-                                        If non-nil and non-empty, only the clusters
-                                        match this filter will be selected.
+                                      description: |-
+                                        FieldSelector is a filter to select member clusters by fields.
+                                        The key(field) of the match expression should be 'provider', 'region', or 'zone',
+                                        and the operator of the match expression should be 'In' or 'NotIn'.
+                                        If non-nil and non-empty, only the clusters match this filter will be selected.
                                       properties:
                                         matchExpressions:
                                           description: A list of field selector requirements.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -547,40 +555,34 @@ spec:
                                           type: array
                                       type: object
                                     labelSelector:
-                                      description: LabelSelector is a filter to select
-                                        member clusters by labels. If non-nil and
-                                        non-empty, only the clusters match this filter
-                                        will be selected.
+                                      description: |-
+                                        LabelSelector is a filter to select member clusters by labels.
+                                        If non-nil and non-empty, only the clusters match this filter will be selected.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -592,12 +594,10 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -627,18 +627,18 @@ spec:
                             groups to be selected.
                           type: integer
                         minGroups:
-                          description: MinGroups restricts the minimum number of cluster
-                            groups to be selected. Defaults to 1.
+                          description: |-
+                            MinGroups restricts the minimum number of cluster groups to be selected.
+                            Defaults to 1.
                           type: integer
                         spreadByField:
-                          description: 'SpreadByField represents the fields on Karmada
-                            cluster API used for dynamically grouping member clusters
-                            into different groups. Resources will be spread among
-                            different cluster groups. Available fields for spreading
-                            are: cluster, region, zone, and provider. SpreadByField
-                            should not co-exist with SpreadByLabel. If both SpreadByField
-                            and SpreadByLabel are empty, SpreadByField will be set
-                            to "cluster" by system.'
+                          description: |-
+                            SpreadByField represents the fields on Karmada cluster API used for
+                            dynamically grouping member clusters into different groups.
+                            Resources will be spread among different cluster groups.
+                            Available fields for spreading are: cluster, region, zone, and provider.
+                            SpreadByField should not co-exist with SpreadByLabel.
+                            If both SpreadByField and SpreadByLabel are empty, SpreadByField will be set to "cluster" by system.
                           enum:
                           - cluster
                           - region
@@ -646,56 +646,66 @@ spec:
                           - provider
                           type: string
                         spreadByLabel:
-                          description: SpreadByLabel represents the label key used
-                            for grouping member clusters into different groups. Resources
-                            will be spread among different cluster groups. SpreadByLabel
-                            should not co-exist with SpreadByField.
+                          description: |-
+                            SpreadByLabel represents the label key used for
+                            grouping member clusters into different groups.
+                            Resources will be spread among different cluster groups.
+                            SpreadByLabel should not co-exist with SpreadByField.
                           type: string
                       type: object
                     type: array
                 type: object
               preemption:
                 default: Never
-                description: Preemption declares the behaviors for preempting. Valid
-                  options are "Always" and "Never".
+                description: |-
+                  Preemption declares the behaviors for preempting.
+                  Valid options are "Always" and "Never".
                 enum:
                 - Always
                 - Never
                 type: string
               priority:
                 default: 0
-                description: "Priority indicates the importance of a policy(PropagationPolicy
-                  or ClusterPropagationPolicy). A policy will be applied for the matched
-                  resource templates if there is no other policies with higher priority
-                  at the point of the resource template be processed. Once a resource
-                  template has been claimed by a policy, by default it will not be
-                  preempted by following policies even with a higher priority. See
-                  Preemption for more details. \n In case of two policies have the
-                  same priority, the one with a more precise matching rules in ResourceSelectors
-                  wins: - matching by name(resourceSelector.name) has higher priority
-                  than by selector(resourceSelector.labelSelector) - matching by selector(resourceSelector.labelSelector)
-                  has higher priority than by APIVersion(resourceSelector.apiVersion)
-                  and Kind(resourceSelector.kind). If there is still no winner at
-                  this point, the one with the lower alphabetic order wins, e.g. policy
-                  'bar' has higher priority than 'foo'. \n The higher the value, the
-                  higher the priority. Defaults to zero."
+                description: |-
+                  Priority indicates the importance of a policy(PropagationPolicy or ClusterPropagationPolicy).
+                  A policy will be applied for the matched resource templates if there is
+                  no other policies with higher priority at the point of the resource
+                  template be processed.
+                  Once a resource template has been claimed by a policy, by default it will
+                  not be preempted by following policies even with a higher priority.
+                  See Preemption for more details.
+
+
+                  In case of two policies have the same priority, the one with a more precise
+                  matching rules in ResourceSelectors wins:
+                  - matching by name(resourceSelector.name) has higher priority than
+                    by selector(resourceSelector.labelSelector)
+                  - matching by selector(resourceSelector.labelSelector) has higher priority
+                    than by APIVersion(resourceSelector.apiVersion) and Kind(resourceSelector.kind).
+                  If there is still no winner at this point, the one with the lower alphabetic
+                  order wins, e.g. policy 'bar' has higher priority than 'foo'.
+
+
+                  The higher the value, the higher the priority. Defaults to zero.
                 format: int32
                 type: integer
               propagateDeps:
-                description: "PropagateDeps tells if relevant resources should be
-                  propagated automatically. Take 'Deployment' which referencing 'ConfigMap'
-                  and 'Secret' as an example, when 'propagateDeps' is 'true', the
-                  referencing resources could be omitted(for saving config effort)
-                  from 'resourceSelectors' as they will be propagated along with the
-                  Deployment. In addition to the propagating process, the referencing
-                  resources will be migrated along with the Deployment in the fail-over
-                  scenario. \n Defaults to false."
+                description: |-
+                  PropagateDeps tells if relevant resources should be propagated automatically.
+                  Take 'Deployment' which referencing 'ConfigMap' and 'Secret' as an example, when 'propagateDeps' is 'true',
+                  the referencing resources could be omitted(for saving config effort) from 'resourceSelectors' as they will be
+                  propagated along with the Deployment. In addition to the propagating process, the referencing resources will be
+                  migrated along with the Deployment in the fail-over scenario.
+
+
+                  Defaults to false.
                 type: boolean
               resourceSelectors:
-                description: ResourceSelectors used to select resources. Nil or empty
-                  selector is not allowed and doesn't mean match all kinds of resources
-                  for security concerns that sensitive resources(like Secret) might
-                  be accidentally propagated.
+                description: |-
+                  ResourceSelectors used to select resources.
+                  Nil or empty selector is not allowed and doesn't mean match all kinds
+                  of resources for security concerns that sensitive resources(like Secret)
+                  might be accidentally propagated.
                 items:
                   description: ResourceSelector the resources will be selected.
                   properties:
@@ -707,32 +717,33 @@ spec:
                       description: Kind represents the Kind of the target resources.
                       type: string
                     labelSelector:
-                      description: A label query over a set of resources. If name
-                        is not empty, labelSelector will be ignored.
+                      description: |-
+                        A label query over a set of resources.
+                        If name is not empty, labelSelector will be ignored.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector
                             requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector
                                   applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship
-                                  to a set of values. Valid operators are In, NotIn,
-                                  Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values.
-                                  If the operator is In or NotIn, the values array
-                                  must be non-empty. If the operator is Exists or
-                                  DoesNotExist, the values array must be empty. This
-                                  array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -744,21 +755,22 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs.
-                            A single {key,value} in the matchLabels map is equivalent
-                            to an element of matchExpressions, whose key field is
-                            "key", the operator is "In", and the values array contains
-                            only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
                     name:
-                      description: Name of the target resource. Default is empty,
-                        which means selecting all resources.
+                      description: |-
+                        Name of the target resource.
+                        Default is empty, which means selecting all resources.
                       type: string
                     namespace:
-                      description: Namespace of the target resource. Default is empty,
-                        which means inherit from the parent object scope.
+                      description: |-
+                        Namespace of the target resource.
+                        Default is empty, which means inherit from the parent object scope.
                       type: string
                   required:
                   - apiVersion
@@ -768,10 +780,10 @@ spec:
                 type: array
               schedulerName:
                 default: default-scheduler
-                description: SchedulerName represents which scheduler to proceed the
-                  scheduling. If specified, the policy will be dispatched by specified
-                  scheduler. If not specified, the policy will be dispatched by default
-                  scheduler.
+                description: |-
+                  SchedulerName represents which scheduler to proceed the scheduling.
+                  If specified, the policy will be dispatched by specified scheduler.
+                  If not specified, the policy will be dispatched by default scheduler.
                 type: string
             required:
             - resourceSelectors

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_federatedresourcequotas.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_federatedresourcequotas.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: federatedresourcequotas.policy.karmada.io
 spec:
   group: policy.karmada.io
@@ -23,14 +23,19 @@ spec:
           per namespace across all clusters.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -48,10 +53,10 @@ spec:
                   resource.
                 type: object
               staticAssignments:
-                description: 'StaticAssignments represents the subset of desired hard
-                  limits for each cluster. Note: for clusters not present in this
-                  list, Karmada will set an empty ResourceQuota to them, which means
-                  these clusters will have no quotas in the referencing namespace.'
+                description: |-
+                  StaticAssignments represents the subset of desired hard limits for each cluster.
+                  Note: for clusters not present in this list, Karmada will set an empty ResourceQuota to them, which means these
+                  clusters will have no quotas in the referencing namespace.
                 items:
                   description: StaticClusterAssignment represents the set of desired
                     hard limits for a specific cluster.
@@ -100,8 +105,9 @@ spec:
                         - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Hard is the set of enforced hard limits for each
-                        named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/'
+                      description: |-
+                        Hard is the set of enforced hard limits for each named resource.
+                        More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
                       type: object
                     used:
                       additionalProperties:

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_overridepolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_overridepolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: overridepolicies.policy.karmada.io
 spec:
   group: policy.karmada.io
@@ -25,14 +25,19 @@ spec:
           resources to one or more clusters.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -67,13 +72,11 @@ spec:
                               value:
                                 additionalProperties:
                                   type: string
-                                description: Value to be applied to annotations/labels
-                                  of workload. Items in Value which will be appended
-                                  after annotations/labels when Operator is 'add'.
-                                  Items in Value which match in annotations/labels
-                                  will be deleted when Operator is 'remove'. Items
-                                  in Value which match in annotations/labels will
-                                  be replaced when Operator is 'replace'.
+                                description: |-
+                                  Value to be applied to annotations/labels of workload.
+                                  Items in Value which will be appended after annotations/labels when Operator is 'add'.
+                                  Items in Value which match in annotations/labels will be deleted when Operator is 'remove'.
+                                  Items in Value which match in annotations/labels will be replaced when Operator is 'replace'.
                                 type: object
                             required:
                             - operator
@@ -97,12 +100,11 @@ spec:
                                 - remove
                                 type: string
                               value:
-                                description: Value to be applied to command/args.
-                                  Items in Value which will be appended after command/args
-                                  when Operator is 'add'. Items in Value which match
-                                  in command/args will be deleted when Operator is
-                                  'remove'. If Value is empty, then the command/args
-                                  will remain the same.
+                                description: |-
+                                  Value to be applied to command/args.
+                                  Items in Value which will be appended after command/args when Operator is 'add'.
+                                  Items in Value which match in command/args will be deleted when Operator is 'remove'.
+                                  If Value is empty, then the command/args will remain the same.
                                 items:
                                   type: string
                                 type: array
@@ -129,12 +131,11 @@ spec:
                                 - remove
                                 type: string
                               value:
-                                description: Value to be applied to command/args.
-                                  Items in Value which will be appended after command/args
-                                  when Operator is 'add'. Items in Value which match
-                                  in command/args will be deleted when Operator is
-                                  'remove'. If Value is empty, then the command/args
-                                  will remain the same.
+                                description: |-
+                                  Value to be applied to command/args.
+                                  Items in Value which will be appended after command/args when Operator is 'add'.
+                                  Items in Value which match in command/args will be deleted when Operator is 'remove'.
+                                  If Value is empty, then the command/args will remain the same.
                                 items:
                                   type: string
                                 type: array
@@ -151,11 +152,19 @@ spec:
                               to handling image overrides.
                             properties:
                               component:
-                                description: 'Component is part of image name. Basically
-                                  we presume an image can be made of ''[registry/]repository[:tag]''.
-                                  The registry could be: - registry.k8s.io - fictional.registry.example:10443
-                                  The repository could be: - kube-apiserver - fictional/nginx
-                                  The tag cloud be: - latest - v1.19.1 - @sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c'
+                                description: |-
+                                  Component is part of image name.
+                                  Basically we presume an image can be made of '[registry/]repository[:tag]'.
+                                  The registry could be:
+                                  - registry.k8s.io
+                                  - fictional.registry.example:10443
+                                  The repository could be:
+                                  - kube-apiserver
+                                  - fictional/nginx
+                                  The tag cloud be:
+                                  - latest
+                                  - v1.19.1
+                                  - @sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c
                                 enum:
                                 - Registry
                                 - Repository
@@ -170,20 +179,22 @@ spec:
                                 - replace
                                 type: string
                               predicate:
-                                description: "Predicate filters images before applying
-                                  the rule. \n Defaults to nil, in that case, the
-                                  system will automatically detect image fields if
-                                  the resource type is Pod, ReplicaSet, Deployment,
-                                  StatefulSet, DaemonSet or Job by following rule:
-                                  - Pod: /spec/containers/<N>/image - ReplicaSet:
-                                  /spec/template/spec/containers/<N>/image - Deployment:
-                                  /spec/template/spec/containers/<N>/image - DaemonSet:
-                                  /spec/template/spec/containers/<N>/image - StatefulSet:
-                                  /spec/template/spec/containers/<N>/image - Job:
-                                  /spec/template/spec/containers/<N>/image In addition,
-                                  all images will be processed if the resource object
-                                  has more than one container. \n If not nil, only
-                                  images matches the filters will be processed."
+                                description: |-
+                                  Predicate filters images before applying the rule.
+
+
+                                  Defaults to nil, in that case, the system will automatically detect image fields if the resource type is
+                                  Pod, ReplicaSet, Deployment, StatefulSet, DaemonSet or Job by following rule:
+                                    - Pod: /spec/containers/<N>/image
+                                    - ReplicaSet: /spec/template/spec/containers/<N>/image
+                                    - Deployment: /spec/template/spec/containers/<N>/image
+                                    - DaemonSet: /spec/template/spec/containers/<N>/image
+                                    - StatefulSet: /spec/template/spec/containers/<N>/image
+                                    - Job: /spec/template/spec/containers/<N>/image
+                                  In addition, all images will be processed if the resource object has more than one container.
+
+
+                                  If not nil, only images matches the filters will be processed.
                                 properties:
                                   path:
                                     description: Path indicates the path of target
@@ -193,9 +204,10 @@ spec:
                                 - path
                                 type: object
                               value:
-                                description: Value to be applied to image. Must not
-                                  be empty when operator is 'add' or 'replace'. Defaults
-                                  to empty and ignored when operator is 'remove'.
+                                description: |-
+                                  Value to be applied to image.
+                                  Must not be empty when operator is 'add' or 'replace'.
+                                  Defaults to empty and ignored when operator is 'remove'.
                                 type: string
                             required:
                             - component
@@ -220,13 +232,11 @@ spec:
                               value:
                                 additionalProperties:
                                   type: string
-                                description: Value to be applied to annotations/labels
-                                  of workload. Items in Value which will be appended
-                                  after annotations/labels when Operator is 'add'.
-                                  Items in Value which match in annotations/labels
-                                  will be deleted when Operator is 'remove'. Items
-                                  in Value which match in annotations/labels will
-                                  be replaced when Operator is 'replace'.
+                                description: |-
+                                  Value to be applied to annotations/labels of workload.
+                                  Items in Value which will be appended after annotations/labels when Operator is 'add'.
+                                  Items in Value which match in annotations/labels will be deleted when Operator is 'remove'.
+                                  Items in Value which match in annotations/labels will be replaced when Operator is 'replace'.
                                 type: object
                             required:
                             - operator
@@ -236,14 +246,14 @@ spec:
                           description: Plaintext represents override rules defined
                             with plaintext overriders.
                           items:
-                            description: PlaintextOverrider is a simple overrider
-                              that overrides target fields according to path, operator
-                              and value.
+                            description: |-
+                              PlaintextOverrider is a simple overrider that overrides target fields
+                              according to path, operator and value.
                             properties:
                               operator:
-                                description: 'Operator indicates the operation on
-                                  target field. Available operators are: add, replace
-                                  and remove.'
+                                description: |-
+                                  Operator indicates the operation on target field.
+                                  Available operators are: add, replace and remove.
                                 enum:
                                 - add
                                 - remove
@@ -253,7 +263,8 @@ spec:
                                 description: Path indicates the path of target field
                                 type: string
                               value:
-                                description: Value to be applied to target field.
+                                description: |-
+                                  Value to be applied to target field.
                                   Must be empty when operator is Remove.
                                 x-kubernetes-preserve-unknown-fields: true
                             required:
@@ -263,9 +274,10 @@ spec:
                           type: array
                       type: object
                     targetCluster:
-                      description: TargetCluster defines restrictions on this override
-                        policy that only applies to resources propagated to the matching
-                        clusters. nil means matching all clusters.
+                      description: |-
+                        TargetCluster defines restrictions on this override policy
+                        that only applies to resources propagated to the matching clusters.
+                        nil means matching all clusters.
                       properties:
                         clusterNames:
                           description: ClusterNames is the list of clusters to be
@@ -280,38 +292,35 @@ spec:
                             type: string
                           type: array
                         fieldSelector:
-                          description: FieldSelector is a filter to select member
-                            clusters by fields. The key(field) of the match expression
-                            should be 'provider', 'region', or 'zone', and the operator
-                            of the match expression should be 'In' or 'NotIn'. If
-                            non-nil and non-empty, only the clusters match this filter
-                            will be selected.
+                          description: |-
+                            FieldSelector is a filter to select member clusters by fields.
+                            The key(field) of the match expression should be 'provider', 'region', or 'zone',
+                            and the operator of the match expression should be 'In' or 'NotIn'.
+                            If non-nil and non-empty, only the clusters match this filter will be selected.
                           properties:
                             matchExpressions:
                               description: A list of field selector requirements.
                               items:
-                                description: A node selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
+                                description: |-
+                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                  that relates the key and values.
                                 properties:
                                   key:
                                     description: The label key that the selector applies
                                       to.
                                     type: string
                                   operator:
-                                    description: Represents a key's relationship to
-                                      a set of values. Valid operators are In, NotIn,
-                                      Exists, DoesNotExist. Gt, and Lt.
+                                    description: |-
+                                      Represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: An array of string values. If the
-                                      operator is In or NotIn, the values array must
-                                      be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator
-                                      is Gt or Lt, the values array must have a single
-                                      element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      An array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                      array must have a single element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -322,16 +331,16 @@ spec:
                               type: array
                           type: object
                         labelSelector:
-                          description: LabelSelector is a filter to select member
-                            clusters by labels. If non-nil and non-empty, only the
-                            clusters match this filter will be selected.
+                          description: |-
+                            LabelSelector is a filter to select member clusters by labels.
+                            If non-nil and non-empty, only the clusters match this filter will be selected.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
                                 requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
                                   relates the key and values.
                                 properties:
                                   key:
@@ -339,17 +348,16 @@ spec:
                                       applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -361,11 +369,10 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
@@ -375,9 +382,11 @@ spec:
                   type: object
                 type: array
               overriders:
-                description: "Overriders represents the override rules that would
-                  apply on resources \n Deprecated: This filed is deprecated in v1.0
-                  and please use the OverrideRules instead."
+                description: |-
+                  Overriders represents the override rules that would apply on resources
+
+
+                  Deprecated: This filed is deprecated in v1.0 and please use the OverrideRules instead.
                 properties:
                   annotationsOverrider:
                     description: AnnotationsOverrider represents the rules dedicated
@@ -397,12 +406,11 @@ spec:
                         value:
                           additionalProperties:
                             type: string
-                          description: Value to be applied to annotations/labels of
-                            workload. Items in Value which will be appended after
-                            annotations/labels when Operator is 'add'. Items in Value
-                            which match in annotations/labels will be deleted when
-                            Operator is 'remove'. Items in Value which match in annotations/labels
-                            will be replaced when Operator is 'replace'.
+                          description: |-
+                            Value to be applied to annotations/labels of workload.
+                            Items in Value which will be appended after annotations/labels when Operator is 'add'.
+                            Items in Value which match in annotations/labels will be deleted when Operator is 'remove'.
+                            Items in Value which match in annotations/labels will be replaced when Operator is 'replace'.
                           type: object
                       required:
                       - operator
@@ -426,11 +434,11 @@ spec:
                           - remove
                           type: string
                         value:
-                          description: Value to be applied to command/args. Items
-                            in Value which will be appended after command/args when
-                            Operator is 'add'. Items in Value which match in command/args
-                            will be deleted when Operator is 'remove'. If Value is
-                            empty, then the command/args will remain the same.
+                          description: |-
+                            Value to be applied to command/args.
+                            Items in Value which will be appended after command/args when Operator is 'add'.
+                            Items in Value which match in command/args will be deleted when Operator is 'remove'.
+                            If Value is empty, then the command/args will remain the same.
                           items:
                             type: string
                           type: array
@@ -457,11 +465,11 @@ spec:
                           - remove
                           type: string
                         value:
-                          description: Value to be applied to command/args. Items
-                            in Value which will be appended after command/args when
-                            Operator is 'add'. Items in Value which match in command/args
-                            will be deleted when Operator is 'remove'. If Value is
-                            empty, then the command/args will remain the same.
+                          description: |-
+                            Value to be applied to command/args.
+                            Items in Value which will be appended after command/args when Operator is 'add'.
+                            Items in Value which match in command/args will be deleted when Operator is 'remove'.
+                            If Value is empty, then the command/args will remain the same.
                           items:
                             type: string
                           type: array
@@ -478,11 +486,19 @@ spec:
                         handling image overrides.
                       properties:
                         component:
-                          description: 'Component is part of image name. Basically
-                            we presume an image can be made of ''[registry/]repository[:tag]''.
-                            The registry could be: - registry.k8s.io - fictional.registry.example:10443
-                            The repository could be: - kube-apiserver - fictional/nginx
-                            The tag cloud be: - latest - v1.19.1 - @sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c'
+                          description: |-
+                            Component is part of image name.
+                            Basically we presume an image can be made of '[registry/]repository[:tag]'.
+                            The registry could be:
+                            - registry.k8s.io
+                            - fictional.registry.example:10443
+                            The repository could be:
+                            - kube-apiserver
+                            - fictional/nginx
+                            The tag cloud be:
+                            - latest
+                            - v1.19.1
+                            - @sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c
                           enum:
                           - Registry
                           - Repository
@@ -497,19 +513,22 @@ spec:
                           - replace
                           type: string
                         predicate:
-                          description: "Predicate filters images before applying the
-                            rule. \n Defaults to nil, in that case, the system will
-                            automatically detect image fields if the resource type
-                            is Pod, ReplicaSet, Deployment, StatefulSet, DaemonSet
-                            or Job by following rule: - Pod: /spec/containers/<N>/image
-                            - ReplicaSet: /spec/template/spec/containers/<N>/image
-                            - Deployment: /spec/template/spec/containers/<N>/image
-                            - DaemonSet: /spec/template/spec/containers/<N>/image
-                            - StatefulSet: /spec/template/spec/containers/<N>/image
-                            - Job: /spec/template/spec/containers/<N>/image In addition,
-                            all images will be processed if the resource object has
-                            more than one container. \n If not nil, only images matches
-                            the filters will be processed."
+                          description: |-
+                            Predicate filters images before applying the rule.
+
+
+                            Defaults to nil, in that case, the system will automatically detect image fields if the resource type is
+                            Pod, ReplicaSet, Deployment, StatefulSet, DaemonSet or Job by following rule:
+                              - Pod: /spec/containers/<N>/image
+                              - ReplicaSet: /spec/template/spec/containers/<N>/image
+                              - Deployment: /spec/template/spec/containers/<N>/image
+                              - DaemonSet: /spec/template/spec/containers/<N>/image
+                              - StatefulSet: /spec/template/spec/containers/<N>/image
+                              - Job: /spec/template/spec/containers/<N>/image
+                            In addition, all images will be processed if the resource object has more than one container.
+
+
+                            If not nil, only images matches the filters will be processed.
                           properties:
                             path:
                               description: Path indicates the path of target field
@@ -518,9 +537,10 @@ spec:
                           - path
                           type: object
                         value:
-                          description: Value to be applied to image. Must not be empty
-                            when operator is 'add' or 'replace'. Defaults to empty
-                            and ignored when operator is 'remove'.
+                          description: |-
+                            Value to be applied to image.
+                            Must not be empty when operator is 'add' or 'replace'.
+                            Defaults to empty and ignored when operator is 'remove'.
                           type: string
                       required:
                       - component
@@ -545,12 +565,11 @@ spec:
                         value:
                           additionalProperties:
                             type: string
-                          description: Value to be applied to annotations/labels of
-                            workload. Items in Value which will be appended after
-                            annotations/labels when Operator is 'add'. Items in Value
-                            which match in annotations/labels will be deleted when
-                            Operator is 'remove'. Items in Value which match in annotations/labels
-                            will be replaced when Operator is 'replace'.
+                          description: |-
+                            Value to be applied to annotations/labels of workload.
+                            Items in Value which will be appended after annotations/labels when Operator is 'add'.
+                            Items in Value which match in annotations/labels will be deleted when Operator is 'remove'.
+                            Items in Value which match in annotations/labels will be replaced when Operator is 'replace'.
                           type: object
                       required:
                       - operator
@@ -560,12 +579,14 @@ spec:
                     description: Plaintext represents override rules defined with
                       plaintext overriders.
                     items:
-                      description: PlaintextOverrider is a simple overrider that overrides
-                        target fields according to path, operator and value.
+                      description: |-
+                        PlaintextOverrider is a simple overrider that overrides target fields
+                        according to path, operator and value.
                       properties:
                         operator:
-                          description: 'Operator indicates the operation on target
-                            field. Available operators are: add, replace and remove.'
+                          description: |-
+                            Operator indicates the operation on target field.
+                            Available operators are: add, replace and remove.
                           enum:
                           - add
                           - remove
@@ -575,8 +596,9 @@ spec:
                           description: Path indicates the path of target field
                           type: string
                         value:
-                          description: Value to be applied to target field. Must be
-                            empty when operator is Remove.
+                          description: |-
+                            Value to be applied to target field.
+                            Must be empty when operator is Remove.
                           x-kubernetes-preserve-unknown-fields: true
                       required:
                       - operator
@@ -585,8 +607,9 @@ spec:
                     type: array
                 type: object
               resourceSelectors:
-                description: ResourceSelectors restricts resource types that this
-                  override policy applies to. nil means matching all resources.
+                description: |-
+                  ResourceSelectors restricts resource types that this override policy applies to.
+                  nil means matching all resources.
                 items:
                   description: ResourceSelector the resources will be selected.
                   properties:
@@ -598,32 +621,33 @@ spec:
                       description: Kind represents the Kind of the target resources.
                       type: string
                     labelSelector:
-                      description: A label query over a set of resources. If name
-                        is not empty, labelSelector will be ignored.
+                      description: |-
+                        A label query over a set of resources.
+                        If name is not empty, labelSelector will be ignored.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector
                             requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector
                                   applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship
-                                  to a set of values. Valid operators are In, NotIn,
-                                  Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values.
-                                  If the operator is In or NotIn, the values array
-                                  must be non-empty. If the operator is Exists or
-                                  DoesNotExist, the values array must be empty. This
-                                  array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -635,21 +659,22 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs.
-                            A single {key,value} in the matchLabels map is equivalent
-                            to an element of matchExpressions, whose key field is
-                            "key", the operator is "In", and the values array contains
-                            only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
                     name:
-                      description: Name of the target resource. Default is empty,
-                        which means selecting all resources.
+                      description: |-
+                        Name of the target resource.
+                        Default is empty, which means selecting all resources.
                       type: string
                     namespace:
-                      description: Namespace of the target resource. Default is empty,
-                        which means inherit from the parent object scope.
+                      description: |-
+                        Namespace of the target resource.
+                        Default is empty, which means inherit from the parent object scope.
                       type: string
                   required:
                   - apiVersion
@@ -657,10 +682,13 @@ spec:
                   type: object
                 type: array
               targetCluster:
-                description: "TargetCluster defines restrictions on this override
-                  policy that only applies to resources propagated to the matching
-                  clusters. nil means matching all clusters. \n Deprecated: This filed
-                  is deprecated in v1.0 and please use the OverrideRules instead."
+                description: |-
+                  TargetCluster defines restrictions on this override policy
+                  that only applies to resources propagated to the matching clusters.
+                  nil means matching all clusters.
+
+
+                  Deprecated: This filed is deprecated in v1.0 and please use the OverrideRules instead.
                 properties:
                   clusterNames:
                     description: ClusterNames is the list of clusters to be selected.
@@ -673,36 +701,35 @@ spec:
                       type: string
                     type: array
                   fieldSelector:
-                    description: FieldSelector is a filter to select member clusters
-                      by fields. The key(field) of the match expression should be
-                      'provider', 'region', or 'zone', and the operator of the match
-                      expression should be 'In' or 'NotIn'. If non-nil and non-empty,
-                      only the clusters match this filter will be selected.
+                    description: |-
+                      FieldSelector is a filter to select member clusters by fields.
+                      The key(field) of the match expression should be 'provider', 'region', or 'zone',
+                      and the operator of the match expression should be 'In' or 'NotIn'.
+                      If non-nil and non-empty, only the clusters match this filter will be selected.
                     properties:
                       matchExpressions:
                         description: A list of field selector requirements.
                         items:
-                          description: A node selector requirement is a selector that
-                            contains values, a key, and an operator that relates the
-                            key and values.
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
                           properties:
                             key:
                               description: The label key that the selector applies
                                 to.
                               type: string
                             operator:
-                              description: Represents a key's relationship to a set
-                                of values. Valid operators are In, NotIn, Exists,
-                                DoesNotExist. Gt, and Lt.
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                               type: string
                             values:
-                              description: An array of string values. If the operator
-                                is In or NotIn, the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist, the values
-                                array must be empty. If the operator is Gt or Lt,
-                                the values array must have a single element, which
-                                will be interpreted as an integer. This array is replaced
-                                during a strategic merge patch.
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
                               items:
                                 type: string
                               type: array
@@ -713,33 +740,33 @@ spec:
                         type: array
                     type: object
                   labelSelector:
-                    description: LabelSelector is a filter to select member clusters
-                      by labels. If non-nil and non-empty, only the clusters match
-                      this filter will be selected.
+                    description: |-
+                      LabelSelector is a filter to select member clusters by labels.
+                      If non-nil and non-empty, only the clusters match this filter will be selected.
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector
                           requirements. The requirements are ANDed.
                         items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
                           properties:
                             key:
                               description: key is the label key that the selector
                                 applies to.
                               type: string
                             operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
                               items:
                                 type: string
                               type: array
@@ -751,11 +778,10 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_propagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_propagationpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: propagationpolicies.policy.karmada.io
 spec:
   group: policy.karmada.io
@@ -25,14 +25,19 @@ spec:
           of resources to one or more clusters.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -40,97 +45,112 @@ spec:
             description: Spec represents the desired behavior of PropagationPolicy.
             properties:
               activationPreference:
-                description: "ActivationPreference indicates how the referencing resource
-                  template will be propagated, in case of policy changes. \n If empty,
-                  the resource template will respond to policy changes immediately,
-                  in other words, any policy changes will drive the resource template
-                  to be propagated immediately as per the current propagation rules.
-                  \n If the value is 'Lazy' means the policy changes will not take
-                  effect for now but defer to the resource template changes, in other
-                  words, the resource template will not be propagated as per the current
-                  propagation rules until there is an update on it. This is an experimental
-                  feature that might help in a scenario where a policy manages huge
-                  amount of resource templates, changes to a policy typically affect
-                  numerous applications simultaneously. A minor misconfiguration could
-                  lead to widespread failures. With this feature, the change can be
-                  gradually rolled out through iterative modifications of resource
-                  templates."
+                description: |-
+                  ActivationPreference indicates how the referencing resource template will
+                  be propagated, in case of policy changes.
+
+
+                  If empty, the resource template will respond to policy changes
+                  immediately, in other words, any policy changes will drive the resource
+                  template to be propagated immediately as per the current propagation rules.
+
+
+                  If the value is 'Lazy' means the policy changes will not take effect for now
+                  but defer to the resource template changes, in other words, the resource
+                  template will not be propagated as per the current propagation rules until
+                  there is an update on it.
+                  This is an experimental feature that might help in a scenario where a policy
+                  manages huge amount of resource templates, changes to a policy typically
+                  affect numerous applications simultaneously. A minor misconfiguration
+                  could lead to widespread failures. With this feature, the change can be
+                  gradually rolled out through iterative modifications of resource templates.
                 enum:
                 - Lazy
                 type: string
               association:
-                description: 'Association tells if relevant resources should be selected
-                  automatically. e.g. a ConfigMap referred by a Deployment. default
-                  false. Deprecated: in favor of PropagateDeps.'
+                description: |-
+                  Association tells if relevant resources should be selected automatically.
+                  e.g. a ConfigMap referred by a Deployment.
+                  default false.
+                  Deprecated: in favor of PropagateDeps.
                 type: boolean
               conflictResolution:
                 default: Abort
-                description: "ConflictResolution declares how potential conflict should
-                  be handled when a resource that is being propagated already exists
-                  in the target cluster. \n It defaults to \"Abort\" which means stop
-                  propagating to avoid unexpected overwrites. The \"Overwrite\" might
-                  be useful when migrating legacy cluster resources to Karmada, in
-                  which case conflict is predictable and can be instructed to Karmada
-                  take over the resource by overwriting."
+                description: |-
+                  ConflictResolution declares how potential conflict should be handled when
+                  a resource that is being propagated already exists in the target cluster.
+
+
+                  It defaults to "Abort" which means stop propagating to avoid unexpected
+                  overwrites. The "Overwrite" might be useful when migrating legacy cluster
+                  resources to Karmada, in which case conflict is predictable and can be
+                  instructed to Karmada take over the resource by overwriting.
                 enum:
                 - Abort
                 - Overwrite
                 type: string
               dependentOverrides:
-                description: "DependentOverrides represents the list of overrides(OverridePolicy)
+                description: |-
+                  DependentOverrides represents the list of overrides(OverridePolicy)
                   which must present before the current PropagationPolicy takes effect.
-                  \n It used to explicitly specify overrides which current PropagationPolicy
-                  rely on. A typical scenario is the users create OverridePolicy(ies)
-                  and resources at the same time, they want to ensure the new-created
-                  policies would be adopted. \n Note: For the overrides, OverridePolicy(ies)
-                  in current namespace and ClusterOverridePolicy(ies), which not present
-                  in this list will still be applied if they matches the resources."
+
+
+                  It used to explicitly specify overrides which current PropagationPolicy rely on.
+                  A typical scenario is the users create OverridePolicy(ies) and resources at the same time,
+                  they want to ensure the new-created policies would be adopted.
+
+
+                  Note: For the overrides, OverridePolicy(ies) in current namespace and ClusterOverridePolicy(ies),
+                  which not present in this list will still be applied if they matches the resources.
                 items:
                   type: string
                 type: array
               failover:
-                description: Failover indicates how Karmada migrates applications
-                  in case of failures. If this value is nil, failover is disabled.
+                description: |-
+                  Failover indicates how Karmada migrates applications in case of failures.
+                  If this value is nil, failover is disabled.
                 properties:
                   application:
-                    description: Application indicates failover behaviors in case
-                      of application failure. If this value is nil, failover is disabled.
-                      If set, the PropagateDeps should be true so that the dependencies
-                      could be migrated along with the application.
+                    description: |-
+                      Application indicates failover behaviors in case of application failure.
+                      If this value is nil, failover is disabled.
+                      If set, the PropagateDeps should be true so that the dependencies could
+                      be migrated along with the application.
                     properties:
                       decisionConditions:
-                        description: 'DecisionConditions indicates the decision conditions
-                          of performing the failover process. Only when all conditions
-                          are met can the failover process be performed. Currently,
-                          DecisionConditions includes several conditions: - TolerationSeconds
-                          (optional)'
+                        description: |-
+                          DecisionConditions indicates the decision conditions of performing the failover process.
+                          Only when all conditions are met can the failover process be performed.
+                          Currently, DecisionConditions includes several conditions:
+                          - TolerationSeconds (optional)
                         properties:
                           tolerationSeconds:
                             default: 300
-                            description: TolerationSeconds represents the period of
-                              time Karmada should wait after reaching the desired
-                              state before performing failover process. If not specified,
-                              Karmada will immediately perform failover process. Defaults
-                              to 300s.
+                            description: |-
+                              TolerationSeconds represents the period of time Karmada should wait
+                              after reaching the desired state before performing failover process.
+                              If not specified, Karmada will immediately perform failover process.
+                              Defaults to 300s.
                             format: int32
                             type: integer
                         type: object
                       gracePeriodSeconds:
-                        description: GracePeriodSeconds is the maximum waiting duration
-                          in seconds before application on the migrated cluster should
-                          be deleted. Required only when PurgeMode is "Graciously"
-                          and defaults to 600s. If the application on the new cluster
-                          cannot reach a Healthy state, Karmada will delete the application
-                          after GracePeriodSeconds is reached. Value must be positive
-                          integer.
+                        description: |-
+                          GracePeriodSeconds is the maximum waiting duration in seconds before
+                          application on the migrated cluster should be deleted.
+                          Required only when PurgeMode is "Graciously" and defaults to 600s.
+                          If the application on the new cluster cannot reach a Healthy state,
+                          Karmada will delete the application after GracePeriodSeconds is reached.
+                          Value must be positive integer.
                         format: int32
                         type: integer
                       purgeMode:
                         default: Graciously
-                        description: PurgeMode represents how to deal with the legacy
-                          applications on the cluster from which the application is
-                          migrated. Valid options are "Immediately", "Graciously"
-                          and "Never". Defaults to "Graciously".
+                        description: |-
+                          PurgeMode represents how to deal with the legacy applications on the
+                          cluster from which the application is migrated.
+                          Valid options are "Immediately", "Graciously" and "Never".
+                          Defaults to "Graciously".
                         type: string
                     required:
                     - decisionConditions
@@ -141,29 +161,41 @@ spec:
                   propagate resources.
                 properties:
                   clusterAffinities:
-                    description: "ClusterAffinities represents scheduling restrictions
-                      to multiple cluster groups that indicated by ClusterAffinityTerm.
-                      \n The scheduler will evaluate these groups one by one in the
-                      order they appear in the spec, the group that does not satisfy
-                      scheduling restrictions will be ignored which means all clusters
-                      in this group will not be selected unless it also belongs to
-                      the next group(a cluster could belong to multiple groups). \n
-                      If none of the groups satisfy the scheduling restrictions, then
-                      scheduling fails, which means no cluster will be selected. \n
-                      Note: 1. ClusterAffinities can not co-exist with ClusterAffinity.
-                      2. If both ClusterAffinity and ClusterAffinities are not set,
-                      any cluster can be scheduling candidates. \n Potential use case
-                      1: The private clusters in the local data center could be the
-                      main group, and the managed clusters provided by cluster providers
-                      could be the secondary group. So that the Karmada scheduler
-                      would prefer to schedule workloads to the main group and the
-                      second group will only be considered in case of the main group
-                      does not satisfy restrictions(like, lack of resources). \n Potential
-                      use case 2: For the disaster recovery scenario, the clusters
-                      could be organized to primary and backup groups, the workloads
-                      would be scheduled to primary clusters firstly, and when primary
-                      cluster fails(like data center power off), Karmada scheduler
-                      could migrate workloads to the backup clusters."
+                    description: |-
+                      ClusterAffinities represents scheduling restrictions to multiple cluster
+                      groups that indicated by ClusterAffinityTerm.
+
+
+                      The scheduler will evaluate these groups one by one in the order they
+                      appear in the spec, the group that does not satisfy scheduling restrictions
+                      will be ignored which means all clusters in this group will not be selected
+                      unless it also belongs to the next group(a cluster could belong to multiple
+                      groups).
+
+
+                      If none of the groups satisfy the scheduling restrictions, then scheduling
+                      fails, which means no cluster will be selected.
+
+
+                      Note:
+                        1. ClusterAffinities can not co-exist with ClusterAffinity.
+                        2. If both ClusterAffinity and ClusterAffinities are not set, any cluster
+                           can be scheduling candidates.
+
+
+                      Potential use case 1:
+                      The private clusters in the local data center could be the main group, and
+                      the managed clusters provided by cluster providers could be the secondary
+                      group. So that the Karmada scheduler would prefer to schedule workloads
+                      to the main group and the second group will only be considered in case of
+                      the main group does not satisfy restrictions(like, lack of resources).
+
+
+                      Potential use case 2:
+                      For the disaster recovery scenario, the clusters could be organized to
+                      primary and backup groups, the workloads would be scheduled to primary
+                      clusters firstly, and when primary cluster fails(like data center power off),
+                      Karmada scheduler could migrate workloads to the backup clusters.
                     items:
                       description: ClusterAffinityTerm selects a set of cluster.
                       properties:
@@ -185,38 +217,35 @@ spec:
                             type: string
                           type: array
                         fieldSelector:
-                          description: FieldSelector is a filter to select member
-                            clusters by fields. The key(field) of the match expression
-                            should be 'provider', 'region', or 'zone', and the operator
-                            of the match expression should be 'In' or 'NotIn'. If
-                            non-nil and non-empty, only the clusters match this filter
-                            will be selected.
+                          description: |-
+                            FieldSelector is a filter to select member clusters by fields.
+                            The key(field) of the match expression should be 'provider', 'region', or 'zone',
+                            and the operator of the match expression should be 'In' or 'NotIn'.
+                            If non-nil and non-empty, only the clusters match this filter will be selected.
                           properties:
                             matchExpressions:
                               description: A list of field selector requirements.
                               items:
-                                description: A node selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
+                                description: |-
+                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                  that relates the key and values.
                                 properties:
                                   key:
                                     description: The label key that the selector applies
                                       to.
                                     type: string
                                   operator:
-                                    description: Represents a key's relationship to
-                                      a set of values. Valid operators are In, NotIn,
-                                      Exists, DoesNotExist. Gt, and Lt.
+                                    description: |-
+                                      Represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: An array of string values. If the
-                                      operator is In or NotIn, the values array must
-                                      be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator
-                                      is Gt or Lt, the values array must have a single
-                                      element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      An array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                      array must have a single element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -227,16 +256,16 @@ spec:
                               type: array
                           type: object
                         labelSelector:
-                          description: LabelSelector is a filter to select member
-                            clusters by labels. If non-nil and non-empty, only the
-                            clusters match this filter will be selected.
+                          description: |-
+                            LabelSelector is a filter to select member clusters by labels.
+                            If non-nil and non-empty, only the clusters match this filter will be selected.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
                                 requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
                                   relates the key and values.
                                 properties:
                                   key:
@@ -244,17 +273,16 @@ spec:
                                       applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -266,11 +294,10 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
@@ -279,11 +306,12 @@ spec:
                       type: object
                     type: array
                   clusterAffinity:
-                    description: 'ClusterAffinity represents scheduling restrictions
-                      to a certain set of clusters. Note: 1. ClusterAffinity can not
-                      co-exist with ClusterAffinities. 2. If both ClusterAffinity
-                      and ClusterAffinities are not set, any cluster can be scheduling
-                      candidates.'
+                    description: |-
+                      ClusterAffinity represents scheduling restrictions to a certain set of clusters.
+                      Note:
+                        1. ClusterAffinity can not co-exist with ClusterAffinities.
+                        2. If both ClusterAffinity and ClusterAffinities are not set, any cluster
+                           can be scheduling candidates.
                     properties:
                       clusterNames:
                         description: ClusterNames is the list of clusters to be selected.
@@ -297,38 +325,35 @@ spec:
                           type: string
                         type: array
                       fieldSelector:
-                        description: FieldSelector is a filter to select member clusters
-                          by fields. The key(field) of the match expression should
-                          be 'provider', 'region', or 'zone', and the operator of
-                          the match expression should be 'In' or 'NotIn'. If non-nil
-                          and non-empty, only the clusters match this filter will
-                          be selected.
+                        description: |-
+                          FieldSelector is a filter to select member clusters by fields.
+                          The key(field) of the match expression should be 'provider', 'region', or 'zone',
+                          and the operator of the match expression should be 'In' or 'NotIn'.
+                          If non-nil and non-empty, only the clusters match this filter will be selected.
                         properties:
                           matchExpressions:
                             description: A list of field selector requirements.
                             items:
-                              description: A node selector requirement is a selector
-                                that contains values, a key, and an operator that
-                                relates the key and values.
+                              description: |-
+                                A node selector requirement is a selector that contains values, a key, and an operator
+                                that relates the key and values.
                               properties:
                                 key:
                                   description: The label key that the selector applies
                                     to.
                                   type: string
                                 operator:
-                                  description: Represents a key's relationship to
-                                    a set of values. Valid operators are In, NotIn,
-                                    Exists, DoesNotExist. Gt, and Lt.
+                                  description: |-
+                                    Represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                   type: string
                                 values:
-                                  description: An array of string values. If the operator
-                                    is In or NotIn, the values array must be non-empty.
-                                    If the operator is Exists or DoesNotExist, the
-                                    values array must be empty. If the operator is
-                                    Gt or Lt, the values array must have a single
-                                    element, which will be interpreted as an integer.
-                                    This array is replaced during a strategic merge
-                                    patch.
+                                  description: |-
+                                    An array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                    array must have a single element, which will be interpreted as an integer.
+                                    This array is replaced during a strategic merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -339,16 +364,16 @@ spec:
                             type: array
                         type: object
                       labelSelector:
-                        description: LabelSelector is a filter to select member clusters
-                          by labels. If non-nil and non-empty, only the clusters match
-                          this filter will be selected.
+                        description: |-
+                          LabelSelector is a filter to select member clusters by labels.
+                          If non-nil and non-empty, only the clusters match this filter will be selected.
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector
                               requirements. The requirements are ANDed.
                             items:
-                              description: A label selector requirement is a selector
-                                that contains values, a key, and an operator that
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
                                 relates the key and values.
                               properties:
                                 key:
@@ -356,17 +381,16 @@ spec:
                                     applies to.
                                   type: string
                                 operator:
-                                  description: operator represents a key's relationship
-                                    to a set of values. Valid operators are In, NotIn,
-                                    Exists and DoesNotExist.
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: values is an array of string values.
-                                    If the operator is In or NotIn, the values array
-                                    must be non-empty. If the operator is Exists or
-                                    DoesNotExist, the values array must be empty.
-                                    This array is replaced during a strategic merge
-                                    patch.
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -378,11 +402,10 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: matchLabels is a map of {key,value} pairs.
-                              A single {key,value} in the matchLabels map is equivalent
-                              to an element of matchExpressions, whose key field is
-                              "key", the operator is "In", and the values array contains
-                              only "value". The requirements are ANDed.
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
@@ -390,85 +413,79 @@ spec:
                   clusterTolerations:
                     description: ClusterTolerations represents the tolerations.
                     items:
-                      description: The pod this Toleration is attached to tolerates
-                        any taint that matches the triple <key,value,effect> using
-                        the matching operator <operator>.
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: Effect indicates the taint effect to match.
-                            Empty means match all taint effects. When specified, allowed
-                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: Key is the taint key that the toleration applies
-                            to. Empty means match all taint keys. If the key is empty,
-                            operator must be Exists; this combination means to match
-                            all values and all keys.
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: Operator represents a key's relationship to
-                            the value. Valid operators are Exists and Equal. Defaults
-                            to Equal. Exists is equivalent to wildcard for value,
-                            so that a pod can tolerate all taints of a particular
-                            category.
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
-                          description: TolerationSeconds represents the period of
-                            time the toleration (which must be of effect NoExecute,
-                            otherwise this field is ignored) tolerates the taint.
-                            By default, it is not set, which means tolerate the taint
-                            forever (do not evict). Zero and negative values will
-                            be treated as 0 (evict immediately) by the system.
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: Value is the taint value the toleration matches
-                            to. If the operator is Exists, the value should be empty,
-                            otherwise just a regular string.
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   replicaScheduling:
-                    description: ReplicaScheduling represents the scheduling policy
-                      on dealing with the number of replicas when propagating resources
-                      that have replicas in spec (e.g. deployments, statefulsets)
-                      to member clusters.
+                    description: |-
+                      ReplicaScheduling represents the scheduling policy on dealing with the number of replicas
+                      when propagating resources that have replicas in spec (e.g. deployments, statefulsets) to member clusters.
                     properties:
                       replicaDivisionPreference:
-                        description: ReplicaDivisionPreference determines how the
-                          replicas is divided when ReplicaSchedulingType is "Divided".
-                          Valid options are Aggregated and Weighted. "Aggregated"
-                          divides replicas into clusters as few as possible, while
-                          respecting clusters' resource availabilities during the
-                          division. "Weighted" divides replicas by weight according
-                          to WeightPreference.
+                        description: |-
+                          ReplicaDivisionPreference determines how the replicas is divided
+                          when ReplicaSchedulingType is "Divided". Valid options are Aggregated and Weighted.
+                          "Aggregated" divides replicas into clusters as few as possible,
+                          while respecting clusters' resource availabilities during the division.
+                          "Weighted" divides replicas by weight according to WeightPreference.
                         enum:
                         - Aggregated
                         - Weighted
                         type: string
                       replicaSchedulingType:
                         default: Divided
-                        description: ReplicaSchedulingType determines how the replicas
-                          is scheduled when karmada propagating a resource. Valid
-                          options are Duplicated and Divided. "Duplicated" duplicates
-                          the same replicas to each candidate member cluster from
-                          resource. "Divided" divides replicas into parts according
-                          to number of valid candidate member clusters, and exact
-                          replicas for each cluster are determined by ReplicaDivisionPreference.
+                        description: |-
+                          ReplicaSchedulingType determines how the replicas is scheduled when karmada propagating
+                          a resource. Valid options are Duplicated and Divided.
+                          "Duplicated" duplicates the same replicas to each candidate member cluster from resource.
+                          "Divided" divides replicas into parts according to number of valid candidate member
+                          clusters, and exact replicas for each cluster are determined by ReplicaDivisionPreference.
                         enum:
                         - Duplicated
                         - Divided
                         type: string
                       weightPreference:
-                        description: WeightPreference describes weight for each cluster
-                          or for each group of cluster If ReplicaDivisionPreference
-                          is set to "Weighted", and WeightPreference is not set, scheduler
-                          will weight all clusters the same.
+                        description: |-
+                          WeightPreference describes weight for each cluster or for each group of cluster
+                          If ReplicaDivisionPreference is set to "Weighted", and WeightPreference is not set, scheduler will weight all clusters the same.
                         properties:
                           dynamicWeight:
-                            description: DynamicWeight specifies the factor to generates
-                              dynamic weight list. If specified, StaticWeightList
-                              will be ignored.
+                            description: |-
+                              DynamicWeight specifies the factor to generates dynamic weight list.
+                              If specified, StaticWeightList will be ignored.
                             enum:
                             - AvailableReplicas
                             type: string
@@ -496,43 +513,35 @@ spec:
                                         type: string
                                       type: array
                                     fieldSelector:
-                                      description: FieldSelector is a filter to select
-                                        member clusters by fields. The key(field)
-                                        of the match expression should be 'provider',
-                                        'region', or 'zone', and the operator of the
-                                        match expression should be 'In' or 'NotIn'.
-                                        If non-nil and non-empty, only the clusters
-                                        match this filter will be selected.
+                                      description: |-
+                                        FieldSelector is a filter to select member clusters by fields.
+                                        The key(field) of the match expression should be 'provider', 'region', or 'zone',
+                                        and the operator of the match expression should be 'In' or 'NotIn'.
+                                        If non-nil and non-empty, only the clusters match this filter will be selected.
                                       properties:
                                         matchExpressions:
                                           description: A list of field selector requirements.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -543,40 +552,34 @@ spec:
                                           type: array
                                       type: object
                                     labelSelector:
-                                      description: LabelSelector is a filter to select
-                                        member clusters by labels. If non-nil and
-                                        non-empty, only the clusters match this filter
-                                        will be selected.
+                                      description: |-
+                                        LabelSelector is a filter to select member clusters by labels.
+                                        If non-nil and non-empty, only the clusters match this filter will be selected.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -588,12 +591,10 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -623,18 +624,18 @@ spec:
                             groups to be selected.
                           type: integer
                         minGroups:
-                          description: MinGroups restricts the minimum number of cluster
-                            groups to be selected. Defaults to 1.
+                          description: |-
+                            MinGroups restricts the minimum number of cluster groups to be selected.
+                            Defaults to 1.
                           type: integer
                         spreadByField:
-                          description: 'SpreadByField represents the fields on Karmada
-                            cluster API used for dynamically grouping member clusters
-                            into different groups. Resources will be spread among
-                            different cluster groups. Available fields for spreading
-                            are: cluster, region, zone, and provider. SpreadByField
-                            should not co-exist with SpreadByLabel. If both SpreadByField
-                            and SpreadByLabel are empty, SpreadByField will be set
-                            to "cluster" by system.'
+                          description: |-
+                            SpreadByField represents the fields on Karmada cluster API used for
+                            dynamically grouping member clusters into different groups.
+                            Resources will be spread among different cluster groups.
+                            Available fields for spreading are: cluster, region, zone, and provider.
+                            SpreadByField should not co-exist with SpreadByLabel.
+                            If both SpreadByField and SpreadByLabel are empty, SpreadByField will be set to "cluster" by system.
                           enum:
                           - cluster
                           - region
@@ -642,56 +643,66 @@ spec:
                           - provider
                           type: string
                         spreadByLabel:
-                          description: SpreadByLabel represents the label key used
-                            for grouping member clusters into different groups. Resources
-                            will be spread among different cluster groups. SpreadByLabel
-                            should not co-exist with SpreadByField.
+                          description: |-
+                            SpreadByLabel represents the label key used for
+                            grouping member clusters into different groups.
+                            Resources will be spread among different cluster groups.
+                            SpreadByLabel should not co-exist with SpreadByField.
                           type: string
                       type: object
                     type: array
                 type: object
               preemption:
                 default: Never
-                description: Preemption declares the behaviors for preempting. Valid
-                  options are "Always" and "Never".
+                description: |-
+                  Preemption declares the behaviors for preempting.
+                  Valid options are "Always" and "Never".
                 enum:
                 - Always
                 - Never
                 type: string
               priority:
                 default: 0
-                description: "Priority indicates the importance of a policy(PropagationPolicy
-                  or ClusterPropagationPolicy). A policy will be applied for the matched
-                  resource templates if there is no other policies with higher priority
-                  at the point of the resource template be processed. Once a resource
-                  template has been claimed by a policy, by default it will not be
-                  preempted by following policies even with a higher priority. See
-                  Preemption for more details. \n In case of two policies have the
-                  same priority, the one with a more precise matching rules in ResourceSelectors
-                  wins: - matching by name(resourceSelector.name) has higher priority
-                  than by selector(resourceSelector.labelSelector) - matching by selector(resourceSelector.labelSelector)
-                  has higher priority than by APIVersion(resourceSelector.apiVersion)
-                  and Kind(resourceSelector.kind). If there is still no winner at
-                  this point, the one with the lower alphabetic order wins, e.g. policy
-                  'bar' has higher priority than 'foo'. \n The higher the value, the
-                  higher the priority. Defaults to zero."
+                description: |-
+                  Priority indicates the importance of a policy(PropagationPolicy or ClusterPropagationPolicy).
+                  A policy will be applied for the matched resource templates if there is
+                  no other policies with higher priority at the point of the resource
+                  template be processed.
+                  Once a resource template has been claimed by a policy, by default it will
+                  not be preempted by following policies even with a higher priority.
+                  See Preemption for more details.
+
+
+                  In case of two policies have the same priority, the one with a more precise
+                  matching rules in ResourceSelectors wins:
+                  - matching by name(resourceSelector.name) has higher priority than
+                    by selector(resourceSelector.labelSelector)
+                  - matching by selector(resourceSelector.labelSelector) has higher priority
+                    than by APIVersion(resourceSelector.apiVersion) and Kind(resourceSelector.kind).
+                  If there is still no winner at this point, the one with the lower alphabetic
+                  order wins, e.g. policy 'bar' has higher priority than 'foo'.
+
+
+                  The higher the value, the higher the priority. Defaults to zero.
                 format: int32
                 type: integer
               propagateDeps:
-                description: "PropagateDeps tells if relevant resources should be
-                  propagated automatically. Take 'Deployment' which referencing 'ConfigMap'
-                  and 'Secret' as an example, when 'propagateDeps' is 'true', the
-                  referencing resources could be omitted(for saving config effort)
-                  from 'resourceSelectors' as they will be propagated along with the
-                  Deployment. In addition to the propagating process, the referencing
-                  resources will be migrated along with the Deployment in the fail-over
-                  scenario. \n Defaults to false."
+                description: |-
+                  PropagateDeps tells if relevant resources should be propagated automatically.
+                  Take 'Deployment' which referencing 'ConfigMap' and 'Secret' as an example, when 'propagateDeps' is 'true',
+                  the referencing resources could be omitted(for saving config effort) from 'resourceSelectors' as they will be
+                  propagated along with the Deployment. In addition to the propagating process, the referencing resources will be
+                  migrated along with the Deployment in the fail-over scenario.
+
+
+                  Defaults to false.
                 type: boolean
               resourceSelectors:
-                description: ResourceSelectors used to select resources. Nil or empty
-                  selector is not allowed and doesn't mean match all kinds of resources
-                  for security concerns that sensitive resources(like Secret) might
-                  be accidentally propagated.
+                description: |-
+                  ResourceSelectors used to select resources.
+                  Nil or empty selector is not allowed and doesn't mean match all kinds
+                  of resources for security concerns that sensitive resources(like Secret)
+                  might be accidentally propagated.
                 items:
                   description: ResourceSelector the resources will be selected.
                   properties:
@@ -703,32 +714,33 @@ spec:
                       description: Kind represents the Kind of the target resources.
                       type: string
                     labelSelector:
-                      description: A label query over a set of resources. If name
-                        is not empty, labelSelector will be ignored.
+                      description: |-
+                        A label query over a set of resources.
+                        If name is not empty, labelSelector will be ignored.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector
                             requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector
                                   applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship
-                                  to a set of values. Valid operators are In, NotIn,
-                                  Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values.
-                                  If the operator is In or NotIn, the values array
-                                  must be non-empty. If the operator is Exists or
-                                  DoesNotExist, the values array must be empty. This
-                                  array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -740,21 +752,22 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs.
-                            A single {key,value} in the matchLabels map is equivalent
-                            to an element of matchExpressions, whose key field is
-                            "key", the operator is "In", and the values array contains
-                            only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
                     name:
-                      description: Name of the target resource. Default is empty,
-                        which means selecting all resources.
+                      description: |-
+                        Name of the target resource.
+                        Default is empty, which means selecting all resources.
                       type: string
                     namespace:
-                      description: Namespace of the target resource. Default is empty,
-                        which means inherit from the parent object scope.
+                      description: |-
+                        Namespace of the target resource.
+                        Default is empty, which means inherit from the parent object scope.
                       type: string
                   required:
                   - apiVersion
@@ -764,10 +777,10 @@ spec:
                 type: array
               schedulerName:
                 default: default-scheduler
-                description: SchedulerName represents which scheduler to proceed the
-                  scheduling. If specified, the policy will be dispatched by specified
-                  scheduler. If not specified, the policy will be dispatched by default
-                  scheduler.
+                description: |-
+                  SchedulerName represents which scheduler to proceed the scheduling.
+                  If specified, the policy will be dispatched by specified scheduler.
+                  If not specified, the policy will be dispatched by default scheduler.
                 type: string
             required:
             - resourceSelectors

--- a/charts/karmada/_crds/bases/remedy/remedy.karmada.io_remedies.yaml
+++ b/charts/karmada/_crds/bases/remedy/remedy.karmada.io_remedies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: remedies.remedy.karmada.io
 spec:
   group: remedy.karmada.io
@@ -23,14 +23,19 @@ spec:
           on cluster conditions.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -38,17 +43,19 @@ spec:
             description: Spec represents the desired behavior of Remedy.
             properties:
               actions:
-                description: Actions specifies the actions that remedy system needs
-                  to perform. If empty, no action will be performed.
+                description: |-
+                  Actions specifies the actions that remedy system needs to perform.
+                  If empty, no action will be performed.
                 items:
                   description: RemedyAction represents the action type the remedy
                     system needs to preform.
                   type: string
                 type: array
               clusterAffinity:
-                description: ClusterAffinity specifies the clusters that Remedy needs
-                  to pay attention to. For clusters that meet the DecisionConditions,
-                  Actions will be preformed. If empty, all clusters will be selected.
+                description: |-
+                  ClusterAffinity specifies the clusters that Remedy needs to pay attention to.
+                  For clusters that meet the DecisionConditions, Actions will be preformed.
+                  If empty, all clusters will be selected.
                 properties:
                   clusterNames:
                     description: ClusterNames is the list of clusters to be selected.
@@ -57,10 +64,11 @@ spec:
                     type: array
                 type: object
               decisionMatches:
-                description: DecisionMatches indicates the decision matches of triggering
-                  the remedy system to perform the actions. As long as any one DecisionMatch
-                  matches, the Actions will be preformed. If empty, the Actions will
-                  be performed immediately.
+                description: |-
+                  DecisionMatches indicates the decision matches of triggering the remedy
+                  system to perform the actions. As long as any one DecisionMatch matches,
+                  the Actions will be preformed.
+                  If empty, the Actions will be performed immediately.
                 items:
                   description: DecisionMatch represents the decision match detail
                     of activating the remedy system.
@@ -78,8 +86,9 @@ spec:
                             type.
                           type: string
                         operator:
-                          description: Operator represents a conditionType's relationship
-                            to a conditionStatus. Valid operators are Equal, NotEqual.
+                          description: |-
+                            Operator represents a conditionType's relationship to a conditionStatus.
+                            Valid operators are Equal, NotEqual.
                           enum:
                           - Equal
                           - NotEqual

--- a/charts/karmada/_crds/bases/work/work.karmada.io_clusterresourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work/work.karmada.io_clusterresourcebindings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: clusterresourcebindings.work.karmada.io
 spec:
   group: work.karmada.io
@@ -25,14 +25,19 @@ spec:
           with a ClusterPropagationPolicy.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -70,11 +75,11 @@ spec:
                     description: Name represents the name of the referent.
                     type: string
                   namespace:
-                    description: Namespace represents the namespace for the referent.
-                      For non-namespace scoped resources(e.g. 'ClusterRole')，do not
-                      need specify Namespace, and for namespace scoped resources,
-                      Namespace is required. If Namespace is not specified, means
-                      the resource is non-namespace scoped.
+                    description: |-
+                      Namespace represents the namespace for the referent.
+                      For non-namespace scoped resources(e.g. 'ClusterRole')，do not need specify Namespace,
+                      and for namespace scoped resources, Namespace is required.
+                      If Namespace is not specified, means the resource is non-namespace scoped.
                     type: string
                   replicas:
                     description: Replicas represents the replica number of the referencing
@@ -92,9 +97,9 @@ spec:
                       required by each replica.
                     type: object
                   resourceVersion:
-                    description: ResourceVersion represents the internal version of
-                      the referenced object, that can be used by clients to determine
-                      when object has changed.
+                    description: |-
+                      ResourceVersion represents the internal version of the referenced object, that can be used by clients to
+                      determine when object has changed.
                     type: string
                 required:
                 - apiVersion
@@ -116,14 +121,14 @@ spec:
                     running in a member cluster.
                   properties:
                     applied:
-                      description: Applied represents if the resource referencing
-                        by ResourceBinding or ClusterResourceBinding is successfully
-                        applied on the cluster.
+                      description: |-
+                        Applied represents if the resource referencing by ResourceBinding or ClusterResourceBinding
+                        is successfully applied on the cluster.
                       type: boolean
                     appliedMessage:
-                      description: AppliedMessage is a human readable message indicating
-                        details about the applied status. This is usually holds the
-                        error message in case of apply failed.
+                      description: |-
+                        AppliedMessage is a human readable message indicating details about the applied status.
+                        This is usually holds the error message in case of apply failed.
                       type: string
                     clusterName:
                       description: ClusterName represents the member cluster name
@@ -141,42 +146,42 @@ spec:
                 description: Conditions contain the different condition statuses.
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -190,11 +195,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -231,14 +237,19 @@ spec:
           with a ClusterPropagationPolicy.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -265,89 +276,97 @@ spec:
                 type: array
               conflictResolution:
                 default: Abort
-                description: "ConflictResolution declares how potential conflict should
-                  be handled when a resource that is being propagated already exists
-                  in the target cluster. \n It defaults to \"Abort\" which means stop
-                  propagating to avoid unexpected overwrites. The \"Overwrite\" might
-                  be useful when migrating legacy cluster resources to Karmada, in
-                  which case conflict is predictable and can be instructed to Karmada
-                  take over the resource by overwriting."
+                description: |-
+                  ConflictResolution declares how potential conflict should be handled when
+                  a resource that is being propagated already exists in the target cluster.
+
+
+                  It defaults to "Abort" which means stop propagating to avoid unexpected
+                  overwrites. The "Overwrite" might be useful when migrating legacy cluster
+                  resources to Karmada, in which case conflict is predictable and can be
+                  instructed to Karmada take over the resource by overwriting.
                 enum:
                 - Abort
                 - Overwrite
                 type: string
               failover:
-                description: Failover indicates how Karmada migrates applications
-                  in case of failures. It inherits directly from the associated PropagationPolicy(or
-                  ClusterPropagationPolicy).
+                description: |-
+                  Failover indicates how Karmada migrates applications in case of failures.
+                  It inherits directly from the associated PropagationPolicy(or ClusterPropagationPolicy).
                 properties:
                   application:
-                    description: Application indicates failover behaviors in case
-                      of application failure. If this value is nil, failover is disabled.
-                      If set, the PropagateDeps should be true so that the dependencies
-                      could be migrated along with the application.
+                    description: |-
+                      Application indicates failover behaviors in case of application failure.
+                      If this value is nil, failover is disabled.
+                      If set, the PropagateDeps should be true so that the dependencies could
+                      be migrated along with the application.
                     properties:
                       decisionConditions:
-                        description: 'DecisionConditions indicates the decision conditions
-                          of performing the failover process. Only when all conditions
-                          are met can the failover process be performed. Currently,
-                          DecisionConditions includes several conditions: - TolerationSeconds
-                          (optional)'
+                        description: |-
+                          DecisionConditions indicates the decision conditions of performing the failover process.
+                          Only when all conditions are met can the failover process be performed.
+                          Currently, DecisionConditions includes several conditions:
+                          - TolerationSeconds (optional)
                         properties:
                           tolerationSeconds:
                             default: 300
-                            description: TolerationSeconds represents the period of
-                              time Karmada should wait after reaching the desired
-                              state before performing failover process. If not specified,
-                              Karmada will immediately perform failover process. Defaults
-                              to 300s.
+                            description: |-
+                              TolerationSeconds represents the period of time Karmada should wait
+                              after reaching the desired state before performing failover process.
+                              If not specified, Karmada will immediately perform failover process.
+                              Defaults to 300s.
                             format: int32
                             type: integer
                         type: object
                       gracePeriodSeconds:
-                        description: GracePeriodSeconds is the maximum waiting duration
-                          in seconds before application on the migrated cluster should
-                          be deleted. Required only when PurgeMode is "Graciously"
-                          and defaults to 600s. If the application on the new cluster
-                          cannot reach a Healthy state, Karmada will delete the application
-                          after GracePeriodSeconds is reached. Value must be positive
-                          integer.
+                        description: |-
+                          GracePeriodSeconds is the maximum waiting duration in seconds before
+                          application on the migrated cluster should be deleted.
+                          Required only when PurgeMode is "Graciously" and defaults to 600s.
+                          If the application on the new cluster cannot reach a Healthy state,
+                          Karmada will delete the application after GracePeriodSeconds is reached.
+                          Value must be positive integer.
                         format: int32
                         type: integer
                       purgeMode:
                         default: Graciously
-                        description: PurgeMode represents how to deal with the legacy
-                          applications on the cluster from which the application is
-                          migrated. Valid options are "Immediately", "Graciously"
-                          and "Never". Defaults to "Graciously".
+                        description: |-
+                          PurgeMode represents how to deal with the legacy applications on the
+                          cluster from which the application is migrated.
+                          Valid options are "Immediately", "Graciously" and "Never".
+                          Defaults to "Graciously".
                         type: string
                     required:
                     - decisionConditions
                     type: object
                 type: object
               gracefulEvictionTasks:
-                description: 'GracefulEvictionTasks holds the eviction tasks that
-                  are expected to perform the eviction in a graceful way. The intended
-                  workflow is: 1. Once the controller(such as ''taint-manager'') decided
-                  to evict the resource that is referenced by current ResourceBinding
-                  or ClusterResourceBinding from a target cluster, it removes(or scale
-                  down the replicas) the target from Clusters(.spec.Clusters) and
-                  builds a graceful eviction task. 2. The scheduler may perform a
-                  re-scheduler and probably select a substitute cluster to take over
-                  the evicting workload(resource). 3. The graceful eviction controller
-                  takes care of the graceful eviction tasks and performs the final
-                  removal after the workload(resource) is available on the substitute
-                  cluster or exceed the grace termination period(defaults to 10 minutes).'
+                description: |-
+                  GracefulEvictionTasks holds the eviction tasks that are expected to perform
+                  the eviction in a graceful way.
+                  The intended workflow is:
+                  1. Once the controller(such as 'taint-manager') decided to evict the resource that
+                     is referenced by current ResourceBinding or ClusterResourceBinding from a target
+                     cluster, it removes(or scale down the replicas) the target from Clusters(.spec.Clusters)
+                     and builds a graceful eviction task.
+                  2. The scheduler may perform a re-scheduler and probably select a substitute cluster
+                     to take over the evicting workload(resource).
+                  3. The graceful eviction controller takes care of the graceful eviction tasks and
+                     performs the final removal after the workload(resource) is available on the substitute
+                     cluster or exceed the grace termination period(defaults to 10 minutes).
                 items:
                   description: GracefulEvictionTask represents a graceful eviction
                     task.
                   properties:
                     creationTimestamp:
-                      description: "CreationTimestamp is a timestamp representing
-                        the server time when this object was created. Clients should
-                        not set this value to avoid the time inconsistency issue.
-                        It is represented in RFC3339 form(like '2021-04-25T10:02:10Z')
-                        and is in UTC. \n Populated by the system. Read-only."
+                      description: |-
+                        CreationTimestamp is a timestamp representing the server time when this object was
+                        created.
+                        Clients should not set this value to avoid the time inconsistency issue.
+                        It is represented in RFC3339 form(like '2021-04-25T10:02:10Z') and is in UTC.
+
+
+                        Populated by the system. Read-only.
                       format: date-time
                       type: string
                     fromCluster:
@@ -355,16 +374,18 @@ spec:
                         from.
                       type: string
                     gracePeriodSeconds:
-                      description: GracePeriodSeconds is the maximum waiting duration
-                        in seconds before the item should be deleted. If the application
-                        on the new cluster cannot reach a Healthy state, Karmada will
-                        delete the item after GracePeriodSeconds is reached. Value
-                        must be positive integer. It can not co-exist with SuppressDeletion.
+                      description: |-
+                        GracePeriodSeconds is the maximum waiting duration in seconds before the item
+                        should be deleted. If the application on the new cluster cannot reach a Healthy state,
+                        Karmada will delete the item after GracePeriodSeconds is reached.
+                        Value must be positive integer.
+                        It can not co-exist with SuppressDeletion.
                       format: int32
                       type: integer
                     message:
-                      description: Message is a human-readable message indicating
-                        details about the eviction. This may be an empty string.
+                      description: |-
+                        Message is a human-readable message indicating details about the eviction.
+                        This may be an empty string.
                       maxLength: 1024
                       type: string
                     producer:
@@ -372,25 +393,27 @@ spec:
                         the eviction.
                       type: string
                     reason:
-                      description: Reason contains a programmatic identifier indicating
-                        the reason for the eviction. Producers may define expected
-                        values and meanings for this field, and whether the values
-                        are considered a guaranteed API. The value should be a CamelCase
-                        string. This field may not be empty.
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the eviction.
+                        Producers may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
                       maxLength: 32
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     replicas:
-                      description: Replicas indicates the number of replicas should
-                        be evicted. Should be ignored for resource type that doesn't
-                        have replica.
+                      description: |-
+                        Replicas indicates the number of replicas should be evicted.
+                        Should be ignored for resource type that doesn't have replica.
                       format: int32
                       type: integer
                     suppressDeletion:
-                      description: SuppressDeletion represents the grace period will
-                        be persistent until the tools or human intervention stops
-                        it. It can not co-exist with GracePeriodSeconds.
+                      description: |-
+                        SuppressDeletion represents the grace period will be persistent until
+                        the tools or human intervention stops it.
+                        It can not co-exist with GracePeriodSeconds.
                       type: boolean
                   required:
                   - fromCluster
@@ -403,29 +426,41 @@ spec:
                   propagate resources.
                 properties:
                   clusterAffinities:
-                    description: "ClusterAffinities represents scheduling restrictions
-                      to multiple cluster groups that indicated by ClusterAffinityTerm.
-                      \n The scheduler will evaluate these groups one by one in the
-                      order they appear in the spec, the group that does not satisfy
-                      scheduling restrictions will be ignored which means all clusters
-                      in this group will not be selected unless it also belongs to
-                      the next group(a cluster could belong to multiple groups). \n
-                      If none of the groups satisfy the scheduling restrictions, then
-                      scheduling fails, which means no cluster will be selected. \n
-                      Note: 1. ClusterAffinities can not co-exist with ClusterAffinity.
-                      2. If both ClusterAffinity and ClusterAffinities are not set,
-                      any cluster can be scheduling candidates. \n Potential use case
-                      1: The private clusters in the local data center could be the
-                      main group, and the managed clusters provided by cluster providers
-                      could be the secondary group. So that the Karmada scheduler
-                      would prefer to schedule workloads to the main group and the
-                      second group will only be considered in case of the main group
-                      does not satisfy restrictions(like, lack of resources). \n Potential
-                      use case 2: For the disaster recovery scenario, the clusters
-                      could be organized to primary and backup groups, the workloads
-                      would be scheduled to primary clusters firstly, and when primary
-                      cluster fails(like data center power off), Karmada scheduler
-                      could migrate workloads to the backup clusters."
+                    description: |-
+                      ClusterAffinities represents scheduling restrictions to multiple cluster
+                      groups that indicated by ClusterAffinityTerm.
+
+
+                      The scheduler will evaluate these groups one by one in the order they
+                      appear in the spec, the group that does not satisfy scheduling restrictions
+                      will be ignored which means all clusters in this group will not be selected
+                      unless it also belongs to the next group(a cluster could belong to multiple
+                      groups).
+
+
+                      If none of the groups satisfy the scheduling restrictions, then scheduling
+                      fails, which means no cluster will be selected.
+
+
+                      Note:
+                        1. ClusterAffinities can not co-exist with ClusterAffinity.
+                        2. If both ClusterAffinity and ClusterAffinities are not set, any cluster
+                           can be scheduling candidates.
+
+
+                      Potential use case 1:
+                      The private clusters in the local data center could be the main group, and
+                      the managed clusters provided by cluster providers could be the secondary
+                      group. So that the Karmada scheduler would prefer to schedule workloads
+                      to the main group and the second group will only be considered in case of
+                      the main group does not satisfy restrictions(like, lack of resources).
+
+
+                      Potential use case 2:
+                      For the disaster recovery scenario, the clusters could be organized to
+                      primary and backup groups, the workloads would be scheduled to primary
+                      clusters firstly, and when primary cluster fails(like data center power off),
+                      Karmada scheduler could migrate workloads to the backup clusters.
                     items:
                       description: ClusterAffinityTerm selects a set of cluster.
                       properties:
@@ -447,38 +482,35 @@ spec:
                             type: string
                           type: array
                         fieldSelector:
-                          description: FieldSelector is a filter to select member
-                            clusters by fields. The key(field) of the match expression
-                            should be 'provider', 'region', or 'zone', and the operator
-                            of the match expression should be 'In' or 'NotIn'. If
-                            non-nil and non-empty, only the clusters match this filter
-                            will be selected.
+                          description: |-
+                            FieldSelector is a filter to select member clusters by fields.
+                            The key(field) of the match expression should be 'provider', 'region', or 'zone',
+                            and the operator of the match expression should be 'In' or 'NotIn'.
+                            If non-nil and non-empty, only the clusters match this filter will be selected.
                           properties:
                             matchExpressions:
                               description: A list of field selector requirements.
                               items:
-                                description: A node selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
+                                description: |-
+                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                  that relates the key and values.
                                 properties:
                                   key:
                                     description: The label key that the selector applies
                                       to.
                                     type: string
                                   operator:
-                                    description: Represents a key's relationship to
-                                      a set of values. Valid operators are In, NotIn,
-                                      Exists, DoesNotExist. Gt, and Lt.
+                                    description: |-
+                                      Represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: An array of string values. If the
-                                      operator is In or NotIn, the values array must
-                                      be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator
-                                      is Gt or Lt, the values array must have a single
-                                      element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      An array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                      array must have a single element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -489,16 +521,16 @@ spec:
                               type: array
                           type: object
                         labelSelector:
-                          description: LabelSelector is a filter to select member
-                            clusters by labels. If non-nil and non-empty, only the
-                            clusters match this filter will be selected.
+                          description: |-
+                            LabelSelector is a filter to select member clusters by labels.
+                            If non-nil and non-empty, only the clusters match this filter will be selected.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
                                 requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
                                   relates the key and values.
                                 properties:
                                   key:
@@ -506,17 +538,16 @@ spec:
                                       applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -528,11 +559,10 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
@@ -541,11 +571,12 @@ spec:
                       type: object
                     type: array
                   clusterAffinity:
-                    description: 'ClusterAffinity represents scheduling restrictions
-                      to a certain set of clusters. Note: 1. ClusterAffinity can not
-                      co-exist with ClusterAffinities. 2. If both ClusterAffinity
-                      and ClusterAffinities are not set, any cluster can be scheduling
-                      candidates.'
+                    description: |-
+                      ClusterAffinity represents scheduling restrictions to a certain set of clusters.
+                      Note:
+                        1. ClusterAffinity can not co-exist with ClusterAffinities.
+                        2. If both ClusterAffinity and ClusterAffinities are not set, any cluster
+                           can be scheduling candidates.
                     properties:
                       clusterNames:
                         description: ClusterNames is the list of clusters to be selected.
@@ -559,38 +590,35 @@ spec:
                           type: string
                         type: array
                       fieldSelector:
-                        description: FieldSelector is a filter to select member clusters
-                          by fields. The key(field) of the match expression should
-                          be 'provider', 'region', or 'zone', and the operator of
-                          the match expression should be 'In' or 'NotIn'. If non-nil
-                          and non-empty, only the clusters match this filter will
-                          be selected.
+                        description: |-
+                          FieldSelector is a filter to select member clusters by fields.
+                          The key(field) of the match expression should be 'provider', 'region', or 'zone',
+                          and the operator of the match expression should be 'In' or 'NotIn'.
+                          If non-nil and non-empty, only the clusters match this filter will be selected.
                         properties:
                           matchExpressions:
                             description: A list of field selector requirements.
                             items:
-                              description: A node selector requirement is a selector
-                                that contains values, a key, and an operator that
-                                relates the key and values.
+                              description: |-
+                                A node selector requirement is a selector that contains values, a key, and an operator
+                                that relates the key and values.
                               properties:
                                 key:
                                   description: The label key that the selector applies
                                     to.
                                   type: string
                                 operator:
-                                  description: Represents a key's relationship to
-                                    a set of values. Valid operators are In, NotIn,
-                                    Exists, DoesNotExist. Gt, and Lt.
+                                  description: |-
+                                    Represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                   type: string
                                 values:
-                                  description: An array of string values. If the operator
-                                    is In or NotIn, the values array must be non-empty.
-                                    If the operator is Exists or DoesNotExist, the
-                                    values array must be empty. If the operator is
-                                    Gt or Lt, the values array must have a single
-                                    element, which will be interpreted as an integer.
-                                    This array is replaced during a strategic merge
-                                    patch.
+                                  description: |-
+                                    An array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                    array must have a single element, which will be interpreted as an integer.
+                                    This array is replaced during a strategic merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -601,16 +629,16 @@ spec:
                             type: array
                         type: object
                       labelSelector:
-                        description: LabelSelector is a filter to select member clusters
-                          by labels. If non-nil and non-empty, only the clusters match
-                          this filter will be selected.
+                        description: |-
+                          LabelSelector is a filter to select member clusters by labels.
+                          If non-nil and non-empty, only the clusters match this filter will be selected.
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector
                               requirements. The requirements are ANDed.
                             items:
-                              description: A label selector requirement is a selector
-                                that contains values, a key, and an operator that
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
                                 relates the key and values.
                               properties:
                                 key:
@@ -618,17 +646,16 @@ spec:
                                     applies to.
                                   type: string
                                 operator:
-                                  description: operator represents a key's relationship
-                                    to a set of values. Valid operators are In, NotIn,
-                                    Exists and DoesNotExist.
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: values is an array of string values.
-                                    If the operator is In or NotIn, the values array
-                                    must be non-empty. If the operator is Exists or
-                                    DoesNotExist, the values array must be empty.
-                                    This array is replaced during a strategic merge
-                                    patch.
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -640,11 +667,10 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: matchLabels is a map of {key,value} pairs.
-                              A single {key,value} in the matchLabels map is equivalent
-                              to an element of matchExpressions, whose key field is
-                              "key", the operator is "In", and the values array contains
-                              only "value". The requirements are ANDed.
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
@@ -652,85 +678,79 @@ spec:
                   clusterTolerations:
                     description: ClusterTolerations represents the tolerations.
                     items:
-                      description: The pod this Toleration is attached to tolerates
-                        any taint that matches the triple <key,value,effect> using
-                        the matching operator <operator>.
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: Effect indicates the taint effect to match.
-                            Empty means match all taint effects. When specified, allowed
-                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: Key is the taint key that the toleration applies
-                            to. Empty means match all taint keys. If the key is empty,
-                            operator must be Exists; this combination means to match
-                            all values and all keys.
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: Operator represents a key's relationship to
-                            the value. Valid operators are Exists and Equal. Defaults
-                            to Equal. Exists is equivalent to wildcard for value,
-                            so that a pod can tolerate all taints of a particular
-                            category.
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
-                          description: TolerationSeconds represents the period of
-                            time the toleration (which must be of effect NoExecute,
-                            otherwise this field is ignored) tolerates the taint.
-                            By default, it is not set, which means tolerate the taint
-                            forever (do not evict). Zero and negative values will
-                            be treated as 0 (evict immediately) by the system.
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: Value is the taint value the toleration matches
-                            to. If the operator is Exists, the value should be empty,
-                            otherwise just a regular string.
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   replicaScheduling:
-                    description: ReplicaScheduling represents the scheduling policy
-                      on dealing with the number of replicas when propagating resources
-                      that have replicas in spec (e.g. deployments, statefulsets)
-                      to member clusters.
+                    description: |-
+                      ReplicaScheduling represents the scheduling policy on dealing with the number of replicas
+                      when propagating resources that have replicas in spec (e.g. deployments, statefulsets) to member clusters.
                     properties:
                       replicaDivisionPreference:
-                        description: ReplicaDivisionPreference determines how the
-                          replicas is divided when ReplicaSchedulingType is "Divided".
-                          Valid options are Aggregated and Weighted. "Aggregated"
-                          divides replicas into clusters as few as possible, while
-                          respecting clusters' resource availabilities during the
-                          division. "Weighted" divides replicas by weight according
-                          to WeightPreference.
+                        description: |-
+                          ReplicaDivisionPreference determines how the replicas is divided
+                          when ReplicaSchedulingType is "Divided". Valid options are Aggregated and Weighted.
+                          "Aggregated" divides replicas into clusters as few as possible,
+                          while respecting clusters' resource availabilities during the division.
+                          "Weighted" divides replicas by weight according to WeightPreference.
                         enum:
                         - Aggregated
                         - Weighted
                         type: string
                       replicaSchedulingType:
                         default: Divided
-                        description: ReplicaSchedulingType determines how the replicas
-                          is scheduled when karmada propagating a resource. Valid
-                          options are Duplicated and Divided. "Duplicated" duplicates
-                          the same replicas to each candidate member cluster from
-                          resource. "Divided" divides replicas into parts according
-                          to number of valid candidate member clusters, and exact
-                          replicas for each cluster are determined by ReplicaDivisionPreference.
+                        description: |-
+                          ReplicaSchedulingType determines how the replicas is scheduled when karmada propagating
+                          a resource. Valid options are Duplicated and Divided.
+                          "Duplicated" duplicates the same replicas to each candidate member cluster from resource.
+                          "Divided" divides replicas into parts according to number of valid candidate member
+                          clusters, and exact replicas for each cluster are determined by ReplicaDivisionPreference.
                         enum:
                         - Duplicated
                         - Divided
                         type: string
                       weightPreference:
-                        description: WeightPreference describes weight for each cluster
-                          or for each group of cluster If ReplicaDivisionPreference
-                          is set to "Weighted", and WeightPreference is not set, scheduler
-                          will weight all clusters the same.
+                        description: |-
+                          WeightPreference describes weight for each cluster or for each group of cluster
+                          If ReplicaDivisionPreference is set to "Weighted", and WeightPreference is not set, scheduler will weight all clusters the same.
                         properties:
                           dynamicWeight:
-                            description: DynamicWeight specifies the factor to generates
-                              dynamic weight list. If specified, StaticWeightList
-                              will be ignored.
+                            description: |-
+                              DynamicWeight specifies the factor to generates dynamic weight list.
+                              If specified, StaticWeightList will be ignored.
                             enum:
                             - AvailableReplicas
                             type: string
@@ -758,43 +778,35 @@ spec:
                                         type: string
                                       type: array
                                     fieldSelector:
-                                      description: FieldSelector is a filter to select
-                                        member clusters by fields. The key(field)
-                                        of the match expression should be 'provider',
-                                        'region', or 'zone', and the operator of the
-                                        match expression should be 'In' or 'NotIn'.
-                                        If non-nil and non-empty, only the clusters
-                                        match this filter will be selected.
+                                      description: |-
+                                        FieldSelector is a filter to select member clusters by fields.
+                                        The key(field) of the match expression should be 'provider', 'region', or 'zone',
+                                        and the operator of the match expression should be 'In' or 'NotIn'.
+                                        If non-nil and non-empty, only the clusters match this filter will be selected.
                                       properties:
                                         matchExpressions:
                                           description: A list of field selector requirements.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -805,40 +817,34 @@ spec:
                                           type: array
                                       type: object
                                     labelSelector:
-                                      description: LabelSelector is a filter to select
-                                        member clusters by labels. If non-nil and
-                                        non-empty, only the clusters match this filter
-                                        will be selected.
+                                      description: |-
+                                        LabelSelector is a filter to select member clusters by labels.
+                                        If non-nil and non-empty, only the clusters match this filter will be selected.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -850,12 +856,10 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -885,18 +889,18 @@ spec:
                             groups to be selected.
                           type: integer
                         minGroups:
-                          description: MinGroups restricts the minimum number of cluster
-                            groups to be selected. Defaults to 1.
+                          description: |-
+                            MinGroups restricts the minimum number of cluster groups to be selected.
+                            Defaults to 1.
                           type: integer
                         spreadByField:
-                          description: 'SpreadByField represents the fields on Karmada
-                            cluster API used for dynamically grouping member clusters
-                            into different groups. Resources will be spread among
-                            different cluster groups. Available fields for spreading
-                            are: cluster, region, zone, and provider. SpreadByField
-                            should not co-exist with SpreadByLabel. If both SpreadByField
-                            and SpreadByLabel are empty, SpreadByField will be set
-                            to "cluster" by system.'
+                          description: |-
+                            SpreadByField represents the fields on Karmada cluster API used for
+                            dynamically grouping member clusters into different groups.
+                            Resources will be spread among different cluster groups.
+                            Available fields for spreading are: cluster, region, zone, and provider.
+                            SpreadByField should not co-exist with SpreadByLabel.
+                            If both SpreadByField and SpreadByLabel are empty, SpreadByField will be set to "cluster" by system.
                           enum:
                           - cluster
                           - region
@@ -904,17 +908,19 @@ spec:
                           - provider
                           type: string
                         spreadByLabel:
-                          description: SpreadByLabel represents the label key used
-                            for grouping member clusters into different groups. Resources
-                            will be spread among different cluster groups. SpreadByLabel
-                            should not co-exist with SpreadByField.
+                          description: |-
+                            SpreadByLabel represents the label key used for
+                            grouping member clusters into different groups.
+                            Resources will be spread among different cluster groups.
+                            SpreadByLabel should not co-exist with SpreadByField.
                           type: string
                       type: object
                     type: array
                 type: object
               propagateDeps:
-                description: PropagateDeps tells if relevant resources should be propagated
-                  automatically. It is inherited from PropagationPolicy or ClusterPropagationPolicy.
+                description: |-
+                  PropagateDeps tells if relevant resources should be propagated automatically.
+                  It is inherited from PropagationPolicy or ClusterPropagationPolicy.
                   default false.
                 type: boolean
               replicaRequirements:
@@ -929,49 +935,45 @@ spec:
                       NodeSelector and Tolerations required by each replica.
                     properties:
                       hardNodeAffinity:
-                        description: A node selector represents the union of the results
-                          of one or more label queries over a set of nodes; that is,
-                          it represents the OR of the selectors represented by the
-                          node selector terms. Note that only PodSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+                        description: |-
+                          A node selector represents the union of the results of one or more label queries over a set of
+                          nodes; that is, it represents the OR of the selectors represented by the node selector terms.
+                          Note that only PodSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
                           is included here because it has a hard limit on pod scheduling.
                         properties:
                           nodeSelectorTerms:
                             description: Required. A list of node selector terms.
                               The terms are ORed.
                             items:
-                              description: A null or empty node selector term matches
-                                no objects. The requirements of them are ANDed. The
-                                TopologySelectorTerm type implements a subset of the
-                                NodeSelectorTerm.
+                              description: |-
+                                A null or empty node selector term matches no objects. The requirements of
+                                them are ANDed.
+                                The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                               properties:
                                 matchExpressions:
                                   description: A list of node selector requirements
                                     by node's labels.
                                   items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
                                     properties:
                                       key:
                                         description: The label key that the selector
                                           applies to.
                                         type: string
                                       operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -984,30 +986,26 @@ spec:
                                   description: A list of node selector requirements
                                     by node's fields.
                                   items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
                                     properties:
                                       key:
                                         description: The label key that the selector
                                           applies to.
                                         type: string
                                       operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -1026,49 +1024,46 @@ spec:
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: NodeSelector is a selector which must be true
-                          for the pod to fit on a node. Selector which must match
-                          a node's labels for the pod to be scheduled on that node.
+                        description: |-
+                          NodeSelector is a selector which must be true for the pod to fit on a node.
+                          Selector which must match a node's labels for the pod to be scheduled on that node.
                         type: object
                       tolerations:
                         description: If specified, the pod's tolerations.
                         items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
@@ -1120,24 +1115,25 @@ spec:
                       description: Name represents the name of the Binding.
                       type: string
                     namespace:
-                      description: Namespace represents the namespace of the Binding.
-                        It is required for ResourceBinding. If Namespace is not specified,
-                        means the referencing is ClusterResourceBinding.
+                      description: |-
+                        Namespace represents the namespace of the Binding.
+                        It is required for ResourceBinding.
+                        If Namespace is not specified, means the referencing is ClusterResourceBinding.
                       type: string
                   required:
                   - name
                   type: object
                 type: array
               rescheduleTriggeredAt:
-                description: "RescheduleTriggeredAt is a timestamp representing when
-                  the referenced resource is triggered rescheduling. When this field
-                  is updated, it means a rescheduling is manually triggered by user,
-                  and the expected behavior of this action is to do a complete recalculation
-                  without referring to last scheduling results. It works with the
-                  status.lastScheduledTime field, and only when this timestamp is
-                  later than timestamp in status.lastScheduledTime will the rescheduling
-                  actually execute, otherwise, ignored. \n It is represented in RFC3339
-                  form (like '2006-01-02T15:04:05Z') and is in UTC."
+                description: |-
+                  RescheduleTriggeredAt is a timestamp representing when the referenced resource is triggered rescheduling.
+                  When this field is updated, it means a rescheduling is manually triggered by user, and the expected behavior
+                  of this action is to do a complete recalculation without referring to last scheduling results.
+                  It works with the status.lastScheduledTime field, and only when this timestamp is later than timestamp in
+                  status.lastScheduledTime will the rescheduling actually execute, otherwise, ignored.
+
+
+                  It is represented in RFC3339 form (like '2006-01-02T15:04:05Z') and is in UTC.
                 format: date-time
                 type: string
               resource:
@@ -1153,16 +1149,16 @@ spec:
                     description: Name represents the name of the referent.
                     type: string
                   namespace:
-                    description: Namespace represents the namespace for the referent.
-                      For non-namespace scoped resources(e.g. 'ClusterRole')，do not
-                      need specify Namespace, and for namespace scoped resources,
-                      Namespace is required. If Namespace is not specified, means
-                      the resource is non-namespace scoped.
+                    description: |-
+                      Namespace represents the namespace for the referent.
+                      For non-namespace scoped resources(e.g. 'ClusterRole')，do not need specify Namespace,
+                      and for namespace scoped resources, Namespace is required.
+                      If Namespace is not specified, means the resource is non-namespace scoped.
                     type: string
                   resourceVersion:
-                    description: ResourceVersion represents the internal version of
-                      the referenced object, that can be used by clients to determine
-                      when object has changed.
+                    description: |-
+                      ResourceVersion represents the internal version of the referenced object, that can be used by clients to
+                      determine when object has changed.
                     type: string
                   uid:
                     description: UID of the referent.
@@ -1173,9 +1169,9 @@ spec:
                 - name
                 type: object
               schedulerName:
-                description: SchedulerName represents which scheduler to proceed the
-                  scheduling. It inherits directly from the associated PropagationPolicy(or
-                  ClusterPropagationPolicy).
+                description: |-
+                  SchedulerName represents which scheduler to proceed the scheduling.
+                  It inherits directly from the associated PropagationPolicy(or ClusterPropagationPolicy).
                 type: string
             required:
             - resource
@@ -1192,23 +1188,23 @@ spec:
                     running in a member cluster.
                   properties:
                     applied:
-                      description: Applied represents if the resource referencing
-                        by ResourceBinding or ClusterResourceBinding is successfully
-                        applied on the cluster.
+                      description: |-
+                        Applied represents if the resource referencing by ResourceBinding or ClusterResourceBinding
+                        is successfully applied on the cluster.
                       type: boolean
                     appliedMessage:
-                      description: AppliedMessage is a human readable message indicating
-                        details about the applied status. This is usually holds the
-                        error message in case of apply failed.
+                      description: |-
+                        AppliedMessage is a human readable message indicating details about the applied status.
+                        This is usually holds the error message in case of apply failed.
                       type: string
                     clusterName:
                       description: ClusterName represents the member cluster name
                         which the resource deployed on.
                       type: string
                     health:
-                      description: Health represents the healthy state of the current
-                        resource. There maybe different rules for different resources
-                        to achieve health status.
+                      description: |-
+                        Health represents the healthy state of the current resource.
+                        There maybe different rules for different resources to achieve health status.
                       enum:
                       - Healthy
                       - Unhealthy
@@ -1226,42 +1222,42 @@ spec:
                 description: Conditions contain the different condition statuses.
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -1275,11 +1271,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -1292,21 +1289,22 @@ spec:
                   type: object
                 type: array
               lastScheduledTime:
-                description: LastScheduledTime representing the latest timestamp when
-                  scheduler successfully finished a scheduling. It is represented
-                  in RFC3339 form (like '2006-01-02T15:04:05Z') and is in UTC.
+                description: |-
+                  LastScheduledTime representing the latest timestamp when scheduler successfully finished a scheduling.
+                  It is represented in RFC3339 form (like '2006-01-02T15:04:05Z') and is in UTC.
                 format: date-time
                 type: string
               schedulerObservedGeneration:
-                description: SchedulerObservedGeneration is the generation(.metadata.generation)
-                  observed by the scheduler. If SchedulerObservedGeneration is less
-                  than the generation in metadata means the scheduler hasn't confirmed
+                description: |-
+                  SchedulerObservedGeneration is the generation(.metadata.generation) observed by the scheduler.
+                  If SchedulerObservedGeneration is less than the generation in metadata means the scheduler hasn't confirmed
                   the scheduling result or hasn't done the schedule yet.
                 format: int64
                 type: integer
               schedulerObservingAffinityName:
-                description: SchedulerObservedAffinityName is the name of affinity
-                  term that is the basis of current scheduling.
+                description: |-
+                  SchedulerObservedAffinityName is the name of affinity term that is
+                  the basis of current scheduling.
                 type: string
             type: object
         required:

--- a/charts/karmada/_crds/bases/work/work.karmada.io_resourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work/work.karmada.io_resourcebindings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: resourcebindings.work.karmada.io
 spec:
   group: work.karmada.io
@@ -25,14 +25,19 @@ spec:
           with a propagation policy.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -70,11 +75,11 @@ spec:
                     description: Name represents the name of the referent.
                     type: string
                   namespace:
-                    description: Namespace represents the namespace for the referent.
-                      For non-namespace scoped resources(e.g. 'ClusterRole')，do not
-                      need specify Namespace, and for namespace scoped resources,
-                      Namespace is required. If Namespace is not specified, means
-                      the resource is non-namespace scoped.
+                    description: |-
+                      Namespace represents the namespace for the referent.
+                      For non-namespace scoped resources(e.g. 'ClusterRole')，do not need specify Namespace,
+                      and for namespace scoped resources, Namespace is required.
+                      If Namespace is not specified, means the resource is non-namespace scoped.
                     type: string
                   replicas:
                     description: Replicas represents the replica number of the referencing
@@ -92,9 +97,9 @@ spec:
                       required by each replica.
                     type: object
                   resourceVersion:
-                    description: ResourceVersion represents the internal version of
-                      the referenced object, that can be used by clients to determine
-                      when object has changed.
+                    description: |-
+                      ResourceVersion represents the internal version of the referenced object, that can be used by clients to
+                      determine when object has changed.
                     type: string
                 required:
                 - apiVersion
@@ -116,14 +121,14 @@ spec:
                     running in a member cluster.
                   properties:
                     applied:
-                      description: Applied represents if the resource referencing
-                        by ResourceBinding or ClusterResourceBinding is successfully
-                        applied on the cluster.
+                      description: |-
+                        Applied represents if the resource referencing by ResourceBinding or ClusterResourceBinding
+                        is successfully applied on the cluster.
                       type: boolean
                     appliedMessage:
-                      description: AppliedMessage is a human readable message indicating
-                        details about the applied status. This is usually holds the
-                        error message in case of apply failed.
+                      description: |-
+                        AppliedMessage is a human readable message indicating details about the applied status.
+                        This is usually holds the error message in case of apply failed.
                       type: string
                     clusterName:
                       description: ClusterName represents the member cluster name
@@ -141,42 +146,42 @@ spec:
                 description: Conditions contain the different condition statuses.
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -190,11 +195,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -231,14 +237,19 @@ spec:
           with a propagation policy.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -265,89 +276,97 @@ spec:
                 type: array
               conflictResolution:
                 default: Abort
-                description: "ConflictResolution declares how potential conflict should
-                  be handled when a resource that is being propagated already exists
-                  in the target cluster. \n It defaults to \"Abort\" which means stop
-                  propagating to avoid unexpected overwrites. The \"Overwrite\" might
-                  be useful when migrating legacy cluster resources to Karmada, in
-                  which case conflict is predictable and can be instructed to Karmada
-                  take over the resource by overwriting."
+                description: |-
+                  ConflictResolution declares how potential conflict should be handled when
+                  a resource that is being propagated already exists in the target cluster.
+
+
+                  It defaults to "Abort" which means stop propagating to avoid unexpected
+                  overwrites. The "Overwrite" might be useful when migrating legacy cluster
+                  resources to Karmada, in which case conflict is predictable and can be
+                  instructed to Karmada take over the resource by overwriting.
                 enum:
                 - Abort
                 - Overwrite
                 type: string
               failover:
-                description: Failover indicates how Karmada migrates applications
-                  in case of failures. It inherits directly from the associated PropagationPolicy(or
-                  ClusterPropagationPolicy).
+                description: |-
+                  Failover indicates how Karmada migrates applications in case of failures.
+                  It inherits directly from the associated PropagationPolicy(or ClusterPropagationPolicy).
                 properties:
                   application:
-                    description: Application indicates failover behaviors in case
-                      of application failure. If this value is nil, failover is disabled.
-                      If set, the PropagateDeps should be true so that the dependencies
-                      could be migrated along with the application.
+                    description: |-
+                      Application indicates failover behaviors in case of application failure.
+                      If this value is nil, failover is disabled.
+                      If set, the PropagateDeps should be true so that the dependencies could
+                      be migrated along with the application.
                     properties:
                       decisionConditions:
-                        description: 'DecisionConditions indicates the decision conditions
-                          of performing the failover process. Only when all conditions
-                          are met can the failover process be performed. Currently,
-                          DecisionConditions includes several conditions: - TolerationSeconds
-                          (optional)'
+                        description: |-
+                          DecisionConditions indicates the decision conditions of performing the failover process.
+                          Only when all conditions are met can the failover process be performed.
+                          Currently, DecisionConditions includes several conditions:
+                          - TolerationSeconds (optional)
                         properties:
                           tolerationSeconds:
                             default: 300
-                            description: TolerationSeconds represents the period of
-                              time Karmada should wait after reaching the desired
-                              state before performing failover process. If not specified,
-                              Karmada will immediately perform failover process. Defaults
-                              to 300s.
+                            description: |-
+                              TolerationSeconds represents the period of time Karmada should wait
+                              after reaching the desired state before performing failover process.
+                              If not specified, Karmada will immediately perform failover process.
+                              Defaults to 300s.
                             format: int32
                             type: integer
                         type: object
                       gracePeriodSeconds:
-                        description: GracePeriodSeconds is the maximum waiting duration
-                          in seconds before application on the migrated cluster should
-                          be deleted. Required only when PurgeMode is "Graciously"
-                          and defaults to 600s. If the application on the new cluster
-                          cannot reach a Healthy state, Karmada will delete the application
-                          after GracePeriodSeconds is reached. Value must be positive
-                          integer.
+                        description: |-
+                          GracePeriodSeconds is the maximum waiting duration in seconds before
+                          application on the migrated cluster should be deleted.
+                          Required only when PurgeMode is "Graciously" and defaults to 600s.
+                          If the application on the new cluster cannot reach a Healthy state,
+                          Karmada will delete the application after GracePeriodSeconds is reached.
+                          Value must be positive integer.
                         format: int32
                         type: integer
                       purgeMode:
                         default: Graciously
-                        description: PurgeMode represents how to deal with the legacy
-                          applications on the cluster from which the application is
-                          migrated. Valid options are "Immediately", "Graciously"
-                          and "Never". Defaults to "Graciously".
+                        description: |-
+                          PurgeMode represents how to deal with the legacy applications on the
+                          cluster from which the application is migrated.
+                          Valid options are "Immediately", "Graciously" and "Never".
+                          Defaults to "Graciously".
                         type: string
                     required:
                     - decisionConditions
                     type: object
                 type: object
               gracefulEvictionTasks:
-                description: 'GracefulEvictionTasks holds the eviction tasks that
-                  are expected to perform the eviction in a graceful way. The intended
-                  workflow is: 1. Once the controller(such as ''taint-manager'') decided
-                  to evict the resource that is referenced by current ResourceBinding
-                  or ClusterResourceBinding from a target cluster, it removes(or scale
-                  down the replicas) the target from Clusters(.spec.Clusters) and
-                  builds a graceful eviction task. 2. The scheduler may perform a
-                  re-scheduler and probably select a substitute cluster to take over
-                  the evicting workload(resource). 3. The graceful eviction controller
-                  takes care of the graceful eviction tasks and performs the final
-                  removal after the workload(resource) is available on the substitute
-                  cluster or exceed the grace termination period(defaults to 10 minutes).'
+                description: |-
+                  GracefulEvictionTasks holds the eviction tasks that are expected to perform
+                  the eviction in a graceful way.
+                  The intended workflow is:
+                  1. Once the controller(such as 'taint-manager') decided to evict the resource that
+                     is referenced by current ResourceBinding or ClusterResourceBinding from a target
+                     cluster, it removes(or scale down the replicas) the target from Clusters(.spec.Clusters)
+                     and builds a graceful eviction task.
+                  2. The scheduler may perform a re-scheduler and probably select a substitute cluster
+                     to take over the evicting workload(resource).
+                  3. The graceful eviction controller takes care of the graceful eviction tasks and
+                     performs the final removal after the workload(resource) is available on the substitute
+                     cluster or exceed the grace termination period(defaults to 10 minutes).
                 items:
                   description: GracefulEvictionTask represents a graceful eviction
                     task.
                   properties:
                     creationTimestamp:
-                      description: "CreationTimestamp is a timestamp representing
-                        the server time when this object was created. Clients should
-                        not set this value to avoid the time inconsistency issue.
-                        It is represented in RFC3339 form(like '2021-04-25T10:02:10Z')
-                        and is in UTC. \n Populated by the system. Read-only."
+                      description: |-
+                        CreationTimestamp is a timestamp representing the server time when this object was
+                        created.
+                        Clients should not set this value to avoid the time inconsistency issue.
+                        It is represented in RFC3339 form(like '2021-04-25T10:02:10Z') and is in UTC.
+
+
+                        Populated by the system. Read-only.
                       format: date-time
                       type: string
                     fromCluster:
@@ -355,16 +374,18 @@ spec:
                         from.
                       type: string
                     gracePeriodSeconds:
-                      description: GracePeriodSeconds is the maximum waiting duration
-                        in seconds before the item should be deleted. If the application
-                        on the new cluster cannot reach a Healthy state, Karmada will
-                        delete the item after GracePeriodSeconds is reached. Value
-                        must be positive integer. It can not co-exist with SuppressDeletion.
+                      description: |-
+                        GracePeriodSeconds is the maximum waiting duration in seconds before the item
+                        should be deleted. If the application on the new cluster cannot reach a Healthy state,
+                        Karmada will delete the item after GracePeriodSeconds is reached.
+                        Value must be positive integer.
+                        It can not co-exist with SuppressDeletion.
                       format: int32
                       type: integer
                     message:
-                      description: Message is a human-readable message indicating
-                        details about the eviction. This may be an empty string.
+                      description: |-
+                        Message is a human-readable message indicating details about the eviction.
+                        This may be an empty string.
                       maxLength: 1024
                       type: string
                     producer:
@@ -372,25 +393,27 @@ spec:
                         the eviction.
                       type: string
                     reason:
-                      description: Reason contains a programmatic identifier indicating
-                        the reason for the eviction. Producers may define expected
-                        values and meanings for this field, and whether the values
-                        are considered a guaranteed API. The value should be a CamelCase
-                        string. This field may not be empty.
+                      description: |-
+                        Reason contains a programmatic identifier indicating the reason for the eviction.
+                        Producers may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
                       maxLength: 32
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     replicas:
-                      description: Replicas indicates the number of replicas should
-                        be evicted. Should be ignored for resource type that doesn't
-                        have replica.
+                      description: |-
+                        Replicas indicates the number of replicas should be evicted.
+                        Should be ignored for resource type that doesn't have replica.
                       format: int32
                       type: integer
                     suppressDeletion:
-                      description: SuppressDeletion represents the grace period will
-                        be persistent until the tools or human intervention stops
-                        it. It can not co-exist with GracePeriodSeconds.
+                      description: |-
+                        SuppressDeletion represents the grace period will be persistent until
+                        the tools or human intervention stops it.
+                        It can not co-exist with GracePeriodSeconds.
                       type: boolean
                   required:
                   - fromCluster
@@ -403,29 +426,41 @@ spec:
                   propagate resources.
                 properties:
                   clusterAffinities:
-                    description: "ClusterAffinities represents scheduling restrictions
-                      to multiple cluster groups that indicated by ClusterAffinityTerm.
-                      \n The scheduler will evaluate these groups one by one in the
-                      order they appear in the spec, the group that does not satisfy
-                      scheduling restrictions will be ignored which means all clusters
-                      in this group will not be selected unless it also belongs to
-                      the next group(a cluster could belong to multiple groups). \n
-                      If none of the groups satisfy the scheduling restrictions, then
-                      scheduling fails, which means no cluster will be selected. \n
-                      Note: 1. ClusterAffinities can not co-exist with ClusterAffinity.
-                      2. If both ClusterAffinity and ClusterAffinities are not set,
-                      any cluster can be scheduling candidates. \n Potential use case
-                      1: The private clusters in the local data center could be the
-                      main group, and the managed clusters provided by cluster providers
-                      could be the secondary group. So that the Karmada scheduler
-                      would prefer to schedule workloads to the main group and the
-                      second group will only be considered in case of the main group
-                      does not satisfy restrictions(like, lack of resources). \n Potential
-                      use case 2: For the disaster recovery scenario, the clusters
-                      could be organized to primary and backup groups, the workloads
-                      would be scheduled to primary clusters firstly, and when primary
-                      cluster fails(like data center power off), Karmada scheduler
-                      could migrate workloads to the backup clusters."
+                    description: |-
+                      ClusterAffinities represents scheduling restrictions to multiple cluster
+                      groups that indicated by ClusterAffinityTerm.
+
+
+                      The scheduler will evaluate these groups one by one in the order they
+                      appear in the spec, the group that does not satisfy scheduling restrictions
+                      will be ignored which means all clusters in this group will not be selected
+                      unless it also belongs to the next group(a cluster could belong to multiple
+                      groups).
+
+
+                      If none of the groups satisfy the scheduling restrictions, then scheduling
+                      fails, which means no cluster will be selected.
+
+
+                      Note:
+                        1. ClusterAffinities can not co-exist with ClusterAffinity.
+                        2. If both ClusterAffinity and ClusterAffinities are not set, any cluster
+                           can be scheduling candidates.
+
+
+                      Potential use case 1:
+                      The private clusters in the local data center could be the main group, and
+                      the managed clusters provided by cluster providers could be the secondary
+                      group. So that the Karmada scheduler would prefer to schedule workloads
+                      to the main group and the second group will only be considered in case of
+                      the main group does not satisfy restrictions(like, lack of resources).
+
+
+                      Potential use case 2:
+                      For the disaster recovery scenario, the clusters could be organized to
+                      primary and backup groups, the workloads would be scheduled to primary
+                      clusters firstly, and when primary cluster fails(like data center power off),
+                      Karmada scheduler could migrate workloads to the backup clusters.
                     items:
                       description: ClusterAffinityTerm selects a set of cluster.
                       properties:
@@ -447,38 +482,35 @@ spec:
                             type: string
                           type: array
                         fieldSelector:
-                          description: FieldSelector is a filter to select member
-                            clusters by fields. The key(field) of the match expression
-                            should be 'provider', 'region', or 'zone', and the operator
-                            of the match expression should be 'In' or 'NotIn'. If
-                            non-nil and non-empty, only the clusters match this filter
-                            will be selected.
+                          description: |-
+                            FieldSelector is a filter to select member clusters by fields.
+                            The key(field) of the match expression should be 'provider', 'region', or 'zone',
+                            and the operator of the match expression should be 'In' or 'NotIn'.
+                            If non-nil and non-empty, only the clusters match this filter will be selected.
                           properties:
                             matchExpressions:
                               description: A list of field selector requirements.
                               items:
-                                description: A node selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
+                                description: |-
+                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                  that relates the key and values.
                                 properties:
                                   key:
                                     description: The label key that the selector applies
                                       to.
                                     type: string
                                   operator:
-                                    description: Represents a key's relationship to
-                                      a set of values. Valid operators are In, NotIn,
-                                      Exists, DoesNotExist. Gt, and Lt.
+                                    description: |-
+                                      Represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: An array of string values. If the
-                                      operator is In or NotIn, the values array must
-                                      be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator
-                                      is Gt or Lt, the values array must have a single
-                                      element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      An array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                      array must have a single element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -489,16 +521,16 @@ spec:
                               type: array
                           type: object
                         labelSelector:
-                          description: LabelSelector is a filter to select member
-                            clusters by labels. If non-nil and non-empty, only the
-                            clusters match this filter will be selected.
+                          description: |-
+                            LabelSelector is a filter to select member clusters by labels.
+                            If non-nil and non-empty, only the clusters match this filter will be selected.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
                                 requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
                                   relates the key and values.
                                 properties:
                                   key:
@@ -506,17 +538,16 @@ spec:
                                       applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -528,11 +559,10 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
@@ -541,11 +571,12 @@ spec:
                       type: object
                     type: array
                   clusterAffinity:
-                    description: 'ClusterAffinity represents scheduling restrictions
-                      to a certain set of clusters. Note: 1. ClusterAffinity can not
-                      co-exist with ClusterAffinities. 2. If both ClusterAffinity
-                      and ClusterAffinities are not set, any cluster can be scheduling
-                      candidates.'
+                    description: |-
+                      ClusterAffinity represents scheduling restrictions to a certain set of clusters.
+                      Note:
+                        1. ClusterAffinity can not co-exist with ClusterAffinities.
+                        2. If both ClusterAffinity and ClusterAffinities are not set, any cluster
+                           can be scheduling candidates.
                     properties:
                       clusterNames:
                         description: ClusterNames is the list of clusters to be selected.
@@ -559,38 +590,35 @@ spec:
                           type: string
                         type: array
                       fieldSelector:
-                        description: FieldSelector is a filter to select member clusters
-                          by fields. The key(field) of the match expression should
-                          be 'provider', 'region', or 'zone', and the operator of
-                          the match expression should be 'In' or 'NotIn'. If non-nil
-                          and non-empty, only the clusters match this filter will
-                          be selected.
+                        description: |-
+                          FieldSelector is a filter to select member clusters by fields.
+                          The key(field) of the match expression should be 'provider', 'region', or 'zone',
+                          and the operator of the match expression should be 'In' or 'NotIn'.
+                          If non-nil and non-empty, only the clusters match this filter will be selected.
                         properties:
                           matchExpressions:
                             description: A list of field selector requirements.
                             items:
-                              description: A node selector requirement is a selector
-                                that contains values, a key, and an operator that
-                                relates the key and values.
+                              description: |-
+                                A node selector requirement is a selector that contains values, a key, and an operator
+                                that relates the key and values.
                               properties:
                                 key:
                                   description: The label key that the selector applies
                                     to.
                                   type: string
                                 operator:
-                                  description: Represents a key's relationship to
-                                    a set of values. Valid operators are In, NotIn,
-                                    Exists, DoesNotExist. Gt, and Lt.
+                                  description: |-
+                                    Represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                   type: string
                                 values:
-                                  description: An array of string values. If the operator
-                                    is In or NotIn, the values array must be non-empty.
-                                    If the operator is Exists or DoesNotExist, the
-                                    values array must be empty. If the operator is
-                                    Gt or Lt, the values array must have a single
-                                    element, which will be interpreted as an integer.
-                                    This array is replaced during a strategic merge
-                                    patch.
+                                  description: |-
+                                    An array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                    array must have a single element, which will be interpreted as an integer.
+                                    This array is replaced during a strategic merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -601,16 +629,16 @@ spec:
                             type: array
                         type: object
                       labelSelector:
-                        description: LabelSelector is a filter to select member clusters
-                          by labels. If non-nil and non-empty, only the clusters match
-                          this filter will be selected.
+                        description: |-
+                          LabelSelector is a filter to select member clusters by labels.
+                          If non-nil and non-empty, only the clusters match this filter will be selected.
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector
                               requirements. The requirements are ANDed.
                             items:
-                              description: A label selector requirement is a selector
-                                that contains values, a key, and an operator that
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
                                 relates the key and values.
                               properties:
                                 key:
@@ -618,17 +646,16 @@ spec:
                                     applies to.
                                   type: string
                                 operator:
-                                  description: operator represents a key's relationship
-                                    to a set of values. Valid operators are In, NotIn,
-                                    Exists and DoesNotExist.
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: values is an array of string values.
-                                    If the operator is In or NotIn, the values array
-                                    must be non-empty. If the operator is Exists or
-                                    DoesNotExist, the values array must be empty.
-                                    This array is replaced during a strategic merge
-                                    patch.
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -640,11 +667,10 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: matchLabels is a map of {key,value} pairs.
-                              A single {key,value} in the matchLabels map is equivalent
-                              to an element of matchExpressions, whose key field is
-                              "key", the operator is "In", and the values array contains
-                              only "value". The requirements are ANDed.
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
@@ -652,85 +678,79 @@ spec:
                   clusterTolerations:
                     description: ClusterTolerations represents the tolerations.
                     items:
-                      description: The pod this Toleration is attached to tolerates
-                        any taint that matches the triple <key,value,effect> using
-                        the matching operator <operator>.
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: Effect indicates the taint effect to match.
-                            Empty means match all taint effects. When specified, allowed
-                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: Key is the taint key that the toleration applies
-                            to. Empty means match all taint keys. If the key is empty,
-                            operator must be Exists; this combination means to match
-                            all values and all keys.
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: Operator represents a key's relationship to
-                            the value. Valid operators are Exists and Equal. Defaults
-                            to Equal. Exists is equivalent to wildcard for value,
-                            so that a pod can tolerate all taints of a particular
-                            category.
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
-                          description: TolerationSeconds represents the period of
-                            time the toleration (which must be of effect NoExecute,
-                            otherwise this field is ignored) tolerates the taint.
-                            By default, it is not set, which means tolerate the taint
-                            forever (do not evict). Zero and negative values will
-                            be treated as 0 (evict immediately) by the system.
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: Value is the taint value the toleration matches
-                            to. If the operator is Exists, the value should be empty,
-                            otherwise just a regular string.
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   replicaScheduling:
-                    description: ReplicaScheduling represents the scheduling policy
-                      on dealing with the number of replicas when propagating resources
-                      that have replicas in spec (e.g. deployments, statefulsets)
-                      to member clusters.
+                    description: |-
+                      ReplicaScheduling represents the scheduling policy on dealing with the number of replicas
+                      when propagating resources that have replicas in spec (e.g. deployments, statefulsets) to member clusters.
                     properties:
                       replicaDivisionPreference:
-                        description: ReplicaDivisionPreference determines how the
-                          replicas is divided when ReplicaSchedulingType is "Divided".
-                          Valid options are Aggregated and Weighted. "Aggregated"
-                          divides replicas into clusters as few as possible, while
-                          respecting clusters' resource availabilities during the
-                          division. "Weighted" divides replicas by weight according
-                          to WeightPreference.
+                        description: |-
+                          ReplicaDivisionPreference determines how the replicas is divided
+                          when ReplicaSchedulingType is "Divided". Valid options are Aggregated and Weighted.
+                          "Aggregated" divides replicas into clusters as few as possible,
+                          while respecting clusters' resource availabilities during the division.
+                          "Weighted" divides replicas by weight according to WeightPreference.
                         enum:
                         - Aggregated
                         - Weighted
                         type: string
                       replicaSchedulingType:
                         default: Divided
-                        description: ReplicaSchedulingType determines how the replicas
-                          is scheduled when karmada propagating a resource. Valid
-                          options are Duplicated and Divided. "Duplicated" duplicates
-                          the same replicas to each candidate member cluster from
-                          resource. "Divided" divides replicas into parts according
-                          to number of valid candidate member clusters, and exact
-                          replicas for each cluster are determined by ReplicaDivisionPreference.
+                        description: |-
+                          ReplicaSchedulingType determines how the replicas is scheduled when karmada propagating
+                          a resource. Valid options are Duplicated and Divided.
+                          "Duplicated" duplicates the same replicas to each candidate member cluster from resource.
+                          "Divided" divides replicas into parts according to number of valid candidate member
+                          clusters, and exact replicas for each cluster are determined by ReplicaDivisionPreference.
                         enum:
                         - Duplicated
                         - Divided
                         type: string
                       weightPreference:
-                        description: WeightPreference describes weight for each cluster
-                          or for each group of cluster If ReplicaDivisionPreference
-                          is set to "Weighted", and WeightPreference is not set, scheduler
-                          will weight all clusters the same.
+                        description: |-
+                          WeightPreference describes weight for each cluster or for each group of cluster
+                          If ReplicaDivisionPreference is set to "Weighted", and WeightPreference is not set, scheduler will weight all clusters the same.
                         properties:
                           dynamicWeight:
-                            description: DynamicWeight specifies the factor to generates
-                              dynamic weight list. If specified, StaticWeightList
-                              will be ignored.
+                            description: |-
+                              DynamicWeight specifies the factor to generates dynamic weight list.
+                              If specified, StaticWeightList will be ignored.
                             enum:
                             - AvailableReplicas
                             type: string
@@ -758,43 +778,35 @@ spec:
                                         type: string
                                       type: array
                                     fieldSelector:
-                                      description: FieldSelector is a filter to select
-                                        member clusters by fields. The key(field)
-                                        of the match expression should be 'provider',
-                                        'region', or 'zone', and the operator of the
-                                        match expression should be 'In' or 'NotIn'.
-                                        If non-nil and non-empty, only the clusters
-                                        match this filter will be selected.
+                                      description: |-
+                                        FieldSelector is a filter to select member clusters by fields.
+                                        The key(field) of the match expression should be 'provider', 'region', or 'zone',
+                                        and the operator of the match expression should be 'In' or 'NotIn'.
+                                        If non-nil and non-empty, only the clusters match this filter will be selected.
                                       properties:
                                         matchExpressions:
                                           description: A list of field selector requirements.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -805,40 +817,34 @@ spec:
                                           type: array
                                       type: object
                                     labelSelector:
-                                      description: LabelSelector is a filter to select
-                                        member clusters by labels. If non-nil and
-                                        non-empty, only the clusters match this filter
-                                        will be selected.
+                                      description: |-
+                                        LabelSelector is a filter to select member clusters by labels.
+                                        If non-nil and non-empty, only the clusters match this filter will be selected.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -850,12 +856,10 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -885,18 +889,18 @@ spec:
                             groups to be selected.
                           type: integer
                         minGroups:
-                          description: MinGroups restricts the minimum number of cluster
-                            groups to be selected. Defaults to 1.
+                          description: |-
+                            MinGroups restricts the minimum number of cluster groups to be selected.
+                            Defaults to 1.
                           type: integer
                         spreadByField:
-                          description: 'SpreadByField represents the fields on Karmada
-                            cluster API used for dynamically grouping member clusters
-                            into different groups. Resources will be spread among
-                            different cluster groups. Available fields for spreading
-                            are: cluster, region, zone, and provider. SpreadByField
-                            should not co-exist with SpreadByLabel. If both SpreadByField
-                            and SpreadByLabel are empty, SpreadByField will be set
-                            to "cluster" by system.'
+                          description: |-
+                            SpreadByField represents the fields on Karmada cluster API used for
+                            dynamically grouping member clusters into different groups.
+                            Resources will be spread among different cluster groups.
+                            Available fields for spreading are: cluster, region, zone, and provider.
+                            SpreadByField should not co-exist with SpreadByLabel.
+                            If both SpreadByField and SpreadByLabel are empty, SpreadByField will be set to "cluster" by system.
                           enum:
                           - cluster
                           - region
@@ -904,17 +908,19 @@ spec:
                           - provider
                           type: string
                         spreadByLabel:
-                          description: SpreadByLabel represents the label key used
-                            for grouping member clusters into different groups. Resources
-                            will be spread among different cluster groups. SpreadByLabel
-                            should not co-exist with SpreadByField.
+                          description: |-
+                            SpreadByLabel represents the label key used for
+                            grouping member clusters into different groups.
+                            Resources will be spread among different cluster groups.
+                            SpreadByLabel should not co-exist with SpreadByField.
                           type: string
                       type: object
                     type: array
                 type: object
               propagateDeps:
-                description: PropagateDeps tells if relevant resources should be propagated
-                  automatically. It is inherited from PropagationPolicy or ClusterPropagationPolicy.
+                description: |-
+                  PropagateDeps tells if relevant resources should be propagated automatically.
+                  It is inherited from PropagationPolicy or ClusterPropagationPolicy.
                   default false.
                 type: boolean
               replicaRequirements:
@@ -929,49 +935,45 @@ spec:
                       NodeSelector and Tolerations required by each replica.
                     properties:
                       hardNodeAffinity:
-                        description: A node selector represents the union of the results
-                          of one or more label queries over a set of nodes; that is,
-                          it represents the OR of the selectors represented by the
-                          node selector terms. Note that only PodSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+                        description: |-
+                          A node selector represents the union of the results of one or more label queries over a set of
+                          nodes; that is, it represents the OR of the selectors represented by the node selector terms.
+                          Note that only PodSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
                           is included here because it has a hard limit on pod scheduling.
                         properties:
                           nodeSelectorTerms:
                             description: Required. A list of node selector terms.
                               The terms are ORed.
                             items:
-                              description: A null or empty node selector term matches
-                                no objects. The requirements of them are ANDed. The
-                                TopologySelectorTerm type implements a subset of the
-                                NodeSelectorTerm.
+                              description: |-
+                                A null or empty node selector term matches no objects. The requirements of
+                                them are ANDed.
+                                The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                               properties:
                                 matchExpressions:
                                   description: A list of node selector requirements
                                     by node's labels.
                                   items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
                                     properties:
                                       key:
                                         description: The label key that the selector
                                           applies to.
                                         type: string
                                       operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -984,30 +986,26 @@ spec:
                                   description: A list of node selector requirements
                                     by node's fields.
                                   items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
                                     properties:
                                       key:
                                         description: The label key that the selector
                                           applies to.
                                         type: string
                                       operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -1026,49 +1024,46 @@ spec:
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: NodeSelector is a selector which must be true
-                          for the pod to fit on a node. Selector which must match
-                          a node's labels for the pod to be scheduled on that node.
+                        description: |-
+                          NodeSelector is a selector which must be true for the pod to fit on a node.
+                          Selector which must match a node's labels for the pod to be scheduled on that node.
                         type: object
                       tolerations:
                         description: If specified, the pod's tolerations.
                         items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
@@ -1120,24 +1115,25 @@ spec:
                       description: Name represents the name of the Binding.
                       type: string
                     namespace:
-                      description: Namespace represents the namespace of the Binding.
-                        It is required for ResourceBinding. If Namespace is not specified,
-                        means the referencing is ClusterResourceBinding.
+                      description: |-
+                        Namespace represents the namespace of the Binding.
+                        It is required for ResourceBinding.
+                        If Namespace is not specified, means the referencing is ClusterResourceBinding.
                       type: string
                   required:
                   - name
                   type: object
                 type: array
               rescheduleTriggeredAt:
-                description: "RescheduleTriggeredAt is a timestamp representing when
-                  the referenced resource is triggered rescheduling. When this field
-                  is updated, it means a rescheduling is manually triggered by user,
-                  and the expected behavior of this action is to do a complete recalculation
-                  without referring to last scheduling results. It works with the
-                  status.lastScheduledTime field, and only when this timestamp is
-                  later than timestamp in status.lastScheduledTime will the rescheduling
-                  actually execute, otherwise, ignored. \n It is represented in RFC3339
-                  form (like '2006-01-02T15:04:05Z') and is in UTC."
+                description: |-
+                  RescheduleTriggeredAt is a timestamp representing when the referenced resource is triggered rescheduling.
+                  When this field is updated, it means a rescheduling is manually triggered by user, and the expected behavior
+                  of this action is to do a complete recalculation without referring to last scheduling results.
+                  It works with the status.lastScheduledTime field, and only when this timestamp is later than timestamp in
+                  status.lastScheduledTime will the rescheduling actually execute, otherwise, ignored.
+
+
+                  It is represented in RFC3339 form (like '2006-01-02T15:04:05Z') and is in UTC.
                 format: date-time
                 type: string
               resource:
@@ -1153,16 +1149,16 @@ spec:
                     description: Name represents the name of the referent.
                     type: string
                   namespace:
-                    description: Namespace represents the namespace for the referent.
-                      For non-namespace scoped resources(e.g. 'ClusterRole')，do not
-                      need specify Namespace, and for namespace scoped resources,
-                      Namespace is required. If Namespace is not specified, means
-                      the resource is non-namespace scoped.
+                    description: |-
+                      Namespace represents the namespace for the referent.
+                      For non-namespace scoped resources(e.g. 'ClusterRole')，do not need specify Namespace,
+                      and for namespace scoped resources, Namespace is required.
+                      If Namespace is not specified, means the resource is non-namespace scoped.
                     type: string
                   resourceVersion:
-                    description: ResourceVersion represents the internal version of
-                      the referenced object, that can be used by clients to determine
-                      when object has changed.
+                    description: |-
+                      ResourceVersion represents the internal version of the referenced object, that can be used by clients to
+                      determine when object has changed.
                     type: string
                   uid:
                     description: UID of the referent.
@@ -1173,9 +1169,9 @@ spec:
                 - name
                 type: object
               schedulerName:
-                description: SchedulerName represents which scheduler to proceed the
-                  scheduling. It inherits directly from the associated PropagationPolicy(or
-                  ClusterPropagationPolicy).
+                description: |-
+                  SchedulerName represents which scheduler to proceed the scheduling.
+                  It inherits directly from the associated PropagationPolicy(or ClusterPropagationPolicy).
                 type: string
             required:
             - resource
@@ -1192,23 +1188,23 @@ spec:
                     running in a member cluster.
                   properties:
                     applied:
-                      description: Applied represents if the resource referencing
-                        by ResourceBinding or ClusterResourceBinding is successfully
-                        applied on the cluster.
+                      description: |-
+                        Applied represents if the resource referencing by ResourceBinding or ClusterResourceBinding
+                        is successfully applied on the cluster.
                       type: boolean
                     appliedMessage:
-                      description: AppliedMessage is a human readable message indicating
-                        details about the applied status. This is usually holds the
-                        error message in case of apply failed.
+                      description: |-
+                        AppliedMessage is a human readable message indicating details about the applied status.
+                        This is usually holds the error message in case of apply failed.
                       type: string
                     clusterName:
                       description: ClusterName represents the member cluster name
                         which the resource deployed on.
                       type: string
                     health:
-                      description: Health represents the healthy state of the current
-                        resource. There maybe different rules for different resources
-                        to achieve health status.
+                      description: |-
+                        Health represents the healthy state of the current resource.
+                        There maybe different rules for different resources to achieve health status.
                       enum:
                       - Healthy
                       - Unhealthy
@@ -1226,42 +1222,42 @@ spec:
                 description: Conditions contain the different condition statuses.
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -1275,11 +1271,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -1292,21 +1289,22 @@ spec:
                   type: object
                 type: array
               lastScheduledTime:
-                description: LastScheduledTime representing the latest timestamp when
-                  scheduler successfully finished a scheduling. It is represented
-                  in RFC3339 form (like '2006-01-02T15:04:05Z') and is in UTC.
+                description: |-
+                  LastScheduledTime representing the latest timestamp when scheduler successfully finished a scheduling.
+                  It is represented in RFC3339 form (like '2006-01-02T15:04:05Z') and is in UTC.
                 format: date-time
                 type: string
               schedulerObservedGeneration:
-                description: SchedulerObservedGeneration is the generation(.metadata.generation)
-                  observed by the scheduler. If SchedulerObservedGeneration is less
-                  than the generation in metadata means the scheduler hasn't confirmed
+                description: |-
+                  SchedulerObservedGeneration is the generation(.metadata.generation) observed by the scheduler.
+                  If SchedulerObservedGeneration is less than the generation in metadata means the scheduler hasn't confirmed
                   the scheduling result or hasn't done the schedule yet.
                 format: int64
                 type: integer
               schedulerObservingAffinityName:
-                description: SchedulerObservedAffinityName is the name of affinity
-                  term that is the basis of current scheduling.
+                description: |-
+                  SchedulerObservedAffinityName is the name of affinity term that is
+                  the basis of current scheduling.
                 type: string
             type: object
         required:

--- a/charts/karmada/_crds/bases/work/work.karmada.io_works.yaml
+++ b/charts/karmada/_crds/bases/work/work.karmada.io_works.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: works.work.karmada.io
 spec:
   group: work.karmada.io
@@ -35,14 +35,19 @@ spec:
           cluster.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -68,51 +73,52 @@ spec:
             description: Status represents the status of PropagationStatus.
             properties:
               conditions:
-                description: 'Conditions contain the different condition statuses
-                  for this work. Valid condition types are: 1. Applied represents
-                  workload in Work is applied successfully on a managed cluster. 2.
-                  Progressing represents workload in Work is being applied on a managed
-                  cluster. 3. Available represents workload in Work exists on the
-                  managed cluster. 4. Degraded represents the current state of workload
-                  does not match the desired state for a certain period.'
+                description: |-
+                  Conditions contain the different condition statuses for this work.
+                  Valid condition types are:
+                  1. Applied represents workload in Work is applied successfully on a managed cluster.
+                  2. Progressing represents workload in Work is being applied on a managed cluster.
+                  3. Available represents workload in Work exists on the managed cluster.
+                  4. Degraded represents the current state of workload does not match the desired
+                  state for a certain period.
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -126,11 +132,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -150,9 +157,9 @@ spec:
                     manifest in spec.
                   properties:
                     health:
-                      description: Health represents the healthy state of the current
-                        resource. There maybe different rules for different resources
-                        to achieve health status.
+                      description: |-
+                        Health represents the healthy state of the current resource.
+                        There maybe different rules for different resources to achieve health status.
                       enum:
                       - Healthy
                       - Unhealthy
@@ -172,13 +179,14 @@ spec:
                           description: Name is the name of the resource
                           type: string
                         namespace:
-                          description: Namespace is the namespace of the resource,
-                            the resource is cluster scoped if the value is empty
+                          description: |-
+                            Namespace is the namespace of the resource, the resource is cluster scoped if the value
+                            is empty
                           type: string
                         ordinal:
-                          description: Ordinal represents an index in manifests list,
-                            so the condition can still be linked to a manifest even
-                            though manifest cannot be parsed successfully.
+                          description: |-
+                            Ordinal represents an index in manifests list, so the condition can still be linked
+                            to a manifest even though manifest cannot be parsed successfully.
                           type: integer
                         resource:
                           description: Resource is the resource type of the resource

--- a/examples/customresourceinterpreter/apis/workload.example.io_workloads.yaml
+++ b/examples/customresourceinterpreter/apis/workload.example.io_workloads.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: workloads.workload.example.io
 spec:
   group: workload.example.io
@@ -20,14 +20,19 @@ spec:
         description: Workload is a simple Deployment.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -35,19 +40,23 @@ spec:
             description: Spec represents the specification of the desired behavior.
             properties:
               paused:
-                description: 'Paused indicates that the deployment is paused. Note:
-                  both user and controllers might set this field.'
+                description: |-
+                  Paused indicates that the deployment is paused.
+                  Note: both user and controllers might set this field.
                 type: boolean
               replicas:
-                description: Number of desired pods. This is a pointer to distinguish
-                  between explicit zero and not specified. Defaults to 1.
+                description: |-
+                  Number of desired pods. This is a pointer to distinguish between explicit
+                  zero and not specified. Defaults to 1.
                 format: int32
                 type: integer
               template:
                 description: Template describes the pods that will be created.
                 properties:
                   metadata:
-                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:
                         additionalProperties:
@@ -67,13 +76,14 @@ spec:
                         type: string
                     type: object
                   spec:
-                    description: 'Specification of the desired behavior of the pod.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    description: |-
+                      Specification of the desired behavior of the pod.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                     properties:
                       activeDeadlineSeconds:
-                        description: Optional duration in seconds the pod may be active
-                          on the node relative to StartTime before the system will
-                          actively try to mark it failed and kill associated containers.
+                        description: |-
+                          Optional duration in seconds the pod may be active on the node relative to
+                          StartTime before the system will actively try to mark it failed and kill associated containers.
                           Value must be a positive integer.
                         format: int64
                         type: integer
@@ -85,23 +95,20 @@ spec:
                               for the pod.
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
-                                description: The scheduler will prefer to schedule
-                                  pods to nodes that satisfy the affinity expressions
-                                  specified by this field, but it may choose a node
-                                  that violates one or more of the expressions. The
-                                  node that is most preferred is the one with the
-                                  greatest sum of weights, i.e. for each node that
-                                  meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions,
-                                  etc.), compute a sum by iterating through the elements
-                                  of this field and adding "weight" to the sum if
-                                  the node matches the corresponding matchExpressions;
-                                  the node(s) with the highest sum are the most preferred.
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                  node(s) with the highest sum are the most preferred.
                                 items:
-                                  description: An empty preferred scheduling term
-                                    matches all objects with implicit weight 0 (i.e.
-                                    it's a no-op). A null preferred scheduling term
-                                    matches no objects (i.e. is also a no-op).
+                                  description: |-
+                                    An empty preferred scheduling term matches all objects with implicit weight 0
+                                    (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                   properties:
                                     preference:
                                       description: A node selector term, associated
@@ -111,32 +118,26 @@ spec:
                                           description: A list of node selector requirements
                                             by node's labels.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -149,32 +150,26 @@ spec:
                                           description: A list of node selector requirements
                                             by node's fields.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -197,53 +192,46 @@ spec:
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: If the affinity requirements specified
-                                  by this field are not met at scheduling time, the
-                                  pod will not be scheduled onto the node. If the
-                                  affinity requirements specified by this field cease
-                                  to be met at some point during pod execution (e.g.
-                                  due to an update), the system may or may not try
-                                  to eventually evict the pod from its node.
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to an update), the system
+                                  may or may not try to eventually evict the pod from its node.
                                 properties:
                                   nodeSelectorTerms:
                                     description: Required. A list of node selector
                                       terms. The terms are ORed.
                                     items:
-                                      description: A null or empty node selector term
-                                        matches no objects. The requirements of them
-                                        are ANDed. The TopologySelectorTerm type implements
-                                        a subset of the NodeSelectorTerm.
+                                      description: |-
+                                        A null or empty node selector term matches no objects. The requirements of
+                                        them are ANDed.
+                                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                       properties:
                                         matchExpressions:
                                           description: A list of node selector requirements
                                             by node's labels.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -256,32 +244,26 @@ spec:
                                           description: A list of node selector requirements
                                             by node's fields.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
                                                 description: The label key that the
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -304,19 +286,16 @@ spec:
                               other pod(s)).
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
-                                description: The scheduler will prefer to schedule
-                                  pods to nodes that satisfy the affinity expressions
-                                  specified by this field, but it may choose a node
-                                  that violates one or more of the expressions. The
-                                  node that is most preferred is the one with the
-                                  greatest sum of weights, i.e. for each node that
-                                  meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions,
-                                  etc.), compute a sum by iterating through the elements
-                                  of this field and adding "weight" to the sum if
-                                  the node has pods which matches the corresponding
-                                  podAffinityTerm; the node(s) with the highest sum
-                                  are the most preferred.
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -335,10 +314,9 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -346,20 +324,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -371,36 +345,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set
-                                            of namespaces that the term applies to.
-                                            The term is applied to the union of the
-                                            namespaces selected by this field and
-                                            the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces
-                                            list means "this pod's namespace". An
-                                            empty selector ({}) matches all namespaces.
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -408,20 +375,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -433,46 +396,37 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static
-                                            list of namespace names that the term
-                                            applies to. The term is applied to the
-                                            union of the namespaces listed in this
-                                            field and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace".
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located
-                                            (affinity) or not co-located (anti-affinity)
-                                            with the pods matching the labelSelector
-                                            in the specified namespaces, where co-located
-                                            is defined as running on a node whose
-                                            value of the label with key topologyKey
-                                            matches that of any node on which any
-                                            of the selected pods is running. Empty
-                                            topologyKey is not allowed.
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
                                           type: string
                                       required:
                                       - topologyKey
                                       type: object
                                     weight:
-                                      description: weight associated with matching
-                                        the corresponding podAffinityTerm, in the
-                                        range 1-100.
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
                                       format: int32
                                       type: integer
                                   required:
@@ -481,25 +435,22 @@ spec:
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: If the affinity requirements specified
-                                  by this field are not met at scheduling time, the
-                                  pod will not be scheduled onto the node. If the
-                                  affinity requirements specified by this field cease
-                                  to be met at some point during pod execution (e.g.
-                                  due to a pod label update), the system may or may
-                                  not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes
-                                  corresponding to each podAffinityTerm are intersected,
-                                  i.e. all terms must be satisfied.
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
-                                  description: Defines a set of pods (namely those
-                                    matching the labelSelector relative to the given
-                                    namespace(s)) that this pod should be co-located
-                                    (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key <topologyKey>
-                                    matches that of any node on which a pod of the
-                                    set of pods is running
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
@@ -510,30 +461,25 @@ spec:
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -545,53 +491,45 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces
-                                        that the term applies to. The term is applied
-                                        to the union of the namespaces selected by
-                                        this field and the ones listed in the namespaces
-                                        field. null selector and null or empty namespaces
-                                        list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces.
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -603,34 +541,28 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: namespaces specifies a static list
-                                        of namespace names that the term applies to.
-                                        The term is applied to the union of the namespaces
-                                        listed in this field and the ones selected
-                                        by namespaceSelector. null or empty namespaces
-                                        list and null namespaceSelector means "this
-                                        pod's namespace".
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity)
-                                        or not co-located (anti-affinity) with the
-                                        pods matching the labelSelector in the specified
-                                        namespaces, where co-located is defined as
-                                        running on a node whose value of the label
-                                        with key topologyKey matches that of any node
-                                        on which any of the selected pods is running.
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
@@ -644,19 +576,16 @@ spec:
                               etc. as some other pod(s)).
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
-                                description: The scheduler will prefer to schedule
-                                  pods to nodes that satisfy the anti-affinity expressions
-                                  specified by this field, but it may choose a node
-                                  that violates one or more of the expressions. The
-                                  node that is most preferred is the one with the
-                                  greatest sum of weights, i.e. for each node that
-                                  meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling anti-affinity
-                                  expressions, etc.), compute a sum by iterating through
-                                  the elements of this field and adding "weight" to
-                                  the sum if the node has pods which matches the corresponding
-                                  podAffinityTerm; the node(s) with the highest sum
-                                  are the most preferred.
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the anti-affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -675,10 +604,9 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -686,20 +614,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -711,36 +635,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set
-                                            of namespaces that the term applies to.
-                                            The term is applied to the union of the
-                                            namespaces selected by this field and
-                                            the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces
-                                            list means "this pod's namespace". An
-                                            empty selector ({}) matches all namespaces.
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -748,20 +665,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -773,46 +686,37 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static
-                                            list of namespace names that the term
-                                            applies to. The term is applied to the
-                                            union of the namespaces listed in this
-                                            field and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace".
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located
-                                            (affinity) or not co-located (anti-affinity)
-                                            with the pods matching the labelSelector
-                                            in the specified namespaces, where co-located
-                                            is defined as running on a node whose
-                                            value of the label with key topologyKey
-                                            matches that of any node on which any
-                                            of the selected pods is running. Empty
-                                            topologyKey is not allowed.
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
                                           type: string
                                       required:
                                       - topologyKey
                                       type: object
                                     weight:
-                                      description: weight associated with matching
-                                        the corresponding podAffinityTerm, in the
-                                        range 1-100.
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
                                       format: int32
                                       type: integer
                                   required:
@@ -821,25 +725,22 @@ spec:
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: If the anti-affinity requirements specified
-                                  by this field are not met at scheduling time, the
-                                  pod will not be scheduled onto the node. If the
-                                  anti-affinity requirements specified by this field
-                                  cease to be met at some point during pod execution
-                                  (e.g. due to a pod label update), the system may
-                                  or may not try to eventually evict the pod from
-                                  its node. When there are multiple elements, the
-                                  lists of nodes corresponding to each podAffinityTerm
-                                  are intersected, i.e. all terms must be satisfied.
+                                description: |-
+                                  If the anti-affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the anti-affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
-                                  description: Defines a set of pods (namely those
-                                    matching the labelSelector relative to the given
-                                    namespace(s)) that this pod should be co-located
-                                    (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key <topologyKey>
-                                    matches that of any node on which a pod of the
-                                    set of pods is running
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
@@ -850,30 +751,25 @@ spec:
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -885,53 +781,45 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces
-                                        that the term applies to. The term is applied
-                                        to the union of the namespaces selected by
-                                        this field and the ones listed in the namespaces
-                                        field. null selector and null or empty namespaces
-                                        list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces.
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -943,34 +831,28 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: namespaces specifies a static list
-                                        of namespace names that the term applies to.
-                                        The term is applied to the union of the namespaces
-                                        listed in this field and the ones selected
-                                        by namespaceSelector. null or empty namespaces
-                                        list and null namespaceSelector means "this
-                                        pod's namespace".
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity)
-                                        or not co-located (anti-affinity) with the
-                                        pods matching the labelSelector in the specified
-                                        namespaces, where co-located is defined as
-                                        running on a node whose value of the label
-                                        with key topologyKey matches that of any node
-                                        on which any of the selected pods is running.
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
@@ -984,46 +866,45 @@ spec:
                           a service account token should be automatically mounted.
                         type: boolean
                       containers:
-                        description: List of containers belonging to the pod. Containers
-                          cannot currently be added or removed. There must be at least
-                          one container in a Pod. Cannot be updated.
+                        description: |-
+                          List of containers belonging to the pod.
+                          Containers cannot currently be added or removed.
+                          There must be at least one container in a Pod.
+                          Cannot be updated.
                         items:
                           description: A single application container that you want
                             to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The container
-                                image''s CMD is used if this is not provided. Variable
-                                references $(VAR_NAME) are expanded using the container''s
-                                environment. If a variable cannot be resolved, the
-                                reference in the input string will be unchanged. Double
-                                $$ are reduced to a single $, which allows for escaping
-                                the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
-                                the string literal "$(VAR_NAME)". Escaped references
-                                will never be expanded, regardless of whether the
-                                variable exists or not. Cannot be updated. More info:
-                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: |-
+                                Arguments to the entrypoint.
+                                The container image's CMD is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within
-                                a shell. The container image''s ENTRYPOINT is used
-                                if this is not provided. Variable references $(VAR_NAME)
-                                are expanded using the container''s environment. If
-                                a variable cannot be resolved, the reference in the
-                                input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME)
-                                syntax: i.e. "$$(VAR_NAME)" will produce the string
-                                literal "$(VAR_NAME)". Escaped references will never
-                                be expanded, regardless of whether the variable exists
-                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: |-
+                                Entrypoint array. Not executed within a shell.
+                                The container image's ENTRYPOINT is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                               items:
                                 type: string
                               type: array
                             env:
-                              description: List of environment variables to set in
-                                the container. Cannot be updated.
+                              description: |-
+                                List of environment variables to set in the container.
+                                Cannot be updated.
                               items:
                                 description: EnvVar represents an environment variable
                                   present in a Container.
@@ -1033,17 +914,16 @@ spec:
                                       Must be a C_IDENTIFIER.
                                     type: string
                                   value:
-                                    description: 'Variable references $(VAR_NAME)
-                                      are expanded using the previously defined environment
-                                      variables in the container and any service environment
-                                      variables. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Defaults
-                                      to "".'
+                                    description: |-
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the previously defined environment variables in the container and
+                                      any service environment variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless of whether the variable
+                                      exists or not.
+                                      Defaults to "".
                                     type: string
                                   valueFrom:
                                     description: Source for the environment variable's
@@ -1056,10 +936,10 @@ spec:
                                             description: The key to select.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the ConfigMap
@@ -1070,11 +950,9 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       fieldRef:
-                                        description: 'Selects a field of the pod:
-                                          supports metadata.name, metadata.namespace,
-                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                          spec.nodeName, spec.serviceAccountName,
-                                          status.hostIP, status.podIP, status.podIPs.'
+                                        description: |-
+                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                         properties:
                                           apiVersion:
                                             description: Version of the schema the
@@ -1090,11 +968,9 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, limits.ephemeral-storage,
-                                          requests.cpu, requests.memory and requests.ephemeral-storage)
-                                          are currently supported.'
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                         properties:
                                           containerName:
                                             description: 'Container name: required
@@ -1126,10 +1002,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -1145,14 +1021,13 @@ spec:
                                 type: object
                               type: array
                             envFrom:
-                              description: List of sources to populate environment
-                                variables in the container. The keys defined within
-                                a source must be a C_IDENTIFIER. All invalid keys
-                                will be reported as an event when the container is
-                                starting. When a key exists in multiple sources, the
-                                value associated with the last source will take precedence.
-                                Values defined by an Env with a duplicate key will
-                                take precedence. Cannot be updated.
+                              description: |-
+                                List of sources to populate environment variables in the container.
+                                The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is starting. When a key exists in multiple
+                                sources, the value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will take precedence.
+                                Cannot be updated.
                               items:
                                 description: EnvFromSource represents the source of
                                   a set of ConfigMaps
@@ -1161,10 +1036,10 @@ spec:
                                     description: The ConfigMap to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: Specify whether the ConfigMap
@@ -1180,10 +1055,10 @@ spec:
                                     description: The Secret to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: Specify whether the Secret must
@@ -1194,44 +1069,42 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                                This field is optional to allow higher level config
-                                management to default or override container images
-                                in workload controllers like Deployments and StatefulSets.'
+                              description: |-
+                                Container image name.
+                                More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config management to default or override
+                                container images in workload controllers like Deployments and StatefulSets.
                               type: string
                             imagePullPolicy:
-                              description: 'Image pull policy. One of Always, Never,
-                                IfNotPresent. Defaults to Always if :latest tag is
-                                specified, or IfNotPresent otherwise. Cannot be updated.
-                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              description: |-
+                                Image pull policy.
+                                One of Always, Never, IfNotPresent.
+                                Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                               type: string
                             lifecycle:
-                              description: Actions that the management system should
-                                take in response to container lifecycle events. Cannot
-                                be updated.
+                              description: |-
+                                Actions that the management system should take in response to container lifecycle events.
+                                Cannot be updated.
                               properties:
                                 postStart:
-                                  description: 'PostStart is called immediately after
-                                    a container is created. If the handler fails,
-                                    the container is terminated and restarted according
-                                    to its restart policy. Other management of the
-                                    container blocks until the hook completes. More
-                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  description: |-
+                                    PostStart is called immediately after a container is created. If the handler fails,
+                                    the container is terminated and restarted according to its restart policy.
+                                    Other management of the container blocks until the hook completes.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
@@ -1241,8 +1114,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -1253,10 +1126,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -1274,24 +1146,24 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     tcpSocket:
-                                      description: Deprecated. TCPSocket is NOT supported
-                                        as a LifecycleHandler and kept for the backward
-                                        compatibility. There are no validation of
-                                        this field and lifecycle hooks will fail in
-                                        runtime when tcp handler is specified.
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for the backward compatibility. There are no validation of this field and
+                                        lifecycle hooks will fail in runtime when tcp handler is specified.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -1301,44 +1173,37 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                   type: object
                                 preStop:
-                                  description: 'PreStop is called immediately before
-                                    a container is terminated due to an API request
-                                    or management event such as liveness/startup probe
-                                    failure, preemption, resource contention, etc.
-                                    The handler is not called if the container crashes
-                                    or exits. The Pod''s termination grace period
-                                    countdown begins before the PreStop hook is executed.
-                                    Regardless of the outcome of the handler, the
-                                    container will eventually terminate within the
-                                    Pod''s termination grace period (unless delayed
-                                    by finalizers). Other management of the container
-                                    blocks until the hook completes or until the termination
-                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  description: |-
+                                    PreStop is called immediately before a container is terminated due to an
+                                    API request or management event such as liveness/startup probe failure,
+                                    preemption, resource contention, etc. The handler is not called if the
+                                    container crashes or exits. The Pod's termination grace period countdown begins before the
+                                    PreStop hook is executed. Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the Pod's termination grace
+                                    period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
@@ -1348,8 +1213,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -1360,10 +1225,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -1381,24 +1245,24 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     tcpSocket:
-                                      description: Deprecated. TCPSocket is NOT supported
-                                        as a LifecycleHandler and kept for the backward
-                                        compatibility. There are no validation of
-                                        this field and lifecycle hooks will fail in
-                                        runtime when tcp handler is specified.
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for the backward compatibility. There are no validation of this field and
+                                        lifecycle hooks will fail in runtime when tcp handler is specified.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -1408,10 +1272,10 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
@@ -1419,30 +1283,29 @@ spec:
                                   type: object
                               type: object
                             livenessProbe:
-                              description: 'Periodic probe of container liveness.
-                                Container will be restarted if the probe fails. Cannot
-                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                Periodic probe of container liveness.
+                                Container will be restarted if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -1456,11 +1319,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -1470,9 +1334,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -1482,10 +1346,9 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -1502,34 +1365,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -1544,61 +1408,59 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             name:
-                              description: Name of the container specified as a DNS_LABEL.
+                              description: |-
+                                Name of the container specified as a DNS_LABEL.
                                 Each container in a pod must have a unique name (DNS_LABEL).
                                 Cannot be updated.
                               type: string
                             ports:
-                              description: List of ports to expose from the container.
-                                Not specifying a port here DOES NOT prevent that port
-                                from being exposed. Any port which is listening on
-                                the default "0.0.0.0" address inside a container will
-                                be accessible from the network. Modifying this array
-                                with strategic merge patch may corrupt the data. For
-                                more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                              description: |-
+                                List of ports to expose from the container. Not specifying a port here
+                                DOES NOT prevent that port from being exposed. Any port which is
+                                listening on the default "0.0.0.0" address inside a container will be
+                                accessible from the network.
+                                Modifying this array with strategic merge patch may corrupt the data.
+                                For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                 Cannot be updated.
                               items:
                                 description: ContainerPort represents a network port
                                   in a single container.
                                 properties:
                                   containerPort:
-                                    description: Number of port to expose on the pod's
-                                      IP address. This must be a valid port number,
-                                      0 < x < 65536.
+                                    description: |-
+                                      Number of port to expose on the pod's IP address.
+                                      This must be a valid port number, 0 < x < 65536.
                                     format: int32
                                     type: integer
                                   hostIP:
@@ -1606,23 +1468,24 @@ spec:
                                       port to.
                                     type: string
                                   hostPort:
-                                    description: Number of port to expose on the host.
-                                      If specified, this must be a valid port number,
-                                      0 < x < 65536. If HostNetwork is specified,
-                                      this must match ContainerPort. Most containers
-                                      do not need this.
+                                    description: |-
+                                      Number of port to expose on the host.
+                                      If specified, this must be a valid port number, 0 < x < 65536.
+                                      If HostNetwork is specified, this must match ContainerPort.
+                                      Most containers do not need this.
                                     format: int32
                                     type: integer
                                   name:
-                                    description: If specified, this must be an IANA_SVC_NAME
-                                      and unique within the pod. Each named port in
-                                      a pod must have a unique name. Name for the
-                                      port that can be referred to by services.
+                                    description: |-
+                                      If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                      named port in a pod must have a unique name. Name for the port that can be
+                                      referred to by services.
                                     type: string
                                   protocol:
                                     default: TCP
-                                    description: Protocol for port. Must be UDP, TCP,
-                                      or SCTP. Defaults to "TCP".
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP.
+                                      Defaults to "TCP".
                                     type: string
                                 required:
                                 - containerPort
@@ -1633,30 +1496,29 @@ spec:
                               - protocol
                               x-kubernetes-list-type: map
                             readinessProbe:
-                              description: 'Periodic probe of container service readiness.
-                                Container will be removed from service endpoints if
-                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -1670,11 +1532,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -1684,9 +1547,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -1696,10 +1559,9 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -1716,34 +1578,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -1758,36 +1621,33 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
@@ -1798,14 +1658,14 @@ spec:
                                   resize policy for the container.
                                 properties:
                                   resourceName:
-                                    description: 'Name of the resource to which this
-                                      resource resize policy applies. Supported values:
-                                      cpu, memory.'
+                                    description: |-
+                                      Name of the resource to which this resource resize policy applies.
+                                      Supported values: cpu, memory.
                                     type: string
                                   restartPolicy:
-                                    description: Restart policy to apply when specified
-                                      resource is resized. If not specified, it defaults
-                                      to NotRequired.
+                                    description: |-
+                                      Restart policy to apply when specified resource is resized.
+                                      If not specified, it defaults to NotRequired.
                                     type: string
                                 required:
                                 - resourceName
@@ -1814,25 +1674,31 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             resources:
-                              description: 'Compute Resources required by this container.
-                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              description: |-
+                                Compute Resources required by this container.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                               properties:
                                 claims:
-                                  description: "Claims lists the names of resources,
-                                    defined in spec.resourceClaims, that are used
-                                    by this container. \n This is an alpha field and
-                                    requires enabling the DynamicResourceAllocation
-                                    feature gate. \n This field is immutable. It can
-                                    only be set for containers."
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+
+                                    This field is immutable. It can only be set for containers.
                                   items:
                                     description: ResourceClaim references one entry
                                       in PodSpec.ResourceClaims.
                                     properties:
                                       name:
-                                        description: Name must match the name of one
-                                          entry in pod.spec.resourceClaims of the
-                                          Pod where this field is used. It makes that
-                                          resource available inside a container.
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
                                         type: string
                                     required:
                                     - name
@@ -1848,8 +1714,9 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount
-                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -1858,57 +1725,52 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount
-                                    of compute resources required. If Requests is
-                                    omitted for a container, it defaults to Limits
-                                    if that is explicitly specified, otherwise to
-                                    an implementation-defined value. Requests cannot
-                                    exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                               type: object
                             restartPolicy:
-                              description: 'RestartPolicy defines the restart behavior
-                                of individual containers in a pod. This field may
-                                only be set for init containers, and the only allowed
-                                value is "Always". For non-init containers or when
-                                this field is not specified, the restart behavior
-                                is defined by the Pod''s restart policy and the container
-                                type. Setting the RestartPolicy as "Always" for the
-                                init container will have the following effect: this
-                                init container will be continually restarted on exit
-                                until all regular containers have terminated. Once
-                                all regular containers have completed, all init containers
-                                with restartPolicy "Always" will be shut down. This
-                                lifecycle differs from normal init containers and
-                                is often referred to as a "sidecar" container. Although
-                                this init container still starts in the init container
-                                sequence, it does not wait for the container to complete
-                                before proceeding to the next init container. Instead,
-                                the next init container starts immediately after this
-                                init container is started, or after any startupProbe
-                                has successfully completed.'
+                              description: |-
+                                RestartPolicy defines the restart behavior of individual containers in a pod.
+                                This field may only be set for init containers, and the only allowed value is "Always".
+                                For non-init containers or when this field is not specified,
+                                the restart behavior is defined by the Pod's restart policy and the container type.
+                                Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                this init container will be continually restarted on
+                                exit until all regular containers have terminated. Once all regular
+                                containers have completed, all init containers with restartPolicy "Always"
+                                will be shut down. This lifecycle differs from normal init containers and
+                                is often referred to as a "sidecar" container. Although this init
+                                container still starts in the init container sequence, it does not wait
+                                for the container to complete before proceeding to the next init
+                                container. Instead, the next init container starts immediately after this
+                                init container is started, or after any startupProbe has successfully
+                                completed.
                               type: string
                             securityContext:
-                              description: 'SecurityContext defines the security options
-                                the container should be run with. If set, the fields
-                                of SecurityContext override the equivalent fields
-                                of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              description: |-
+                                SecurityContext defines the security options the container should be run with.
+                                If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                               properties:
                                 allowPrivilegeEscalation:
-                                  description: 'AllowPrivilegeEscalation controls
-                                    whether a process can gain more privileges than
-                                    its parent process. This bool directly controls
-                                    if the no_new_privs flag will be set on the container
-                                    process. AllowPrivilegeEscalation is true always
-                                    when the container is: 1) run as Privileged 2)
-                                    has CAP_SYS_ADMIN Note that this field cannot
-                                    be set when spec.os.name is windows.'
+                                  description: |-
+                                    AllowPrivilegeEscalation controls whether a process can gain more
+                                    privileges than its parent process. This bool directly controls if
+                                    the no_new_privs flag will be set on the container process.
+                                    AllowPrivilegeEscalation is true always when the container is:
+                                    1) run as Privileged
+                                    2) has CAP_SYS_ADMIN
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 capabilities:
-                                  description: The capabilities to add/drop when running
-                                    containers. Defaults to the default set of capabilities
-                                    granted by the container runtime. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The capabilities to add/drop when running containers.
+                                    Defaults to the default set of capabilities granted by the container runtime.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     add:
                                       description: Added capabilities
@@ -1926,66 +1788,60 @@ spec:
                                       type: array
                                   type: object
                                 privileged:
-                                  description: Run container in privileged mode. Processes
-                                    in privileged containers are essentially equivalent
-                                    to root on the host. Defaults to false. Note that
-                                    this field cannot be set when spec.os.name is
-                                    windows.
+                                  description: |-
+                                    Run container in privileged mode.
+                                    Processes in privileged containers are essentially equivalent to root on the host.
+                                    Defaults to false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 procMount:
-                                  description: procMount denotes the type of proc
-                                    mount to use for the containers. The default is
-                                    DefaultProcMount which uses the container runtime
-                                    defaults for readonly paths and masked paths.
-                                    This requires the ProcMountType feature flag to
-                                    be enabled. Note that this field cannot be set
-                                    when spec.os.name is windows.
+                                  description: |-
+                                    procMount denotes the type of proc mount to use for the containers.
+                                    The default is DefaultProcMount which uses the container runtime defaults for
+                                    readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to be enabled.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: string
                                 readOnlyRootFilesystem:
-                                  description: Whether this container has a read-only
-                                    root filesystem. Default is false. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    Whether this container has a read-only root filesystem.
+                                    Default is false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the
-                                    container process. Uses runtime default if unset.
-                                    May also be set in PodSecurityContext.  If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run
-                                    as a non-root user. If true, the Kubelet will
-                                    validate the image at runtime to ensure that it
-                                    does not run as UID 0 (root) and fail to start
-                                    the container if it does. If unset or false, no
-                                    such validation will be performed. May also be
-                                    set in PodSecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence.
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the
-                                    container process. Defaults to user specified
-                                    in image metadata if unspecified. May also be
-                                    set in PodSecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to
-                                    the container. If unspecified, the container runtime
-                                    will allocate a random SELinux context for each
-                                    container.  May also be set in PodSecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The SELinux context to be applied to the container.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -2005,104 +1861,92 @@ spec:
                                       type: string
                                   type: object
                                 seccompProfile:
-                                  description: The seccomp options to use by this
-                                    container. If seccomp options are provided at
-                                    both the pod & container level, the container
-                                    options override the pod options. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The seccomp options to use by this container. If seccomp options are
+                                    provided at both the pod & container level, the container options
+                                    override the pod options.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
-                                      description: localhostProfile indicates a profile
-                                        defined in a file on the node should be used.
-                                        The profile must be preconfigured on the node
-                                        to work. Must be a descending path, relative
-                                        to the kubelet's configured seccomp profile
-                                        location. Must be set if type is "Localhost".
-                                        Must NOT be set for any other type.
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
                                       type: string
                                     type:
-                                      description: "type indicates which kind of seccomp
-                                        profile will be applied. Valid options are:
-                                        \n Localhost - a profile defined in a file
-                                        on the node should be used. RuntimeDefault
-                                        - the container runtime default profile should
-                                        be used. Unconfined - no profile should be
-                                        applied."
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
                                       type: string
                                   required:
                                   - type
                                   type: object
                                 windowsOptions:
-                                  description: The Windows specific settings applied
-                                    to all containers. If unspecified, the options
-                                    from the PodSecurityContext will be used. If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options from the PodSecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the
-                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                        inlines the contents of the GMSA credential
-                                        spec named by the GMSACredentialSpecName field.
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
                                     hostProcess:
-                                      description: HostProcess determines if a container
-                                        should be run as a 'Host Process' container.
-                                        All of a Pod's containers must have the same
-                                        effective HostProcess value (it is not allowed
-                                        to have a mix of HostProcess containers and
-                                        non-HostProcess containers). In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
                                       type: boolean
                                     runAsUserName:
-                                      description: The UserName in Windows to run
-                                        the entrypoint of the container process. Defaults
-                                        to the user specified in image metadata if
-                                        unspecified. May also be set in PodSecurityContext.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             startupProbe:
-                              description: 'StartupProbe indicates that the Pod has
-                                successfully initialized. If specified, no other probes
-                                are executed until this completes successfully. If
-                                this probe fails, the Pod will be restarted, just
-                                as if the livenessProbe failed. This can be used to
-                                provide different probe parameters at the beginning
-                                of a Pod''s lifecycle, when it might take a long time
-                                to load data or warm a cache, than during steady-state
-                                operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                StartupProbe indicates that the Pod has successfully initialized.
+                                If specified, no other probes are executed until this completes successfully.
+                                If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                This cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -2116,11 +1960,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -2130,9 +1975,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -2142,10 +1987,9 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -2162,34 +2006,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -2204,83 +2049,75 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             stdin:
-                              description: Whether this container should allocate
-                                a buffer for stdin in the container runtime. If this
-                                is not set, reads from stdin in the container will
-                                always result in EOF. Default is false.
+                              description: |-
+                                Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will always result in EOF.
+                                Default is false.
                               type: boolean
                             stdinOnce:
-                              description: Whether the container runtime should close
-                                the stdin channel after it has been opened by a single
-                                attach. When stdin is true the stdin stream will remain
-                                open across multiple attach sessions. If stdinOnce
-                                is set to true, stdin is opened on container start,
-                                is empty until the first client attaches to stdin,
-                                and then remains open and accepts data until the client
-                                disconnects, at which time stdin is closed and remains
-                                closed until the container is restarted. If this flag
-                                is false, a container processes that reads from stdin
-                                will never receive an EOF. Default is false
+                              description: |-
+                                Whether the container runtime should close the stdin channel after it has been opened by
+                                a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                at which time stdin is closed and remains closed until the container is restarted. If this
+                                flag is false, a container processes that reads from stdin will never receive an EOF.
+                                Default is false
                               type: boolean
                             terminationMessagePath:
-                              description: 'Optional: Path at which the file to which
-                                the container''s termination message will be written
-                                is mounted into the container''s filesystem. Message
-                                written is intended to be brief final status, such
-                                as an assertion failure message. Will be truncated
-                                by the node if greater than 4096 bytes. The total
-                                message length across all containers will be limited
-                                to 12kb. Defaults to /dev/termination-log. Cannot
-                                be updated.'
+                              description: |-
+                                Optional: Path at which the file to which the container's termination message
+                                will be written is mounted into the container's filesystem.
+                                Message written is intended to be brief final status, such as an assertion failure message.
+                                Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                all containers will be limited to 12kb.
+                                Defaults to /dev/termination-log.
+                                Cannot be updated.
                               type: string
                             terminationMessagePolicy:
-                              description: Indicate how the termination message should
-                                be populated. File will use the contents of terminationMessagePath
-                                to populate the container status message on both success
-                                and failure. FallbackToLogsOnError will use the last
-                                chunk of container log output if the termination message
-                                file is empty and the container exited with an error.
-                                The log output is limited to 2048 bytes or 80 lines,
-                                whichever is smaller. Defaults to File. Cannot be
-                                updated.
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of
+                                terminationMessagePath to populate the container status message on both success and failure.
+                                FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                message file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                Defaults to File.
+                                Cannot be updated.
                               type: string
                             tty:
-                              description: Whether this container should allocate
-                                a TTY for itself, also requires 'stdin' to be true.
+                              description: |-
+                                Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
                                 Default is false.
                               type: boolean
                             volumeDevices:
@@ -2305,44 +2142,44 @@ spec:
                                 type: object
                               type: array
                             volumeMounts:
-                              description: Pod volumes to mount into the container's
-                                filesystem. Cannot be updated.
+                              description: |-
+                                Pod volumes to mount into the container's filesystem.
+                                Cannot be updated.
                               items:
                                 description: VolumeMount describes a mounting of a
                                   Volume within a container.
                                 properties:
                                   mountPath:
-                                    description: Path within the container at which
-                                      the volume should be mounted.  Must not contain
-                                      ':'.
+                                    description: |-
+                                      Path within the container at which the volume should be mounted.  Must
+                                      not contain ':'.
                                     type: string
                                   mountPropagation:
-                                    description: mountPropagation determines how mounts
-                                      are propagated from the host to container and
-                                      the other way around. When not set, MountPropagationNone
-                                      is used. This field is beta in 1.10.
+                                    description: |-
+                                      mountPropagation determines how mounts are propagated from the host
+                                      to container and the other way around.
+                                      When not set, MountPropagationNone is used.
+                                      This field is beta in 1.10.
                                     type: string
                                   name:
                                     description: This must match the Name of a Volume.
                                     type: string
                                   readOnly:
-                                    description: Mounted read-only if true, read-write
-                                      otherwise (false or unspecified). Defaults to
-                                      false.
+                                    description: |-
+                                      Mounted read-only if true, read-write otherwise (false or unspecified).
+                                      Defaults to false.
                                     type: boolean
                                   subPath:
-                                    description: Path within the volume from which
-                                      the container's volume should be mounted. Defaults
-                                      to "" (volume's root).
+                                    description: |-
+                                      Path within the volume from which the container's volume should be mounted.
+                                      Defaults to "" (volume's root).
                                     type: string
                                   subPathExpr:
-                                    description: Expanded path within the volume from
-                                      which the container's volume should be mounted.
-                                      Behaves similarly to SubPath but environment
-                                      variable references $(VAR_NAME) are expanded
-                                      using the container's environment. Defaults
-                                      to "" (volume's root). SubPathExpr and SubPath
-                                      are mutually exclusive.
+                                    description: |-
+                                      Expanded path within the volume from which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                      Defaults to "" (volume's root).
+                                      SubPathExpr and SubPath are mutually exclusive.
                                     type: string
                                 required:
                                 - mountPath
@@ -2350,33 +2187,36 @@ spec:
                                 type: object
                               type: array
                             workingDir:
-                              description: Container's working directory. If not specified,
-                                the container runtime's default will be used, which
-                                might be configured in the container image. Cannot
-                                be updated.
+                              description: |-
+                                Container's working directory.
+                                If not specified, the container runtime's default will be used, which
+                                might be configured in the container image.
+                                Cannot be updated.
                               type: string
                           required:
                           - name
                           type: object
                         type: array
                       dnsConfig:
-                        description: Specifies the DNS parameters of a pod. Parameters
-                          specified here will be merged to the generated DNS configuration
-                          based on DNSPolicy.
+                        description: |-
+                          Specifies the DNS parameters of a pod.
+                          Parameters specified here will be merged to the generated DNS
+                          configuration based on DNSPolicy.
                         properties:
                           nameservers:
-                            description: A list of DNS name server IP addresses. This
-                              will be appended to the base nameservers generated from
-                              DNSPolicy. Duplicated nameservers will be removed.
+                            description: |-
+                              A list of DNS name server IP addresses.
+                              This will be appended to the base nameservers generated from DNSPolicy.
+                              Duplicated nameservers will be removed.
                             items:
                               type: string
                             type: array
                           options:
-                            description: A list of DNS resolver options. This will
-                              be merged with the base options generated from DNSPolicy.
-                              Duplicated entries will be removed. Resolution options
-                              given in Options will override those that appear in
-                              the base DNSPolicy.
+                            description: |-
+                              A list of DNS resolver options.
+                              This will be merged with the base options generated from DNSPolicy.
+                              Duplicated entries will be removed. Resolution options given in Options
+                              will override those that appear in the base DNSPolicy.
                             items:
                               description: PodDNSConfigOption defines DNS resolver
                                 options of a pod.
@@ -2389,80 +2229,77 @@ spec:
                               type: object
                             type: array
                           searches:
-                            description: A list of DNS search domains for host-name
-                              lookup. This will be appended to the base search paths
-                              generated from DNSPolicy. Duplicated search paths will
-                              be removed.
+                            description: |-
+                              A list of DNS search domains for host-name lookup.
+                              This will be appended to the base search paths generated from DNSPolicy.
+                              Duplicated search paths will be removed.
                             items:
                               type: string
                             type: array
                         type: object
                       dnsPolicy:
-                        description: Set DNS policy for the pod. Defaults to "ClusterFirst".
-                          Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst',
-                          'Default' or 'None'. DNS parameters given in DNSConfig will
-                          be merged with the policy selected with DNSPolicy. To have
-                          DNS options set along with hostNetwork, you have to specify
-                          DNS policy explicitly to 'ClusterFirstWithHostNet'.
+                        description: |-
+                          Set DNS policy for the pod.
+                          Defaults to "ClusterFirst".
+                          Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                          DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                          To have DNS options set along with hostNetwork, you have to specify DNS policy
+                          explicitly to 'ClusterFirstWithHostNet'.
                         type: string
                       enableServiceLinks:
-                        description: 'EnableServiceLinks indicates whether information
-                          about services should be injected into pod''s environment
-                          variables, matching the syntax of Docker links. Optional:
-                          Defaults to true.'
+                        description: |-
+                          EnableServiceLinks indicates whether information about services should be injected into pod's
+                          environment variables, matching the syntax of Docker links.
+                          Optional: Defaults to true.
                         type: boolean
                       ephemeralContainers:
-                        description: List of ephemeral containers run in this pod.
-                          Ephemeral containers may be run in an existing pod to perform
-                          user-initiated actions such as debugging. This list cannot
-                          be specified when creating a pod, and it cannot be modified
-                          by updating the pod spec. In order to add an ephemeral container
-                          to an existing pod, use the pod's ephemeralcontainers subresource.
+                        description: |-
+                          List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
+                          pod to perform user-initiated actions such as debugging. This list cannot be specified when
+                          creating a pod, and it cannot be modified by updating the pod spec. In order to add an
+                          ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
                         items:
-                          description: "An EphemeralContainer is a temporary container
-                            that you may add to an existing Pod for user-initiated
-                            activities such as debugging. Ephemeral containers have
-                            no resource or scheduling guarantees, and they will not
-                            be restarted when they exit or when a Pod is removed or
-                            restarted. The kubelet may evict a Pod if an ephemeral
-                            container causes the Pod to exceed its resource allocation.
-                            \n To add an ephemeral container, use the ephemeralcontainers
-                            subresource of an existing Pod. Ephemeral containers may
-                            not be removed or restarted."
+                          description: |-
+                            An EphemeralContainer is a temporary container that you may add to an existing Pod for
+                            user-initiated activities such as debugging. Ephemeral containers have no resource or
+                            scheduling guarantees, and they will not be restarted when they exit or when a Pod is
+                            removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
+                            Pod to exceed its resource allocation.
+
+
+                            To add an ephemeral container, use the ephemeralcontainers subresource of an existing
+                            Pod. Ephemeral containers may not be removed or restarted.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The image''s
-                                CMD is used if this is not provided. Variable references
-                                $(VAR_NAME) are expanded using the container''s environment.
-                                If a variable cannot be resolved, the reference in
-                                the input string will be unchanged. Double $$ are
-                                reduced to a single $, which allows for escaping the
-                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
-                                the string literal "$(VAR_NAME)". Escaped references
-                                will never be expanded, regardless of whether the
-                                variable exists or not. Cannot be updated. More info:
-                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: |-
+                                Arguments to the entrypoint.
+                                The image's CMD is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within
-                                a shell. The image''s ENTRYPOINT is used if this is
-                                not provided. Variable references $(VAR_NAME) are
-                                expanded using the container''s environment. If a
-                                variable cannot be resolved, the reference in the
-                                input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME)
-                                syntax: i.e. "$$(VAR_NAME)" will produce the string
-                                literal "$(VAR_NAME)". Escaped references will never
-                                be expanded, regardless of whether the variable exists
-                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: |-
+                                Entrypoint array. Not executed within a shell.
+                                The image's ENTRYPOINT is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                               items:
                                 type: string
                               type: array
                             env:
-                              description: List of environment variables to set in
-                                the container. Cannot be updated.
+                              description: |-
+                                List of environment variables to set in the container.
+                                Cannot be updated.
                               items:
                                 description: EnvVar represents an environment variable
                                   present in a Container.
@@ -2472,17 +2309,16 @@ spec:
                                       Must be a C_IDENTIFIER.
                                     type: string
                                   value:
-                                    description: 'Variable references $(VAR_NAME)
-                                      are expanded using the previously defined environment
-                                      variables in the container and any service environment
-                                      variables. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Defaults
-                                      to "".'
+                                    description: |-
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the previously defined environment variables in the container and
+                                      any service environment variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless of whether the variable
+                                      exists or not.
+                                      Defaults to "".
                                     type: string
                                   valueFrom:
                                     description: Source for the environment variable's
@@ -2495,10 +2331,10 @@ spec:
                                             description: The key to select.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the ConfigMap
@@ -2509,11 +2345,9 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       fieldRef:
-                                        description: 'Selects a field of the pod:
-                                          supports metadata.name, metadata.namespace,
-                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                          spec.nodeName, spec.serviceAccountName,
-                                          status.hostIP, status.podIP, status.podIPs.'
+                                        description: |-
+                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                         properties:
                                           apiVersion:
                                             description: Version of the schema the
@@ -2529,11 +2363,9 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, limits.ephemeral-storage,
-                                          requests.cpu, requests.memory and requests.ephemeral-storage)
-                                          are currently supported.'
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                         properties:
                                           containerName:
                                             description: 'Container name: required
@@ -2565,10 +2397,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -2584,14 +2416,13 @@ spec:
                                 type: object
                               type: array
                             envFrom:
-                              description: List of sources to populate environment
-                                variables in the container. The keys defined within
-                                a source must be a C_IDENTIFIER. All invalid keys
-                                will be reported as an event when the container is
-                                starting. When a key exists in multiple sources, the
-                                value associated with the last source will take precedence.
-                                Values defined by an Env with a duplicate key will
-                                take precedence. Cannot be updated.
+                              description: |-
+                                List of sources to populate environment variables in the container.
+                                The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is starting. When a key exists in multiple
+                                sources, the value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will take precedence.
+                                Cannot be updated.
                               items:
                                 description: EnvFromSource represents the source of
                                   a set of ConfigMaps
@@ -2600,10 +2431,10 @@ spec:
                                     description: The ConfigMap to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: Specify whether the ConfigMap
@@ -2619,10 +2450,10 @@ spec:
                                     description: The Secret to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: Specify whether the Secret must
@@ -2633,40 +2464,39 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                              description: |-
+                                Container image name.
+                                More info: https://kubernetes.io/docs/concepts/containers/images
                               type: string
                             imagePullPolicy:
-                              description: 'Image pull policy. One of Always, Never,
-                                IfNotPresent. Defaults to Always if :latest tag is
-                                specified, or IfNotPresent otherwise. Cannot be updated.
-                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              description: |-
+                                Image pull policy.
+                                One of Always, Never, IfNotPresent.
+                                Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                               type: string
                             lifecycle:
                               description: Lifecycle is not allowed for ephemeral
                                 containers.
                               properties:
                                 postStart:
-                                  description: 'PostStart is called immediately after
-                                    a container is created. If the handler fails,
-                                    the container is terminated and restarted according
-                                    to its restart policy. Other management of the
-                                    container blocks until the hook completes. More
-                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  description: |-
+                                    PostStart is called immediately after a container is created. If the handler fails,
+                                    the container is terminated and restarted according to its restart policy.
+                                    Other management of the container blocks until the hook completes.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
@@ -2676,8 +2506,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -2688,10 +2518,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -2709,24 +2538,24 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     tcpSocket:
-                                      description: Deprecated. TCPSocket is NOT supported
-                                        as a LifecycleHandler and kept for the backward
-                                        compatibility. There are no validation of
-                                        this field and lifecycle hooks will fail in
-                                        runtime when tcp handler is specified.
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for the backward compatibility. There are no validation of this field and
+                                        lifecycle hooks will fail in runtime when tcp handler is specified.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -2736,44 +2565,37 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                   type: object
                                 preStop:
-                                  description: 'PreStop is called immediately before
-                                    a container is terminated due to an API request
-                                    or management event such as liveness/startup probe
-                                    failure, preemption, resource contention, etc.
-                                    The handler is not called if the container crashes
-                                    or exits. The Pod''s termination grace period
-                                    countdown begins before the PreStop hook is executed.
-                                    Regardless of the outcome of the handler, the
-                                    container will eventually terminate within the
-                                    Pod''s termination grace period (unless delayed
-                                    by finalizers). Other management of the container
-                                    blocks until the hook completes or until the termination
-                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  description: |-
+                                    PreStop is called immediately before a container is terminated due to an
+                                    API request or management event such as liveness/startup probe failure,
+                                    preemption, resource contention, etc. The handler is not called if the
+                                    container crashes or exits. The Pod's termination grace period countdown begins before the
+                                    PreStop hook is executed. Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the Pod's termination grace
+                                    period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
@@ -2783,8 +2605,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -2795,10 +2617,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -2816,24 +2637,24 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     tcpSocket:
-                                      description: Deprecated. TCPSocket is NOT supported
-                                        as a LifecycleHandler and kept for the backward
-                                        compatibility. There are no validation of
-                                        this field and lifecycle hooks will fail in
-                                        runtime when tcp handler is specified.
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for the backward compatibility. There are no validation of this field and
+                                        lifecycle hooks will fail in runtime when tcp handler is specified.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -2843,10 +2664,10 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
@@ -2860,22 +2681,19 @@ spec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -2889,11 +2707,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -2903,9 +2722,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -2915,10 +2734,9 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -2935,34 +2753,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -2977,43 +2796,40 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             name:
-                              description: Name of the ephemeral container specified
-                                as a DNS_LABEL. This name must be unique among all
-                                containers, init containers and ephemeral containers.
+                              description: |-
+                                Name of the ephemeral container specified as a DNS_LABEL.
+                                This name must be unique among all containers, init containers and ephemeral containers.
                               type: string
                             ports:
                               description: Ports are not allowed for ephemeral containers.
@@ -3022,9 +2838,9 @@ spec:
                                   in a single container.
                                 properties:
                                   containerPort:
-                                    description: Number of port to expose on the pod's
-                                      IP address. This must be a valid port number,
-                                      0 < x < 65536.
+                                    description: |-
+                                      Number of port to expose on the pod's IP address.
+                                      This must be a valid port number, 0 < x < 65536.
                                     format: int32
                                     type: integer
                                   hostIP:
@@ -3032,23 +2848,24 @@ spec:
                                       port to.
                                     type: string
                                   hostPort:
-                                    description: Number of port to expose on the host.
-                                      If specified, this must be a valid port number,
-                                      0 < x < 65536. If HostNetwork is specified,
-                                      this must match ContainerPort. Most containers
-                                      do not need this.
+                                    description: |-
+                                      Number of port to expose on the host.
+                                      If specified, this must be a valid port number, 0 < x < 65536.
+                                      If HostNetwork is specified, this must match ContainerPort.
+                                      Most containers do not need this.
                                     format: int32
                                     type: integer
                                   name:
-                                    description: If specified, this must be an IANA_SVC_NAME
-                                      and unique within the pod. Each named port in
-                                      a pod must have a unique name. Name for the
-                                      port that can be referred to by services.
+                                    description: |-
+                                      If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                      named port in a pod must have a unique name. Name for the port that can be
+                                      referred to by services.
                                     type: string
                                   protocol:
                                     default: TCP
-                                    description: Protocol for port. Must be UDP, TCP,
-                                      or SCTP. Defaults to "TCP".
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP.
+                                      Defaults to "TCP".
                                     type: string
                                 required:
                                 - containerPort
@@ -3065,22 +2882,19 @@ spec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -3094,11 +2908,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -3108,9 +2923,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -3120,10 +2935,9 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -3140,34 +2954,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -3182,36 +2997,33 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
@@ -3222,14 +3034,14 @@ spec:
                                   resize policy for the container.
                                 properties:
                                   resourceName:
-                                    description: 'Name of the resource to which this
-                                      resource resize policy applies. Supported values:
-                                      cpu, memory.'
+                                    description: |-
+                                      Name of the resource to which this resource resize policy applies.
+                                      Supported values: cpu, memory.
                                     type: string
                                   restartPolicy:
-                                    description: Restart policy to apply when specified
-                                      resource is resized. If not specified, it defaults
-                                      to NotRequired.
+                                    description: |-
+                                      Restart policy to apply when specified resource is resized.
+                                      If not specified, it defaults to NotRequired.
                                     type: string
                                 required:
                                 - resourceName
@@ -3238,26 +3050,30 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             resources:
-                              description: Resources are not allowed for ephemeral
-                                containers. Ephemeral containers use spare resources
+                              description: |-
+                                Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
                                 already allocated to the pod.
                               properties:
                                 claims:
-                                  description: "Claims lists the names of resources,
-                                    defined in spec.resourceClaims, that are used
-                                    by this container. \n This is an alpha field and
-                                    requires enabling the DynamicResourceAllocation
-                                    feature gate. \n This field is immutable. It can
-                                    only be set for containers."
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+
+                                    This field is immutable. It can only be set for containers.
                                   items:
                                     description: ResourceClaim references one entry
                                       in PodSpec.ResourceClaims.
                                     properties:
                                       name:
-                                        description: Name must match the name of one
-                                          entry in pod.spec.resourceClaims of the
-                                          Pod where this field is used. It makes that
-                                          resource available inside a container.
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
                                         type: string
                                     required:
                                     - name
@@ -3273,8 +3089,9 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount
-                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -3283,41 +3100,40 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount
-                                    of compute resources required. If Requests is
-                                    omitted for a container, it defaults to Limits
-                                    if that is explicitly specified, otherwise to
-                                    an implementation-defined value. Requests cannot
-                                    exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                               type: object
                             restartPolicy:
-                              description: Restart policy for the container to manage
-                                the restart behavior of each container within a pod.
-                                This may only be set for init containers. You cannot
-                                set this field on ephemeral containers.
+                              description: |-
+                                Restart policy for the container to manage the restart behavior of each
+                                container within a pod.
+                                This may only be set for init containers. You cannot set this field on
+                                ephemeral containers.
                               type: string
                             securityContext:
-                              description: 'Optional: SecurityContext defines the
-                                security options the ephemeral container should be
-                                run with. If set, the fields of SecurityContext override
-                                the equivalent fields of PodSecurityContext.'
+                              description: |-
+                                Optional: SecurityContext defines the security options the ephemeral container should be run with.
+                                If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
                               properties:
                                 allowPrivilegeEscalation:
-                                  description: 'AllowPrivilegeEscalation controls
-                                    whether a process can gain more privileges than
-                                    its parent process. This bool directly controls
-                                    if the no_new_privs flag will be set on the container
-                                    process. AllowPrivilegeEscalation is true always
-                                    when the container is: 1) run as Privileged 2)
-                                    has CAP_SYS_ADMIN Note that this field cannot
-                                    be set when spec.os.name is windows.'
+                                  description: |-
+                                    AllowPrivilegeEscalation controls whether a process can gain more
+                                    privileges than its parent process. This bool directly controls if
+                                    the no_new_privs flag will be set on the container process.
+                                    AllowPrivilegeEscalation is true always when the container is:
+                                    1) run as Privileged
+                                    2) has CAP_SYS_ADMIN
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 capabilities:
-                                  description: The capabilities to add/drop when running
-                                    containers. Defaults to the default set of capabilities
-                                    granted by the container runtime. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The capabilities to add/drop when running containers.
+                                    Defaults to the default set of capabilities granted by the container runtime.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     add:
                                       description: Added capabilities
@@ -3335,66 +3151,60 @@ spec:
                                       type: array
                                   type: object
                                 privileged:
-                                  description: Run container in privileged mode. Processes
-                                    in privileged containers are essentially equivalent
-                                    to root on the host. Defaults to false. Note that
-                                    this field cannot be set when spec.os.name is
-                                    windows.
+                                  description: |-
+                                    Run container in privileged mode.
+                                    Processes in privileged containers are essentially equivalent to root on the host.
+                                    Defaults to false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 procMount:
-                                  description: procMount denotes the type of proc
-                                    mount to use for the containers. The default is
-                                    DefaultProcMount which uses the container runtime
-                                    defaults for readonly paths and masked paths.
-                                    This requires the ProcMountType feature flag to
-                                    be enabled. Note that this field cannot be set
-                                    when spec.os.name is windows.
+                                  description: |-
+                                    procMount denotes the type of proc mount to use for the containers.
+                                    The default is DefaultProcMount which uses the container runtime defaults for
+                                    readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to be enabled.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: string
                                 readOnlyRootFilesystem:
-                                  description: Whether this container has a read-only
-                                    root filesystem. Default is false. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    Whether this container has a read-only root filesystem.
+                                    Default is false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the
-                                    container process. Uses runtime default if unset.
-                                    May also be set in PodSecurityContext.  If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run
-                                    as a non-root user. If true, the Kubelet will
-                                    validate the image at runtime to ensure that it
-                                    does not run as UID 0 (root) and fail to start
-                                    the container if it does. If unset or false, no
-                                    such validation will be performed. May also be
-                                    set in PodSecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence.
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the
-                                    container process. Defaults to user specified
-                                    in image metadata if unspecified. May also be
-                                    set in PodSecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to
-                                    the container. If unspecified, the container runtime
-                                    will allocate a random SELinux context for each
-                                    container.  May also be set in PodSecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The SELinux context to be applied to the container.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -3414,70 +3224,62 @@ spec:
                                       type: string
                                   type: object
                                 seccompProfile:
-                                  description: The seccomp options to use by this
-                                    container. If seccomp options are provided at
-                                    both the pod & container level, the container
-                                    options override the pod options. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The seccomp options to use by this container. If seccomp options are
+                                    provided at both the pod & container level, the container options
+                                    override the pod options.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
-                                      description: localhostProfile indicates a profile
-                                        defined in a file on the node should be used.
-                                        The profile must be preconfigured on the node
-                                        to work. Must be a descending path, relative
-                                        to the kubelet's configured seccomp profile
-                                        location. Must be set if type is "Localhost".
-                                        Must NOT be set for any other type.
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
                                       type: string
                                     type:
-                                      description: "type indicates which kind of seccomp
-                                        profile will be applied. Valid options are:
-                                        \n Localhost - a profile defined in a file
-                                        on the node should be used. RuntimeDefault
-                                        - the container runtime default profile should
-                                        be used. Unconfined - no profile should be
-                                        applied."
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
                                       type: string
                                   required:
                                   - type
                                   type: object
                                 windowsOptions:
-                                  description: The Windows specific settings applied
-                                    to all containers. If unspecified, the options
-                                    from the PodSecurityContext will be used. If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options from the PodSecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the
-                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                        inlines the contents of the GMSA credential
-                                        spec named by the GMSACredentialSpecName field.
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
                                     hostProcess:
-                                      description: HostProcess determines if a container
-                                        should be run as a 'Host Process' container.
-                                        All of a Pod's containers must have the same
-                                        effective HostProcess value (it is not allowed
-                                        to have a mix of HostProcess containers and
-                                        non-HostProcess containers). In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
                                       type: boolean
                                     runAsUserName:
-                                      description: The UserName in Windows to run
-                                        the entrypoint of the container process. Defaults
-                                        to the user specified in image metadata if
-                                        unspecified. May also be set in PodSecurityContext.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
@@ -3488,22 +3290,19 @@ spec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -3517,11 +3316,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -3531,9 +3331,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -3543,10 +3343,9 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -3563,34 +3362,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -3605,94 +3405,85 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             stdin:
-                              description: Whether this container should allocate
-                                a buffer for stdin in the container runtime. If this
-                                is not set, reads from stdin in the container will
-                                always result in EOF. Default is false.
+                              description: |-
+                                Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will always result in EOF.
+                                Default is false.
                               type: boolean
                             stdinOnce:
-                              description: Whether the container runtime should close
-                                the stdin channel after it has been opened by a single
-                                attach. When stdin is true the stdin stream will remain
-                                open across multiple attach sessions. If stdinOnce
-                                is set to true, stdin is opened on container start,
-                                is empty until the first client attaches to stdin,
-                                and then remains open and accepts data until the client
-                                disconnects, at which time stdin is closed and remains
-                                closed until the container is restarted. If this flag
-                                is false, a container processes that reads from stdin
-                                will never receive an EOF. Default is false
+                              description: |-
+                                Whether the container runtime should close the stdin channel after it has been opened by
+                                a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                at which time stdin is closed and remains closed until the container is restarted. If this
+                                flag is false, a container processes that reads from stdin will never receive an EOF.
+                                Default is false
                               type: boolean
                             targetContainerName:
-                              description: "If set, the name of the container from
-                                PodSpec that this ephemeral container targets. The
-                                ephemeral container will be run in the namespaces
-                                (IPC, PID, etc) of this container. If not set then
-                                the ephemeral container uses the namespaces configured
-                                in the Pod spec. \n The container runtime must implement
-                                support for this feature. If the runtime does not
-                                support namespace targeting then the result of setting
-                                this field is undefined."
+                              description: |-
+                                If set, the name of the container from PodSpec that this ephemeral container targets.
+                                The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
+                                If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+
+                                The container runtime must implement support for this feature. If the runtime does not
+                                support namespace targeting then the result of setting this field is undefined.
                               type: string
                             terminationMessagePath:
-                              description: 'Optional: Path at which the file to which
-                                the container''s termination message will be written
-                                is mounted into the container''s filesystem. Message
-                                written is intended to be brief final status, such
-                                as an assertion failure message. Will be truncated
-                                by the node if greater than 4096 bytes. The total
-                                message length across all containers will be limited
-                                to 12kb. Defaults to /dev/termination-log. Cannot
-                                be updated.'
+                              description: |-
+                                Optional: Path at which the file to which the container's termination message
+                                will be written is mounted into the container's filesystem.
+                                Message written is intended to be brief final status, such as an assertion failure message.
+                                Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                all containers will be limited to 12kb.
+                                Defaults to /dev/termination-log.
+                                Cannot be updated.
                               type: string
                             terminationMessagePolicy:
-                              description: Indicate how the termination message should
-                                be populated. File will use the contents of terminationMessagePath
-                                to populate the container status message on both success
-                                and failure. FallbackToLogsOnError will use the last
-                                chunk of container log output if the termination message
-                                file is empty and the container exited with an error.
-                                The log output is limited to 2048 bytes or 80 lines,
-                                whichever is smaller. Defaults to File. Cannot be
-                                updated.
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of
+                                terminationMessagePath to populate the container status message on both success and failure.
+                                FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                message file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                Defaults to File.
+                                Cannot be updated.
                               type: string
                             tty:
-                              description: Whether this container should allocate
-                                a TTY for itself, also requires 'stdin' to be true.
+                              description: |-
+                                Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
                                 Default is false.
                               type: boolean
                             volumeDevices:
@@ -3717,45 +3508,44 @@ spec:
                                 type: object
                               type: array
                             volumeMounts:
-                              description: Pod volumes to mount into the container's
-                                filesystem. Subpath mounts are not allowed for ephemeral
-                                containers. Cannot be updated.
+                              description: |-
+                                Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
+                                Cannot be updated.
                               items:
                                 description: VolumeMount describes a mounting of a
                                   Volume within a container.
                                 properties:
                                   mountPath:
-                                    description: Path within the container at which
-                                      the volume should be mounted.  Must not contain
-                                      ':'.
+                                    description: |-
+                                      Path within the container at which the volume should be mounted.  Must
+                                      not contain ':'.
                                     type: string
                                   mountPropagation:
-                                    description: mountPropagation determines how mounts
-                                      are propagated from the host to container and
-                                      the other way around. When not set, MountPropagationNone
-                                      is used. This field is beta in 1.10.
+                                    description: |-
+                                      mountPropagation determines how mounts are propagated from the host
+                                      to container and the other way around.
+                                      When not set, MountPropagationNone is used.
+                                      This field is beta in 1.10.
                                     type: string
                                   name:
                                     description: This must match the Name of a Volume.
                                     type: string
                                   readOnly:
-                                    description: Mounted read-only if true, read-write
-                                      otherwise (false or unspecified). Defaults to
-                                      false.
+                                    description: |-
+                                      Mounted read-only if true, read-write otherwise (false or unspecified).
+                                      Defaults to false.
                                     type: boolean
                                   subPath:
-                                    description: Path within the volume from which
-                                      the container's volume should be mounted. Defaults
-                                      to "" (volume's root).
+                                    description: |-
+                                      Path within the volume from which the container's volume should be mounted.
+                                      Defaults to "" (volume's root).
                                     type: string
                                   subPathExpr:
-                                    description: Expanded path within the volume from
-                                      which the container's volume should be mounted.
-                                      Behaves similarly to SubPath but environment
-                                      variable references $(VAR_NAME) are expanded
-                                      using the container's environment. Defaults
-                                      to "" (volume's root). SubPathExpr and SubPath
-                                      are mutually exclusive.
+                                    description: |-
+                                      Expanded path within the volume from which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                      Defaults to "" (volume's root).
+                                      SubPathExpr and SubPath are mutually exclusive.
                                     type: string
                                 required:
                                 - mountPath
@@ -3763,23 +3553,24 @@ spec:
                                 type: object
                               type: array
                             workingDir:
-                              description: Container's working directory. If not specified,
-                                the container runtime's default will be used, which
-                                might be configured in the container image. Cannot
-                                be updated.
+                              description: |-
+                                Container's working directory.
+                                If not specified, the container runtime's default will be used, which
+                                might be configured in the container image.
+                                Cannot be updated.
                               type: string
                           required:
                           - name
                           type: object
                         type: array
                       hostAliases:
-                        description: HostAliases is an optional list of hosts and
-                          IPs that will be injected into the pod's hosts file if specified.
-                          This is only valid for non-hostNetwork pods.
+                        description: |-
+                          HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                          file if specified. This is only valid for non-hostNetwork pods.
                         items:
-                          description: HostAlias holds the mapping between IP and
-                            hostnames that will be injected as an entry in the pod's
-                            hosts file.
+                          description: |-
+                            HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                            pod's hosts file.
                           properties:
                             hostnames:
                               description: Hostnames for the above IP address.
@@ -3792,105 +3583,106 @@ spec:
                           type: object
                         type: array
                       hostIPC:
-                        description: 'Use the host''s ipc namespace. Optional: Default
-                          to false.'
+                        description: |-
+                          Use the host's ipc namespace.
+                          Optional: Default to false.
                         type: boolean
                       hostNetwork:
-                        description: Host networking requested for this pod. Use the
-                          host's network namespace. If this option is set, the ports
-                          that will be used must be specified. Default to false.
+                        description: |-
+                          Host networking requested for this pod. Use the host's network namespace.
+                          If this option is set, the ports that will be used must be specified.
+                          Default to false.
                         type: boolean
                       hostPID:
-                        description: 'Use the host''s pid namespace. Optional: Default
-                          to false.'
+                        description: |-
+                          Use the host's pid namespace.
+                          Optional: Default to false.
                         type: boolean
                       hostUsers:
-                        description: 'Use the host''s user namespace. Optional: Default
-                          to true. If set to true or not present, the pod will be
-                          run in the host user namespace, useful for when the pod
-                          needs a feature only available to the host user namespace,
-                          such as loading a kernel module with CAP_SYS_MODULE. When
-                          set to false, a new userns is created for the pod. Setting
-                          false is useful for mitigating container breakout vulnerabilities
-                          even allowing users to run their containers as root without
-                          actually having root privileges on the host. This field
-                          is alpha-level and is only honored by servers that enable
-                          the UserNamespacesSupport feature.'
+                        description: |-
+                          Use the host's user namespace.
+                          Optional: Default to true.
+                          If set to true or not present, the pod will be run in the host user namespace, useful
+                          for when the pod needs a feature only available to the host user namespace, such as
+                          loading a kernel module with CAP_SYS_MODULE.
+                          When set to false, a new userns is created for the pod. Setting false is useful for
+                          mitigating container breakout vulnerabilities even allowing users to run their
+                          containers as root without actually having root privileges on the host.
+                          This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                         type: boolean
                       hostname:
-                        description: Specifies the hostname of the Pod If not specified,
-                          the pod's hostname will be set to a system-defined value.
+                        description: |-
+                          Specifies the hostname of the Pod
+                          If not specified, the pod's hostname will be set to a system-defined value.
                         type: string
                       imagePullSecrets:
-                        description: 'ImagePullSecrets is an optional list of references
-                          to secrets in the same namespace to use for pulling any
-                          of the images used by this PodSpec. If specified, these
-                          secrets will be passed to individual puller implementations
-                          for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                        description: |-
+                          ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                          If specified, these secrets will be passed to individual puller implementations for them to use.
+                          More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
                         items:
-                          description: LocalObjectReference contains enough information
-                            to let you locate the referenced object inside the same
-                            namespace.
+                          description: |-
+                            LocalObjectReference contains enough information to let you locate the
+                            referenced object inside the same namespace.
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
                       initContainers:
-                        description: 'List of initialization containers belonging
-                          to the pod. Init containers are executed in order prior
-                          to containers being started. If any init container fails,
-                          the pod is considered to have failed and is handled according
-                          to its restartPolicy. The name for an init container or
-                          normal container must be unique among all containers. Init
-                          containers may not have Lifecycle actions, Readiness probes,
-                          Liveness probes, or Startup probes. The resourceRequirements
-                          of an init container are taken into account during scheduling
-                          by finding the highest request/limit for each resource type,
-                          and then using the max of of that value or the sum of the
-                          normal containers. Limits are applied to init containers
-                          in a similar fashion. Init containers cannot currently be
-                          added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                        description: |-
+                          List of initialization containers belonging to the pod.
+                          Init containers are executed in order prior to containers being started. If any
+                          init container fails, the pod is considered to have failed and is handled according
+                          to its restartPolicy. The name for an init container or normal container must be
+                          unique among all containers.
+                          Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+                          The resourceRequirements of an init container are taken into account during scheduling
+                          by finding the highest request/limit for each resource type, and then using the max of
+                          of that value or the sum of the normal containers. Limits are applied to init containers
+                          in a similar fashion.
+                          Init containers cannot currently be added or removed.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
                         items:
                           description: A single application container that you want
                             to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The container
-                                image''s CMD is used if this is not provided. Variable
-                                references $(VAR_NAME) are expanded using the container''s
-                                environment. If a variable cannot be resolved, the
-                                reference in the input string will be unchanged. Double
-                                $$ are reduced to a single $, which allows for escaping
-                                the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
-                                the string literal "$(VAR_NAME)". Escaped references
-                                will never be expanded, regardless of whether the
-                                variable exists or not. Cannot be updated. More info:
-                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: |-
+                                Arguments to the entrypoint.
+                                The container image's CMD is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within
-                                a shell. The container image''s ENTRYPOINT is used
-                                if this is not provided. Variable references $(VAR_NAME)
-                                are expanded using the container''s environment. If
-                                a variable cannot be resolved, the reference in the
-                                input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME)
-                                syntax: i.e. "$$(VAR_NAME)" will produce the string
-                                literal "$(VAR_NAME)". Escaped references will never
-                                be expanded, regardless of whether the variable exists
-                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: |-
+                                Entrypoint array. Not executed within a shell.
+                                The container image's ENTRYPOINT is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                               items:
                                 type: string
                               type: array
                             env:
-                              description: List of environment variables to set in
-                                the container. Cannot be updated.
+                              description: |-
+                                List of environment variables to set in the container.
+                                Cannot be updated.
                               items:
                                 description: EnvVar represents an environment variable
                                   present in a Container.
@@ -3900,17 +3692,16 @@ spec:
                                       Must be a C_IDENTIFIER.
                                     type: string
                                   value:
-                                    description: 'Variable references $(VAR_NAME)
-                                      are expanded using the previously defined environment
-                                      variables in the container and any service environment
-                                      variables. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Defaults
-                                      to "".'
+                                    description: |-
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the previously defined environment variables in the container and
+                                      any service environment variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless of whether the variable
+                                      exists or not.
+                                      Defaults to "".
                                     type: string
                                   valueFrom:
                                     description: Source for the environment variable's
@@ -3923,10 +3714,10 @@ spec:
                                             description: The key to select.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the ConfigMap
@@ -3937,11 +3728,9 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       fieldRef:
-                                        description: 'Selects a field of the pod:
-                                          supports metadata.name, metadata.namespace,
-                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                          spec.nodeName, spec.serviceAccountName,
-                                          status.hostIP, status.podIP, status.podIPs.'
+                                        description: |-
+                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                         properties:
                                           apiVersion:
                                             description: Version of the schema the
@@ -3957,11 +3746,9 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, limits.ephemeral-storage,
-                                          requests.cpu, requests.memory and requests.ephemeral-storage)
-                                          are currently supported.'
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                         properties:
                                           containerName:
                                             description: 'Container name: required
@@ -3993,10 +3780,10 @@ spec:
                                               key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -4012,14 +3799,13 @@ spec:
                                 type: object
                               type: array
                             envFrom:
-                              description: List of sources to populate environment
-                                variables in the container. The keys defined within
-                                a source must be a C_IDENTIFIER. All invalid keys
-                                will be reported as an event when the container is
-                                starting. When a key exists in multiple sources, the
-                                value associated with the last source will take precedence.
-                                Values defined by an Env with a duplicate key will
-                                take precedence. Cannot be updated.
+                              description: |-
+                                List of sources to populate environment variables in the container.
+                                The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is starting. When a key exists in multiple
+                                sources, the value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will take precedence.
+                                Cannot be updated.
                               items:
                                 description: EnvFromSource represents the source of
                                   a set of ConfigMaps
@@ -4028,10 +3814,10 @@ spec:
                                     description: The ConfigMap to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: Specify whether the ConfigMap
@@ -4047,10 +3833,10 @@ spec:
                                     description: The Secret to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: Specify whether the Secret must
@@ -4061,44 +3847,42 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                                This field is optional to allow higher level config
-                                management to default or override container images
-                                in workload controllers like Deployments and StatefulSets.'
+                              description: |-
+                                Container image name.
+                                More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config management to default or override
+                                container images in workload controllers like Deployments and StatefulSets.
                               type: string
                             imagePullPolicy:
-                              description: 'Image pull policy. One of Always, Never,
-                                IfNotPresent. Defaults to Always if :latest tag is
-                                specified, or IfNotPresent otherwise. Cannot be updated.
-                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              description: |-
+                                Image pull policy.
+                                One of Always, Never, IfNotPresent.
+                                Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                               type: string
                             lifecycle:
-                              description: Actions that the management system should
-                                take in response to container lifecycle events. Cannot
-                                be updated.
+                              description: |-
+                                Actions that the management system should take in response to container lifecycle events.
+                                Cannot be updated.
                               properties:
                                 postStart:
-                                  description: 'PostStart is called immediately after
-                                    a container is created. If the handler fails,
-                                    the container is terminated and restarted according
-                                    to its restart policy. Other management of the
-                                    container blocks until the hook completes. More
-                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  description: |-
+                                    PostStart is called immediately after a container is created. If the handler fails,
+                                    the container is terminated and restarted according to its restart policy.
+                                    Other management of the container blocks until the hook completes.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
@@ -4108,8 +3892,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -4120,10 +3904,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -4141,24 +3924,24 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     tcpSocket:
-                                      description: Deprecated. TCPSocket is NOT supported
-                                        as a LifecycleHandler and kept for the backward
-                                        compatibility. There are no validation of
-                                        this field and lifecycle hooks will fail in
-                                        runtime when tcp handler is specified.
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for the backward compatibility. There are no validation of this field and
+                                        lifecycle hooks will fail in runtime when tcp handler is specified.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -4168,44 +3951,37 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                   type: object
                                 preStop:
-                                  description: 'PreStop is called immediately before
-                                    a container is terminated due to an API request
-                                    or management event such as liveness/startup probe
-                                    failure, preemption, resource contention, etc.
-                                    The handler is not called if the container crashes
-                                    or exits. The Pod''s termination grace period
-                                    countdown begins before the PreStop hook is executed.
-                                    Regardless of the outcome of the handler, the
-                                    container will eventually terminate within the
-                                    Pod''s termination grace period (unless delayed
-                                    by finalizers). Other management of the container
-                                    blocks until the hook completes or until the termination
-                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  description: |-
+                                    PreStop is called immediately before a container is terminated due to an
+                                    API request or management event such as liveness/startup probe failure,
+                                    preemption, resource contention, etc. The handler is not called if the
+                                    container crashes or exits. The Pod's termination grace period countdown begins before the
+                                    PreStop hook is executed. Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the Pod's termination grace
+                                    period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
@@ -4215,8 +3991,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -4227,10 +4003,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -4248,24 +4023,24 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     tcpSocket:
-                                      description: Deprecated. TCPSocket is NOT supported
-                                        as a LifecycleHandler and kept for the backward
-                                        compatibility. There are no validation of
-                                        this field and lifecycle hooks will fail in
-                                        runtime when tcp handler is specified.
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for the backward compatibility. There are no validation of this field and
+                                        lifecycle hooks will fail in runtime when tcp handler is specified.
                                       properties:
                                         host:
                                           description: 'Optional: Host name to connect
@@ -4275,10 +4050,10 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
@@ -4286,30 +4061,29 @@ spec:
                                   type: object
                               type: object
                             livenessProbe:
-                              description: 'Periodic probe of container liveness.
-                                Container will be restarted if the probe fails. Cannot
-                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                Periodic probe of container liveness.
+                                Container will be restarted if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -4323,11 +4097,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -4337,9 +4112,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -4349,10 +4124,9 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -4369,34 +4143,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -4411,61 +4186,59 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             name:
-                              description: Name of the container specified as a DNS_LABEL.
+                              description: |-
+                                Name of the container specified as a DNS_LABEL.
                                 Each container in a pod must have a unique name (DNS_LABEL).
                                 Cannot be updated.
                               type: string
                             ports:
-                              description: List of ports to expose from the container.
-                                Not specifying a port here DOES NOT prevent that port
-                                from being exposed. Any port which is listening on
-                                the default "0.0.0.0" address inside a container will
-                                be accessible from the network. Modifying this array
-                                with strategic merge patch may corrupt the data. For
-                                more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                              description: |-
+                                List of ports to expose from the container. Not specifying a port here
+                                DOES NOT prevent that port from being exposed. Any port which is
+                                listening on the default "0.0.0.0" address inside a container will be
+                                accessible from the network.
+                                Modifying this array with strategic merge patch may corrupt the data.
+                                For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                 Cannot be updated.
                               items:
                                 description: ContainerPort represents a network port
                                   in a single container.
                                 properties:
                                   containerPort:
-                                    description: Number of port to expose on the pod's
-                                      IP address. This must be a valid port number,
-                                      0 < x < 65536.
+                                    description: |-
+                                      Number of port to expose on the pod's IP address.
+                                      This must be a valid port number, 0 < x < 65536.
                                     format: int32
                                     type: integer
                                   hostIP:
@@ -4473,23 +4246,24 @@ spec:
                                       port to.
                                     type: string
                                   hostPort:
-                                    description: Number of port to expose on the host.
-                                      If specified, this must be a valid port number,
-                                      0 < x < 65536. If HostNetwork is specified,
-                                      this must match ContainerPort. Most containers
-                                      do not need this.
+                                    description: |-
+                                      Number of port to expose on the host.
+                                      If specified, this must be a valid port number, 0 < x < 65536.
+                                      If HostNetwork is specified, this must match ContainerPort.
+                                      Most containers do not need this.
                                     format: int32
                                     type: integer
                                   name:
-                                    description: If specified, this must be an IANA_SVC_NAME
-                                      and unique within the pod. Each named port in
-                                      a pod must have a unique name. Name for the
-                                      port that can be referred to by services.
+                                    description: |-
+                                      If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                      named port in a pod must have a unique name. Name for the port that can be
+                                      referred to by services.
                                     type: string
                                   protocol:
                                     default: TCP
-                                    description: Protocol for port. Must be UDP, TCP,
-                                      or SCTP. Defaults to "TCP".
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP.
+                                      Defaults to "TCP".
                                     type: string
                                 required:
                                 - containerPort
@@ -4500,30 +4274,29 @@ spec:
                               - protocol
                               x-kubernetes-list-type: map
                             readinessProbe:
-                              description: 'Periodic probe of container service readiness.
-                                Container will be removed from service endpoints if
-                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -4537,11 +4310,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -4551,9 +4325,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -4563,10 +4337,9 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -4583,34 +4356,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -4625,36 +4399,33 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
@@ -4665,14 +4436,14 @@ spec:
                                   resize policy for the container.
                                 properties:
                                   resourceName:
-                                    description: 'Name of the resource to which this
-                                      resource resize policy applies. Supported values:
-                                      cpu, memory.'
+                                    description: |-
+                                      Name of the resource to which this resource resize policy applies.
+                                      Supported values: cpu, memory.
                                     type: string
                                   restartPolicy:
-                                    description: Restart policy to apply when specified
-                                      resource is resized. If not specified, it defaults
-                                      to NotRequired.
+                                    description: |-
+                                      Restart policy to apply when specified resource is resized.
+                                      If not specified, it defaults to NotRequired.
                                     type: string
                                 required:
                                 - resourceName
@@ -4681,25 +4452,31 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             resources:
-                              description: 'Compute Resources required by this container.
-                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              description: |-
+                                Compute Resources required by this container.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                               properties:
                                 claims:
-                                  description: "Claims lists the names of resources,
-                                    defined in spec.resourceClaims, that are used
-                                    by this container. \n This is an alpha field and
-                                    requires enabling the DynamicResourceAllocation
-                                    feature gate. \n This field is immutable. It can
-                                    only be set for containers."
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+
+                                    This field is immutable. It can only be set for containers.
                                   items:
                                     description: ResourceClaim references one entry
                                       in PodSpec.ResourceClaims.
                                     properties:
                                       name:
-                                        description: Name must match the name of one
-                                          entry in pod.spec.resourceClaims of the
-                                          Pod where this field is used. It makes that
-                                          resource available inside a container.
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
                                         type: string
                                     required:
                                     - name
@@ -4715,8 +4492,9 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount
-                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -4725,57 +4503,52 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount
-                                    of compute resources required. If Requests is
-                                    omitted for a container, it defaults to Limits
-                                    if that is explicitly specified, otherwise to
-                                    an implementation-defined value. Requests cannot
-                                    exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                               type: object
                             restartPolicy:
-                              description: 'RestartPolicy defines the restart behavior
-                                of individual containers in a pod. This field may
-                                only be set for init containers, and the only allowed
-                                value is "Always". For non-init containers or when
-                                this field is not specified, the restart behavior
-                                is defined by the Pod''s restart policy and the container
-                                type. Setting the RestartPolicy as "Always" for the
-                                init container will have the following effect: this
-                                init container will be continually restarted on exit
-                                until all regular containers have terminated. Once
-                                all regular containers have completed, all init containers
-                                with restartPolicy "Always" will be shut down. This
-                                lifecycle differs from normal init containers and
-                                is often referred to as a "sidecar" container. Although
-                                this init container still starts in the init container
-                                sequence, it does not wait for the container to complete
-                                before proceeding to the next init container. Instead,
-                                the next init container starts immediately after this
-                                init container is started, or after any startupProbe
-                                has successfully completed.'
+                              description: |-
+                                RestartPolicy defines the restart behavior of individual containers in a pod.
+                                This field may only be set for init containers, and the only allowed value is "Always".
+                                For non-init containers or when this field is not specified,
+                                the restart behavior is defined by the Pod's restart policy and the container type.
+                                Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                this init container will be continually restarted on
+                                exit until all regular containers have terminated. Once all regular
+                                containers have completed, all init containers with restartPolicy "Always"
+                                will be shut down. This lifecycle differs from normal init containers and
+                                is often referred to as a "sidecar" container. Although this init
+                                container still starts in the init container sequence, it does not wait
+                                for the container to complete before proceeding to the next init
+                                container. Instead, the next init container starts immediately after this
+                                init container is started, or after any startupProbe has successfully
+                                completed.
                               type: string
                             securityContext:
-                              description: 'SecurityContext defines the security options
-                                the container should be run with. If set, the fields
-                                of SecurityContext override the equivalent fields
-                                of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              description: |-
+                                SecurityContext defines the security options the container should be run with.
+                                If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                               properties:
                                 allowPrivilegeEscalation:
-                                  description: 'AllowPrivilegeEscalation controls
-                                    whether a process can gain more privileges than
-                                    its parent process. This bool directly controls
-                                    if the no_new_privs flag will be set on the container
-                                    process. AllowPrivilegeEscalation is true always
-                                    when the container is: 1) run as Privileged 2)
-                                    has CAP_SYS_ADMIN Note that this field cannot
-                                    be set when spec.os.name is windows.'
+                                  description: |-
+                                    AllowPrivilegeEscalation controls whether a process can gain more
+                                    privileges than its parent process. This bool directly controls if
+                                    the no_new_privs flag will be set on the container process.
+                                    AllowPrivilegeEscalation is true always when the container is:
+                                    1) run as Privileged
+                                    2) has CAP_SYS_ADMIN
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 capabilities:
-                                  description: The capabilities to add/drop when running
-                                    containers. Defaults to the default set of capabilities
-                                    granted by the container runtime. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The capabilities to add/drop when running containers.
+                                    Defaults to the default set of capabilities granted by the container runtime.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     add:
                                       description: Added capabilities
@@ -4793,66 +4566,60 @@ spec:
                                       type: array
                                   type: object
                                 privileged:
-                                  description: Run container in privileged mode. Processes
-                                    in privileged containers are essentially equivalent
-                                    to root on the host. Defaults to false. Note that
-                                    this field cannot be set when spec.os.name is
-                                    windows.
+                                  description: |-
+                                    Run container in privileged mode.
+                                    Processes in privileged containers are essentially equivalent to root on the host.
+                                    Defaults to false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 procMount:
-                                  description: procMount denotes the type of proc
-                                    mount to use for the containers. The default is
-                                    DefaultProcMount which uses the container runtime
-                                    defaults for readonly paths and masked paths.
-                                    This requires the ProcMountType feature flag to
-                                    be enabled. Note that this field cannot be set
-                                    when spec.os.name is windows.
+                                  description: |-
+                                    procMount denotes the type of proc mount to use for the containers.
+                                    The default is DefaultProcMount which uses the container runtime defaults for
+                                    readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to be enabled.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: string
                                 readOnlyRootFilesystem:
-                                  description: Whether this container has a read-only
-                                    root filesystem. Default is false. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    Whether this container has a read-only root filesystem.
+                                    Default is false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the
-                                    container process. Uses runtime default if unset.
-                                    May also be set in PodSecurityContext.  If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run
-                                    as a non-root user. If true, the Kubelet will
-                                    validate the image at runtime to ensure that it
-                                    does not run as UID 0 (root) and fail to start
-                                    the container if it does. If unset or false, no
-                                    such validation will be performed. May also be
-                                    set in PodSecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence.
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the
-                                    container process. Defaults to user specified
-                                    in image metadata if unspecified. May also be
-                                    set in PodSecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to
-                                    the container. If unspecified, the container runtime
-                                    will allocate a random SELinux context for each
-                                    container.  May also be set in PodSecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The SELinux context to be applied to the container.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -4872,104 +4639,92 @@ spec:
                                       type: string
                                   type: object
                                 seccompProfile:
-                                  description: The seccomp options to use by this
-                                    container. If seccomp options are provided at
-                                    both the pod & container level, the container
-                                    options override the pod options. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The seccomp options to use by this container. If seccomp options are
+                                    provided at both the pod & container level, the container options
+                                    override the pod options.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
-                                      description: localhostProfile indicates a profile
-                                        defined in a file on the node should be used.
-                                        The profile must be preconfigured on the node
-                                        to work. Must be a descending path, relative
-                                        to the kubelet's configured seccomp profile
-                                        location. Must be set if type is "Localhost".
-                                        Must NOT be set for any other type.
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
                                       type: string
                                     type:
-                                      description: "type indicates which kind of seccomp
-                                        profile will be applied. Valid options are:
-                                        \n Localhost - a profile defined in a file
-                                        on the node should be used. RuntimeDefault
-                                        - the container runtime default profile should
-                                        be used. Unconfined - no profile should be
-                                        applied."
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
                                       type: string
                                   required:
                                   - type
                                   type: object
                                 windowsOptions:
-                                  description: The Windows specific settings applied
-                                    to all containers. If unspecified, the options
-                                    from the PodSecurityContext will be used. If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options from the PodSecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the
-                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                        inlines the contents of the GMSA credential
-                                        spec named by the GMSACredentialSpecName field.
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
                                     hostProcess:
-                                      description: HostProcess determines if a container
-                                        should be run as a 'Host Process' container.
-                                        All of a Pod's containers must have the same
-                                        effective HostProcess value (it is not allowed
-                                        to have a mix of HostProcess containers and
-                                        non-HostProcess containers). In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
                                       type: boolean
                                     runAsUserName:
-                                      description: The UserName in Windows to run
-                                        the entrypoint of the container process. Defaults
-                                        to the user specified in image metadata if
-                                        unspecified. May also be set in PodSecurityContext.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             startupProbe:
-                              description: 'StartupProbe indicates that the Pod has
-                                successfully initialized. If specified, no other probes
-                                are executed until this completes successfully. If
-                                this probe fails, the Pod will be restarted, just
-                                as if the livenessProbe failed. This can be used to
-                                provide different probe parameters at the beginning
-                                of a Pod''s lifecycle, when it might take a long time
-                                to load data or warm a cache, than during steady-state
-                                operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                StartupProbe indicates that the Pod has successfully initialized.
+                                If specified, no other probes are executed until this completes successfully.
+                                If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                This cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -4983,11 +4738,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -4997,9 +4753,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -5009,10 +4765,9 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -5029,34 +4784,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -5071,83 +4827,75 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             stdin:
-                              description: Whether this container should allocate
-                                a buffer for stdin in the container runtime. If this
-                                is not set, reads from stdin in the container will
-                                always result in EOF. Default is false.
+                              description: |-
+                                Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will always result in EOF.
+                                Default is false.
                               type: boolean
                             stdinOnce:
-                              description: Whether the container runtime should close
-                                the stdin channel after it has been opened by a single
-                                attach. When stdin is true the stdin stream will remain
-                                open across multiple attach sessions. If stdinOnce
-                                is set to true, stdin is opened on container start,
-                                is empty until the first client attaches to stdin,
-                                and then remains open and accepts data until the client
-                                disconnects, at which time stdin is closed and remains
-                                closed until the container is restarted. If this flag
-                                is false, a container processes that reads from stdin
-                                will never receive an EOF. Default is false
+                              description: |-
+                                Whether the container runtime should close the stdin channel after it has been opened by
+                                a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                at which time stdin is closed and remains closed until the container is restarted. If this
+                                flag is false, a container processes that reads from stdin will never receive an EOF.
+                                Default is false
                               type: boolean
                             terminationMessagePath:
-                              description: 'Optional: Path at which the file to which
-                                the container''s termination message will be written
-                                is mounted into the container''s filesystem. Message
-                                written is intended to be brief final status, such
-                                as an assertion failure message. Will be truncated
-                                by the node if greater than 4096 bytes. The total
-                                message length across all containers will be limited
-                                to 12kb. Defaults to /dev/termination-log. Cannot
-                                be updated.'
+                              description: |-
+                                Optional: Path at which the file to which the container's termination message
+                                will be written is mounted into the container's filesystem.
+                                Message written is intended to be brief final status, such as an assertion failure message.
+                                Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                all containers will be limited to 12kb.
+                                Defaults to /dev/termination-log.
+                                Cannot be updated.
                               type: string
                             terminationMessagePolicy:
-                              description: Indicate how the termination message should
-                                be populated. File will use the contents of terminationMessagePath
-                                to populate the container status message on both success
-                                and failure. FallbackToLogsOnError will use the last
-                                chunk of container log output if the termination message
-                                file is empty and the container exited with an error.
-                                The log output is limited to 2048 bytes or 80 lines,
-                                whichever is smaller. Defaults to File. Cannot be
-                                updated.
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of
+                                terminationMessagePath to populate the container status message on both success and failure.
+                                FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                message file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                Defaults to File.
+                                Cannot be updated.
                               type: string
                             tty:
-                              description: Whether this container should allocate
-                                a TTY for itself, also requires 'stdin' to be true.
+                              description: |-
+                                Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
                                 Default is false.
                               type: boolean
                             volumeDevices:
@@ -5172,44 +4920,44 @@ spec:
                                 type: object
                               type: array
                             volumeMounts:
-                              description: Pod volumes to mount into the container's
-                                filesystem. Cannot be updated.
+                              description: |-
+                                Pod volumes to mount into the container's filesystem.
+                                Cannot be updated.
                               items:
                                 description: VolumeMount describes a mounting of a
                                   Volume within a container.
                                 properties:
                                   mountPath:
-                                    description: Path within the container at which
-                                      the volume should be mounted.  Must not contain
-                                      ':'.
+                                    description: |-
+                                      Path within the container at which the volume should be mounted.  Must
+                                      not contain ':'.
                                     type: string
                                   mountPropagation:
-                                    description: mountPropagation determines how mounts
-                                      are propagated from the host to container and
-                                      the other way around. When not set, MountPropagationNone
-                                      is used. This field is beta in 1.10.
+                                    description: |-
+                                      mountPropagation determines how mounts are propagated from the host
+                                      to container and the other way around.
+                                      When not set, MountPropagationNone is used.
+                                      This field is beta in 1.10.
                                     type: string
                                   name:
                                     description: This must match the Name of a Volume.
                                     type: string
                                   readOnly:
-                                    description: Mounted read-only if true, read-write
-                                      otherwise (false or unspecified). Defaults to
-                                      false.
+                                    description: |-
+                                      Mounted read-only if true, read-write otherwise (false or unspecified).
+                                      Defaults to false.
                                     type: boolean
                                   subPath:
-                                    description: Path within the volume from which
-                                      the container's volume should be mounted. Defaults
-                                      to "" (volume's root).
+                                    description: |-
+                                      Path within the volume from which the container's volume should be mounted.
+                                      Defaults to "" (volume's root).
                                     type: string
                                   subPathExpr:
-                                    description: Expanded path within the volume from
-                                      which the container's volume should be mounted.
-                                      Behaves similarly to SubPath but environment
-                                      variable references $(VAR_NAME) are expanded
-                                      using the container's environment. Defaults
-                                      to "" (volume's root). SubPathExpr and SubPath
-                                      are mutually exclusive.
+                                    description: |-
+                                      Expanded path within the volume from which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                      Defaults to "" (volume's root).
+                                      SubPathExpr and SubPath are mutually exclusive.
                                     type: string
                                 required:
                                 - mountPath
@@ -5217,54 +4965,70 @@ spec:
                                 type: object
                               type: array
                             workingDir:
-                              description: Container's working directory. If not specified,
-                                the container runtime's default will be used, which
-                                might be configured in the container image. Cannot
-                                be updated.
+                              description: |-
+                                Container's working directory.
+                                If not specified, the container runtime's default will be used, which
+                                might be configured in the container image.
+                                Cannot be updated.
                               type: string
                           required:
                           - name
                           type: object
                         type: array
                       nodeName:
-                        description: NodeName is a request to schedule this pod onto
-                          a specific node. If it is non-empty, the scheduler simply
-                          schedules this pod onto that node, assuming that it fits
-                          resource requirements.
+                        description: |-
+                          NodeName is a request to schedule this pod onto a specific node. If it is non-empty,
+                          the scheduler simply schedules this pod onto that node, assuming that it fits resource
+                          requirements.
                         type: string
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: 'NodeSelector is a selector which must be true
-                          for the pod to fit on a node. Selector which must match
-                          a node''s labels for the pod to be scheduled on that node.
-                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                        description: |-
+                          NodeSelector is a selector which must be true for the pod to fit on a node.
+                          Selector which must match a node's labels for the pod to be scheduled on that node.
+                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                         type: object
                         x-kubernetes-map-type: atomic
                       os:
-                        description: "Specifies the OS of the containers in the pod.
-                          Some pod and container fields are restricted if this is
-                          set. \n If the OS field is set to linux, the following fields
-                          must be unset: -securityContext.windowsOptions \n If the
-                          OS field is set to windows, following fields must be unset:
-                          - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions
-                          - spec.securityContext.seccompProfile - spec.securityContext.fsGroup
-                          - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls
-                          - spec.shareProcessNamespace - spec.securityContext.runAsUser
-                          - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups
-                          - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile
-                          - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem
-                          - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation
-                          - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
-                          - spec.containers[*].securityContext.runAsGroup"
+                        description: |-
+                          Specifies the OS of the containers in the pod.
+                          Some pod and container fields are restricted if this is set.
+
+
+                          If the OS field is set to linux, the following fields must be unset:
+                          -securityContext.windowsOptions
+
+
+                          If the OS field is set to windows, following fields must be unset:
+                          - spec.hostPID
+                          - spec.hostIPC
+                          - spec.hostUsers
+                          - spec.securityContext.seLinuxOptions
+                          - spec.securityContext.seccompProfile
+                          - spec.securityContext.fsGroup
+                          - spec.securityContext.fsGroupChangePolicy
+                          - spec.securityContext.sysctls
+                          - spec.shareProcessNamespace
+                          - spec.securityContext.runAsUser
+                          - spec.securityContext.runAsGroup
+                          - spec.securityContext.supplementalGroups
+                          - spec.containers[*].securityContext.seLinuxOptions
+                          - spec.containers[*].securityContext.seccompProfile
+                          - spec.containers[*].securityContext.capabilities
+                          - spec.containers[*].securityContext.readOnlyRootFilesystem
+                          - spec.containers[*].securityContext.privileged
+                          - spec.containers[*].securityContext.allowPrivilegeEscalation
+                          - spec.containers[*].securityContext.procMount
+                          - spec.containers[*].securityContext.runAsUser
+                          - spec.containers[*].securityContext.runAsGroup
                         properties:
                           name:
-                            description: 'Name is the name of the operating system.
-                              The currently supported values are linux and windows.
-                              Additional value may be defined in future and can be
-                              one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
-                              Clients should expect to handle additional values and
-                              treat unrecognized values in this field as os: null'
+                            description: |-
+                              Name is the name of the operating system. The currently supported values are linux and windows.
+                              Additional value may be defined in future and can be one of:
+                              https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                              Clients should expect to handle additional values and treat unrecognized values in this field as os: null
                             type: string
                         required:
                         - name
@@ -5276,46 +5040,45 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Overhead represents the resource overhead associated
-                          with running a pod for a given RuntimeClass. This field
-                          will be autopopulated at admission time by the RuntimeClass
-                          admission controller. If the RuntimeClass admission controller
-                          is enabled, overhead must not be set in Pod create requests.
-                          The RuntimeClass admission controller will reject Pod create
-                          requests which have the overhead already set. If RuntimeClass
-                          is configured and selected in the PodSpec, Overhead will
-                          be set to the value defined in the corresponding RuntimeClass,
-                          otherwise it will remain unset and treated as zero. More
-                          info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                        description: |-
+                          Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+                          This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+                          the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+                          The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+                          set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value
+                          defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero.
+                          More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
                         type: object
                       preemptionPolicy:
-                        description: PreemptionPolicy is the Policy for preempting
-                          pods with lower priority. One of Never, PreemptLowerPriority.
+                        description: |-
+                          PreemptionPolicy is the Policy for preempting pods with lower priority.
+                          One of Never, PreemptLowerPriority.
                           Defaults to PreemptLowerPriority if unset.
                         type: string
                       priority:
-                        description: The priority value. Various system components
-                          use this field to find the priority of the pod. When Priority
-                          Admission Controller is enabled, it prevents users from
-                          setting this field. The admission controller populates this
-                          field from PriorityClassName. The higher the value, the
-                          higher the priority.
+                        description: |-
+                          The priority value. Various system components use this field to find the
+                          priority of the pod. When Priority Admission Controller is enabled, it
+                          prevents users from setting this field. The admission controller populates
+                          this field from PriorityClassName.
+                          The higher the value, the higher the priority.
                         format: int32
                         type: integer
                       priorityClassName:
-                        description: If specified, indicates the pod's priority. "system-node-critical"
-                          and "system-cluster-critical" are two special keywords which
-                          indicate the highest priorities with the former being the
-                          highest priority. Any other name must be defined by creating
-                          a PriorityClass object with that name. If not specified,
-                          the pod priority will be default or zero if there is no
+                        description: |-
+                          If specified, indicates the pod's priority. "system-node-critical" and
+                          "system-cluster-critical" are two special keywords which indicate the
+                          highest priorities with the former being the highest priority. Any other
+                          name must be defined by creating a PriorityClass object with that name.
+                          If not specified, the pod priority will be default or zero if there is no
                           default.
                         type: string
                       readinessGates:
-                        description: 'If specified, all readiness gates will be evaluated
-                          for pod readiness. A pod is ready when all its containers
-                          are ready AND all conditions specified in the readiness
-                          gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                        description: |-
+                          If specified, all readiness gates will be evaluated for pod readiness.
+                          A pod is ready when all its containers are ready AND
+                          all conditions specified in the readiness gates have status equal to "True"
+                          More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
                         items:
                           description: PodReadinessGate contains the reference to
                             a pod condition
@@ -5329,45 +5092,53 @@ spec:
                           type: object
                         type: array
                       resourceClaims:
-                        description: "ResourceClaims defines which ResourceClaims
-                          must be allocated and reserved before the Pod is allowed
-                          to start. The resources will be made available to those
-                          containers which consume them by name. \n This is an alpha
-                          field and requires enabling the DynamicResourceAllocation
-                          feature gate. \n This field is immutable."
+                        description: |-
+                          ResourceClaims defines which ResourceClaims must be allocated
+                          and reserved before the Pod is allowed to start. The resources
+                          will be made available to those containers which consume them
+                          by name.
+
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+
+                          This field is immutable.
                         items:
-                          description: PodResourceClaim references exactly one ResourceClaim
-                            through a ClaimSource. It adds a name to it that uniquely
-                            identifies the ResourceClaim inside the Pod. Containers
-                            that need access to the ResourceClaim reference it with
-                            this name.
+                          description: |-
+                            PodResourceClaim references exactly one ResourceClaim through a ClaimSource.
+                            It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                            Containers that need access to the ResourceClaim reference it with this name.
                           properties:
                             name:
-                              description: Name uniquely identifies this resource
-                                claim inside the pod. This must be a DNS_LABEL.
+                              description: |-
+                                Name uniquely identifies this resource claim inside the pod.
+                                This must be a DNS_LABEL.
                               type: string
                             source:
                               description: Source describes where to find the ResourceClaim.
                               properties:
                                 resourceClaimName:
-                                  description: ResourceClaimName is the name of a
-                                    ResourceClaim object in the same namespace as
-                                    this pod.
+                                  description: |-
+                                    ResourceClaimName is the name of a ResourceClaim object in the same
+                                    namespace as this pod.
                                   type: string
                                 resourceClaimTemplateName:
-                                  description: "ResourceClaimTemplateName is the name
-                                    of a ResourceClaimTemplate object in the same
-                                    namespace as this pod. \n The template will be
-                                    used to create a new ResourceClaim, which will
-                                    be bound to this pod. When this pod is deleted,
-                                    the ResourceClaim will also be deleted. The pod
-                                    name and resource name, along with a generated
-                                    component, will be used to form a unique name
-                                    for the ResourceClaim, which will be recorded
-                                    in pod.status.resourceClaimStatuses. \n This field
-                                    is immutable and no changes will be made to the
-                                    corresponding ResourceClaim by the control plane
-                                    after creating the ResourceClaim."
+                                  description: |-
+                                    ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                                    object in the same namespace as this pod.
+
+
+                                    The template will be used to create a new ResourceClaim, which will
+                                    be bound to this pod. When this pod is deleted, the ResourceClaim
+                                    will also be deleted. The pod name and resource name, along with a
+                                    generated component, will be used to form a unique name for the
+                                    ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+
+                                    This field is immutable and no changes will be made to the
+                                    corresponding ResourceClaim by the control plane after creating the
+                                    ResourceClaim.
                                   type: string
                               type: object
                           required:
@@ -5378,40 +5149,44 @@ spec:
                         - name
                         x-kubernetes-list-type: map
                       restartPolicy:
-                        description: 'Restart policy for all containers within the
-                          pod. One of Always, OnFailure, Never. In some contexts,
-                          only a subset of those values may be permitted. Default
-                          to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                        description: |-
+                          Restart policy for all containers within the pod.
+                          One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted.
+                          Default to Always.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
                         type: string
                       runtimeClassName:
-                        description: 'RuntimeClassName refers to a RuntimeClass object
-                          in the node.k8s.io group, which should be used to run this
-                          pod.  If no RuntimeClass resource matches the named class,
-                          the pod will not be run. If unset or empty, the "legacy"
-                          RuntimeClass will be used, which is an implicit class with
-                          an empty definition that uses the default runtime handler.
-                          More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                        description: |-
+                          RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
+                          to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
+                          If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
+                          empty definition that uses the default runtime handler.
+                          More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
                         type: string
                       schedulerName:
-                        description: If specified, the pod will be dispatched by specified
-                          scheduler. If not specified, the pod will be dispatched
-                          by default scheduler.
+                        description: |-
+                          If specified, the pod will be dispatched by specified scheduler.
+                          If not specified, the pod will be dispatched by default scheduler.
                         type: string
                       schedulingGates:
-                        description: "SchedulingGates is an opaque list of values
-                          that if specified will block scheduling the pod. If schedulingGates
-                          is not empty, the pod will stay in the SchedulingGated state
-                          and the scheduler will not attempt to schedule the pod.
-                          \n SchedulingGates can only be set at pod creation time,
-                          and be removed only afterwards. \n This is a beta feature
-                          enabled by the PodSchedulingReadiness feature gate."
+                        description: |-
+                          SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
+                          If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
+                          scheduler will not attempt to schedule the pod.
+
+
+                          SchedulingGates can only be set at pod creation time, and be removed only afterwards.
+
+
+                          This is a beta feature enabled by the PodSchedulingReadiness feature gate.
                         items:
                           description: PodSchedulingGate is associated to a Pod to
                             guard its scheduling.
                           properties:
                             name:
-                              description: Name of the scheduling gate. Each scheduling
-                                gate must have a unique name field.
+                              description: |-
+                                Name of the scheduling gate.
+                                Each scheduling gate must have a unique name field.
                               type: string
                           required:
                           - name
@@ -5421,71 +5196,73 @@ spec:
                         - name
                         x-kubernetes-list-type: map
                       securityContext:
-                        description: 'SecurityContext holds pod-level security attributes
-                          and common container settings. Optional: Defaults to empty.  See
-                          type description for default values of each field.'
+                        description: |-
+                          SecurityContext holds pod-level security attributes and common container settings.
+                          Optional: Defaults to empty.  See type description for default values of each field.
                         properties:
                           fsGroup:
-                            description: "A special supplemental group that applies
-                              to all containers in a pod. Some volume types allow
-                              the Kubelet to change the ownership of that volume to
-                              be owned by the pod: \n 1. The owning GID will be the
-                              FSGroup 2. The setgid bit is set (new files created
-                              in the volume will be owned by FSGroup) 3. The permission
-                              bits are OR'd with rw-rw---- \n If unset, the Kubelet
-                              will not modify the ownership and permissions of any
-                              volume. Note that this field cannot be set when spec.os.name
-                              is windows."
+                            description: |-
+                              A special supplemental group that applies to all containers in a pod.
+                              Some volume types allow the Kubelet to change the ownership of that volume
+                              to be owned by the pod:
+
+
+                              1. The owning GID will be the FSGroup
+                              2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                              3. The permission bits are OR'd with rw-rw----
+
+
+                              If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           fsGroupChangePolicy:
-                            description: 'fsGroupChangePolicy defines behavior of
-                              changing ownership and permission of the volume before
-                              being exposed inside Pod. This field will only apply
-                              to volume types which support fsGroup based ownership(and
-                              permissions). It will have no effect on ephemeral volume
-                              types such as: secret, configmaps and emptydir. Valid
-                              values are "OnRootMismatch" and "Always". If not specified,
-                              "Always" is used. Note that this field cannot be set
-                              when spec.os.name is windows.'
+                            description: |-
+                              fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                              before being exposed inside Pod. This field will only apply to
+                              volume types which support fsGroup based ownership(and permissions).
+                              It will have no effect on ephemeral volume types such as: secret, configmaps
+                              and emptydir.
+                              Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           runAsGroup:
-                            description: The GID to run the entrypoint of the container
-                              process. Uses runtime default if unset. May also be
-                              set in SecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence for that container. Note that this
-                              field cannot be set when spec.os.name is windows.
+                            description: |-
+                              The GID to run the entrypoint of the container process.
+                              Uses runtime default if unset.
+                              May also be set in SecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence
+                              for that container.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           runAsNonRoot:
-                            description: Indicates that the container must run as
-                              a non-root user. If true, the Kubelet will validate
-                              the image at runtime to ensure that it does not run
-                              as UID 0 (root) and fail to start the container if it
-                              does. If unset or false, no such validation will be
-                              performed. May also be set in SecurityContext.  If set
-                              in both SecurityContext and PodSecurityContext, the
-                              value specified in SecurityContext takes precedence.
+                            description: |-
+                              Indicates that the container must run as a non-root user.
+                              If true, the Kubelet will validate the image at runtime to ensure that it
+                              does not run as UID 0 (root) and fail to start the container if it does.
+                              If unset or false, no such validation will be performed.
+                              May also be set in SecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: boolean
                           runAsUser:
-                            description: The UID to run the entrypoint of the container
-                              process. Defaults to user specified in image metadata
-                              if unspecified. May also be set in SecurityContext.  If
-                              set in both SecurityContext and PodSecurityContext,
-                              the value specified in SecurityContext takes precedence
-                              for that container. Note that this field cannot be set
-                              when spec.os.name is windows.
+                            description: |-
+                              The UID to run the entrypoint of the container process.
+                              Defaults to user specified in image metadata if unspecified.
+                              May also be set in SecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence
+                              for that container.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           seLinuxOptions:
-                            description: The SELinux context to be applied to all
-                              containers. If unspecified, the container runtime will
-                              allocate a random SELinux context for each container.  May
-                              also be set in SecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence for that container. Note that this
-                              field cannot be set when spec.os.name is windows.
+                            description: |-
+                              The SELinux context to be applied to all containers.
+                              If unspecified, the container runtime will allocate a random SELinux context for each
+                              container.  May also be set in SecurityContext.  If set in
+                              both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               level:
                                 description: Level is SELinux level label that applies
@@ -5505,50 +5282,48 @@ spec:
                                 type: string
                             type: object
                           seccompProfile:
-                            description: The seccomp options to use by the containers
-                              in this pod. Note that this field cannot be set when
-                              spec.os.name is windows.
+                            description: |-
+                              The seccomp options to use by the containers in this pod.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               localhostProfile:
-                                description: localhostProfile indicates a profile
-                                  defined in a file on the node should be used. The
-                                  profile must be preconfigured on the node to work.
-                                  Must be a descending path, relative to the kubelet's
-                                  configured seccomp profile location. Must be set
-                                  if type is "Localhost". Must NOT be set for any
-                                  other type.
+                                description: |-
+                                  localhostProfile indicates a profile defined in a file on the node should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                  Must be set if type is "Localhost". Must NOT be set for any other type.
                                 type: string
                               type:
-                                description: "type indicates which kind of seccomp
-                                  profile will be applied. Valid options are: \n Localhost
-                                  - a profile defined in a file on the node should
-                                  be used. RuntimeDefault - the container runtime
-                                  default profile should be used. Unconfined - no
-                                  profile should be applied."
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied.
+                                  Valid options are:
+
+
+                                  Localhost - a profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile should be used.
+                                  Unconfined - no profile should be applied.
                                 type: string
                             required:
                             - type
                             type: object
                           supplementalGroups:
-                            description: A list of groups applied to the first process
-                              run in each container, in addition to the container's
-                              primary GID, the fsGroup (if specified), and group memberships
-                              defined in the container image for the uid of the container
-                              process. If unspecified, no additional groups are added
-                              to any container. Note that group memberships defined
-                              in the container image for the uid of the container
-                              process are still effective, even if they are not included
-                              in this list. Note that this field cannot be set when
-                              spec.os.name is windows.
+                            description: |-
+                              A list of groups applied to the first process run in each container, in addition
+                              to the container's primary GID, the fsGroup (if specified), and group memberships
+                              defined in the container image for the uid of the container process. If unspecified,
+                              no additional groups are added to any container. Note that group memberships
+                              defined in the container image for the uid of the container process are still effective,
+                              even if they are not included in this list.
+                              Note that this field cannot be set when spec.os.name is windows.
                             items:
                               format: int64
                               type: integer
                             type: array
                           sysctls:
-                            description: Sysctls hold a list of namespaced sysctls
-                              used for the pod. Pods with unsupported sysctls (by
-                              the container runtime) might fail to launch. Note that
-                              this field cannot be set when spec.os.name is windows.
+                            description: |-
+                              Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                              sysctls (by the container runtime) might fail to launch.
+                              Note that this field cannot be set when spec.os.name is windows.
                             items:
                               description: Sysctl defines a kernel parameter to be
                                 set
@@ -5565,170 +5340,158 @@ spec:
                               type: object
                             type: array
                           windowsOptions:
-                            description: The Windows specific settings applied to
-                              all containers. If unspecified, the options within a
-                              container's SecurityContext will be used. If set in
-                              both SecurityContext and PodSecurityContext, the value
-                              specified in SecurityContext takes precedence. Note
-                              that this field cannot be set when spec.os.name is linux.
+                            description: |-
+                              The Windows specific settings applied to all containers.
+                              If unspecified, the options within a container's SecurityContext will be used.
+                              If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is linux.
                             properties:
                               gmsaCredentialSpec:
-                                description: GMSACredentialSpec is where the GMSA
-                                  admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                  inlines the contents of the GMSA credential spec
-                                  named by the GMSACredentialSpecName field.
+                                description: |-
+                                  GMSACredentialSpec is where the GMSA admission webhook
+                                  (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                  GMSA credential spec named by the GMSACredentialSpecName field.
                                 type: string
                               gmsaCredentialSpecName:
                                 description: GMSACredentialSpecName is the name of
                                   the GMSA credential spec to use.
                                 type: string
                               hostProcess:
-                                description: HostProcess determines if a container
-                                  should be run as a 'Host Process' container. All
-                                  of a Pod's containers must have the same effective
-                                  HostProcess value (it is not allowed to have a mix
-                                  of HostProcess containers and non-HostProcess containers).
-                                  In addition, if HostProcess is true then HostNetwork
-                                  must also be set to true.
+                                description: |-
+                                  HostProcess determines if a container should be run as a 'Host Process' container.
+                                  All of a Pod's containers must have the same effective HostProcess value
+                                  (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                  In addition, if HostProcess is true then HostNetwork must also be set to true.
                                 type: boolean
                               runAsUserName:
-                                description: The UserName in Windows to run the entrypoint
-                                  of the container process. Defaults to the user specified
-                                  in image metadata if unspecified. May also be set
-                                  in PodSecurityContext. If set in both SecurityContext
-                                  and PodSecurityContext, the value specified in SecurityContext
-                                  takes precedence.
+                                description: |-
+                                  The UserName in Windows to run the entrypoint of the container process.
+                                  Defaults to the user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: string
                             type: object
                         type: object
                       serviceAccount:
-                        description: 'DeprecatedServiceAccount is a depreciated alias
-                          for ServiceAccountName. Deprecated: Use serviceAccountName
-                          instead.'
+                        description: |-
+                          DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
+                          Deprecated: Use serviceAccountName instead.
                         type: string
                       serviceAccountName:
-                        description: 'ServiceAccountName is the name of the ServiceAccount
-                          to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                        description: |-
+                          ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
                         type: string
                       setHostnameAsFQDN:
-                        description: If true the pod's hostname will be configured
-                          as the pod's FQDN, rather than the leaf name (the default).
-                          In Linux containers, this means setting the FQDN in the
-                          hostname field of the kernel (the nodename field of struct
-                          utsname). In Windows containers, this means setting the
-                          registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters
-                          to FQDN. If a pod does not have FQDN, this has no effect.
+                        description: |-
+                          If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+                          In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
+                          In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN.
+                          If a pod does not have FQDN, this has no effect.
                           Default to false.
                         type: boolean
                       shareProcessNamespace:
-                        description: 'Share a single process namespace between all
-                          of the containers in a pod. When this is set containers
-                          will be able to view and signal processes from other containers
-                          in the same pod, and the first process in each container
-                          will not be assigned PID 1. HostPID and ShareProcessNamespace
-                          cannot both be set. Optional: Default to false.'
+                        description: |-
+                          Share a single process namespace between all of the containers in a pod.
+                          When this is set containers will be able to view and signal processes from other containers
+                          in the same pod, and the first process in each container will not be assigned PID 1.
+                          HostPID and ShareProcessNamespace cannot both be set.
+                          Optional: Default to false.
                         type: boolean
                       subdomain:
-                        description: If specified, the fully qualified Pod hostname
-                          will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
-                          domain>". If not specified, the pod will not have a domainname
-                          at all.
+                        description: |-
+                          If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                          If not specified, the pod will not have a domainname at all.
                         type: string
                       terminationGracePeriodSeconds:
-                        description: Optional duration in seconds the pod needs to
-                          terminate gracefully. May be decreased in delete request.
-                          Value must be non-negative integer. The value zero indicates
-                          stop immediately via the kill signal (no opportunity to
-                          shut down). If this value is nil, the default grace period
-                          will be used instead. The grace period is the duration in
-                          seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are
-                          forcibly halted with a kill signal. Set this value longer
-                          than the expected cleanup time for your process. Defaults
-                          to 30 seconds.
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          If this value is nil, the default grace period will be used instead.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          Defaults to 30 seconds.
                         format: int64
                         type: integer
                       tolerations:
                         description: If specified, the pod's tolerations.
                         items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       topologySpreadConstraints:
-                        description: TopologySpreadConstraints describes how a group
-                          of pods ought to spread across topology domains. Scheduler
-                          will schedule pods in a way which abides by the constraints.
+                        description: |-
+                          TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                          domains. Scheduler will schedule pods in a way which abides by the constraints.
                           All topologySpreadConstraints are ANDed.
                         items:
                           description: TopologySpreadConstraint specifies how to spread
                             matching pods among the given topology.
                           properties:
                             labelSelector:
-                              description: LabelSelector is used to find matching
-                                pods. Pods that match this label selector are counted
-                                to determine the number of pods in their corresponding
-                                topology domain.
+                              description: |-
+                                LabelSelector is used to find matching pods.
+                                Pods that match this label selector are counted to determine the number of pods
+                                in their corresponding topology domain.
                               properties:
                                 matchExpressions:
                                   description: matchExpressions is a list of label
                                     selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
                                         description: key is the label key that the
                                           selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -5740,139 +5503,134 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: "MatchLabelKeys is a set of pod label keys
-                                to select the pods over which spreading will be calculated.
-                                The keys are used to lookup values from the incoming
-                                pod labels, those key-value labels are ANDed with
-                                labelSelector to select the group of existing pods
-                                over which spreading will be calculated for the incoming
-                                pod. The same key is forbidden to exist in both MatchLabelKeys
-                                and LabelSelector. MatchLabelKeys cannot be set when
-                                LabelSelector isn't set. Keys that don't exist in
-                                the incoming pod labels will be ignored. A null or
-                                empty list means only match against labelSelector.
-                                \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread
-                                feature gate to be enabled (enabled by default)."
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select the pods over which
+                                spreading will be calculated. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are ANDed with labelSelector
+                                to select the group of existing pods over which spreading will be calculated
+                                for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                Keys that don't exist in the incoming pod labels will
+                                be ignored. A null or empty list means only match against labelSelector.
+
+
+                                This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             maxSkew:
-                              description: 'MaxSkew describes the degree to which
-                                pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
-                                it is the maximum permitted difference between the
-                                number of matching pods in the target topology and
-                                the global minimum. The global minimum is the minimum
-                                number of matching pods in an eligible domain or zero
-                                if the number of eligible domains is less than MinDomains.
-                                For example, in a 3-zone cluster, MaxSkew is set to
-                                1, and pods with the same labelSelector spread as
-                                2/2/1: In this case, the global minimum is 1. | zone1
-                                | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
-                                is 1, incoming pod can only be scheduled to zone3
-                                to become 2/2/2; scheduling it onto zone1(zone2) would
-                                make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1).
-                                - if MaxSkew is 2, incoming pod can be scheduled onto
-                                any zone. When `whenUnsatisfiable=ScheduleAnyway`,
-                                it is used to give higher precedence to topologies
-                                that satisfy it. It''s a required field. Default value
-                                is 1 and 0 is not allowed.'
+                              description: |-
+                                MaxSkew describes the degree to which pods may be unevenly distributed.
+                                When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                between the number of matching pods in the target topology and the global minimum.
+                                The global minimum is the minimum number of matching pods in an eligible domain
+                                or zero if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 2/2/1:
+                                In this case, the global minimum is 1.
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |   P   |
+                                - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                to topologies that satisfy it.
+                                It's a required field. Default value is 1 and 0 is not allowed.
                               format: int32
                               type: integer
                             minDomains:
-                              description: "MinDomains indicates a minimum number
-                                of eligible domains. When the number of eligible domains
-                                with matching topology keys is less than minDomains,
-                                Pod Topology Spread treats \"global minimum\" as 0,
-                                and then the calculation of Skew is performed. And
-                                when the number of eligible domains with matching
-                                topology keys equals or greater than minDomains, this
-                                value has no effect on scheduling. As a result, when
-                                the number of eligible domains is less than minDomains,
-                                scheduler won't schedule more than maxSkew Pods to
-                                those domains. If value is nil, the constraint behaves
-                                as if MinDomains is equal to 1. Valid values are integers
-                                greater than 0. When value is not nil, WhenUnsatisfiable
-                                must be DoNotSchedule. \n For example, in a 3-zone
-                                cluster, MaxSkew is set to 2, MinDomains is set to
-                                5 and pods with the same labelSelector spread as 2/2/2:
-                                | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  |
-                                The number of domains is less than 5(MinDomains),
-                                so \"global minimum\" is treated as 0. In this situation,
-                                new pod with the same labelSelector cannot be scheduled,
-                                because computed skew will be 3(3 - 0) if new Pod
-                                is scheduled to any of the three zones, it will violate
-                                MaxSkew. \n This is a beta field and requires the
-                                MinDomainsInPodTopologySpread feature gate to be enabled
-                                (enabled by default)."
+                              description: |-
+                                MinDomains indicates a minimum number of eligible domains.
+                                When the number of eligible domains with matching topology keys is less than minDomains,
+                                Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                this value has no effect on scheduling.
+                                As a result, when the number of eligible domains is less than minDomains,
+                                scheduler won't schedule more than maxSkew Pods to those domains.
+                                If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                Valid values are integers greater than 0.
+                                When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+
+                                For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                labelSelector spread as 2/2/2:
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |  P P  |
+                                The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                In this situation, new pod with the same labelSelector cannot be scheduled,
+                                because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                it will violate MaxSkew.
+
+
+                                This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
                               format: int32
                               type: integer
                             nodeAffinityPolicy:
-                              description: "NodeAffinityPolicy indicates how we will
-                                treat Pod's nodeAffinity/nodeSelector when calculating
-                                pod topology spread skew. Options are: - Honor: only
-                                nodes matching nodeAffinity/nodeSelector are included
-                                in the calculations. - Ignore: nodeAffinity/nodeSelector
-                                are ignored. All nodes are included in the calculations.
-                                \n If this value is nil, the behavior is equivalent
-                                to the Honor policy. This is a beta-level feature
-                                default enabled by the NodeInclusionPolicyInPodTopologySpread
-                                feature flag."
+                              description: |-
+                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                when calculating pod topology spread skew. Options are:
+                                - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+
+                                If this value is nil, the behavior is equivalent to the Honor policy.
+                                This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                               type: string
                             nodeTaintsPolicy:
-                              description: "NodeTaintsPolicy indicates how we will
-                                treat node taints when calculating pod topology spread
-                                skew. Options are: - Honor: nodes without taints,
-                                along with tainted nodes for which the incoming pod
-                                has a toleration, are included. - Ignore: node taints
-                                are ignored. All nodes are included. \n If this value
-                                is nil, the behavior is equivalent to the Ignore policy.
-                                This is a beta-level feature default enabled by the
-                                NodeInclusionPolicyInPodTopologySpread feature flag."
+                              description: |-
+                                NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                pod topology spread skew. Options are:
+                                - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                has a toleration, are included.
+                                - Ignore: node taints are ignored. All nodes are included.
+
+
+                                If this value is nil, the behavior is equivalent to the Ignore policy.
+                                This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                               type: string
                             topologyKey:
-                              description: TopologyKey is the key of node labels.
-                                Nodes that have a label with this key and identical
-                                values are considered to be in the same topology.
-                                We consider each <key, value> as a "bucket", and try
-                                to put balanced number of pods into each bucket. We
-                                define a domain as a particular instance of a topology.
-                                Also, we define an eligible domain as a domain whose
-                                nodes meet the requirements of nodeAffinityPolicy
-                                and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
-                                each Node is a domain of that topology. And, if TopologyKey
-                                is "topology.kubernetes.io/zone", each zone is a domain
-                                of that topology. It's a required field.
+                              description: |-
+                                TopologyKey is the key of node labels. Nodes that have a label with this key
+                                and identical values are considered to be in the same topology.
+                                We consider each <key, value> as a "bucket", and try to put balanced number
+                                of pods into each bucket.
+                                We define a domain as a particular instance of a topology.
+                                Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                nodeAffinityPolicy and nodeTaintsPolicy.
+                                e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                It's a required field.
                               type: string
                             whenUnsatisfiable:
-                              description: 'WhenUnsatisfiable indicates how to deal
-                                with a pod if it doesn''t satisfy the spread constraint.
-                                - DoNotSchedule (default) tells the scheduler not
-                                to schedule it. - ScheduleAnyway tells the scheduler
-                                to schedule the pod in any location, but giving higher
-                                precedence to topologies that would help reduce the
-                                skew. A constraint is considered "Unsatisfiable" for
-                                an incoming pod if and only if every possible node
-                                assignment for that pod would violate "MaxSkew" on
-                                some topology. For example, in a 3-zone cluster, MaxSkew
-                                is set to 1, and pods with the same labelSelector
-                                spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P
-                                |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule,
-                                incoming pod can only be scheduled to zone2(zone3)
-                                to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3)
-                                satisfies MaxSkew(1). In other words, the cluster
-                                can still be imbalanced, but scheduler won''t make
-                                it *more* imbalanced. It''s a required field.'
+                              description: |-
+                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                the spread constraint.
+                                - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                  but giving higher precedence to topologies that would help reduce the
+                                  skew.
+                                A constraint is considered "Unsatisfiable" for an incoming pod
+                                if and only if every possible node assignment for that pod would violate
+                                "MaxSkew" on some topology.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 3/1/1:
+                                | zone1 | zone2 | zone3 |
+                                | P P P |   P   |   P   |
+                                If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                won't make it *more* imbalanced.
+                                It's a required field.
                               type: string
                           required:
                           - maxSkew
@@ -5885,44 +5643,44 @@ spec:
                         - whenUnsatisfiable
                         x-kubernetes-list-type: map
                       volumes:
-                        description: 'List of volumes that can be mounted by containers
-                          belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                        description: |-
+                          List of volumes that can be mounted by containers belonging to the pod.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes
                         items:
                           description: Volume represents a named volume in a pod that
                             may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: 'awsElasticBlockStore represents an AWS
-                                Disk resource that is attached to a kubelet''s host
-                                machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              description: |-
+                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type of the
-                                    volume that you want to mount. Tip: Ensure that
-                                    the filesystem type is supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: 'partition is the partition in the
-                                    volume that you want to mount. If omitted, the
-                                    default is to mount by volume name. Examples:
-                                    For volume /dev/sda1, you specify the partition
-                                    as "1". Similarly, the volume partition for /dev/sda
-                                    is "0" (or you can leave the property empty).'
+                                  description: |-
+                                    partition is the partition in the volume that you want to mount.
+                                    If omitted, the default is to mount by volume name.
+                                    Examples: For volume /dev/sda1, you specify the partition as "1".
+                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'readOnly value true will force the
-                                    readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: |-
+                                    readOnly value true will force the readOnly setting in VolumeMounts.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: 'volumeID is unique ID of the persistent
-                                    disk resource in AWS (Amazon EBS volume). More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: |-
+                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
@@ -5944,10 +5702,10 @@ spec:
                                     the blob storage
                                   type: string
                                 fsType:
-                                  description: fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is Filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
                                   description: 'kind expected values are Shared: multiple
@@ -5957,9 +5715,9 @@ spec:
                                     set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: readOnly Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
@@ -5970,9 +5728,9 @@ spec:
                                 mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
                                   description: secretName is the  name of secret that
@@ -5990,8 +5748,9 @@ spec:
                                 host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: 'monitors is Required: Monitors is
-                                    a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    monitors is Required: Monitors is a collection of Ceph monitors
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
@@ -6001,67 +5760,72 @@ spec:
                                     is /'
                                   type: string
                                 readOnly:
-                                  description: 'readOnly is Optional: Defaults to
-                                    false (read/write). ReadOnly here will force the
-                                    ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: 'secretFile is Optional: SecretFile
-                                    is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: 'secretRef is Optional: SecretRef is
-                                    reference to the authentication secret for User,
-                                    default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: 'user is optional: User is the rados
-                                    user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    user is optional: User is the rados user name, default is admin
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: 'cinder represents a cinder volume attached
-                                and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              description: |-
+                                cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Examples: "ext4", "xfs", "ntfs".
-                                    Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: 'readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: 'secretRef is optional: points to a
-                                    secret object containing parameters used to connect
-                                    to OpenStack.'
+                                  description: |-
+                                    secretRef is optional: points to a secret object containing parameters used to connect
+                                    to OpenStack.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: 'volumeID used to identify the volume
-                                    in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: |-
+                                    volumeID used to identify the volume in cinder.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
@@ -6071,30 +5835,25 @@ spec:
                                 populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'defaultMode is optional: mode bits
-                                    used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Defaults to 0644. Directories
-                                    within the path are not affected by this setting.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
+                                  description: |-
+                                    defaultMode is optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: items if unspecified, each key-value
-                                    pair in the Data field of the referenced ConfigMap
-                                    will be projected into the volume as a file whose
-                                    name is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the ConfigMap, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
+                                  description: |-
+                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                    ConfigMap will be projected into the volume as a file whose name is the
+                                    key and content is the value. If specified, the listed keys will be
+                                    projected into the specified paths, and unlisted keys will not be
+                                    present. If a key is specified which is not present in the ConfigMap,
+                                    the volume setup will error unless it is marked optional. Paths must be
+                                    relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within
                                       a volume.
@@ -6103,25 +5862,21 @@ spec:
                                         description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'mode is Optional: mode bits
-                                          used to set permissions on this file. Must
-                                          be an octal value between 0000 and 0777
-                                          or a decimal value between 0 and 511. YAML
-                                          accepts both octal and decimal values, JSON
-                                          requires decimal values for mode bits. If
-                                          not specified, the volume defaultMode will
-                                          be used. This might be in conflict with
-                                          other options that affect the file mode,
-                                          like fsGroup, and the result can be other
-                                          mode bits set.'
+                                        description: |-
+                                          mode is Optional: mode bits used to set permissions on this file.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: path is the relative path of
-                                          the file to map the key to. May not be an
-                                          absolute path. May not contain the path
-                                          element '..'. May not start with the string
-                                          '..'.
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
+                                          May not contain the path element '..'.
+                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -6129,9 +5884,10 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description: optional specify whether the ConfigMap
@@ -6145,45 +5901,43 @@ spec:
                                 CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: driver is the name of the CSI driver
-                                    that handles this volume. Consult with your admin
-                                    for the correct name as registered in the cluster.
+                                  description: |-
+                                    driver is the name of the CSI driver that handles this volume.
+                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: fsType to mount. Ex. "ext4", "xfs",
-                                    "ntfs". If not provided, the empty value is passed
-                                    to the associated CSI driver which will determine
-                                    the default filesystem to apply.
+                                  description: |-
+                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                    If not provided, the empty value is passed to the associated CSI driver
+                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: nodePublishSecretRef is a reference
-                                    to the secret object containing sensitive information
-                                    to pass to the CSI driver to complete the CSI
+                                  description: |-
+                                    nodePublishSecretRef is a reference to the secret object containing
+                                    sensitive information to pass to the CSI driver to complete the CSI
                                     NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no
-                                    secret is required. If the secret object contains
-                                    more than one secret, all secret references are
-                                    passed.
+                                    This field is optional, and  may be empty if no secret is required. If the
+                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: readOnly specifies a read-only configuration
-                                    for the volume. Defaults to false (read/write).
+                                  description: |-
+                                    readOnly specifies a read-only configuration for the volume.
+                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: volumeAttributes stores driver-specific
-                                    properties that are passed to the CSI driver.
-                                    Consult your driver's documentation for supported
-                                    values.
+                                  description: |-
+                                    volumeAttributes stores driver-specific properties that are passed to the CSI
+                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
@@ -6193,17 +5947,15 @@ spec:
                                 the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits to use on created
-                                    files by default. Must be a Optional: mode bits
-                                    used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Defaults to 0644. Directories
-                                    within the path are not affected by this setting.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
+                                  description: |-
+                                    Optional: mode bits to use on created files by default. Must be a
+                                    Optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
@@ -6233,16 +5985,13 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on this file, must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. If not specified,
-                                          the volume defaultMode will be used. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: |-
+                                          Optional: mode bits used to set permissions on this file, must be an octal value
+                                          between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
@@ -6253,10 +6002,9 @@ spec:
                                           the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, requests.cpu and requests.memory)
-                                          are currently supported.'
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
                                             description: 'Container name: required
@@ -6284,82 +6032,94 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: 'emptyDir represents a temporary directory
-                                that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              description: |-
+                                emptyDir represents a temporary directory that shares a pod's lifetime.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: 'medium represents what type of storage
-                                    medium should back this directory. The default
-                                    is "" which means to use the node''s default medium.
-                                    Must be an empty string (default) or Memory. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: |-
+                                    medium represents what type of storage medium should back this directory.
+                                    The default is "" which means to use the node's default medium.
+                                    Must be an empty string (default) or Memory.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'sizeLimit is the total amount of local
-                                    storage required for this EmptyDir volume. The
-                                    size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would
-                                    be the minimum value between the SizeLimit specified
-                                    here and the sum of memory limits of all containers
-                                    in a pod. The default is nil which means that
-                                    the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: |-
+                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                    The size limit is also applicable for memory medium.
+                                    The maximum usage on memory medium EmptyDir would be the minimum value between
+                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                    The default is nil which means that the limit is undefined.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: "ephemeral represents a volume that is
-                                handled by a cluster storage driver. The volume's
-                                lifecycle is tied to the pod that defines it - it
-                                will be created before the pod starts, and deleted
-                                when the pod is removed. \n Use this if: a) the volume
-                                is only needed while the pod runs, b) features of
-                                normal volumes like restoring from snapshot or capacity
-                                tracking are needed, c) the storage driver is specified
-                                through a storage class, and d) the storage driver
-                                supports dynamic volume provisioning through a PersistentVolumeClaim
-                                (see EphemeralVolumeSource for more information on
-                                the connection between this volume type and PersistentVolumeClaim).
-                                \n Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the
-                                lifecycle of an individual pod. \n Use CSI for light-weight
-                                local ephemeral volumes if the CSI driver is meant
-                                to be used that way - see the documentation of the
-                                driver for more information. \n A pod can use both
-                                types of ephemeral volumes and persistent volumes
-                                at the same time."
+                              description: |-
+                                ephemeral represents a volume that is handled by a cluster storage driver.
+                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                and deleted when the pod is removed.
+
+
+                                Use this if:
+                                a) the volume is only needed while the pod runs,
+                                b) features of normal volumes like restoring from snapshot or capacity
+                                   tracking are needed,
+                                c) the storage driver is specified through a storage class, and
+                                d) the storage driver supports dynamic volume provisioning through
+                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                   information on the connection between this volume type
+                                   and PersistentVolumeClaim).
+
+
+                                Use PersistentVolumeClaim or one of the vendor-specific
+                                APIs for volumes that persist for longer than the lifecycle
+                                of an individual pod.
+
+
+                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                be used that way - see the documentation of the driver for
+                                more information.
+
+
+                                A pod can use both types of ephemeral volumes and
+                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: "Will be used to create a stand-alone
-                                    PVC to provision the volume. The pod in which
-                                    this EphemeralVolumeSource is embedded will be
-                                    the owner of the PVC, i.e. the PVC will be deleted
-                                    together with the pod.  The name of the PVC will
-                                    be `<pod name>-<volume name>` where `<volume name>`
-                                    is the name from the `PodSpec.Volumes` array entry.
-                                    Pod validation will reject the pod if the concatenated
-                                    name is not valid for a PVC (for example, too
-                                    long). \n An existing PVC with that name that
-                                    is not owned by the pod will *not* be used for
-                                    the pod to avoid using an unrelated volume by
-                                    mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created
-                                    PVC is meant to be used by the pod, the PVC has
-                                    to updated with an owner reference to the pod
-                                    once the pod exists. Normally this should not
-                                    be necessary, but it may be useful when manually
-                                    reconstructing a broken cluster. \n This field
-                                    is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created. \n Required,
-                                    must not be nil."
+                                  description: |-
+                                    Will be used to create a stand-alone PVC to provision the volume.
+                                    The pod in which this EphemeralVolumeSource is embedded will be the
+                                    owner of the PVC, i.e. the PVC will be deleted together with the
+                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                    `<volume name>` is the name from the `PodSpec.Volumes` array
+                                    entry. Pod validation will reject the pod if the concatenated name
+                                    is not valid for a PVC (for example, too long).
+
+
+                                    An existing PVC with that name that is not owned by the pod
+                                    will *not* be used for the pod to avoid using an unrelated
+                                    volume by mistake. Starting the pod is then blocked until
+                                    the unrelated PVC is removed. If such a pre-created PVC is
+                                    meant to be used by the pod, the PVC has to updated with an
+                                    owner reference to the pod once the pod exists. Normally
+                                    this should not be necessary, but it may be useful when
+                                    manually reconstructing a broken cluster.
+
+
+                                    This field is read-only and no changes will be made by Kubernetes
+                                    to the PVC after it has been created.
+
+
+                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: May contain labels and annotations
-                                        that will be copied into the PVC when creating
-                                        it. No other fields are allowed and will be
-                                        rejected during validation.
+                                      description: |-
+                                        May contain labels and annotations that will be copied into the PVC
+                                        when creating it. No other fields are allowed and will be rejected during
+                                        validation.
                                       properties:
                                         annotations:
                                           additionalProperties:
@@ -6379,43 +6139,35 @@ spec:
                                           type: string
                                       type: object
                                     spec:
-                                      description: The specification for the PersistentVolumeClaim.
-                                        The entire content is copied unchanged into
-                                        the PVC that gets created from this template.
-                                        The same fields as in a PersistentVolumeClaim
+                                      description: |-
+                                        The specification for the PersistentVolumeClaim. The entire content is
+                                        copied unchanged into the PVC that gets created from this
+                                        template. The same fields as in a PersistentVolumeClaim
                                         are also valid here.
                                       properties:
                                         accessModes:
-                                          description: 'accessModes contains the desired
-                                            access modes the volume should have. More
-                                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                          description: |-
+                                            accessModes contains the desired access modes the volume should have.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: 'dataSource field can be used
-                                            to specify either: * An existing VolumeSnapshot
-                                            object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          description: |-
+                                            dataSource field can be used to specify either:
+                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                             * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller
-                                            can support the specified data source,
-                                            it will create a new volume based on the
-                                            contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate
-                                            is enabled, dataSource contents will be
-                                            copied to dataSourceRef, and dataSourceRef
-                                            contents will be copied to dataSource
-                                            when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef
-                                            will not be copied to dataSource.'
+                                            If the provisioner or an external controller can support the specified data source,
+                                            it will create a new volume based on the contents of the specified data source.
+                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                           properties:
                                             apiGroup:
-                                              description: APIGroup is the group for
-                                                the resource being referenced. If
-                                                APIGroup is not specified, the specified
-                                                Kind must be in the core API group.
-                                                For any other third-party types, APIGroup
-                                                is required.
+                                              description: |-
+                                                APIGroup is the group for the resource being referenced.
+                                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
                                               description: Kind is the type of resource
@@ -6431,50 +6183,36 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: 'dataSourceRef specifies the
-                                            object from which to populate the volume
-                                            with data, if a non-empty volume is desired.
-                                            This may be any object from a non-empty
-                                            API group (non core object) or a PersistentVolumeClaim
-                                            object. When this field is specified,
-                                            volume binding will only succeed if the
-                                            type of the specified object matches some
-                                            installed volume populator or dynamic
-                                            provisioner. This field will replace the
-                                            functionality of the dataSource field
-                                            and as such if both fields are non-empty,
-                                            they must have the same value. For backwards
-                                            compatibility, when namespace isn''t specified
-                                            in dataSourceRef, both fields (dataSource
-                                            and dataSourceRef) will be set to the
-                                            same value automatically if one of them
-                                            is empty and the other is non-empty. When
-                                            namespace is specified in dataSourceRef,
-                                            dataSource isn''t set to the same value
-                                            and must be empty. There are three important
-                                            differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific
-                                            types of objects, dataSourceRef allows
-                                            any non-core object, as well as PersistentVolumeClaim
-                                            objects. * While dataSource ignores disallowed
-                                            values (dropping them), dataSourceRef
-                                            preserves all values, and generates an
-                                            error if a disallowed value is specified.
-                                            * While dataSource only allows local objects,
-                                            dataSourceRef allows objects in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource
-                                            feature gate to be enabled. (Alpha) Using
-                                            the namespace field of dataSourceRef requires
-                                            the CrossNamespaceVolumeDataSource feature
-                                            gate to be enabled.'
+                                          description: |-
+                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                            volume is desired. This may be any object from a non-empty API group (non
+                                            core object) or a PersistentVolumeClaim object.
+                                            When this field is specified, volume binding will only succeed if the type of
+                                            the specified object matches some installed volume populator or dynamic
+                                            provisioner.
+                                            This field will replace the functionality of the dataSource field and as such
+                                            if both fields are non-empty, they must have the same value. For backwards
+                                            compatibility, when namespace isn't specified in dataSourceRef,
+                                            both fields (dataSource and dataSourceRef) will be set to the same
+                                            value automatically if one of them is empty and the other is non-empty.
+                                            When namespace is specified in dataSourceRef,
+                                            dataSource isn't set to the same value and must be empty.
+                                            There are three important differences between dataSource and dataSourceRef:
+                                            * While dataSource only allows two specific types of objects, dataSourceRef
+                                              allows any non-core object, as well as PersistentVolumeClaim objects.
+                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                              preserves all values, and generates an error if a disallowed value is
+                                              specified.
+                                            * While dataSource only allows local objects, dataSourceRef allows objects
+                                              in any namespaces.
+                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                           properties:
                                             apiGroup:
-                                              description: APIGroup is the group for
-                                                the resource being referenced. If
-                                                APIGroup is not specified, the specified
-                                                Kind must be in the core API group.
-                                                For any other third-party types, APIGroup
-                                                is required.
+                                              description: |-
+                                                APIGroup is the group for the resource being referenced.
+                                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
                                               description: Kind is the type of resource
@@ -6485,50 +6223,43 @@ spec:
                                                 being referenced
                                               type: string
                                             namespace:
-                                              description: Namespace is the namespace
-                                                of resource being referenced Note
-                                                that when a namespace is specified,
-                                                a gateway.networking.k8s.io/ReferenceGrant
-                                                object is required in the referent
-                                                namespace to allow that namespace's
-                                                owner to accept the reference. See
-                                                the ReferenceGrant documentation for
-                                                details. (Alpha) This field requires
-                                                the CrossNamespaceVolumeDataSource
-                                                feature gate to be enabled.
+                                              description: |-
+                                                Namespace is the namespace of resource being referenced
+                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: 'resources represents the minimum
-                                            resources the volume should have. If RecoverVolumeExpansionFailure
-                                            feature is enabled users are allowed to
-                                            specify resource requirements that are
-                                            lower than previous value but must still
-                                            be higher than capacity recorded in the
-                                            status field of the claim. More info:
-                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                          description: |-
+                                            resources represents the minimum resources the volume should have.
+                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                            that are lower than previous value but must still be higher than capacity recorded in the
+                                            status field of the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                           properties:
                                             claims:
-                                              description: "Claims lists the names
-                                                of resources, defined in spec.resourceClaims,
-                                                that are used by this container. \n
-                                                This is an alpha field and requires
-                                                enabling the DynamicResourceAllocation
-                                                feature gate. \n This field is immutable.
-                                                It can only be set for containers."
+                                              description: |-
+                                                Claims lists the names of resources, defined in spec.resourceClaims,
+                                                that are used by this container.
+
+
+                                                This is an alpha field and requires enabling the
+                                                DynamicResourceAllocation feature gate.
+
+
+                                                This field is immutable. It can only be set for containers.
                                               items:
                                                 description: ResourceClaim references
                                                   one entry in PodSpec.ResourceClaims.
                                                 properties:
                                                   name:
-                                                    description: Name must match the
-                                                      name of one entry in pod.spec.resourceClaims
-                                                      of the Pod where this field
-                                                      is used. It makes that resource
-                                                      available inside a container.
+                                                    description: |-
+                                                      Name must match the name of one entry in pod.spec.resourceClaims of
+                                                      the Pod where this field is used. It makes that resource available
+                                                      inside a container.
                                                     type: string
                                                 required:
                                                 - name
@@ -6544,9 +6275,9 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: 'Limits describes the maximum
-                                                amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              description: |-
+                                                Limits describes the maximum amount of compute resources allowed.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -6555,14 +6286,11 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: 'Requests describes the
-                                                minimum amount of compute resources
-                                                required. If Requests is omitted for
-                                                a container, it defaults to Limits
-                                                if that is explicitly specified, otherwise
-                                                to an implementation-defined value.
-                                                Requests cannot exceed Limits. More
-                                                info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              description: |-
+                                                Requests describes the minimum amount of compute resources required.
+                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                           type: object
                                         selector:
@@ -6574,10 +6302,9 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -6585,20 +6312,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -6610,27 +6333,22 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: 'storageClassName is the name
-                                            of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          description: |-
+                                            storageClassName is the name of the StorageClass required by the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeMode:
-                                          description: volumeMode defines what type
-                                            of volume is required by the claim. Value
-                                            of Filesystem is implied when not included
-                                            in claim spec.
+                                          description: |-
+                                            volumeMode defines what type of volume is required by the claim.
+                                            Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
                                           description: volumeName is the binding reference
@@ -6647,21 +6365,20 @@ spec:
                                 exposed to the pod.
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. TODO: how
-                                    do we prevent errors in the filesystem from compromising
-                                    the machine'
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 lun:
                                   description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'readOnly is Optional: Defaults to
-                                    false (read/write). ReadOnly here will force the
-                                    ReadOnly setting in VolumeMounts.'
+                                  description: |-
+                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
                                   description: 'targetWWNs is Optional: FC target
@@ -6670,28 +6387,27 @@ spec:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: 'wwids Optional: FC volume world wide
-                                    identifiers (wwids) Either wwids or combination
-                                    of targetWWNs and lun must be set, but not both
-                                    simultaneously.'
+                                  description: |-
+                                    wwids Optional: FC volume world wide identifiers (wwids)
+                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: flexVolume represents a generic volume
-                                resource that is provisioned/attached using an exec
-                                based plugin.
+                              description: |-
+                                flexVolume represents a generic volume resource that is
+                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
                                   description: driver is the name of the driver to
                                     use for this volume.
                                   type: string
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". The
-                                    default filesystem depends on FlexVolume script.
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
@@ -6700,23 +6416,23 @@ spec:
                                     extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: 'readOnly is Optional: defaults to
-                                    false (read/write). ReadOnly here will force the
-                                    ReadOnly setting in VolumeMounts.'
+                                  description: |-
+                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: 'secretRef is Optional: secretRef is
-                                    reference to the secret object containing sensitive
-                                    information to pass to the plugin scripts. This
-                                    may be empty if no secret object is specified.
-                                    If the secret object contains more than one secret,
-                                    all secrets are passed to the plugin scripts.'
+                                  description: |-
+                                    secretRef is Optional: secretRef is reference to the secret object containing
+                                    sensitive information to pass to the plugin scripts. This may be
+                                    empty if no secret object is specified. If the secret object
+                                    contains more than one secret, all secrets are passed to the plugin
+                                    scripts.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -6729,9 +6445,9 @@ spec:
                                 control service being running
                               properties:
                                 datasetName:
-                                  description: datasetName is Name of the dataset
-                                    stored as metadata -> name on the dataset for
-                                    Flocker should be considered as deprecated
+                                  description: |-
+                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
                                   description: datasetUUID is the UUID of the dataset.
@@ -6739,57 +6455,55 @@ spec:
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: 'gcePersistentDisk represents a GCE Disk
-                                resource that is attached to a kubelet''s host machine
-                                and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              description: |-
+                                gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: 'fsType is filesystem type of the volume
-                                    that you want to mount. Tip: Ensure that the filesystem
-                                    type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
-                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: 'partition is the partition in the
-                                    volume that you want to mount. If omitted, the
-                                    default is to mount by volume name. Examples:
-                                    For volume /dev/sda1, you specify the partition
-                                    as "1". Similarly, the volume partition for /dev/sda
-                                    is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: |-
+                                    partition is the partition in the volume that you want to mount.
+                                    If omitted, the default is to mount by volume name.
+                                    Examples: For volume /dev/sda1, you specify the partition as "1".
+                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: 'pdName is unique name of the PD resource
-                                    in GCE. Used to identify the disk in GCE. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: |-
+                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the ReadOnly
-                                    setting in VolumeMounts. Defaults to false. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: 'gitRepo represents a git repository at
-                                a particular revision. DEPRECATED: GitRepo is deprecated.
-                                To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo
-                                using git, then mount the EmptyDir into the Pod''s
-                                container.'
+                              description: |-
+                                gitRepo represents a git repository at a particular revision.
+                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is
-                                    supplied, the volume directory will be the git
-                                    repository.  Otherwise, if specified, the volume
-                                    will contain the git repository in the subdirectory
-                                    with the given name.
+                                  description: |-
+                                    directory is the target directory name.
+                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                    the subdirectory with the given name.
                                   type: string
                                 repository:
                                   description: repository is the URL
@@ -6802,54 +6516,61 @@ spec:
                               - repository
                               type: object
                             glusterfs:
-                              description: 'glusterfs represents a Glusterfs mount
-                                on the host that shares a pod''s lifetime. More info:
-                                https://examples.k8s.io/volumes/glusterfs/README.md'
+                              description: |-
+                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: 'endpoints is the endpoint name that
-                                    details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: |-
+                                    endpoints is the endpoint name that details Glusterfs topology.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 path:
-                                  description: 'path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: |-
+                                    path is the Glusterfs volume path.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the Glusterfs
-                                    volume to be mounted with read-only permissions.
-                                    Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: |-
+                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: 'hostPath represents a pre-existing file
-                                or directory on the host machine that is directly
-                                exposed to the container. This is generally used for
-                                system agents or other privileged things that are
-                                allowed to see the host machine. Most containers will
-                                NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                --- TODO(jonesdl) We need to restrict who can use
-                                host directory mounts and who can/can not mount host
-                                directories as read/write.'
+                              description: |-
+                                hostPath represents a pre-existing file or directory on the host
+                                machine that is directly exposed to the container. This is generally
+                                used for system agents or other privileged things that are allowed
+                                to see the host machine. Most containers will NOT need this.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                ---
+                                TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
+                                mount host directories as read/write.
                               properties:
                                 path:
-                                  description: 'path of the directory on the host.
-                                    If the path is a symlink, it will follow the link
-                                    to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: |-
+                                    path of the directory on the host.
+                                    If the path is a symlink, it will follow the link to the real path.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: 'type for HostPath Volume Defaults
-                                    to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: |-
+                                    type for HostPath Volume
+                                    Defaults to ""
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: 'iscsi represents an ISCSI Disk resource
-                                that is attached to a kubelet''s host machine and
-                                then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              description: |-
+                                iscsi represents an ISCSI Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
                                   description: chapAuthDiscovery defines whether support
@@ -6860,62 +6581,59 @@ spec:
                                     iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: 'fsType is the filesystem type of the
-                                    volume that you want to mount. Tip: Ensure that
-                                    the filesystem type is supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 initiatorName:
-                                  description: initiatorName is the custom iSCSI Initiator
-                                    Name. If initiatorName is specified with iscsiInterface
-                                    simultaneously, new iSCSI interface <target portal>:<volume
-                                    name> will be created for the connection.
+                                  description: |-
+                                    initiatorName is the custom iSCSI Initiator Name.
+                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
                                   description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: iscsiInterface is the interface Name
-                                    that uses an iSCSI transport. Defaults to 'default'
-                                    (tcp).
+                                  description: |-
+                                    iscsiInterface is the interface Name that uses an iSCSI transport.
+                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
                                   description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: portals is the iSCSI Target Portal
-                                    List. The portal is either an IP or ip_addr:port
-                                    if the port is other than default (typically TCP
-                                    ports 860 and 3260).
+                                  description: |-
+                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: readOnly here will force the ReadOnly
-                                    setting in VolumeMounts. Defaults to false.
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
                                   type: boolean
                                 secretRef:
                                   description: secretRef is the CHAP Secret for iSCSI
                                     target and initiator authentication
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: targetPortal is iSCSI Target Portal.
-                                    The Portal is either an IP or ip_addr:port if
-                                    the port is other than default (typically TCP
-                                    ports 860 and 3260).
+                                  description: |-
+                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -6923,43 +6641,51 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: 'name of the volume. Must be a DNS_LABEL
-                                and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              description: |-
+                                name of the volume.
+                                Must be a DNS_LABEL and unique within the pod.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             nfs:
-                              description: 'nfs represents an NFS mount on the host
-                                that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: 'path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the NFS export
-                                    to be mounted with read-only permissions. Defaults
-                                    to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: 'server is the hostname or IP address
-                                    of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: 'persistentVolumeClaimVolumeSource represents
-                                a reference to a PersistentVolumeClaim in the same
-                                namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              description: |-
+                                persistentVolumeClaimVolumeSource represents a reference to a
+                                PersistentVolumeClaim in the same namespace.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: 'claimName is the name of a PersistentVolumeClaim
-                                    in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: |-
+                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: readOnly Will force the ReadOnly setting
-                                    in VolumeMounts. Default false.
+                                  description: |-
+                                    readOnly Will force the ReadOnly setting in VolumeMounts.
+                                    Default false.
                                   type: boolean
                               required:
                               - claimName
@@ -6970,10 +6696,10 @@ spec:
                                 machine
                               properties:
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
                                   description: pdID is the ID that identifies Photon
@@ -6987,15 +6713,15 @@ spec:
                                 attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: fSType represents the filesystem type
-                                    to mount Must be a filesystem type supported by
-                                    the host operating system. Ex. "ext4", "xfs".
-                                    Implicitly inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fSType represents the filesystem type to mount
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
                                   description: volumeID uniquely identifies a Portworx
@@ -7009,16 +6735,13 @@ spec:
                                 secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: defaultMode are the mode bits used
-                                    to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Directories within the path
-                                    are not affected by this setting. This might be
-                                    in conflict with other options that affect the
-                                    file mode, like fsGroup, and the result can be
-                                    other mode bits set.
+                                  description: |-
+                                    defaultMode are the mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
@@ -7032,19 +6755,14 @@ spec:
                                           configMap data to project
                                         properties:
                                           items:
-                                            description: items if unspecified, each
-                                              key-value pair in the Data field of
-                                              the referenced ConfigMap will be projected
-                                              into the volume as a file whose name
-                                              is the key and content is the value.
-                                              If specified, the listed keys will be
-                                              projected into the specified paths,
-                                              and unlisted keys will not be present.
-                                              If a key is specified which is not present
-                                              in the ConfigMap, the volume setup will
-                                              error unless it is marked optional.
-                                              Paths must be relative and may not contain
-                                              the '..' path or start with '..'.
+                                            description: |-
+                                              items if unspecified, each key-value pair in the Data field of the referenced
+                                              ConfigMap will be projected into the volume as a file whose name is the
+                                              key and content is the value. If specified, the listed keys will be
+                                              projected into the specified paths, and unlisted keys will not be
+                                              present. If a key is specified which is not present in the ConfigMap,
+                                              the volume setup will error unless it is marked optional. Paths must be
+                                              relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
@@ -7053,29 +6771,21 @@ spec:
                                                   description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional:
-                                                    mode bits used to set permissions
-                                                    on this file. Must be an octal
-                                                    value between 0000 and 0777 or
-                                                    a decimal value between 0 and
-                                                    511. YAML accepts both octal and
-                                                    decimal values, JSON requires
-                                                    decimal values for mode bits.
-                                                    If not specified, the volume defaultMode
-                                                    will be used. This might be in
-                                                    conflict with other options that
-                                                    affect the file mode, like fsGroup,
-                                                    and the result can be other mode
-                                                    bits set.'
+                                                  description: |-
+                                                    mode is Optional: mode bits used to set permissions on this file.
+                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: path is the relative
-                                                    path of the file to map the key
-                                                    to. May not be an absolute path.
-                                                    May not contain the path element
-                                                    '..'. May not start with the string
-                                                    '..'.
+                                                  description: |-
+                                                    path is the relative path of the file to map the key to.
+                                                    May not be an absolute path.
+                                                    May not contain the path element '..'.
+                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -7083,10 +6793,10 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: optional specify whether
@@ -7127,20 +6837,13 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: 'Optional: mode bits
-                                                    used to set permissions on this
-                                                    file, must be an octal value between
-                                                    0000 and 0777 or a decimal value
-                                                    between 0 and 511. YAML accepts
-                                                    both octal and decimal values,
-                                                    JSON requires decimal values for
-                                                    mode bits. If not specified, the
-                                                    volume defaultMode will be used.
-                                                    This might be in conflict with
-                                                    other options that affect the
-                                                    file mode, like fsGroup, and the
-                                                    result can be other mode bits
-                                                    set.'
+                                                  description: |-
+                                                    Optional: mode bits used to set permissions on this file, must be an octal value
+                                                    between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
@@ -7153,12 +6856,9 @@ spec:
                                                     start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: 'Selects a resource
-                                                    of the container: only resources
-                                                    limits and requests (limits.cpu,
-                                                    limits.memory, requests.cpu and
-                                                    requests.memory) are currently
-                                                    supported.'
+                                                  description: |-
+                                                    Selects a resource of the container: only resources limits and requests
+                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
                                                       description: 'Container name:
@@ -7192,19 +6892,14 @@ spec:
                                           secret data to project
                                         properties:
                                           items:
-                                            description: items if unspecified, each
-                                              key-value pair in the Data field of
-                                              the referenced Secret will be projected
-                                              into the volume as a file whose name
-                                              is the key and content is the value.
-                                              If specified, the listed keys will be
-                                              projected into the specified paths,
-                                              and unlisted keys will not be present.
-                                              If a key is specified which is not present
-                                              in the Secret, the volume setup will
-                                              error unless it is marked optional.
-                                              Paths must be relative and may not contain
-                                              the '..' path or start with '..'.
+                                            description: |-
+                                              items if unspecified, each key-value pair in the Data field of the referenced
+                                              Secret will be projected into the volume as a file whose name is the
+                                              key and content is the value. If specified, the listed keys will be
+                                              projected into the specified paths, and unlisted keys will not be
+                                              present. If a key is specified which is not present in the Secret,
+                                              the volume setup will error unless it is marked optional. Paths must be
+                                              relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
@@ -7213,29 +6908,21 @@ spec:
                                                   description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional:
-                                                    mode bits used to set permissions
-                                                    on this file. Must be an octal
-                                                    value between 0000 and 0777 or
-                                                    a decimal value between 0 and
-                                                    511. YAML accepts both octal and
-                                                    decimal values, JSON requires
-                                                    decimal values for mode bits.
-                                                    If not specified, the volume defaultMode
-                                                    will be used. This might be in
-                                                    conflict with other options that
-                                                    affect the file mode, like fsGroup,
-                                                    and the result can be other mode
-                                                    bits set.'
+                                                  description: |-
+                                                    mode is Optional: mode bits used to set permissions on this file.
+                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: path is the relative
-                                                    path of the file to map the key
-                                                    to. May not be an absolute path.
-                                                    May not contain the path element
-                                                    '..'. May not start with the string
-                                                    '..'.
+                                                  description: |-
+                                                    path is the relative path of the file to map the key to.
+                                                    May not be an absolute path.
+                                                    May not contain the path element '..'.
+                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -7243,10 +6930,10 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: optional field specify whether
@@ -7259,32 +6946,26 @@ spec:
                                           about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: audience is the intended
-                                              audience of the token. A recipient of
-                                              a token must identify itself with an
-                                              identifier specified in the audience
-                                              of the token, and otherwise should reject
-                                              the token. The audience defaults to
-                                              the identifier of the apiserver.
+                                            description: |-
+                                              audience is the intended audience of the token. A recipient of a token
+                                              must identify itself with an identifier specified in the audience of the
+                                              token, and otherwise should reject the token. The audience defaults to the
+                                              identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: expirationSeconds is the
-                                              requested duration of validity of the
-                                              service account token. As the token
-                                              approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service
-                                              account token. The kubelet will start
-                                              trying to rotate the token if the token
-                                              is older than 80 percent of its time
-                                              to live or if the token is older than
-                                              24 hours.Defaults to 1 hour and must
-                                              be at least 10 minutes.
+                                            description: |-
+                                              expirationSeconds is the requested duration of validity of the service
+                                              account token. As the token approaches expiration, the kubelet volume
+                                              plugin will proactively rotate the service account token. The kubelet will
+                                              start trying to rotate the token if the token is older than 80 percent of
+                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                              and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: path is the path relative
-                                              to the mount point of the file to project
-                                              the token into.
+                                            description: |-
+                                              path is the path relative to the mount point of the file to project the
+                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -7297,29 +6978,30 @@ spec:
                                 host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: group to map volume access to Default
-                                    is no group
+                                  description: |-
+                                    group to map volume access to
+                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: readOnly here will force the Quobyte
-                                    volume to be mounted with read-only permissions.
+                                  description: |-
+                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
                                     Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: registry represents a single or multiple
-                                    Quobyte Registry services specified as a string
-                                    as host:port pair (multiple entries are separated
-                                    with commas) which acts as the central registry
-                                    for volumes
+                                  description: |-
+                                    registry represents a single or multiple Quobyte Registry services
+                                    specified as a string as host:port pair (multiple entries are separated with commas)
+                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: tenant owning the given Quobyte volume
-                                    in the Backend Used with dynamically provisioned
-                                    Quobyte volumes, value is set by the plugin
+                                  description: |-
+                                    tenant owning the given Quobyte volume in the Backend
+                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: user to map volume access to Defaults
-                                    to serivceaccount user
+                                  description: |-
+                                    user to map volume access to
+                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
                                   description: volume is a string that references
@@ -7330,60 +7012,68 @@ spec:
                               - volume
                               type: object
                             rbd:
-                              description: 'rbd represents a Rados Block Device mount
-                                on the host that shares a pod''s lifetime. More info:
-                                https://examples.k8s.io/volumes/rbd/README.md'
+                              description: |-
+                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type of the
-                                    volume that you want to mount. Tip: Ensure that
-                                    the filesystem type is supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 image:
-                                  description: 'image is the rados image name. More
-                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    image is the rados image name.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
-                                  description: 'keyring is the path to key ring for
-                                    RBDUser. Default is /etc/ceph/keyring. More info:
-                                    https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    keyring is the path to key ring for RBDUser.
+                                    Default is /etc/ceph/keyring.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: 'monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    monitors is a collection of Ceph monitors.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: 'pool is the rados pool name. Default
-                                    is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    pool is the rados pool name.
+                                    Default is rbd.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the ReadOnly
-                                    setting in VolumeMounts. Defaults to false. More
-                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: 'secretRef is name of the authentication
-                                    secret for RBDUser. If provided overrides keyring.
-                                    Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    secretRef is name of the authentication secret for RBDUser. If provided
+                                    overrides keyring.
+                                    Default is nil.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: 'user is the rados user name. Default
-                                    is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    user is the rados user name.
+                                    Default is admin.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
@@ -7394,10 +7084,11 @@ spec:
                                 volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Default
-                                    is "xfs".
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs".
+                                    Default is "xfs".
                                   type: string
                                 gateway:
                                   description: gateway is the host address of the
@@ -7408,21 +7099,20 @@ spec:
                                     ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: readOnly Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef references to the secret
-                                    for ScaleIO user and other sensitive information.
-                                    If this is not provided, Login operation will
-                                    fail.
+                                  description: |-
+                                    secretRef references to the secret for ScaleIO user and other
+                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -7431,8 +7121,8 @@ spec:
                                     communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: storageMode indicates whether the storage
-                                    for a volume should be ThickProvisioned or ThinProvisioned.
+                                  description: |-
+                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                                     Default is ThinProvisioned.
                                   type: string
                                 storagePool:
@@ -7444,9 +7134,9 @@ spec:
                                     as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: volumeName is the name of a volume
-                                    already created in the ScaleIO system that is
-                                    associated with this volume source.
+                                  description: |-
+                                    volumeName is the name of a volume already created in the ScaleIO system
+                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -7454,34 +7144,30 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: 'secret represents a secret that should
-                                populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              description: |-
+                                secret represents a secret that should populate this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: 'defaultMode is Optional: mode bits
-                                    used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Defaults to 0644. Directories
-                                    within the path are not affected by this setting.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
+                                  description: |-
+                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values
+                                    for mode bits. Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: items If unspecified, each key-value
-                                    pair in the Data field of the referenced Secret
-                                    will be projected into the volume as a file whose
-                                    name is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the Secret, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
+                                  description: |-
+                                    items If unspecified, each key-value pair in the Data field of the referenced
+                                    Secret will be projected into the volume as a file whose name is the
+                                    key and content is the value. If specified, the listed keys will be
+                                    projected into the specified paths, and unlisted keys will not be
+                                    present. If a key is specified which is not present in the Secret,
+                                    the volume setup will error unless it is marked optional. Paths must be
+                                    relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within
                                       a volume.
@@ -7490,25 +7176,21 @@ spec:
                                         description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'mode is Optional: mode bits
-                                          used to set permissions on this file. Must
-                                          be an octal value between 0000 and 0777
-                                          or a decimal value between 0 and 511. YAML
-                                          accepts both octal and decimal values, JSON
-                                          requires decimal values for mode bits. If
-                                          not specified, the volume defaultMode will
-                                          be used. This might be in conflict with
-                                          other options that affect the file mode,
-                                          like fsGroup, and the result can be other
-                                          mode bits set.'
+                                        description: |-
+                                          mode is Optional: mode bits used to set permissions on this file.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: path is the relative path of
-                                          the file to map the key to. May not be an
-                                          absolute path. May not contain the path
-                                          element '..'. May not start with the string
-                                          '..'.
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
+                                          May not contain the path element '..'.
+                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -7520,8 +7202,9 @@ spec:
                                     Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: 'secretName is the name of the secret
-                                    in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: |-
+                                    secretName is the name of the secret in the pod's namespace to use.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
@@ -7529,44 +7212,42 @@ spec:
                                 attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef specifies the secret to use
-                                    for obtaining the StorageOS API credentials.  If
-                                    not specified, default values will be attempted.
+                                  description: |-
+                                    secretRef specifies the secret to use for obtaining the StorageOS API
+                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: volumeName is the human-readable name
-                                    of the StorageOS volume.  Volume names are only
-                                    unique within a namespace.
+                                  description: |-
+                                    volumeName is the human-readable name of the StorageOS volume.  Volume
+                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: volumeNamespace specifies the scope
-                                    of the volume within StorageOS.  If no namespace
-                                    is specified then the Pod's namespace will be
-                                    used.  This allows the Kubernetes name scoping
-                                    to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default
-                                    behaviour. Set to "default" if you are not using
-                                    namespaces within StorageOS. Namespaces that do
-                                    not pre-exist within StorageOS will be created.
+                                  description: |-
+                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                    namespace is specified then the Pod's namespace will be used.  This allows the
+                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                    Set VolumeName to any name to override the default behaviour.
+                                    Set to "default" if you are not using namespaces within StorageOS.
+                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
@@ -7574,10 +7255,10 @@ spec:
                                 attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
                                   description: storagePolicyID is the storage Policy
@@ -7613,42 +7294,42 @@ spec:
                 description: Conditions is an array of current cluster conditions.
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -7662,11 +7343,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/hack/update-crdgen.sh
+++ b/hack/update-crdgen.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 CONTROLLER_GEN_PKG="sigs.k8s.io/controller-tools/cmd/controller-gen"
-CONTROLLER_GEN_VER="v0.13.0"
+CONTROLLER_GEN_VER="v0.14.0"
 
 source hack/util.sh
 

--- a/operator/config/crds/operator.karmada.io_karmadas.yaml
+++ b/operator/config/crds/operator.karmada.io_karmadas.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: karmadas.operator.karmada.io
 spec:
   group: operator.karmada.io
@@ -29,14 +29,19 @@ spec:
         description: Karmada enables declarative installation of karmada.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -44,26 +49,28 @@ spec:
             description: Spec defines the desired behavior of the Karmada.
             properties:
               components:
-                description: Components define all of karmada components. not all
-                  of these components need to be installed.
+                description: |-
+                  Components define all of karmada components.
+                  not all of these components need to be installed.
                 properties:
                   etcd:
                     description: Etcd holds configuration for etcd.
                     properties:
                       external:
-                        description: External describes how to connect to an external
-                          etcd cluster Local and External are mutually exclusive
+                        description: |-
+                          External describes how to connect to an external etcd cluster
+                          Local and External are mutually exclusive
                         properties:
                           caData:
-                            description: CAData is an SSL Certificate Authority file
-                              used to secure etcd communication. Required if using
-                              a TLS connection.
+                            description: |-
+                              CAData is an SSL Certificate Authority file used to secure etcd communication.
+                              Required if using a TLS connection.
                             format: byte
                             type: string
                           certData:
-                            description: CertData is an SSL certification file used
-                              to secure etcd communication. Required if using a TLS
-                              connection.
+                            description: |-
+                              CertData is an SSL certification file used to secure etcd communication.
+                              Required if using a TLS connection.
                             format: byte
                             type: string
                           endpoints:
@@ -72,8 +79,9 @@ spec:
                               type: string
                             type: array
                           keyData:
-                            description: KeyData is an SSL key file used to secure
-                              etcd communication. Required if using a TLS connection.
+                            description: |-
+                              KeyData is an SSL key file used to secure etcd communication.
+                              Required if using a TLS connection.
                             format: byte
                             type: string
                         required:
@@ -83,42 +91,43 @@ spec:
                         - keyData
                         type: object
                       local:
-                        description: Local provides configuration knobs for configuring
-                          the built-in etcd instance Local and External are mutually
-                          exclusive
+                        description: |-
+                          Local provides configuration knobs for configuring the built-in etcd instance
+                          Local and External are mutually exclusive
                         properties:
                           annotations:
                             additionalProperties:
                               type: string
-                            description: 'Annotations is an unstructured key value
-                              map stored with a resource that may be set by external
-                              tools to store and retrieve arbitrary metadata. They
-                              are not queryable and should be preserved when modifying
-                              objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                            description: |-
+                              Annotations is an unstructured key value map stored with a resource that may be
+                              set by external tools to store and retrieve arbitrary metadata. They are not
+                              queryable and should be preserved when modifying objects.
+                              More info: http://kubernetes.io/docs/user-guide/annotations
                             type: object
                           imagePullPolicy:
-                            description: ImagePullPolicy defines the policy for pulling
-                              the container image. If not specified, it defaults to
-                              IfNotPresent.
+                            description: |-
+                              ImagePullPolicy defines the policy for pulling the container image.
+                              If not specified, it defaults to IfNotPresent.
                             type: string
                           imageRepository:
-                            description: ImageRepository sets the container registry
-                              to pull images from. if not set, the ImageRepository
-                              defined in KarmadaSpec will be used instead.
+                            description: |-
+                              ImageRepository sets the container registry to pull images from.
+                              if not set, the ImageRepository defined in KarmadaSpec will be used instead.
                             type: string
                           imageTag:
-                            description: ImageTag allows to specify a tag for the
-                              image. In case this value is set, operator does not
-                              change automatically the version of the above components
-                              during upgrades.
+                            description: |-
+                              ImageTag allows to specify a tag for the image.
+                              In case this value is set, operator does not change automatically the version
+                              of the above components during upgrades.
                             type: string
                           labels:
                             additionalProperties:
                               type: string
-                            description: 'Map of string keys and values that can be
-                              used to organize and categorize (scope and select) objects.
-                              May match selectors of replication controllers and services.
-                              More info: http://kubernetes.io/docs/user-guide/labels'
+                            description: |-
+                              Map of string keys and values that can be used to organize and categorize
+                              (scope and select) objects. May match selectors of replication controllers
+                              and services.
+                              More info: http://kubernetes.io/docs/user-guide/labels
                             type: object
                           peerCertSANs:
                             description: PeerCertSANs sets extra Subject Alternative
@@ -127,31 +136,36 @@ spec:
                               type: string
                             type: array
                           replicas:
-                            description: Number of desired pods. This is a pointer
-                              to distinguish between explicit zero and not specified.
-                              Defaults to 1.
+                            description: |-
+                              Number of desired pods. This is a pointer to distinguish between explicit
+                              zero and not specified. Defaults to 1.
                             format: int32
                             type: integer
                           resources:
-                            description: 'Compute Resources required by this component.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Compute Resources required by this component.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             properties:
                               claims:
-                                description: "Claims lists the names of resources,
-                                  defined in spec.resourceClaims, that are used by
-                                  this container. \n This is an alpha field and requires
-                                  enabling the DynamicResourceAllocation feature gate.
-                                  \n This field is immutable. It can only be set for
-                                  containers."
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+
+                                  This is an alpha field and requires enabling the
+                                  DynamicResourceAllocation feature gate.
+
+
+                                  This field is immutable. It can only be set for containers.
                                 items:
                                   description: ResourceClaim references one entry
                                     in PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description: Name must match the name of one
-                                        entry in pod.spec.resourceClaims of the Pod
-                                        where this field is used. It makes that resource
-                                        available inside a container.
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
                                       type: string
                                   required:
                                   - name
@@ -167,8 +181,9 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount
-                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                               requests:
                                 additionalProperties:
@@ -177,12 +192,11 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. Requests cannot exceed Limits. More info:
-                                  https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
                           serverCertSANs:
@@ -192,72 +206,74 @@ spec:
                               type: string
                             type: array
                           volumeData:
-                            description: 'VolumeData describes the settings of etcd
-                              data store. We will support 3 modes: emptyDir, hostPath,
-                              PVC. default by hostPath.'
+                            description: |-
+                              VolumeData describes the settings of etcd data store.
+                              We will support 3 modes: emptyDir, hostPath, PVC. default by hostPath.
                             properties:
                               emptyDir:
-                                description: 'EmptyDir represents a temporary directory
-                                  that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                description: |-
+                                  EmptyDir represents a temporary directory that shares a pod's lifetime.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                 properties:
                                   medium:
-                                    description: 'medium represents what type of storage
-                                      medium should back this directory. The default
-                                      is "" which means to use the node''s default
-                                      medium. Must be an empty string (default) or
-                                      Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    description: |-
+                                      medium represents what type of storage medium should back this directory.
+                                      The default is "" which means to use the node's default medium.
+                                      Must be an empty string (default) or Memory.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                     type: string
                                   sizeLimit:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: 'sizeLimit is the total amount of
-                                      local storage required for this EmptyDir volume.
-                                      The size limit is also applicable for memory
-                                      medium. The maximum usage on memory medium EmptyDir
-                                      would be the minimum value between the SizeLimit
-                                      specified here and the sum of memory limits
-                                      of all containers in a pod. The default is nil
-                                      which means that the limit is undefined. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    description: |-
+                                      sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                      The size limit is also applicable for memory medium.
+                                      The maximum usage on memory medium EmptyDir would be the minimum value between
+                                      the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                      The default is nil which means that the limit is undefined.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 type: object
                               hostPath:
-                                description: 'HostPath represents a pre-existing file
-                                  or directory on the host machine that is directly
-                                  exposed to the container. This is generally used
-                                  for system agents or other privileged things that
-                                  are allowed to see the host machine. Most containers
-                                  will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                  --- TODO(jonesdl) We need to restrict who can use
-                                  host directory mounts and who can/can not mount
-                                  host directories as read/write.'
+                                description: |-
+                                  HostPath represents a pre-existing file or directory on the host
+                                  machine that is directly exposed to the container. This is generally
+                                  used for system agents or other privileged things that are allowed
+                                  to see the host machine. Most containers will NOT need this.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                  ---
+                                  TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
+                                  mount host directories as read/write.
                                 properties:
                                   path:
-                                    description: 'path of the directory on the host.
-                                      If the path is a symlink, it will follow the
-                                      link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                    description: |-
+                                      path of the directory on the host.
+                                      If the path is a symlink, it will follow the link to the real path.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                     type: string
                                   type:
-                                    description: 'type for HostPath Volume Defaults
-                                      to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                    description: |-
+                                      type for HostPath Volume
+                                      Defaults to ""
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                     type: string
                                 required:
                                 - path
                                 type: object
                               volumeClaim:
-                                description: The specification for the PersistentVolumeClaim.
-                                  The entire content is copied unchanged into the
-                                  PVC that gets created from this template. The same
-                                  fields as in a PersistentVolumeClaim are also valid
-                                  here.
+                                description: |-
+                                  The specification for the PersistentVolumeClaim. The entire content is
+                                  copied unchanged into the PVC that gets created from this
+                                  template. The same fields as in a PersistentVolumeClaim
+                                  are also valid here.
                                 properties:
                                   metadata:
-                                    description: May contain labels and annotations
-                                      that will be copied into the PVC when creating
-                                      it. No other fields are allowed and will be
-                                      rejected during validation.
+                                    description: |-
+                                      May contain labels and annotations that will be copied into the PVC
+                                      when creating it. No other fields are allowed and will be rejected during
+                                      validation.
                                     properties:
                                       annotations:
                                         additionalProperties:
@@ -277,42 +293,35 @@ spec:
                                         type: string
                                     type: object
                                   spec:
-                                    description: The specification for the PersistentVolumeClaim.
-                                      The entire content is copied unchanged into
-                                      the PVC that gets created from this template.
-                                      The same fields as in a PersistentVolumeClaim
+                                    description: |-
+                                      The specification for the PersistentVolumeClaim. The entire content is
+                                      copied unchanged into the PVC that gets created from this
+                                      template. The same fields as in a PersistentVolumeClaim
                                       are also valid here.
                                     properties:
                                       accessModes:
-                                        description: 'accessModes contains the desired
-                                          access modes the volume should have. More
-                                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                        description: |-
+                                          accessModes contains the desired access modes the volume should have.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                         items:
                                           type: string
                                         type: array
                                       dataSource:
-                                        description: 'dataSource field can be used
-                                          to specify either: * An existing VolumeSnapshot
-                                          object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                        description: |-
+                                          dataSource field can be used to specify either:
+                                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                           * An existing PVC (PersistentVolumeClaim)
-                                          If the provisioner or an external controller
-                                          can support the specified data source, it
-                                          will create a new volume based on the contents
-                                          of the specified data source. When the AnyVolumeDataSource
-                                          feature gate is enabled, dataSource contents
-                                          will be copied to dataSourceRef, and dataSourceRef
-                                          contents will be copied to dataSource when
-                                          dataSourceRef.namespace is not specified.
-                                          If the namespace is specified, then dataSourceRef
-                                          will not be copied to dataSource.'
+                                          If the provisioner or an external controller can support the specified data source,
+                                          it will create a new volume based on the contents of the specified data source.
+                                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                         properties:
                                           apiGroup:
-                                            description: APIGroup is the group for
-                                              the resource being referenced. If APIGroup
-                                              is not specified, the specified Kind
-                                              must be in the core API group. For any
-                                              other third-party types, APIGroup is
-                                              required.
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
                                             type: string
                                           kind:
                                             description: Kind is the type of resource
@@ -328,50 +337,36 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       dataSourceRef:
-                                        description: 'dataSourceRef specifies the
-                                          object from which to populate the volume
-                                          with data, if a non-empty volume is desired.
-                                          This may be any object from a non-empty
-                                          API group (non core object) or a PersistentVolumeClaim
-                                          object. When this field is specified, volume
-                                          binding will only succeed if the type of
-                                          the specified object matches some installed
-                                          volume populator or dynamic provisioner.
-                                          This field will replace the functionality
-                                          of the dataSource field and as such if both
-                                          fields are non-empty, they must have the
-                                          same value. For backwards compatibility,
-                                          when namespace isn''t specified in dataSourceRef,
-                                          both fields (dataSource and dataSourceRef)
-                                          will be set to the same value automatically
-                                          if one of them is empty and the other is
-                                          non-empty. When namespace is specified in
-                                          dataSourceRef, dataSource isn''t set to
-                                          the same value and must be empty. There
-                                          are three important differences between
-                                          dataSource and dataSourceRef: * While dataSource
-                                          only allows two specific types of objects,
-                                          dataSourceRef allows any non-core object,
-                                          as well as PersistentVolumeClaim objects.
-                                          * While dataSource ignores disallowed values
-                                          (dropping them), dataSourceRef preserves
-                                          all values, and generates an error if a
-                                          disallowed value is specified. * While dataSource
-                                          only allows local objects, dataSourceRef
-                                          allows objects in any namespaces. (Beta)
-                                          Using this field requires the AnyVolumeDataSource
-                                          feature gate to be enabled. (Alpha) Using
-                                          the namespace field of dataSourceRef requires
-                                          the CrossNamespaceVolumeDataSource feature
-                                          gate to be enabled.'
+                                        description: |-
+                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                          volume is desired. This may be any object from a non-empty API group (non
+                                          core object) or a PersistentVolumeClaim object.
+                                          When this field is specified, volume binding will only succeed if the type of
+                                          the specified object matches some installed volume populator or dynamic
+                                          provisioner.
+                                          This field will replace the functionality of the dataSource field and as such
+                                          if both fields are non-empty, they must have the same value. For backwards
+                                          compatibility, when namespace isn't specified in dataSourceRef,
+                                          both fields (dataSource and dataSourceRef) will be set to the same
+                                          value automatically if one of them is empty and the other is non-empty.
+                                          When namespace is specified in dataSourceRef,
+                                          dataSource isn't set to the same value and must be empty.
+                                          There are three important differences between dataSource and dataSourceRef:
+                                          * While dataSource only allows two specific types of objects, dataSourceRef
+                                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                            preserves all values, and generates an error if a disallowed value is
+                                            specified.
+                                          * While dataSource only allows local objects, dataSourceRef allows objects
+                                            in any namespaces.
+                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                         properties:
                                           apiGroup:
-                                            description: APIGroup is the group for
-                                              the resource being referenced. If APIGroup
-                                              is not specified, the specified Kind
-                                              must be in the core API group. For any
-                                              other third-party types, APIGroup is
-                                              required.
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
                                             type: string
                                           kind:
                                             description: Kind is the type of resource
@@ -382,46 +377,42 @@ spec:
                                               being referenced
                                             type: string
                                           namespace:
-                                            description: Namespace is the namespace
-                                              of resource being referenced Note that
-                                              when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant
-                                              object is required in the referent namespace
-                                              to allow that namespace's owner to accept
-                                              the reference. See the ReferenceGrant
-                                              documentation for details. (Alpha) This
-                                              field requires the CrossNamespaceVolumeDataSource
-                                              feature gate to be enabled.
+                                            description: |-
+                                              Namespace is the namespace of resource being referenced
+                                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                             type: string
                                         required:
                                         - kind
                                         - name
                                         type: object
                                       resources:
-                                        description: 'resources represents the minimum
-                                          resources the volume should have. If RecoverVolumeExpansionFailure
-                                          feature is enabled users are allowed to
-                                          specify resource requirements that are lower
-                                          than previous value but must still be higher
-                                          than capacity recorded in the status field
-                                          of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                        description: |-
+                                          resources represents the minimum resources the volume should have.
+                                          If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                          that are lower than previous value but must still be higher than capacity recorded in the
+                                          status field of the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                         properties:
                                           claims:
-                                            description: "Claims lists the names of
-                                              resources, defined in spec.resourceClaims,
-                                              that are used by this container. \n
-                                              This is an alpha field and requires
-                                              enabling the DynamicResourceAllocation
-                                              feature gate. \n This field is immutable.
-                                              It can only be set for containers."
+                                            description: |-
+                                              Claims lists the names of resources, defined in spec.resourceClaims,
+                                              that are used by this container.
+
+
+                                              This is an alpha field and requires enabling the
+                                              DynamicResourceAllocation feature gate.
+
+
+                                              This field is immutable. It can only be set for containers.
                                             items:
                                               description: ResourceClaim references
                                                 one entry in PodSpec.ResourceClaims.
                                               properties:
                                                 name:
-                                                  description: Name must match the
-                                                    name of one entry in pod.spec.resourceClaims
-                                                    of the Pod where this field is
-                                                    used. It makes that resource available
+                                                  description: |-
+                                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                                    the Pod where this field is used. It makes that resource available
                                                     inside a container.
                                                   type: string
                                               required:
@@ -438,9 +429,9 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: 'Limits describes the maximum
-                                              amount of compute resources allowed.
-                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            description: |-
+                                              Limits describes the maximum amount of compute resources allowed.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                             type: object
                                           requests:
                                             additionalProperties:
@@ -449,13 +440,11 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: 'Requests describes the minimum
-                                              amount of compute resources required.
-                                              If Requests is omitted for a container,
-                                              it defaults to Limits if that is explicitly
-                                              specified, otherwise to an implementation-defined
-                                              value. Requests cannot exceed Limits.
-                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            description: |-
+                                              Requests describes the minimum amount of compute resources required.
+                                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                             type: object
                                         type: object
                                       selector:
@@ -467,29 +456,24 @@ spec:
                                               of label selector requirements. The
                                               requirements are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
                                               properties:
                                                 key:
                                                   description: key is the label key
                                                     that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
                                                     merge patch.
                                                   items:
                                                     type: string
@@ -502,25 +486,22 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       storageClassName:
-                                        description: 'storageClassName is the name
-                                          of the StorageClass required by the claim.
-                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                        description: |-
+                                          storageClassName is the name of the StorageClass required by the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                         type: string
                                       volumeMode:
-                                        description: volumeMode defines what type
-                                          of volume is required by the claim. Value
-                                          of Filesystem is implied when not included
-                                          in claim spec.
+                                        description: |-
+                                          volumeMode defines what type of volume is required by the claim.
+                                          Value of Filesystem is implied when not included in claim spec.
                                         type: string
                                       volumeName:
                                         description: volumeName is the binding reference
@@ -534,18 +515,18 @@ spec:
                         type: object
                     type: object
                   karmadaAPIServer:
-                    description: KarmadaAPIServer holds settings to kube-apiserver
-                      component. Currently, kube-apiserver is used as the apiserver
-                      of karmada. we had the same experience as k8s apiserver.
+                    description: |-
+                      KarmadaAPIServer holds settings to kube-apiserver component. Currently, kube-apiserver
+                      is used as the apiserver of karmada. we had the same experience as k8s apiserver.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                       certSANs:
                         description: CertSANs sets extra Subject Alternative Names
@@ -556,71 +537,84 @@ spec:
                       extraArgs:
                         additionalProperties:
                           type: string
-                        description: "ExtraArgs is an extra set of flags to pass to
-                          the kube-apiserver component or override. A key in this
-                          map is the flag name as it appears on the command line except
-                          without leading dash(es). \n Note: This is a temporary solution
-                          to allow for the configuration of the kube-apiserver component.
-                          In the future, we will provide a more structured way to
-                          configure the component. Once that is done, this field will
-                          be discouraged to be used. Incorrect settings on this field
-                          maybe lead to the corresponding component in an unhealthy
-                          state. Before you do it, please confirm that you understand
-                          the risks of this configuration. \n For supported flags,
-                          please see https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
-                          for details."
+                        description: |-
+                          ExtraArgs is an extra set of flags to pass to the kube-apiserver component or
+                          override. A key in this map is the flag name as it appears on the command line except
+                          without leading dash(es).
+
+
+                          Note: This is a temporary solution to allow for the configuration of the
+                          kube-apiserver component. In the future, we will provide a more structured way
+                          to configure the component. Once that is done, this field will be discouraged to be used.
+                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
+                          state. Before you do it, please confirm that you understand the risks of this configuration.
+
+
+                          For supported flags, please see
+                          https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
+                          for details.
                         type: object
                       featureGates:
                         additionalProperties:
                           type: boolean
-                        description: 'FeatureGates enabled by the user. More info:
-                          https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/'
+                        description: |-
+                          FeatureGates enabled by the user.
+                          More info: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
                         type: object
                       imagePullPolicy:
-                        description: ImagePullPolicy defines the policy for pulling
-                          the container image. If not specified, it defaults to IfNotPresent.
+                        description: |-
+                          ImagePullPolicy defines the policy for pulling the container image.
+                          If not specified, it defaults to IfNotPresent.
                         type: string
                       imageRepository:
-                        description: ImageRepository sets the container registry to
-                          pull images from. if not set, the ImageRepository defined
-                          in KarmadaSpec will be used instead.
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          if not set, the ImageRepository defined in KarmadaSpec will be used instead.
                         type: string
                       imageTag:
-                        description: ImageTag allows to specify a tag for the image.
-                          In case this value is set, operator does not change automatically
-                          the version of the above components during upgrades.
+                        description: |-
+                          ImageTag allows to specify a tag for the image.
+                          In case this value is set, operator does not change automatically the version
+                          of the above components during upgrades.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Map of string keys and values that can be used
-                          to organize and categorize (scope and select) objects. May
-                          match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
                       replicas:
-                        description: Number of desired pods. This is a pointer to
-                          distinguish between explicit zero and not specified. Defaults
-                          to 1.
+                        description: |-
+                          Number of desired pods. This is a pointer to distinguish between explicit
+                          zero and not specified. Defaults to 1.
                         format: int32
                         type: integer
                       resources:
-                        description: 'Compute Resources required by this component.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this component.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                              in spec.resourceClaims, that are used by this container.
-                              \n This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate. \n This field
-                              is immutable. It can only be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -637,8 +631,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -647,26 +642,28 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       serviceAnnotations:
                         additionalProperties:
                           type: string
-                        description: 'ServiceAnnotations is an extra set of annotations
-                          for service of karmada apiserver. more info: https://github.com/karmada-io/karmada/issues/4634'
+                        description: |-
+                          ServiceAnnotations is an extra set of annotations for service of karmada apiserver.
+                          more info: https://github.com/karmada-io/karmada/issues/4634
                         type: object
                       serviceSubnet:
                         description: ServiceSubnet is the subnet used by k8s services.
                           Defaults to "10.96.0.0/12".
                         type: string
                       serviceType:
-                        description: ServiceType represents the service type of karmada
-                          apiserver. it is ClusterIP by default.
+                        description: |-
+                          ServiceType represents the service type of karmada apiserver.
+                          it is ClusterIP by default.
                         type: string
                     type: object
                   karmadaAggregatedAPIServer:
@@ -676,11 +673,11 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                       certSANs:
                         description: CertSANs sets extra Subject Alternative Names
@@ -691,72 +688,85 @@ spec:
                       extraArgs:
                         additionalProperties:
                           type: string
-                        description: "ExtraArgs is an extra set of flags to pass to
-                          the karmada-aggregated-apiserver component or override.
-                          A key in this map is the flag name as it appears on the
-                          command line except without leading dash(es). \n Note: This
-                          is a temporary solution to allow for the configuration of
-                          the karmada-aggregated-apiserver component. In the future,
-                          we will provide a more structured way to configure the component.
-                          Once that is done, this field will be discouraged to be
-                          used. Incorrect settings on this field maybe lead to the
-                          corresponding component in an unhealthy state. Before you
-                          do it, please confirm that you understand the risks of this
-                          configuration. \n For supported flags, please see https://karmada.io/docs/reference/components/karmada-aggregated-apiserver
-                          for details."
+                        description: |-
+                          ExtraArgs is an extra set of flags to pass to the karmada-aggregated-apiserver component or
+                          override. A key in this map is the flag name as it appears on the command line except
+                          without leading dash(es).
+
+
+                          Note: This is a temporary solution to allow for the configuration of the
+                          karmada-aggregated-apiserver component. In the future, we will provide a more structured way
+                          to configure the component. Once that is done, this field will be discouraged to be used.
+                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
+                          state. Before you do it, please confirm that you understand the risks of this configuration.
+
+
+                          For supported flags, please see
+                          https://karmada.io/docs/reference/components/karmada-aggregated-apiserver
+                          for details.
                         type: object
                       featureGates:
                         additionalProperties:
                           type: boolean
-                        description: 'FeatureGates enabled by the user. - CustomizedClusterResourceModeling:
-                          https://karmada.io/docs/userguide/scheduling/cluster-resources#start-to-use-cluster-resource-models
-                          More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go'
+                        description: |-
+                          FeatureGates enabled by the user.
+                          - CustomizedClusterResourceModeling: https://karmada.io/docs/userguide/scheduling/cluster-resources#start-to-use-cluster-resource-models
+                          More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go
                         type: object
                       imagePullPolicy:
-                        description: ImagePullPolicy defines the policy for pulling
-                          the container image. If not specified, it defaults to IfNotPresent.
+                        description: |-
+                          ImagePullPolicy defines the policy for pulling the container image.
+                          If not specified, it defaults to IfNotPresent.
                         type: string
                       imageRepository:
-                        description: ImageRepository sets the container registry to
-                          pull images from. if not set, the ImageRepository defined
-                          in KarmadaSpec will be used instead.
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          if not set, the ImageRepository defined in KarmadaSpec will be used instead.
                         type: string
                       imageTag:
-                        description: ImageTag allows to specify a tag for the image.
-                          In case this value is set, operator does not change automatically
-                          the version of the above components during upgrades.
+                        description: |-
+                          ImageTag allows to specify a tag for the image.
+                          In case this value is set, operator does not change automatically the version
+                          of the above components during upgrades.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Map of string keys and values that can be used
-                          to organize and categorize (scope and select) objects. May
-                          match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
                       replicas:
-                        description: Number of desired pods. This is a pointer to
-                          distinguish between explicit zero and not specified. Defaults
-                          to 1.
+                        description: |-
+                          Number of desired pods. This is a pointer to distinguish between explicit
+                          zero and not specified. Defaults to 1.
                         format: int32
                         type: integer
                       resources:
-                        description: 'Compute Resources required by this component.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this component.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                              in spec.resourceClaims, that are used by this container.
-                              \n This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate. \n This field
-                              is immutable. It can only be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -773,8 +783,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -783,11 +794,11 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                     type: object
@@ -798,98 +809,114 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                       controllers:
-                        description: "A list of controllers to enable. '*' enables
-                          all on-by-default controllers, 'foo' enables the controller
-                          named 'foo', '-foo' disables the controller named 'foo'.
-                          \n All controllers: binding, cluster, clusterStatus, endpointSlice,
-                          execution, federatedResourceQuotaStatus, federatedResourceQuotaSync,
-                          hpa, namespace, serviceExport, serviceImport, unifiedAuth,
-                          workStatus. Disabled-by-default controllers: hpa (default
-                          [*]) Actual Supported controllers depend on the version
-                          of Karmada. See https://karmada.io/docs/administrator/configuration/configure-controllers#configure-karmada-controllers
-                          for details."
+                        description: |-
+                          A list of controllers to enable. '*' enables all on-by-default controllers,
+                          'foo' enables the controller named 'foo', '-foo' disables the controller named
+                          'foo'.
+
+
+                          All controllers: binding, cluster, clusterStatus, endpointSlice, execution,
+                          federatedResourceQuotaStatus, federatedResourceQuotaSync, hpa, namespace,
+                          serviceExport, serviceImport, unifiedAuth, workStatus.
+                          Disabled-by-default controllers: hpa (default [*])
+                          Actual Supported controllers depend on the version of Karmada. See
+                          https://karmada.io/docs/administrator/configuration/configure-controllers#configure-karmada-controllers
+                          for details.
                         items:
                           type: string
                         type: array
                       extraArgs:
                         additionalProperties:
                           type: string
-                        description: "ExtraArgs is an extra set of flags to pass to
-                          the karmada-controller-manager component or override. A
-                          key in this map is the flag name as it appears on the command
-                          line except without leading dash(es). \n Note: This is a
-                          temporary solution to allow for the configuration of the
-                          karmada-controller-manager component. In the future, we
-                          will provide a more structured way to configure the component.
-                          Once that is done, this field will be discouraged to be
-                          used. Incorrect settings on this field maybe lead to the
-                          corresponding component in an unhealthy state. Before you
-                          do it, please confirm that you understand the risks of this
-                          configuration. \n For supported flags, please see https://karmada.io/docs/reference/components/karmada-controller-manager
-                          for details."
+                        description: |-
+                          ExtraArgs is an extra set of flags to pass to the karmada-controller-manager component or
+                          override. A key in this map is the flag name as it appears on the command line except
+                          without leading dash(es).
+
+
+                          Note: This is a temporary solution to allow for the configuration of the
+                          karmada-controller-manager component. In the future, we will provide a more structured way
+                          to configure the component. Once that is done, this field will be discouraged to be used.
+                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
+                          state. Before you do it, please confirm that you understand the risks of this configuration.
+
+
+                          For supported flags, please see
+                          https://karmada.io/docs/reference/components/karmada-controller-manager
+                          for details.
                         type: object
                       featureGates:
                         additionalProperties:
                           type: boolean
-                        description: 'FeatureGates enabled by the user. - Failover:
-                          https://karmada.io/docs/userguide/failover/#failover - GracefulEviction:
-                          https://karmada.io/docs/userguide/failover/#graceful-eviction-feature
+                        description: |-
+                          FeatureGates enabled by the user.
+                          - Failover: https://karmada.io/docs/userguide/failover/#failover
+                          - GracefulEviction: https://karmada.io/docs/userguide/failover/#graceful-eviction-feature
                           - PropagateDeps: https://karmada.io/docs/userguide/scheduling/propagate-dependencies
                           - CustomizedClusterResourceModeling: https://karmada.io/docs/userguide/scheduling/cluster-resources#start-to-use-cluster-resource-models
-                          More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go'
+                          More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go
                         type: object
                       imagePullPolicy:
-                        description: ImagePullPolicy defines the policy for pulling
-                          the container image. If not specified, it defaults to IfNotPresent.
+                        description: |-
+                          ImagePullPolicy defines the policy for pulling the container image.
+                          If not specified, it defaults to IfNotPresent.
                         type: string
                       imageRepository:
-                        description: ImageRepository sets the container registry to
-                          pull images from. if not set, the ImageRepository defined
-                          in KarmadaSpec will be used instead.
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          if not set, the ImageRepository defined in KarmadaSpec will be used instead.
                         type: string
                       imageTag:
-                        description: ImageTag allows to specify a tag for the image.
-                          In case this value is set, operator does not change automatically
-                          the version of the above components during upgrades.
+                        description: |-
+                          ImageTag allows to specify a tag for the image.
+                          In case this value is set, operator does not change automatically the version
+                          of the above components during upgrades.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Map of string keys and values that can be used
-                          to organize and categorize (scope and select) objects. May
-                          match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
                       replicas:
-                        description: Number of desired pods. This is a pointer to
-                          distinguish between explicit zero and not specified. Defaults
-                          to 1.
+                        description: |-
+                          Number of desired pods. This is a pointer to distinguish between explicit
+                          zero and not specified. Defaults to 1.
                         format: int32
                         type: integer
                       resources:
-                        description: 'Compute Resources required by this component.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this component.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                              in spec.resourceClaims, that are used by this container.
-                              \n This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate. \n This field
-                              is immutable. It can only be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -906,8 +933,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -916,11 +944,11 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                     type: object
@@ -931,74 +959,86 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                       extraArgs:
                         additionalProperties:
                           type: string
-                        description: "ExtraArgs is an extra set of flags to pass to
-                          the karmada-descheduler component or override. A key in
-                          this map is the flag name as it appears on the command line
-                          except without leading dash(es). \n Note: This is a temporary
-                          solution to allow for the configuration of the karmada-descheduler
-                          component. In the future, we will provide a more structured
-                          way to configure the component. Once that is done, this
-                          field will be discouraged to be used. Incorrect settings
-                          on this field maybe lead to the corresponding component
-                          in an unhealthy state. Before you do it, please confirm
-                          that you understand the risks of this configuration. \n
-                          For supported flags, please see https://karmada.io/docs/reference/components/karmada-descheduler
-                          for details."
+                        description: |-
+                          ExtraArgs is an extra set of flags to pass to the karmada-descheduler component or override.
+                          A key in this map is the flag name as it appears on the command line except without
+                          leading dash(es).
+
+
+                          Note: This is a temporary solution to allow for the configuration of the karmada-descheduler
+                          component. In the future, we will provide a more structured way to configure the component.
+                          Once that is done, this field will be discouraged to be used.
+                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
+                          state. Before you do it, please confirm that you understand the risks of this configuration.
+
+
+                          For supported flags, please see
+                          https://karmada.io/docs/reference/components/karmada-descheduler
+                          for details.
                         type: object
                       imagePullPolicy:
-                        description: ImagePullPolicy defines the policy for pulling
-                          the container image. If not specified, it defaults to IfNotPresent.
+                        description: |-
+                          ImagePullPolicy defines the policy for pulling the container image.
+                          If not specified, it defaults to IfNotPresent.
                         type: string
                       imageRepository:
-                        description: ImageRepository sets the container registry to
-                          pull images from. if not set, the ImageRepository defined
-                          in KarmadaSpec will be used instead.
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          if not set, the ImageRepository defined in KarmadaSpec will be used instead.
                         type: string
                       imageTag:
-                        description: ImageTag allows to specify a tag for the image.
-                          In case this value is set, operator does not change automatically
-                          the version of the above components during upgrades.
+                        description: |-
+                          ImageTag allows to specify a tag for the image.
+                          In case this value is set, operator does not change automatically the version
+                          of the above components during upgrades.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Map of string keys and values that can be used
-                          to organize and categorize (scope and select) objects. May
-                          match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
                       replicas:
-                        description: Number of desired pods. This is a pointer to
-                          distinguish between explicit zero and not specified. Defaults
-                          to 1.
+                        description: |-
+                          Number of desired pods. This is a pointer to distinguish between explicit
+                          zero and not specified. Defaults to 1.
                         format: int32
                         type: integer
                       resources:
-                        description: 'Compute Resources required by this component.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this component.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                              in spec.resourceClaims, that are used by this container.
-                              \n This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate. \n This field
-                              is immutable. It can only be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -1015,8 +1055,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1025,11 +1066,11 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                     type: object
@@ -1040,74 +1081,86 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                       extraArgs:
                         additionalProperties:
                           type: string
-                        description: "ExtraArgs is an extra set of flags to pass to
-                          the karmada-metrics-adapter component or override. A key
-                          in this map is the flag name as it appears on the command
-                          line except without leading dash(es). \n Note: This is a
-                          temporary solution to allow for the configuration of the
-                          karmada-metrics-adapter component. In the future, we will
-                          provide a more structured way to configure the component.
-                          Once that is done, this field will be discouraged to be
-                          used. Incorrect settings on this field maybe lead to the
-                          corresponding component in an unhealthy state. Before you
-                          do it, please confirm that you understand the risks of this
-                          configuration. \n For supported flags, please see https://karmada.io/docs/reference/components/karmada-metrics-adapter
-                          for details."
+                        description: |-
+                          ExtraArgs is an extra set of flags to pass to the karmada-metrics-adapter component or override.
+                          A key in this map is the flag name as it appears on the command line except without
+                          leading dash(es).
+
+
+                          Note: This is a temporary solution to allow for the configuration of the karmada-metrics-adapter
+                          component. In the future, we will provide a more structured way to configure the component.
+                          Once that is done, this field will be discouraged to be used.
+                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
+                          state. Before you do it, please confirm that you understand the risks of this configuration.
+
+
+                          For supported flags, please see
+                          https://karmada.io/docs/reference/components/karmada-metrics-adapter
+                          for details.
                         type: object
                       imagePullPolicy:
-                        description: ImagePullPolicy defines the policy for pulling
-                          the container image. If not specified, it defaults to IfNotPresent.
+                        description: |-
+                          ImagePullPolicy defines the policy for pulling the container image.
+                          If not specified, it defaults to IfNotPresent.
                         type: string
                       imageRepository:
-                        description: ImageRepository sets the container registry to
-                          pull images from. if not set, the ImageRepository defined
-                          in KarmadaSpec will be used instead.
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          if not set, the ImageRepository defined in KarmadaSpec will be used instead.
                         type: string
                       imageTag:
-                        description: ImageTag allows to specify a tag for the image.
-                          In case this value is set, operator does not change automatically
-                          the version of the above components during upgrades.
+                        description: |-
+                          ImageTag allows to specify a tag for the image.
+                          In case this value is set, operator does not change automatically the version
+                          of the above components during upgrades.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Map of string keys and values that can be used
-                          to organize and categorize (scope and select) objects. May
-                          match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
                       replicas:
-                        description: Number of desired pods. This is a pointer to
-                          distinguish between explicit zero and not specified. Defaults
-                          to 1.
+                        description: |-
+                          Number of desired pods. This is a pointer to distinguish between explicit
+                          zero and not specified. Defaults to 1.
                         format: int32
                         type: integer
                       resources:
-                        description: 'Compute Resources required by this component.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this component.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                              in spec.resourceClaims, that are used by this container.
-                              \n This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate. \n This field
-                              is immutable. It can only be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -1124,8 +1177,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1134,11 +1188,11 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                     type: object
@@ -1149,81 +1203,94 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                       extraArgs:
                         additionalProperties:
                           type: string
-                        description: "ExtraArgs is an extra set of flags to pass to
-                          the karmada-scheduler component or override. A key in this
-                          map is the flag name as it appears on the command line except
-                          without leading dash(es). \n Note: This is a temporary solution
-                          to allow for the configuration of the karmada-scheduler
-                          component. In the future, we will provide a more structured
-                          way to configure the component. Once that is done, this
-                          field will be discouraged to be used. Incorrect settings
-                          on this field maybe lead to the corresponding component
-                          in an unhealthy state. Before you do it, please confirm
-                          that you understand the risks of this configuration. \n
-                          For supported flags, please see https://karmada.io/docs/reference/components/karmada-scheduler
-                          for details."
+                        description: |-
+                          ExtraArgs is an extra set of flags to pass to the karmada-scheduler component or override.
+                          A key in this map is the flag name as it appears on the command line except without
+                          leading dash(es).
+
+
+                          Note: This is a temporary solution to allow for the configuration of the karmada-scheduler
+                          component. In the future, we will provide a more structured way to configure the component.
+                          Once that is done, this field will be discouraged to be used.
+                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
+                          state. Before you do it, please confirm that you understand the risks of this configuration.
+
+
+                          For supported flags, please see
+                          https://karmada.io/docs/reference/components/karmada-scheduler
+                          for details.
                         type: object
                       featureGates:
                         additionalProperties:
                           type: boolean
-                        description: 'FeatureGates enabled by the user. - CustomizedClusterResourceModeling:
-                          https://karmada.io/docs/userguide/scheduling/cluster-resources#start-to-use-cluster-resource-models
-                          More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go'
+                        description: |-
+                          FeatureGates enabled by the user.
+                          - CustomizedClusterResourceModeling: https://karmada.io/docs/userguide/scheduling/cluster-resources#start-to-use-cluster-resource-models
+                          More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go
                         type: object
                       imagePullPolicy:
-                        description: ImagePullPolicy defines the policy for pulling
-                          the container image. If not specified, it defaults to IfNotPresent.
+                        description: |-
+                          ImagePullPolicy defines the policy for pulling the container image.
+                          If not specified, it defaults to IfNotPresent.
                         type: string
                       imageRepository:
-                        description: ImageRepository sets the container registry to
-                          pull images from. if not set, the ImageRepository defined
-                          in KarmadaSpec will be used instead.
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          if not set, the ImageRepository defined in KarmadaSpec will be used instead.
                         type: string
                       imageTag:
-                        description: ImageTag allows to specify a tag for the image.
-                          In case this value is set, operator does not change automatically
-                          the version of the above components during upgrades.
+                        description: |-
+                          ImageTag allows to specify a tag for the image.
+                          In case this value is set, operator does not change automatically the version
+                          of the above components during upgrades.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Map of string keys and values that can be used
-                          to organize and categorize (scope and select) objects. May
-                          match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
                       replicas:
-                        description: Number of desired pods. This is a pointer to
-                          distinguish between explicit zero and not specified. Defaults
-                          to 1.
+                        description: |-
+                          Number of desired pods. This is a pointer to distinguish between explicit
+                          zero and not specified. Defaults to 1.
                         format: int32
                         type: integer
                       resources:
-                        description: 'Compute Resources required by this component.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this component.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                              in spec.resourceClaims, that are used by this container.
-                              \n This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate. \n This field
-                              is immutable. It can only be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -1240,8 +1307,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1250,11 +1318,11 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                     type: object
@@ -1265,74 +1333,86 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                       extraArgs:
                         additionalProperties:
                           type: string
-                        description: "ExtraArgs is an extra set of flags to pass to
-                          the karmada-search component or override. A key in this
-                          map is the flag name as it appears on the command line except
-                          without leading dash(es). \n Note: This is a temporary solution
-                          to allow for the configuration of the karmada-search component.
-                          In the future, we will provide a more structured way to
-                          configure the component. Once that is done, this field will
-                          be discouraged to be used. Incorrect settings on this field
-                          maybe lead to the corresponding component in an unhealthy
-                          state. Before you do it, please confirm that you understand
-                          the risks of this configuration. \n For supported flags,
-                          please see https://karmada.io/docs/reference/components/karmada-search
-                          for details."
+                        description: |-
+                          ExtraArgs is an extra set of flags to pass to the karmada-search component or override.
+                          A key in this map is the flag name as it appears on the command line except without
+                          leading dash(es).
+
+
+                          Note: This is a temporary solution to allow for the configuration of the karmada-search
+                          component. In the future, we will provide a more structured way to configure the component.
+                          Once that is done, this field will be discouraged to be used.
+                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
+                          state. Before you do it, please confirm that you understand the risks of this configuration.
+
+
+                          For supported flags, please see
+                          https://karmada.io/docs/reference/components/karmada-search
+                          for details.
                         type: object
                       imagePullPolicy:
-                        description: ImagePullPolicy defines the policy for pulling
-                          the container image. If not specified, it defaults to IfNotPresent.
+                        description: |-
+                          ImagePullPolicy defines the policy for pulling the container image.
+                          If not specified, it defaults to IfNotPresent.
                         type: string
                       imageRepository:
-                        description: ImageRepository sets the container registry to
-                          pull images from. if not set, the ImageRepository defined
-                          in KarmadaSpec will be used instead.
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          if not set, the ImageRepository defined in KarmadaSpec will be used instead.
                         type: string
                       imageTag:
-                        description: ImageTag allows to specify a tag for the image.
-                          In case this value is set, operator does not change automatically
-                          the version of the above components during upgrades.
+                        description: |-
+                          ImageTag allows to specify a tag for the image.
+                          In case this value is set, operator does not change automatically the version
+                          of the above components during upgrades.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Map of string keys and values that can be used
-                          to organize and categorize (scope and select) objects. May
-                          match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
                       replicas:
-                        description: Number of desired pods. This is a pointer to
-                          distinguish between explicit zero and not specified. Defaults
-                          to 1.
+                        description: |-
+                          Number of desired pods. This is a pointer to distinguish between explicit
+                          zero and not specified. Defaults to 1.
                         format: int32
                         type: integer
                       resources:
-                        description: 'Compute Resources required by this component.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this component.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                              in spec.resourceClaims, that are used by this container.
-                              \n This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate. \n This field
-                              is immutable. It can only be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -1349,8 +1429,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1359,11 +1440,11 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                     type: object
@@ -1374,74 +1455,86 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                       extraArgs:
                         additionalProperties:
                           type: string
-                        description: "ExtraArgs is an extra set of flags to pass to
-                          the karmada-webhook component or override. A key in this
-                          map is the flag name as it appears on the command line except
-                          without leading dash(es). \n Note: This is a temporary solution
-                          to allow for the configuration of the karmada-webhook component.
-                          In the future, we will provide a more structured way to
-                          configure the component. Once that is done, this field will
-                          be discouraged to be used. Incorrect settings on this field
-                          maybe lead to the corresponding component in an unhealthy
-                          state. Before you do it, please confirm that you understand
-                          the risks of this configuration. \n For supported flags,
-                          please see https://karmada.io/docs/reference/components/karmada-webhook
-                          for details."
+                        description: |-
+                          ExtraArgs is an extra set of flags to pass to the karmada-webhook component or
+                          override. A key in this map is the flag name as it appears on the command line except
+                          without leading dash(es).
+
+
+                          Note: This is a temporary solution to allow for the configuration of the
+                          karmada-webhook component. In the future, we will provide a more structured way
+                          to configure the component. Once that is done, this field will be discouraged to be used.
+                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
+                          state. Before you do it, please confirm that you understand the risks of this configuration.
+
+
+                          For supported flags, please see
+                          https://karmada.io/docs/reference/components/karmada-webhook
+                          for details.
                         type: object
                       imagePullPolicy:
-                        description: ImagePullPolicy defines the policy for pulling
-                          the container image. If not specified, it defaults to IfNotPresent.
+                        description: |-
+                          ImagePullPolicy defines the policy for pulling the container image.
+                          If not specified, it defaults to IfNotPresent.
                         type: string
                       imageRepository:
-                        description: ImageRepository sets the container registry to
-                          pull images from. if not set, the ImageRepository defined
-                          in KarmadaSpec will be used instead.
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          if not set, the ImageRepository defined in KarmadaSpec will be used instead.
                         type: string
                       imageTag:
-                        description: ImageTag allows to specify a tag for the image.
-                          In case this value is set, operator does not change automatically
-                          the version of the above components during upgrades.
+                        description: |-
+                          ImageTag allows to specify a tag for the image.
+                          In case this value is set, operator does not change automatically the version
+                          of the above components during upgrades.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Map of string keys and values that can be used
-                          to organize and categorize (scope and select) objects. May
-                          match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
                       replicas:
-                        description: Number of desired pods. This is a pointer to
-                          distinguish between explicit zero and not specified. Defaults
-                          to 1.
+                        description: |-
+                          Number of desired pods. This is a pointer to distinguish between explicit
+                          zero and not specified. Defaults to 1.
                         format: int32
                         type: integer
                       resources:
-                        description: 'Compute Resources required by this component.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this component.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                              in spec.resourceClaims, that are used by this container.
-                              \n This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate. \n This field
-                              is immutable. It can only be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -1458,8 +1551,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1468,11 +1562,11 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                     type: object
@@ -1483,117 +1577,136 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                       controllers:
-                        description: "A list of controllers to enable. '*' enables
-                          all on-by-default controllers, 'foo' enables the controller
-                          named 'foo', '-foo' disables the controller named 'foo'.
-                          \n All controllers: attachdetach, bootstrapsigner, cloud-node-lifecycle,
-                          clusterrole-aggregation, cronjob, csrapproving, csrcleaner,
-                          csrsigning, daemonset, deployment, disruption, endpoint,
-                          endpointslice, endpointslicemirroring, ephemeral-volume,
-                          garbagecollector, horizontalpodautoscaling, job, namespace,
-                          nodeipam, nodelifecycle, persistentvolume-binder, persistentvolume-expander,
-                          podgc, pv-protection, pvc-protection, replicaset, replicationcontroller,
-                          resourcequota, root-ca-cert-publisher, route, service, serviceaccount,
-                          serviceaccount-token, statefulset, tokencleaner, ttl, ttl-after-finished
-                          Disabled-by-default controllers: bootstrapsigner, tokencleaner
-                          (default [*]) Actual Supported controllers depend on the
-                          version of Kubernetes. See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/
-                          for details. \n However, Karmada uses Kubernetes Native
-                          API definitions for federated resource template, so it doesn't
-                          need enable some resource related controllers like daemonset,
-                          deployment etc. On the other hand, Karmada leverages the
-                          capabilities of the Kubernetes controller to manage the
-                          lifecycle of the federated resource, so it needs to enable
-                          some controllers. For example, the `namespace` controller
-                          is used to manage the lifecycle of the namespace and the
-                          `garbagecollector` controller handles automatic clean-up
-                          of redundant items in your karmada. \n According to the
-                          user feedback and karmada requirements, the following controllers
-                          are enabled by default: namespace, garbagecollector, serviceaccount-token,
-                          ttl-after-finished, bootstrapsigner,csrapproving,csrcleaner,csrsigning.
-                          See https://karmada.io/docs/administrator/configuration/configure-controllers#kubernetes-controllers
-                          \n Others are disabled by default. If you want to enable
-                          or disable other controllers, you have to explicitly specify
-                          all the controllers that kube-controller-manager should
-                          enable at startup phase."
+                        description: |-
+                          A list of controllers to enable. '*' enables all on-by-default controllers,
+                          'foo' enables the controller named 'foo', '-foo' disables the controller named
+                          'foo'.
+
+
+                          All controllers: attachdetach, bootstrapsigner, cloud-node-lifecycle,
+                          clusterrole-aggregation, cronjob, csrapproving, csrcleaner, csrsigning,
+                          daemonset, deployment, disruption, endpoint, endpointslice,
+                          endpointslicemirroring, ephemeral-volume, garbagecollector,
+                          horizontalpodautoscaling, job, namespace, nodeipam, nodelifecycle,
+                          persistentvolume-binder, persistentvolume-expander, podgc, pv-protection,
+                          pvc-protection, replicaset, replicationcontroller, resourcequota,
+                          root-ca-cert-publisher, route, service, serviceaccount, serviceaccount-token,
+                          statefulset, tokencleaner, ttl, ttl-after-finished
+                          Disabled-by-default controllers: bootstrapsigner, tokencleaner (default [*])
+                          Actual Supported controllers depend on the version of Kubernetes. See
+                          https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/
+                          for details.
+
+
+                          However, Karmada uses Kubernetes Native API definitions for federated resource template,
+                          so it doesn't need enable some resource related controllers like daemonset, deployment etc.
+                          On the other hand, Karmada leverages the capabilities of the Kubernetes controller to
+                          manage the lifecycle of the federated resource, so it needs to enable some controllers.
+                          For example, the `namespace` controller is used to manage the lifecycle of the namespace
+                          and the `garbagecollector` controller handles automatic clean-up of redundant items in
+                          your karmada.
+
+
+                          According to the user feedback and karmada requirements, the following controllers are
+                          enabled by default: namespace, garbagecollector, serviceaccount-token, ttl-after-finished,
+                          bootstrapsigner,csrapproving,csrcleaner,csrsigning. See
+                          https://karmada.io/docs/administrator/configuration/configure-controllers#kubernetes-controllers
+
+
+                          Others are disabled by default. If you want to enable or disable other controllers, you
+                          have to explicitly specify all the controllers that kube-controller-manager should enable
+                          at startup phase.
                         items:
                           type: string
                         type: array
                       extraArgs:
                         additionalProperties:
                           type: string
-                        description: "ExtraArgs is an extra set of flags to pass to
-                          the kube-controller-manager component or override. A key
-                          in this map is the flag name as it appears on the command
-                          line except without leading dash(es). \n Note: This is a
-                          temporary solution to allow for the configuration of the
-                          kube-controller-manager component. In the future, we will
-                          provide a more structured way to configure the component.
-                          Once that is done, this field will be discouraged to be
-                          used. Incorrect settings on this field maybe lead to the
-                          corresponding component in an unhealthy state. Before you
-                          do it, please confirm that you understand the risks of this
-                          configuration. \n For supported flags, please see https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/
-                          for details."
+                        description: |-
+                          ExtraArgs is an extra set of flags to pass to the kube-controller-manager component or
+                          override. A key in this map is the flag name as it appears on the command line except
+                          without leading dash(es).
+
+
+                          Note: This is a temporary solution to allow for the configuration of the
+                          kube-controller-manager component. In the future, we will provide a more structured way
+                          to configure the component. Once that is done, this field will be discouraged to be used.
+                          Incorrect settings on this field maybe lead to the corresponding component in an unhealthy
+                          state. Before you do it, please confirm that you understand the risks of this configuration.
+
+
+                          For supported flags, please see
+                          https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/
+                          for details.
                         type: object
                       featureGates:
                         additionalProperties:
                           type: boolean
-                        description: 'FeatureGates enabled by the user. More info:
-                          https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/'
+                        description: |-
+                          FeatureGates enabled by the user.
+                          More info: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/
                         type: object
                       imagePullPolicy:
-                        description: ImagePullPolicy defines the policy for pulling
-                          the container image. If not specified, it defaults to IfNotPresent.
+                        description: |-
+                          ImagePullPolicy defines the policy for pulling the container image.
+                          If not specified, it defaults to IfNotPresent.
                         type: string
                       imageRepository:
-                        description: ImageRepository sets the container registry to
-                          pull images from. if not set, the ImageRepository defined
-                          in KarmadaSpec will be used instead.
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          if not set, the ImageRepository defined in KarmadaSpec will be used instead.
                         type: string
                       imageTag:
-                        description: ImageTag allows to specify a tag for the image.
-                          In case this value is set, operator does not change automatically
-                          the version of the above components during upgrades.
+                        description: |-
+                          ImageTag allows to specify a tag for the image.
+                          In case this value is set, operator does not change automatically the version
+                          of the above components during upgrades.
                         type: string
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Map of string keys and values that can be used
-                          to organize and categorize (scope and select) objects. May
-                          match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
                       replicas:
-                        description: Number of desired pods. This is a pointer to
-                          distinguish between explicit zero and not specified. Defaults
-                          to 1.
+                        description: |-
+                          Number of desired pods. This is a pointer to distinguish between explicit
+                          zero and not specified. Defaults to 1.
                         format: int32
                         type: integer
                       resources:
-                        description: 'Compute Resources required by this component.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this component.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                              in spec.resourceClaims, that are used by this container.
-                              \n This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate. \n This field
-                              is immutable. It can only be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -1610,8 +1723,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1620,11 +1734,11 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                     type: object
@@ -1632,21 +1746,25 @@ spec:
               featureGates:
                 additionalProperties:
                   type: boolean
-                description: 'FeatureGates enabled by the user. - Failover: https://karmada.io/docs/userguide/failover/#failover
+                description: |-
+                  FeatureGates enabled by the user.
+                  - Failover: https://karmada.io/docs/userguide/failover/#failover
                   - GracefulEviction: https://karmada.io/docs/userguide/failover/#graceful-eviction-feature
                   - PropagateDeps: https://karmada.io/docs/userguide/scheduling/propagate-dependencies
                   - CustomizedClusterResourceModeling: https://karmada.io/docs/userguide/scheduling/cluster-resources#start-to-use-cluster-resource-models
-                  More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go'
+                  More info: https://github.com/karmada-io/karmada/blob/master/pkg/features/features.go
                 type: object
               hostCluster:
-                description: HostCluster represents the cluster where to install the
-                  Karmada control plane. If not set, the control plane will be installed
-                  on the cluster where running the operator.
+                description: |-
+                  HostCluster represents the cluster where to install the Karmada control plane.
+                  If not set, the control plane will be installed on the cluster where
+                  running the operator.
                 properties:
                   apiEndpoint:
-                    description: APIEndpoint is the API endpoint of the cluster where
-                      deploy Karmada control plane on. This can be a hostname, hostname:port,
-                      IP or IP:port.
+                    description: |-
+                      APIEndpoint is the API endpoint of the cluster where deploy Karmada
+                      control plane on.
+                      This can be a hostname, hostname:port, IP or IP:port.
                     type: string
                   networking:
                     description: Networking holds configuration for the networking
@@ -1658,9 +1776,12 @@ spec:
                         type: string
                     type: object
                   secretRef:
-                    description: 'SecretRef represents the secret contains mandatory
-                      credentials to access the cluster. The secret should hold credentials
-                      as follows: - secret.data.token - secret.data.caBundle'
+                    description: |-
+                      SecretRef represents the secret contains mandatory credentials to
+                      access the cluster.
+                      The secret should hold credentials as follows:
+                      - secret.data.token
+                      - secret.data.caBundle
                     properties:
                       name:
                         description: Name is the name of resource being referenced.
@@ -1672,14 +1793,17 @@ spec:
                     type: object
                 type: object
               privateRegistry:
-                description: PrivateRegistry is the global image registry. If set,
-                  the operator will pull all required images from it, no matter the
-                  image is maintained by Karmada or Kubernetes. It will be useful
-                  for offline installation to specify an accessible registry.
+                description: |-
+                  PrivateRegistry is the global image registry.
+                  If set, the operator will pull all required images from it, no matter
+                  the image is maintained by Karmada or Kubernetes.
+                  It will be useful for offline installation to specify an accessible registry.
                 properties:
                   registry:
-                    description: 'Registry is the image registry hostname, like: -
-                      docker.io - fictional.registry.example'
+                    description: |-
+                      Registry is the image registry hostname, like:
+                      - docker.io
+                      - fictional.registry.example
                     type: string
                 required:
                 - registry
@@ -1693,42 +1817,42 @@ spec:
                   of a karmada's current state.
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -1742,11 +1866,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
This PR bumps controller-tools and refreshes the generated CRDs.


**Which issue(s) this PR fixes**:
Fixes #4873

**Special notes for your reviewer**:
Notable changes of controller-tools:
- Remove usages of deprecated io/ioutil
- Add support for empty maps or lists
- CRD: Respect multiline comments at godocs

**Does this PR introduce a user-facing change?**:
`NONE`