### PR TITLE
multi cluster cache list and get skip problem clusters

### DIFF
--- a/pkg/search/proxy/store/multi_cluster_cache.go
+++ b/pkg/search/proxy/store/multi_cluster_cache.go
@@ -264,14 +264,16 @@ func (c *MultiClusterCache) List(ctx context.Context, gvr schema.GroupVersionRes
 		for _, cluster := range clusters {
 			_, _, err := listFunc(cluster)
 			if err != nil {
-				return nil, err
+				klog.Errorf("Fail to list %s from %s: %v", gvr, cluster, err)
+				continue
 			}
 		}
 	} else {
 		for clusterIdx, cluster := range clusters {
 			n, cont, err := listFunc(cluster)
 			if err != nil {
-				return nil, err
+				klog.Errorf("Fail to list %s from %s: %v", gvr, cluster, err)
+				continue
 			}
 
 			options.Limit -= int64(n)
@@ -407,7 +409,8 @@ func (c *MultiClusterCache) getResourceFromCache(ctx context.Context, gvr schema
 			continue
 		}
 		if err != nil {
-			return nil, "", nil, fmt.Errorf("fail to get %v %v from %v: %v", namespace, name, clusterName, err)
+			klog.Errorf("Fail to get %v %v from %v: %v", namespace, name, clusterName, err)
+			continue
 		}
 		findObjects = append(findObjects, obj)
 		findCaches = append(findCaches, cache)


### PR DESCRIPTION
Signed-off-by: huangyanfeng <huangyanfeng1992@gmail.com>

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

When some member clusters are in the ready state but the member cluster apiserver has problems, search cannot obtain search results through /apis/search.karmada.io/v1alpha1/proxying/karmada/proxy


log in karmada-search

```
E0625 09:15:01.629270       1 cacher.go:450] cacher (xxxx): unexpected ListAndWatch error: failed to list xxx, Kind=xxxx: Get "https://10.253.48.22:6443/apis/xxx.io/v1alpha1/xxxx?limit=10000": http: server gave HTTP response to HTTPS client; reinitializing...

W0625 09:15:02.635162       1 reflector.go:424] storage/cacher.go:xxx: failed to list xxx, Kind=xxx Get "https://10.253.48.22:6443/apis/xxx.io/v1alpha1/xxx?limit=10000": http: server gave HTTP response to HTTPS client
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-search`: multi cluster cache list and get skip problem clusters
```

