### PR TITLE
Add missing command line arguments for karmada-operator

### DIFF
--- a/operator/cmd/operator/app/operator.go
+++ b/operator/cmd/operator/app/operator.go
@@ -20,9 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"net"
 	"os"
-	"strconv"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -174,7 +172,7 @@ func createControllerManager(ctx context.Context, o *options.Options) (controlle
 		RenewDeadline:              &o.LeaderElection.RenewDeadline.Duration,
 		RetryPeriod:                &o.LeaderElection.RetryPeriod.Duration,
 		LeaderElectionResourceLock: o.LeaderElection.ResourceLock,
-		HealthProbeBindAddress:     net.JoinHostPort(o.BindAddress, strconv.Itoa(o.SecurePort)),
+		HealthProbeBindAddress:     o.HealthProbeBindAddress,
 		LivenessEndpointName:       "/healthz",
 		Metrics:                    metricsserver.Options{BindAddress: o.MetricsBindAddress},
 		Controller: config.Controller{

--- a/operator/cmd/operator/app/options/options.go
+++ b/operator/cmd/operator/app/options/options.go
@@ -39,11 +39,6 @@ type Options struct {
 	Controllers []string
 	// LeaderElection defines the configuration of leader election client.
 	LeaderElection componentbaseconfig.LeaderElectionConfiguration
-	// BindAddress is the IP address on which to listen for the --secure-port port.
-	BindAddress string
-	// SecurePort is the port that the the server serves at.
-	// Note: We hope support https in the future once controller-runtime provides the functionality.
-	SecurePort int
 	// KubeAPIQPS is the QPS to use while talking with karmada-apiserver.
 	KubeAPIQPS float32
 	// KubeAPIBurst is the burst to allow while talking with karmada-apiserver.
@@ -56,6 +51,10 @@ type Options struct {
 	// It can be set to "0" to disable the metrics serving.
 	// Defaults to ":8080".
 	MetricsBindAddress string
+	// HealthProbeBindAddress is the TCP address that the controller should bind to
+	// for serving health probes
+	// It can be set to "0" or "" to disable serving the health probe.
+	HealthProbeBindAddress string
 	// ConcurrentKarmadaSyncs is the number of karmada objects that are allowed to sync concurrently.
 	ConcurrentKarmadaSyncs int
 }
@@ -73,8 +72,6 @@ func NewOptions() *Options {
 			ResourceNamespace: "karmada-system",
 			ResourceName:      "karmada-operator",
 		},
-		BindAddress:            "0.0.0.0",
-		SecurePort:             8443,
 		KubeAPIQPS:             50,
 		KubeAPIBurst:           100,
 		ConcurrentKarmadaSyncs: 5,
@@ -84,6 +81,8 @@ func NewOptions() *Options {
 
 // AddFlags adds flags to the specified FlagSet.
 func (o *Options) AddFlags(fs *pflag.FlagSet, allControllers []string, disabledByDefaultControllers []string) {
+	fs.StringVar(&o.MetricsBindAddress, "metrics-bind-address", ":8080", "The TCP address that the controller should bind to for serving prometheus metrics(e.g. 127.0.0.1:8080, :8080). It can be set to \"0\" to disable the metrics serving.")
+	fs.StringVar(&o.HealthProbeBindAddress, "health-probe-bind-address", ":8443", "The TCP address that the controller should bind to for serving health probes(e.g. 127.0.0.1:8443, :8443). It can be set to \"0\" or \"\" to disable serving the health probe.")
 	fs.DurationVar(&o.ResyncPeriod.Duration, "resync-period", o.ResyncPeriod.Duration, "ResyncPeriod determines the minimum frequency at which watched resources are reconciled.")
 	fs.Float32Var(&o.KubeAPIQPS, "kube-api-qps", o.KubeAPIQPS, "QPS to use while talking with kubernetes apiserver.")
 	fs.Int32Var(&o.KubeAPIBurst, "kube-api-burst", o.KubeAPIBurst, "Burst to use while talking with kubernetes apiserver.")


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-operator`: Introduced `--metrics-bind-address` and `--health-probe-bind-address` flags, it's a compatible change as the default value does not change from previous versions. 
```

