### PR TITLE
support auto delete WorkloadRebalancer when time up

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16759,6 +16759,11 @@
         "workloads"
       ],
       "properties": {
+        "ttlSecondsAfterFinished": {
+          "description": "TTLSecondsAfterFinished limits the lifetime of a WorkloadRebalancer that has finished execution (means each target workload is finished with result of Successful or Failed). If this field is set, ttlSecondsAfterFinished after the WorkloadRebalancer finishes, it is eligible to be automatically deleted. If this field is unset, the WorkloadRebalancer won't be automatically deleted. If this field is set to zero, the WorkloadRebalancer becomes eligible to be deleted immediately after it finishes.",
+          "type": "integer",
+          "format": "int32"
+        },
         "workloads": {
           "description": "Workloads used to specify the list of expected resource. Nil or empty list is not allowed.",
           "type": "array",
@@ -16773,6 +16778,15 @@
       "description": "WorkloadRebalancerStatus contains information about the current status of a WorkloadRebalancer updated periodically by schedule trigger controller.",
       "type": "object",
       "properties": {
+        "finishTime": {
+          "description": "FinishTime represents the finish time of rebalancer.",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the generation(.metadata.generation) observed by the controller. If ObservedGeneration is less than the generation in metadata means the controller hasn't confirmed the rebalance result or hasn't done the rebalance yet.",
+          "type": "integer",
+          "format": "int64"
+        },
         "observedWorkloads": {
           "description": "ObservedWorkloads contains information about the execution states and messages of target resources.",
           "type": "array",

--- a/charts/karmada/_crds/bases/apps/apps.karmada.io_workloadrebalancers.yaml
+++ b/charts/karmada/_crds/bases/apps/apps.karmada.io_workloadrebalancers.yaml
@@ -41,6 +41,15 @@ spec:
             description: Spec represents the specification of the desired behavior
               of WorkloadRebalancer.
             properties:
+              ttlSecondsAfterFinished:
+                description: |-
+                  TTLSecondsAfterFinished limits the lifetime of a WorkloadRebalancer that has finished execution (means each
+                  target workload is finished with result of Successful or Failed).
+                  If this field is set, ttlSecondsAfterFinished after the WorkloadRebalancer finishes, it is eligible to be automatically deleted.
+                  If this field is unset, the WorkloadRebalancer won't be automatically deleted.
+                  If this field is set to zero, the WorkloadRebalancer becomes eligible to be deleted immediately after it finishes.
+                format: int32
+                type: integer
               workloads:
                 description: |-
                   Workloads used to specify the list of expected resource.
@@ -76,6 +85,17 @@ spec:
           status:
             description: Status represents the status of WorkloadRebalancer.
             properties:
+              finishTime:
+                description: FinishTime represents the finish time of rebalancer.
+                format: date-time
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the generation(.metadata.generation) observed by the controller.
+                  If ObservedGeneration is less than the generation in metadata means the controller hasn't confirmed
+                  the rebalance result or hasn't done the rebalance yet.
+                format: int64
+                type: integer
               observedWorkloads:
                 description: ObservedWorkloads contains information about the execution
                   states and messages of target resources.

--- a/pkg/apis/apps/v1alpha1/workloadrebalancer_types.go
+++ b/pkg/apis/apps/v1alpha1/workloadrebalancer_types.go
@@ -57,6 +57,14 @@ type WorkloadRebalancerSpec struct {
 	// +kubebuilder:validation:MinItems=1
 	// +required
 	Workloads []ObjectReference `json:"workloads"`
+
+	// TTLSecondsAfterFinished limits the lifetime of a WorkloadRebalancer that has finished execution (means each
+	// target workload is finished with result of Successful or Failed).
+	// If this field is set, ttlSecondsAfterFinished after the WorkloadRebalancer finishes, it is eligible to be automatically deleted.
+	// If this field is unset, the WorkloadRebalancer won't be automatically deleted.
+	// If this field is set to zero, the WorkloadRebalancer becomes eligible to be deleted immediately after it finishes.
+	// +optional
+	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
 }
 
 // ObjectReference the expected resource.
@@ -85,6 +93,16 @@ type WorkloadRebalancerStatus struct {
 	// ObservedWorkloads contains information about the execution states and messages of target resources.
 	// +optional
 	ObservedWorkloads []ObservedWorkload `json:"observedWorkloads,omitempty"`
+
+	// ObservedGeneration is the generation(.metadata.generation) observed by the controller.
+	// If ObservedGeneration is less than the generation in metadata means the controller hasn't confirmed
+	// the rebalance result or hasn't done the rebalance yet.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	// FinishTime represents the finish time of rebalancer.
+	// +optional
+	FinishTime *metav1.Time `json:"finishTime,omitempty"`
 }
 
 // ObservedWorkload the observed resource.
@@ -117,7 +135,7 @@ type RebalanceFailedReason string
 
 const (
 	// RebalanceObjectNotFound the resource referenced binding not found.
-	RebalanceObjectNotFound RebalanceFailedReason = "NotFound"
+	RebalanceObjectNotFound RebalanceFailedReason = "ReferencedBindingNotFound"
 )
 
 // +kubebuilder:resource:scope="Cluster"

--- a/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
@@ -127,6 +127,11 @@ func (in *WorkloadRebalancerSpec) DeepCopyInto(out *WorkloadRebalancerSpec) {
 		*out = make([]ObjectReference, len(*in))
 		copy(*out, *in)
 	}
+	if in.TTLSecondsAfterFinished != nil {
+		in, out := &in.TTLSecondsAfterFinished, &out.TTLSecondsAfterFinished
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 
@@ -147,6 +152,10 @@ func (in *WorkloadRebalancerStatus) DeepCopyInto(out *WorkloadRebalancerStatus) 
 		in, out := &in.ObservedWorkloads, &out.ObservedWorkloads
 		*out = make([]ObservedWorkload, len(*in))
 		copy(*out, *in)
+	}
+	if in.FinishTime != nil {
+		in, out := &in.FinishTime, &out.FinishTime
+		*out = (*in).DeepCopy()
 	}
 	return
 }

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -759,6 +759,13 @@ func schema_pkg_apis_apps_v1alpha1_WorkloadRebalancerSpec(ref common.ReferenceCa
 							},
 						},
 					},
+					"ttlSecondsAfterFinished": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TTLSecondsAfterFinished limits the lifetime of a WorkloadRebalancer that has finished execution (means each target workload is finished with result of Successful or Failed). If this field is set, ttlSecondsAfterFinished after the WorkloadRebalancer finishes, it is eligible to be automatically deleted. If this field is unset, the WorkloadRebalancer won't be automatically deleted. If this field is set to zero, the WorkloadRebalancer becomes eligible to be deleted immediately after it finishes.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
 				Required: []string{"workloads"},
 			},
