### PR TITLE
Only update krew index for latest stable version.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,11 +200,22 @@ jobs:
       base64-subjects: "${{ needs.sbom-assests.outputs.hashes }}"
       provenance-name: "karmada-sbom.intoto.jsonl"
       upload-assets: true
+
   update-krew-index:
-    needs: release-assests
+    needs: 
+    - release-assests
     name: Update krew-index
     runs-on: ubuntu-22.04
     steps:
+    - name: get latest tag
+      id: get-latest-tag
+      run: |
+        export LATEST_TAG=`gh api repos/karmada-io/karmada/releases/latest | jq -r '.tag_name'`
+        echo "Got the latest tag:$LATEST_TAG"
+        echo "event.tag:"${{ github.event.release.tag_name }}
+        echo "latestTag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
     - uses: actions/checkout@v4
+      if: steps.get-latest-tag.outputs.latestTag == github.event.release.tag_name
     - name: Update new version in krew-index
+      if: steps.get-latest-tag.outputs.latestTag == github.event.release.tag_name
       uses: rajatjindal/krew-release-bot@v0.0.46


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind cleanup
**What this PR does / why we need it**:

Only update krew index for latest stable version. Avoid sending noisy PRs and in the future,we don't need some PR anymore like:
- https://github.com/karmada-io/karmada/pull/4767

/cc @RainbowMango @zhzhuang-zju 

**Which issue(s) this PR fixes**:

Ref https://github.com/karmada-io/karmada/issues/4703
Fixes #

**Special notes for your reviewer**:

Tested on my fork repo:

- https://github.com/liangyuanpeng/karmada/actions/runs/9987870100/job/27603262187  (release v1.10.2,running the step `Update krew index`)
- https://github.com/liangyuanpeng/karmada/actions/runs/9987694858  (release v1.99.3, skip the step`Update krew index` due to karmada latest stable version is v1.10.2 and not v1.99.3 )
 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

