### PR TITLE
Expose containing port of serving metrics

### DIFF
--- a/charts/karmada/templates/karmada-agent.yaml
+++ b/charts/karmada/templates/karmada-agent.yaml
@@ -122,6 +122,10 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 15
             timeoutSeconds: 5
+          ports:
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
           volumeMounts:
             - name: kubeconfig
               mountPath: /etc/kubeconfig

--- a/charts/karmada/templates/karmada-controller-manager.yaml
+++ b/charts/karmada/templates/karmada-controller-manager.yaml
@@ -71,6 +71,10 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 15
             timeoutSeconds: 5
+          ports:
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
           volumeMounts:
           {{- include "karmada.kubeconfig.volumeMount" . | nindent 12 }}
           resources:

--- a/charts/karmada/templates/karmada-scheduler.yaml
+++ b/charts/karmada/templates/karmada-scheduler.yaml
@@ -60,6 +60,10 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 15
             timeoutSeconds: 5
+          ports:
+            - containerPort: 10351
+              name: http
+              protocol: TCP
           volumeMounts:
           {{- include "karmada.kubeconfig.volumeMount" . | nindent 12 }}
           resources:


### PR DESCRIPTION
…erviceMonitor

**What type of PR is this?**
This is improve for installation, the port of karmada-apiserver is exposed, but other componment is not.

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Expose the default port  for the karmada-controller-manager, scheduler and agent when creating a PodMonitor.
```

