### PR TITLE
[Cleanup] Add empty judgment for placement in taint-manager

### DIFF
--- a/pkg/controllers/gracefuleviction/crb_graceful_eviction_controller.go
+++ b/pkg/controllers/gracefuleviction/crb_graceful_eviction_controller.go
@@ -92,6 +92,8 @@ func (c *CRBGracefulEvictionController) syncBinding(binding *workv1alpha2.Cluste
 	}
 
 	for _, cluster := range evictedClusters {
+		klog.V(2).Infof("Success to evict Cluster(%s) from ClusterResourceBinding(%s) gracefulEvictionTasks",
+			cluster, binding.Name)
 		helper.EmitClusterEvictionEventForClusterResourceBinding(binding, cluster, c.EventRecorder, err)
 	}
 	return nextRetry(keptTask, c.GracefulEvictionTimeout, metav1.Now().Time), nil

--- a/pkg/controllers/gracefuleviction/rb_graceful_eviction_controller.go
+++ b/pkg/controllers/gracefuleviction/rb_graceful_eviction_controller.go
@@ -92,6 +92,8 @@ func (c *RBGracefulEvictionController) syncBinding(binding *workv1alpha2.Resourc
 	}
 
 	for _, cluster := range evictedCluster {
+		klog.V(2).Infof("Success to evict Cluster(%s) from ResourceBinding(%s/%s) gracefulEvictionTasks",
+			cluster, binding.Namespace, binding.Name)
 		helper.EmitClusterEvictionEventForResourceBinding(binding, cluster, c.EventRecorder, err)
 	}
 	return nextRetry(keptTask, c.GracefulEvictionTimeout, metav1.Now().Time), nil


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanupA
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

1. Add empty judgment for placement in taint-manager, avoid panic when the obtained placement is nil:
https://github.com/karmada-io/karmada/blob/90b461603c8025edc9696e3a0c54181e36b4b607/pkg/controllers/cluster/taint_manager.go#L267
2. Add more logs to facilitate fault locating.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

In order to make the program more robust, nil judgment is added. 

This is because when users define their own scheduler, the placement recorded in the annotation in the binding may be empty.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

