### PR TITLE
Remove pp/cpp name length limit

### DIFF
--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -31,9 +31,6 @@ import (
 	"github.com/karmada-io/karmada/pkg/util"
 )
 
-// LabelValueMaxLength is a label's max length
-const LabelValueMaxLength int = 63
-
 // ValidatePropagationSpec validates a PropagationSpec before creation or update.
 func ValidatePropagationSpec(spec policyv1alpha1.PropagationSpec) field.ErrorList {
 	var allErrs field.ErrorList

--- a/pkg/webhook/clusterpropagationpolicy/mutating.go
+++ b/pkg/webhook/clusterpropagationpolicy/mutating.go
@@ -19,7 +19,6 @@ package clusterpropagationpolicy
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -30,7 +29,6 @@ import (
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/helper"
-	"github.com/karmada-io/karmada/pkg/util/validation"
 )
 
 // MutatingAdmission mutates API request if necessary.
@@ -66,10 +64,6 @@ func (a *MutatingAdmission) Handle(_ context.Context, req admission.Request) adm
 	helper.SetDefaultSpreadConstraints(policy.Spec.Placement.SpreadConstraints)
 	helper.AddTolerations(&policy.Spec.Placement, helper.NewNotReadyToleration(a.DefaultNotReadyTolerationSeconds),
 		helper.NewUnreachableToleration(a.DefaultUnreachableTolerationSeconds))
-
-	if len(policy.Name) > validation.LabelValueMaxLength {
-		return admission.Errored(http.StatusBadRequest, fmt.Errorf("ClusterPropagationPolicy's name should be no more than %d characters", validation.LabelValueMaxLength))
-	}
 
 	if helper.ContainsServiceImport(policy.Spec.ResourceSelectors) {
 		policy.Spec.PropagateDeps = true

--- a/pkg/webhook/propagationpolicy/mutating.go
+++ b/pkg/webhook/propagationpolicy/mutating.go
@@ -19,7 +19,6 @@ package propagationpolicy
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -31,7 +30,6 @@ import (
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/helper"
-	"github.com/karmada-io/karmada/pkg/util/validation"
 )
 
 // MutatingAdmission mutates API request if necessary.
@@ -75,9 +73,6 @@ func (a *MutatingAdmission) Handle(_ context.Context, req admission.Request) adm
 		}
 	}
 