@@ -789,11 +796,24 @@ func schema_pkg_apis_apps_v1alpha1_WorkloadRebalancerStatus(ref common.Reference
 							},
 						},
 					},
+					"observedGeneration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ObservedGeneration is the generation(.metadata.generation) observed by the controller. If ObservedGeneration is less than the generation in metadata means the controller hasn't confirmed the rebalance result or hasn't done the rebalance yet.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"finishTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FinishTime represents the finish time of rebalancer.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/karmada-io/karmada/pkg/apis/apps/v1alpha1.ObservedWorkload"},
+			"github.com/karmada-io/karmada/pkg/apis/apps/v1alpha1.ObservedWorkload", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
 	}
 }
 

--- a/test/e2e/workloadrebalancer_test.go
+++ b/test/e2e/workloadrebalancer_test.go
@@ -160,9 +160,6 @@ var _ = framework.SerialDescribe("workload rebalancer testing", func() {
 
 			ginkgo.By("step3: trigger a reschedule by WorkloadRebalancer", func() {
 				framework.CreateWorkloadRebalancer(karmadaClient, rebalancer)
-				ginkgo.DeferCleanup(func() {
-					framework.RemoveWorkloadRebalancer(karmadaClient, rebalancerName)
-				})
 
 				// actual replicas propagation of deployment should reschedule back to `targetClusters`,
 				// which represents rebalancer changed deployment replicas propagation.
@@ -179,7 +176,7 @@ var _ = framework.SerialDescribe("workload rebalancer testing", func() {
 			ginkgo.By("step4: update WorkloadRebalancer spec workloads", func() {
 				// update workload list from {deploy, clusterrole, notExistDeployObjRef} to {clusterroleObjRef, newAddedDeployObjRef}
 				updatedWorkloads := []appsv1alpha1.ObjectReference{clusterroleObjRef, newAddedDeployObjRef}
-				framework.UpdateWorkloadRebalancer(karmadaClient, rebalancerName, updatedWorkloads)
+				framework.UpdateWorkloadRebalancer(karmadaClient, rebalancerName, &updatedWorkloads, nil)
 
 				expectedWorkloads := []appsv1alpha1.ObservedWorkload{
 					{Workload: deployObjRef, Result: appsv1alpha1.RebalanceSuccessful},
@@ -187,6 +184,13 @@ var _ = framework.SerialDescribe("workload rebalancer testing", func() {
 					{Workload: clusterroleObjRef, Result: appsv1alpha1.RebalanceSuccessful},
 				}
 				framework.WaitRebalancerObservedWorkloads(karmadaClient, rebalancerName, expectedWorkloads)
+			})
+
+			ginkgo.By("step5: auto clean WorkloadRebalancer", func() {
+				ttlSecondsAfterFinished := int32(5)
+				framework.UpdateWorkloadRebalancer(karmadaClient, rebalancerName, nil, &ttlSecondsAfterFinished)
+
+				framework.WaitRebalancerDisappear(karmadaClient, rebalancerName)
 			})
 		})
 	})
@@ -223,9 +227,6 @@ var _ = framework.SerialDescribe("workload rebalancer testing", func() {
 
 			ginkgo.By("step3: trigger a reschedule by WorkloadRebalancer", func() {
 				framework.CreateWorkloadRebalancer(karmadaClient, rebalancer)
-				ginkgo.DeferCleanup(func() {
-					framework.RemoveWorkloadRebalancer(karmadaClient, rebalancerName)
-				})
 
 				// actual replicas propagation of deployment should reschedule back to `targetClusters`,
 				// which represents rebalancer changed deployment replicas propagation.
@@ -242,7 +243,7 @@ var _ = framework.SerialDescribe("workload rebalancer testing", func() {
 			ginkgo.By("step4: update WorkloadRebalancer spec workloads", func() {
 				// update workload list from {deploy, clusterrole, notExistDeployObjRef} to {clusterroleObjRef, newAddedDeployObjRef}
 				updatedWorkloads := []appsv1alpha1.ObjectReference{clusterroleObjRef, newAddedDeployObjRef}
-				framework.UpdateWorkloadRebalancer(karmadaClient, rebalancerName, updatedWorkloads)
+				framework.UpdateWorkloadRebalancer(karmadaClient, rebalancerName, &updatedWorkloads, nil)
 
 				expectedWorkloads := []appsv1alpha1.ObservedWorkload{
 					{Workload: deployObjRef, Result: appsv1alpha1.RebalanceSuccessful},
@@ -250,6 +251,13 @@ var _ = framework.SerialDescribe("workload rebalancer testing", func() {
 					{Workload: clusterroleObjRef, Result: appsv1alpha1.RebalanceSuccessful},
 				}
 				framework.WaitRebalancerObservedWorkloads(karmadaClient, rebalancerName, expectedWorkloads)
+			})
+
+			ginkgo.By("step5: auto clean WorkloadRebalancer", func() {
+				ttlSecondsAfterFinished := int32(5)
+				framework.UpdateWorkloadRebalancer(karmadaClient, rebalancerName, nil, &ttlSecondsAfterFinished)
+
+				framework.WaitRebalancerDisappear(karmadaClient, rebalancerName)
 			})
 		})
 	})
@@ -273,9 +281,6 @@ var _ = framework.SerialDescribe("workload rebalancer testing", func() {
 
 			ginkgo.By("step2: trigger a reschedule by WorkloadRebalancer", func() {
 				framework.CreateWorkloadRebalancer(karmadaClient, rebalancer)
-				ginkgo.DeferCleanup(func() {
-					framework.RemoveWorkloadRebalancer(karmadaClient, rebalancerName)
-				})
 
 				expectedWorkloads := []appsv1alpha1.ObservedWorkload{
 					{Workload: deployObjRef, Result: appsv1alpha1.RebalanceSuccessful},
@@ -288,7 +293,7 @@ var _ = framework.SerialDescribe("workload rebalancer testing", func() {
 			ginkgo.By("step3: update WorkloadRebalancer spec workloads", func() {
 				// update workload list from {deploy, clusterrole, notExistDeployObjRef} to {clusterroleObjRef, newAddedDeployObjRef}
 				updatedWorkloads := []appsv1alpha1.ObjectReference{clusterroleObjRef, newAddedDeployObjRef}
-				framework.UpdateWorkloadRebalancer(karmadaClient, rebalancerName, updatedWorkloads)
+				framework.UpdateWorkloadRebalancer(karmadaClient, rebalancerName, &updatedWorkloads, nil)
 
 				expectedWorkloads := []appsv1alpha1.ObservedWorkload{
 					{Workload: deployObjRef, Result: appsv1alpha1.RebalanceSuccessful},
@@ -296,6 +301,13 @@ var _ = framework.SerialDescribe("workload rebalancer testing", func() {
 					{Workload: clusterroleObjRef, Result: appsv1alpha1.RebalanceSuccessful},
 				}
 				framework.WaitRebalancerObservedWorkloads(karmadaClient, rebalancerName, expectedWorkloads)
+			})
+
+			ginkgo.By("step4: auto clean WorkloadRebalancer", func() {
+				ttlSecondsAfterFinished := int32(5)
+				framework.UpdateWorkloadRebalancer(karmadaClient, rebalancerName, nil, &ttlSecondsAfterFinished)
+
+				framework.WaitRebalancerDisappear(karmadaClient, rebalancerName)
 			})
 		})
 	})


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Support auto delete WorkloadRebalancer when time up:

referring to [Automatic Cleanup for Finished Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/).

Introduces field `ttlSecondsAfterFinished` which limits the lifetime of a WorkloadRebalancer that has finished execution 
(finished execution means each target workload is finished with result of `Successful` or `Failed`).

* If this field is set, `ttlSecondsAfterFinished` after the WorkloadRebalancer finishes, it is eligible to be automatically deleted.
* If this field is unset, the WorkloadRebalancer won't be automatically deleted.
* If this field is set to zero, the WorkloadRebalancer becomes eligible to be deleted immediately after it finishes.

Considering several corner cases:

* case 1: if a new target workload was added into `WorkloadRebalancer` before `ttlSecondsAfterFinished` expired, 
  which means the finish time of the `WorkloadRebalancer` is refreshed, so the `delete` action is deferred since expire time is refreshed too.
* case 2: if `ttlSecondsAfterFinished` is modified before `ttlSecondsAfterFinished` expired, 
  `delete` action should be performed according to latest `ttlSecondsAfterFinished`.
* case 3: when we have got and checked latest `WorkloadRebalancer` object and try to delete it, 
  if a modification to `WorkloadRebalancer` occurred just right between the two time point, the previous `delete` action should be Interrupted.

Several key implementation:
* A `WorkloadRebalancer` is judged as finished should meet two requirements:
  *  all expected workloads are finished with result of `Successful` or `Failed`.
  *  introduce a new field named `ObservedGeneration` to `Status` of WorkloadRebalancer, and it should be equal to `.metadata.Generation`,
     to prevent that the WorkloadRebalancer is updated but controller hasn't in time refreshed its `Status`.
* When `WorkloadRebalancer` is `Created` or `Updated`, add it to the workqueue and calculate its expiring time, and 
  call `workqueue.AddAfter()` function to re-enqueue it once more if it hasn't expired.
* Before deleting the `WorkloadRebalancer`, do a final sanity check. Use the latest `WorkloadRebalancer` directly 
  fetched from api server to see if the TTL truly expires, rather than object from lister cache.
* When deleting the `WorkloadRebalancer`, it is needed to confirm that the `resourceVersion` of the deleted object is as expected,
  to prevent from above corner case 3.

**Which issue(s) this PR fixes**:

Fixes part of #4840

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
support auto delete WorkloadRebalancer when time up
```

