### PR TITLE
cleanup: use patches instead to patchesStrategicMerge for kustomize.

### DIFF
--- a/charts/karmada/_crds/kustomization.yaml
+++ b/charts/karmada/_crds/kustomization.yaml
@@ -18,6 +18,6 @@ resources:
 - bases/remedy/remedy.karmada.io_remedies.yaml
 - bases/apps/apps.karmada.io_workloadrebalancers.yaml
 
-patchesStrategicMerge:
-- patches/webhook_in_resourcebindings.yaml
-- patches/webhook_in_clusterresourcebindings.yaml
+patches:
+- path: patches/webhook_in_resourcebindings.yaml
+- path: patches/webhook_in_clusterresourcebindings.yaml


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind cleanup
**What this PR does / why we need it**:

patchesStrategicMerge is deprecated, following the warning message to run command of `kustomize edit fix` for update it.

```shell
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