-	if len(policy.Name) > validation.LabelValueMaxLength {
-		return admission.Errored(http.StatusBadRequest, fmt.Errorf("PropagationPolicy's name should be no more than %d characters", validation.LabelValueMaxLength))
-	}
 	// Set default spread constraints if both 'SpreadByField' and 'SpreadByLabel' not set.
 	helper.SetDefaultSpreadConstraints(policy.Spec.Placement.SpreadConstraints)
 	helper.AddTolerations(&policy.Spec.Placement, helper.NewNotReadyToleration(a.DefaultNotReadyTolerationSeconds),

--- a/test/e2e/propagationpolicy_test.go
+++ b/test/e2e/propagationpolicy_test.go
@@ -53,12 +53,20 @@ import (
 )
 
 // BasicPropagation focus on basic propagation functionality testing.
-var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
+var _ = ginkgo.Describe("[BasicCase] PropagationPolicy testing", func() {
+	var policyNamespace, policyName string
+	var policy *policyv1alpha1.PropagationPolicy
+
+	ginkgo.JustBeforeEach(func() {
+		framework.CreatePropagationPolicy(karmadaClient, policy)
+		ginkgo.DeferCleanup(func() {
+			framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
+		})
+	})
+
 	ginkgo.Context("Deployment propagation testing", func() {
-		var policyNamespace, policyName string
 		var deploymentNamespace, deploymentName string
 		var deployment *appsv1.Deployment
-		var policy *policyv1alpha1.PropagationPolicy
 
 		ginkgo.BeforeEach(func() {
 			policyNamespace = testNamespace
@@ -81,10 +89,8 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 		})
 
 		ginkgo.BeforeEach(func() {
-			framework.CreatePropagationPolicy(karmadaClient, policy)
 			framework.CreateDeployment(kubeClient, deployment)
 			ginkgo.DeferCleanup(func() {
-				framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
 				framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
 				framework.WaitDeploymentDisappearOnClusters(framework.ClusterNames(), deployment.Namespace, deployment.Name)
 			})
@@ -114,10 +120,8 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 	})
 
 	ginkgo.Context("Service propagation testing", func() {
-		var policyNamespace, policyName string
 		var serviceNamespace, serviceName string
 		var service *corev1.Service
-		var policy *policyv1alpha1.PropagationPolicy
 
 		ginkgo.BeforeEach(func() {
 			policyNamespace = testNamespace
@@ -140,10 +144,8 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 		})
 
 		ginkgo.BeforeEach(func() {
-			framework.CreatePropagationPolicy(karmadaClient, policy)
 			framework.CreateService(kubeClient, service)
 			ginkgo.DeferCleanup(func() {
-				framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
 				framework.RemoveService(kubeClient, service.Namespace, service.Name)
 				framework.WaitServiceDisappearOnClusters(framework.ClusterNames(), service.Namespace, service.Name)
 			})
@@ -166,10 +168,8 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 	})
 
 	ginkgo.Context("Pod propagation testing", func() {
-		var policyNamespace, policyName string
 		var podNamespace, podName string
 		var pod *corev1.Pod
-		var policy *policyv1alpha1.PropagationPolicy
 		ginkgo.BeforeEach(func() {
 			policyNamespace = testNamespace
 			policyName = podNamePrefix + rand.String(RandomStrLength)
@@ -191,10 +191,8 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 		})
 
 		ginkgo.BeforeEach(func() {
-			framework.CreatePropagationPolicy(karmadaClient, policy)
 			framework.CreatePod(kubeClient, pod)
 			ginkgo.DeferCleanup(func() {
-				framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
 				framework.RemovePod(kubeClient, pod.Namespace, pod.Name)
 				framework.WaitPodDisappearOnClusters(framework.ClusterNames(), pod.Namespace, pod.Name)
 			})
@@ -226,7 +224,6 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 		var crGVR schema.GroupVersionResource
 		var crAPIVersion string
 		var cr *unstructured.Unstructured
-		var crPolicy *policyv1alpha1.PropagationPolicy
 
 		ginkgo.BeforeEach(func() {
 			crdGroup = fmt.Sprintf("example-%s.karmada.io", rand.String(RandomStrLength))
@@ -256,7 +253,7 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 
 			crAPIVersion = fmt.Sprintf("%s/%s", crd.Spec.Group, "v1alpha1")
 			cr = testhelper.NewCustomResource(crAPIVersion, crd.Spec.Names.Kind, crNamespace, crName)
-			crPolicy = testhelper.NewPropagationPolicy(crNamespace, crName, []policyv1alpha1.ResourceSelector{
+			policy = testhelper.NewPropagationPolicy(crNamespace, crName, []policyv1alpha1.ResourceSelector{
 				{
 					APIVersion: crAPIVersion,
 					Kind:       crd.Spec.Names.Kind,
@@ -272,6 +269,8 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 		ginkgo.BeforeEach(func() {
 			framework.CreateClusterPropagationPolicy(karmadaClient, crdPolicy)
 			framework.CreateCRD(dynamicClient, crd)
+			framework.WaitCRDPresentOnClusters(karmadaClient, framework.ClusterNames(),
+				fmt.Sprintf("%s/%s", crd.Spec.Group, "v1alpha1"), crd.Spec.Names.Kind)
 			ginkgo.DeferCleanup(func() {
 				framework.RemoveClusterPropagationPolicy(karmadaClient, crdPolicy.Name)
 				framework.RemoveCRD(dynamicClient, crd.Name)
@@ -279,15 +278,6 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 		})
 
 		ginkgo.It("namespaceScoped cr propagation testing", func() {
-			framework.GetCRD(dynamicClient, crd.Name)
-			framework.WaitCRDPresentOnClusters(karmadaClient, framework.ClusterNames(),
-				fmt.Sprintf("%s/%s", crd.Spec.Group, "v1alpha1"), crd.Spec.Names.Kind)
-
-			framework.CreatePropagationPolicy(karmadaClient, crPolicy)
-			ginkgo.DeferCleanup(func() {
-				framework.RemovePropagationPolicy(karmadaClient, crPolicy.Namespace, crPolicy.Name)
-			})
-
 			ginkgo.By(fmt.Sprintf("creating cr(%s/%s)", crNamespace, crName), func() {
 				_, err := dynamicClient.Resource(crGVR).Namespace(crNamespace).Create(context.TODO(), cr, metav1.CreateOptions{})
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -383,10 +373,8 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 	})
 
 	ginkgo.Context("Job propagation testing", func() {
-		var policyNamespace, policyName string
 		var jobNamespace, jobName string
 		var job *batchv1.Job
-		var policy *policyv1alpha1.PropagationPolicy
 
 		ginkgo.BeforeEach(func() {
 			policyNamespace = testNamespace
@@ -409,10 +397,8 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 		})
 
 		ginkgo.BeforeEach(func() {
-			framework.CreatePropagationPolicy(karmadaClient, policy)
 			framework.CreateJob(kubeClient, job)
 			ginkgo.DeferCleanup(func() {
-				framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
 				framework.RemoveJob(kubeClient, job.Namespace, job.Name)
 				framework.WaitJobDisappearOnClusters(framework.ClusterNames(), job.Namespace, job.Name)
 			})
@@ -439,8 +425,6 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 	ginkgo.Context("Role propagation testing", func() {
 		var (
 			roleNamespace, roleName string
-			policyName              string
-			policy                  *policyv1alpha1.PropagationPolicy
 			role                    *rbacv1.Role
 		)
 
@@ -464,10 +448,8 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 		})
 
 		ginkgo.BeforeEach(func() {
-			framework.CreatePropagationPolicy(karmadaClient, policy)
 			framework.CreateRole(kubeClient, role)
 			ginkgo.DeferCleanup(func() {
-				framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
 				framework.RemoveRole(kubeClient, role.Namespace, role.Name)
 				framework.WaitRoleDisappearOnClusters(framework.ClusterNames(), role.Namespace, role.Name)
 			})
@@ -484,8 +466,6 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 	ginkgo.Context("RoleBinding propagation testing", func() {
 		var (
 			roleBindingNamespace, roleBindingName string
-			policyName                            string
-			policy                                *policyv1alpha1.PropagationPolicy
 			roleBinding                           *rbacv1.RoleBinding
 		)
 
@@ -509,10 +489,8 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 		})
 
 		ginkgo.BeforeEach(func() {
-			framework.CreatePropagationPolicy(karmadaClient, policy)
 			framework.CreateRoleBinding(kubeClient, roleBinding)
 			ginkgo.DeferCleanup(func() {
-				framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
 				framework.RemoveRoleBinding(kubeClient, roleBinding.Namespace, roleBinding.Name)
 				framework.WaitRoleBindingDisappearOnClusters(framework.ClusterNames(), roleBinding.Namespace, roleBinding.Name)
 			})
@@ -527,9 +505,67 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 	})
 })
 
+var _ = ginkgo.Describe("[CornerCase] PropagationPolicy testing", func() {
+	var policyNamespace, policyName string
+	var policy *policyv1alpha1.PropagationPolicy
+
+	ginkgo.JustBeforeEach(func() {
+		framework.CreatePropagationPolicy(karmadaClient, policy)
+		ginkgo.DeferCleanup(func() {
+			framework.RemovePropagationPolicy(karmadaClient, policy.Namespace, policy.Name)
+		})
+	})
+
+	ginkgo.Context("Propagate Deployment with long pp name (exceed 63 character)", func() {
+		var deploymentNamespace, deploymentName string
+		var deployment *appsv1.Deployment
+
+		ginkgo.BeforeEach(func() {
+			policyNamespace = testNamespace
+			policyName = deploymentNamePrefix + "-longname-longname-longname-longname-longname-longname-" + rand.String(RandomStrLength)
+			deploymentNamespace = testNamespace
+			deploymentName = policyName
+
+			deployment = testhelper.NewDeployment(deploymentNamespace, deploymentName)
+			policy = testhelper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: deployment.APIVersion,
+					Kind:       deployment.Kind,
+					Name:       deployment.Name,
+				},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: framework.ClusterNames(),
+				},
+			})
+		})
+
+		ginkgo.BeforeEach(func() {
+			framework.CreateDeployment(kubeClient, deployment)
+			ginkgo.DeferCleanup(func() {
+				framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
+				framework.WaitDeploymentDisappearOnClusters(framework.ClusterNames(), deployment.Namespace, deployment.Name)
+			})
+		})
+
+		ginkgo.It("deployment propagation testing", func() {
+			framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
+				func(*appsv1.Deployment) bool {
+					return true
+				})
+
+			framework.UpdateDeploymentReplicas(kubeClient, deployment, updateDeploymentReplicas)
+			framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
+				func(deployment *appsv1.Deployment) bool {
+					return *deployment.Spec.Replicas == updateDeploymentReplicas
+				})
+		})
+	})
+})
+
 // ImplicitPriority more than one PP matches the object, we should choose the most suitable one.
 // Set it to run sequentially to avoid affecting other test cases.
-var _ = framework.SerialDescribe("[ImplicitPriority] propagation testing", func() {
+var _ = framework.SerialDescribe("[ImplicitPriority] PropagationPolicy testing", func() {
 	ginkgo.Context("priorityMatchName propagation testing", func() {
 		var policyNamespace, priorityMatchName, priorityMatchLabelSelector, priorityMatchAll string
 		var deploymentNamespace, deploymentName string
@@ -621,7 +657,7 @@ var _ = framework.SerialDescribe("[ImplicitPriority] propagation testing", func(
 
 // ExplicitPriority more than one PP matches the object, we should select the one with the highest explicit priority, if the
 // explicit priority is same, select the one with the highest implicit priority.
-var _ = ginkgo.Describe("[ExplicitPriority] propagation testing", func() {
+var _ = ginkgo.Describe("[ExplicitPriority] PropagationPolicy testing", func() {
 	ginkgo.Context("high explicit/low priority/implicit priority PropagationPolicy propagation testing", func() {
 		var policyNamespace, higherPriorityLabelSelector, lowerPriorityMatchName, implicitPriorityMatchName string
 		var deploymentNamespace, deploymentName string
@@ -781,7 +817,7 @@ var _ = ginkgo.Describe("[ExplicitPriority] propagation testing", func() {
 })
 
 // AdvancedPropagation focus on some advanced propagation testing.
-var _ = ginkgo.Describe("[AdvancedPropagation] propagation testing", func() {
+var _ = ginkgo.Describe("[AdvancedCase] PropagationPolicy testing", func() {
 	ginkgo.Context("Edit PropagationPolicy ResourceSelectors", func() {
 		var policy *policyv1alpha1.PropagationPolicy
 		var deployment01, deployment02 *appsv1.Deployment


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

In the previous release, the names of PP and CPP are not allowed to exceed 63 characters. Now, we remove this limit.

**Which issue(s) this PR fixes**:
Fix #4711

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-webhook: Remove the limit of 63 name lengths with PropagationPolicy/ClusterPropagationPolicy resource.
```

