### PR TITLE
Automated cherry pick of #5144: GroupClusters should sort by score and availableReplica count

### DIFF
--- a/pkg/scheduler/core/spreadconstraint/group_clusters.go
+++ b/pkg/scheduler/core/spreadconstraint/group_clusters.go
@@ -17,6 +17,8 @@ limitations under the License.
 package spreadconstraint
 
 import (
+	"k8s.io/utils/ptr"
+
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
@@ -143,7 +145,12 @@ func (info *GroupClustersInfo) generateClustersInfo(clustersScore framework.Clus
 		info.Clusters[i].AvailableReplicas += int64(rbSpec.AssignedReplicasForCluster(clustersReplica.Name))
 	}
 
-	sortClusters(info.Clusters)
+	sortClusters(info.Clusters, func(i *ClusterDetailInfo, j *ClusterDetailInfo) *bool {
+		if i.AvailableReplicas != j.AvailableReplicas {
+			return ptr.To(i.AvailableReplicas > j.AvailableReplicas)
+		}
+		return nil
+	})
 }
 
 func (info *GroupClustersInfo) generateZoneInfo(spreadConstraints []policyv1alpha1.SpreadConstraint) {


### PR DESCRIPTION
Cherry pick of #5144 into release-1.10. 

With this small change, we now sort clusters by taking their availableReplicas into account, rather than defaulting to the cluster's name. This helps spread resource usage across all clusters and would be helpful to use as part of the current v1.10 release.

