### PR TITLE
Align federated ocirepositories.source.toolkit.fluxcd.io observedGeneration semantics with its native

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/OCIRepository/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/OCIRepository/customizations.yaml
@@ -22,22 +22,42 @@ spec:
     statusAggregation:
       luaScript: >
         function AggregateStatus(desiredObj, statusItems)
+          if desiredObj.status == nil then
+            desiredObj.status = {}
+          end
+          if desiredObj.metadata.generation == nil then
+            desiredObj.metadata.generation = 0
+          end
+          if desiredObj.status.observedGeneration == nil then
+            desiredObj.status.observedGeneration = 0
+          end
+
+          -- Initialize status fields if status doest not exist
+          -- If the OCIRepository is not spread to any cluster, its status also should be aggregated
           if statusItems == nil then
+            desiredObj.status.artifact = {}
+            desiredObj.status.conditions = {}
+            desiredObj.status.observedGeneration = desiredObj.metadata.generation
+            desiredObj.status.url = ''
             return desiredObj
           end
-          desiredObj.status = {}
-          desiredObj.status.conditions = {}
-          conditions = {}          
+
+          local artifact = {}
+          local conditions = {}
+          local generation = desiredObj.metadata.generation
+          local observedGeneration = desiredObj.status.observedGeneration
+          local url = ''
+
+          -- Count all members that their status is updated to the latest generation
+          local observedResourceTemplateGenerationCount = 0
+
           local conditionsIndex = 1
           for i = 1, #statusItems do
             if statusItems[i].status ~= nil and statusItems[i].status.artifact ~= nil then
-              desiredObj.status.artifact = statusItems[i].status.artifact
-            end
-            if statusItems[i].status ~= nil and statusItems[i].status.lastHandledReconcileAt ~= nil and statusItems[i].status.lastHandledReconcileAt ~= '' then
-              desiredObj.status.lastHandledReconcileAt = statusItems[i].status.lastHandledReconcileAt
+              artifact = statusItems[i].status.artifact
             end
             if statusItems[i].status ~= nil and statusItems[i].status.url ~= nil and statusItems[i].status.url ~= '' then
-              desiredObj.status.url = statusItems[i].status.url
+              url = statusItems[i].status.url
             end
             if statusItems[i].status ~= nil and statusItems[i].status.conditions ~= nil then
               for conditionIndex = 1, #statusItems[i].status.conditions do
@@ -56,9 +76,34 @@ spec:
                 end
               end
             end
+            -- Check if the member's status is updated to the latest generation
+            local resourceTemplateGeneration = 0
+            if statusItems[i].status ~= nil and statusItems[i].status.resourceTemplateGeneration ~= nil then 
+              resourceTemplateGeneration = statusItems[i].status.resourceTemplateGeneration
+            end
+            local memberGeneration = 0
+            if statusItems[i].status ~= nil and statusItems[i].status.generation ~= nil then
+              memberGeneration = statusItems[i].status.generation
+            end
+            local memberObservedGeneration = 0
+            if statusItems[i].status ~= nil and statusItems[i].status.observedGeneration ~= nil then
+              memberObservedGeneration = statusItems[i].status.observedGeneration
+            end
+            if resourceTemplateGeneration == generation and memberGeneration == memberObservedGeneration then
+              observedResourceTemplateGenerationCount = observedResourceTemplateGenerationCount + 1
+            end
           end
-          desiredObj.status.observedGeneration = desiredObj.metadata.generation
+
+          -- Update the observed generation based on the observedResourceTemplateGenerationCount
+          if observedResourceTemplateGenerationCount == #statusItems then
+            desiredObj.status.observedGeneration = generation
+          else
+            desiredObj.status.observedGeneration = observedGeneration 
+          end
+
+          desiredObj.status.artifact = artifact
           desiredObj.status.conditions = conditions
+          desiredObj.status.url = url
           return desiredObj
         end
     retention:
@@ -72,16 +117,30 @@ spec:
     statusReflection:
       luaScript: >
         function ReflectStatus (observedObj)
-          status = {}
-          if observedObj == nil or observedObj.status == nil then 
+          local status = {}
+          if observedObj == nil or observedObj.status == nil then
             return status
           end
+          status.artifact = observedObj.status.artifact
           status.conditions = observedObj.status.conditions
           status.url = observedObj.status.url
-          status.artifact = observedObj.status.artifact
+          status.observedGeneration = observedObj.status.observedGeneration
           status.observedIgnore = observedObj.status.observedIgnore
           status.observedLayerSelector = observedObj.status.observedLayerSelector
-          status.lastHandledReconcileAt = observedObj.status.lastHandledReconcileAt
+
+          -- handle resource generation report
+          if observedObj.metadata == nil then
+            return status
+          end
+          status.generation = observedObj.metadata.generation
+
+          if observedObj.metadata.annotations == nil then
+            return status
+          end
+          local resourceTemplateGeneration = tonumber(observedObj.metadata.annotations["resourcetemplate.karmada.io/generation"])
+          if resourceTemplateGeneration ~= nil then
+              status.resourceTemplateGeneration = resourceTemplateGeneration
+          end          
           return status
         end
     dependencyInterpretation:

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/OCIRepository/testdata/desired-ocirepository.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/OCIRepository/testdata/desired-ocirepository.yaml
@@ -3,6 +3,7 @@ kind: OCIRepository
 metadata:
   name: sample
   namespace: test-ocirepository
+  generation: 1
 spec:
   interval: 5m
   ref:

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/OCIRepository/testdata/observed-ocirepository.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/OCIRepository/testdata/observed-ocirepository.yaml
@@ -1,8 +1,11 @@
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: OCIRepository
 metadata:
+  annotations:
+    resourcetemplate.karmada.io/generation: "1"
   name: sample
   namespace: test-ocirepository
+  generation: 1
 spec:
   interval: 5m
   provider: generic

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/OCIRepository/testdata/status-file.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/OCIRepository/testdata/status-file.yaml
@@ -26,6 +26,9 @@ status:
     reason: Succeeded
     status: "True"
     type: ArtifactInStorage
+  generation: 1
+  observedGeneration: 1
+  resourceTemplateGeneration: 1
   url: http://source-controller.flux-system.svc.cluster.local./ocirepository/test-ocirepository/sample/latest.tar.gz
 ---
 applied: true
@@ -56,4 +59,7 @@ status:
     reason: Succeeded
     status: "True"
     type: ArtifactInStorage
+  generation: 1
+  observedGeneration: 1
+  resourceTemplateGeneration: 1
   url: http://source-controller.flux-system.svc.cluster.local./ocirepository/test-ocirepository/sample/latest.tar.gz


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of #4870 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Mark `.status.observedGeneration` of ocirepositories.source.toolkit.fluxcd.io with `.metadata.generation` only when all members' statuses are algined with its resource template generation.
```

