### PR TITLE
chore: add slsa provenance to release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,11 @@ jobs:
         GOOS: ${{ matrix.os }}
         GOARCH: ${{ matrix.arch }}
       run: make release-${{ matrix.target }}
-    - name: Making helm charts
-      env:
-        VERSION: ${{ github.ref_name }}
-      run: make package-chart
+    - name: upload cli
+      uses: actions/upload-artifact@v4
+      with:
+        name: cli-${{ matrix.target }}-${{ matrix.os }}-${{ matrix.arch }}.tgz
+        path: _output/release/${{ matrix.target }}-${{ matrix.os }}-${{ matrix.arch }}.tgz
     - name: Uploading assets...
       if: ${{ !env.ACT }}
       uses: softprops/action-gh-release@v2
@@ -44,10 +45,43 @@ jobs:
         files: |
           _output/release/${{ matrix.target }}-${{ matrix.os }}-${{ matrix.arch }}.tgz
           _output/release/${{ matrix.target }}-${{ matrix.os }}-${{ matrix.arch }}.tgz.sha256
+  generate-subject-for-cli-provenance:
+    needs: [release-assests]
+    runs-on: ubuntu-22.04
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+    steps:
+      - name: download cli
+        uses: actions/download-artifact@v4
+        with:
+          path: _output/release
+          pattern: cli-*
+          merge-multiple: true
+      - name: generate cli hash
+        id: hash
+        run: |
+          cd _output/release
+          # sha256sum generates sha256 hash for cli.
+          # base64 -w0 encodes to base64 and outputs on a single line.
+          echo "hashes=$(sha256sum *.tgz|base64 -w0)" >> "$GITHUB_OUTPUT"
+  cli-provenance:
+    needs: [generate-subject-for-cli-provenance]
+    permissions:
+      actions: read # for detecting the Github Actions environment
+      id-token: write # Needed for provenance signing and ID
+      contents: write #  Needed for release uploads
+    # Must be referenced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    with:
+      base64-subjects: "${{ needs.generate-subject-for-cli-provenance.outputs.hashes }}"
+      provenance-name: "karmada-cli.intoto.jsonl"
+      upload-assets: true
   release-crds-assests:
     permissions:
       contents: write  # for softprops/action-gh-release to create GitHub release
     name: release crds
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
@@ -61,15 +95,35 @@ jobs:
         cwd: ./charts/karmada/
         files: crds
         outPath: crds.tar.gz
+    - name: generate crds hash
+      id: hash
+      run: |
+        # sha256sum generates sha256 hash for crds.
+        # base64 -w0 encodes to base64 and outputs on a single line.
+        echo "hashes=$(sha256sum crds.tar.gz | base64 -w0)" >> "$GITHUB_OUTPUT"
     - name: Uploading crd assets...
       uses: softprops/action-gh-release@v2
       with:
         files: |
           crds.tar.gz
+  crds-provenance:
+    needs: [release-crds-assests]
+    permissions:
+      actions: read # for detecting the Github Actions environment
+      id-token: write # Needed for provenance signing and ID
+      contents: write #  Needed for release uploads
+    # Must be referenced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    with:
+      base64-subjects: "${{ needs.release-crds-assests.outputs.hashes }}"
+      provenance-name: "karmada-crds.intoto.jsonl"
+      upload-assets: true
   release-charts:
     permissions:
       contents: write  # for softprops/action-gh-release to create GitHub release
     name: Release charts
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
@@ -86,10 +140,29 @@ jobs:
           _output/charts/karmada-chart-${{ github.ref_name }}.tgz.sha256
           _output/charts/karmada-operator-chart-${{ github.ref_name }}.tgz
           _output/charts/karmada-operator-chart-${{ github.ref_name }}.tgz.sha256
