### PR TITLE
Automated cherry pick of #5030: fix-remedy-e2e-errors

### DIFF
--- a/pkg/controllers/remediation/remedy_controller.go
+++ b/pkg/controllers/remediation/remedy_controller.go
@@ -93,7 +93,7 @@ func (c *RemedyController) Reconcile(ctx context.Context, req controllerruntime.
 		klog.Errorf("Failed to sync cluster(%s) remedy actions: %v", cluster.Name, err)
 		return controllerruntime.Result{}, err
 	}
-	klog.V(4).Infof("Success to sync cluster(%s) remedy actions", cluster.Name)
+	klog.V(4).Infof("Success to sync cluster(%s) remedy actions: %v", cluster.Name, actions)
 	return controllerruntime.Result{}, nil
 }
 

--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -277,7 +277,11 @@ func (c *ClusterStatusController) updateStatusIfNeeded(cluster *clusterv1alpha1.
 	if !equality.Semantic.DeepEqual(cluster.Status, currentClusterStatus) {
 		klog.V(4).Infof("Start to update cluster status: %s", cluster.Name)
 		err := retry.RetryOnConflict(retry.DefaultRetry, func() (err error) {
-			cluster.Status = currentClusterStatus
+			cluster.Status.KubernetesVersion = currentClusterStatus.KubernetesVersion
+			cluster.Status.APIEnablements = currentClusterStatus.APIEnablements
+			cluster.Status.Conditions = currentClusterStatus.Conditions
+			cluster.Status.NodeSummary = currentClusterStatus.NodeSummary
+			cluster.Status.ResourceSummary = currentClusterStatus.ResourceSummary
 			updateErr := c.Status().Update(context.TODO(), cluster)
 			if updateErr == nil {
 				return nil


### PR DESCRIPTION
Cherry pick of #5030 on release-1.10.
#5030: fix-remedy-e2e-errors
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`: Fixed an issue that the cluster-status-controller overwrites the remedyActions field.
```