### PR TITLE
ci: delete the step for upgrade/downupgrade karmada-apiserver.

### DIFF
--- a/.github/workflows/ci-schedule-compatibility.yaml
+++ b/.github/workflows/ci-schedule-compatibility.yaml
@@ -17,7 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         kubeapiserver-version: [ v1.23.4, v1.24.2, v1.25.0, v1.26.0, v1.27.3, v1.28.0, v1.29.0, v1.30.0 ]
-        karmada-version: [ release-1.10, release-1.9, release-1.8 ]
+        karmada-version: [ master, release-1.10, release-1.9, release-1.8 ]
+    env:
+      KARMADA_APISERVER_VERSION: ${{ matrix.kubeapiserver-version }}
     steps:
       # Free up disk space on Ubuntu
       - name: Free Disk Space (Ubuntu)
@@ -50,21 +52,6 @@ jobs:
           timeout_minutes: 20
           command: |
             hack/local-up-karmada.sh
-      - name: change kube-apiserver and kube-controller-manager version
-        run: |
-          # Update images
-          kubectl --kubeconfig=${HOME}/.kube/karmada.config --context=karmada-host \
-            set image deployment/karmada-apiserver -nkarmada-system \
-            karmada-apiserver=registry.k8s.io/kube-apiserver:${{ matrix.kubeapiserver-version }}
-          kubectl --kubeconfig=${HOME}/.kube/karmada.config --context=karmada-host \
-            set image deployment/karmada-kube-controller-manager -nkarmada-system \
-            kube-controller-manager=registry.k8s.io/kube-controller-manager:${{ matrix.kubeapiserver-version }}
-
-          # Wait ready
-          kubectl --kubeconfig=${HOME}/.kube/karmada.config --context=karmada-host \
-            rollout status deployment/karmada-kube-controller-manager -nkarmada-system --timeout=5m
-          kubectl --kubeconfig=${HOME}/.kube/karmada.config --context=karmada-host \
-            rollout status deployment/karmada-apiserver -nkarmada-system --timeout=5m
       - name: run e2e
         run: |
           export ARTIFACTS_PATH=${{ github.workspace }}/karmada-e2e-logs/${{ matrix.kubeapiserver-version }}-${{ matrix.karmada-version }}/


### PR DESCRIPTION
* Add master branch to run workflow of karmada-apiserver compatibility.

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind cleanup
**What this PR does / why we need it**:

changes:
- delete the step for upgrade/downupgrade karmada-apiserver. (resolve the compatibility problem of karmada-apiserver downupgrade https://github.com/karmada-io/karmada/actions/runs/9734577204/job/26862782887 )
- Add master branch to run karmada-apiserver compatibility

cc @zhzhuang-zju 

Tested on my fork repo: https://github.com/liangyuanpeng/karmada/actions/runs/9802951091
And reason of workflow is failing is have a test need to update for karmada-apiserver 1.30, it's working at https://github.com/karmada-io/karmada/pull/5141


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

