### PR TITLE
 Bump golangci-lint to v1.58.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,22 +5,6 @@ run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   timeout: 10m
 
-  # which dirs to skip: issues from them won't be reported;
-  # can use regexp here: generated.*, regexp is applied on full path;
-  # default value is empty list, but default dirs are skipped independently
-  # from this option's value (see skip-dirs-use-default).
-  # "/" will be replaced by current OS file path separator to properly work
-  # on Windows.
-  skip-dirs:
-  - hack/tools/preferredimports # This code is directly lifted from the Kubernetes codebase, skip checking
-  - (^|/)vendor($|/)
-  - (^|/)third_party($|/)
-  - pkg/util/lifted # This code is lifted from other projects(Kubernetes, Kubefed, and so on), skip checking.
-
-  # default is true. Enables skipping of directories:
-  #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  skip-dirs-use-default: false
-
   # One of 'readonly' and 'vendor'.
   #  - readonly: the go command is disallowed from the implicit automatic updating of go.mod described above.
   #              Instead, it fails when any changes to go.mod are needed. This setting is most useful to check
@@ -111,3 +95,18 @@ issues:
   - EXC0012
   - EXC0013
   - EXC0014
+  # Which dirs to exclude: issues from them won't be reported.
+  # Can use regexp here: `generated.*`, regexp is applied on full path,
+  # including the path prefix if one is set.
+  # Default dirs are skipped independently of this option's value (see exclude-dirs-use-default).
+  # "/" will be replaced by current OS file path separator to properly work on Windows.
+  # Default: []
+  exclude-dirs:
+    - hack/tools/preferredimports # This code is directly lifted from the Kubernetes codebase, skip checking
+    - (^|/)vendor($|/)
+    - (^|/)third_party($|/)
+    - pkg/util/lifted # This code is lifted from other projects(Kubernetes, Kubefed, and so on), skip checking.
+  # Enables exclude of directories:
+  # - vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
+  # Default: true
+  exclude-dirs-use-default: false

