### PR TITLE
[1.9] karmadactl init: set default value of imagePullPolicy to IfNotPresent

### DIFF
--- a/pkg/karmadactl/cmdinit/kubernetes/deployments.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deployments.go
@@ -444,8 +444,9 @@ func (i *CommandInitOption) makeKarmadaSchedulerDeployment() *appsv1.Deployment 
 		},
 		Containers: []corev1.Container{
 			{
-				Name:  schedulerDeploymentNameAndServiceAccountName,
-				Image: i.karmadaSchedulerImage(),
+				Name:            schedulerDeploymentNameAndServiceAccountName,
+				Image:           i.karmadaSchedulerImage(),
+				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command: []string{
 					"/bin/karmada-scheduler",
 					"--kubeconfig=/etc/kubeconfig",
@@ -559,8 +560,9 @@ func (i *CommandInitOption) makeKarmadaControllerManagerDeployment() *appsv1.Dep
 		},
 		Containers: []corev1.Container{
 			{
-				Name:  controllerManagerDeploymentAndServiceName,
-				Image: i.karmadaControllerManagerImage(),
+				Name:            controllerManagerDeploymentAndServiceName,
+				Image:           i.karmadaControllerManagerImage(),
+				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command: []string{
 					"/bin/karmada-controller-manager",
 					"--kubeconfig=/etc/kubeconfig",
@@ -677,8 +679,9 @@ func (i *CommandInitOption) makeKarmadaWebhookDeployment() *appsv1.Deployment {
 		AutomountServiceAccountToken: pointer.Bool(false),
 		Containers: []corev1.Container{
 			{
-				Name:  webhookDeploymentAndServiceAccountAndServiceName,
-				Image: i.karmadaWebhookImage(),
+				Name:            webhookDeploymentAndServiceAccountAndServiceName,
+				Image:           i.karmadaWebhookImage(),
+				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command: []string{
 					"/bin/karmada-webhook",
 					"--kubeconfig=/etc/kubeconfig",
@@ -847,9 +850,10 @@ func (i *CommandInitOption) makeKarmadaAggregatedAPIServerDeployment() *appsv1.D
 		AutomountServiceAccountToken: pointer.Bool(false),
 		Containers: []corev1.Container{
 			{
-				Name:    karmadaAggregatedAPIServerDeploymentAndServiceName,
-				Image:   i.karmadaAggregatedAPIServerImage(),
-				Command: command,
+				Name:            karmadaAggregatedAPIServerDeploymentAndServiceName,
+				Image:           i.karmadaAggregatedAPIServerImage(),
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Command:         command,
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      KubeConfigSecretAndMountName,


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
refer to https://github.com/karmada-io/karmada/pull/4976#issuecomment-2132557294 and https://github.com/karmada-io/karmada/pull/4976#issuecomment-2132565157 and https://github.com/karmada-io/karmada/pull/4976#issuecomment-2132577100

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`:  The policy for when to pull a container image now is `IfNotPresent in `init` command.
````

