### PR TITLE
fixes an issue where the cluster-status-controller overwrites the remedyActions field

### DIFF
--- a/pkg/controllers/remediation/remedy_controller.go
+++ b/pkg/controllers/remediation/remedy_controller.go
@@ -79,7 +79,7 @@ func (c *RemedyController) Reconcile(ctx context.Context, req controllerruntime.
 		klog.Errorf("Failed to sync cluster(%s) remedy actions: %v", cluster.Name, err)
 		return controllerruntime.Result{}, err
 	}
-	klog.V(4).Infof("Success to sync cluster(%s) remedy actions", cluster.Name)
+	klog.V(4).Infof("Success to sync cluster(%s) remedy actions: %v", cluster.Name, actions)
 	return controllerruntime.Result{}, nil
 }
 

--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -278,7 +278,11 @@ func (c *ClusterStatusController) updateStatusIfNeeded(cluster *clusterv1alpha1.
 		klog.V(4).Infof("Start to update cluster status: %s", cluster.Name)
 		err := retry.RetryOnConflict(retry.DefaultRetry, func() (err error) {
 			_, err = helper.UpdateStatus(context.Background(), c.Client, cluster, func() error {
-				cluster.Status = currentClusterStatus
+				cluster.Status.KubernetesVersion = currentClusterStatus.KubernetesVersion
+				cluster.Status.APIEnablements = currentClusterStatus.APIEnablements
+				cluster.Status.Conditions = currentClusterStatus.Conditions
+				cluster.Status.NodeSummary = currentClusterStatus.NodeSummary
+				cluster.Status.ResourceSummary = currentClusterStatus.ResourceSummary
 				return nil
 			})
 			return err

--- a/test/e2e/remedy_test.go
+++ b/test/e2e/remedy_test.go
@@ -45,6 +45,9 @@ var _ = framework.SerialDescribe("remedy testing", func() {
 			remedy = &remedyv1alpha1.Remedy{
 				ObjectMeta: metav1.ObjectMeta{Name: remedyName},
 				Spec: remedyv1alpha1.RemedySpec{
+					ClusterAffinity: &remedyv1alpha1.ClusterAffinity{
+						ClusterNames: []string{targetCluster},
+					},
 					DecisionMatches: []remedyv1alpha1.DecisionMatch{
 						{
 							ClusterConditionMatch: &remedyv1alpha1.ClusterConditionRequirement{
@@ -74,9 +77,10 @@ var _ = framework.SerialDescribe("remedy testing", func() {
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 
-			ginkgo.By("wait cluster status has TrafficControl RemedyAction", func() {
+			ginkgo.By(fmt.Sprintf("wait Cluster(%s) status has TrafficControl RemedyAction", targetCluster), func() {
 				framework.WaitClusterFitWith(controlPlaneClient, targetCluster, func(cluster *clusterv1alpha1.Cluster) bool {
 					actions := sets.NewString(cluster.Status.RemedyActions...)
+					fmt.Printf("Cluster(%s) remedyActions: %v\n", cluster.Name, actions)
 					return actions.Has(string(remedyv1alpha1.TrafficControl))
 				})
 			})
@@ -93,9 +97,10 @@ var _ = framework.SerialDescribe("remedy testing", func() {
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 
-			ginkgo.By("wait cluster status doesn't has TrafficControl RemedyAction", func() {
+			ginkgo.By(fmt.Sprintf("wait Cluster(%s) status doesn't has TrafficControl RemedyAction", targetCluster), func() {
 				framework.WaitClusterFitWith(controlPlaneClient, targetCluster, func(cluster *clusterv1alpha1.Cluster) bool {
 					actions := sets.NewString(cluster.Status.RemedyActions...)
+					fmt.Printf("Cluster(%s) remedyActions: %v\n", cluster.Name, actions)
 					return !actions.Has(string(remedyv1alpha1.TrafficControl))
 				})
 			})
@@ -118,9 +123,10 @@ var _ = framework.SerialDescribe("remedy testing", func() {
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 
-			ginkgo.By("wait cluster status has TrafficControl RemedyAction", func() {
+			ginkgo.By(fmt.Sprintf("wait Cluster(%s) status has TrafficControl RemedyAction", targetCluster), func() {
 				framework.WaitClusterFitWith(controlPlaneClient, targetCluster, func(cluster *clusterv1alpha1.Cluster) bool {
 					actions := sets.NewString(cluster.Status.RemedyActions...)
+					fmt.Printf("Cluster(%s) remedyActions: %v\n", cluster.Name, actions)
 					return actions.Has(string(remedyv1alpha1.TrafficControl))
 				})
 			})
@@ -129,9 +135,10 @@ var _ = framework.SerialDescribe("remedy testing", func() {
 				karmadaresource.RemoveRemedy(karmadaClient, remedyName)
 			})
 
-			ginkgo.By("wait cluster status doesn't has TrafficControl RemedyAction", func() {
+			ginkgo.By(fmt.Sprintf("wait Cluster(%s) status doesn't has TrafficControl RemedyAction", targetCluster), func() {
 				framework.WaitClusterFitWith(controlPlaneClient, targetCluster, func(cluster *clusterv1alpha1.Cluster) bool {
 					actions := sets.NewString(cluster.Status.RemedyActions...)
+					fmt.Printf("Cluster(%s) remedyActions: %v\n", cluster.Name, actions)
 					return !actions.Has(string(remedyv1alpha1.TrafficControl))
 				})
 			})
@@ -157,10 +164,12 @@ var _ = framework.SerialDescribe("remedy testing", func() {
 			remedy = &remedyv1alpha1.Remedy{
 				ObjectMeta: metav1.ObjectMeta{Name: remedyName},
 				Spec: remedyv1alpha1.RemedySpec{
+					ClusterAffinity: &remedyv1alpha1.ClusterAffinity{
+						ClusterNames: []string{targetCluster},
+					},
 					Actions: []remedyv1alpha1.RemedyAction{remedyv1alpha1.TrafficControl},
 				},
 			}
-
 		})
 
 		ginkgo.It("Create an immediately type remedy, then remove it", func() {
@@ -168,9 +177,10 @@ var _ = framework.SerialDescribe("remedy testing", func() {
 				karmadaresource.CreateRemedy(karmadaClient, remedy)
 			})
 
-			ginkgo.By("wait cluster status has TrafficControl RemedyAction", func() {
+			ginkgo.By(fmt.Sprintf("wait Cluster(%s) status has TrafficControl RemedyAction", targetCluster), func() {
 				framework.WaitClusterFitWith(controlPlaneClient, targetCluster, func(cluster *clusterv1alpha1.Cluster) bool {
 					actions := sets.NewString(cluster.Status.RemedyActions...)
+					fmt.Printf("Cluster(%s) remedyActions: %v\n", cluster.Name, actions)
 					return actions.Has(string(remedyv1alpha1.TrafficControl))
 				})
 			})
@@ -179,9 +189,10 @@ var _ = framework.SerialDescribe("remedy testing", func() {
 				karmadaresource.RemoveRemedy(karmadaClient, remedyName)
 			})
 
-			ginkgo.By("wait cluster status doesn't has TrafficControl RemedyAction", func() {
+			ginkgo.By(fmt.Sprintf("wait Cluster(%s) status doesn't has TrafficControl RemedyAction", targetCluster), func() {
 				framework.WaitClusterFitWith(controlPlaneClient, targetCluster, func(cluster *clusterv1alpha1.Cluster) bool {
 					actions := sets.NewString(cluster.Status.RemedyActions...)
+					fmt.Printf("Cluster(%s) remedyActions: %v\n", cluster.Name, actions)
 					return !actions.Has(string(remedyv1alpha1.TrafficControl))
 				})
 			})


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

In order to fix the ci error:

https://github.com/karmada-io/karmada/actions/runs/9410947609/job/25923580671
https://github.com/karmada-io/karmada/actions/runs/9413749877/job/25931419319?pr=4986

Root error:

The cluster-status-controller updates cluster status while remedy-controller is updating cluster status, `remedyActions` field is overwritten by the cluster-status-controller.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-controller-manager: fixes an issue where the cluster-status-controller overwrites the remedyActions field.
```

