### PR TITLE
Adopt deprecated AddToScheme functions

### DIFF
--- a/pkg/apis/cluster/install/install.go
+++ b/pkg/apis/cluster/install/install.go
@@ -18,6 +18,7 @@ package install
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/karmada-io/karmada/pkg/apis/cluster"
@@ -27,6 +28,6 @@ import (
 // Install registers the API group and adds types to a scheme.
 func Install(scheme *runtime.Scheme) {
 	utilruntime.Must(cluster.AddToScheme(scheme))
-	utilruntime.Must(clusterv1alpha1.AddToScheme(scheme))
-	utilruntime.Must(scheme.SetVersionPriority(clusterv1alpha1.SchemeGroupVersion))
+	utilruntime.Must(clusterv1alpha1.Install(scheme))
+	utilruntime.Must(scheme.SetVersionPriority(schema.GroupVersion{Group: clusterv1alpha1.GroupVersion.Group, Version: clusterv1alpha1.GroupVersion.Version}))
 }

--- a/pkg/apis/search/install/install.go
+++ b/pkg/apis/search/install/install.go
@@ -18,6 +18,7 @@ package install
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/karmada-io/karmada/pkg/apis/search"
@@ -27,6 +28,6 @@ import (
 // Install registers the API group and adds types to a scheme.
 func Install(scheme *runtime.Scheme) {
 	utilruntime.Must(search.AddToScheme(scheme))
-	utilruntime.Must(searchv1alpha1.AddToScheme(scheme))
-	utilruntime.Must(scheme.SetVersionPriority(searchv1alpha1.SchemeGroupVersion))
+	utilruntime.Must(searchv1alpha1.Install(scheme))
+	utilruntime.Must(scheme.SetVersionPriority(schema.GroupVersion{Group: searchv1alpha1.GroupVersion.Group, Version: searchv1alpha1.GroupVersion.Version}))
 }

--- a/pkg/resourceinterpreter/customized/webhook/customized.go
+++ b/pkg/resourceinterpreter/customized/webhook/customized.go
@@ -53,8 +53,13 @@ type CustomizedInterpreter struct {
 // NewCustomizedInterpreter return a new CustomizedInterpreter.
 func NewCustomizedInterpreter(informer genericmanager.SingleClusterInformerManager, serviceLister corev1.ServiceLister) (*CustomizedInterpreter, error) {
 	cm, err := webhookutil.NewClientManager(
-		[]schema.GroupVersion{configv1alpha1.SchemeGroupVersion},
-		configv1alpha1.AddToScheme,
+		[]schema.GroupVersion{
+			{
+				Group:   configv1alpha1.GroupVersion.Group,
+				Version: configv1alpha1.GroupVersion.Version,
+			},
+		},
+		configv1alpha1.Install,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/util/gclient/gclient.go
+++ b/pkg/util/gclient/gclient.go
@@ -41,19 +41,19 @@ import (
 var aggregatedScheme = runtime.NewScheme()
 
 func init() {
-	utilruntime.Must(scheme.AddToScheme(aggregatedScheme))              // add Kubernetes schemes
-	utilruntime.Must(clusterv1alpha1.AddToScheme(aggregatedScheme))     // add cluster schemes
-	utilruntime.Must(configv1alpha1.AddToScheme(aggregatedScheme))      // add config v1alpha1 schemes
-	utilruntime.Must(networkingv1alpha1.AddToScheme(aggregatedScheme))  // add network v1alpha1 schemes
-	utilruntime.Must(policyv1alpha1.AddToScheme(aggregatedScheme))      // add propagation schemes
-	utilruntime.Must(workv1alpha1.AddToScheme(aggregatedScheme))        // add work v1alpha1 schemes
-	utilruntime.Must(workv1alpha2.AddToScheme(aggregatedScheme))        // add work v1alpha2 schemes
-	utilruntime.Must(searchv1alpha1.AddToScheme(aggregatedScheme))      // add search v1alpha1 schemes
-	utilruntime.Must(mcsv1alpha1.AddToScheme(aggregatedScheme))         // add mcs-api schemes
-	utilruntime.Must(clusterapiv1beta1.AddToScheme(aggregatedScheme))   // add cluster-api v1beta1 schemes
-	utilruntime.Must(autoscalingv1alpha1.AddToScheme(aggregatedScheme)) // add autoscaling v1alpha1 schemes
-	utilruntime.Must(remedyv1alpha1.AddToScheme(aggregatedScheme))      // add remedy v1alpha1 schemes
-	utilruntime.Must(appsv1alpha1.AddToScheme(aggregatedScheme))        // add apps v1alpha1 schemes
+	utilruntime.Must(scheme.AddToScheme(aggregatedScheme))            // add Kubernetes schemes
+	utilruntime.Must(clusterv1alpha1.Install(aggregatedScheme))       // add cluster schemes
+	utilruntime.Must(configv1alpha1.Install(aggregatedScheme))        // add config v1alpha1 schemes
+	utilruntime.Must(networkingv1alpha1.Install(aggregatedScheme))    // add network v1alpha1 schemes
+	utilruntime.Must(policyv1alpha1.Install(aggregatedScheme))        // add propagation schemes
+	utilruntime.Must(workv1alpha1.Install(aggregatedScheme))          // add work v1alpha1 schemes
+	utilruntime.Must(workv1alpha2.Install(aggregatedScheme))          // add work v1alpha2 schemes
+	utilruntime.Must(searchv1alpha1.Install(aggregatedScheme))        // add search v1alpha1 schemes
+	utilruntime.Must(mcsv1alpha1.Install(aggregatedScheme))           // add mcs-api schemes
+	utilruntime.Must(autoscalingv1alpha1.Install(aggregatedScheme))   // add autoscaling v1alpha1 schemes
+	utilruntime.Must(remedyv1alpha1.Install(aggregatedScheme))        // add remedy v1alpha1 schemes
+	utilruntime.Must(appsv1alpha1.Install(aggregatedScheme))          // add apps v1alpha1 schemes
+	utilruntime.Must(clusterapiv1beta1.AddToScheme(aggregatedScheme)) // add cluster-api v1beta1 schemes
 }
 
 // NewSchema returns a singleton schema set which aggregated Kubernetes's schemes and extended schemes.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR adopts the deprecated `AddToScheme` and `SchemeGroupVersion`, which becomes the blocker of #5146.

```
# hack/verify-staticcheck.sh 
Using golangci-lint version:
golangci-lint has version 1.59.0 built with go1.22.3 from 2059b18a on 2024-05-26T18:13:27Z
pkg/apis/search/install/install.go:30:19: SA1019: searchv1alpha1.AddToScheme is deprecated: use Install instead (staticcheck)
	utilruntime.Must(searchv1alpha1.AddToScheme(scheme))
	                 ^
pkg/util/gclient/gclient.go:45:19: SA1019: clusterv1alpha1.AddToScheme is deprecated: use Install instead (staticcheck)
	utilruntime.Must(clusterv1alpha1.AddToScheme(aggregatedScheme))     // add cluster schemes
	                 ^
pkg/util/gclient/gclient.go:46:19: SA1019: configv1alpha1.AddToScheme is deprecated: use Install instead (staticcheck)
	utilruntime.Must(configv1alpha1.AddToScheme(aggregatedScheme))      // add config v1alpha1 schemes
	                 ^
pkg/util/gclient/gclient.go:47:19: SA1019: networkingv1alpha1.AddToScheme is deprecated: use Install instead (staticcheck)
	utilruntime.Must(networkingv1alpha1.AddToScheme(aggregatedScheme))  // add network v1alpha1 schemes
	                 ^
pkg/util/gclient/gclient.go:48:19: SA1019: policyv1alpha1.AddToScheme is deprecated: use Install instead (staticcheck)
	utilruntime.Must(policyv1alpha1.AddToScheme(aggregatedScheme))      // add propagation schemes
	                 ^
pkg/util/gclient/gclient.go:49:19: SA1019: workv1alpha1.AddToScheme is deprecated: use Install instead (staticcheck)
	utilruntime.Must(workv1alpha1.AddToScheme(aggregatedScheme))        // add work v1alpha1 schemes
	                 ^
pkg/util/gclient/gclient.go:50:19: SA1019: workv1alpha2.AddToScheme is deprecated: use Install instead (staticcheck)
	utilruntime.Must(workv1alpha2.AddToScheme(aggregatedScheme))        // add work v1alpha2 schemes
	                 ^
pkg/util/gclient/gclient.go:51:19: SA1019: searchv1alpha1.AddToScheme is deprecated: use Install instead (staticcheck)
	utilruntime.Must(searchv1alpha1.AddToScheme(aggregatedScheme))      // add search v1alpha1 schemes
	                 ^
pkg/util/gclient/gclient.go:54:19: SA1019: autoscalingv1alpha1.AddToScheme is deprecated: use Install instead (staticcheck)
	utilruntime.Must(autoscalingv1alpha1.AddToScheme(aggregatedScheme)) // add autoscaling v1alpha1 schemes
	                 ^
pkg/util/gclient/gclient.go:55:19: SA1019: remedyv1alpha1.AddToScheme is deprecated: use Install instead (staticcheck)
	utilruntime.Must(remedyv1alpha1.AddToScheme(aggregatedScheme))      // add remedy v1alpha1 schemes
	                 ^
pkg/util/gclient/gclient.go:56:19: SA1019: appsv1alpha1.AddToScheme is deprecated: use Install instead (staticcheck)
	utilruntime.Must(appsv1alpha1.AddToScheme(aggregatedScheme))        // add apps v1alpha1 schemes
	                 ^
pkg/apis/cluster/install/install.go:30:19: SA1019: clusterv1alpha1.AddToScheme is deprecated: use Install instead (staticcheck)
	utilruntime.Must(clusterv1alpha1.AddToScheme(scheme))
	                 ^
pkg/resourceinterpreter/customized/webhook/customized.go:57:3: SA1019: configv1alpha1.AddToScheme is deprecated: use Install instead (staticcheck)
		configv1alpha1.AddToScheme,
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This is a kind of technical debt that I hope to do by a separate PR so that we can review it more carefully.
**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

