### PR TITLE
Automated cherry pick of #5188: Fix the issue of residual work in the MultiClusterService

### DIFF
--- a/pkg/controllers/multiclusterservice/endpointslice_collect_controller.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_collect_controller.go
@@ -421,8 +421,12 @@ func getEndpointSliceWorkMeta(c client.Client, ns string, workName string, endpo
 		controllerSet.Insert(util.MultiClusterServiceKind)
 		labels[util.EndpointSliceWorkManagedByLabel] = strings.Join(controllerSet.UnsortedList(), ".")
 	}
-	workMeta := metav1.ObjectMeta{Name: workName, Namespace: ns, Labels: labels}
-	return workMeta, nil
+	return metav1.ObjectMeta{
+		Name:       workName,
+		Namespace:  ns,
+		Labels:     labels,
+		Finalizers: []string{util.MCSEndpointSliceDispatchControllerFinalizer},
+	}, nil
 }
 
 func cleanupWorkWithEndpointSliceDelete(c client.Client, endpointSliceKey keys.FederatedKey) error {

--- a/pkg/controllers/multiclusterservice/endpointslice_dispatch_controller.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_dispatch_controller.go
@@ -308,7 +308,7 @@ func (c *EndpointsliceDispatchController) cleanOrphanDispatchedEndpointSlice(ctx
 	return nil
 }
 
-func (c *EndpointsliceDispatchController) dispatchEndpointSlice(ctx context.Context, work *workv1alpha1.Work, mcs *networkingv1alpha1.MultiClusterService) error {
+func (c *EndpointsliceDispatchController) dispatchEndpointSlice(_ context.Context, work *workv1alpha1.Work, mcs *networkingv1alpha1.MultiClusterService) error {
 	epsSourceCluster, err := names.GetClusterName(work.Namespace)
 	if err != nil {
 		klog.Errorf("Failed to get EndpointSlice source cluster name for work %s/%s", work.Namespace, work.Name)
@@ -347,14 +347,6 @@ func (c *EndpointsliceDispatchController) dispatchEndpointSlice(ctx context.Cont
 			return err
 		}
 	}
-
-	if controllerutil.AddFinalizer(work, util.MCSEndpointSliceDispatchControllerFinalizer) {
-		if err := c.Client.Update(ctx, work); err != nil {
-			klog.Errorf("Failed to add finalizer %s for work %s/%s:%v", util.MCSEndpointSliceDispatchControllerFinalizer, work.Namespace, work.Name, err)
-			return err
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/util/helper/work.go
+++ b/pkg/util/helper/work.go
@@ -84,6 +84,7 @@ func CreateOrUpdateWork(client client.Client, workMeta metav1.ObjectMeta, resour
 			runtimeObject.Spec = work.Spec
 			runtimeObject.Labels = util.DedupeAndMergeLabels(runtimeObject.Labels, work.Labels)
 			runtimeObject.Annotations = util.DedupeAndMergeAnnotations(runtimeObject.Annotations, work.Annotations)
+			runtimeObject.Finalizers = work.Finalizers
 			return nil
 		})
 		return err


### PR DESCRIPTION
Cherry pick of #5188 on release-1.10.
#5188: Fix the issue of residual work in the MultiClusterService
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
karmada-controller-manager: fix the issue of residual work in the MultiClusterService feature.
```