### PR TITLE
Automated cherry pick of #5095: Fix the bug in interpreting the replicas of Job

### DIFF
--- a/pkg/resourceinterpreter/default/native/replica.go
+++ b/pkg/resourceinterpreter/default/native/replica.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/util"
@@ -85,6 +86,13 @@ func jobReplica(object *unstructured.Unstructured) (int32, *workv1alpha2.Replica
 	// parallelism might never be nil as the kube-apiserver will set it to 1 by default if not specified.
 	if job.Spec.Parallelism != nil {
 		replica = *job.Spec.Parallelism
+	}
+	// For fixed completion count Jobs, the actual number of pods running in parallel will not exceed the number of remaining completions.
+	// Higher values of .spec.parallelism are effectively ignored.
+	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/job/
+	completions := pointer.Int32Deref(job.Spec.Completions, replica)
+	if replica > completions {
+		replica = completions
 	}
 	requirement := helper.GenerateReplicaRequirements(&job.Spec.Template)
 


### PR DESCRIPTION
Cherry pick of #5095 on release-1.8.
#5095: Fix the bug in interpreting the replicas of Job
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`: Fixed the issue that the default resource interpreter doesn't accurately interpret the numbers of replicas.
```