### PR TITLE
fix: update scheduler estimator cache when cluster changed

### DIFF
--- a/pkg/descheduler/descheduler_test.go
+++ b/pkg/descheduler/descheduler_test.go
@@ -505,7 +505,7 @@ func TestDescheduler_worker(t *testing.T) {
 					mock.MatchedBy(func(context.Context) bool { return true }),
 					mock.MatchedBy(func(in *pb.UnschedulableReplicasRequest) bool { return in.Cluster == cluster.Name }),
 				).Return(mockResultFn, nil)
-				desched.schedulerEstimatorCache.AddCluster(cluster.Name, nil, mockClient)
+				desched.schedulerEstimatorCache.AddOrUpdateCluster(cluster.Name, nil, mockClient)
 			}
 
 			desched.informerFactory.Start(ctx.Done())


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
fix: update scheduler estimator cache when cluster changed

Currently, when a cluster update occurs, if the cache already contains a clientWrapper for the corresponding cluster, the cache data will not be updated. This issue needs to be fixed.
**Which issue(s) this PR fixes**:
Fixes #5152 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

