### PR TITLE
GroupClusters should sort by score and availableReplica count

### DIFF
--- a/pkg/scheduler/core/spreadconstraint/group_clusters.go
+++ b/pkg/scheduler/core/spreadconstraint/group_clusters.go
@@ -17,6 +17,8 @@ limitations under the License.
 package spreadconstraint
 
 import (
+	"k8s.io/utils/ptr"
+
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
@@ -143,7 +145,12 @@ func (info *GroupClustersInfo) generateClustersInfo(clustersScore framework.Clus
 		info.Clusters[i].AvailableReplicas += int64(rbSpec.AssignedReplicasForCluster(clustersReplica.Name))
 	}
 
-	sortClusters(info.Clusters)
+	sortClusters(info.Clusters, func(i *ClusterDetailInfo, j *ClusterDetailInfo) *bool {
+		if i.AvailableReplicas != j.AvailableReplicas {
+			return ptr.To(i.AvailableReplicas > j.AvailableReplicas)
+		}
+		return nil
+	})
 }
 
 func (info *GroupClustersInfo) generateZoneInfo(spreadConstraints []policyv1alpha1.SpreadConstraint) {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
With the PR, Karmada will sort clusterInfo by score, and fallback to sorting by availableReplicas. This will help cases in which some clusters have the same score, but we should prefer scheduling on clusters with higher availableReplicas.

**Which issue(s) this PR fixes**:
Fixes #5129

**Does this PR introduce a user-facing change?**:

```release-note
`karmada-scheduler`: GroupClusters will sort clusters by score and availableReplica count.
```

