### PR TITLE
Add OSSF scorecard badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Releases](https://img.shields.io/github/v/release/karmada-io/karmada)](https://github.com/karmada-io/karmada/releases/latest)
 [![Slack](https://img.shields.io/badge/slack-join-brightgreen)](https://slack.cncf.io)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/5301/badge)](https://bestpractices.coreinfrastructure.org/projects/5301)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/karmada-io/karmada/badge)](https://scorecard.dev/viewer/?uri=github.com/karmada-io/karmada)
 ![build](https://github.com/karmada-io/karmada/actions/workflows/ci.yml/badge.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/karmada-io/karmada)](https://goreportcard.com/report/github.com/karmada-io/karmada)
 [![codecov](https://codecov.io/gh/karmada-io/karmada/branch/master/graph/badge.svg?token=ROM8CMPXZ6)](https://codecov.io/gh/karmada-io/karmada)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR added OSSF [scorecard badges](https://github.com/ossf/scorecard?tab=readme-ov-file#scorecard-badges) to README.

The badge is required by some tools like https://clomonitor.io/. 

The current score is 5.9, we are going to improve it specifically. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
See the [preview here](https://github.com/RainbowMango/karmada/blob/594e1867c8b1fe868665a6249037f3e8e5fdfe69/README.md).
**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

