### PR TITLE
fix patching WorkloadRebalancer failed due to misuse of shared slices

### DIFF
--- a/pkg/controllers/workloadrebalancer/workloadrebalancer_controller.go
+++ b/pkg/controllers/workloadrebalancer/workloadrebalancer_controller.go
@@ -80,7 +80,7 @@ func (c *RebalancerController) Reconcile(ctx context.Context, req controllerrunt
 	newStatus, successNum, retryNum := c.doWorkloadRebalance(ctx, rebalancer)
 
 	// 3. update status of WorkloadRebalancer
-	if err := c.updateWorkloadRebalancerStatus(rebalancer, newStatus); err != nil {
+	if err := c.updateWorkloadRebalancerStatus(ctx, rebalancer, newStatus); err != nil {
 		return controllerruntime.Result{}, err
 	}
 	klog.Infof("Finish handling WorkloadRebalancer (%s), %d/%d resource success in all, while %d resource need retry",
@@ -92,22 +92,22 @@ func (c *RebalancerController) Reconcile(ctx context.Context, req controllerrunt
 	return controllerruntime.Result{}, nil
 }
 
-func (c *RebalancerController) buildWorkloadRebalancerStatus(rebalancer *appsv1alpha1.WorkloadRebalancer) appsv1alpha1.WorkloadRebalancerStatus {
+func (c *RebalancerController) buildWorkloadRebalancerStatus(rebalancer *appsv1alpha1.WorkloadRebalancer) *appsv1alpha1.WorkloadRebalancerStatus {
 	resourceList := make([]appsv1alpha1.ObservedWorkload, 0)
 	for _, resource := range rebalancer.Spec.Workloads {
 		resourceList = append(resourceList, appsv1alpha1.ObservedWorkload{
 			Workload: resource,
 		})
 	}
-	return appsv1alpha1.WorkloadRebalancerStatus{
+	return &appsv1alpha1.WorkloadRebalancerStatus{
 		ObservedWorkloads: resourceList,
 	}
 }
 
 func (c *RebalancerController) doWorkloadRebalance(ctx context.Context, rebalancer *appsv1alpha1.WorkloadRebalancer) (
-	newStatus appsv1alpha1.WorkloadRebalancerStatus, successNum int64, retryNum int64) {
+	newStatus *appsv1alpha1.WorkloadRebalancerStatus, successNum int64, retryNum int64) {
 	// get previous status and update basing on it
-	newStatus = rebalancer.Status
+	newStatus = rebalancer.Status.DeepCopy()
 	if len(newStatus.ObservedWorkloads) == 0 {
 		newStatus = c.buildWorkloadRebalancerStatus(rebalancer)
 	}
@@ -127,8 +127,8 @@ func (c *RebalancerController) doWorkloadRebalance(ctx context.Context, rebalanc
 		if resource.Workload.Namespace != "" {
 			binding := &workv1alpha2.ResourceBinding{}
 			if err := c.Client.Get(ctx, client.ObjectKey{Namespace: resource.Workload.Namespace, Name: bindingName}, binding); err != nil {
-				klog.Errorf("get binding failed: %+v", err)
-				c.recordWorkloadRebalanceFailed(&newStatus.ObservedWorkloads[i], &retryNum, err)
+				klog.Errorf("get binding for resource %+v failed: %+v", resource.Workload, err)
+				c.recordAndCountRebalancerFailed(&newStatus.ObservedWorkloads[i], &retryNum, err)
 				continue
 			}
 			// update spec.rescheduleTriggeredAt of referenced fetchTargetRefBindings to trigger a rescheduling
@@ -136,17 +136,17 @@ func (c *RebalancerController) doWorkloadRebalance(ctx context.Context, rebalanc
 				binding.Spec.RescheduleTriggeredAt = &rebalancer.CreationTimestamp
 
 				if err := c.Client.Update(ctx, binding); err != nil {
-					klog.Errorf("update binding failed: %+v", err)
-					c.recordWorkloadRebalanceFailed(&newStatus.ObservedWorkloads[i], &retryNum, err)
+					klog.Errorf("update binding for resource %+v failed: %+v", resource.Workload, err)
+					c.recordAndCountRebalancerFailed(&newStatus.ObservedWorkloads[i], &retryNum, err)
 					continue
 				}
 			}
-			c.recordWorkloadRebalanceSuccess(&newStatus.ObservedWorkloads[i], &successNum)
+			c.recordAndCountRebalancerSuccess(&newStatus.ObservedWorkloads[i], &successNum)
 		} else {
 			clusterbinding := &workv1alpha2.ClusterResourceBinding{}
 			if err := c.Client.Get(ctx, client.ObjectKey{Name: bindingName}, clusterbinding); err != nil {
-				klog.Errorf("get cluster binding failed: %+v", err)
-				c.recordWorkloadRebalanceFailed(&newStatus.ObservedWorkloads[i], &retryNum, err)
+				klog.Errorf("get cluster binding for resource %+v failed: %+v", resource.Workload, err)
+				c.recordAndCountRebalancerFailed(&newStatus.ObservedWorkloads[i], &retryNum, err)
 				continue
 			}
 			// update spec.rescheduleTriggeredAt of referenced clusterbinding to trigger a rescheduling
@@ -154,12 +154,12 @@ func (c *RebalancerController) doWorkloadRebalance(ctx context.Context, rebalanc
 				clusterbinding.Spec.RescheduleTriggeredAt = &rebalancer.CreationTimestamp
 
 				if err := c.Client.Update(ctx, clusterbinding); err != nil {
-					klog.Errorf("update cluster binding failed: %+v", err)
-					c.recordWorkloadRebalanceFailed(&newStatus.ObservedWorkloads[i], &retryNum, err)
+					klog.Errorf("update cluster binding for resource %+v failed: %+v", resource.Workload, err)
+					c.recordAndCountRebalancerFailed(&newStatus.ObservedWorkloads[i], &retryNum, err)
 					continue
 				}
 			}
-			c.recordWorkloadRebalanceSuccess(&newStatus.ObservedWorkloads[i], &successNum)
+			c.recordAndCountRebalancerSuccess(&newStatus.ObservedWorkloads[i], &successNum)
 		}
 	}
 	return
@@ -169,29 +169,30 @@ func (c *RebalancerController) needTriggerReschedule(creationTimestamp metav1.Ti
 	return rescheduleTriggeredAt == nil || creationTimestamp.After(rescheduleTriggeredAt.Time)
 }
 
-func (c *RebalancerController) recordWorkloadRebalanceSuccess(resource *appsv1alpha1.ObservedWorkload, successNum *int64) {
+func (c *RebalancerController) recordAndCountRebalancerSuccess(resource *appsv1alpha1.ObservedWorkload, successNum *int64) {
 	resource.Result = appsv1alpha1.RebalanceSuccessful
 	*successNum++
 }
 
-func (c *RebalancerController) recordWorkloadRebalanceFailed(resource *appsv1alpha1.ObservedWorkload, retryNum *int64, err error) {
-	resource.Result = appsv1alpha1.RebalanceFailed
+func (c *RebalancerController) recordAndCountRebalancerFailed(resource *appsv1alpha1.ObservedWorkload, retryNum *int64, err error) {
 	reason := apierrors.ReasonForError(err)
 	if reason == metav1.StatusReasonNotFound {
+		resource.Result = appsv1alpha1.RebalanceFailed
 		resource.Reason = appsv1alpha1.RebalanceObjectNotFound
 	} else {
 		*retryNum++
 	}
 }
 
-func (c *RebalancerController) updateWorkloadRebalancerStatus(rebalancer *appsv1alpha1.WorkloadRebalancer, newStatus appsv1alpha1.WorkloadRebalancerStatus) error {
+func (c *RebalancerController) updateWorkloadRebalancerStatus(ctx context.Context, rebalancer *appsv1alpha1.WorkloadRebalancer,
+	newStatus *appsv1alpha1.WorkloadRebalancerStatus) error {
 	rebalancerPatch := client.MergeFrom(rebalancer)
-	rebalancerCopy := rebalancer.DeepCopy()
-	rebalancerCopy.Status = newStatus
+	modifiedRebalancer := rebalancer.DeepCopy()
+	modifiedRebalancer.Status = *newStatus
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() (err error) {
 		klog.V(4).Infof("Start to patch WorkloadRebalancer(%s) status", rebalancer.Name)
-		if err := c.Client.Status().Patch(context.TODO(), rebalancerCopy, rebalancerPatch); err != nil {
+		if err = c.Client.Status().Patch(ctx, modifiedRebalancer, rebalancerPatch); err != nil {
 			klog.Errorf("Failed to patch WorkloadRebalancer (%s) status, err: %+v", rebalancer.Name, err)
 			return err
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

fix patching WorkloadRebalancer failed due to misuse of shared slices.

in previous code:

```go
// get previous status and update basing on it
newStatus = rebalancer.Status
if len(newStatus.ObservedWorkloads) == 0 {
	newStatus = c.buildWorkloadRebalancerStatus(rebalancer)
}
```

actually `newStatus` and `rebalancer.Status` shared the slice of `rebalancer.Status.ObservedWorkloads`.

if this slice didn't change from nil to non-nil or occurs expansion, modification to `newStatus` will also be applied to the `rebalancer.Status`, which will lead to `patch status` failed. 

**Which issue(s) this PR fixes**:

Fixes part of #4840

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

