### PR TITLE
Align federated Kustomization's observedGeneration semantics with its native

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kustomize.toolkit.fluxcd.io/v1/Kustomization/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kustomize.toolkit.fluxcd.io/v1/Kustomization/customizations.yaml
@@ -22,22 +22,42 @@ spec:
     statusAggregation:
       luaScript: >
         function AggregateStatus(desiredObj, statusItems)
+          if desiredObj.status == nil then
+            desiredObj.status = {}
+          end
+          if desiredObj.metadata.generation == nil then
+            desiredObj.metadata.generation = 0
+          end
+          if desiredObj.status.observedGeneration == nil then
+            desiredObj.status.observedGeneration = 0
+          end
+
+          -- Initialize status fields if status doest not exist
+          -- If the Kustomization is not spread to any cluster, its status also should be aggregated
           if statusItems == nil then
+            desiredObj.status.observedGeneration = desiredObj.metadata.generation
+            desiredObj.status.lastAttemptedRevision = ''
+            desiredObj.status.lastAppliedRevision = ''
+            desiredObj.status.conditions = {}
             return desiredObj
           end
-          desiredObj.status = {}
-          desiredObj.status.conditions = {}
-          conditions = {}
+
+          local conditions = {}
+          local generation = desiredObj.metadata.generation
+          local lastAppliedRevision = desiredObj.status.lastAppliedRevision
+          local lastAttemptedRevision = desiredObj.status.lastAttemptedRevision
+          local observedGeneration = desiredObj.status.observedGeneration
+
+          -- Count all members that their status is updated to the latest generation
+          local observedResourceTemplateGenerationCount = 0
+          
           local conditionsIndex = 1
           for i = 1, #statusItems do
             if statusItems[i].status ~= nil and statusItems[i].status.lastAttemptedRevision ~= nil and statusItems[i].status.lastAttemptedRevision ~= '' then
-              desiredObj.status.lastAttemptedRevision = statusItems[i].status.lastAttemptedRevision
+              lastAttemptedRevision = statusItems[i].status.lastAttemptedRevision
             end
             if statusItems[i].status ~= nil and statusItems[i].status.lastAppliedRevision ~= nil and statusItems[i].status.lastAppliedRevision ~= '' then
-              desiredObj.status.lastAppliedRevision = statusItems[i].status.lastAppliedRevision
-            end                        
-            if statusItems[i].status ~= nil and statusItems[i].status.lastHandledReconcileAt ~= nil and statusItems[i].status.lastHandledReconcileAt ~= '' then
-              desiredObj.status.lastHandledReconcileAt = statusItems[i].status.lastHandledReconcileAt
+              lastAppliedRevision = statusItems[i].status.lastAppliedRevision
             end
             if statusItems[i].status ~= nil and statusItems[i].status.conditions ~= nil then
               for conditionIndex = 1, #statusItems[i].status.conditions do
@@ -56,9 +76,35 @@ spec:
                 end
               end
             end
+            
+            -- Check if the member's status is updated to the latest generation
+            local resourceTemplateGeneration = 0
+            if statusItems[i].status ~= nil and statusItems[i].status.resourceTemplateGeneration ~= nil then 
+              resourceTemplateGeneration = statusItems[i].status.resourceTemplateGeneration
+            end
+            local memberGeneration = 0
+            if statusItems[i].status ~= nil and statusItems[i].status.generation ~= nil then
+              memberGeneration = statusItems[i].status.generation
+            end
+            local memberObservedGeneration = 0
+            if statusItems[i].status ~= nil and statusItems[i].status.observedGeneration ~= nil then
+              memberObservedGeneration = statusItems[i].status.observedGeneration
+            end
+            if resourceTemplateGeneration == generation and memberGeneration == memberObservedGeneration then
+              observedResourceTemplateGenerationCount = observedResourceTemplateGenerationCount + 1
+            end
           end
-          desiredObj.status.observedGeneration = desiredObj.metadata.generation
+
+          -- Update the observed generation based on the observedResourceTemplateGenerationCount
+          if observedResourceTemplateGenerationCount == #statusItems then
+            desiredObj.status.observedGeneration = generation
+          else
+            desiredObj.status.observedGeneration = observedGeneration 
+          end
+
           desiredObj.status.conditions = conditions
+          desiredObj.status.lastAppliedRevision = lastAppliedRevision
+          desiredObj.status.lastAttemptedRevision = lastAttemptedRevision
           return desiredObj
         end
     retention:
@@ -72,14 +118,29 @@ spec:
     statusReflection:
       luaScript: >
         function ReflectStatus (observedObj)
-          status = {}
-          if observedObj == nil or observedObj.status == nil then 
+          local status = {}
+          if observedObj == nil or observedObj.status == nil then
             return status
           end
           status.conditions = observedObj.status.conditions
           status.lastAppliedRevision = observedObj.status.lastAppliedRevision
           status.lastAttemptedRevision = observedObj.status.lastAttemptedRevision
-          status.lastHandledReconcileAt = observedObj.status.lastHandledReconcileAt
+          status.observedGeneration = observedObj.status.observedGeneration
+
+          -- handle resource generation report
+          if observedObj.metadata == nil then
+            return status
+          end
+          status.generation = observedObj.metadata.generation
+
+          if observedObj.metadata.annotations == nil then
+            return status
+          end
+          local resourceTemplateGeneration = tonumber(observedObj.metadata.annotations["resourcetemplate.karmada.io/generation"])
+          if resourceTemplateGeneration ~= nil then
+              status.resourceTemplateGeneration = resourceTemplateGeneration
+          end
+
           return status
         end
     dependencyInterpretation:

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kustomize.toolkit.fluxcd.io/v1/Kustomization/testdata/desired-kustomization.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kustomize.toolkit.fluxcd.io/v1/Kustomization/testdata/desired-kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 metadata:
   name: sample
   namespace: test-kustomization
+  generation: 1
 spec:
   interval: 10m
   targetNamespace: test-kustomization

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kustomize.toolkit.fluxcd.io/v1/Kustomization/testdata/observed-kustomization.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kustomize.toolkit.fluxcd.io/v1/Kustomization/testdata/observed-kustomization.yaml
@@ -1,8 +1,11 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  annotations:
+    resourcetemplate.karmada.io/generation: "1"
   name: sample
   namespace: test-kustomization
+  generation: 1
 spec:
   interval: 10m
   targetNamespace: test-kustomization

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kustomize.toolkit.fluxcd.io/v1/Kustomization/testdata/status-file.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kustomize.toolkit.fluxcd.io/v1/Kustomization/testdata/status-file.yaml
@@ -9,8 +9,11 @@ status:
     reason: ReconciliationSucceeded
     status: "True"
     type: Ready
+  generation: 1
   lastAppliedRevision: master@sha1:0647aea75b85755411b007a290b9321668370be5
   lastAttemptedRevision: master@sha1:0647aea75b85755411b007a290b9321668370be5
+  observedGeneration: 1
+  resourceTemplateGeneration: 1
 ---
 applied: true
 clusterName: member3
@@ -23,5 +26,8 @@ status:
     reason: ReconciliationSucceeded
     status: "True"
     type: Ready
+  generation: 1
   lastAppliedRevision: master@sha1:0647aea75b85755411b007a290b9321668370be5
   lastAttemptedRevision: master@sha1:0647aea75b85755411b007a290b9321668370be5
+  observedGeneration: 1
+  resourceTemplateGeneration: 1


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Part of #4870 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Mark `.status.observedGeneration` of Kustomization with `.metadata.generation` only when all members' statuses are algined with its resource template generation.
```

