### PR TITLE
cleanup: update relate binding name and comments for ease of understanding

### DIFF
--- a/pkg/dependenciesdistributor/dependencies_distributor_test.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor_test.go
@@ -60,7 +60,7 @@ func Test_dependentObjectReferenceMatches(t *testing.T) {
 				},
 				referenceBinding: &workv1alpha2.ResourceBinding{
 					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-						bindingDependenciesAnnotationKey: "[{\"apiVersion\":\"example-stgzr.karmada.io/v1alpha1\",\"kind\":\"Foot5zmh\",\"namespace\":\"karmadatest-vpvll\",\"name\":\"cr-fxzq6\"}]",
+						dependenciesAnnotationKey: "[{\"apiVersion\":\"example-stgzr.karmada.io/v1alpha1\",\"kind\":\"Foot5zmh\",\"namespace\":\"karmadatest-vpvll\",\"name\":\"cr-fxzq6\"}]",
 					}},
 				},
 			},
@@ -81,7 +81,7 @@ func Test_dependentObjectReferenceMatches(t *testing.T) {
 				},
 				referenceBinding: &workv1alpha2.ResourceBinding{
 					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-						bindingDependenciesAnnotationKey: "[{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"namespace\":\"karmadatest-h46wh\",\"name\":\"configmap-8w426\"}]",
+						dependenciesAnnotationKey: "[{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"namespace\":\"karmadatest-h46wh\",\"name\":\"configmap-8w426\"}]",
 					}},
 				},
 			},
@@ -103,7 +103,7 @@ func Test_dependentObjectReferenceMatches(t *testing.T) {
 				},
 				referenceBinding: &workv1alpha2.ResourceBinding{
 					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-						bindingDependenciesAnnotationKey: "[{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"namespace\":\"test\",\"labelSelector\":{\"matchExpressions\":[{\"key\":\"app\",\"operator\":\"In\",\"values\":[\"test\"]}]}}]",
+						dependenciesAnnotationKey: "[{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"namespace\":\"test\",\"labelSelector\":{\"matchExpressions\":[{\"key\":\"app\",\"operator\":\"In\",\"values\":[\"test\"]}]}}]",
 					}},
 				},
 			},
@@ -112,9 +112,9 @@ func Test_dependentObjectReferenceMatches(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := dependentObjectReferenceMatches(tt.args.objectKey, tt.args.referenceBinding)
+			got := matchesWithBindingDependencies(tt.args.objectKey, tt.args.referenceBinding)
 			if got != tt.want {
-				t.Errorf("dependentObjectReferenceMatches() got = %v, want %v", got, tt.want)
+				t.Errorf("matchesWithBindingDependencies() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/util/helper/binding.go
+++ b/pkg/util/helper/binding.go
@@ -278,11 +278,11 @@ func FetchResourceTemplate(
 	return unstructuredObj, nil
 }
 
-// FetchResourceTemplateByLabelSelector fetches the resource template by label selector to be propagated.
+// FetchResourceTemplatesByLabelSelector fetches the resource templates by label selector to be propagated.
 // Any updates to this resource template are not recommended as it may come from the informer cache.
 // We should abide by the principle of making a deep copy first and then modifying it.
 // See issue: https://github.com/karmada-io/karmada/issues/3878.
-func FetchResourceTemplateByLabelSelector(
+func FetchResourceTemplatesByLabelSelector(
 	dynamicClient dynamic.Interface,
 	informerManager genericmanager.SingleClusterInformerManager,
 	restMapper meta.RESTMapper,

--- a/pkg/util/helper/binding_test.go
+++ b/pkg/util/helper/binding_test.go
@@ -959,7 +959,7 @@ func TestFetchWorkloadByLabelSelector(t *testing.T) {
 			stopCh := make(chan struct{})
 			mgr := tt.args.informerManager(stopCh)
 			selector, _ := metav1.LabelSelectorAsSelector(tt.args.selector)
-			got, err := FetchResourceTemplateByLabelSelector(tt.args.dynamicClient, mgr, tt.args.restMapper, tt.args.resource, selector)
+			got, err := FetchResourceTemplatesByLabelSelector(tt.args.dynamicClient, mgr, tt.args.restMapper, tt.args.resource, selector)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FetchResourceTemplate() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

In the dependencies distributor module, we have two kinds of binding, one is the binding that is followed, and the other is the binding that follows.

We have a clear explanation of these names:

https://github.com/karmada-io/karmada/blob/0084c8a97eba3b9ff3a0a355cbc95531bcb5c634/pkg/dependenciesdistributor/dependencies_distributor.go#L83-L84

But in the code, some places are not named according to such names, which makes us a little confused when reading the code and we need to repeatedly confirm the intent of the code.

Therefore, this PR unified the confusing naming and modified some comments.

In addition, the code uses two words, `depended` and `dependencies`, which correspond to the binding that is followed and binding that follows, respectively.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

/cc @RainbowMango @chaunceyjiang @whitewindmills 
