### PR TITLE
fix: prune deployment revision annotation

### DIFF
--- a/pkg/resourceinterpreter/default/native/prune/prune.go
+++ b/pkg/resourceinterpreter/default/native/prune/prune.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	storagevolume "k8s.io/component-helpers/storage/volume"
+	utildeployment "k8s.io/kubectl/pkg/util/deployment"
 
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/helper"
@@ -33,6 +34,7 @@ import (
 type irrelevantFieldPruneFunc func(*unstructured.Unstructured) error
 
 var kindIrrelevantFieldPruners = map[string]irrelevantFieldPruneFunc{
+	util.DeploymentKind:            removeDeploymentIrrelevantField,
 	util.JobKind:                   removeJobIrrelevantField,
 	util.SecretKind:                removeSecretIrrelevantField,
 	util.ServiceAccountKind:        removeServiceAccountIrrelevantField,
@@ -126,6 +128,14 @@ func removeGenerateSelectorOfJob(workload *unstructured.Unstructured) error {
 			return err
 		}
 	}
+	return nil
+}
+
+func removeDeploymentIrrelevantField(workload *unstructured.Unstructured) error {
+	for _, annotation := range []string{utildeployment.RevisionAnnotation, utildeployment.RevisionHistoryAnnotation} {
+		unstructured.RemoveNestedField(workload.Object, "metadata", "annotations", annotation)
+	}
+
 	return nil
 }
 

--- a/pkg/resourceinterpreter/default/native/prune/prune_test.go
+++ b/pkg/resourceinterpreter/default/native/prune/prune_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	storagevolume "k8s.io/component-helpers/storage/volume"
+	utildeployment "k8s.io/kubectl/pkg/util/deployment"
 
 	"github.com/karmada-io/karmada/pkg/util"
 )
@@ -237,6 +238,38 @@ func TestRemoveIrrelevantField(t *testing.T) {
 			},
 			unexpectedFields: []field{
 				{"metadata", "annotations", storagevolume.AnnSelectedNode},
+			},
+		},
+		{
+			name: "removes deployment revision annotation",
+			workload: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": util.DeploymentKind,
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							utildeployment.RevisionAnnotation: 1,
+						},
+					},
+				},
+			},
+			unexpectedFields: []field{
+				{"metadata", "annotations", utildeployment.RevisionAnnotation},
+			},
+		},
+		{
+			name: "removes deployment revision history annotation",
+			workload: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": util.DeploymentKind,
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							utildeployment.RevisionHistoryAnnotation: "1,2",
+						},
+					},
+				},
+			},
+			unexpectedFields: []field{
+				{"metadata", "annotations", utildeployment.RevisionHistoryAnnotation},
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind bug

**What this PR does / why we need it**:

We noticed that karmada and member cluster controller-manager are fighting against each other where we get over 6k updates for a single deployment per hour.

the culprit seems to be the revision annotation.

<img width="1188" alt="Screenshot 2024-05-15 at 8 49 36 PM" src="https://github.com/karmada-io/karmada/assets/9448877/0a4c7436-8723-4b8d-a62d-cc51819e1c38">

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

while generally the karmdaa setup doesn't run the Deployment controller on the karmada-apiserver, it does support promoting resources which can lead to having these annotations cause a diff with the member cluster(s).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
fix: prune deployment revision annotations
```

