### PR TITLE
Align federated DaemonSet's observedGeneration semantics with its native

### DIFF
--- a/pkg/resourceinterpreter/default/native/reflectstatus.go
+++ b/pkg/resourceinterpreter/default/native/reflectstatus.go
@@ -78,8 +78,10 @@ func reflectDeploymentStatus(object *unstructured.Unstructured) (*runtime.RawExt
 	}
 
 	grabStatus := &WrappedDeploymentStatus{
-		Generation:                 object.GetGeneration(),
-		ResourceTemplateGeneration: resourceTemplateGenerationInt,
+		FederatedGeneration: FederatedGeneration{
+			Generation:                 object.GetGeneration(),
+			ResourceTemplateGeneration: resourceTemplateGenerationInt,
+		},
 		DeploymentStatus: appsv1.DeploymentStatus{
 			Replicas:            deploymentStatus.Replicas,
 			UpdatedReplicas:     deploymentStatus.UpdatedReplicas,
@@ -194,15 +196,31 @@ func reflectDaemonSetStatus(object *unstructured.Unstructured) (*runtime.RawExte
 		return nil, fmt.Errorf("failed to convert DaemonSetStatus from map[string]interface{}: %v", err)
 	}
 
-	grabStatus := appsv1.DaemonSetStatus{
-		CurrentNumberScheduled: daemonSetStatus.CurrentNumberScheduled,
-		DesiredNumberScheduled: daemonSetStatus.DesiredNumberScheduled,
-		NumberAvailable:        daemonSetStatus.NumberAvailable,
-		NumberMisscheduled:     daemonSetStatus.NumberMisscheduled,
-		NumberReady:            daemonSetStatus.NumberReady,
-		UpdatedNumberScheduled: daemonSetStatus.UpdatedNumberScheduled,
-		NumberUnavailable:      daemonSetStatus.NumberUnavailable,
+	resourceTemplateGenerationInt := int64(0)
+	resourceTemplateGenerationStr := util.GetAnnotationValue(object.GetAnnotations(), v1alpha2.ResourceTemplateGenerationAnnotationKey)
+	err = runtime.Convert_string_To_int64(&resourceTemplateGenerationStr, &resourceTemplateGenerationInt, nil)
+	if err != nil {
+		klog.Errorf("Failed to parse DaemonSet(%s/%s) generation from annotation(%s:%s): %v", object.GetNamespace(), object.GetName(), v1alpha2.ResourceTemplateGenerationAnnotationKey, resourceTemplateGenerationStr, err)
+		return nil, err
 	}
+
+	grabStatus := &WrappedDaemonSetStatus{
+		FederatedGeneration: FederatedGeneration{
+			Generation:                 object.GetGeneration(),
+			ResourceTemplateGeneration: resourceTemplateGenerationInt,
+		},
+		DaemonSetStatus: appsv1.DaemonSetStatus{
+			CurrentNumberScheduled: daemonSetStatus.CurrentNumberScheduled,
+			DesiredNumberScheduled: daemonSetStatus.DesiredNumberScheduled,
+			NumberAvailable:        daemonSetStatus.NumberAvailable,
+			NumberMisscheduled:     daemonSetStatus.NumberMisscheduled,
+			NumberReady:            daemonSetStatus.NumberReady,
+			UpdatedNumberScheduled: daemonSetStatus.UpdatedNumberScheduled,
+			NumberUnavailable:      daemonSetStatus.NumberUnavailable,
+			ObservedGeneration:     daemonSetStatus.ObservedGeneration,
+		},
+	}
+
 	return helper.BuildStatusRawExtension(grabStatus)
 }
 

--- a/pkg/resourceinterpreter/default/native/status_type.go
+++ b/pkg/resourceinterpreter/default/native/status_type.go
@@ -18,13 +18,24 @@ package native
 
 import appsv1 "k8s.io/api/apps/v1"
 
-// WrappedDeploymentStatus is a wrapper for appsv1.DeploymentStatus.
-type WrappedDeploymentStatus struct {
-	appsv1.DeploymentStatus `json:",inline"`
-
+// FederatedGeneration holds the generation of the same resource in the member cluster and the Karmada control plane.
+type FederatedGeneration struct {
 	// Generation holds the generation(.metadata.generation) of resource running on member cluster.
 	Generation int64 `json:"generation,omitempty"`
+
 	// ResourceTemplateGeneration holds the value of annotation resourcetemplate.karmada.io/generation grabbed
 	// from resource running on member cluster.
 	ResourceTemplateGeneration int64 `json:"resourceTemplateGeneration,omitempty"`
+}
+
+// WrappedDeploymentStatus is a wrapper for appsv1.DeploymentStatus.
+type WrappedDeploymentStatus struct {
+	FederatedGeneration     `json:",inline"`
+	appsv1.DeploymentStatus `json:",inline"`
+}
+
+// WrappedDaemonSetStatus is a wrapper for appsv1.DaemonSetStatus.
+type WrappedDaemonSetStatus struct {
+	FederatedGeneration    `json:",inline"`
+	appsv1.DaemonSetStatus `json:",inline"`
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
part of #4870

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Mark `.status.observedGeneration` of DaemonSet with `.metadata.generation` only when all members' statuses are algined with its resource template generation.
```

