### PR TITLE
Align federated CloneSet's observedGeneration semantics with its native

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/customizations.yaml
@@ -24,25 +24,44 @@ spec:
     statusAggregation:
       luaScript: >
         function AggregateStatus(desiredObj, statusItems)
-          if statusItems == nil then
-            return desiredObj
-          end
           if desiredObj.status == nil then
             desiredObj.status = {}
           end
           if desiredObj.metadata.generation == nil then
             desiredObj.metadata.generation = 0
           end
-          generation = desiredObj.metadata.generation
-          replicas = 0
-          updatedReplicas = 0 
-          readyReplicas = 0
-          availableReplicas = 0
-          updatedReadyReplicas = 0
-          expectedUpdatedReplicas = 0
-          updateRevision = ''
-          currentRevision = ''
-          labelSelector = ''
+          if desiredObj.status.observedGeneration == nil then
+            desiredObj.status.observedGeneration = 0
+          end
+        
+          -- Initialize status fields if status doest not exist
+          -- If the CloneSet is not spread to any cluster, its status also should be aggregated
+          if statusItems == nil then
+            desiredObj.status.observedGeneration = desiredObj.metadata.generation 
+            desiredObj.status.replicas = 0
+            desiredObj.status.readyReplicas = 0
+            desiredObj.status.updatedReplicas = 0
+            desiredObj.status.availableReplicas = 0
+            desiredObj.status.updatedReadyReplicas = 0
+            desiredObj.status.expectedUpdatedReplicas = 0
+            return desiredObj
+          end
+        
+          local generation = desiredObj.metadata.generation
+          local observedGeneration = desiredObj.status.observedGeneration
+          local replicas = 0
+          local updatedReplicas = 0
+          local readyReplicas = 0
+          local availableReplicas = 0
+          local updatedReadyReplicas = 0
+          local expectedUpdatedReplicas = 0
+          local updateRevision = ''
+          local currentRevision = ''
+          local labelSelector = ''
+        
+          -- Count all members that their status is updated to the latest generation
+          local observedResourceTemplateGenerationCount = 0
+        
           for i = 1, #statusItems do
             if statusItems[i].status ~= nil and statusItems[i].status.replicas ~= nil then
               replicas = replicas + statusItems[i].status.replicas
@@ -68,14 +87,36 @@ spec:
             if statusItems[i].status ~= nil and statusItems[i].status.currentRevision ~= nil and statusItems[i].status.currentRevision ~= '' then
               currentRevision = statusItems[i].status.currentRevision
             end
-            if statusItems[i].status ~= nil and statusItems[i].status.observedGeneration ~= nil and statusItems[i].status.observedGeneration ~= '' then
-              generation = statusItems[i].status.observedGeneration
-            end
             if statusItems[i].status ~= nil and statusItems[i].status.labelSelector ~= nil and statusItems[i].status.labelSelector ~= '' then
               labelSelector = statusItems[i].status.labelSelector 
             end
+            
+            -- Check if the member's status is updated to the latest generation
+            local resourceTemplateGeneration = 0
+            if statusItems[i].status ~= nil and statusItems[i].status.resourceTemplateGeneration ~= nil then 
+               resourceTemplateGeneration = statusItems[i].status.resourceTemplateGeneration
+            end
+            local memberGeneration = 0
+            if statusItems[i].status ~= nil and statusItems[i].status.generation ~= nil then
+              memberGeneration = statusItems[i].status.generation
+            end
+            local memberObservedGeneration = 0
+            if statusItems[i].status ~= nil and statusItems[i].status.observedGeneration ~= nil then
+              memberObservedGeneration = statusItems[i].status.observedGeneration
+            end
+            if resourceTemplateGeneration == generation and memberGeneration == memberObservedGeneration then
+              observedResourceTemplateGenerationCount = observedResourceTemplateGenerationCount + 1
+            end
           end
-          desiredObj.status.observedGeneration = generation
+        
+        
+          -- Update the observed generation based on the observedResourceTemplateGenerationCount
+          if observedResourceTemplateGenerationCount == #statusItems then
+            desiredObj.status.observedGeneration = generation
+          else
+            desiredObj.status.observedGeneration = observedGeneration 
+          end
+        
           desiredObj.status.replicas = replicas
           desiredObj.status.updatedReplicas = updatedReplicas
           desiredObj.status.readyReplicas = readyReplicas
@@ -89,9 +130,9 @@ spec:
         end
     statusReflection:
       luaScript: >
-        function ReflectStatus (observedObj)
-          status = {}
-          if observedObj == nil or observedObj.status == nil then 
+        function ReflectStatus(observedObj)
+          local status = {}
+          if observedObj == nil or observedObj.status == nil then
             return status
           end
           status.replicas = observedObj.status.replicas
@@ -104,6 +145,21 @@ spec:
           status.currentRevision = observedObj.status.currentRevision
           status.observedGeneration = observedObj.status.observedGeneration
           status.labelSelector = observedObj.status.labelSelector
+        
+          -- handle member resource generation report
+          if observedObj.metadata == nil then
+            return status
+          end
+          status.generation = observedObj.metadata.generation
+        
+          -- handle resource template generation report
+          if observedObj.metadata.annotations == nil then
+            return status
+          end
+          local resourceTemplateGeneration = tonumber(observedObj.metadata.annotations["resourcetemplate.karmada.io/generation"])
+          if resourceTemplateGeneration ~= nil then
+              status.resourceTemplateGeneration = resourceTemplateGeneration
+          end
           return status
         end
     healthInterpretation:

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/desired-cloneset-nginx.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/desired-cloneset-nginx.yaml
@@ -5,6 +5,7 @@ metadata:
     app: sample
   name: sample
   namespace: test-cloneset
+  generation: 1
 spec:
   replicas: 4
   selector:

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/observed-cloneset-nginx.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/observed-cloneset-nginx.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps.kruise.io/v1alpha1
 kind: CloneSet
 metadata:
+  annotations:
+    resourcetemplate.karmada.io/generation: "1"
   labels:
     app: sample
   name: sample

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/status-file.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/status-file.yaml
@@ -12,6 +12,8 @@ status:
   updateRevision: sample-59df6bd888
   updatedReadyReplicas: 2
   updatedReplicas: 2
+  generation: 1
+  resourceTemplateGeneration: 1
 ---
 applied: true
 clusterName: member3
@@ -27,3 +29,5 @@ status:
   updateRevision: sample-59df6bd888
   updatedReadyReplicas: 2
   updatedReplicas: 2
+  generation: 1
+  resourceTemplateGeneration: 1


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of https://github.com/karmada-io/karmada/issues/4870, https://github.com/karmada-io/karmada/issues/5021

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Mark `.status.observedGeneration` of CloneSet with `.metadata.generation` only when all members' statuses are algined with its resource template generation.
```

