### PR TITLE
Add more columns for cluster

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -17,6 +17,7 @@ limitations under the License.
 package internalversion
 
 import (
+	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +36,11 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Mode", Type: "string", Description: "SyncMode describes how a cluster sync resources from karmada control plane."},
 		{Name: "Ready", Type: "string", Description: "The aggregate readiness state of this cluster for accepting workloads."},
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
-		{Name: "APIEndpoint", Type: "string", Priority: 1, Description: "The API endpoint of the member cluster."},
+		{Name: "Zones", Type: "string", Priority: 1, Description: "Zones represents the failure zones(also called availability zones) of the member cluster. The zones are presented as a slice to support the case that cluster runs across multiple failure zones."},
+		{Name: "Region", Type: "string", Priority: 1, Description: "Region represents the region of the member cluster locate in."},
+		{Name: "Provider", Type: "string", Priority: 1, Description: "Provider represents the cloud provider name of the member cluster."},
+		{Name: "API-Endpoint", Type: "string", Priority: 1, Description: "The API endpoint of the member cluster."},
+		{Name: "Proxy-URL", Type: "string", Priority: 1, Description: "ProxyURL is the proxy URL for the cluster."},
 	}
 	// ignore errors because we enable errcheck golangci-lint.
 	_ = h.TableHandler(clusterColumnDefinitions, printClusterList)
@@ -74,7 +79,13 @@ func printCluster(cluster *clusterapis.Cluster, options printers.GenerateOptions
 		ready,
 		translateTimestampSince(cluster.CreationTimestamp))
 	if options.Wide {
-		row.Cells = append(row.Cells, cluster.Spec.APIEndpoint)
+		row.Cells = append(
+			row.Cells,
+			translateZones(cluster.Spec.Zones),
+			translateOptionalStringField(cluster.Spec.Region),
+			translateOptionalStringField(cluster.Spec.Provider),
+			cluster.Spec.APIEndpoint,
+			translateOptionalStringField(cluster.Spec.ProxyURL))
 	}
 	return []metav1.TableRow{row}, nil
 }
@@ -87,4 +98,20 @@ func translateTimestampSince(timestamp metav1.Time) string {
 	}
 
 	return duration.HumanDuration(time.Since(timestamp.Time))
+}
+
+func translateOptionalStringField(field string) string {
+	if len(field) == 0 {
+		return "<none>"
+	}
+
+	return field
+}
+
+func translateZones(zones []string) string {
+	if len(zones) == 0 {
+		return "<none>"
+	}
+
+	return strings.Join(zones, ",")
 }

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -56,6 +56,8 @@ func TestPrintCluster(t *testing.T) {
 				Spec: clusterapis.ClusterSpec{
 					SyncMode:    clusterapis.Push,
 					APIEndpoint: "https://kubernetes.default.svc.cluster.local:6443",
+					ProxyURL:    "https://anp-server.default.svc.cluster.local:443",
+					Zones:       []string{"foo", "bar"},
 				},
 				Status: clusterapis.ClusterStatus{
 					KubernetesVersion: "1.24.2",
@@ -65,7 +67,12 @@ func TestPrintCluster(t *testing.T) {
 				},
 			},
 			printers.GenerateOptions{Wide: true},
-			[]metav1.TableRow{{Cells: []interface{}{"test2", "1.24.2", clusterapis.ClusterSyncMode("Push"), "True", "<unknown>", "https://kubernetes.default.svc.cluster.local:6443"}}},
+			[]metav1.TableRow{{Cells: []interface{}{"test2", "1.24.2", clusterapis.ClusterSyncMode("Push"), "True", "<unknown>",
+				"foo,bar",
+				"<none>",
+				"<none>",
+				"https://kubernetes.default.svc.cluster.local:6443",
+				"https://anp-server.default.svc.cluster.local:443"}}},
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
In daily operation and maintenance, the command `kubectl get cluster xxx -owide` displays too little information, and usually the administrator need to view it through `kubectl get cluster xxx -oyaml`.
Therefore, in order to improve operation and maintenance efficiency, this PR prints more valuable fields.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Test result:
```shell
[root@whitewindmills ~]# kubectl --kubeconfig karmada.config get cluster -owide
NAME          VERSION                           MODE   READY   AGE   ZONES    REGION    PROVIDER   API-ENDPOINT                          PROXY-URL
member1       v1.25.8-79+a42148b1deb54e-dirty   Pull   True    18h   foo,bar  default   <none>     https://api.member1.sam.cn:6443       https://anp.member1.sam.cn:443

```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

