### PR TITLE
chore: support auto bump container images with dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,26 @@ updates:
   schedule:
     # Check for updates to GitHub Actions every week
     interval: "weekly"
+    
+- package-ecosystem: docker
+  directory: /cluster/images/
+  schedule:
+    interval: weekly
+
+- package-ecosystem: docker
+  directory: /cluster/images/
+  target-branch: "release-1.9"
+  schedule:
+    interval: weekly
+
+- package-ecosystem: docker
+  directory: /cluster/images/
+  target-branch: "release-1.8"
+  schedule:
+    interval: weekly
+
+- package-ecosystem: docker
+  directory: /cluster/images/
+  target-branch: "release-1.7"
+  schedule:
+    interval: weekly


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind cleanup

**What this PR does / why we need it**:

support auto bump container images with dependabot, but I'm not sure whether we should treat release branch like this, it's means we need to update release branch from this file when a new release is out.

option2 is only auto bump container image for master and cherry pick the PR of dependabot to release branch if need.

**Which issue(s) this PR fixes**:
Fixes #4908

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

