### PR TITLE
fix register cluster creates agent missing --cluster-namespace parameter

### DIFF
--- a/pkg/karmadactl/register/register.go
+++ b/pkg/karmadactl/register/register.go
@@ -708,6 +708,7 @@ func (o *CommandRegisterOption) makeKarmadaAgentDeployment() *appsv1.Deployment 
 					fmt.Sprintf("--controllers=%s", strings.Join(controllers, ",")),
 					fmt.Sprintf("--proxy-server-address=%s", o.ProxyServerAddress),
 					fmt.Sprintf("--leader-elect-resource-namespace=%s", o.Namespace),
+					fmt.Sprintf("--cluster-namespace=%s", o.ClusterNamespace),
 					"--cluster-status-update-frequency=10s",
 					"--bind-address=0.0.0.0",
 					"--secure-port=10357",


### PR DESCRIPTION
Signed-off-by: huangyanfeng <huangyanfeng1992@gmail.com>

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

register cluster creates agent deployment missing --cluster-namespace parameter

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`:  Fix register cluster creates agent missing --cluster-namespace parameter
```

