### PR TITLE
remove unused id label in the dependencise distributor

### DIFF
--- a/pkg/dependenciesdistributor/dependencies_distributor.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor.go
@@ -63,10 +63,6 @@ import (
 
 // well-know labels
 const (
-	// dependedIDLabelKey is added to the attached binding, it describes the
-	// resource id of the independent binding which the attached binding depends on.
-	dependedIDLabelKey = "resourcebinding.karmada.io/depended-id"
-
 	// dependedByLabelKeyPrefix is added to the attached binding, it is the
 	// prefix of the label key which specifying the current attached binding
 	// referred by which independent binding.
@@ -687,8 +683,6 @@ func buildAttachedBinding(independentBinding *workv1alpha2.ResourceBinding, obje
 		Clusters:  independentBinding.Spec.Clusters,
 	})
 
-	bindingID := util.GetLabelValue(independentBinding.Labels, workv1alpha2.ResourceBindingPermanentIDLabel)
-	dependedLabels = util.DedupeAndMergeLabels(dependedLabels, map[string]string{dependedIDLabelKey: bindingID})
 	return &workv1alpha2.ResourceBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      names.GenerateBindingName(object.GetKind(), object.GetName()),


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Remove unused id label in the dependencies distributor, ref talk: https://github.com/karmada-io/karmada/pull/4989#discussion_r1618124114

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Deprecation: The label `resourcebinding.karmada.io/depended-id` on attached ResourceBinding now has been deprecated and removed now as it never been used.
```