--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -79,7 +79,7 @@ func NewAgentCommand(ctx context.Context) *cobra.Command {
 		Long: `The karmada-agent is the agent of member clusters. It can register a specific cluster to the Karmada control
 plane and sync manifests from the Karmada control plane to the member cluster. In addition, it also syncs the status of member
 cluster and manifests to the Karmada control plane.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			// validate options
 			if errs := opts.Validate(); len(errs) != 0 {
 				return errs.ToAggregate()

--- a/cmd/aggregated-apiserver/app/aggregated-apiserver.go
+++ b/cmd/aggregated-apiserver/app/aggregated-apiserver.go
@@ -38,7 +38,7 @@ func NewAggregatedApiserverCommand(ctx context.Context) *cobra.Command {
 		Long: `The karmada-aggregated-apiserver starts an aggregated server. 
 It is responsible for registering the Cluster API and provides the ability to aggregate APIs, 
 allowing users to access member clusters from the control plane directly.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := opts.Complete(); err != nil {
 				return err
 			}

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -101,7 +101,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 		Long: `The karmada-controller-manager runs various controllers.
 The controllers watch Karmada objects and then talk to the underlying clusters' API servers
 to create regular Kubernetes resources.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			// validate options
 			if errs := opts.Validate(); len(errs) != 0 {
 				return errs.ToAggregate()
@@ -305,7 +305,7 @@ func startClusterStatusController(ctx controllerscontext.Context) (enabled bool,
 
 			return obj.Spec.SyncMode == clusterv1alpha1.Push
 		},
-		GenericFunc: func(genericEvent event.GenericEvent) bool {
+		GenericFunc: func(event.GenericEvent) bool {
 			return false
 		},
 	}

--- a/cmd/descheduler/app/descheduler.go
+++ b/cmd/descheduler/app/descheduler.go
@@ -86,7 +86,7 @@ func NewDeschedulerCommand(stopChan <-chan struct{}) *cobra.Command {
 		Long: `The karmada-descheduler evicts replicas from member clusters
 if they are failed to be scheduled for a period of time. It relies on 
 karmada-scheduler-estimator to get replica status.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			// validate options
 			if errs := opts.Validate(); len(errs) != 0 {
 				return errs.ToAggregate()

--- a/cmd/karmada-search/app/karmada-search.go
+++ b/cmd/karmada-search/app/karmada-search.go
@@ -65,7 +65,7 @@ func NewKarmadaSearchCommand(ctx context.Context, registryOptions ...Option) *co
 		Use: "karmada-search",
 		Long: `The karmada-search starts an aggregated server. It provides 
 capabilities such as global search and resource proxy in a multi-cloud environment.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := opts.Complete(); err != nil {
 				return err
 			}

--- a/cmd/metrics-adapter/app/metrics-adapter.go
+++ b/cmd/metrics-adapter/app/metrics-adapter.go
@@ -37,7 +37,7 @@ func NewMetricsAdapterCommand(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:  "karmada-metrics-adapter",
 		Long: `The karmada-metrics-adapter is a adapter to aggregate the metrics from member clusters.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := opts.Complete(); err != nil {
 				return err
 			}

--- a/cmd/scheduler-estimator/app/scheduler-estimator.go
+++ b/cmd/scheduler-estimator/app/scheduler-estimator.go
@@ -82,7 +82,7 @@ func NewSchedulerEstimatorCommand(ctx context.Context) *cobra.Command {
 		Use: "karmada-scheduler-estimator",
 		Long: `The karmada-scheduler-estimator runs an accurate scheduler estimator of a cluster. It 
 provides the scheduler with more accurate cluster resource information.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			// validate options
 			if errs := opts.Validate(); len(errs) != 0 {
 				return errs.ToAggregate()

--- a/cmd/scheduler/app/scheduler.go
+++ b/cmd/scheduler/app/scheduler.go
@@ -99,7 +99,7 @@ func NewSchedulerCommand(stopChan <-chan struct{}, registryOptions ...Option) *c
 The scheduler determines which clusters are valid placements for each resource in the scheduling queue according to
 constraints and available resources. The scheduler then ranks each valid cluster and binds the resource to
 the most suitable cluster.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			// validate options
 			if errs := opts.Validate(); len(errs) != 0 {
 				return errs.ToAggregate()

--- a/cmd/service-name-resolution-detector-example/app/service-name-resolution-detector.go
+++ b/cmd/service-name-resolution-detector-example/app/service-name-resolution-detector.go
@@ -48,7 +48,7 @@ func NewDetector(ctx context.Context) *cobra.Command {
 		Use: "service-name-resolution-detector-example",
 		Long: `The service-name-resolution-detector-example is an agent deployed in member clusters. It can periodically detect health 
 condition of components in member cluster(such as coredns), and sync conditions to Karmada control plane.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := opts.Complete(); err != nil {
 				return err
 			}

--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -66,7 +66,7 @@ func NewWebhookCommand(ctx context.Context) *cobra.Command {
 		Use: "karmada-webhook",
 		Long: `The karmada-webhook starts a webhook server and manages policies about how to mutate and validate
 Karmada resources including 'PropagationPolicy', 'OverridePolicy' and so on.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			// validate options
 			if errs := opts.Validate(); len(errs) != 0 {
 				return errs.ToAggregate()

--- a/examples/customresourceinterpreter/webhook/app/webhook.go
+++ b/examples/customresourceinterpreter/webhook/app/webhook.go
@@ -45,7 +45,7 @@ func NewWebhookCommand(ctx context.Context) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use: "karmada-interpreter-webhook-example",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			// validate options
 			if errs := opts.Validate(); len(errs) != 0 {
 				fmt.Fprintf(os.Stderr, "configuration is not valid: %v\n", errs.ToAggregate())

--- a/hack/verify-staticcheck.sh
+++ b/hack/verify-staticcheck.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-GOLANGCI_LINT_VER="v1.55.2"
+GOLANGCI_LINT_VER="v1.58.0"
 
 cd "${REPO_ROOT}"
 source "hack/util.sh"

--- a/operator/cmd/operator/app/operator.go
+++ b/operator/cmd/operator/app/operator.go
@@ -59,7 +59,7 @@ func NewOperatorCommand(ctx context.Context) *cobra.Command {
 			restclient.SetDefaultWarningHandler(restclient.NoWarnings{})
 			return nil
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := o.Validate(); err != nil {
 				return err
 			}

--- a/operator/pkg/util/util.go
+++ b/operator/pkg/util/util.go
@@ -150,7 +150,7 @@ func ioCopyN(outFile *os.File, tr *tar.Reader) error {
 // ListFiles traverse directory files
 func ListFiles(path string) []os.FileInfo {
 	var files []os.FileInfo
-	if err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+	if err := filepath.Walk(path, func(_ string, info os.FileInfo, _ error) error {
 		if !info.IsDir() {
 			files = append(files, info)
 		}
@@ -171,7 +171,7 @@ type FileExtInfo struct {
 // ListFileWithSuffix traverse directory files with suffix
 func ListFileWithSuffix(path, suffix string) []FileExtInfo {
 	files := []FileExtInfo{}
-	if err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+	if err := filepath.Walk(path, func(path string, info os.FileInfo, _ error) error {
 		if !info.IsDir() && strings.HasSuffix(path, suffix) {
 			files = append(files, FileExtInfo{
 				AbsPath:  path,

--- a/pkg/apis/cluster/mutation/mutation_test.go
+++ b/pkg/apis/cluster/mutation/mutation_test.go
@@ -357,7 +357,7 @@ func TestSetDefaultClusterResourceModels(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(*testing.T) {
 			SetDefaultClusterResourceModels(tt.args.cluster)
 		})
 		if !reflect.DeepEqual(tt.args.cluster.Spec.ResourceModels, tt.wantModels) {

--- a/pkg/apis/cluster/validation/validation.go
+++ b/pkg/apis/cluster/validation/validation.go
@@ -59,7 +59,7 @@ var (
 
 // ValidateCluster tests if required fields in the Cluster are set.
 func ValidateCluster(cluster *api.Cluster) field.ErrorList {
-	allErrs := apimachineryvalidation.ValidateObjectMeta(&cluster.ObjectMeta, false, func(name string, prefix bool) []string { return ValidateClusterName(name) }, field.NewPath("metadata"))
+	allErrs := apimachineryvalidation.ValidateObjectMeta(&cluster.ObjectMeta, false, func(name string, _ bool) []string { return ValidateClusterName(name) }, field.NewPath("metadata"))
 	allErrs = append(allErrs, ValidateClusterSpec(&cluster.Spec, field.NewPath("spec"))...)
 	return allErrs
 }

--- a/pkg/controllers/applicationfailover/crb_application_failover_controller.go
+++ b/pkg/controllers/applicationfailover/crb_application_failover_controller.go
@@ -226,7 +226,7 @@ func (c *CRBApplicationFailoverController) SetupWithManager(mgr controllerruntim
 			}
 			return true
 		},
-		GenericFunc: func(genericEvent event.GenericEvent) bool { return false },
+		GenericFunc: func(event.GenericEvent) bool { return false },
 	}
 
 	return controllerruntime.NewControllerManagedBy(mgr).

--- a/pkg/controllers/applicationfailover/rb_application_failover_controller.go
+++ b/pkg/controllers/applicationfailover/rb_application_failover_controller.go
@@ -228,7 +228,7 @@ func (c *RBApplicationFailoverController) SetupWithManager(mgr controllerruntime
 			}
 			return true
 		},
-		GenericFunc: func(genericEvent event.GenericEvent) bool { return false },
+		GenericFunc: func(event.GenericEvent) bool { return false },
 	}
 
 	return controllerruntime.NewControllerManagedBy(mgr).

--- a/pkg/controllers/binding/binding_controller.go
+++ b/pkg/controllers/binding/binding_controller.go
@@ -174,7 +174,7 @@ func (c *ResourceBindingController) SetupWithManager(mgr controllerruntime.Manag
 }
 
 func (c *ResourceBindingController) newOverridePolicyFunc() handler.MapFunc {
-	return func(ctx context.Context, a client.Object) []reconcile.Request {
+	return func(_ context.Context, a client.Object) []reconcile.Request {
 		var overrideRS []policyv1alpha1.ResourceSelector
 		var namespace string
 		switch t := a.(type) {

--- a/pkg/controllers/binding/cluster_resource_binding_controller.go
+++ b/pkg/controllers/binding/cluster_resource_binding_controller.go
@@ -169,7 +169,7 @@ func (c *ClusterResourceBindingController) SetupWithManager(mgr controllerruntim
 }
 
 func (c *ClusterResourceBindingController) newOverridePolicyFunc() handler.MapFunc {
-	return func(ctx context.Context, a client.Object) []reconcile.Request {
+	return func(_ context.Context, a client.Object) []reconcile.Request {
 		var overrideRS []policyv1alpha1.ResourceSelector
 		switch t := a.(type) {
 		case *policyv1alpha1.ClusterOverridePolicy:

--- a/pkg/controllers/deploymentreplicassyncer/deployment_replicas_syncer_controller.go
+++ b/pkg/controllers/deploymentreplicassyncer/deployment_replicas_syncer_controller.go
@@ -49,7 +49,7 @@ type DeploymentReplicasSyncer struct {
 }
 
 var predicateFunc = predicate.Funcs{
-	CreateFunc: func(e event.CreateEvent) bool { return false },
+	CreateFunc: func(event.CreateEvent) bool { return false },
 	UpdateFunc: func(e event.UpdateEvent) bool {
 		oldObj := e.ObjectOld.(*appsv1.Deployment)
 		newObj := e.ObjectNew.(*appsv1.Deployment)

--- a/pkg/controllers/federatedresourcequota/federated_resource_quota_status_controller.go
+++ b/pkg/controllers/federatedresourcequota/federated_resource_quota_status_controller.go
@@ -89,7 +89,7 @@ func (c *StatusController) Reconcile(ctx context.Context, req controllerruntime.
 // SetupWithManager creates a controller and register to controller manager.
 func (c *StatusController) SetupWithManager(mgr controllerruntime.Manager) error {
 	fn := handler.MapFunc(
-		func(ctx context.Context, obj client.Object) []reconcile.Request {
+		func(_ context.Context, obj client.Object) []reconcile.Request {
 			var requests []reconcile.Request
 
 			quotaNamespace, namespaceExist := obj.GetLabels()[util.FederatedResourceQuotaNamespaceLabel]
@@ -108,7 +108,7 @@ func (c *StatusController) SetupWithManager(mgr controllerruntime.Manager) error
 	)
 
 	workPredicate := builder.WithPredicates(predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
+		CreateFunc: func(event.CreateEvent) bool {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
@@ -121,10 +121,10 @@ func (c *StatusController) SetupWithManager(mgr controllerruntime.Manager) error
 			}
 			return !reflect.DeepEqual(objOld.Status, objNew.Status)
 		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
+		DeleteFunc: func(event.DeleteEvent) bool {
 			return false
 		},
-		GenericFunc: func(e event.GenericEvent) bool {
+		GenericFunc: func(event.GenericEvent) bool {
 			return false
 		},
 	})

--- a/pkg/controllers/federatedresourcequota/federated_resource_quota_sync_controller.go
+++ b/pkg/controllers/federatedresourcequota/federated_resource_quota_sync_controller.go
@@ -114,16 +114,16 @@ func (c *SyncController) SetupWithManager(mgr controllerruntime.Manager) error {
 	)
 
 	clusterPredicate := builder.WithPredicates(predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
+		CreateFunc: func(event.CreateEvent) bool {
 			return true
 		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
+		UpdateFunc: func(event.UpdateEvent) bool {
 			return false
 		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
+		DeleteFunc: func(event.DeleteEvent) bool {
 			return false
 		},
-		GenericFunc: func(e event.GenericEvent) bool {
+		GenericFunc: func(event.GenericEvent) bool {
 			return false
 		},
 	})

--- a/pkg/controllers/gracefuleviction/crb_graceful_eviction_controller.go
+++ b/pkg/controllers/gracefuleviction/crb_graceful_eviction_controller.go
@@ -118,8 +118,8 @@ func (c *CRBGracefulEvictionController) SetupWithManager(mgr controllerruntime.M
 
 			return newObj.Status.SchedulerObservedGeneration == newObj.Generation
 		},
-		DeleteFunc:  func(deleteEvent event.DeleteEvent) bool { return false },
-		GenericFunc: func(genericEvent event.GenericEvent) bool { return false },
+		DeleteFunc:  func(event.DeleteEvent) bool { return false },
+		GenericFunc: func(event.GenericEvent) bool { return false },
 	}
 
 	return controllerruntime.NewControllerManagedBy(mgr).

--- a/pkg/controllers/gracefuleviction/rb_graceful_eviction_controller.go
+++ b/pkg/controllers/gracefuleviction/rb_graceful_eviction_controller.go
@@ -118,8 +118,8 @@ func (c *RBGracefulEvictionController) SetupWithManager(mgr controllerruntime.Ma
 
 			return newObj.Status.SchedulerObservedGeneration == newObj.Generation
 		},
-		DeleteFunc:  func(deleteEvent event.DeleteEvent) bool { return false },
-		GenericFunc: func(genericEvent event.GenericEvent) bool { return false },
+		DeleteFunc:  func(event.DeleteEvent) bool { return false },
+		GenericFunc: func(event.GenericEvent) bool { return false },
 	}
 
 	return controllerruntime.NewControllerManagedBy(mgr).

--- a/pkg/controllers/mcs/endpointslice_controller.go
+++ b/pkg/controllers/mcs/endpointslice_controller.go
@@ -129,7 +129,7 @@ func (c *EndpointSliceController) SetupWithManager(mgr controllerruntime.Manager
 		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
 			return util.GetLabelValue(deleteEvent.Object.GetLabels(), util.ServiceNameLabel) != ""
 		},
-		GenericFunc: func(genericEvent event.GenericEvent) bool {
+		GenericFunc: func(event.GenericEvent) bool {
 			return false
 		},
 	}

--- a/pkg/controllers/multiclusterservice/endpointslice_dispatch_controller.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_dispatch_controller.go
@@ -163,7 +163,7 @@ func (c *EndpointsliceDispatchController) SetupWithManager(mgr controllerruntime
 			return util.GetLabelValue(deleteEvent.Object.GetLabels(), util.MultiClusterServiceNameLabel) != "" &&
 				util.GetAnnotationValue(deleteEvent.Object.GetAnnotations(), util.EndpointSliceProvisionClusterAnnotation) == ""
 		},
-		GenericFunc: func(genericEvent event.GenericEvent) bool {
+		GenericFunc: func(event.GenericEvent) bool {
 			return false
 		},
 	}
@@ -174,7 +174,7 @@ func (c *EndpointsliceDispatchController) SetupWithManager(mgr controllerruntime
 }
 
 func (c *EndpointsliceDispatchController) newClusterFunc() handler.MapFunc {
-	return func(ctx context.Context, a client.Object) []reconcile.Request {
+	return func(_ context.Context, a client.Object) []reconcile.Request {
 		var clusterName string
 		switch t := a.(type) {
 		case *clusterv1alpha1.Cluster:
@@ -237,7 +237,7 @@ func (c *EndpointsliceDispatchController) getClusterEndpointSliceWorks(mcsNamesp
 }
 
 func (c *EndpointsliceDispatchController) newMultiClusterServiceFunc() handler.MapFunc {
-	return func(ctx context.Context, a client.Object) []reconcile.Request {
+	return func(_ context.Context, a client.Object) []reconcile.Request {
 		var mcsName, mcsNamespace string
 		switch t := a.(type) {
 		case *networkingv1alpha1.MultiClusterService:

--- a/pkg/controllers/multiclusterservice/mcs_controller.go
+++ b/pkg/controllers/multiclusterservice/mcs_controller.go
@@ -616,7 +616,7 @@ func (c *MCSController) SetupWithManager(mgr controllerruntime.Manager) error {
 	}
 
 	svcMapFunc := handler.MapFunc(
-		func(ctx context.Context, svcObj client.Object) []reconcile.Request {
+		func(_ context.Context, svcObj client.Object) []reconcile.Request {
 			return []reconcile.Request{{
 				NamespacedName: types.NamespacedName{
 					Namespace: svcObj.GetNamespace(),
@@ -647,7 +647,7 @@ func (c *MCSController) serviceHasCrossClusterMultiClusterService(svc *corev1.Se
 }
 
 func (c *MCSController) clusterMapFunc() handler.MapFunc {
-	return func(ctx context.Context, a client.Object) []reconcile.Request {
+	return func(_ context.Context, a client.Object) []reconcile.Request {
 		var clusterName string
 		switch t := a.(type) {
 		case *clusterv1alpha1.Cluster:

--- a/pkg/controllers/namespace/namespace_sync_controller.go
+++ b/pkg/controllers/namespace/namespace_sync_controller.go
@@ -178,7 +178,7 @@ func (c *Controller) buildWorks(namespace *corev1.Namespace, clusters []clusterv
 // SetupWithManager creates a controller and register to controller manager.
 func (c *Controller) SetupWithManager(mgr controllerruntime.Manager) error {
 	clusterNamespaceFn := handler.MapFunc(
-		func(ctx context.Context, a client.Object) []reconcile.Request {
+		func(_ context.Context, _ client.Object) []reconcile.Request {
 			var requests []reconcile.Request
 			namespaceList := &corev1.NamespaceList{}
 			if err := c.Client.List(context.TODO(), namespaceList); err != nil {
@@ -195,10 +195,10 @@ func (c *Controller) SetupWithManager(mgr controllerruntime.Manager) error {
 		})
 
 	clusterPredicate := builder.WithPredicates(predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
+		CreateFunc: func(event.CreateEvent) bool {
 			return true
 		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
+		UpdateFunc: func(event.UpdateEvent) bool {
 			return false
 		},
 		DeleteFunc: func(event.DeleteEvent) bool {
@@ -210,7 +210,7 @@ func (c *Controller) SetupWithManager(mgr controllerruntime.Manager) error {
 	})
 
 	clusterOverridePolicyNamespaceFn := handler.MapFunc(
-		func(ctx context.Context, obj client.Object) []reconcile.Request {
+		func(_ context.Context, obj client.Object) []reconcile.Request {
 			var requests []reconcile.Request
 			cop, ok := obj.(*policyv1alpha1.ClusterOverridePolicy)
 			if !ok {
@@ -258,10 +258,10 @@ func (c *Controller) SetupWithManager(mgr controllerruntime.Manager) error {
 		})
 
 	clusterOverridePolicyPredicate := builder.WithPredicates(predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
+		CreateFunc: func(event.CreateEvent) bool {
 			return true
 		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
+		UpdateFunc: func(event.UpdateEvent) bool {
 			return true
 		},
 		DeleteFunc: func(event.DeleteEvent) bool {

--- a/pkg/controllers/status/cluster_status_controller_test.go
+++ b/pkg/controllers/status/cluster_status_controller_test.go
@@ -990,7 +990,7 @@ func NewClusterDynamicClientSetForAgentWithError(_ string, _ client.Client) (*ut
 }
 
 func TestClusterStatusController_initializeGenericInformerManagerForCluster(t *testing.T) {
-	t.Run("failed to create dynamicClient", func(t *testing.T) {
+	t.Run("failed to create dynamicClient", func(*testing.T) {
 		c := &ClusterStatusController{
 			Client:                 fake.NewClientBuilder().WithScheme(gclient.NewSchema()).Build(),
 			GenericInformerManager: genericmanager.GetInstance(),
@@ -1009,7 +1009,7 @@ func TestClusterStatusController_initializeGenericInformerManagerForCluster(t *t
 		c.initializeGenericInformerManagerForCluster(clusterClientSet)
 	})
 
-	t.Run("suc to create dynamicClient", func(t *testing.T) {
+	t.Run("suc to create dynamicClient", func(*testing.T) {
 		c := &ClusterStatusController{
 			Client:                 fake.NewClientBuilder().WithScheme(gclient.NewSchema()).Build(),
 			GenericInformerManager: genericmanager.GetInstance(),
@@ -1096,7 +1096,7 @@ func mockServer(statusCode int, existError bool) *httptest.Server {
 		Body:       io.NopCloser(bytes.NewBufferString(respBody)),
 	}
 	// Create an HTTP test server to handle the request
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// Write the response to the client
 		if existError {
 			statusCode := statusCode

--- a/pkg/controllers/status/common.go
+++ b/pkg/controllers/status/common.go
@@ -40,7 +40,7 @@ import (
 )
 
 var bindingPredicateFn = builder.WithPredicates(predicate.Funcs{
-	CreateFunc: func(e event.CreateEvent) bool { return false },
+	CreateFunc: func(event.CreateEvent) bool { return false },
 	UpdateFunc: func(e event.UpdateEvent) bool {
 		var oldResourceVersion, newResourceVersion string
 
@@ -70,11 +70,11 @@ var bindingPredicateFn = builder.WithPredicates(predicate.Funcs{
 
 		return oldResourceVersion != newResourceVersion
 	},
-	DeleteFunc: func(e event.DeleteEvent) bool { return false },
+	DeleteFunc: func(event.DeleteEvent) bool { return false },
 })
 
 var workPredicateFn = builder.WithPredicates(predicate.Funcs{
-	CreateFunc: func(e event.CreateEvent) bool { return false },
+	CreateFunc: func(event.CreateEvent) bool { return false },
 	UpdateFunc: func(e event.UpdateEvent) bool {
 		var oldStatus, newStatus workv1alpha1.WorkStatus
 

--- a/pkg/controllers/status/crb_status_controller.go
+++ b/pkg/controllers/status/crb_status_controller.go
@@ -85,7 +85,7 @@ func (c *CRBStatusController) Reconcile(ctx context.Context, req controllerrunti
 // SetupWithManager creates a controller and register to controller manager.
 func (c *CRBStatusController) SetupWithManager(mgr controllerruntime.Manager) error {
 	workMapFunc := handler.MapFunc(
-		func(ctx context.Context, workObj client.Object) []reconcile.Request {
+		func(_ context.Context, workObj client.Object) []reconcile.Request {
 			var requests []reconcile.Request
 
 			annotations := workObj.GetAnnotations()

--- a/pkg/controllers/status/rb_status_controller.go
+++ b/pkg/controllers/status/rb_status_controller.go
@@ -85,7 +85,7 @@ func (c *RBStatusController) Reconcile(ctx context.Context, req controllerruntim
 // SetupWithManager creates a controller and register to controller manager.
 func (c *RBStatusController) SetupWithManager(mgr controllerruntime.Manager) error {
 	workMapFunc := handler.MapFunc(
-		func(ctx context.Context, workObj client.Object) []reconcile.Request {
+		func(_ context.Context, workObj client.Object) []reconcile.Request {
 			var requests []reconcile.Request
 
 			annotations := workObj.GetAnnotations()

--- a/pkg/controllers/unifiedauth/unified_auth_controller.go
+++ b/pkg/controllers/unifiedauth/unified_auth_controller.go
@@ -256,14 +256,14 @@ func (c *Controller) SetupWithManager(mgr controllerruntime.Manager) error {
 }
 
 func (c *Controller) newClusterRoleMapFunc() handler.MapFunc {
-	return func(ctx context.Context, a client.Object) []reconcile.Request {
+	return func(_ context.Context, a client.Object) []reconcile.Request {
 		clusterRole := a.(*rbacv1.ClusterRole)
 		return c.generateRequestsFromClusterRole(clusterRole)
 	}
 }
 
 func (c *Controller) newClusterRoleBindingMapFunc() handler.MapFunc {
-	return func(ctx context.Context, a client.Object) []reconcile.Request {
+	return func(_ context.Context, a client.Object) []reconcile.Request {
 		clusterRoleBinding := a.(*rbacv1.ClusterRoleBinding)
 		if clusterRoleBinding.RoleRef.Kind != util.ClusterRoleKind {
 			return nil

--- a/pkg/controllers/workloadrebalancer/workloadrebalancer_controller.go
+++ b/pkg/controllers/workloadrebalancer/workloadrebalancer_controller.go
@@ -51,7 +51,7 @@ type RebalancerController struct {
 // SetupWithManager creates a controller and register to controller manager.
 func (c *RebalancerController) SetupWithManager(mgr controllerruntime.Manager) error {
 	var predicateFunc = predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool { return true },
+		CreateFunc: func(event.CreateEvent) bool { return true },
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			oldObj := e.ObjectOld.(*appsv1alpha1.WorkloadRebalancer)
 			newObj := e.ObjectNew.(*appsv1alpha1.WorkloadRebalancer)

--- a/pkg/descheduler/descheduler_test.go
+++ b/pkg/descheduler/descheduler_test.go
@@ -492,9 +492,9 @@ func TestDescheduler_worker(t *testing.T) {
 				cluster := c
 				mockClient := &estimatorservice.MockEstimatorClient{}
 				mockResultFn := func(
-					ctx context.Context,
-					in *pb.UnschedulableReplicasRequest,
-					opts ...grpc.CallOption,
+					_ context.Context,
+					_ *pb.UnschedulableReplicasRequest,
+					_ ...grpc.CallOption,
 				) *pb.UnschedulableReplicasResponse {
 					return &pb.UnschedulableReplicasResponse{
 						UnschedulableReplicas: cluster.Replicas,

--- a/pkg/estimator/server/framework/runtime/framework_test.go
+++ b/pkg/estimator/server/framework/runtime/framework_test.go
@@ -234,7 +234,7 @@ func Test_frameworkImpl_RunEstimateReplicasPlugins(t *testing.T) {
 			r := make(Registry)
 			for _, p := range tt.plugins {
 				p := p
-				if err := r.Register(p.name, func(fh framework.Handle) (framework.Plugin, error) {
+				if err := r.Register(p.name, func(framework.Handle) (framework.Plugin, error) {
 					return p, nil
 				}); err != nil {
 					t.Fatalf("fail to register PreScorePlugins plugin (%s)", p.Name())

--- a/pkg/karmadactl/addons/disable.go
+++ b/pkg/karmadactl/addons/disable.go
@@ -60,7 +60,7 @@ func NewCmdAddonsDisable(parentCommand string) *cobra.Command {
 		Example:               fmt.Sprintf(disableExample, parentCommand),
 		SilenceUsage:          true,
 		DisableFlagsInUseLine: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if err := opts.Complete(); err != nil {
 				return err
 			}

--- a/pkg/karmadactl/addons/enable.go
+++ b/pkg/karmadactl/addons/enable.go
@@ -65,7 +65,7 @@ func NewCmdAddonsEnable(parentCommand string) *cobra.Command {
 		Example:               fmt.Sprintf(enableExample, parentCommand),
 		SilenceUsage:          true,
 		DisableFlagsInUseLine: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if err := opts.Complete(); err != nil {
 				return err
 			}

--- a/pkg/karmadactl/addons/list.go
+++ b/pkg/karmadactl/addons/list.go
@@ -54,7 +54,7 @@ func NewCmdAddonsList(parentCommand string) *cobra.Command {
 		Example:               fmt.Sprintf(listExample, parentCommand),
 		SilenceUsage:          true,
 		DisableFlagsInUseLine: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := opts.Complete(); err != nil {
 				return err
 			}

--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -89,7 +89,7 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 		Example:               initExample(parentCommand),
 		SilenceUsage:          true,
 		DisableFlagsInUseLine: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := opts.Validate(parentCommand); err != nil {
 				return err
 			}

--- a/pkg/karmadactl/cmdinit/utils/util.go
+++ b/pkg/karmadactl/cmdinit/utils/util.go
@@ -145,7 +145,7 @@ func ioCopyN(outFile *os.File, tr *tar.Reader) error {
 // ListFiles traverse directory files
 func ListFiles(path string) []string {
 	var files []string
-	if err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+	if err := filepath.Walk(path, func(path string, info os.FileInfo, _ error) error {
 		if !info.IsDir() {
 			files = append(files, path)
 		}

--- a/pkg/karmadactl/cmdinit/utils/util_test.go
+++ b/pkg/karmadactl/cmdinit/utils/util_test.go
@@ -62,7 +62,7 @@ func TestDownloadFile(t *testing.T) {
 		return buf
 	}()
 
-	s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		if _, err := io.Copy(rw, serverTar); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/karmadactl/cordon/cordon.go
+++ b/pkg/karmadactl/cordon/cordon.go
@@ -68,7 +68,7 @@ func NewCmdCordon(f util.Factory, parentCommand string) *cobra.Command {
 		Example:               fmt.Sprintf(cordonExample, parentCommand),
 		SilenceUsage:          true,
 		DisableFlagsInUseLine: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if err := opts.Complete(args); err != nil {
 				return err
 			}
@@ -99,7 +99,7 @@ func NewCmdUncordon(f util.Factory, parentCommand string) *cobra.Command {
 		Example:               fmt.Sprintf(uncordonExample, parentCommand),
 		SilenceUsage:          true,
 		DisableFlagsInUseLine: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if err := opts.Complete(args); err != nil {
 				return err
 			}

--- a/pkg/karmadactl/deinit/deinit.go
+++ b/pkg/karmadactl/deinit/deinit.go
@@ -70,7 +70,7 @@ func NewCmdDeInit(parentCommand string) *cobra.Command {
 		Example:               fmt.Sprintf(deInitExample, parentCommand),
 		SilenceUsage:          true,
 		DisableFlagsInUseLine: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := opts.Complete(); err != nil {
 				return err
 			}

--- a/pkg/karmadactl/describe/describe.go
+++ b/pkg/karmadactl/describe/describe.go
@@ -72,7 +72,7 @@ func NewCmdDescribe(f util.Factory, parentCommand string, streams genericiooptio
 		SilenceUsage:          true,
 		DisableFlagsInUseLine: true,
 		Example:               fmt.Sprintf(describeExample, parentCommand),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if err := o.Complete(f, args, kubedescribeFlags, parentCommand); err != nil {
 				return err
 			}

--- a/pkg/karmadactl/join/join.go
+++ b/pkg/karmadactl/join/join.go
@@ -56,7 +56,7 @@ func NewCmdJoin(f cmdutil.Factory, parentCommand string) *cobra.Command {
 		Example:               fmt.Sprintf(joinExample, parentCommand),
 		SilenceUsage:          true,
 		DisableFlagsInUseLine: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if err := opts.Complete(args); err != nil {
 				return err
 			}

--- a/pkg/karmadactl/options/options.go
+++ b/pkg/karmadactl/options/options.go
@@ -37,7 +37,7 @@ func NewCmdOptions(parentCommand string, out io.Writer) *cobra.Command {
 		Short:   "Print the list of flags inherited by all commands",
 		Long:    "Print the list of flags inherited by all commands",
 		Example: fmt.Sprintf(optionsExample, parentCommand),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := cmd.Usage(); err != nil {
 				return err
 			}

--- a/pkg/karmadactl/promote/promote.go
+++ b/pkg/karmadactl/promote/promote.go
@@ -103,7 +103,7 @@ func NewCmdPromote(f util.Factory, parentCommand string) *cobra.Command {
 		Example:               fmt.Sprintf(promoteExample, parentCommand),
 		SilenceUsage:          true,
 		DisableFlagsInUseLine: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if err := opts.Complete(f, args); err != nil {
 				return err
 			}
@@ -197,7 +197,7 @@ func (o *CommandPromoteOption) Complete(f util.Factory, args []string) error {
 	o.name = args[1]
 
 	if o.OutputFormat == "yaml" || o.OutputFormat == "json" {
-		o.Printer = func(mapping *meta.RESTMapping, outputObjects *bool, withNamespace bool, withKind bool) (printers.ResourcePrinterFunc, error) {
+		o.Printer = func(_ *meta.RESTMapping, _ *bool, _ bool, _ bool) (printers.ResourcePrinterFunc, error) {
 			printer, err := o.JSONYamlPrintFlags.ToPrinter(o.OutputFormat)
 
 			if genericclioptions.IsNoCompatiblePrinterError(err) {

--- a/pkg/karmadactl/register/register.go
+++ b/pkg/karmadactl/register/register.go
@@ -152,7 +152,7 @@ func NewCmdRegister(parentCommand string) *cobra.Command {
 		Example:               fmt.Sprintf(registerExample, parentCommand),
 		SilenceUsage:          true,
 		DisableFlagsInUseLine: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if err := opts.Complete(args); err != nil {
 				return err
 			}

--- a/pkg/karmadactl/taint/taint.go
+++ b/pkg/karmadactl/taint/taint.go
@@ -84,7 +84,7 @@ func NewCmdTaint(f util.Factory, parentCommand string) *cobra.Command {
 		Example:               fmt.Sprintf(taintExample, parentCommand),
 		SilenceUsage:          true,
 		DisableFlagsInUseLine: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if err := opts.Complete(f, args); err != nil {
 				return err
 			}

--- a/pkg/karmadactl/token/token.go
+++ b/pkg/karmadactl/token/token.go
@@ -116,7 +116,7 @@ func NewCmdTokenCreate(f util.Factory, out io.Writer, tokenOpts *CommandTokenOpt
 		`),
 		SilenceUsage:          true,
 		DisableFlagsInUseLine: true,
-		RunE: func(Cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			// Get control plane kube-apiserver client
 			client, err := f.KubernetesClientSet()
 			if err != nil {
@@ -144,7 +144,7 @@ func NewCmdTokenList(f util.Factory, out io.Writer, errW io.Writer, tokenOpts *C
 		Use:   "list",
 		Short: "List bootstrap tokens on the server",
 		Long:  "This command will list all bootstrap tokens for you.",
-		RunE: func(tokenCmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			// Get control plane kube-apiserver client
 			client, err := f.KubernetesClientSet()
 			if err != nil {
@@ -173,7 +173,7 @@ func NewCmdTokenDelete(f util.Factory, out io.Writer, tokenOpts *CommandTokenOpt
 			The [token-value] is the full Token of the form "[a-z0-9]{6}.[a-z0-9]{16}" or the
 			Token ID of the form "[a-z0-9]{6}" to delete.
 		`),
-		RunE: func(tokenCmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return fmt.Errorf("missing subcommand; 'token delete' is missing token of form %q", bootstrapapi.BootstrapTokenIDPattern)
 			}

--- a/pkg/karmadactl/unjoin/unjoin.go
+++ b/pkg/karmadactl/unjoin/unjoin.go
@@ -65,7 +65,7 @@ func NewCmdUnjoin(f cmdutil.Factory, parentCommand string) *cobra.Command {
 		Example:               fmt.Sprintf(unjoinExample, parentCommand),
 		SilenceUsage:          true,
 		DisableFlagsInUseLine: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if err := opts.Complete(args); err != nil {
 				return err
 			}

--- a/pkg/karmadactl/util/idempotency_test.go
+++ b/pkg/karmadactl/util/idempotency_test.go
@@ -65,7 +65,7 @@ func TestCreateOrUpdateSecret(t *testing.T) {
 			args: args{
 				client: func() kubernetes.Interface {
 					c := fake.NewSimpleClientset()
-					c.PrependReactor("create", "*", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+					c.PrependReactor("create", "*", func(coretesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("create secret error")
 					})
 					return c
@@ -79,7 +79,7 @@ func TestCreateOrUpdateSecret(t *testing.T) {
 			args: args{
 				client: func() kubernetes.Interface {
 					c := fake.NewSimpleClientset(makeSecret("test"))
-					c.PrependReactor("update", "*", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+					c.PrependReactor("update", "*", func(coretesting.Action) (handled bool, ret runtime.Object, err error) {
 						return true, nil, errors.New("update secret error")
 					})
 					return c

--- a/pkg/registry/cluster/storage/storage.go
+++ b/pkg/registry/cluster/storage/storage.go
@@ -113,7 +113,7 @@ func (r *REST) ResourceLocation(ctx context.Context, name string) (*url.URL, htt
 		return nil, nil, err
 	}
 
-	secretGetter := func(ctx context.Context, namespace, name string) (*corev1.Secret, error) {
+	secretGetter := func(_ context.Context, namespace, name string) (*corev1.Secret, error) {
 		return r.secretLister.Secrets(namespace).Get(name)
 	}
 	tlsConfig, err := proxy.GetTLSConfigForCluster(ctx, cluster, secretGetter)

--- a/pkg/registry/search/storage/opensearch.go
+++ b/pkg/registry/search/storage/opensearch.go
@@ -24,7 +24,7 @@ import (
 )
 
 func (r *SearchREST) newOpenSearchHandler(_ *genericrequest.RequestInfo, _ rest.Responder) (http.Handler, error) {
-	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+	return http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		// Construct a handler and send the request to the ES.
 	}), nil
 }

--- a/pkg/resourceinterpreter/default/native/retain_test.go
+++ b/pkg/resourceinterpreter/default/native/retain_test.go
@@ -113,6 +113,10 @@ func Test_retainK8sWorkloadReplicas(t *testing.T) {
 func Test_retainSecretServiceAccountToken(t *testing.T) {
 	createSecret := func(secretType corev1.SecretType, uuid, key, value string) *unstructured.Unstructured {
 		ret, _ := helper.ToUnstructured(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{corev1.ServiceAccountUIDKey: uuid},
+			},
+			Data: map[string][]byte{key: []byte(value)},
 			Type: secretType,
 		})
 		return ret

--- a/pkg/scheduler/core/spreadconstraint/group_clusters_test.go
+++ b/pkg/scheduler/core/spreadconstraint/group_clusters_test.go
@@ -187,7 +187,7 @@ func Test_GroupClustersWithScore(t *testing.T) {
 		},
 	}
 
-	calAvailableReplicasFunc := func(clusters []*clusterv1alpha1.Cluster, spec *workv1alpha2.ResourceBindingSpec) []workv1alpha2.TargetCluster {
+	calAvailableReplicasFunc := func(clusters []*clusterv1alpha1.Cluster, _ *workv1alpha2.ResourceBindingSpec) []workv1alpha2.TargetCluster {
 		availableTargetClusters := make([]workv1alpha2.TargetCluster, len(clusters))
 
 		for i := range availableTargetClusters {

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -139,7 +139,7 @@ func Test_frameworkImpl_RunScorePlugins(t *testing.T) {
 		},
 		{
 			name: "Test score func error",
-			mockFunc: func(mockScorePlugin *frameworktesting.MockScorePlugin, mockScoreExtension *frameworktesting.MockScoreExtensions) {
+			mockFunc: func(mockScorePlugin *frameworktesting.MockScorePlugin, _ *frameworktesting.MockScoreExtensions) {
 				mockScorePlugin.EXPECT().Score(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(int64(-1), framework.NewResult(framework.Error, "foo"))
 				mockScorePlugin.EXPECT().Name().AnyTimes().Return("foo")

--- a/pkg/search/backendstore/defaultstore.go
+++ b/pkg/search/backendstore/defaultstore.go
@@ -41,7 +41,7 @@ func NewDefaultBackend(cluster string) *Default {
 				klog.V(4).Infof("AddFunc Cluster(%s) GVK(%s) Name(%s/%s)",
 					cluster, us.GroupVersionKind().String(), us.GetNamespace(), us.GetName())
 			},
-			UpdateFunc: func(oldObj, curObj interface{}) {
+			UpdateFunc: func(_, curObj interface{}) {
 				us, ok := curObj.(*unstructured.Unstructured)
 				if !ok {
 					klog.Errorf("unexpected type %T", curObj)

--- a/pkg/search/backendstore/opensearch.go
+++ b/pkg/search/backendstore/opensearch.go
@@ -143,7 +143,7 @@ func (os *OpenSearch) ResourceEventHandlerFuncs() cache.ResourceEventHandler {
 		AddFunc: func(obj interface{}) {
 			os.upsert(obj)
 		},
-		UpdateFunc: func(oldObj, curObj interface{}) {
+		UpdateFunc: func(_, curObj interface{}) {
 			os.upsert(curObj)
 		},
 		DeleteFunc: func(obj interface{}) {

--- a/pkg/search/proxy/framework/plugins/cluster/cluster.go
+++ b/pkg/search/proxy/framework/plugins/cluster/cluster.go
@@ -102,7 +102,7 @@ func (c *Cluster) Connect(ctx context.Context, request framework.ProxyRequest) (
 		return nil, err
 	}
 
-	secretGetter := func(ctx context.Context, namespace, name string) (*corev1.Secret, error) {
+	secretGetter := func(_ context.Context, namespace, name string) (*corev1.Secret, error) {
 		return c.secretLister.Secrets(namespace).Get(name)
 	}
 

--- a/pkg/search/proxy/framework/plugins/cluster/cluster_test.go
+++ b/pkg/search/proxy/framework/plugins/cluster/cluster_test.go
@@ -217,7 +217,7 @@ func Test_clusterProxy_connect(t *testing.T) {
 			name: "get cache error",
 			fields: fields{
 				store: &proxytest.MockStore{
-					GetResourceFromCacheFunc: func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string) (runtime.Object, string, error) {
+					GetResourceFromCacheFunc: func(_ context.Context, _ schema.GroupVersionResource, _, _ string) (runtime.Object, string, error) {
 						return nil, "", errors.New("test error")
 					},
 				},
@@ -233,7 +233,7 @@ func Test_clusterProxy_connect(t *testing.T) {
 			name: "cluster not found",
 			fields: fields{
 				store: &proxytest.MockStore{
-					GetResourceFromCacheFunc: func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string) (runtime.Object, string, error) {
+					GetResourceFromCacheFunc: func(_ context.Context, _ schema.GroupVersionResource, _, _ string) (runtime.Object, string, error) {
 						return nil, "cluster1", nil
 					},
 				},
@@ -249,7 +249,7 @@ func Test_clusterProxy_connect(t *testing.T) {
 			name: "API endpoint of cluster cluster1 should not be empty",
 			fields: fields{
 				store: &proxytest.MockStore{
-					GetResourceFromCacheFunc: func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string) (runtime.Object, string, error) {
+					GetResourceFromCacheFunc: func(_ context.Context, _ schema.GroupVersionResource, _, _ string) (runtime.Object, string, error) {
 						return nil, "cluster1", nil
 					},
 				},
@@ -269,7 +269,7 @@ func Test_clusterProxy_connect(t *testing.T) {
 			name: "impersonatorSecretRef is nil",
 			fields: fields{
 				store: &proxytest.MockStore{
-					GetResourceFromCacheFunc: func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string) (runtime.Object, string, error) {
+					GetResourceFromCacheFunc: func(_ context.Context, _ schema.GroupVersionResource, _, _ string) (runtime.Object, string, error) {
 						return nil, "cluster1", nil
 					},
 				},
@@ -291,7 +291,7 @@ func Test_clusterProxy_connect(t *testing.T) {
 			name: "secret not found",
 			fields: fields{
 				store: &proxytest.MockStore{
-					GetResourceFromCacheFunc: func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string) (runtime.Object, string, error) {
+					GetResourceFromCacheFunc: func(_ context.Context, _ schema.GroupVersionResource, _, _ string) (runtime.Object, string, error) {
 						return nil, "cluster1", nil
 					},
 				},
@@ -317,7 +317,7 @@ func Test_clusterProxy_connect(t *testing.T) {
 			name: "response ok",
 			fields: fields{
 				store: &proxytest.MockStore{
-					GetResourceFromCacheFunc: func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string) (runtime.Object, string, error) {
+					GetResourceFromCacheFunc: func(_ context.Context, _ schema.GroupVersionResource, _, _ string) (runtime.Object, string, error) {
 						return nil, "cluster1", nil
 					},
 				},
@@ -354,7 +354,7 @@ func Test_clusterProxy_connect(t *testing.T) {
 			name: "update error",
 			fields: fields{
 				store: &proxytest.MockStore{
-					GetResourceFromCacheFunc: func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string) (runtime.Object, string, error) {
+					GetResourceFromCacheFunc: func(_ context.Context, _ schema.GroupVersionResource, _, _ string) (runtime.Object, string, error) {
 						return nil, "cluster1", nil
 					},
 				},

--- a/pkg/search/proxy/framework/plugins/karmada/karmada_test.go
+++ b/pkg/search/proxy/framework/plugins/karmada/karmada_test.go
@@ -32,7 +32,7 @@ import (
 
 func Test_karmadaProxy(t *testing.T) {
 	var gotRequest *http.Request
-	s := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+	s := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
 		gotRequest = req
 	}))
 	defer s.Close()

--- a/pkg/search/proxy/store/multi_cluster_cache_test.go
+++ b/pkg/search/proxy/store/multi_cluster_cache_test.go
@@ -68,7 +68,7 @@ func init() {
 }
 
 func TestMultiClusterCache_UpdateCache(t *testing.T) {
-	newClientFunc := func(cluster string) (dynamic.Interface, error) {
+	newClientFunc := func(string) (dynamic.Interface, error) {
 		return fakedynamic.NewSimpleDynamicClient(scheme), nil
 	}
 	cache := NewMultiClusterCache(newClientFunc, restMapper)
@@ -104,7 +104,7 @@ func TestMultiClusterCache_UpdateCache(t *testing.T) {
 
 func TestMultiClusterCache_HasResource(t *testing.T) {
 	fakeClient := fakedynamic.NewSimpleDynamicClient(scheme)
-	newClientFunc := func(cluster string) (dynamic.Interface, error) {
+	newClientFunc := func(string) (dynamic.Interface, error) {
 		return fakeClient, nil
 	}
 	cache := NewMultiClusterCache(newClientFunc, restMapper)

--- a/pkg/search/proxy/store/resource_cache.go
+++ b/pkg/search/proxy/store/resource_cache.go
@@ -110,7 +110,7 @@ func storageWithCacher(gvr schema.GroupVersionResource, multiNS *MultiNamespace,
 		newFunc func() runtime.Object,
 		newListFunc func() runtime.Object,
 		getAttrsFunc storage.AttrFunc,
-		triggerFuncs storage.IndexerFuncs,
+		_ storage.IndexerFuncs,
 		indexers *cache.Indexers) (storage.Interface, factory.DestroyFunc, error) {
 		cacherConfig := cacherstorage.Config{
 			Storage:        newStore(gvr, multiNS, newClientFunc, versioner, resourcePrefix),

--- a/pkg/search/proxy/store/util_test.go
+++ b/pkg/search/proxy/store/util_test.go
@@ -39,7 +39,7 @@ func Test_watchMux_StopBySelf(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		w := newFakeWatcher(wait.NeverStop)
-		m.AddSource(w, func(event watch.Event) {})
+		m.AddSource(w, func(watch.Event) {})
 		go func() {
 			ticker := time.NewTimer(time.Second)
 			for {
@@ -84,7 +84,7 @@ func Test_watchMux_StopBySource(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		w := newFakeWatcher(ctx.Done())
-		m.AddSource(w, func(event watch.Event) {})
+		m.AddSource(w, func(watch.Event) {})
 		go func() {
 			ticker := time.NewTimer(time.Second)
 			for {

--- a/pkg/sharedcli/commandusage.go
+++ b/pkg/sharedcli/commandusage.go
@@ -61,7 +61,7 @@ func SetUsageAndHelpFunc(cmd *cobra.Command, fss cliflag.NamedFlagSets, cols int
 		return nil
 	})
 
-	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+	cmd.SetHelpFunc(func(cmd *cobra.Command, _ []string) {
 		fmt.Fprintf(cmd.OutOrStdout(), "%s\n\n"+usageFmt, cmd.Long, cmd.UseLine())
 		if cmd.HasAvailableSubCommands() {
 			fmt.Fprintf(cmd.OutOrStdout(), "%s\n", strings.Join(generatesAvailableSubCommands(cmd), "\n"))

--- a/pkg/util/fixedpool/fixedpool_test.go
+++ b/pkg/util/fixedpool/fixedpool_test.go
@@ -70,7 +70,7 @@ func TestFixedPool_Get(t *testing.T) {
 				pool:        tt.fields.pool,
 				capacity:    tt.fields.capacity,
 				newFunc:     func() (any, error) { return &struct{}{}, nil },
-				destroyFunc: func(a any) {},
+				destroyFunc: func(any) {},
 			}
 			g, err := p.Get()
 			if err != nil {
@@ -143,7 +143,7 @@ func TestFixedPool_Put(t *testing.T) {
 				pool:        tt.fields.pool,
 				capacity:    tt.fields.capacity,
 				newFunc:     func() (any, error) { return &struct{}{}, nil },
-				destroyFunc: func(a any) { destroyed = true },
+				destroyFunc: func(any) { destroyed = true },
 			}
 			p.Put(&struct{}{})
 			if got := len(p.pool); got != tt.want.len {

--- a/pkg/util/helper/predicate.go
+++ b/pkg/util/helper/predicate.go
@@ -68,7 +68,7 @@ func NewExecutionPredicate(mgr controllerruntime.Manager) predicate.Funcs {
 		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
 			return predFunc("delete", deleteEvent.Object)
 		},
-		GenericFunc: func(genericEvent event.GenericEvent) bool {
+		GenericFunc: func(event.GenericEvent) bool {
 			return false
 		},
 	}
@@ -99,16 +99,16 @@ func NewPredicateForServiceExportController(mgr controllerruntime.Manager) predi
 	}
 
 	return predicate.Funcs{
-		CreateFunc: func(createEvent event.CreateEvent) bool {
+		CreateFunc: func(event.CreateEvent) bool {
 			return false
 		},
 		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
 			return predFunc("update", updateEvent.ObjectNew) || predFunc("update", updateEvent.ObjectOld)
 		},
-		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+		DeleteFunc: func(event.DeleteEvent) bool {
 			return false
 		},
-		GenericFunc: func(genericEvent event.GenericEvent) bool {
+		GenericFunc: func(event.GenericEvent) bool {
 			return false
 		},
 	}
@@ -116,7 +116,7 @@ func NewPredicateForServiceExportController(mgr controllerruntime.Manager) predi
 
 // NewPredicateForEndpointSliceCollectController generates an event filter function for EndpointSliceCollectController running by karmada-controller-manager.
 func NewPredicateForEndpointSliceCollectController(mgr controllerruntime.Manager) predicate.Funcs {
-	predFunc := func(eventType string, object client.Object) bool {
+	predFunc := func(_ string, object client.Object) bool {
 		obj := object.(*workv1alpha1.Work)
 		clusterName, err := names.GetClusterName(obj.GetNamespace())
 		if err != nil {
@@ -142,7 +142,7 @@ func NewPredicateForEndpointSliceCollectController(mgr controllerruntime.Manager
 		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
 			return predFunc("delete", deleteEvent.Object)
 		},
-		GenericFunc: func(genericEvent event.GenericEvent) bool {
+		GenericFunc: func(event.GenericEvent) bool {
 			return false
 		},
 	}
@@ -160,7 +160,7 @@ func NewClusterPredicateOnAgent(clusterName string) predicate.Funcs {
 		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
 			return deleteEvent.Object.GetName() == clusterName
 		},
-		GenericFunc: func(genericEvent event.GenericEvent) bool {
+		GenericFunc: func(event.GenericEvent) bool {
 			return false
 		},
 	}
@@ -185,16 +185,16 @@ func NewPredicateForServiceExportControllerOnAgent(curClusterName string) predic
 	}
 
 	return predicate.Funcs{
-		CreateFunc: func(createEvent event.CreateEvent) bool {
+		CreateFunc: func(event.CreateEvent) bool {
 			return false
 		},
 		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
 			return predFunc("update", updateEvent.ObjectNew) || predFunc("update", updateEvent.ObjectOld)
 		},
-		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+		DeleteFunc: func(event.DeleteEvent) bool {
 			return false
 		},
-		GenericFunc: func(genericEvent event.GenericEvent) bool {
+		GenericFunc: func(event.GenericEvent) bool {
 			return false
 		},
 	}
@@ -202,7 +202,7 @@ func NewPredicateForServiceExportControllerOnAgent(curClusterName string) predic
 
 // NewPredicateForEndpointSliceCollectControllerOnAgent generates an event filter function for EndpointSliceCollectController running by karmada-agent.
 func NewPredicateForEndpointSliceCollectControllerOnAgent(curClusterName string) predicate.Funcs {
-	predFunc := func(eventType string, object client.Object) bool {
+	predFunc := func(_ string, object client.Object) bool {
 		obj := object.(*workv1alpha1.Work)
 		clusterName, err := names.GetClusterName(obj.GetNamespace())
 		if err != nil {
@@ -222,7 +222,7 @@ func NewPredicateForEndpointSliceCollectControllerOnAgent(curClusterName string)
 		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
 			return predFunc("delete", deleteEvent.Object)
 		},
-		GenericFunc: func(genericEvent event.GenericEvent) bool {
+		GenericFunc: func(event.GenericEvent) bool {
 			return false
 		},
 	}
@@ -255,7 +255,7 @@ func NewExecutionPredicateOnAgent() predicate.Funcs {
 		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
 			return predFunc("delete", deleteEvent.Object)
 		},
-		GenericFunc: func(genericEvent event.GenericEvent) bool {
+		GenericFunc: func(event.GenericEvent) bool {
 			return false
 		},
 	}

--- a/pkg/util/membercluster_client_test.go
+++ b/pkg/util/membercluster_client_test.go
@@ -242,7 +242,7 @@ func TestNewClusterClientSet(t *testing.T) {
 }
 
 func TestNewClusterClientSet_ClientWorks(t *testing.T) {
-	s := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+	s := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		rw.Header().Add("Content-Type", "application/json")
 		_, _ = io.WriteString(rw, `
 {
@@ -466,7 +466,7 @@ func TestNewClusterDynamicClientSet(t *testing.T) {
 }
 
 func TestNewClusterDynamicClientSet_ClientWorks(t *testing.T) {
-	s := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+	s := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		rw.Header().Add("Content-Type", "application/json")
 		_, _ = io.WriteString(rw, `
 {

--- a/pkg/util/namespace_test.go
+++ b/pkg/util/namespace_test.go
@@ -48,7 +48,7 @@ func TestIsNamespaceExist(t *testing.T) {
 			args: args{
 				client:    fake.NewSimpleClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}),
 				namespace: metav1.NamespaceDefault,
-				reactor: func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+				reactor: func(_ coretesting.Action) (handled bool, ret runtime.Object, err error) {
 					return true, &corev1.Namespace{}, errors.New("failed to get namespace")
 				},
 			},
@@ -130,7 +130,7 @@ func TestCreateNamespace(t *testing.T) {
 			args: args{
 				client:       fake.NewSimpleClientset(),
 				namespaceObj: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
-				reactor: func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+				reactor: func(_ coretesting.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, errors.New("failed to create namespace")
 				},
 			},
@@ -180,7 +180,7 @@ func TestDeleteNamespace(t *testing.T) {
 			args: args{
 				client:    fake.NewSimpleClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}),
 				namespace: "default",
-				reactor: func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+				reactor: func(_ coretesting.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, errors.New("failed to delete namespaces")
 				},
 			},
@@ -237,7 +237,7 @@ func TestEnsureNamespaceExist(t *testing.T) {
 			args: args{
 				client:    fake.NewSimpleClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}),
 				namespace: "default",
-				reactorCreate: func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+				reactorCreate: func(_ coretesting.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, apierrors.NewAlreadyExists(schema.ParseGroupResource("namespaces"), "default")
 				},
 			},
@@ -248,7 +248,7 @@ func TestEnsureNamespaceExist(t *testing.T) {
 			args: args{
 				client:    fake.NewSimpleClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}),
 				namespace: metav1.NamespaceDefault,
-				reactorGet: func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+				reactorGet: func(_ coretesting.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, errors.New("failed to get namespace")
 				},
 			},
@@ -259,7 +259,7 @@ func TestEnsureNamespaceExist(t *testing.T) {
 			args: args{
 				client:    fake.NewSimpleClientset(),
 				namespace: metav1.NamespaceDefault,
-				reactorCreate: func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+				reactorCreate: func(_ coretesting.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, errors.New("failed to create namespace")
 				},
 			},
@@ -315,7 +315,7 @@ func TestEnsureNamespaceExistWithLabels(t *testing.T) {
 				client:    fake.NewSimpleClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}),
 				namespace: "default",
 				labels:    map[string]string{"testkey": "testvalue"},
-				reactorCreate: func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+				reactorCreate: func(_ coretesting.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, apierrors.NewAlreadyExists(schema.ParseGroupResource("namespaces"), "default")
 				},
 			},
@@ -327,7 +327,7 @@ func TestEnsureNamespaceExistWithLabels(t *testing.T) {
 				client:    fake.NewSimpleClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}),
 				namespace: metav1.NamespaceDefault,
 				labels:    map[string]string{"testkey": "testvalue"},
-				reactorGet: func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+				reactorGet: func(_ coretesting.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, errors.New("failed to get namespace")
 				},
 			},
@@ -339,7 +339,7 @@ func TestEnsureNamespaceExistWithLabels(t *testing.T) {
 				client:    fake.NewSimpleClientset(),
 				namespace: metav1.NamespaceDefault,
 				labels:    map[string]string{"testkey": "testvalue"},
-				reactorCreate: func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+				reactorCreate: func(_ coretesting.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, errors.New("failed to create namespace")
 				},
 			},

--- a/pkg/util/proxy/proxy_test.go
+++ b/pkg/util/proxy/proxy_test.go
@@ -128,7 +128,7 @@ func TestConnectCluster(t *testing.T) {
 						ImpersonatorSecretRef: &clusterapis.LocalSecretReference{Namespace: "ns", Name: "secret"},
 					},
 				},
-				secretGetter: func(_ context.Context, ns string, name string) (*corev1.Secret, error) {
+				secretGetter: func(_ context.Context, _ string, name string) (*corev1.Secret, error) {
 					return nil, apierrors.NewNotFound(corev1.Resource("secrets"), name)
 				},
 			},

--- a/pkg/util/restmapper/restmapper.go
+++ b/pkg/util/restmapper/restmapper.go
@@ -104,7 +104,7 @@ func (g *cachedRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) 
 			g.mu.Lock()
 			g.restMapper = newMapper
 			g.mu.Unlock()
-			g.gvkToGVR.Range(func(key, value any) bool {
+			g.gvkToGVR.Range(func(key, _ any) bool {
 				g.gvkToGVR.Delete(key)
 				return true
 			})

--- a/pkg/version/sharedcommand/sharedcommand.go
+++ b/pkg/version/sharedcommand/sharedcommand.go
@@ -42,7 +42,7 @@ func NewCmdVersion(parentCommand string) *cobra.Command {
 		Short:   versionShort,
 		Long:    versionLong,
 		Example: fmt.Sprintf(versionExample, parentCommand),
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			fmt.Fprintf(os.Stdout, "%s version: %s\n", parentCommand, version.Get())
 		},
 	}

--- a/test/e2e/clusteraffinities_test.go
+++ b/test/e2e/clusteraffinities_test.go
@@ -96,21 +96,21 @@ var _ = ginkgo.Describe("[ClusterAffinities] propagation testing", func() {
 
 			ginkgo.It("propagate deployment and then update the cluster label", func() {
 				// 1. wait for deployment present on member1 cluster
-				framework.WaitDeploymentPresentOnClusterFitWith("member1", deployment.Namespace, deployment.Name, func(deployment *appsv1.Deployment) bool { return true })
+				framework.WaitDeploymentPresentOnClusterFitWith("member1", deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 
 				// 2. update member1 cluster label to make it's unmatched with the policy
 				framework.UpdateClusterLabels(karmadaClient, "member1", map[string]string{member1LabelKey: "not-ok"})
 				framework.WaitDeploymentDisappearOnCluster("member1", deployment.Namespace, deployment.Name)
 
 				// 3. wait for deployment present on member2 cluster
-				framework.WaitDeploymentPresentOnClusterFitWith("member2", deployment.Namespace, deployment.Name, func(deployment *appsv1.Deployment) bool { return true })
+				framework.WaitDeploymentPresentOnClusterFitWith("member2", deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 
 				// 4. update member2 cluster label to make it's unmatched with the policy
 				framework.UpdateClusterLabels(karmadaClient, "member2", map[string]string{member2LabelKey: "not-ok"})
 				framework.WaitDeploymentDisappearOnCluster("member2", deployment.Namespace, deployment.Name)
 
 				// 5. wait for deployment present on member1 cluster
-				framework.WaitDeploymentPresentOnClusterFitWith("member1", deployment.Namespace, deployment.Name, func(deployment *appsv1.Deployment) bool { return true })
+				framework.WaitDeploymentPresentOnClusterFitWith("member1", deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 			})
 		})
 
@@ -142,7 +142,7 @@ var _ = ginkgo.Describe("[ClusterAffinities] propagation testing", func() {
 
 			ginkgo.It("propagate deployment and then update the cluster label", func() {
 				// 1. wait for deployment present on member1 cluster
-				framework.WaitDeploymentPresentOnClusterFitWith("member1", deployment.Namespace, deployment.Name, func(deployment *appsv1.Deployment) bool { return true })
+				framework.WaitDeploymentPresentOnClusterFitWith("member1", deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 
 				// 2. update policy placement with clusterAffinities
 				policy.Spec.Placement.ClusterAffinity = nil
@@ -153,7 +153,7 @@ var _ = ginkgo.Describe("[ClusterAffinities] propagation testing", func() {
 				framework.UpdatePropagationPolicyWithSpec(karmadaClient, policy.Namespace, policy.Name, policy.Spec)
 
 				// 3. wait for deployment present on member2 cluster
-				framework.WaitDeploymentPresentOnClusterFitWith("member2", deployment.Namespace, deployment.Name, func(deployment *appsv1.Deployment) bool { return true })
+				framework.WaitDeploymentPresentOnClusterFitWith("member2", deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 			})
 		})
 
@@ -188,7 +188,7 @@ var _ = ginkgo.Describe("[ClusterAffinities] propagation testing", func() {
 
 			ginkgo.It("propagate deployment and then update the cluster label", func() {
 				// 1. wait for deployment present on member1 cluster
-				framework.WaitDeploymentPresentOnClusterFitWith("member1", deployment.Namespace, deployment.Name, func(deployment *appsv1.Deployment) bool { return true })
+				framework.WaitDeploymentPresentOnClusterFitWith("member1", deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 
 				// 2. update policy placement with clusterAffinities
 				policy.Spec.Placement.ClusterAffinity = &policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member2"}}
@@ -196,7 +196,7 @@ var _ = ginkgo.Describe("[ClusterAffinities] propagation testing", func() {
 				framework.UpdatePropagationPolicyWithSpec(karmadaClient, policy.Namespace, policy.Name, policy.Spec)
 
 				// 3. wait for deployment present on member2 cluster
-				framework.WaitDeploymentPresentOnClusterFitWith("member2", deployment.Namespace, deployment.Name, func(deployment *appsv1.Deployment) bool { return true })
+				framework.WaitDeploymentPresentOnClusterFitWith("member2", deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 			})
 		})
 	})
@@ -259,21 +259,21 @@ var _ = ginkgo.Describe("[ClusterAffinities] propagation testing", func() {
 
 			ginkgo.It("propagate clusterRole and then update the cluster label", func() {
 				// 1. wait for clusterRole present on member1 cluster
-				framework.WaitClusterRolePresentOnClusterFitWith("member1", clusterRole.Name, func(clusterRole *rbacv1.ClusterRole) bool { return true })
+				framework.WaitClusterRolePresentOnClusterFitWith("member1", clusterRole.Name, func(*rbacv1.ClusterRole) bool { return true })
 
 				// 2. update member1 cluster label to make it's unmatched with the policy
 				framework.UpdateClusterLabels(karmadaClient, "member1", map[string]string{member1LabelKey: "not-ok"})
 				framework.WaitClusterRoleDisappearOnCluster("member1", clusterRole.Name)
 
 				// 3. wait for clusterRole present on member2 cluster
-				framework.WaitClusterRolePresentOnClusterFitWith("member2", clusterRole.Name, func(clusterRole *rbacv1.ClusterRole) bool { return true })
+				framework.WaitClusterRolePresentOnClusterFitWith("member2", clusterRole.Name, func(*rbacv1.ClusterRole) bool { return true })
 
 				// 4. update member2 cluster label to make it's unmatched with the policy
 				framework.UpdateClusterLabels(karmadaClient, "member2", map[string]string{member2LabelKey: "not-ok"})
 				framework.WaitClusterRoleDisappearOnCluster("member2", clusterRole.Name)
 
 				// 5. wait for deployment present on member1 cluster
-				framework.WaitClusterRolePresentOnClusterFitWith("member1", clusterRole.Name, func(clusterRole *rbacv1.ClusterRole) bool { return true })
+				framework.WaitClusterRolePresentOnClusterFitWith("member1", clusterRole.Name, func(*rbacv1.ClusterRole) bool { return true })
 			})
 		})
 
@@ -305,7 +305,7 @@ var _ = ginkgo.Describe("[ClusterAffinities] propagation testing", func() {
 
 			ginkgo.It("propagate clusterRole and then update the cluster label", func() {
 				// 1. wait for clusterRole present on member1 cluster
-				framework.WaitClusterRolePresentOnClusterFitWith("member1", clusterRole.Name, func(clusterRole *rbacv1.ClusterRole) bool { return true })
+				framework.WaitClusterRolePresentOnClusterFitWith("member1", clusterRole.Name, func(*rbacv1.ClusterRole) bool { return true })
 
 				// 2. update policy placement with clusterAffinities
 				policy.Spec.Placement.ClusterAffinity = nil
@@ -316,7 +316,7 @@ var _ = ginkgo.Describe("[ClusterAffinities] propagation testing", func() {
 				framework.UpdateClusterPropagationPolicyWithSpec(karmadaClient, policy.Name, policy.Spec)
 
 				// 3. wait for clusterRole present on member2 cluster
-				framework.WaitClusterRolePresentOnClusterFitWith("member2", clusterRole.Name, func(clusterRole *rbacv1.ClusterRole) bool { return true })
+				framework.WaitClusterRolePresentOnClusterFitWith("member2", clusterRole.Name, func(*rbacv1.ClusterRole) bool { return true })
 			})
 		})
 
@@ -351,7 +351,7 @@ var _ = ginkgo.Describe("[ClusterAffinities] propagation testing", func() {
 
 			ginkgo.It("propagate clusterRole and then update the cluster label", func() {
 				// 1. wait for clusterRole present on member1 cluster
-				framework.WaitClusterRolePresentOnClusterFitWith("member1", clusterRole.Name, func(clusterRole *rbacv1.ClusterRole) bool { return true })
+				framework.WaitClusterRolePresentOnClusterFitWith("member1", clusterRole.Name, func(*rbacv1.ClusterRole) bool { return true })
 
 				// 2. update policy placement with clusterAffinities
 				policy.Spec.Placement.ClusterAffinity = &policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member2"}}
@@ -359,7 +359,7 @@ var _ = ginkgo.Describe("[ClusterAffinities] propagation testing", func() {
 				framework.UpdateClusterPropagationPolicyWithSpec(karmadaClient, policy.Name, policy.Spec)
 
 				// 3. wait for clusterRole present on member2 cluster
-				framework.WaitClusterRolePresentOnClusterFitWith("member2", clusterRole.Name, func(clusterRole *rbacv1.ClusterRole) bool { return true })
+				framework.WaitClusterRolePresentOnClusterFitWith("member2", clusterRole.Name, func(*rbacv1.ClusterRole) bool { return true })
 			})
 		})
 	})
@@ -414,7 +414,7 @@ var _ = ginkgo.Describe("[ClusterAffinities] propagation testing", func() {
 			})
 
 			// 2. wait for deployment present on member2 cluster
-			framework.WaitDeploymentPresentOnClusterFitWith("member2", deployment.Namespace, deployment.Name, func(deployment *appsv1.Deployment) bool { return true })
+			framework.WaitDeploymentPresentOnClusterFitWith("member2", deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 
 			// 3. recover not ready cluster
 			ginkgo.By("recover not ready cluster", func() {

--- a/test/e2e/clusteroverridepolicy_test.go
+++ b/test/e2e/clusteroverridepolicy_test.go
@@ -93,7 +93,7 @@ var _ = ginkgo.Describe("The basic ClusterOverridePolicy testing", func() {
 					gomega.Expect(clusterClient).ShouldNot(gomega.BeNil())
 
 					klog.Infof("Waiting for namespace present on cluster(%s)", clusterName)
-					gomega.Eventually(func(g gomega.Gomega) (bool, error) {
+					gomega.Eventually(func(gomega.Gomega) (bool, error) {
 						clusterNs, err := clusterClient.CoreV1().Namespaces().Get(context.TODO(), ns.Name, metav1.GetOptions{})
 						if err != nil {
 							if apierrors.IsNotFound(err) {
@@ -176,7 +176,7 @@ var _ = framework.SerialDescribe("The ClusterOverridePolicy with nil resourceSel
 		ginkgo.It("deployment imageOverride testing", func() {
 			ginkgo.By("Check if deployment have presented on member clusters", func() {
 				framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
-					func(deployment *appsv1.Deployment) bool {
+					func(*appsv1.Deployment) bool {
 						return true
 					})
 			})

--- a/test/e2e/clusterpropagationpolicy_test.go
+++ b/test/e2e/clusterpropagationpolicy_test.go
@@ -125,7 +125,7 @@ var _ = ginkgo.Describe("[BasicClusterPropagation] propagation testing", func() 
 
 		ginkgo.It("clusterRole propagation testing", func() {
 			framework.WaitClusterRolePresentOnClustersFitWith(framework.ClusterNames(), clusterRole.Name,
-				func(role *rbacv1.ClusterRole) bool {
+				func(*rbacv1.ClusterRole) bool {
 					return true
 				})
 		})
@@ -169,7 +169,7 @@ var _ = ginkgo.Describe("[BasicClusterPropagation] propagation testing", func() 
 
 		ginkgo.It("clusterRoleBinding propagation testing", func() {
 			framework.WaitClusterRoleBindingPresentOnClustersFitWith(framework.ClusterNames(), clusterRoleBinding.Name,
-				func(binding *rbacv1.ClusterRoleBinding) bool {
+				func(*rbacv1.ClusterRoleBinding) bool {
 					return true
 				})
 		})
@@ -213,7 +213,7 @@ var _ = ginkgo.Describe("[AdvancedClusterPropagation] propagation testing", func
 				})
 
 				framework.WaitDeploymentPresentOnClusterFitWith(targetMember, deployment01.Namespace, deployment01.Name,
-					func(deployment *appsv1.Deployment) bool { return true })
+					func(*appsv1.Deployment) bool { return true })
 			})
 
 			ginkgo.It("add resourceSelectors item", func() {
@@ -231,7 +231,7 @@ var _ = ginkgo.Describe("[AdvancedClusterPropagation] propagation testing", func
 				})
 
 				framework.WaitDeploymentPresentOnClusterFitWith(targetMember, deployment02.Namespace, deployment02.Name,
-					func(deployment *appsv1.Deployment) bool { return true })
+					func(*appsv1.Deployment) bool { return true })
 			})
 
 			ginkgo.It("update resourceSelectors item", func() {
@@ -244,7 +244,7 @@ var _ = ginkgo.Describe("[AdvancedClusterPropagation] propagation testing", func
 				})
 
 				framework.WaitDeploymentPresentOnClusterFitWith(targetMember, deployment02.Namespace, deployment02.Name,
-					func(deployment *appsv1.Deployment) bool { return true })
+					func(*appsv1.Deployment) bool { return true })
 				framework.WaitDeploymentGetByClientFitWith(kubeClient, deployment01.Namespace, deployment01.Name,
 					func(deployment *appsv1.Deployment) bool {
 						if deployment.Labels == nil {
@@ -292,7 +292,7 @@ var _ = ginkgo.Describe("[AdvancedClusterPropagation] propagation testing", func
 				})
 
 				framework.WaitClusterRolePresentOnClusterFitWith(targetMember, clusterRole01.Name,
-					func(role *rbacv1.ClusterRole) bool {
+					func(*rbacv1.ClusterRole) bool {
 						return true
 					})
 			})
@@ -312,7 +312,7 @@ var _ = ginkgo.Describe("[AdvancedClusterPropagation] propagation testing", func
 				})
 
 				framework.WaitClusterRolePresentOnClusterFitWith(targetMember, clusterRole02.Name,
-					func(role *rbacv1.ClusterRole) bool {
+					func(*rbacv1.ClusterRole) bool {
 						return true
 					})
 			})
@@ -327,7 +327,7 @@ var _ = ginkgo.Describe("[AdvancedClusterPropagation] propagation testing", func
 				})
 
 				framework.WaitClusterRolePresentOnClusterFitWith(targetMember, clusterRole02.Name,
-					func(role *rbacv1.ClusterRole) bool {
+					func(*rbacv1.ClusterRole) bool {
 						return true
 					})
 				framework.WaitClusterRoleGetByClientFitWith(kubeClient, clusterRole01.Name,
@@ -434,7 +434,7 @@ var _ = ginkgo.Describe("[AdvancedClusterPropagation] propagation testing", func
 				framework.PatchClusterPropagationPolicy(karmadaClient, policy.Name, patch, types.JSONPatchType)
 				framework.WaitDeploymentDisappearOnCluster(targetMember, deployment.Namespace, deployment.Name)
 				framework.WaitDeploymentPresentOnClusterFitWith(updatedMember, deployment.Namespace, deployment.Name,
-					func(deployment *appsv1.Deployment) bool { return true })
+					func(*appsv1.Deployment) bool { return true })
 			})
 		})
 
@@ -471,7 +471,7 @@ var _ = ginkgo.Describe("[AdvancedClusterPropagation] propagation testing", func
 				})
 
 				framework.WaitClusterRolePresentOnClusterFitWith(targetMember, clusterRole.Name,
-					func(role *rbacv1.ClusterRole) bool {
+					func(*rbacv1.ClusterRole) bool {
 						return true
 					})
 			})
@@ -491,7 +491,7 @@ var _ = ginkgo.Describe("[AdvancedClusterPropagation] propagation testing", func
 				framework.PatchClusterPropagationPolicy(karmadaClient, policy.Name, patch, types.JSONPatchType)
 				framework.WaitClusterRoleDisappearOnCluster(targetMember, clusterRole.Name)
 				framework.WaitClusterRolePresentOnClusterFitWith(updatedMember, clusterRole.Name,
-					func(role *rbacv1.ClusterRole) bool {
+					func(*rbacv1.ClusterRole) bool {
 						return true
 					})
 			})
@@ -800,7 +800,7 @@ var _ = ginkgo.Describe("[Delete] clusterPropagation testing", func() {
 			})
 
 			resourceBindingName := names.GenerateBindingName(crd.Kind, crd.Name)
-			framework.WaitClusterResourceBindingFitWith(karmadaClient, resourceBindingName, func(crb *workv1alpha2.ClusterResourceBinding) bool {
+			framework.WaitClusterResourceBindingFitWith(karmadaClient, resourceBindingName, func(*workv1alpha2.ClusterResourceBinding) bool {
 				if crd.Labels != nil && crd.Labels[policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel] != "" {
 					return false
 				}

--- a/test/e2e/dependenciesdistributor_test.go
+++ b/test/e2e/dependenciesdistributor_test.go
@@ -95,12 +95,12 @@ var _ = ginkgo.Describe("[DependenciesDistributor] automatically propagate relev
 			ginkgo.It("configmap automatically propagation testing", func() {
 				ginkgo.By("check if the configmap is propagated automatically", func() {
 					framework.WaitDeploymentPresentOnClustersFitWith(initClusterNames, deployment.Namespace, deployment.Name,
-						func(deployment *appsv1.Deployment) bool {
+						func(*appsv1.Deployment) bool {
 							return true
 						})
 
 					framework.WaitConfigMapPresentOnClustersFitWith(initClusterNames, configMap.Namespace, configMapName,
-						func(configmap *corev1.ConfigMap) bool {
+						func(*corev1.ConfigMap) bool {
 							return true
 						})
 				})
@@ -116,12 +116,12 @@ var _ = ginkgo.Describe("[DependenciesDistributor] automatically propagate relev
 
 					framework.PatchPropagationPolicy(karmadaClient, policy.Namespace, policyName, patch, types.JSONPatchType)
 					framework.WaitDeploymentPresentOnClustersFitWith(updateClusterNames, deployment.Namespace, deploymentName,
-						func(deployment *appsv1.Deployment) bool {
+						func(*appsv1.Deployment) bool {
 							return true
 						})
 
 					framework.WaitConfigMapPresentOnClustersFitWith(updateClusterNames, configMap.Namespace, configMapName,
-						func(configmap *corev1.ConfigMap) bool {
+						func(*corev1.ConfigMap) bool {
 							return true
 						})
 				})
@@ -189,12 +189,12 @@ var _ = ginkgo.Describe("[DependenciesDistributor] automatically propagate relev
 			ginkgo.It("secret automatically propagation testing", func() {
 				ginkgo.By("check if the secret is propagated automatically", func() {
 					framework.WaitDeploymentPresentOnClustersFitWith(initClusterNames, deployment.Namespace, deployment.Name,
-						func(deployment *appsv1.Deployment) bool {
+						func(*appsv1.Deployment) bool {
 							return true
 						})
 
 					framework.WaitSecretPresentOnClustersFitWith(initClusterNames, secret.Namespace, secretName,
-						func(secret *corev1.Secret) bool {
+						func(*corev1.Secret) bool {
 							return true
 						})
 				})
@@ -264,12 +264,12 @@ var _ = ginkgo.Describe("[DependenciesDistributor] automatically propagate relev
 			ginkgo.It("persistentVolumeClaim automatically propagation testing", func() {
 				ginkgo.By("check if the persistentVolumeClaim is propagated automatically", func() {
 					framework.WaitDeploymentPresentOnClustersFitWith(initClusterNames, deployment.Namespace, deployment.Name,
-						func(deployment *appsv1.Deployment) bool {
+						func(*appsv1.Deployment) bool {
 							return true
 						})
 
 					framework.WaitPVCPresentOnClustersFitWith(initClusterNames, pvc.GetNamespace(), pvc.GetName(),
-						func(pvc *corev1.PersistentVolumeClaim) bool {
+						func(*corev1.PersistentVolumeClaim) bool {
 							return true
 						})
 				})
@@ -325,12 +325,12 @@ var _ = ginkgo.Describe("[DependenciesDistributor] automatically propagate relev
 				})
 				ginkgo.By("check if the serviceAccount is propagated automatically", func() {
 					framework.WaitDeploymentPresentOnClustersFitWith(initClusterNames, deployment.Namespace, deployment.Name,
-						func(deployment *appsv1.Deployment) bool {
+						func(*appsv1.Deployment) bool {
 							return true
 						})
 
 					framework.WaitServiceAccountPresentOnClustersFitWith(initClusterNames, sa.GetNamespace(), sa.GetName(),
-						func(sa *corev1.ServiceAccount) bool {
+						func(*corev1.ServiceAccount) bool {
 							return true
 						})
 				})
@@ -408,12 +408,12 @@ var _ = ginkgo.Describe("[DependenciesDistributor] automatically propagate relev
 			ginkgo.It("configmap automatically propagation testing", func() {
 				ginkgo.By("check if the configmap is propagated automatically", func() {
 					framework.WaitDeploymentPresentOnClustersFitWith(initClusterNames, deployment.Namespace, deployment.Name,
-						func(deployment *appsv1.Deployment) bool {
+						func(*appsv1.Deployment) bool {
 							return true
 						})
 
 					framework.WaitConfigMapPresentOnClustersFitWith(initClusterNames, configMap.Namespace, configMapName,
-						func(configmap *corev1.ConfigMap) bool {
+						func(*corev1.ConfigMap) bool {
 							return true
 						})
 				})
@@ -429,12 +429,12 @@ var _ = ginkgo.Describe("[DependenciesDistributor] automatically propagate relev
 
 					framework.PatchClusterPropagationPolicy(karmadaClient, policyName, patch, types.JSONPatchType)
 					framework.WaitDeploymentPresentOnClustersFitWith(updateClusterNames, deployment.Namespace, deploymentName,
-						func(deployment *appsv1.Deployment) bool {
+						func(*appsv1.Deployment) bool {
 							return true
 						})
 
 					framework.WaitConfigMapPresentOnClustersFitWith(updateClusterNames, configMap.Namespace, configMapName,
-						func(configmap *corev1.ConfigMap) bool {
+						func(*corev1.ConfigMap) bool {
 							return true
 						})
 				})

--- a/test/e2e/failover_test.go
+++ b/test/e2e/failover_test.go
@@ -513,7 +513,7 @@ var _ = framework.SerialDescribe("failover testing", func() {
 			})
 
 			ginkgo.By("check whether the failed deployment is present on the disabledClusters", func() {
-				framework.WaitDeploymentPresentOnClustersFitWith(disabledClusters, deploymentNamespace, deploymentName, func(deployment *appsv1.Deployment) bool { return true })
+				framework.WaitDeploymentPresentOnClustersFitWith(disabledClusters, deploymentNamespace, deploymentName, func(*appsv1.Deployment) bool { return true })
 			})
 
 			ginkgo.By("delete the error op", func() {

--- a/test/e2e/overridepolicy_test.go
+++ b/test/e2e/overridepolicy_test.go
@@ -820,7 +820,7 @@ var _ = framework.SerialDescribe("OverrideRules with nil resourceSelector testin
 		ginkgo.It("deployment imageOverride testing", func() {
 			ginkgo.By("Check if deployment have presented on member clusters", func() {
 				framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
-					func(deployment *appsv1.Deployment) bool {
+					func(*appsv1.Deployment) bool {
 						return true
 					})
 			})

--- a/test/e2e/preemption_test.go
+++ b/test/e2e/preemption_test.go
@@ -76,17 +76,17 @@ var _ = ginkgo.Describe("[Preemption] propagation policy preemption testing", fu
 
 			ginkgo.It("Propagate the deployment with the low-priority PropagationPolicy and then create the high-priority PropagationPolicy to preempt it", func() {
 				ginkgo.By("Wait for propagating deployment by the low-priority PropagationPolicy", func() {
-					framework.WaitDeploymentPresentOnClusterFitWith(preemptedClusterName, deployment.Namespace, deployment.Name, func(deployment *appsv1.Deployment) bool { return true })
+					framework.WaitDeploymentPresentOnClusterFitWith(preemptedClusterName, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 				})
 
 				ginkgo.By("Create the high-priority PropagationPolicy to preempt the low-priority PropagationPolicy", func() {
 					framework.CreatePropagationPolicy(karmadaClient, highPriorityPolicy)
-					framework.WaitDeploymentPresentOnClusterFitWith(preemptingClusterName, deployment.Namespace, deployment.Name, func(deployment *appsv1.Deployment) bool { return true })
+					framework.WaitDeploymentPresentOnClusterFitWith(preemptingClusterName, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 				})
 
 				ginkgo.By("Delete the high-priority PropagationPolicy to let the low-priority PropagationPolicy preempt the deployment", func() {
 					framework.RemovePropagationPolicy(karmadaClient, highPriorityPolicy.Namespace, highPriorityPolicy.Name)
-					framework.WaitDeploymentPresentOnClusterFitWith(preemptedClusterName, deployment.Namespace, deployment.Name, func(deployment *appsv1.Deployment) bool { return true })
+					framework.WaitDeploymentPresentOnClusterFitWith(preemptedClusterName, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 				})
 			})
 		})
@@ -135,17 +135,17 @@ var _ = ginkgo.Describe("[Preemption] propagation policy preemption testing", fu
 
 			ginkgo.It("Propagate the deployment with the ClusterPropagationPolicy and then create the PropagationPolicy to preempt it", func() {
 				ginkgo.By("Wait for propagating deployment by the ClusterPropagationPolicy", func() {
-					framework.WaitDeploymentPresentOnClusterFitWith(preemptedClusterName, deployment.Namespace, deployment.Name, func(deployment *appsv1.Deployment) bool { return true })
+					framework.WaitDeploymentPresentOnClusterFitWith(preemptedClusterName, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 				})
 
 				ginkgo.By("Create the PropagationPolicy to preempt the ClusterPropagationPolicy", func() {
 					framework.CreatePropagationPolicy(karmadaClient, propagationPolicy)
-					framework.WaitDeploymentPresentOnClusterFitWith(preemptingClusterName, deployment.Namespace, deployment.Name, func(deployment *appsv1.Deployment) bool { return true })
+					framework.WaitDeploymentPresentOnClusterFitWith(preemptingClusterName, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 				})
 
 				ginkgo.By("Delete the PropagationPolicy to let the ClusterPropagationPolicy preempt the deployment", func() {
 					framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
-					framework.WaitDeploymentPresentOnClusterFitWith(preemptedClusterName, deployment.Namespace, deployment.Name, func(deployment *appsv1.Deployment) bool { return true })
+					framework.WaitDeploymentPresentOnClusterFitWith(preemptedClusterName, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 				})
 			})
 		})
@@ -197,7 +197,7 @@ var _ = ginkgo.Describe("[Preemption] propagation policy preemption testing", fu
 
 			ginkgo.It("Propagate the deployment with the high-priority PropagationPolicy and then reduce it's priority to be preempted by the low-priority PropagationPolicy", func() {
 				ginkgo.By("Wait for propagating deployment by the high-priority PropagationPolicy", func() {
-					framework.WaitDeploymentPresentOnClusterFitWith(preemptedClusterName, deployment.Namespace, deployment.Name, func(deployment *appsv1.Deployment) bool { return true })
+					framework.WaitDeploymentPresentOnClusterFitWith(preemptedClusterName, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 				})
 
 				ginkgo.By("Reduce the priority of the high-priority PropagationPolicy to be preempted by the low-priority PropagationPolicy", func() {
@@ -210,7 +210,7 @@ var _ = ginkgo.Describe("[Preemption] propagation policy preemption testing", fu
 						},
 					}
 					framework.PatchPropagationPolicy(karmadaClient, highPriorityPolicy.Namespace, highPriorityPolicy.Name, patch, types.JSONPatchType)
-					framework.WaitDeploymentPresentOnClusterFitWith(preemptingClusterName, deployment.Namespace, deployment.Name, func(deployment *appsv1.Deployment) bool { return true })
+					framework.WaitDeploymentPresentOnClusterFitWith(preemptingClusterName, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 				})
 			})
 		})
@@ -260,17 +260,17 @@ var _ = ginkgo.Describe("[Preemption] propagation policy preemption testing", fu
 
 			ginkgo.It("Propagate the deployment with the low-priority ClusterPropagationPolicy and then create the high-priority ClusterPropagationPolicy to preempt it", func() {
 				ginkgo.By("Wait for propagating deployment by the low-priority ClusterPropagationPolicy", func() {
-					framework.WaitDeploymentPresentOnClusterFitWith(preemptedClusterName, deployment.Namespace, deployment.Name, func(deployment *appsv1.Deployment) bool { return true })
+					framework.WaitDeploymentPresentOnClusterFitWith(preemptedClusterName, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 				})
 
 				ginkgo.By("Create the high-priority ClusterPropagationPolicy to preempt the low-priority ClusterPropagationPolicy", func() {
 					framework.CreateClusterPropagationPolicy(karmadaClient, highPriorityPolicy)
-					framework.WaitDeploymentPresentOnClusterFitWith(preemptingClusterName, deployment.Namespace, deployment.Name, func(deployment *appsv1.Deployment) bool { return true })
+					framework.WaitDeploymentPresentOnClusterFitWith(preemptingClusterName, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 				})
 
 				ginkgo.By("Delete the high-priority ClusterPropagationPolicy to let the low-priority ClusterPropagationPolicy preempt the deployment", func() {
 					framework.RemoveClusterPropagationPolicy(karmadaClient, highPriorityPolicy.Name)
-					framework.WaitDeploymentPresentOnClusterFitWith(preemptedClusterName, deployment.Namespace, deployment.Name, func(deployment *appsv1.Deployment) bool { return true })
+					framework.WaitDeploymentPresentOnClusterFitWith(preemptedClusterName, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 				})
 			})
 		})
@@ -322,7 +322,7 @@ var _ = ginkgo.Describe("[Preemption] propagation policy preemption testing", fu
 
 			ginkgo.It("Propagate the deployment with the high-priority ClusterPropagationPolicy and then reduce it's priority to be preempted by the low-priority ClusterPropagationPolicy", func() {
 				ginkgo.By("Wait for propagating deployment by the high-priority ClusterPropagationPolicy", func() {
-					framework.WaitDeploymentPresentOnClusterFitWith(preemptedClusterName, deployment.Namespace, deployment.Name, func(deployment *appsv1.Deployment) bool { return true })
+					framework.WaitDeploymentPresentOnClusterFitWith(preemptedClusterName, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 				})
 
 				ginkgo.By("Reduce the priority of the high-priority ClusterPropagationPolicy to be preempted by the low-priority ClusterPropagationPolicy", func() {
@@ -335,7 +335,7 @@ var _ = ginkgo.Describe("[Preemption] propagation policy preemption testing", fu
 						},
 					}
 					framework.PatchClusterPropagationPolicy(karmadaClient, highPriorityPolicy.Name, patch, types.JSONPatchType)
-					framework.WaitDeploymentPresentOnClusterFitWith(preemptingClusterName, deployment.Namespace, deployment.Name, func(deployment *appsv1.Deployment) bool { return true })
+					framework.WaitDeploymentPresentOnClusterFitWith(preemptingClusterName, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 				})
 			})
 		})

--- a/test/e2e/propagationpolicy_test.go
+++ b/test/e2e/propagationpolicy_test.go
@@ -87,7 +87,7 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 
 		ginkgo.It("deployment propagation testing", func() {
 			framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
-				func(deployment *appsv1.Deployment) bool {
+				func(*appsv1.Deployment) bool {
 					return true
 				})
 
@@ -137,7 +137,7 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 
 		ginkgo.It("service propagation testing", func() {
 			framework.WaitServicePresentOnClustersFitWith(framework.ClusterNames(), service.Namespace, service.Name,
-				func(service *corev1.Service) bool {
+				func(*corev1.Service) bool {
 					return true
 				})
 
@@ -188,7 +188,7 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 
 		ginkgo.It("pod propagation testing", func() {
 			framework.WaitPodPresentOnClustersFitWith(framework.ClusterNames(), pod.Namespace, pod.Name,
-				func(pod *corev1.Pod) bool {
+				func(*corev1.Pod) bool {
 					return true
 				})
 
@@ -406,7 +406,7 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 
 		ginkgo.It("job propagation testing", func() {
 			framework.WaitJobPresentOnClustersFitWith(framework.ClusterNames(), job.Namespace, job.Name,
-				func(job *batchv1.Job) bool {
+				func(*batchv1.Job) bool {
 					return true
 				})
 
@@ -461,7 +461,7 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 
 		ginkgo.It("role propagation testing", func() {
 			framework.WaitRolePresentOnClustersFitWith(framework.ClusterNames(), role.Namespace, role.Name,
-				func(role *rbacv1.Role) bool {
+				func(*rbacv1.Role) bool {
 					return true
 				})
 		})
@@ -506,7 +506,7 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 
 		ginkgo.It("roleBinding propagation testing", func() {
 			framework.WaitRoleBindingPresentOnClustersFitWith(framework.ClusterNames(), roleBinding.Namespace, roleBinding.Name,
-				func(roleBinding *rbacv1.RoleBinding) bool {
+				func(*rbacv1.RoleBinding) bool {
 					return true
 				})
 		})
@@ -803,7 +803,7 @@ var _ = ginkgo.Describe("[AdvancedPropagation] propagation testing", func() {
 			})
 
 			framework.WaitDeploymentPresentOnClusterFitWith(targetMember, deployment01.Namespace, deployment01.Name,
-				func(deployment *appsv1.Deployment) bool { return true })
+				func(*appsv1.Deployment) bool { return true })
 		})
 
 		ginkgo.It("add resourceSelectors item", func() {
@@ -822,7 +822,7 @@ var _ = ginkgo.Describe("[AdvancedPropagation] propagation testing", func() {
 			framework.UpdatePropagationPolicyWithSpec(karmadaClient, policy.Namespace, policy.Name, policy.Spec)
 
 			framework.WaitDeploymentPresentOnClusterFitWith(targetMember, deployment02.Namespace, deployment02.Name,
-				func(deployment *appsv1.Deployment) bool { return true })
+				func(*appsv1.Deployment) bool { return true })
 		})
 
 		ginkgo.It("update resourceSelectors item", func() {
@@ -838,7 +838,7 @@ var _ = ginkgo.Describe("[AdvancedPropagation] propagation testing", func() {
 			framework.UpdatePropagationPolicyWithSpec(karmadaClient, policy.Namespace, policy.Name, policySpec)
 
 			framework.WaitDeploymentPresentOnClusterFitWith(targetMember, deployment02.Namespace, deployment02.Name,
-				func(deployment *appsv1.Deployment) bool { return true })
+				func(*appsv1.Deployment) bool { return true })
 			framework.WaitDeploymentGetByClientFitWith(kubeClient, deployment01.Namespace, deployment01.Name,
 				func(deployment *appsv1.Deployment) bool {
 					if deployment.Annotations == nil {
@@ -946,7 +946,7 @@ var _ = ginkgo.Describe("[AdvancedPropagation] propagation testing", func() {
 			framework.PatchPropagationPolicy(karmadaClient, policy.Namespace, policy.Name, patch, types.JSONPatchType)
 			framework.WaitDeploymentDisappearOnCluster(targetMember, deployment.Namespace, deployment.Name)
 			framework.WaitDeploymentPresentOnClusterFitWith(updatedMember, deployment.Namespace, deployment.Name,
-				func(deployment *appsv1.Deployment) bool { return true })
+				func(*appsv1.Deployment) bool { return true })
 		})
 	})
 
@@ -1071,7 +1071,7 @@ var _ = ginkgo.Describe("[AdvancedPropagation] propagation testing", func() {
 		ginkgo.It("modify the old propagationPolicy to unbind and create a new one", func() {
 			framework.CreatePropagationPolicy(karmadaClient, policy01)
 			framework.WaitConfigMapPresentOnClusterFitWith(member1, configmap.Namespace, configmap.Name,
-				func(configmap *corev1.ConfigMap) bool { return true })
+				func(*corev1.ConfigMap) bool { return true })
 			framework.UpdatePropagationPolicyWithSpec(karmadaClient, policy01.Namespace, policy01.Name, policyv1alpha1.PropagationSpec{
 				ResourceSelectors: []policyv1alpha1.ResourceSelector{
 					{
@@ -1090,7 +1090,7 @@ var _ = ginkgo.Describe("[AdvancedPropagation] propagation testing", func() {
 			framework.CreatePropagationPolicy(karmadaClient, policy02)
 			framework.WaitConfigMapDisappearOnCluster(member1, configmap.Namespace, configmap.Name)
 			framework.WaitConfigMapPresentOnClusterFitWith(member2, configmap.Namespace, configmap.Name,
-				func(configmap *corev1.ConfigMap) bool { return true })
+				func(*corev1.ConfigMap) bool { return true })
 			framework.RemovePropagationPolicy(karmadaClient, policy01.Namespace, policy01.Name)
 			framework.RemovePropagationPolicy(karmadaClient, policy02.Namespace, policy02.Name)
 		})
@@ -1098,13 +1098,13 @@ var _ = ginkgo.Describe("[AdvancedPropagation] propagation testing", func() {
 		ginkgo.It("delete the old propagationPolicy to unbind and create a new one", func() {
 			framework.CreatePropagationPolicy(karmadaClient, policy01)
 			framework.WaitConfigMapPresentOnClusterFitWith(member1, configmap.Namespace, configmap.Name,
-				func(configmap *corev1.ConfigMap) bool { return true })
+				func(*corev1.ConfigMap) bool { return true })
 			framework.RemovePropagationPolicy(karmadaClient, policy01.Namespace, policy01.Name)
 
 			framework.CreatePropagationPolicy(karmadaClient, policy02)
 			framework.WaitConfigMapDisappearOnCluster(member1, configmap.Namespace, configmap.Name)
 			framework.WaitConfigMapPresentOnClusterFitWith(member2, configmap.Namespace, configmap.Name,
-				func(configmap *corev1.ConfigMap) bool { return true })
+				func(*corev1.ConfigMap) bool { return true })
 			framework.RemovePropagationPolicy(karmadaClient, policy02.Namespace, policy02.Name)
 		})
 	})

--- a/test/e2e/rescheduling_test.go
+++ b/test/e2e/rescheduling_test.go
@@ -142,7 +142,7 @@ var _ = ginkgo.Describe("[cluster unjoined] reschedule testing", func() {
 			})
 
 			ginkgo.By("check whether the deployment is rescheduled to other available clusters", func() {
-				gomega.Eventually(func(g gomega.Gomega) bool {
+				gomega.Eventually(func(gomega.Gomega) bool {
 					targetClusterNames = framework.ExtractTargetClustersFrom(controlPlaneClient, deployment)
 					return testhelper.IsExclude(newClusterName, targetClusterNames)
 				}, pollTimeout, pollInterval).Should(gomega.BeTrue())
@@ -257,7 +257,7 @@ var _ = ginkgo.Describe("[cluster joined] reschedule testing", func() {
 				})
 
 				ginkgo.By("check whether the deployment is rescheduled to a new cluster")
-				gomega.Eventually(func(g gomega.Gomega) bool {
+				gomega.Eventually(func(gomega.Gomega) bool {
 					targetClusterNames := framework.ExtractTargetClustersFrom(controlPlaneClient, deployment)
 					return !testhelper.IsExclude(newClusterName, targetClusterNames)
 				}, pollTimeout, pollInterval).Should(gomega.BeTrue())
@@ -292,7 +292,7 @@ var _ = ginkgo.Describe("[cluster joined] reschedule testing", func() {
 					framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
 					framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
 				})
-				gomega.Eventually(func(g gomega.Gomega) bool {
+				gomega.Eventually(func(gomega.Gomega) bool {
 					targetClusterNames := framework.ExtractTargetClustersFrom(controlPlaneClient, deployment)
 					return testhelper.IsExclude(newClusterName, targetClusterNames)
 				}, pollTimeout, pollInterval).Should(gomega.BeTrue())
@@ -314,7 +314,7 @@ var _ = ginkgo.Describe("[cluster joined] reschedule testing", func() {
 				})
 
 				ginkgo.By("check whether the deployment is rescheduled to a new cluster")
-				gomega.Eventually(func(g gomega.Gomega) bool {
+				gomega.Eventually(func(gomega.Gomega) bool {
 					targetClusterNames := framework.ExtractTargetClustersFrom(controlPlaneClient, deployment)
 					for _, clusterName := range initClusterNames {
 						if testhelper.IsExclude(clusterName, targetClusterNames) {
@@ -324,7 +324,7 @@ var _ = ginkgo.Describe("[cluster joined] reschedule testing", func() {
 					return true
 				}, pollTimeout, pollInterval).Should(gomega.BeTrue())
 
-				gomega.Eventually(func(g gomega.Gomega) bool {
+				gomega.Eventually(func(gomega.Gomega) bool {
 					targetClusterNames := framework.ExtractTargetClustersFrom(controlPlaneClient, deployment)
 					return testhelper.IsExclude("member3", targetClusterNames)
 				}, pollTimeout, pollInterval).Should(gomega.BeTrue())
@@ -386,7 +386,7 @@ var _ = ginkgo.Describe("[cluster labels changed] reschedule testing while polic
 			})
 
 			framework.WaitDeploymentPresentOnClusterFitWith(targetMember, deployment.Namespace, deployment.Name,
-				func(deployment *appsv1.Deployment) bool { return true })
+				func(*appsv1.Deployment) bool { return true })
 		})
 
 		ginkgo.It("change labels to testing deployment reschedule(PropagationPolicy)", func() {
@@ -397,7 +397,7 @@ var _ = ginkgo.Describe("[cluster labels changed] reschedule testing while polic
 			labelsUpdate = map[string]string{labelKey: "ok"}
 			framework.UpdateClusterLabels(karmadaClient, targetMember, labelsUpdate)
 			framework.WaitDeploymentPresentOnClusterFitWith(targetMember, deployment.Namespace, deployment.Name,
-				func(deployment *appsv1.Deployment) bool { return true })
+				func(*appsv1.Deployment) bool { return true })
 		})
 	})
 
@@ -425,7 +425,7 @@ var _ = ginkgo.Describe("[cluster labels changed] reschedule testing while polic
 				framework.RemoveClusterPropagationPolicy(karmadaClient, policy.Name)
 			})
 			framework.WaitDeploymentPresentOnClusterFitWith(targetMember, deployment.Namespace, deployment.Name,
-				func(deployment *appsv1.Deployment) bool { return true })
+				func(*appsv1.Deployment) bool { return true })
 		})
 
 		ginkgo.It("change labels to testing deployment reschedule(ClusterPropagationPolicy)", func() {
@@ -436,7 +436,7 @@ var _ = ginkgo.Describe("[cluster labels changed] reschedule testing while polic
 			labelsUpdate = map[string]string{labelKey: "ok"}
 			framework.UpdateClusterLabels(karmadaClient, targetMember, labelsUpdate)
 			framework.WaitDeploymentPresentOnClusterFitWith(targetMember, deployment.Namespace, deployment.Name,
-				func(deployment *appsv1.Deployment) bool { return true })
+				func(*appsv1.Deployment) bool { return true })
 		})
 	})
 })

--- a/test/e2e/resourceinterpreter_test.go
+++ b/test/e2e/resourceinterpreter_test.go
@@ -1027,17 +1027,17 @@ end `,
 			ginkgo.It("DependencyInterpretation testing", func() {
 				ginkgo.By("check if the resources is propagated automatically", func() {
 					framework.WaitDeploymentPresentOnClusterFitWith(targetCluster, deployment.Namespace, deployment.Name,
-						func(deployment *appsv1.Deployment) bool {
+						func(*appsv1.Deployment) bool {
 							return true
 						})
 
 					framework.WaitServiceAccountPresentOnClusterFitWith(targetCluster, sa.Namespace, sa.Name,
-						func(sa *corev1.ServiceAccount) bool {
+						func(*corev1.ServiceAccount) bool {
 							return true
 						})
 
 					framework.WaitConfigMapPresentOnClusterFitWith(targetCluster, configMap.Namespace, configMap.Name,
-						func(configmap *corev1.ConfigMap) bool {
+						func(*corev1.ConfigMap) bool {
 							return true
 						})
 				})

--- a/test/e2e/scheduling_test.go
+++ b/test/e2e/scheduling_test.go
@@ -116,7 +116,7 @@ var _ = ginkgo.Describe("propagation with label and group constraints testing", 
 			ginkgo.By("check if deployment present on right clusters", func() {
 				for _, targetClusterName := range targetClusterNames {
 					framework.WaitDeploymentPresentOnClusterFitWith(targetClusterName, deployment.Namespace, deployment.Name,
-						func(deployment *appsv1.Deployment) bool {
+						func(*appsv1.Deployment) bool {
 							return true
 						})
 					groupMatchedClusters = append(groupMatchedClusters, targetClusterName)
@@ -330,7 +330,7 @@ var _ = ginkgo.Describe("propagation with label and group constraints testing", 
 			ginkgo.By("check if job present on right clusters", func() {
 				for _, targetClusterName := range targetClusterNames {
 					framework.WaitJobPresentOnClusterFitWith(targetClusterName, job.Namespace, job.Name,
-						func(job *batchv1.Job) bool {
+						func(*batchv1.Job) bool {
 							return true
 						})
 					groupMatchedClusters = append(groupMatchedClusters, targetClusterName)
@@ -425,7 +425,7 @@ var _ = ginkgo.Describe("[ReplicaScheduling] ReplicaSchedulingStrategy testing",
 		ginkgo.It("replicas duplicated testing when rescheduling", func() {
 			klog.Infof("make sure deployment has been propagated to member clusters")
 			framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
-				func(deployment *appsv1.Deployment) bool {
+				func(*appsv1.Deployment) bool {
 					return true
 				})
 
@@ -479,7 +479,7 @@ var _ = ginkgo.Describe("[ReplicaScheduling] ReplicaSchedulingStrategy testing",
 
 		ginkgo.It("replicas divided and weighted testing when rescheduling", func() {
 			framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
-				func(deployment *appsv1.Deployment) bool {
+				func(*appsv1.Deployment) bool {
 					return true
 				})
 
@@ -579,7 +579,7 @@ var _ = ginkgo.Describe("[ReplicaScheduling] ReplicaSchedulingStrategy testing",
 
 		ginkgo.It("replicas divided and weighted testing when rescheduling", func() {
 			framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
-				func(deployment *appsv1.Deployment) bool {
+				func(*appsv1.Deployment) bool {
 					return true
 				})
 

--- a/test/e2e/seamless_migration_test.go
+++ b/test/e2e/seamless_migration_test.go
@@ -178,7 +178,7 @@ var _ = ginkgo.Describe("Seamless migration testing", func() {
 			ginkgo.By(fmt.Sprintf("Verify ClusterResourceBinding %s got Applied by overwriting conflict resource", bindingName), func() {
 				klog.Infof("Waiting to verify ResourceBinding %s got Applied by overwriting conflict resource", bindingName)
 				gomega.Eventually(func() bool {
-					framework.WaitClusterRolePresentOnClusterFitWith(member1, clusterRoleName, func(clusterRole *rbacv1.ClusterRole) bool {
+					framework.WaitClusterRolePresentOnClusterFitWith(member1, clusterRoleName, func(*rbacv1.ClusterRole) bool {
 						return true
 					})
 					_, e1 := kubeClient.RbacV1().ClusterRoles().Get(context.TODO(), clusterRoleName, metav1.GetOptions{})
@@ -236,7 +236,7 @@ var _ = ginkgo.Describe("Seamless migration testing", func() {
 			ginkgo.By(fmt.Sprintf("Verify PropagationPolicy %s got Applied by overwriting conflict resource", bindingName), func() {
 				klog.Infof("Waiting to verify ResourceBinding %s got Applied by overwriting conflict resource", bindingName)
 				gomega.Eventually(func() bool {
-					framework.WaitServicePresentOnClusterFitWith(member1, testNamespace, serviceName, func(service *corev1.Service) bool {
+					framework.WaitServicePresentOnClusterFitWith(member1, testNamespace, serviceName, func(*corev1.Service) bool {
 						return true
 					})
 					_, e1 := kubeClient.CoreV1().Services(testNamespace).Get(context.TODO(), serviceName, metav1.GetOptions{})

--- a/test/e2e/spread_by_region_test.go
+++ b/test/e2e/spread_by_region_test.go
@@ -111,7 +111,7 @@ var _ = framework.SerialDescribe("spread-by-region testing", func() {
 		ginkgo.It("multiple region deployment testing", func() {
 			ginkgo.By("check whether deployment is scheduled to multiple regions", func() {
 				framework.WaitDeploymentPresentOnClustersFitWith(regionClusters, deployment.Namespace, deployment.Name,
-					func(deployment *appsv1.Deployment) bool {
+					func(*appsv1.Deployment) bool {
 						return true
 					})
 			})

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -126,7 +126,7 @@ func TestE2E(t *testing.T) {
 
 var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	return nil
-}, func(bytes []byte) {
+}, func([]byte) {
 	kubeconfig = os.Getenv("KUBECONFIG")
 	gomega.Expect(kubeconfig).ShouldNot(gomega.BeEmpty())
 

--- a/test/helper/request.go
+++ b/test/helper/request.go
@@ -80,9 +80,8 @@ func DoRequest(urlPath string, token string) (int, error) {
 	}
 	res.Header.Add("Authorization", bearToken)
 
-	// #nosec
 	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // nolint:gosec // G402: TLS InsecureSkipVerify set true.
 	}
 	httpClient := &http.Client{Transport: transport}
 	resp, err := httpClient.Do(res)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Bump [golangci-lint](https://github.com/karmada-io/karmada/blob/98c6158c06f51998ddce2f01ef7b10a5fd082754/hack/verify-staticcheck.sh#L22) to [v1.58.0](https://github.com/golangci/golangci-lint/releases/tag/v1.58.0). The following tasks are included：
- Update the `golangci-lint` version in `hack/verify-staticcheck.sh`
- The configuration option `run.skip-dirs` is deprecated, use `issues.exclude-dirs` instead. 
- The configuration option `run.skip-dirs-use-default` is deprecated, use `issues.exclude-dirs-use-default` instead. 
- Fix newly scanned errors

**Which issue(s) this PR fixes**:
Fixes #4907

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

