### PR TITLE
Align federated StatefulSet's observedGeneration semantics with its native

### DIFF
--- a/pkg/resourceinterpreter/default/native/status_type.go
+++ b/pkg/resourceinterpreter/default/native/status_type.go
@@ -39,3 +39,9 @@ type WrappedDaemonSetStatus struct {
 	FederatedGeneration    `json:",inline"`
 	appsv1.DaemonSetStatus `json:",inline"`
 }
+
+// WrappedStatefulSetStatus is a wrapper for appsv1.StatefulSetStatus.
+type WrappedStatefulSetStatus struct {
+	FederatedGeneration      `json:",inline"`
+	appsv1.StatefulSetStatus `json:",inline"`
+}


### PR DESCRIPTION


**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
/kind feature

**Which issue(s) this PR fixes**:
part of https://github.com/karmada-io/karmada/issues/4870

/cc  @yike21 @XiShanYongYe-Chang 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Mark `.status.observedGeneration` of StatefulSet with `.metadata.generation` only when all members' statuses are algined with its resource template generation.
```

