### PR TITLE
chore: fix broken link

### DIFF
--- a/hack/update-estimator-protobuf.sh
+++ b/hack/update-estimator-protobuf.sh
@@ -20,8 +20,6 @@ set -o pipefail
 
 KARMADA_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 
-# Use `hack/generate-proto.sh` to generate proto files.
-
 DEFAULT_GOPATH=$(go env GOPATH | awk -F ':' '{print $1}')
 export GOPATH=${DEFAULT_GOPATH}
 export PATH=$PATH:$GOPATH/bin
@@ -45,7 +43,7 @@ source "${KARMADA_ROOT}"/hack/util.sh
 util:create_gopath_tree "${KARMADA_ROOT}" "${go_path}"
 export GOPATH="${go_path}"
 
-#ref https://github.com/kubernetes/kubernetes/blob/master/hack/update-generated-protobuf-dockerized.sh
+# https://github.com/kubernetes/kubernetes/blob/release-1.23/hack/update-generated-protobuf-dockerized.sh
 if [[ -z "$(which protoc)" || $(protoc --version | sed -r "s/libprotoc ([0-9]+).*/\1/g") -lt 3 ]]; then
   echo "Generating protobuf requires protoc 3.0.0-beta1 or newer. Please download and"
   echo "install the platform appropriate Protobuf package for your OS: "


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
fix broken link

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
With the release of k8s release v1.24 and newer, the protoc versions it restricts are also being updated. And k8s begin to tighten checking of protoc version in https://github.com/kubernetes/kubernetes/pull/115243. Do we need to synchronize operations on the version of protoc in karmada repo？  cc @RainbowMango @Garrybest 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

