### PR TITLE
feat: karmadactl add ca-cert-path and ca-key-path opts

### DIFF
--- a/pkg/karmadactl/cmdinit/cert/cert_test.go
+++ b/pkg/karmadactl/cmdinit/cert/cert_test.go
@@ -29,10 +29,12 @@ import (
 )
 
 const (
-	TestCertsTmp = "./test-certs-tmp"
+	TestCertsTmp   = "./test-certs-tmp"
+	TestCaCertPath = "./test-certs-tmp/ca.crt"
+	TestCaKeyPath  = "./test-certs-tmp/ca.key"
 )
 
-func TestGenCerts(_ *testing.T) {
+func TestGenCerts(t *testing.T) {
 	defer os.RemoveAll(TestCertsTmp)
 
 	notAfter := time.Now().Add(Duration365d * 10).UTC()
@@ -101,7 +103,10 @@ func TestGenCerts(_ *testing.T) {
 	apiserverCertCfg := NewCertConfig("karmada-apiserver", []string{""}, karmadaAltNames, &notAfter)
 	frontProxyClientCertCfg := NewCertConfig("front-proxy-client", []string{}, certutil.AltNames{}, &notAfter)
 
-	if err := GenCerts(TestCertsTmp, etcdServerCertConfig, etcdClientCertCfg, karmadaCertCfg, apiserverCertCfg, frontProxyClientCertCfg); err != nil {
+	if err := GenCerts(TestCertsTmp, "", "", etcdServerCertConfig, etcdClientCertCfg, karmadaCertCfg, apiserverCertCfg, frontProxyClientCertCfg); err != nil {
+		t.Fatal(err)
+	}
+	if err := GenCerts(TestCertsTmp, TestCaCertPath, TestCaKeyPath, etcdServerCertConfig, etcdClientCertCfg, karmadaCertCfg, apiserverCertCfg, frontProxyClientCertCfg); err != nil {
 		fmt.Println(err)
 	}
 }

--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -125,6 +125,8 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 	flags.StringVar(&opts.ExternalIP, "cert-external-ip", "", "the external IP of Karmada certificate (e.g 192.168.1.2,172.16.1.2)")
 	flags.StringVar(&opts.ExternalDNS, "cert-external-dns", "", "the external DNS of Karmada certificate (e.g localhost,localhost.com)")
 	flags.DurationVar(&opts.CertValidity, "cert-validity-period", cert.Duration365d, "the validity period of Karmada certificate (e.g 8760h0m0s, that is 365 days)")
+	flags.StringVarP(&opts.CaCertFile, "ca-cert-file", "", "", "The root CA certificate file which will be used to issue new certificates for Karmada components. If not set, a new self-signed root CA certificate will be generated. This must be used together with --ca-key-file.")
+	flags.StringVarP(&opts.CaKeyFile, "ca-key-file", "", "", "The root CA private key file which will be used to issue new certificates for Karmada components. If not set, a new self-signed root CA key will be generated. This must be used together with --ca-cert-file.")
 	// Kubernetes
 	flags.StringVarP(&opts.Namespace, "namespace", "n", "karmada-system", "Kubernetes namespace")
 	flags.StringVar(&opts.StorageClassesName, "storage-classes-name", "", "Kubernetes StorageClasses Name")

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -171,6 +171,8 @@ type CommandInitOption struct {
 	KarmadaAPIServerIP                 []net.IP
 	HostClusterDomain                  string
 	WaitComponentReadyTimeout          int
+	CaCertFile                         string
+	CaKeyFile                          string
 }
 
 func (i *CommandInitOption) validateLocalEtcd(parentCommand string) error {
@@ -224,6 +226,9 @@ func (i *CommandInitOption) Validate(parentCommand string) error {
 		if netutils.ParseIPSloppy(i.KarmadaAPIServerAdvertiseAddress) == nil {
 			return fmt.Errorf("karmada apiserver advertise address is not valid")
 		}
+	}
+	if (i.CaCertFile != "") != (i.CaKeyFile != "") {
+		return fmt.Errorf("ca-cert-file and ca-key-file must be used together")
 	}
 
 	switch i.ImagePullPolicy {
@@ -353,7 +358,7 @@ func (i *CommandInitOption) genCerts() error {
 	apiserverCertCfg := cert.NewCertConfig("karmada-apiserver", []string{""}, karmadaAltNames, &notAfter)
 
 	frontProxyClientCertCfg := cert.NewCertConfig("front-proxy-client", []string{}, certutil.AltNames{}, &notAfter)
-	if err = cert.GenCerts(i.KarmadaPkiPath, etcdServerCertConfig, etcdClientCertCfg, karmadaCertCfg, apiserverCertCfg, frontProxyClientCertCfg); err != nil {
+	if err = cert.GenCerts(i.KarmadaPkiPath, i.CaCertFile, i.CaKeyFile, etcdServerCertConfig, etcdClientCertCfg, karmadaCertCfg, apiserverCertCfg, frontProxyClientCertCfg); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
issue: https://github.com/karmada-io/karmada/issues/5103

**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/karmada/issues/5103

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
`karmadactl`: Introduced `--ca-cert-file` and `--ca-key-file` flags to `init` command to specify the root CA which will be used to issue the certificate for components.
```

