### PR TITLE
Account for unschedulable plugin result during maxreplica estimation

### DIFF
--- a/pkg/estimator/server/estimate.go
+++ b/pkg/estimator/server/estimate.go
@@ -76,6 +76,12 @@ func (es *AccurateSchedulerEstimatorServer) estimateReplicas(
 
 	var res int32
 	replicas, ret := es.estimateFramework.RunEstimateReplicasPlugins(ctx, snapshot, &requirements)
+
+	// No replicas can be scheduled on the cluster, skip further checks and return 0
+	if ret.IsUnschedulable() {
+		return 0, nil
+	}
+
 	if !ret.IsSuccess() && !ret.IsNoOperation() {
 		return replicas, fmt.Errorf(fmt.Sprintf("estimate replice plugins fails with %s", ret.Reasons()))
 	}

--- a/pkg/estimator/server/framework/interface.go
+++ b/pkg/estimator/server/framework/interface.go
@@ -155,7 +155,12 @@ func (s *Result) IsSuccess() bool {
 	return s == nil || s.code == Success
 }
 
-// IsNoOperation return true if "Result" is not nil and Code is "Nooperation"
+// IsUnschedulable returns true if "Result" is not nil and Code is "Unschedulable".
+func (s *Result) IsUnschedulable() bool {
+	return s != nil && s.code == Unschedulable
+}
+
+// IsNoOperation returns true if "Result" is not nil and Code is "Nooperation"
 // ToDo (wengyao04): we can remove it once we include node resource estimation as the default plugin in the future
 func (s *Result) IsNoOperation() bool {
 	return s != nil && s.code == Noopperation

--- a/pkg/estimator/server/framework/runtime/framework.go
+++ b/pkg/estimator/server/framework/runtime/framework.go
@@ -125,7 +125,7 @@ func (frw *frameworkImpl) RunEstimateReplicasPlugins(ctx context.Context, snapsh
 	results := make(framework.PluginToResult)
 	for _, pl := range frw.estimateReplicasPlugins {
 		plReplica, ret := frw.runEstimateReplicasPlugins(ctx, pl, snapshot, replicaRequirements)
-		if ret.IsSuccess() && plReplica < replica {
+		if (ret.IsSuccess() || ret.IsUnschedulable()) && plReplica < replica {
 			replica = plReplica
 		}
 		results[pl.Name()] = ret

--- a/pkg/estimator/server/framework/runtime/framework_test.go
+++ b/pkg/estimator/server/framework/runtime/framework_test.go
@@ -117,7 +117,7 @@ func Test_frameworkImpl_RunEstimateReplicasPlugins(t *testing.T) {
 				},
 			},
 			expected: estimateReplicaResult{
-				replica: 1,
+				replica: 0,
 				ret:     framework.NewResult(framework.Unschedulable, "plugin 2 is unschedulable"),
 			},
 		},
@@ -144,7 +144,7 @@ func Test_frameworkImpl_RunEstimateReplicasPlugins(t *testing.T) {
 				},
 			},
 			expected: estimateReplicaResult{
-				replica: math.MaxInt32,
+				replica: 0,
 				ret:     framework.NewResult(framework.Unschedulable, "plugin 1 is unschedulable", "plugin 2 is no operation"),
 			},
 		},

--- a/pkg/scheduler/core/util.go
+++ b/pkg/scheduler/core/util.go
@@ -62,9 +62,10 @@ func calAvailableReplicas(clusters []*clusterv1alpha1.Cluster, spec *workv1alpha
 
 	// For non-workload, like ServiceAccount, ConfigMap, Secret and etc, it's unnecessary to calculate available replicas in member clusters.
 	// See issue: https://github.com/karmada-io/karmada/issues/3743.
+	namespacedKey := names.NamespacedKey(spec.Resource.Namespace, spec.Resource.Name)
 	if spec.Replicas == 0 {
 		klog.V(4).Infof("Do not calculate available replicas for non-workload(%s, kind=%s, %s).", spec.Resource.APIVersion,
-			spec.Resource.Kind, names.NamespacedKey(spec.Resource.Namespace, spec.Resource.Name))
+			spec.Resource.Kind, namespacedKey)
 		return availableTargetClusters
 	}
 
@@ -72,12 +73,14 @@ func calAvailableReplicas(clusters []*clusterv1alpha1.Cluster, spec *workv1alpha
 	estimators := estimatorclient.GetReplicaEstimators()
 	ctx := context.WithValue(context.TODO(), util.ContextKeyObject,
 		fmt.Sprintf("kind=%s, name=%s/%s", spec.Resource.Kind, spec.Resource.Namespace, spec.Resource.Name))
-	for _, estimator := range estimators {
+	for name, estimator := range estimators {
 		res, err := estimator.MaxAvailableReplicas(ctx, clusters, spec.ReplicaRequirements)
 		if err != nil {
 			klog.Errorf("Max cluster available replicas error: %v", err)
 			continue
 		}
+		klog.V(4).Infof("Invoked MaxAvailableReplicas of estimator %s for workload(%s, kind=%s, %s): %v", name,
+			spec.Resource.APIVersion, spec.Resource.Kind, namespacedKey, res)
 		for i := range res {
 			if res[i].Replicas == estimatorclient.UnauthenticReplica {
 				continue


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Bugfix related to maxReplica estimation.

**Testing**

Local:
```
mszacillo@HXQDWP921L estimator % go test ./...
?   	github.com/karmada-io/karmada/pkg/estimator/client	[no test files]
?   	github.com/karmada-io/karmada/pkg/estimator/pb	[no test files]
?   	github.com/karmada-io/karmada/pkg/estimator/server/framework	[no test files]
?   	github.com/karmada-io/karmada/pkg/estimator/server/framework/plugins	[no test files]
?   	github.com/karmada-io/karmada/pkg/estimator/server/metrics	[no test files]
?   	github.com/karmada-io/karmada/pkg/estimator/server/nodes	[no test files]
?   	github.com/karmada-io/karmada/pkg/estimator/server/replica	[no test files]
?   	github.com/karmada-io/karmada/pkg/estimator/service	[no test files]
ok  	github.com/karmada-io/karmada/pkg/estimator/server	1.626s
ok  	github.com/karmada-io/karmada/pkg/estimator/server/framework/plugins/resourcequota	2.148s
ok  	github.com/karmada-io/karmada/pkg/estimator/server/framework/runtime	1.244s
```
E2E test with added logs:
```
I0601 16:19:48.700057       1 generic_scheduler.go:95] Feasible clusters scores: [{cluster-A 0} {cluster-B 0}]
I0601 16:19:48.700159       1 util.go:76] Running score for estimator: general-estimator
I0601 16:19:48.700212       1 general.go:77] cluster cluster-A has max available replicas: 8 according to cluster resource models
I0601 16:19:48.700234       1 general.go:77] cluster cluster-B has max available replicas: 8 according to cluster resource models
I0601 16:19:48.700257       1 util.go:83] Result for cluster: cluster-A was score 8
I0601 16:19:48.700270       1 util.go:83] Result for cluster: cluster-B was score 8
I0601 16:19:48.700282       1 util.go:76] Running score for estimator: scheduler-estimator
I0601 16:19:48.704222       1 util.go:83] Result for cluster: cluster-A was score 0
I0601 16:19:48.704248       1 util.go:83] Result for cluster: cluster-B was score 4
I0601 16:19:48.704253       1 util.go:101] Target cluster calculated by estimators (available cluster && maxAvailableReplicas): [{cluster-A 0} {cluster-B 4}]
I0601 16:19:48.704275       1 generic_scheduler.go:101] Selected clusters: [cluster-B]
```

**Which issue(s) this PR fixes**:
Fixes #5011

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-scheduler-estimator`: Fixed the `Unschedulable` result returned by plugins to be treated as an exception issue.
```

