### PR TITLE
additional print columns for CRDs: `ResourceInterpreterCustomization`…

### DIFF
--- a/charts/karmada/_crds/bases/config/config.karmada.io_resourceinterpretercustomizations.yaml
+++ b/charts/karmada/_crds/bases/config/config.karmada.io_resourceinterpretercustomizations.yaml
@@ -18,7 +18,16 @@ spec:
     singular: resourceinterpretercustomization
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.target.apiVersion
+      name: TARGET-API-VERSION
+      priority: 1
+      type: string
+    - jsonPath: .spec.target.kind
+      name: TARGET-KIND
+      priority: 1
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
@@ -372,3 +381,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_clusterpropagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_clusterpropagationpolicies.yaml
@@ -18,7 +18,16 @@ spec:
     singular: clusterpropagationpolicy
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.conflictResolution
+      name: CONFLICT-RESOLUTION
+      priority: 1
+      type: string
+    - jsonPath: .spec.priority
+      name: PRIORITY
+      priority: 1
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
@@ -793,3 +802,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_propagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_propagationpolicies.yaml
@@ -18,7 +18,16 @@ spec:
     singular: propagationpolicy
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.conflictResolution
+      name: CONFLICT-RESOLUTION
+      priority: 1
+      type: string
+    - jsonPath: .spec.priority
+      name: PRIORITY
+      priority: 1
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: PropagationPolicy represents the policy that propagates a group
@@ -790,3 +799,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/pkg/apis/config/v1alpha1/resourceinterpretercustomization_types.go
+++ b/pkg/apis/config/v1alpha1/resourceinterpretercustomization_types.go
@@ -36,6 +36,8 @@ const (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:path=resourceinterpretercustomizations,scope="Cluster",shortName=ric,categories={karmada-io}
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:JSONPath=`.spec.target.apiVersion`,name="TARGET-API-VERSION",type=string,priority=1
+// +kubebuilder:printcolumn:JSONPath=`.spec.target.kind`,name="TARGET-KIND",type=string,priority=1
 
 // ResourceInterpreterCustomization describes the configuration of a specific
 // resource for Karmada to get the structure.

--- a/pkg/apis/policy/v1alpha1/propagation_types.go
+++ b/pkg/apis/policy/v1alpha1/propagation_types.go
@@ -44,6 +44,8 @@ const (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:path=propagationpolicies,scope=Namespaced,shortName=pp,categories={karmada-io}
+// +kubebuilder:printcolumn:JSONPath=`.spec.conflictResolution`,name="CONFLICT-RESOLUTION",type=string,priority=1
+// +kubebuilder:printcolumn:JSONPath=`.spec.priority`,name="PRIORITY",type=string,priority=1
 
 // PropagationPolicy represents the policy that propagates a group of resources to one or more clusters.
 type PropagationPolicy struct {
@@ -562,6 +564,8 @@ type PropagationPolicyList struct {
 // +genclient:nonNamespaced
 // +kubebuilder:resource:path=clusterpropagationpolicies,scope="Cluster",shortName=cpp,categories={karmada-io}
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:printcolumn:JSONPath=`.spec.conflictResolution`,name="CONFLICT-RESOLUTION",type=string,priority=1
+// +kubebuilder:printcolumn:JSONPath=`.spec.priority`,name="PRIORITY",type=string,priority=1
 
 // ClusterPropagationPolicy represents the cluster-wide policy that propagates a group of resources to one or more clusters.
 // Different with PropagationPolicy that could only propagate resources in its own namespace, ClusterPropagationPolicy


### PR DESCRIPTION
… `ClusterPropagationPolicy` and `PropagationPolicy`

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature

**What this PR does / why we need it**:
currently:
```
NAME                                    AGE
retain-configmap                        43d
retain-crd                              63d
retain-cronjob                          46d
retain-daemonset                        46d
retain-deployment                       46d
retain-mutatingwebhookconfiguration     63d
retain-pvc-annotations                  52d
retain-secret                           63d
retain-statefulset                      46d
retain-validatingwebhookconfiguration   63d
```

vs.
```
NAME                                    TARGET-API-VERSION                TARGET-KIND
retain-configmap                        v1                                ConfigMap
retain-crd                              apiextensions.k8s.io/v1           CustomResourceDefinition
retain-cronjob                          batch/v1                          CronJob
retain-daemonset                        apps/v1                           DaemonSet
retain-deployment                       apps/v1                           Deployment
retain-mutatingwebhookconfiguration     admissionregistration.k8s.io/v1   MutatingWebhookConfiguration
retain-pv-annotations                   v1                                PersistentVolume
retain-pvc-annotations                  v1                                PersistentVolumeClaim
retain-secret                           v1                                Secret
retain-statefulset                      apps/v1                           StatefulSet
retain-validatingwebhookconfiguration   admissionregistration.k8s.io/v1   ValidatingWebhookConfiguration
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`ResourceInterpreterCustomization`: Added two additional printer columns, TARGET-API-VERSION and TARGET-KIND, to represent the target resource type, these columns will be displayed in the output of kubectl get.

`PropagationPolicy`/`ClusterPropagationPolicy`: Added two additional printer columns, `Conflict-Resolution` and `Priority`, to represent the conflict resolution strategy and priority, these columns will be displayed in the output of kubectl get.
```

