### PR TITLE
cleanup: replace text/template with html/template

### DIFF
--- a/operator/pkg/util/template.go
+++ b/operator/pkg/util/template.go
@@ -19,7 +19,7 @@ package util
 import (
 	"bytes"
 	"fmt"
-	"text/template"
+	"html/template"
 )
 
 // ParseTemplate validates and parses passed as argument template

--- a/pkg/karmadactl/addons/utils/template.go
+++ b/pkg/karmadactl/addons/utils/template.go
@@ -19,7 +19,7 @@ package utils
 import (
 	"bytes"
 	"fmt"
-	"text/template"
+	"html/template"
 )
 
 // ParseTemplate validates and parses passed as argument template


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Go provides two template packages, one for `text/template` and the other for `html/template`. `html/template` is basically the same as `text/template`, but `text/template` has no protection for XSS or any type of HTML encoding, while `html/template` adds security protection such as HTML encoding and has stronger functions.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

