### PR TITLE
replace RecommendedOptions with needed subset options in karmada-aggregate-apiserver component

### DIFF
--- a/cmd/aggregated-apiserver/app/options/options.go
+++ b/cmd/aggregated-apiserver/app/options/options.go
@@ -27,13 +27,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/endpoints/openapi"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericfilters "k8s.io/apiserver/pkg/server/filters"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
+	"k8s.io/apiserver/pkg/storage/storagebackend"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	netutils "k8s.io/utils/net"
 
@@ -41,8 +42,6 @@ import (
 	clusterscheme "github.com/karmada-io/karmada/pkg/apis/cluster/scheme"
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	pkgfeatures "github.com/karmada-io/karmada/pkg/features"
-	clientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
-	informers "github.com/karmada-io/karmada/pkg/generated/informers/externalversions"
 	generatedopenapi "github.com/karmada-io/karmada/pkg/generated/openapi"
 	"github.com/karmada-io/karmada/pkg/sharedcli/profileflag"
 	"github.com/karmada-io/karmada/pkg/util/lifted"
@@ -53,8 +52,13 @@ const defaultEtcdPathPrefix = "/registry"
 
 // Options contains everything necessary to create and run aggregated-apiserver.
 type Options struct {
-	RecommendedOptions    *genericoptions.RecommendedOptions
-	SharedInformerFactory informers.SharedInformerFactory
+	Etcd           *genericoptions.EtcdOptions
+	SecureServing  *genericoptions.SecureServingOptionsWithLoopback
+	Authentication *genericoptions.DelegatingAuthenticationOptions
+	Authorization  *genericoptions.DelegatingAuthorizationOptions
+	Audit          *genericoptions.AuditOptions
+	Features       *genericoptions.FeatureOptions
+	CoreAPI        *genericoptions.CoreAPIOptions
 
 	// KubeAPIQPS is the QPS to use while talking with karmada-apiserver.
 	KubeAPIQPS float32
@@ -67,17 +71,28 @@ type Options struct {
 // NewOptions returns a new Options.
 func NewOptions() *Options {
 	o := &Options{
-		RecommendedOptions: genericoptions.NewRecommendedOptions(
-			defaultEtcdPathPrefix,
-			clusterscheme.Codecs.LegacyCodec(clusterv1alpha1.SchemeGroupVersion)),
+		Etcd:           genericoptions.NewEtcdOptions(storagebackend.NewDefaultConfig(defaultEtcdPathPrefix, clusterscheme.Codecs.LegacyCodec(schema.GroupVersion{Group: clusterv1alpha1.GroupVersion.Group, Version: clusterv1alpha1.GroupVersion.Version}))),
+		SecureServing:  genericoptions.NewSecureServingOptions().WithLoopback(),
+		Authentication: genericoptions.NewDelegatingAuthenticationOptions(),
+		Authorization:  genericoptions.NewDelegatingAuthorizationOptions(),
+		Audit:          genericoptions.NewAuditOptions(),
+		Features:       genericoptions.NewFeatureOptions(),
+		CoreAPI:        genericoptions.NewCoreAPIOptions(),
 	}
-	o.RecommendedOptions.Etcd.StorageConfig.EncodeVersioner = runtime.NewMultiGroupVersioner(clusterv1alpha1.SchemeGroupVersion, schema.GroupKind{Group: clusterv1alpha1.GroupName})
+	o.Etcd.StorageConfig.EncodeVersioner = runtime.NewMultiGroupVersioner(schema.GroupVersion{Group: clusterv1alpha1.GroupVersion.Group, Version: clusterv1alpha1.GroupVersion.Version}, schema.GroupKind{Group: clusterv1alpha1.GroupName})
 	return o
 }
 
 // AddFlags adds flags to the specified FlagSet.
 func (o *Options) AddFlags(flags *pflag.FlagSet) {
-	o.RecommendedOptions.AddFlags(flags)
+	o.Etcd.AddFlags(flags)
+	o.SecureServing.AddFlags(flags)
+	o.Authentication.AddFlags(flags)
+	o.Authorization.AddFlags(flags)
+	o.Audit.AddFlags(flags)
+	o.Features.AddFlags(flags)
+	o.CoreAPI.AddFlags(flags)
+
 	flags.Lookup("kubeconfig").Usage = "Path to karmada control plane kubeconfig file."
 
 	flags.Float32Var(&o.KubeAPIQPS, "kube-api-qps", 40.0, "QPS to use while talking with karmada-apiserver.")
@@ -114,7 +129,6 @@ func (o *Options) Run(ctx context.Context) error {
 
 	server.GenericAPIServer.AddPostStartHookOrDie("start-aggregated-server-informers", func(context genericapiserver.PostStartHookContext) error {
 		config.GenericConfig.SharedInformerFactory.Start(context.StopCh)
-		o.SharedInformerFactory.Start(context.StopCh)
 		return nil
 	})
 
@@ -124,20 +138,11 @@ func (o *Options) Run(ctx context.Context) error {
 // Config returns config for the api server given Options
 func (o *Options) Config() (*aggregatedapiserver.Config, error) {
 	// TODO have a "real" external address
-	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{netutils.ParseIPSloppy("127.0.0.1")}); err != nil {
+	if err := o.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{netutils.ParseIPSloppy("127.0.0.1")}); err != nil {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
 
-	o.RecommendedOptions.ExtraAdmissionInitializers = func(c *genericapiserver.RecommendedConfig) ([]admission.PluginInitializer, error) {
-		client, err := clientset.NewForConfig(c.LoopbackClientConfig)
-		if err != nil {
-			return nil, err
-		}
-		informerFactory := informers.NewSharedInformerFactory(client, c.LoopbackClientConfig.Timeout)
-		o.SharedInformerFactory = informerFactory
-		return []admission.PluginInitializer{}, nil
-	}
-	o.RecommendedOptions.Features = &genericoptions.FeatureOptions{EnableProfiling: false}
+	o.Features = &genericoptions.FeatureOptions{EnableProfiling: false}
 
 	serverConfig := genericapiserver.NewRecommendedConfig(clusterscheme.Codecs)
 	serverConfig.LongRunningFunc = customLongRunningRequestCheck(sets.NewString("watch", "proxy"),
@@ -145,7 +150,7 @@ func (o *Options) Config() (*aggregatedapiserver.Config, error) {
 	serverConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(generatedopenapi.GetOpenAPIDefinitions, openapi.NewDefinitionNamer(clusterscheme.Scheme))
 	serverConfig.OpenAPIV3Config = genericapiserver.DefaultOpenAPIV3Config(generatedopenapi.GetOpenAPIDefinitions, openapi.NewDefinitionNamer(clusterscheme.Scheme))
 	serverConfig.OpenAPIConfig.Info.Title = "Karmada"
-	if err := o.RecommendedOptions.ApplyTo(serverConfig); err != nil {
+	if err := o.applyTo(serverConfig); err != nil {
 		return nil, err
 	}
 
@@ -154,6 +159,35 @@ func (o *Options) Config() (*aggregatedapiserver.Config, error) {
 		ExtraConfig:   aggregatedapiserver.ExtraConfig{},
 	}
 	return config, nil
+}
+
+func (o *Options) applyTo(config *genericapiserver.RecommendedConfig) error {
+	if err := o.Etcd.ApplyTo(&config.Config); err != nil {
+		return err
+	}
+	if err := o.SecureServing.ApplyTo(&config.Config.SecureServing, &config.Config.LoopbackClientConfig); err != nil {
+		return err
+	}
+	if err := o.Authentication.ApplyTo(&config.Config.Authentication, config.SecureServing, config.OpenAPIConfig); err != nil {
+		return err
+	}
+	if err := o.Authorization.ApplyTo(&config.Config.Authorization); err != nil {
+		return err
+	}
+	if err := o.Audit.ApplyTo(&config.Config); err != nil {
+		return err
+	}
+	if err := o.CoreAPI.ApplyTo(config); err != nil {
+		return err
+	}
+	kubeClient, err := kubernetes.NewForConfig(config.ClientConfig)
+	if err != nil {
+		return err
+	}
+	if err = o.Features.ApplyTo(&config.Config, kubeClient, config.SharedInformerFactory); err != nil {
+		return err
+	}
+	return nil
 }
 
 // disable `deprecation` check until the underlying genericfilters.BasicLongRunningRequestCheck starts using generic Set.

--- a/cmd/aggregated-apiserver/app/options/validation.go
+++ b/cmd/aggregated-apiserver/app/options/validation.go
@@ -23,7 +23,12 @@ import (
 // Validate validates Options.
 func (o *Options) Validate() error {
 	var errs []error
-	errs = append(errs, o.RecommendedOptions.Validate()...)
-
+	errs = append(errs, o.Etcd.Validate()...)
+	errs = append(errs, o.SecureServing.Validate()...)
+	errs = append(errs, o.Authentication.Validate()...)
+	errs = append(errs, o.Authorization.Validate()...)
+	errs = append(errs, o.Audit.Validate()...)
+	errs = append(errs, o.Features.Validate()...)
+	errs = append(errs, o.CoreAPI.Validate()...)
 	return utilerrors.NewAggregate(errs)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

When upgrading the Kubernetes dependency to version 1.30, the following errors are reported by the component `karmada-aggregate-apiserver`:

```log
I0712 09:39:04.225311       1 options.go:97] karmada-aggregated-apiserver version: version.Info{GitVersion:"v1.11.0-alpha.0-142-g32068dc9b", GitCommit:"32068dc9b81eaa30e36743f4b6c57539fa79bf5a", GitTreeState:"clean", BuildDate:"2024-07-12T09:34:00Z", GoVersion:"go1.22.4", Compiler:"gc", Platform:"linux/amd64"}
I0712 09:39:04.490806       1 shared_informer.go:313] Waiting for caches to sync for *generic.policySource[*k8s.io/api/admissionregistration/v1.ValidatingAdmissionPolicy,*k8s.io/api/admissionregistration/v1.ValidatingAdmissionPolicyBinding,k8s.io/apiserver/pkg/admission/plugin/policy/validating.Validator]
...
W0712 09:39:04.587344       1 reflector.go:547] k8s.io/client-go/informers/factory.go:160: failed to list *v1.ValidatingAdmissionPolicyBinding: the server could not find the requested resource
E0712 09:39:04.587376       1 reflector.go:150] k8s.io/client-go/informers/factory.go:160: Failed to watch *v1.ValidatingAdmissionPolicyBinding: failed to list *v1.ValidatingAdmissionPolicyBinding: the server could not find the requested resource
```

We need to remove the logic related to these two APIs, as it does not affect the normal functionality of the current component.

So I replace `RecommendedOptions` with needed subset options in `karmada-aggregate-apiserver` component.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

