### PR TITLE
deprecate karmada-* options in favor of host-* options

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -138,7 +138,7 @@ func run(ctx context.Context, opts *options.Options) error {
 
 	profileflag.ListenAndServe(opts.ProfileOpts)
 
-	controlPlaneRestConfig, err := apiclient.RestConfig(opts.KarmadaContext, opts.KarmadaKubeConfig)
+	controlPlaneRestConfig, err := apiclient.RestConfig(opts.HostContext, opts.KarmadaKubeConfig)
 	if err != nil {
 		return fmt.Errorf("error building kubeconfig of karmada control plane: %w", err)
 	}

--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -58,8 +58,8 @@ type Options struct {
 	KarmadaKubeConfig string
 	// ClusterContext is the name of the cluster context in control plane KUBECONFIG file.
 	// Default value is the current-context.
-	KarmadaContext string
-	ClusterName    string
+	HostContext string
+	ClusterName string
 	// ClusterNamespace holds the namespace name where the member cluster secrets are stored.
 	ClusterNamespace string
 	// ClusterStatusUpdateFrequency is the frequency that controller computes and report cluster status.
@@ -184,7 +184,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, allControllers []string) {
 		"The duration the clients should wait between attempting acquisition and renewal "+
 		"of a leadership. This is only applicable if leader election is enabled.")
 	fs.StringVar(&o.KarmadaKubeConfig, "karmada-kubeconfig", o.KarmadaKubeConfig, "Path to karmada control plane kubeconfig file.")
-	fs.StringVar(&o.KarmadaContext, "karmada-context", "", "Name of the cluster context in karmada control plane kubeconfig file.")
+	fs.StringVar(&o.HostContext, "host-context", "", "Name of the cluster context in karmada control plane kubeconfig file.")
+	fs.StringVar(&o.HostContext, "karmada-context", "", "DEPRECATED: use host-context -- Name of the cluster context in karmada control plane kubeconfig file.")
 	fs.StringVar(&o.ClusterName, "cluster-name", o.ClusterName, "Name of member cluster that the agent serves for.")
 	fs.StringVar(&o.ClusterNamespace, "cluster-namespace", DefaultKarmadaClusterNamespace, "Namespace in the control plane where member cluster secrets are stored.")
 	fs.DurationVar(&o.ClusterStatusUpdateFrequency.Duration, "cluster-status-update-frequency", 10*time.Second, "Specifies how often karmada-agent posts cluster status to karmada-apiserver. Note: be cautious when changing the constant, it must work with ClusterMonitorGracePeriod in karmada-controller-manager.")

--- a/cmd/service-name-resolution-detector-example/README.md
+++ b/cmd/service-name-resolution-detector-example/README.md
@@ -35,8 +35,8 @@ spec:
           name: service-name-resolution-detector
           command:
             - service-name-resolution-detector
-              --karmada-kubeconfig=/tmp/config
-              --karmada-context=<context-of-control-plane>
+              --host-kubeconfig=/tmp/config
+              --host-context=<context-of-control-plane>
               --cluster-name=<your-cluster-name>
               --host-name=${HOST_NAME}
               --bind-address=${POD_ADDRESS}

--- a/cmd/service-name-resolution-detector-example/app/options/generic.go
+++ b/cmd/service-name-resolution-detector-example/app/options/generic.go
@@ -37,8 +37,8 @@ import (
 
 // GenericOptions contains some generic options.
 type GenericOptions struct {
-	KarmadaKubeConfig   string
-	KarmadaContext      string
+	HostKubeConfig      string
+	HostContext         string
 	KarmadaConfig       *rest.Config
 	MemberClusterConfig *rest.Config
 
@@ -70,8 +70,10 @@ func NewGenericOptions() *GenericOptions {
 
 // AddFlags adds flags of generic options to the specified FlagSet.
 func (o *GenericOptions) AddFlags(fs *pflag.FlagSet, allDetectors []string) {
-	fs.StringVar(&o.KarmadaKubeConfig, "karmada-kubeconfig", o.KarmadaKubeConfig, "Path to karmada control plane kubeconfig file.")
-	fs.StringVar(&o.KarmadaContext, "karmada-context", "", "Name of the cluster context in karmada control plane kubeconfig file.")
+	fs.StringVar(&o.HostKubeConfig, "host-kubeconfig", o.HostKubeConfig, "Path to karmada control plane kubeconfig file.")
+	fs.StringVar(&o.HostKubeConfig, "karmada-kubeconfig", o.HostKubeConfig, "DEPRECATED: use host-kubeconfig -- Path to karmada control plane kubeconfig file.")
+	fs.StringVar(&o.HostContext, "host-context", "", "DEPRECATED: use host-context -- Name of the cluster context in karmada control plane kubeconfig file.")
+	fs.StringVar(&o.HostContext, "karmada-context", "", "Name of the cluster context in karmada control plane kubeconfig file.")
 
 	fs.StringVar(&o.ClusterName, "cluster-name", o.ClusterName, "Name of member cluster that the agent serves for.")
 	fs.StringVar(&o.Hostname, "host-name", o.Hostname, "Name of host that the agent runs on, used as lock holder identity.")
@@ -93,7 +95,7 @@ func (o *GenericOptions) Complete() error {
 		return nil
 	}
 
-	controlPlaneRestConfig, err := apiclient.RestConfig(o.KarmadaContext, o.KarmadaKubeConfig)
+	controlPlaneRestConfig, err := apiclient.RestConfig(o.HostContext, o.HostKubeConfig)
 	if err != nil {
 		return fmt.Errorf("failed to build kubeconfig of karmada control plane: %v", err)
 	}


### PR DESCRIPTION
as followup to https://github.com/karmada-io/karmada/pull/5016 which added host-as/group/uid

cli will be stable, not sure if anyone uses the karmada code directly to set these options

**What type of PR is this?**

/kind deprecation

**What this PR does / why we need it**:
makes cli options consistent

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
- deprecates --karmada-context in favor of --host-context
- deprecates --karmada-kubeconfig in favor of --host-kubeconfig
```

