### PR TITLE
Automated cherry pick of #5188: Fix the issue of residual work in the MultiClusterService

### DIFF
--- a/pkg/controllers/multiclusterservice/endpointslice_collect_controller.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_collect_controller.go
@@ -439,6 +439,7 @@ func reportEndpointSlice(c client.Client, endpointSlice *unstructured.Unstructur
 			util.PropagationInstruction: util.PropagationInstructionSuppressed,
 			util.ManagedByKarmadaLabel:  util.ManagedByKarmadaLabelValue,
 		},
+		Finalizers: []string{util.MCSEndpointSliceDispatchControllerFinalizer},
 	}
 
 	if err := helper.CreateOrUpdateWork(c, workMeta, endpointSlice); err != nil {

--- a/pkg/controllers/multiclusterservice/endpointslice_dispatch_controller.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_dispatch_controller.go
@@ -327,14 +327,6 @@ func (c *EndpointsliceDispatchController) syncEndpointSlice(ctx context.Context,
 			return err
 		}
 	}
-
-	if controllerutil.AddFinalizer(work, util.MCSEndpointSliceDispatchControllerFinalizer) {
-		if err := c.Client.Update(ctx, work); err != nil {
-			klog.Errorf("Failed to add finalizer %s for work %s/%s:%v", util.MCSEndpointSliceDispatchControllerFinalizer, work.Namespace, work.Name, err)
-			return err
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/util/helper/work.go
+++ b/pkg/util/helper/work.go
@@ -85,6 +85,7 @@ func CreateOrUpdateWork(client client.Client, workMeta metav1.ObjectMeta, resour
 			if util.GetLabelValue(runtimeObject.Labels, workv1alpha2.WorkPermanentIDLabel) == "" {
 				runtimeObject.Labels = util.DedupeAndMergeLabels(runtimeObject.Labels, map[string]string{workv1alpha2.WorkPermanentIDLabel: uuid.New().String()})
 			}
+			runtimeObject.Finalizers = work.Finalizers
 			return nil
 		})
 		if err != nil {


### PR DESCRIPTION
Cherry pick of #5188 on release-1.8.
#5188: Fix the issue of residual work in the MultiClusterService
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
karmada-controller-manager: fix the issue of residual work in the MultiClusterService feature.
```