### PR TITLE
add binding dependencies distributor finalizer to the independent binding

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -138,6 +138,10 @@ const (
 
 	// ClusterPropagationPolicyControllerFinalizer is added to ClusterPropagationPolicy to ensure the related resources have been unbound before itself is deleted.
 	ClusterPropagationPolicyControllerFinalizer = "karmada.io/cluster-propagation-policy-controller"
+
+	// BindingDependenciesDistributorFinalizer is added to independent binding to ensure
+	// the attached binding have been removed or cleaned up before itself is deleted.
+	BindingDependenciesDistributorFinalizer = "karmada.io/binding-dependencies-distributor"
 )
 
 const (


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

In dependencies distributor module, we need to deal with independent binding cleanup with the right pattern -- control with finalizer, so I add a new finalizer `karmada.io/binding-dependencies-distributor`.

In addition, in the issue #1741, we can see that the label value of `resourcebinding.karmada.io/depended-by-xxx` will exceed 63 characters, we need to use the binding permanent ID to replace it, this also prompts us to use finalizer to clean up resources.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

