### PR TITLE
ci: add kubernetes 1.30

### DIFF
--- a/.github/workflows/ci-schedule-compatibility.yaml
+++ b/.github/workflows/ci-schedule-compatibility.yaml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 5
       fail-fast: false
       matrix:
-        kubeapiserver-version: [ v1.23.4, v1.24.2, v1.25.0, v1.26.0, v1.27.3, v1.28.0, v1.29.0 ]
+        kubeapiserver-version: [ v1.23.4, v1.24.2, v1.25.0, v1.26.0, v1.27.3, v1.28.0, v1.29.0, v1.30.0 ]
         karmada-version: [ release-1.7, release-1.8, release-1.9 ]
     steps:
       # Free up disk space on Ubuntu

--- a/.github/workflows/ci-schedule.yml
+++ b/.github/workflows/ci-schedule.yml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 5
       fail-fast: false
       matrix:
-        k8s: [ v1.23.4, v1.24.2, v1.25.0, v1.26.0, v1.27.3, v1.28.0, v1.29.0 ]
+        k8s: [ v1.23.4, v1.24.2, v1.25.0, v1.26.0, v1.27.3, v1.28.0, v1.29.0, v1.30.0 ]
     steps:
       # Free up disk space on Ubuntu
       - name: Free Disk Space (Ubuntu)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
         # Here support the latest three minor releases of Kubernetes, this can be considered to be roughly
         # the same as the End of Life of the Kubernetes release: https://kubernetes.io/releases/
         # Please remember to update the CI Schedule Workflow when we add a new version.
-        k8s: [ v1.27.3, v1.28.0, v1.29.0 ]
+        k8s: [ v1.28.0, v1.29.0, v1.30.0 ]
     steps:
       # Free up disk space on Ubuntu
       - name: Free Disk Space (Ubuntu)

--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -22,7 +22,7 @@ jobs:
         # Here support the latest three minor releases of Kubernetes, this can be considered to be roughly
         # the same as the End of Life of the Kubernetes release: https://kubernetes.io/releases/
         # Please remember to update the CI Schedule Workflow when we add a new version.
-        k8s: [ v1.27.3, v1.28.0, v1.29.0 ]
+        k8s: [ v1.28.0, v1.29.0, v1.30.0 ]
     steps:
       - name: checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind cleanup
**What this PR does / why we need it**:

kubernetes 1.30 is live, This allows us to use 1.30 for testing in CI. If we still want to use 1.27 for CI testing, we can add 1.30 to the scheduler workflow first.
https://github.com/karmada-io/karmada/blob/master/.github/workflows/ci-schedule-compatibility.yaml
and
https://github.com/karmada-io/karmada/blob/master/.github/workflows/ci-schedule.yml

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

