### PR TITLE
Adding FlinkDeployment CRD to supported third party resource customizations

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/customizations.yaml
@@ -38,8 +38,18 @@ spec:
             jm_replicas = 1
           end
 
-          parallelism = observedObj.spec.job.parallelism
-          tm_replicas = math.ceil(parallelism / observedObj.spec.flinkConfiguration['taskmanager.numberOfTaskSlots'])
+          -- TaskManager replica setting takes precedence over parallelism setting
+
+          tm_replicas = observedObj.spec.taskManager.replicas
+          if isempty(tm_replicas) then
+            parallelism = observedObj.spec.job.parallelism
+            task_slots = observedObj.spec.flinkConfiguration['taskmanager.numberOfTaskSlots']
+            if isempty(parallelism) or isempty(task_slots) then
+              tm_replicas = 1
+            else
+              tm_replicas = math.ceil(parallelism / observedObj.spec.flinkConfiguration['taskmanager.numberOfTaskSlots'])
+            end
+          end
 
           replica = jm_replicas + tm_replicas
 

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/customizations.yaml
@@ -11,7 +11,11 @@ spec:
       luaScript: >
         function InterpretHealth(observedObj)
           if observedObj.status ~= nil and observedObj.status.jobStatus ~= nil then
-            return observedObj.status.jobStatus.state ~= 'CREATED' and observedObj.status.jobStatus.state ~= 'RECONCILING'
+            if observedObj.status.jobStatus.state ~= 'CREATED' and observedObj.status.jobStatus.state ~= 'RECONCILING' then
+              return true
+            else
+              return observedObj.status.jobManagerDeploymentStatus == 'ERROR'
+            end
           end
           return false
         end
@@ -24,32 +28,36 @@ spec:
         end
 
         function GetReplicas(observedObj)
-          -- FlinkDeployments presently will not be subdivided among clusters, replica should be 1
-          replica = 1
           requires = {
             resourceRequest = {},
+            nodeClaim = {},
           }
-          -- Add jobmanager resources into replica requirement
 
           jm_replicas = observedObj.spec.jobManager.replicas
           if isempty(jm_replicas) then
             jm_replicas = 1
           end
 
-          for i = 1, jm_replicas do
-            requires.resourceRequest.cpu = kube.resourceAdd(requires.resourceRequest.cpu, tostring(observedObj.spec.jobManager.resource.cpu))
-            requires.resourceRequest.memory = kube.resourceAdd(requires.resourceRequest.memory, observedObj.spec.jobManager.resource.memory)
-          end
-
-          -- Add task manager resources into replica requirement
-
           parallelism = observedObj.spec.job.parallelism
-          tms = math.ceil(parallelism / observedObj.spec.flinkConfiguration['taskmanager.numberOfTaskSlots'])
+          tm_replicas = math.ceil(parallelism / observedObj.spec.flinkConfiguration['taskmanager.numberOfTaskSlots'])
 
-          for i = 1, tms do
-            requires.resourceRequest.cpu = kube.resourceAdd(requires.resourceRequest.cpu, tostring(observedObj.spec.taskManager.resource.cpu))
-            requires.resourceRequest.memory = kube.resourceAdd(requires.resourceRequest.memory, observedObj.spec.taskManager.resource.memory)
+          replica = jm_replicas + tm_replicas
+
+          -- Until multiple podTemplates are supported in replicaRequirements, take max of cpu + memory values as requirement
+
+          requires.resourceRequest.cpu = math.max(observedObj.spec.taskManager.resource.cpu, observedObj.spec.jobManager.resource.cpu)
+          jm_memory_value = kube.getResourceQuantity(observedObj.spec.jobManager.resource.memory)
+          tm_memory_value = kube.getResourceQuantity(observedObj.spec.taskManager.resource.memory)
+          if jm_memory_value > tm_memory_value then
+            requires.resourceRequest.memory = observedObj.spec.jobManager.resource.memory
+          else
+            requires.resourceRequest.memory = observedObj.spec.taskManager.resource.memory
           end
