### PR TITLE
Skip generating proto for kubernetes apis in vendor

### DIFF
--- a/hack/update-estimator-protobuf.sh
+++ b/hack/update-estimator-protobuf.sh
@@ -59,12 +59,12 @@ PACKAGES=(
 )
 
 APIMACHINERY_PKGS=(
-  +k8s.io/apimachinery/pkg/util/intstr
-  +k8s.io/apimachinery/pkg/api/resource
-  +k8s.io/apimachinery/pkg/runtime/schema
-  +k8s.io/apimachinery/pkg/runtime
-  k8s.io/apimachinery/pkg/apis/meta/v1
-  k8s.io/api/core/v1
+  -k8s.io/apimachinery/pkg/util/intstr
+  -k8s.io/apimachinery/pkg/api/resource
+  -k8s.io/apimachinery/pkg/runtime/schema
+  -k8s.io/apimachinery/pkg/runtime
+  -k8s.io/apimachinery/pkg/apis/meta/v1
+  -k8s.io/api/core/v1
 )
 
 go-to-protobuf \
@@ -72,10 +72,7 @@ go-to-protobuf \
   --apimachinery-packages=$(IFS=, ; echo "${APIMACHINERY_PKGS[*]}") \
   --packages=$(IFS=, ; echo "${PACKAGES[*]}") \
   --proto-import="${KARMADA_ROOT}/vendor" \
-  --proto-import="${KARMADA_ROOT}/third_party/protobuf"
+  --proto-import="${KARMADA_ROOT}/third_party/protobuf" \
+  --output-base="${GOPATH}/src"
 
 go generate ./pkg/estimator/service
-
-# The `go-to-protobuf` tool will modify all import proto files in vendor, so we should use go mod vendor to prevent.
-export GOPATH=${DEFAULT_GOPATH}
-go mod vendor


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Skip generates proto files in vendor.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

As per the help of `--apimachinery-packages`, directories prefixed with `-` are not generated:
```
--apimachinery-packages string     comma-separated list of directories to get apimachinery input types from which are needed by any API. Directories prefixed with '-' are not generated, directories prefixed with '+' only create types with explicit IDL instructions. (default "+k8s.io/apimachinery/pkg/util/intstr,+k8s.io/apimachinery/pkg/api/resource,+k8s.io/apimachinery/pkg/runtime/schema,+k8s.io/apimachinery/pkg/runtime,k8s.io/apimachinery/pkg/apis/meta/v1,k8s.io/apimachinery/pkg/apis/meta/v1beta1,k8s.io/apimachinery/pkg/apis/testapigroup/v1")

```
**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

