### PR TITLE
Align federated daemonsets.apps.kruise.io observedGeneration semantics with its native

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/customizations.yaml
@@ -10,24 +10,45 @@ spec:
     statusAggregation:
       luaScript: >
         function AggregateStatus(desiredObj, statusItems)
-          if statusItems == nil then
-            return desiredObj
-          end
           if desiredObj.status == nil then
             desiredObj.status = {}
           end
           if desiredObj.metadata.generation == nil then
             desiredObj.metadata.generation = 0
           end
-          generation = desiredObj.metadata.generation
-          currentNumberScheduled = 0
-          numberMisscheduled = 0 
-          desiredNumberScheduled = 0
-          numberReady = 0
-          updatedNumberScheduled = 0
-          numberAvailable = 0
-          numberUnavailable = 0
-          daemonSetHash = 0
+        
+          if desiredObj.status.observedGeneration == nil then
+            desiredObj.status.observedGeneration = 0
+          end
+
+          -- Initialize status fields if status doest not exist
+          -- If the DaemonSet is not spread to any cluster, its status also should be aggregated
+          if statusItems == nil then
+            desiredObj.status.observedGeneration = desiredObj.metadata.generation 
+            desiredObj.status.currentNumberScheduled = 0
+            desiredObj.status.numberMisscheduled = 0
+            desiredObj.status.desiredNumberScheduled = 0
+            desiredObj.status.numberReady = 0
+            desiredObj.status.updatedNumberScheduled = 0
+            desiredObj.status.numberAvailable = 0
+            desiredObj.status.numberUnavailable = 0
+            desiredObj.status.daemonSetHash = 0
+            return desiredObj
+          end
+
+          local generation = desiredObj.metadata.generation
+          local observedGeneration = desiredObj.status.observedGeneration
+          local currentNumberScheduled = 0
+          local numberMisscheduled = 0 
+          local desiredNumberScheduled = 0
+          local numberReady = 0
+          local updatedNumberScheduled = 0
+          local numberAvailable = 0
+          local numberUnavailable = 0
+          local daemonSetHash = 0
+
+          -- Count all members that their status is updated to the latest generation
+          local observedResourceTemplateGenerationCount = 0
           for i = 1, #statusItems do
             if statusItems[i].status ~= nil and statusItems[i].status.currentNumberScheduled ~= nil then
               currentNumberScheduled = currentNumberScheduled + statusItems[i].status.currentNumberScheduled
@@ -50,14 +71,35 @@ spec:
             if statusItems[i].status ~= nil and statusItems[i].status.numberUnavailable ~= nil then
               numberUnavailable = numberUnavailable + statusItems[i].status.numberUnavailable
             end
-            if statusItems[i].status ~= nil and statusItems[i].status.observedGeneration ~= nil and statusItems[i].status.observedGeneration ~= '' then
-              generation = statusItems[i].status.observedGeneration
-            end
             if statusItems[i].status ~= nil and statusItems[i].status.daemonSetHash ~= nil and statusItems[i].status.daemonSetHash ~= '' then
               daemonSetHash = statusItems[i].status.daemonSetHash
             end
+
+            -- Check if the member's status is updated to the latest generation
+            local resourceTemplateGeneration = 0
+            if statusItems[i].status ~= nil and statusItems[i].status.resourceTemplateGeneration ~= nil then 
+              resourceTemplateGeneration = statusItems[i].status.resourceTemplateGeneration
+            end
+            local memberGeneration = 0
+            if statusItems[i].status ~= nil and statusItems[i].status.generation ~= nil then
+              memberGeneration = statusItems[i].status.generation
+            end
+            local memberObservedGeneration = 0
+            if statusItems[i].status ~= nil and statusItems[i].status.observedGeneration ~= nil then
+              memberObservedGeneration = statusItems[i].status.observedGeneration
+            end
+            if resourceTemplateGeneration == generation and memberGeneration == memberObservedGeneration then
+              observedResourceTemplateGenerationCount = observedResourceTemplateGenerationCount + 1
+            end
           end
-          desiredObj.status.observedGeneration = generation
+
+          -- Update the observed generation based on the observedResourceTemplateGenerationCount
+          if observedResourceTemplateGenerationCount == #statusItems then
+            desiredObj.status.observedGeneration = generation
+          else
+            desiredObj.status.observedGeneration = observedGeneration 
+          end
+
           desiredObj.status.currentNumberScheduled = currentNumberScheduled
           desiredObj.status.numberMisscheduled = numberMisscheduled
           desiredObj.status.desiredNumberScheduled = desiredNumberScheduled
@@ -70,9 +112,9 @@ spec:
         end
     statusReflection:
       luaScript: >
-        function ReflectStatus (observedObj)
-          status = {}
-          if observedObj == nil or observedObj.status == nil then 
+        function ReflectStatus(observedObj)
+          local status = {}
+          if observedObj == nil or observedObj.status == nil then
             return status
           end
           status.observedGeneration = observedObj.status.observedGeneration
@@ -84,6 +126,21 @@ spec:
           status.numberAvailable = observedObj.status.numberAvailable
           status.numberUnavailable = observedObj.status.numberUnavailable
           status.daemonSetHash = observedObj.status.daemonSetHash
+
+          -- handle member resource generation report
+          if observedObj.metadata == nil then
+            return status
+          end
+          status.generation = observedObj.metadata.generation
+
+          -- handle resource template generation report
+          if observedObj.metadata.annotations == nil then
+            return status
+          end
+          local resourceTemplateGeneration = tonumber(observedObj.metadata.annotations["resourcetemplate.karmada.io/generation"])
+          if resourceTemplateGeneration ~= nil then
+            status.resourceTemplateGeneration = resourceTemplateGeneration
+          end
           return status
         end
     healthInterpretation:

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/testdata/desired-daemonset-nginx.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/testdata/desired-daemonset-nginx.yaml
@@ -5,6 +5,7 @@ metadata:
     app: sample-daemonset
   name: sample
   namespace: test-kruise-daemonset
+  generation: 1
 spec:
   selector:
     matchLabels:

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/testdata/observed-daemonset-nginx.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/testdata/observed-daemonset-nginx.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps.kruise.io/v1alpha1
 kind: DaemonSet
 metadata:
+  annotations:
+    resourcetemplate.karmada.io/generation: "1"
   labels:
     app: sample-daemonset
   name: sample

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/testdata/status-file.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/testdata/status-file.yaml
@@ -10,6 +10,8 @@ status:
   numberReady: 1
   observedGeneration: 1
   updatedNumberScheduled: 1
+  generation: 1
+  resourceTemplateGeneration: 1
 ---
 applied: true
 clusterName: member3
@@ -23,3 +25,5 @@ status:
   numberReady: 1
   observedGeneration: 1
   updatedNumberScheduled: 1
+  generation: 1
+  resourceTemplateGeneration: 1


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
part of https://github.com/karmada-io/karmada/issues/4870

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Mark `.status.observedGeneration` of daemonsets.apps.kruise.io with `.metadata.generation` only when all members' statuses are algined with its resource template generation.
```