+
+          -- Until multiple podTemplates are supported, interpreter will only take affinity and toleration input to common podTemplate
+
+          requires.nodeClaim.nodeSelector = observedObj.spec.podTemplate.spec.nodeSelector
+          requires.nodeClaim.tolerations = observedObj.spec.podTemplate.spec.tolerations
 
           return replica, requires
         end

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/customizations.yaml
@@ -56,8 +56,10 @@ spec:
 
           -- Until multiple podTemplates are supported, interpreter will only take affinity and toleration input to common podTemplate
 
-          requires.nodeClaim.nodeSelector = observedObj.spec.podTemplate.spec.nodeSelector
-          requires.nodeClaim.tolerations = observedObj.spec.podTemplate.spec.tolerations
+          if observedObj.spec.podTemplate ~= nil and observedObj.spec.podTemplate.spec ~= nil then
+            requires.nodeClaim.nodeSelector = observedObj.spec.podTemplate.spec.nodeSelector
+            requires.nodeClaim.tolerations = observedObj.spec.podTemplate.spec.tolerations
+          end
 
           return replica, requires
         end

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/customizations.yaml
@@ -1,0 +1,110 @@
+apiVersion: config.karmada.io/v1alpha1
+kind: ResourceInterpreterCustomization
+metadata:
+  name: declarative-configuration-flinkdeployment
+spec:
+  target:
+    apiVersion: flink.apache.org/v1beta1
+    kind: FlinkDeployment
+  customizations:
+    healthInterpretation:
+      luaScript: >
+        function InterpretHealth(observedObj)
+          if observedObj.status ~= nil and observedObj.status.jobStatus ~= nil then
+            return observedObj.status.jobStatus.state ~= 'CREATED' and observedObj.status.jobStatus.state ~= 'RECONCILING'
+          end
+          return false
+        end
+    replicaResource:
+      luaScript: >
+        local kube = require("kube")
+
+        local function isempty(s)
+          return s == nil or s == ''
+        end
+
+        function GetReplicas(observedObj)
+          -- FlinkDeployments presently will not be subdivided among clusters, replica should be 1
+          replica = 1
+          requires = {
+            resourceRequest = {},
+          }
+          -- Add jobmanager resources into replica requirement
+
+          jm_replicas = observedObj.spec.jobManager.replicas
+          if isempty(jm_replicas) then
+            jm_replicas = 1
+          end
+
+          for i = 1, jm_replicas do
+            requires.resourceRequest.cpu = kube.resourceAdd(requires.resourceRequest.cpu, tostring(observedObj.spec.jobManager.resource.cpu))
+            requires.resourceRequest.memory = kube.resourceAdd(requires.resourceRequest.memory, observedObj.spec.jobManager.resource.memory)
+          end
+
+          -- Add task manager resources into replica requirement
+
+          parallelism = observedObj.spec.job.parallelism
+          tms = math.ceil(parallelism / observedObj.spec.flinkConfiguration['taskmanager.numberOfTaskSlots'])
+
+          for i = 1, tms do
+            requires.resourceRequest.cpu = kube.resourceAdd(requires.resourceRequest.cpu, tostring(observedObj.spec.taskManager.resource.cpu))
+            requires.resourceRequest.memory = kube.resourceAdd(requires.resourceRequest.memory, observedObj.spec.taskManager.resource.memory)
+          end
+
+          return replica, requires
+        end
+    statusAggregation:
+      luaScript: >
+        function AggregateStatus(desiredObj, statusItems)
+          if statusItems == nil then
+            return desiredObj
+          end
+          if desiredObj.status == nil then
+            desiredObj.status = {}
+          end
+          clusterInfo = {}
+          jobManagerDeploymentStatus = ''
+          jobStatus = {}
+          lifecycleState = ''
+          observedGeneration = 0
+          reconciliationStatus = {}
+          taskManager = {}
+
+          for i = 1, #statusItems do
+            currentStatus = statusItems[i].status
+            if currentStatus ~= nil then
+              clusterInfo = currentStatus.clusterInfo
+              jobManagerDeploymentStatus = currentStatus.jobManagerDeploymentStatus
+              jobStatus = currentStatus.jobStatus
+              observedGeneration = currentStatus.observedGeneration
+              lifecycleState = currentStatus.lifecycleState
+              reconciliationStatus = currentStatus.reconciliationStatus
+              taskManager = currentStatus.taskManager
+            end
+          end
+
+          desiredObj.status.clusterInfo = clusterInfo
+          desiredObj.status.jobManagerDeploymentStatus = jobManagerDeploymentStatus
+          desiredObj.status.jobStatus = jobStatus
+          desiredObj.status.lifecycleState = lifecycleState
+          desiredObj.status.observedGeneration = observedGeneration
+          desiredObj.status.reconciliationStatus = reconciliationStatus
+          desiredObj.status.taskManager = taskManager
+          return desiredObj
+        end
+    statusReflection:
+      luaScript: >
+        function ReflectStatus(observedObj)
+          status = {}
+          if observedObj == nil or observedObj.status == nil then
+            return status
+          end
+          status.clusterInfo = observedObj.status.clusterInfo
+          status.jobManagerDeploymentStatus = observedObj.status.jobManagerDeploymentStatus
+          status.jobStatus = observedObj.status.jobStatus
+          status.observedGeneration = observedObj.status.observedGeneration
+          status.lifecycleState = observedObj.status.lifecycleState
+          status.reconciliationStatus = observedObj.status.reconciliationStatus
+          status.taskManager = observedObj.status.taskManager
+          return status
+        end

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/customizations_tests.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/customizations_tests.yaml
@@ -1,0 +1,10 @@
+tests:
+  - desiredInputPath: testdata/desired-flinkdeployment.yaml
+    statusInputPath: testdata/status-file.yaml
+    operation: AggregateStatus
+  - observedInputPath: testdata/observed-flinkdeployment.yaml
+    operation: InterpretReplica
+  - observedInputPath: testdata/observed-flinkdeployment.yaml
+    operation: InterpretHealth
+  - observedInputPath: testdata/observed-flinkdeployment.yaml
+    operation: InterpretStatus

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/testdata/desired-flinkdeployment.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/testdata/desired-flinkdeployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkDeployment
+metadata:
+  name: basic-example
+  namespace: test-namespace
+spec:
+  flinkConfiguration:
+    taskmanager.numberOfTaskSlots: "2"
+  flinkVersion: v1_17
+  image: flink:1.17
+  job:
+    jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
+    parallelism: 2
+    upgradeMode: stateless
+  jobManager:
+    replicas: 1
+    resource:
+      cpu: 1
+      memory: 2048m
+  mode: native
+  serviceAccount: flink
+  taskManager:
+    resource:
+      cpu: 1
+      memory: 2048m

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/testdata/observed-flinkdeployment.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/testdata/observed-flinkdeployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkDeployment
+metadata:
+  creationTimestamp: "2024-06-05T14:52:28Z"
+  finalizers:
+  - flinkdeployments.flink.apache.org/finalizer
+  generation: 1
+  name: basic-example
+  namespace: test-namespace
+  resourceVersion: "5053661"
+  uid: 87ef77ca-7bf0-4998-b275-06f459872e03
+spec:
+  flinkConfiguration:
+    taskmanager.numberOfTaskSlots: "2"
+  flinkVersion: v1_17
+  image: flink:1.17
+  job:
+    args: []
+    jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
+    parallelism: 2
+    state: running
+    upgradeMode: stateless
+  jobManager:
+    replicas: 1
+    resource:
+      cpu: 1
+      memory: 2048m
+  serviceAccount: flink
+  taskManager:
+    resource:
+      cpu: 1
+      memory: 2048m
+status:
+  clusterInfo:
+    flink-revision: 2750d5c @ 2023-05-19T10:45:46+02:00
+    flink-version: 1.17.1
+    total-cpu: "2.0"
+    total-memory: "4294967296"
+  jobManagerDeploymentStatus: READY
+  jobStatus:
+    checkpointInfo:
+      lastPeriodicCheckpointTimestamp: 0
+    jobId: 44cc5573945d1d4925732d915c70b9ac
+    jobName: Minimal Spec Example
+    savepointInfo:
+      lastPeriodicSavepointTimestamp: 0
+      savepointHistory: []
+    startTime: "1717599166365"
+    state: RUNNING
+    updateTime: "1717599182544"
+  lifecycleState: STABLE
+  observedGeneration: 1
+  reconciliationStatus:
+    lastReconciledSpec: '{"spec":{"job":{"jarURI":"local:///opt/flink/examples/streaming/StateMachineExample.jar","parallelism":2,"entryClass":null,"args":[],"state":"running","savepointTriggerNonce":null,"initialSavepointPath":null,"checkpointTriggerNonce":null,"upgradeMode":"stateless","allowNonRestoredState":null,"savepointRedeployNonce":null},"restartNonce":null,"flinkConfiguration":{"taskmanager.numberOfTaskSlots":"2"},"image":"flink:1.17","imagePullPolicy":null,"serviceAccount":"flink","flinkVersion":"v1_17","ingress":null,"podTemplate":null,"jobManager":{"resource":{"cpu":1.0,"memory":"2048m","ephemeralStorage":null},"replicas":1,"podTemplate":null},"taskManager":{"resource":{"cpu":1.0,"memory":"2048m","ephemeralStorage":null},"replicas":null,"podTemplate":null},"logConfiguration":null,"mode":null},"resource_metadata":{"apiVersion":"flink.apache.org/v1beta1","metadata":{"generation":2},"firstDeployment":true}}'
+    lastStableSpec: '{"spec":{"job":{"jarURI":"local:///opt/flink/examples/streaming/StateMachineExample.jar","parallelism":2,"entryClass":null,"args":[],"state":"running","savepointTriggerNonce":null,"initialSavepointPath":null,"checkpointTriggerNonce":null,"upgradeMode":"stateless","allowNonRestoredState":null,"savepointRedeployNonce":null},"restartNonce":null,"flinkConfiguration":{"taskmanager.numberOfTaskSlots":"2"},"image":"flink:1.17","imagePullPolicy":null,"serviceAccount":"flink","flinkVersion":"v1_17","ingress":null,"podTemplate":null,"jobManager":{"resource":{"cpu":1.0,"memory":"2048m","ephemeralStorage":null},"replicas":1,"podTemplate":null},"taskManager":{"resource":{"cpu":1.0,"memory":"2048m","ephemeralStorage":null},"replicas":null,"podTemplate":null},"logConfiguration":null,"mode":null},"resource_metadata":{"apiVersion":"flink.apache.org/v1beta1","metadata":{"generation":2},"firstDeployment":true}}'
+    reconciliationTimestamp: 1717599148930
+    state: DEPLOYED
+  taskManager:
+    labelSelector: component=taskmanager,app=basic-example
+    replicas: 1

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/testdata/status-file.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/testdata/status-file.yaml
@@ -1,0 +1,31 @@
+applied: true
+clusterName: member1
+health: Healthy
+status:
+  clusterInfo:
+    flink-revision: 2750d5c @ 2023-05-19T10:45:46+02:00
+    flink-version: 1.17.1
+    total-cpu: "2.0"
+    total-memory: "4294967296"
+  jobManagerDeploymentStatus: READY
+  jobStatus:
+    checkpointInfo:
+      lastPeriodicCheckpointTimestamp: 0
+    jobId: 44cc5573945d1d4925732d915c70b9ac
+    jobName: Minimal Spec Example
+    savepointInfo:
+      lastPeriodicSavepointTimestamp: 0
+      savepointHistory: []
+    startTime: "1717599166365"
+    state: RUNNING
+    updateTime: "1717599182544"
+  lifecycleState: STABLE
+  observedGeneration: 1
+  reconciliationStatus:
+    lastReconciledSpec: '{"spec":{"job":{"jarURI":"local:///opt/flink/examples/streaming/StateMachineExample.jar","parallelism":2,"entryClass":null,"args":[],"state":"running","savepointTriggerNonce":null,"initialSavepointPath":null,"checkpointTriggerNonce":null,"upgradeMode":"stateless","allowNonRestoredState":null,"savepointRedeployNonce":null},"restartNonce":null,"flinkConfiguration":{"taskmanager.numberOfTaskSlots":"2"},"image":"flink:1.17","imagePullPolicy":null,"serviceAccount":"flink","flinkVersion":"v1_17","ingress":null,"podTemplate":null,"jobManager":{"resource":{"cpu":1.0,"memory":"2048m","ephemeralStorage":null},"replicas":1,"podTemplate":null},"taskManager":{"resource":{"cpu":1.0,"memory":"2048m","ephemeralStorage":null},"replicas":null,"podTemplate":null},"logConfiguration":null,"mode":null},"resource_metadata":{"apiVersion":"flink.apache.org/v1beta1","metadata":{"generation":2},"firstDeployment":true}}'
+    lastStableSpec: '{"spec":{"job":{"jarURI":"local:///opt/flink/examples/streaming/StateMachineExample.jar","parallelism":2,"entryClass":null,"args":[],"state":"running","savepointTriggerNonce":null,"initialSavepointPath":null,"checkpointTriggerNonce":null,"upgradeMode":"stateless","allowNonRestoredState":null,"savepointRedeployNonce":null},"restartNonce":null,"flinkConfiguration":{"taskmanager.numberOfTaskSlots":"2"},"image":"flink:1.17","imagePullPolicy":null,"serviceAccount":"flink","flinkVersion":"v1_17","ingress":null,"podTemplate":null,"jobManager":{"resource":{"cpu":1.0,"memory":"2048m","ephemeralStorage":null},"replicas":1,"podTemplate":null},"taskManager":{"resource":{"cpu":1.0,"memory":"2048m","ephemeralStorage":null},"replicas":null,"podTemplate":null},"logConfiguration":null,"mode":null},"resource_metadata":{"apiVersion":"flink.apache.org/v1beta1","metadata":{"generation":2},"firstDeployment":true}}'
+    reconciliationTimestamp: 1717599148930
+    state: DEPLOYED
+  taskManager:
+    labelSelector: component=taskmanager,app=basic-example
+    replicas: 1


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This PR adds a default resource customization for FlinkDeployments. Below is a summary of the supported default interpretations:

