### PR TITLE
nominate infra owners

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -1,13 +1,7 @@
 reviewers:
-- chaosi-zju
-- ikaven1024
-- lfbear
 - liangyuanpeng
-- mrlihanbo
 - zhzhuang-zju
+
 approvers:
-- ikaven1024
 - liangyuanpeng
-- lfbear
-- mrlihanbo
 - zhzhuang-zju


### PR DESCRIPTION
**What type of PR is this?**

This PR nominates @liangyuanpeng @zhzhuang-zju as the owners of infrastructure.
@liangyuanpeng and @zhzhuang-zju contributed a lot to improve the infrastructure, such as :
- Introduced dependabot for automated dependency management
- Introduced trivy for security scanning
- Maintains test matrix 
- And so on.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/hold
for current owners to vote and approval
/assign @ikaven1024 @lfbear @mrlihanbo