### PR TITLE
Improve access to member-cluster resources that use pb/json protocol …

### DIFF
--- a/cmd/karmada-search/app/karmada-search.go
+++ b/cmd/karmada-search/app/karmada-search.go
@@ -214,6 +214,8 @@ func config(o *options.Options, outOfTreeRegistryOptions ...Option) (*search.Con
 			KarmadaFactory:    factory,
 			MinRequestTimeout: time.Second * time.Duration(serverConfig.Config.MinRequestTimeout),
 			OutOfTreeRegistry: outOfTreeRegistry,
+			MemberClientQPS:   o.MemberClusterKubeAPIQPS,
+			MemberClientBurst: o.MemberClusterKubeAPIBurst,
 		})
 
 		if err != nil {

--- a/cmd/karmada-search/app/options/options.go
+++ b/cmd/karmada-search/app/options/options.go
@@ -39,6 +39,10 @@ type Options struct {
 	KubeAPIQPS float32
 	// KubeAPIBurst is the burst to allow while talking with karmada-search.
 	KubeAPIBurst int
+	// MemberClusterKubeAPIQPS is the QPS to use while talking to member cluster.
+	MemberClusterKubeAPIQPS float32
+	// MemberClusterKubeAPIBurst is the burst to allow while talking to member cluster.
+	MemberClusterKubeAPIBurst int
 
 	ProfileOpts profileflag.Options
 
@@ -66,6 +70,8 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 
 	flags.Float32Var(&o.KubeAPIQPS, "kube-api-qps", 40.0, "QPS to use while talking with karmada-apiserver.")
 	flags.IntVar(&o.KubeAPIBurst, "kube-api-burst", 60, "Burst to use while talking with karmada-apiserver.")
+	flags.Float32Var(&o.MemberClusterKubeAPIQPS, "member-client-kube-api-qps", 40.0, "QPS to use while talking to member client.")
+	flags.IntVar(&o.MemberClusterKubeAPIBurst, "member-client-kube-api-burst", 60, "Burst to use while talking to member client.")
 	flags.BoolVar(&o.DisableSearch, "disable-search", false, "Disable search feature that would save memory usage significantly.")
 	flags.BoolVar(&o.DisableProxy, "disable-proxy", false, "Disable proxy feature that would save memory usage significantly.")
 

--- a/pkg/metricsadapter/multiclient/client.go
+++ b/pkg/metricsadapter/multiclient/client.go
@@ -70,7 +70,7 @@ func (m *MultiClusterDiscovery) Set(clusterName string) error {
 	secretGetter := func(namespace string, name string) (*corev1.Secret, error) {
 		return m.secretLister.Secrets(namespace).Get(name)
 	}
-	clusterConfig, err := util.BuildClusterConfig(clusterName, clusterGetter, secretGetter)
+	clusterConfig, err := util.BuildClusterConfig(clusterName, clusterGetter, secretGetter, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/framework/pod.go
+++ b/test/e2e/framework/pod.go
@@ -75,7 +75,7 @@ func WaitPodMetricsReady(kubeClient kubernetes.Interface, karmadaClient karmada.
 	secretGetter := func(namespace string, name string) (*corev1.Secret, error) {
 		return kubeClient.CoreV1().Secrets(namespace).Get(context.Background(), name, metav1.GetOptions{})
 	}
-	config, err := util.BuildClusterConfig(cluster, clusterGetter, secretGetter)
+	config, err := util.BuildClusterConfig(cluster, clusterGetter, secretGetter, nil, nil)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	metricsClient, err := metricsclientset.NewForConfig(config)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())


### PR DESCRIPTION
…and allow users to set qps, burst values.

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature
**What this PR does / why we need it**:
In the large cluster, reasonable qps and burst values need to be set when accessing resources. to improve speed to resources.And use the pb/jsion protocol to improve the communication speed of sub-clusters for resources.

We  design a compatibiity processing. when a null pointer is passed in qps and burst are not set.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
In the large cluster, reasonable qps and burst values need to be set when accessing resources. to improve speed to resources.And use the pb/jsion protocol to improve the communication speed of sub-clusters for resources.
```