**Supported**
1. InterpretHealth
    - We monitor the internal flink state that is added to the FlinkDeployment status via Flink Operator: `spec.status.jobStatus.state`. FlinkDeployments can enter errored states due to user related code issues, rather than due to bad cluster health or lack of cluster resources. As a result we want to differentiate from these cases so that Karmada only reschedules these apps when needed. 
    - We chose to mark FlinkDeployments as `Unhealthy` only if the internal flink state is trapped in a non-terminal state - these states include:
        1. CREATED (job was created but not started)
        2. RECONCILING (state unknown, normally due to JM unable to communicate with operator)
    - More info on flink state transitions here: https://nightlies.apache.org/flink/flink-docs-master/docs/internals/job_scheduling/ 
    
2. InterpretReplica
    - FlinkDeployments do not currently get subdivided amongst clusters. The reasoning here is that each Flink Cluster (JM + TMs) should be colocated to reduce request latency and boost performance. 
    - Since Karmada interprets scheduling using replicas, we set the replica of the FlinkDeployment to 1, and Karmada will simply schedule the FlinkDeployment CRD to a member cluster, at which point the FlinkOperator will take over. 
    - Replica resource requirements for CPU and Memory are set to equal (n * JM) + (k * TM), where n is the number of JobManagers and k is the number of Task Managers. 
    
3. InterpretStatus
    - We currently pull the full FlinkDeployment status from the resource. 

4. AggregateStatus
    - Since the replica count is 1, the aggregation isn't technically necessary. But in order for the status to show up on the FlinkDeployment resource in Karmada, this definition is needed. I've defined the interpreter to set the Aggregate status equal to the latest status pulled by Karmada.

**Not Supported**
1. Retention
    - At the moment not necessary. We do not plan on changes being made to FlinkDeployment spec on the cluster that need to be retained by Karmada.

2. ReplicaRevision
    - As mentioned, we currently don't plan on increasing the replica size for the FlinkDeployment. Even though JM and TM values can be scaled, the total number of FlinkDeployments will stay 1. 

3. InterpretDependency
    - There are no general dependencies needed for FlinkDeployments. Secrets or other configmaps can be handled on a case-by-case basis. 

**Which issue(s) this PR fixes**:
Fixes #4953

**Testing**
Tested on cluster and confirmed default interpreters work with FlinkDeployment. 

**Does this PR introduce a user-facing change?**:
```release-note
Adding FlinkDeployment v1beta1 CRD to supported third party resource customizatons.
```

