### PR TITLE
silence the 'log.SetLogger(...) was never called; logs will not be displayed' error

### DIFF
--- a/cmd/controller-manager/controller-manager.go
+++ b/cmd/controller-manager/controller-manager.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/component-base/cli"
 	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
+	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	_ "sigs.k8s.io/controller-runtime/pkg/metrics"
 
@@ -29,6 +30,12 @@ import (
 
 func main() {
 	ctx := controllerruntime.SetupSignalHandler()
+	// Starting from version 0.15.0, controller-runtime expects its consumers to set a logger through log.SetLogger.
+	// If SetLogger is not called within the first 30 seconds of a binaries lifetime, it will get
+	// set to a NullLogSink and report an error. Here's to silence the "log.SetLogger(...) was never called; logs will not be displayed" error
+	// by setting a logger through log.SetLogger.
+	// More info refer to: https://github.com/karmada-io/karmada/pull/4885.
+	controllerruntime.SetLogger(klog.Background())
 	cmd := app.NewControllerManagerCommand(ctx)
 	code := cli.Run(cmd)
 	os.Exit(code)

--- a/cmd/metrics-adapter/main.go
+++ b/cmd/metrics-adapter/main.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/component-base/cli"
 	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
+	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 
 	"github.com/karmada-io/karmada/cmd/metrics-adapter/app"
@@ -28,6 +29,12 @@ import (
 
 func main() {
 	ctx := controllerruntime.SetupSignalHandler()
+	// Starting from version 0.15.0, controller-runtime expects its consumers to set a logger through log.SetLogger.
+	// If SetLogger is not called within the first 30 seconds of a binaries lifetime, it will get
+	// set to a NullLogSink and report an error. Here's to silence the "log.SetLogger(...) was never called; logs will not be displayed" error
+	// by setting a logger through log.SetLogger.
+	// More info refer to: https://github.com/karmada-io/karmada/pull/4885.
+	controllerruntime.SetLogger(klog.Background())
 	cmd := app.NewMetricsAdapterCommand(ctx)
 	code := cli.Run(cmd)
 	os.Exit(code)

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/component-base/cli"
 	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
+	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 
 	"github.com/karmada-io/karmada/cmd/webhook/app"
@@ -28,6 +29,12 @@ import (
 
 func main() {
 	ctx := controllerruntime.SetupSignalHandler()
+	// Starting from version 0.15.0, controller-runtime expects its consumers to set a logger through log.SetLogger.
+	// If SetLogger is not called within the first 30 seconds of a binaries lifetime, it will get
+	// set to a NullLogSink and report an error. Here's to silence the "log.SetLogger(...) was never called; logs will not be displayed" error
+	// by setting a logger through log.SetLogger.
+	// More info refer to: https://github.com/karmada-io/karmada/pull/4885.
+	controllerruntime.SetLogger(klog.Background())
 	cmd := app.NewWebhookCommand(ctx)
 	code := cli.Run(cmd)
 	os.Exit(code)

--- a/examples/customresourceinterpreter/webhook/main.go
+++ b/examples/customresourceinterpreter/webhook/main.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/component-base/cli"
 	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
+	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 
 	"github.com/karmada-io/karmada/examples/customresourceinterpreter/webhook/app"
@@ -28,6 +29,12 @@ import (
 
 func main() {
 	ctx := controllerruntime.SetupSignalHandler()
+	// Starting from version 0.15.0, controller-runtime expects its consumers to set a logger through log.SetLogger.
+	// If SetLogger is not called within the first 30 seconds of a binaries lifetime, it will get
+	// set to a NullLogSink and report an error. Here's to silence the "log.SetLogger(...) was never called; logs will not be displayed" error
+	// by setting a logger through log.SetLogger.
+	// More info refer to: https://github.com/karmada-io/karmada/pull/4885.
+	controllerruntime.SetLogger(klog.Background())
 	cmd := app.NewWebhookCommand(ctx)
 	code := cli.Run(cmd)
 	os.Exit(code)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Refer to #4868, when `karmada-webhook` is started, the error `log.SetLogger(...) was never called; logs will not be displayed` will be displayed, which is very confusing. 
Here's the answer to why this log appears and how to fix it.
Viewing the function call chain, refer to: https://github.com/karmada-io/karmada/blob/95bf37f4d4b82cd9ab68e5879020c070acec1ce0/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission/webhook.go#L178-L184
If the log of webhook is nil, it will end up calling 
https://github.com/karmada-io/karmada/blob/95bf37f4d4b82cd9ab68e5879020c070acec1ce0/vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go#L54-L72
And the `SetLogger` is not called within the first 30 seconds of a binaries lifetime, finally printed out `log.SetLogger(...) was never called; logs will not be displayed` error.
Through the above analysis, there are two ways to solve this problem：
- Initializing the webhook's log
Looking at the source code, there are two ways to initialize, in addition to the one above, there is one as follows:
https://github.com/karmada-io/karmada/blob/95bf37f4d4b82cd9ab68e5879020c070acec1ce0/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission/webhook.go#L216-L233
Since this initialization method does not apply to `webhook.Server`, this method does not work

- call `SetLogger` to get any actual logging.
  That's what I ended up using, by calling `SetLogger` first to silence the 'log.SetLogger(...) was never called; logs will not be displayed' error.

BTW, it was a breaking change in the release notes `0.15.0` of `controller-runtime`. Previously, when the `pkg/log` package was imported, there was an `init` function that spawned a goroutine, which set a null logger after 30 seconds. Therefore, versions prior to `0.15.0` will not have this problem.

**Which issue(s) this PR fixes**:
Fixes #4868

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

