### PR TITLE
silence gosec warning G107

### DIFF
--- a/pkg/karmadactl/util/genericresource/visitor.go
+++ b/pkg/karmadactl/util/genericresource/visitor.go
@@ -243,11 +243,16 @@ type httpget func(url string) (int, string, io.ReadCloser, error)
 
 // httpgetImpl Implements a function to retrieve a url and return the results.
 func httpgetImpl(url string) (int, string, io.ReadCloser, error) {
-	// nolint:gosec
-	resp, err := http.Get(url)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return 0, "", nil, err
 	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, "", nil, err
+	}
+
 	return resp.StatusCode, resp.Status, resp.Body, nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
silence gosec warning G107

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Silence gosec warning G107:  Potential HTTP request made with variable url by replacing `http.Get` with `http.NewRequest` and `http.DefaultClient.Do`


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

