### PR TITLE
chore: let kube version of artifaces/deploy/karmada-apiserver versionsupport configuration.

### DIFF
--- a/artifacts/deploy/karmada-apiserver.yaml
+++ b/artifacts/deploy/karmada-apiserver.yaml
@@ -64,7 +64,7 @@ spec:
             - --tls-private-key-file=/etc/karmada/pki/apiserver.key
             - --tls-min-version=VersionTLS13
           name: karmada-apiserver
-          image: registry.k8s.io/kube-apiserver:v1.27.11
+          image: registry.k8s.io/kube-apiserver:{{karmada_apiserver_version}}
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 8

--- a/artifacts/deploy/kube-controller-manager.yaml
+++ b/artifacts/deploy/kube-controller-manager.yaml
@@ -52,7 +52,7 @@ spec:
             - --service-cluster-ip-range=10.96.0.0/12
             - --use-service-account-credentials=true
             - --v=4
-          image: registry.k8s.io/kube-controller-manager:v1.27.11
+          image: registry.k8s.io/kube-controller-manager:{{karmada_apiserver_version}}
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 8

--- a/hack/deploy-karmada.sh
+++ b/hack/deploy-karmada.sh
@@ -200,8 +200,10 @@ fi
 # deploy karmada apiserver
 TEMP_PATH_APISERVER=$(mktemp -d)
 trap '{ rm -rf ${TEMP_PATH_APISERVER}; }' EXIT
+KARMADA_APISERVER_VERSION=${KARMADA_APISERVER_VERSION:-"v1.27.11"}
 cp "${REPO_ROOT}"/artifacts/deploy/karmada-apiserver.yaml "${TEMP_PATH_APISERVER}"/karmada-apiserver.yaml
 sed -i'' -e "s/{{service_type}}/${KARMADA_APISERVER_SERVICE_TYPE}/g" "${TEMP_PATH_APISERVER}"/karmada-apiserver.yaml
+sed -i'' -e "s/{{karmada_apiserver_version}}/${KARMADA_APISERVER_VERSION}/g" "${TEMP_PATH_APISERVER}"/karmada-apiserver.yaml
 echo -e "\nApply dynamic rendered apiserver service in ${TEMP_PATH_APISERVER}/karmada-apiserver.yaml."
 kubectl --context="${HOST_CLUSTER_NAME}" apply -f "${TEMP_PATH_APISERVER}"/karmada-apiserver.yaml
 
@@ -238,7 +240,9 @@ fi
 util::append_client_kubeconfig "${HOST_CLUSTER_KUBECONFIG}" "${CERT_DIR}/karmada.crt" "${CERT_DIR}/karmada.key" "${KARMADA_APISERVER_IP}" "${KARMADA_APISERVER_SECURE_PORT}" karmada-apiserver
 
 # deploy kube controller manager
-kubectl --context="${HOST_CLUSTER_NAME}" apply -f "${REPO_ROOT}/artifacts/deploy/kube-controller-manager.yaml"
+cp "${REPO_ROOT}"/artifacts/deploy/kube-controller-manager.yaml "${TEMP_PATH_APISERVER}"/kube-controller-manager.yaml
+sed -i'' -e "s/{{karmada_apiserver_version}}/${KARMADA_APISERVER_VERSION}/g" "${TEMP_PATH_APISERVER}"/kube-controller-manager.yaml
+kubectl --context="${HOST_CLUSTER_NAME}" apply -f "${TEMP_PATH_APISERVER}"/kube-controller-manager.yaml
 # deploy aggregated-apiserver on host cluster
 kubectl --context="${HOST_CLUSTER_NAME}" apply -f "${REPO_ROOT}/artifacts/deploy/karmada-aggregated-apiserver.yaml"
 util::wait_pod_ready "${HOST_CLUSTER_NAME}" "${KARMADA_AGGREGATION_APISERVER_LABEL}" "${KARMADA_SYSTEM_NAMESPACE}"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The workflow of APIServer compatibility is failing when it's running with master, see 

- https://github.com/karmada-io/karmada/pull/4898
- https://github.com/karmada-io/karmada/actions/runs/8950239870/job/24585393557

The reason is master is running with karmada-apiserver v1.27.11, and the workflow of `APIServer compatibility` is change the version of karmada-apiserver by patching karmada-apiserver, and actually it's happening the downgrade/upgrade of karmada-apiserver, it's always failing if karmada-apiserver have add some new API. For now, it's `flowcontrol.apiserver.k8s.io/v1beta3`, 
available with v1.26, so it will always failed if karmada-apiserver downgrade to lessthan v1.26

So this PR is working for useing environment to config the karmada-apiserver version, Avoid karmada-apiserver downgrade/upgrade happening.



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This PR CI is failing with the confict artifact name, will resolve by  https://github.com/karmada-io/karmada/pull/4897


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

