### PR TITLE
Enable deprecation check and bump golangci-lint to v1.59.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,10 +82,6 @@ linters-settings:
       - name: unexported-return
       - name: time-naming
       - name: empty-block
-  staticcheck:
-    checks:
-      - all
-      - '-SA1019' # disable deprecation check. Tracked by https://github.com/karmada-io/karmada/issues/3835.
 
 issues:
   # The list of ids of default excludes to include or disable. By default it's empty.

--- a/hack/verify-staticcheck.sh
+++ b/hack/verify-staticcheck.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-GOLANGCI_LINT_VER="v1.58.0"
+GOLANGCI_LINT_VER="v1.59.0"
 
 cd "${REPO_ROOT}"
 source "hack/util.sh"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR enabled the deprecation check which was disabled by #3730 during the dependency update.

**Which issue(s) this PR fixes**:
Fixes #3835

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

