### PR TITLE
Fix mockgen generated files not group imports issue

### DIFF
--- a/hack/update-import-aliases.sh
+++ b/hack/update-import-aliases.sh
@@ -22,7 +22,7 @@ SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${SCRIPT_ROOT}"
 ROOT_PATH=$(pwd)
 
-GO111MODULE=on go install "golang.org/x/tools/cmd/goimports@v0.1.5"
+GO111MODULE=on go install "golang.org/x/tools/cmd/goimports"
 
 IMPORT_ALIASES_PATH="${ROOT_PATH}/hack/.import-aliases"
 INCLUDE_PATH="(${ROOT_PATH}/cmd|${ROOT_PATH}/test/e2e|${ROOT_PATH}/test/helper|\

--- a/hack/update-mocks.sh
+++ b/hack/update-mocks.sh
@@ -30,10 +30,15 @@ trap EXIT
 
 echo 'installing mockgen'
 source "${KARMADA_ROOT}"/hack/util.sh
-echo -n "Preparing: 'mockgen' existence check - "
+echo "Preparing: 'mockgen' existence check - "
 if [ ! $(util::cmd_exist mockgen) ]; then
   # install from vendor with the pinned version in go.mod file
   GO111MODULE=on go install "go.uber.org/mock/mockgen"
+fi
+echo "Preparing: 'goimports' existence check - "
+if [ ! $(util::cmd_exist goimports) ]; then
+  # install from vendor with the pinned version in go.mod file
+  GO111MODULE=on go install "golang.org/x/tools/cmd/goimports"
 fi
 
 find_files() {

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -14,7 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Given mockgen does not group imports according to our project's conventions.
+// Following the mockgen command, we run 'goimports', which reformats the
+// generated file to ensure that all imports are properly grouped and sorted,
+// maintaining consistency with the rest of our codebase.
 //go:generate mockgen -source=interface.go -destination=testing/mock_interface.go -package=testing FilterPlugin ScorePlugin ScoreExtensions
+//go:generate goimports -local "github.com/karmada-io/karmada" -w testing/mock_interface.go
 
 package framework
 

--- a/pkg/scheduler/framework/testing/mock_interface.go
+++ b/pkg/scheduler/framework/testing/mock_interface.go
@@ -13,10 +13,11 @@ import (
 	context "context"
 	reflect "reflect"
 
+	gomock "go.uber.org/mock/gomock"
+
 	v1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	v1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	framework "github.com/karmada-io/karmada/pkg/scheduler/framework"
-	gomock "go.uber.org/mock/gomock"
 )
 
 // MockFramework is a mock of Framework interface.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes the generated file doesn't group imports(`gomock "go.uber.org/mock/gomock"`) issue.
https://github.com/karmada-io/karmada/blob/8a101ebcb7c798a440153a3243f4992d87bad5db/pkg/scheduler/framework/testing/mock_interface.go#L12-L19

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

