### PR TITLE
Align federated buckets.source.toolkit.fluxcd.io observedGeneration semantics with its native

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/Bucket/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/Bucket/customizations.yaml
@@ -22,22 +22,42 @@ spec:
     statusAggregation:
       luaScript: >
         function AggregateStatus(desiredObj, statusItems)
+          if desiredObj.status == nil then
+            desiredObj.status = {}
+          end
+          if desiredObj.metadata.generation == nil then
+            desiredObj.metadata.generation = 0
+          end
+          if desiredObj.status.observedGeneration == nil then
+            desiredObj.status.observedGeneration = 0
+          end
+
+          -- Initialize status fields if status doest not exist
+          -- If the Bucket is not spread to any cluster, its status also should be aggregated
           if statusItems == nil then
+            desiredObj.status.artifact = {}
+            desiredObj.status.conditions = {}
+            desiredObj.status.observedGeneration = desiredObj.metadata.generation 
+            desiredObj.status.url = ''
             return desiredObj
           end
-          desiredObj.status = {}
-          desiredObj.status.conditions = {}
-          conditions = {} 
+
+          local artifact = {}
+          local conditions = {}
+          local generation = desiredObj.metadata.generation
+          local observedGeneration = desiredObj.status.observedGeneration
+          local url = ''
+
+          -- Count all members that their status is updated to the latest generation
+          local observedResourceTemplateGenerationCount = 0
+
           local conditionsIndex = 1
           for i = 1, #statusItems do
             if statusItems[i].status ~= nil and statusItems[i].status.artifact ~= nil then
-              desiredObj.status.artifact = statusItems[i].status.artifact
-            end
-            if statusItems[i].status ~= nil and statusItems[i].status.lastHandledReconcileAt ~= nil and statusItems[i].status.lastHandledReconcileAt ~= '' then
-              desiredObj.status.lastHandledReconcileAt = statusItems[i].status.lastHandledReconcileAt
+              artifact = statusItems[i].status.artifact
             end
             if statusItems[i].status ~= nil and statusItems[i].status.url ~= nil and statusItems[i].status.url ~= '' then
-              desiredObj.status.url = statusItems[i].status.url
+              url = statusItems[i].status.url
             end
             if statusItems[i].status ~= nil and statusItems[i].status.conditions ~= nil then
               for conditionIndex = 1, #statusItems[i].status.conditions do
@@ -56,9 +76,35 @@ spec:
                 end
               end
             end
+
+            -- Check if the member's status is updated to the latest generation
+            local resourceTemplateGeneration = 0
+            if statusItems[i].status ~= nil and statusItems[i].status.resourceTemplateGeneration ~= nil then 
+              resourceTemplateGeneration = statusItems[i].status.resourceTemplateGeneration
+            end
+            local memberGeneration = 0
+            if statusItems[i].status ~= nil and statusItems[i].status.generation ~= nil then
+              memberGeneration = statusItems[i].status.generation
+            end
+            local memberObservedGeneration = 0
+            if statusItems[i].status ~= nil and statusItems[i].status.observedGeneration ~= nil then
+              memberObservedGeneration = statusItems[i].status.observedGeneration
+            end
+            if resourceTemplateGeneration == generation and memberGeneration == memberObservedGeneration then
+              observedResourceTemplateGenerationCount = observedResourceTemplateGenerationCount + 1
+            end          
           end
-          desiredObj.status.observedGeneration = desiredObj.metadata.generation
+
+          -- Update the observed generation based on the observedResourceTemplateGenerationCount
+          if observedResourceTemplateGenerationCount == #statusItems then
+            desiredObj.status.observedGeneration = generation
+          else
+            desiredObj.status.observedGeneration = observedGeneration 
+          end
+
+          desiredObj.status.artifact = artifact
           desiredObj.status.conditions = conditions
+          desiredObj.status.url = url
           return desiredObj
         end
     retention:
@@ -72,15 +118,30 @@ spec:
     statusReflection:
       luaScript: >
         function ReflectStatus (observedObj)
-          status = {}
+          local status = {}
           if observedObj == nil or observedObj.status == nil then 
             return status
           end
           status.conditions = observedObj.status.conditions
           status.artifact = observedObj.status.artifact
           status.observedIgnore = observedObj.status.observedIgnore
+          status.observedGeneration = observedObj.status.observedGeneration
           status.url = observedObj.status.url
-          status.lastHandledReconcileAt = observedObj.status.lastHandledReconcileAt
+
+          -- handle resource generation report
+          if observedObj.metadata == nil then
+            return status
+          end
+          status.generation = observedObj.metadata.generation
+
+          if observedObj.metadata.annotations == nil then
+            return status
+          end
+          local resourceTemplateGeneration = tonumber(observedObj.metadata.annotations["resourcetemplate.karmada.io/generation"])
+          if resourceTemplateGeneration ~= nil then
+              status.resourceTemplateGeneration = resourceTemplateGeneration
+          end
+
           return status
         end
     dependencyInterpretation:

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/Bucket/testdata/desired-bucket.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/Bucket/testdata/desired-bucket.yaml
@@ -3,6 +3,7 @@ kind: Bucket
 metadata:
   name: sample
   namespace: test-bucket
+  generation: 1
 spec:
   provider: generic
   interval: 5m0s

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/Bucket/testdata/observed-bucket.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/Bucket/testdata/observed-bucket.yaml
@@ -3,6 +3,9 @@ kind: Bucket
 metadata:
   name: sample
   namespace: test-bucket
+  annotations:
+    resourcetemplate.karmada.io/generation: "1"
+  generation: 1
 spec:
   provider: generic
   interval: 5m0s

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/Bucket/testdata/status-file.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/Bucket/testdata/status-file.yaml
@@ -23,6 +23,9 @@ status:
     reason: AuthenticationFailed
     status: "True"
     type: FetchFailed
+  generation: 1
+  observedGeneration: -1
+  resourceTemplateGeneration: 1
 ---
 applied: true
 clusterName: member3
@@ -49,3 +52,6 @@ status:
     reason: AuthenticationFailed
     status: "True"
     type: FetchFailed
+  generation: 1
+  observedGeneration: -1
+  resourceTemplateGeneration: 1


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
part of #4870

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Mark `.status.observedGeneration` of buckets.source.toolkit.fluxcd.io with `.metadata.generation` only when all members' statuses are algined with its resource template generation.
```