+    - name: generate charts hash
+      id: hash
+      run: |
+        cd _output/charts
+        echo "hashes=$(sha256sum *.tgz|base64 -w0)" >> "$GITHUB_OUTPUT"
+  charts-provenance:
+    needs: [release-charts]
+    permissions:
+      actions: read # for detecting the Github Actions environment
+      id-token: write # Needed for provenance signing and ID
+      contents: write #  Needed for release uploads
+    # Must be referenced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    with:
+      base64-subjects: "${{ needs.release-charts.outputs.hashes }}"
+      provenance-name: "karmada-charts.intoto.jsonl"
+      upload-assets: true
   sbom-assests:
     permissions:
       contents: write  # for softprops/action-gh-release to create GitHub release
     name: Release sbom
+    outputs:
+      hashes: ${{ steps.sbom-hash.outputs.hashes}}
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
@@ -103,11 +176,30 @@ jobs:
     - name: Tar the sbom files
       run: |
         tar -zcf sbom.tar.gz *.spdx
+    - name: Generate SBOM hash
+      shell: bash
+      id: sbom-hash
+      run: |
+        # sha256sum generates sha256 hash for sbom.
+        # base64 -w0 encodes to base64 and outputs on a single line.
+        echo "hashes=$(sha256sum sbom.tar.gz | base64 -w0)" >> "$GITHUB_OUTPUT"
     - name: Uploading sbom assets...
       uses: softprops/action-gh-release@v2
       with:
         files: |
           sbom.tar.gz
+  sbom-provenance:
+    needs: [sbom-assests]
+    permissions:
+      actions: read # for detecting the Github Actions environment
+      id-token: write # Needed for provenance signing and ID
+      contents: write #  Needed for release uploads
+    # Must be referenced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    with:
+      base64-subjects: "${{ needs.sbom-assests.outputs.hashes }}"
+      provenance-name: "karmada-sbom.intoto.jsonl"
+      upload-assets: true
   update-krew-index:
     needs: release-assests
     name: Update krew-index


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
This PR includes the following two things in total:
- remove unused workflow step
https://github.com/karmada-io/karmada/blob/71de3dc02247e22da249c285fa0c0c032ae01445/.github/workflows/release.yml#L36-L39

- add slsa provenance to release assets
This PR will generate a non-forgeable attestation to the artifacts' digests using the identity of the GitHub workflow. This can be used to create a positive attestation to a software artifact coming from karmada repository.
That means that once karmada users verify the artifacts they have downloaded they can be sure that the artifacts were created by karmada repository's workflow and haven't been tampered with.
This time a total of four slsa provenance are introduced as follows:
  1. karmada-charts.intoto.jsonl # used to verify charts artifact
  2. karmada-cli.intoto.jsonl # used to verify karmada cli artifacts
  3. karmada-crds.intoto.jsonl # used to verify crds artifact
  4. karmada-sbom.intoto.jsonl # used to verify sbom artifact

How to use them:
take `karmada-cli.intoto.jsonl` as example:
Attestation `karmada-cli.intoto.jsonl` can be used with [slsa-verifier](https://github.com/slsa-framework/slsa-verifier#verification-for-github-builders) to verify that a CLI binary was generated using Karmada workflows on GitHub and ensures it was cryptographically signed.
```bash
# download `karmada-cli.intoto.jsonl`, `karmadactl-darwin-arm64.tgz ` and `kubectl-karmada-linux-arm64.tgz` from one of karmada's release assests.
$  fileCar slsa-verifier verify-artifact karmadactl-darwin-arm64.tgz \verify
  --provenance-path karmada-cli.intoto.jsonl \
  --source-uri github.com/karmada-io/karmada \
  --source-tag v1.10.0

$  fileCar slsa-verifier verify-artifact kubectl-karmada-linux-arm64.tgz \verify
  --provenance-path karmada-cli.intoto.jsonl \
  --source-uri github.com/karmada-io/karmada \
  --source-tag v1.10.0
```

**Which issue(s) this PR fixes**:
Parts of #5048

**Special notes for your reviewer**:
local test can refer to: https://github.com/zhzhuang-zju/karmada/actions/runs/9888187096
I will update the verification method to https://karmada.io/docs/administrator/security/verify-artifacts if this pr get merged and the next release version is released

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

