### PR TITLE
Standardize the health probe arguments

### DIFF
--- a/artifacts/agent/karmada-agent.yaml
+++ b/artifacts/agent/karmada-agent.yaml
@@ -30,8 +30,7 @@ spec:
             - --cluster-name={{member_cluster_name}}
             - --cluster-api-endpoint={{member_cluster_api_endpoint}}
             - --cluster-status-update-frequency=10s
-            - --bind-address=0.0.0.0
-            - --secure-port=10357
+            - --health-probe-bind-address=0.0.0.0:10357
             - --feature-gates=CustomizedClusterResourceModeling=true,MultiClusterService=true
             - --v=4
           livenessProbe:

--- a/charts/karmada/templates/karmada-agent.yaml
+++ b/charts/karmada/templates/karmada-agent.yaml
@@ -110,8 +110,7 @@ spec:
             {{- end }}
             - --cluster-status-update-frequency=10s
             - --leader-elect-resource-namespace={{ include "karmada.namespace" . }}
-            - --bind-address=0.0.0.0
-            - --secure-port=10357
+            - --health-probe-bind-address=0.0.0.0:10357
             - --v=4
           livenessProbe:
             httpGet:

--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"net"
-	"strconv"
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -80,6 +78,10 @@ func NewAgentCommand(ctx context.Context) *cobra.Command {
 plane and sync manifests from the Karmada control plane to the member cluster. In addition, it also syncs the status of member
 cluster and manifests to the Karmada control plane.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
+			// complete options
+			if err := opts.Complete(); err != nil {
+				return err
+			}
 			// validate options
 			if errs := opts.Validate(); len(errs) != 0 {
 				return errs.ToAggregate()
@@ -205,7 +207,7 @@ func run(ctx context.Context, opts *options.Options) error {
 		LeaseDuration:              &opts.LeaderElection.LeaseDuration.Duration,
 		RenewDeadline:              &opts.LeaderElection.RenewDeadline.Duration,
 		RetryPeriod:                &opts.LeaderElection.RetryPeriod.Duration,
-		HealthProbeBindAddress:     net.JoinHostPort(opts.BindAddress, strconv.Itoa(opts.SecurePort)),
+		HealthProbeBindAddress:     opts.HealthProbeBindAddress,
 		LivenessEndpointName:       "/healthz",
 		Metrics:                    metricsserver.Options{BindAddress: opts.MetricsBindAddress},
 		MapperProvider:             restmapper.MapperProvider,

--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -18,6 +18,8 @@ package options
 
 import (
 	"fmt"
+	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -51,9 +53,11 @@ type Options struct {
 	Controllers    []string
 	LeaderElection componentbaseconfig.LeaderElectionConfiguration
 	// BindAddress is the IP address on which to listen for the --secure-port port.
+	// Deprecated: Use HealthProbeBindAddress instead. And will be removed in release 1.12+.
 	BindAddress string
 	// SecurePort is the port that the the server serves at.
 	// Note: We hope support https in the future once controller-runtime provides the functionality.
+	// Deprecated: Use HealthProbeBindAddress instead. And will be removed in release 1.12+.
 	SecurePort        int
 	KarmadaKubeConfig string
 	// ClusterContext is the name of the cluster context in control plane KUBECONFIG file.
@@ -104,6 +108,11 @@ type Options struct {
 	// It can be set to "0" to disable the metrics serving.
 	// Defaults to ":8080".
 	MetricsBindAddress string
+	// HealthProbeBindAddress is the TCP address that the controller should bind to
+	// for serving health probes
+	// It can be set to "0" to disable serving the health probe.
+	// Defaults to ":10357".
+	HealthProbeBindAddress string
 
 	RateLimiterOpts ratelimiterflag.Options
 
@@ -168,6 +177,10 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, allControllers []string) {
 		"The IP address on which to listen for the --secure-port port.")
 	fs.IntVar(&o.SecurePort, "secure-port", defaultPort,
 		"The secure port on which to serve HTTPS.")
+	// nolint: errcheck
+	fs.MarkDeprecated("bind-address", "This flag is deprecated and will be removed in release 1.12+. Use --health-probe-bind-address instead.")
+	// nolint: errcheck
+	fs.MarkDeprecated("secure-port", "This flag is deprecated and will be removed in release 1.12+. Use --health-probe-bind-address instead.")
 	fs.BoolVar(&o.LeaderElection.LeaderElect, "leader-elect", true, "Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.")
 	fs.StringVar(&o.LeaderElection.ResourceNamespace, "leader-elect-resource-namespace", util.NamespaceKarmadaSystem, "The namespace of resource object that is used for locking during leader election.")
 	fs.DurationVar(&o.LeaderElection.LeaseDuration.Duration, "leader-elect-lease-duration", defaultElectionLeaseDuration.Duration, ""+
@@ -206,6 +219,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, allControllers []string) {
 	fs.IntVar(&o.ConcurrentWorkSyncs, "concurrent-work-syncs", 5, "The number of Works that are allowed to sync concurrently.")
 	fs.StringSliceVar(&o.ReportSecrets, "report-secrets", []string{"KubeCredentials", "KubeImpersonator"}, "The secrets that are allowed to be reported to the Karmada control plane during registering. Valid values are 'KubeCredentials', 'KubeImpersonator' and 'None'. e.g 'KubeCredentials,KubeImpersonator' or 'None'.")
 	fs.StringVar(&o.MetricsBindAddress, "metrics-bind-address", ":8080", "The TCP address that the controller should bind to for serving prometheus metrics(e.g. 127.0.0.1:8080, :8080). It can be set to \"0\" to disable the metrics serving.")
+	fs.StringVar(&o.HealthProbeBindAddress, "health-probe-bind-address", "", "The TCP address that the controller should bind to for serving health probes(e.g. 127.0.0.1:10357, :10357). It can be set to \"0\" to disable serving the health probe. Defaults to 0.0.0.0:10357.")
 	fs.StringVar(&o.ClusterProvider, "cluster-provider", "", "Provider of the joining cluster. The Karmada scheduler can use this information to spread workloads across providers for higher availability.")
 	fs.StringVar(&o.ClusterRegion, "cluster-region", "", "The region of the joining cluster. The Karmada scheduler can use this information to spread workloads across regions for higher availability.")
 	fs.StringSliceVar(&o.ClusterZones, "cluster-zones", []string{}, "The zones of the joining cluster. The Karmada scheduler can use this information to spread workloads across zones for higher availability.")
@@ -218,4 +232,12 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, allControllers []string) {
 	o.RateLimiterOpts.AddFlags(fs)
 	features.FeatureGate.AddFlag(fs)
 	o.ProfileOpts.AddFlags(fs)
+}
+
+// Complete ensures that options are valid and marshals them if necessary.
+func (o *Options) Complete() error {
+	if len(o.HealthProbeBindAddress) == 0 {
+		o.HealthProbeBindAddress = net.JoinHostPort(o.BindAddress, strconv.Itoa(o.SecurePort))
+	}
+	return nil
 }

--- a/cmd/agent/app/options/validation.go
+++ b/cmd/agent/app/options/validation.go
@@ -33,10 +33,6 @@ func (o *Options) Validate() field.ErrorList {
 		errs = append(errs, field.Invalid(newPath.Child("ClusterName"), o.ClusterName, strings.Join(errMsgs, ",")))
 	}
 
-	if o.SecurePort < 0 || o.SecurePort > 65535 {
-		errs = append(errs, field.Invalid(newPath.Child("SecurePort"), o.SecurePort, "must be between 0 and 65535 inclusive"))
-	}
-
 	if o.ClusterStatusUpdateFrequency.Duration < 0 {
 		errs = append(errs, field.Invalid(newPath.Child("ClusterStatusUpdateFrequency"), o.ClusterStatusUpdateFrequency, "must be greater than or equal to 0"))
 	}

--- a/cmd/agent/app/options/validation_test.go
+++ b/cmd/agent/app/options/validation_test.go
@@ -35,7 +35,6 @@ func New(modifyOptions ModifyOptions) Options {
 			LeaderElect: false,
 		},
 		ClusterName:                       "demo",
-		SecurePort:                        8090,
 		ClusterStatusUpdateFrequency:      metav1.Duration{Duration: 10 * time.Second},
 		ClusterLeaseDuration:              metav1.Duration{Duration: 40 * time.Second},
 		ClusterLeaseRenewIntervalFraction: 0.25,
@@ -71,12 +70,6 @@ func TestValidateKarmadaAgentConfiguration(t *testing.T) {
 				options.ClusterName = ""
 			}),
 			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("ClusterName"), "", "must be not empty")},
-		},
-		"invalid SecurePort": {
-			opt: New(func(options *Options) {
-				options.SecurePort = -10
-			}),
-			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("SecurePort"), -10, "must be between 0 and 65535 inclusive")},
 		},
 		"invalid ClusterStatusUpdateFrequency": {
 			opt: New(func(options *Options) {

--- a/pkg/karmadactl/cmdinit/utils/examples.go
+++ b/pkg/karmadactl/cmdinit/utils/examples.go
@@ -93,8 +93,7 @@ spec:
             - --cluster-name={member_cluster_name}
             - --cluster-api-endpoint={member_cluster_api_endpoint}
             - --cluster-status-update-frequency=10s
-            - --bind-address=0.0.0.0
-            - --secure-port=10357
+            - --health-probe-bind-address=0.0.0.0:10357
             - --v=4
           livenessProbe:
             httpGet:

--- a/pkg/karmadactl/register/register.go
+++ b/pkg/karmadactl/register/register.go
@@ -722,9 +722,8 @@ func (o *CommandRegisterOption) makeKarmadaAgentDeployment() *appsv1.Deployment 
 					fmt.Sprintf("--leader-elect-resource-namespace=%s", o.Namespace),
 					fmt.Sprintf("--cluster-namespace=%s", o.ClusterNamespace),
 					"--cluster-status-update-frequency=10s",
-					"--bind-address=0.0.0.0",
 					"--metrics-bind-address=:8080",
-					"--secure-port=10357",
+					"--health-probe-bind-address=0.0.0.0:10357",
 					"--v=4",
 				},
 				Ports: []corev1.ContainerPort{


### PR DESCRIPTION
**What type of PR is this?**
/kind deprecation
/kind feature
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
part of https://github.com/karmada-io/karmada/issues/5219

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-agent`:  Add health probe argument `health-probe-bind-address`, deprecate `--bind-address` and `--secure-port` flag.
```

