### PR TITLE
chore: Use != for RV comparison

### DIFF
--- a/pkg/controllers/status/common.go
+++ b/pkg/controllers/status/common.go
@@ -68,7 +68,7 @@ var bindingPredicateFn = builder.WithPredicates(predicate.Funcs{
 			return false
 		}
 
-		return !reflect.DeepEqual(oldResourceVersion, newResourceVersion)
+		return oldResourceVersion != newResourceVersion
 	},
 	DeleteFunc: func(e event.DeleteEvent) bool { return false },
 })


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
There is no need to use `reflect.DeepEqual` for string comparison, so to improve it!

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

