### PR TITLE
Adding generic handling of priorityclass + namespace for flinkdeployment interpreter

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/customizations.yaml
@@ -64,11 +64,19 @@ spec:
             requires.resourceRequest.memory = observedObj.spec.taskManager.resource.memory
           end
 
-          -- Until multiple podTemplates are supported, interpreter will only take affinity and toleration input to common podTemplate
+          -- Until multiple podTemplates are supported, interpreter will only take affinity, toleration, and priorityclass input to common podTemplate
 
           if observedObj.spec.podTemplate ~= nil and observedObj.spec.podTemplate.spec ~= nil then
             requires.nodeClaim.nodeSelector = observedObj.spec.podTemplate.spec.nodeSelector
             requires.nodeClaim.tolerations = observedObj.spec.podTemplate.spec.tolerations
+            priorityclass = observedObj.spec.podTemplate.spec.priorityClassName
+            if not isempty(priorityclass) then
+              requires.priorityClassName = priorityclass
+            end
+          end
+
+          if not isempty(observedObj.metadata.namespace) then
+            requires.namespace = observedObj.metadata.namespace
           end
 
           return replica, requires


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
The default interpreter for FlinkDeployment does not currently account for namespace or priorityclass. This was done because in our use-case, the priorityclass is shared amongst tenants and can be set statically. But after thinking again, it makes more sense to have this interpretation be generic.

This is a quick PR that adds that capability. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Added generic handling of priorityclass and namespace for default flinkdeployment interpreter
```

