### PR TITLE
Align federated StatefulSet's observedGeneration semantics with its native

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/customizations.yaml
@@ -24,24 +24,46 @@ spec:
     statusAggregation:
       luaScript: >
         function AggregateStatus(desiredObj, statusItems)
-          if statusItems == nil then
-            return desiredObj
-          end
           if desiredObj.status == nil then
             desiredObj.status = {}
           end
           if desiredObj.metadata.generation == nil then
             desiredObj.metadata.generation = 0
           end
-          generation = desiredObj.metadata.generation
-          replicas = 0
-          readyReplicas = 0 
-          currentReplicas = 0
-          updatedReplicas = 0
-          availableReplicas = 0
-          updatedReadyReplicas = 0
-          updateRevision = ''
-          currentRevision = ''
+          if desiredObj.status.observedGeneration == nil then
+            desiredObj.status.observedGeneration = 0
+          end
+        
+          -- Initialize status fields if status doest not exist
+          -- If the StatefulSet is not spread to any cluster, its status also should be aggregated
+          if statusItems == nil then
+            desiredObj.status.observedGeneration = desiredObj.metadata.generation 
+            desiredObj.status.replicas = 0
+            desiredObj.status.readyReplicas = 0
+            desiredObj.status.currentReplicas = 0
+            desiredObj.status.updatedReplicas = 0
+            desiredObj.status.availableReplicas = 0
+            desiredObj.status.updatedReadyReplicas = 0
+            desiredObj.status.updateRevision = ''
+            desiredObj.status.currentRevision = ''
+            return desiredObj
+          end
+        
+          local generation = desiredObj.metadata.generation
+          local observedGeneration = desiredObj.status.observedGeneration
+          local replicas = 0
+          local readyReplicas = 0
+          local currentReplicas = 0
+          local updatedReplicas = 0
+          local availableReplicas = 0
+          local updatedReadyReplicas = 0
+          local updateRevision = ''
+          local currentRevision = ''
+          local labelSelector = ''
+        
+          -- Count all members that their status is updated to the latest generation
+          local observedResourceTemplateGenerationCount = 0
+        
           for i = 1, #statusItems do
             if statusItems[i].status ~= nil and statusItems[i].status.replicas ~= nil then
               replicas = replicas + statusItems[i].status.replicas
@@ -67,11 +89,32 @@ spec:
             if statusItems[i].status ~= nil and statusItems[i].status.currentRevision ~= nil and statusItems[i].status.currentRevision ~= '' then
               currentRevision = statusItems[i].status.currentRevision
             end
-            if statusItems[i].status ~= nil and statusItems[i].status.observedGeneration ~= nil and statusItems[i].status.observedGeneration ~= '' then
-              generation = statusItems[i].status.observedGeneration
-            end            
+          
+            -- Check if the member's status is updated to the latest generation
+            local resourceTemplateGeneration = 0
+            if statusItems[i].status ~= nil and statusItems[i].status.resourceTemplateGeneration ~= nil then 
+               resourceTemplateGeneration = statusItems[i].status.resourceTemplateGeneration
+            end
+            local memberGeneration = 0
+            if statusItems[i].status ~= nil and statusItems[i].status.generation ~= nil then
+              memberGeneration = statusItems[i].status.generation
+            end
+            local memberObservedGeneration = 0
+            if statusItems[i].status ~= nil and statusItems[i].status.observedGeneration ~= nil then
+              memberObservedGeneration = statusItems[i].status.observedGeneration
+            end
+            if resourceTemplateGeneration == generation and memberGeneration == memberObservedGeneration then
+              observedResourceTemplateGenerationCount = observedResourceTemplateGenerationCount + 1
+            end           
           end
-          desiredObj.status.observedGeneration = generation
+        
+          -- Update the observed generation based on the observedResourceTemplateGenerationCount
+          if observedResourceTemplateGenerationCount == #statusItems then
+            desiredObj.status.observedGeneration = generation
+          else
+            desiredObj.status.observedGeneration = observedGeneration 
+          end
+        
           desiredObj.status.replicas = replicas
           desiredObj.status.readyReplicas = readyReplicas
           desiredObj.status.currentReplicas = currentReplicas
@@ -84,8 +127,8 @@ spec:
         end
     statusReflection:
       luaScript: >
-        function ReflectStatus (observedObj)
-          status = {}
+        function ReflectStatus(observedObj)
+          local status = {}
           if observedObj == nil or observedObj.status == nil then
             return status
           end
@@ -98,6 +141,20 @@ spec:
           status.currentRevision = observedObj.status.currentRevision
           status.updatedReadyReplicas = observedObj.status.updatedReadyReplicas
           status.observedGeneration = observedObj.status.observedGeneration
+          
+          -- handle resource generation report
+          if observedObj.metadata == nil then
+            return status
+          end
+          status.generation = observedObj.metadata.generation
+        
+          if observedObj.metadata.annotations == nil then
+            return status
+          end
+          local resourceTemplateGeneration = tonumber(observedObj.metadata.annotations["resourcetemplate.karmada.io/generation"])
+          if resourceTemplateGeneration ~= nil then
+            status.resourceTemplateGeneration = resourceTemplateGeneration
+          end
           return status
         end
     healthInterpretation:

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/desired-statefulset-nginx.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/desired-statefulset-nginx.yaml
@@ -3,6 +3,7 @@ kind: StatefulSet
 metadata:
   name: sample
   namespace: test-statefulset
+  generation: 1
 spec:
   replicas: 2
   serviceName: sample-statefulset-headless-service

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/observed-statefulset-nginx.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/observed-statefulset-nginx.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps.kruise.io/v1beta1
 kind: StatefulSet
 metadata:
+  annotations:
+    resourcetemplate.karmada.io/generation: "1"
   name: sample
   namespace: test-statefulset
   generation: 1

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/status-file.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/status-file.yaml
@@ -5,6 +5,8 @@ status:
   availableReplicas: 2
   currentReplicas: 2
   currentRevision: sample-5675547df7
+  generation: 1
+  resourceTemplateGeneration: 1
   observedGeneration: 1
   readyReplicas: 2
   replicas: 2
@@ -19,7 +21,9 @@ status:
   availableReplicas: 2
   currentReplicas: 2
   currentRevision: sample-5675547df7
+  generation: 1
   observedGeneration: 1
+  resourceTemplateGeneration: 1
   readyReplicas: 2
   replicas: 2
   updateRevision: sample-5675547df7


### PR DESCRIPTION

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Align federated StatefulSet's observedGeneration semantics with its native

**Which issue(s) this PR fixes**:
Part of #4870 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Mark `.status.observedGeneration` of StatefulSet with `.metadata.generation` only when all members' statuses are algined with its resource template generation.
```

