### PR TITLE
Transplant propagation policy finalizer to karmada-webhook

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -980,16 +980,6 @@ func (d *ResourceDetector) ReconcilePropagationPolicy(key util.QueueKey) error {
 		return nil
 	}
 
-	// TODO(whitewindmills): In order to adapt to the upgrade scenario, we temporarily add finalizer here.
-	// Transplant it to karmada-webhook in the next release. More info: https://github.com/karmada-io/karmada/pull/4836#discussion_r1568186728.
-	if controllerutil.AddFinalizer(propagationObject, util.PropagationPolicyControllerFinalizer) {
-		if err = d.Client.Update(context.TODO(), propagationObject); err != nil {
-			klog.Errorf("Failed to add finalizer for PropagationPolicy(%s), err: %v", ckey.NamespaceKey(), err)
-			return err
-		}
-		return nil
-	}
-
 	klog.Infof("PropagationPolicy(%s) has been added or updated.", ckey.NamespaceKey())
 	return d.HandlePropagationPolicyCreationOrUpdate(propagationObject)
 }
@@ -1088,16 +1078,6 @@ func (d *ResourceDetector) ReconcileClusterPropagationPolicy(key util.QueueKey) 
 				klog.Errorf("Failed to remove finalizer for ClusterPropagationPolicy(%s), err: %v", ckey.NamespaceKey(), err)
 				return err
 			}
-		}
-		return nil
-	}
-
-	// TODO(whitewindmills): In order to adapt to the upgrade scenario, we temporarily add finalizer here.
-	// Transplant it to karmada-webhook in the next release. More info: https://github.com/karmada-io/karmada/pull/4836#discussion_r1568186728.
-	if controllerutil.AddFinalizer(propagationObject, util.ClusterPropagationPolicyControllerFinalizer) {
-		if err = d.Client.Update(context.TODO(), propagationObject); err != nil {
-			klog.Errorf("Failed to add finalizer for ClusterPropagationPolicy(%s), err: %v", ckey.NamespaceKey(), err)
-			return err
 		}
 		return nil
 	}

--- a/pkg/webhook/clusterpropagationpolicy/mutating.go
+++ b/pkg/webhook/clusterpropagationpolicy/mutating.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/uuid"
 	admissionv1 "k8s.io/api/admission/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
@@ -85,6 +86,7 @@ func (a *MutatingAdmission) Handle(_ context.Context, req admission.Request) adm
 
 	if req.Operation == admissionv1.Create {
 		util.MergeLabel(policy, policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel, uuid.New().String())
+		controllerutil.AddFinalizer(policy, util.ClusterPropagationPolicyControllerFinalizer)
 	}
 
 	marshaledBytes, err := json.Marshal(policy)

--- a/pkg/webhook/propagationpolicy/mutating.go
+++ b/pkg/webhook/propagationpolicy/mutating.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/uuid"
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
@@ -97,6 +98,7 @@ func (a *MutatingAdmission) Handle(_ context.Context, req admission.Request) adm
 
 	if req.Operation == admissionv1.Create {
 		util.MergeLabel(policy, policyv1alpha1.PropagationPolicyPermanentIDLabel, uuid.New().String())
+		controllerutil.AddFinalizer(policy, util.PropagationPolicyControllerFinalizer)
 	}
 
 	marshaledBytes, err := json.Marshal(policy)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
we need to transplant this finalizer to karmada-webhook in v1.11 release.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

