### PR TITLE
fix golint issue introduced by #4950

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

#4950 introduced a lint issue which will block PRs:
> Error: pkg/detector/detector.go:26:2: "github.com/google/uuid" imported and not used) (typecheck)


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Haven't figured out why CI cannot detect it at #4950.
cc @whitewindmills 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

