### PR TITLE
Remove pp/cpp namespace/name labels

### DIFF
--- a/pkg/apis/policy/v1alpha1/well_known_constants.go
+++ b/pkg/apis/policy/v1alpha1/well_known_constants.go
@@ -54,18 +54,3 @@ const (
 	// ClusterPropagationPolicyAnnotation is added to objects to specify associated ClusterPropagationPolicy name.
 	ClusterPropagationPolicyAnnotation = "clusterpropagationpolicy.karmada.io/name"
 )
-
-// TODO(whitewindmills): These deprecated labels will be removed in a future version.
-const (
-	// PropagationPolicyNamespaceLabel is added to objects to specify associated PropagationPolicy namespace.
-	// Deprecated
-	PropagationPolicyNamespaceLabel = "propagationpolicy.karmada.io/namespace"
-
-	// PropagationPolicyNameLabel is added to objects to specify associated PropagationPolicy's name.
-	// Deprecated
-	PropagationPolicyNameLabel = "propagationpolicy.karmada.io/name"
-
-	// ClusterPropagationPolicyLabel is added to objects to specify associated ClusterPropagationPolicy.
-	// Deprecated
-	ClusterPropagationPolicyLabel = "clusterpropagationpolicy.karmada.io/name"
-)

--- a/pkg/controllers/multiclusterservice/mcs_controller.go
+++ b/pkg/controllers/multiclusterservice/mcs_controller.go
@@ -489,11 +489,7 @@ func (c *MCSController) claimMultiClusterServiceForService(svc *corev1.Service, 
 		svcCopy.Annotations = map[string]string{}
 	}
 
-	// cleanup the policy labels
-	delete(svcCopy.Labels, policyv1alpha1.PropagationPolicyNameLabel)
-	delete(svcCopy.Labels, policyv1alpha1.PropagationPolicyNamespaceLabel)
 	delete(svcCopy.Labels, policyv1alpha1.PropagationPolicyPermanentIDLabel)
-	delete(svcCopy.Labels, policyv1alpha1.ClusterPropagationPolicyLabel)
 	delete(svcCopy.Labels, policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel)
 
 	svcCopy.Labels[util.ResourceTemplateClaimedByLabel] = util.MultiClusterServiceKind

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -65,9 +65,6 @@ import (
 var (
 	propagationPolicyMarkedLabels = []string{
 		policyv1alpha1.PropagationPolicyPermanentIDLabel,
-		// TODO(whitewindmills): Delete the following two lines in a future version.
-		policyv1alpha1.PropagationPolicyNamespaceLabel,
-		policyv1alpha1.PropagationPolicyNameLabel,
 	}
 	propagationPolicyMarkedAnnotations = []string{
 		policyv1alpha1.PropagationPolicyNamespaceAnnotation,
@@ -75,8 +72,6 @@ var (
 	}
 	clusterPropagationPolicyMarkedLabels = []string{
 		policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel,
-		// TODO(whitewindmills): Delete the following line in a future version.
-		policyv1alpha1.ClusterPropagationPolicyLabel,
 	}
 	clusterPropagationPolicyMarkedAnnotations = []string{
 		policyv1alpha1.ClusterPropagationPolicyAnnotation,
@@ -470,9 +465,6 @@ func (d *ResourceDetector) ApplyPolicy(object *unstructured.Unstructured, object
 	}
 
 	policyLabels := map[string]string{
-		// TODO(whitewindmills): Delete the following two lines in a future version.
-		policyv1alpha1.PropagationPolicyNamespaceLabel:   policy.GetNamespace(),
-		policyv1alpha1.PropagationPolicyNameLabel:        policy.GetName(),
 		policyv1alpha1.PropagationPolicyPermanentIDLabel: policyID,
 	}
 	policyAnnotations := map[string]string{
@@ -564,8 +556,6 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 	}
 
 	policyLabels := map[string]string{
-		// TODO(whitewindmills): Delete the following line in a future version.
-		policyv1alpha1.ClusterPropagationPolicyLabel:            policy.GetName(),
 		policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel: policyID,
 	}
 	policyAnnotations := map[string]string{
@@ -722,9 +712,6 @@ func (d *ResourceDetector) ClaimPolicyForObject(object *unstructured.Unstructure
 		}
 	}
 
-	// TODO(whitewindmills): Delete the following two lines in a future version.
-	objLabels[policyv1alpha1.PropagationPolicyNamespaceLabel] = policy.Namespace
-	objLabels[policyv1alpha1.PropagationPolicyNameLabel] = policy.Name
 	objLabels[policyv1alpha1.PropagationPolicyPermanentIDLabel] = policyID
 
 	objectAnnotations := object.GetAnnotations()
@@ -751,8 +738,6 @@ func (d *ResourceDetector) ClaimClusterPolicyForObject(object *unstructured.Unst
 	}
 
 	objectCopy := object.DeepCopy()
-	// TODO(whitewindmills): Delete the following line in a future version.
-	util.MergeLabel(objectCopy, policyv1alpha1.ClusterPropagationPolicyLabel, policy.Name)
 	util.MergeLabel(objectCopy, policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel, policyID)
 
 	util.MergeAnnotation(objectCopy, policyv1alpha1.ClusterPropagationPolicyAnnotation, policy.Name)

--- a/pkg/detector/policy.go
+++ b/pkg/detector/policy.go
@@ -345,7 +345,5 @@ func excludeClusterPolicy(objLabels map[string]string) bool {
 		return false
 	}
 	delete(objLabels, policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel)
-	// TODO(whitewindmills): Delete the following line in a future version.
-	delete(objLabels, policyv1alpha1.ClusterPropagationPolicyLabel)
 	return true
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of #4711 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
The following labels that were deprecated(replaced by `propagationpolicy.karmada.io/permanent-id` and `clusterpropagationpolicy.karmada.io/permanent-id`) at release-10 now have been removed:
- propagationpolicy.karmada.io/namespace
- propagationpolicy.karmada.io/name
- clusterpropagationpolicy.karmada.io/name
```

