### PR TITLE
Switch openapi-gen from k8s.io/code-generator to k8s.io/kube-openapi

### DIFF
--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -25,4 +25,5 @@ import (
 	_ "go.uber.org/mock/mockgen"
 	_ "golang.org/x/tools/cmd/goimports"
 	_ "k8s.io/code-generator"
+	_ "k8s.io/kube-openapi/cmd/openapi-gen"
 )

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -28,7 +28,7 @@ GO111MODULE=on go install k8s.io/code-generator/cmd/conversion-gen
 GO111MODULE=on go install k8s.io/code-generator/cmd/client-gen
 GO111MODULE=on go install k8s.io/code-generator/cmd/lister-gen
 GO111MODULE=on go install k8s.io/code-generator/cmd/informer-gen
-GO111MODULE=on go install k8s.io/code-generator/cmd/openapi-gen
+GO111MODULE=on go install k8s.io/kube-openapi/cmd/openapi-gen
 export GOPATH=$(go env GOPATH | awk -F ':' '{print $1}')
 export PATH=$PATH:$GOPATH/bin
 

--- a/vendor/k8s.io/kube-openapi/cmd/openapi-gen/openapi-gen.go
+++ b/vendor/k8s.io/kube-openapi/cmd/openapi-gen/openapi-gen.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This package generates openAPI definition file to be used in open API spec generation on API servers. To generate
+// definition for a specific type or package add "+k8s:openapi-gen=true" tag to the type/package comment lines. To
+// exclude a type from a tagged package, add "+k8s:openapi-gen=false" tag to the type comment lines.
+
+package main
+
+import (
+	"flag"
+	"log"
+
+	generatorargs "k8s.io/kube-openapi/cmd/openapi-gen/args"
+	"k8s.io/kube-openapi/pkg/generators"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/klog/v2"
+)
+
+func main() {
+	klog.InitFlags(nil)
+	genericArgs, customArgs := generatorargs.NewDefaults()
+
+	genericArgs.AddFlags(pflag.CommandLine)
+	customArgs.AddFlags(pflag.CommandLine)
+	flag.Set("logtostderr", "true")
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
+
+	if err := generatorargs.Validate(genericArgs); err != nil {
+		log.Fatalf("Arguments validation error: %v", err)
+	}
+
+	// Generates the code for the OpenAPIDefinitions.
+	if err := genericArgs.Execute(
+		generators.NameSystems(),
+		generators.DefaultNameSystem(),
+		generators.Packages,
+	); err != nil {
+		log.Fatalf("OpenAPI code generation error: %v", err)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1643,6 +1643,7 @@ k8s.io/kube-aggregator/pkg/registry/apiservice/etcd
 k8s.io/kube-aggregator/pkg/registry/apiservice/rest
 # k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00
 ## explicit; go 1.19
+k8s.io/kube-openapi/cmd/openapi-gen
 k8s.io/kube-openapi/cmd/openapi-gen/args
 k8s.io/kube-openapi/pkg/aggregator
 k8s.io/kube-openapi/pkg/builder


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The `openapi-gen` has been removed from [k8s.io/code-generator](https://github.com/kubernetes/code-generator/tree/master/cmd) by https://github.com/kubernetes/kubernetes/pull/123529 because it is redundant with [the one in k8s.io/kube-openapi](https://github.com/kubernetes/kube-openapi/tree/master/cmd/openapi-gen).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
We are going to bump Kubernetes dependencies to v1.30, this PR solves one of the blockers.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

