### PR TITLE
test/e2e: unify access to cluster members utilizing `framework.ClusterMembers()[i]`

### DIFF
--- a/test/e2e/aggregatedapi_test.go
+++ b/test/e2e/aggregatedapi_test.go
@@ -122,7 +122,7 @@ var _ = framework.SerialDescribe("Aggregated Kubernetes API Endpoint testing", f
 	})
 
 	ginkgo.BeforeEach(func() {
-		member1, member2 = "member1", "member2"
+		member1, member2 = framework.ClusterNames()[0], framework.ClusterNames()[1]
 
 		saName = fmt.Sprintf("tom-%s", rand.String(RandomStrLength))
 		saNamespace = testNamespace
@@ -207,7 +207,7 @@ var _ = framework.SerialDescribe("Aggregated Kubernetes API Endpoint testing", f
 				framework.RemoveClusterRoleBinding(clusterClient, tomClusterRoleBindingOnMember.Name)
 			})
 
-			ginkgo.It("tom access the member1 cluster api with and without right", func() {
+			ginkgo.It(fmt.Sprintf("tom access the %s cluster api with and without right", member1), func() {
 				ginkgo.By(fmt.Sprintf("access the %s cluster `/api` path with right", member1), func() {
 					gomega.Eventually(func(g gomega.Gomega) (int, error) {
 						code, err := helper.DoRequest(fmt.Sprintf(karmadaHost+clusterProxy+"api", member1), tomToken)
@@ -238,7 +238,7 @@ var _ = framework.SerialDescribe("Aggregated Kubernetes API Endpoint testing", f
 		})
 
 		ginkgo.When(fmt.Sprintf("Serviceaccount(tom) access the %s cluster", member2), func() {
-			ginkgo.It("tom access the member2 cluster without right", func() {
+			ginkgo.It(fmt.Sprintf("tom access the %s cluster without right", member2), func() {
 				ginkgo.By(fmt.Sprintf("access the %s cluster `/api` path without right", member2), func() {
 					code, err := helper.DoRequest(fmt.Sprintf(karmadaHost+clusterProxy, member2), tomToken)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())

--- a/test/e2e/dependenciesdistributor_test.go
+++ b/test/e2e/dependenciesdistributor_test.go
@@ -38,8 +38,8 @@ var _ = ginkgo.Describe("[DependenciesDistributor] automatically propagate relev
 		var policy *policyv1alpha1.PropagationPolicy
 
 		ginkgo.BeforeEach(func() {
-			initClusterNames = []string{"member1"}
-			updateClusterNames = []string{"member2"}
+			initClusterNames = []string{framework.ClusterNames()[0]}
+			updateClusterNames = []string{framework.ClusterNames()[1]}
 
 			policyName = deploymentNamePrefix + rand.String(RandomStrLength)
 			deploymentName = policyName
@@ -351,8 +351,8 @@ var _ = ginkgo.Describe("[DependenciesDistributor] automatically propagate relev
 		var policy *policyv1alpha1.ClusterPropagationPolicy
 
 		ginkgo.BeforeEach(func() {
-			initClusterNames = []string{"member1"}
-			updateClusterNames = []string{"member2"}
+			initClusterNames = []string{framework.ClusterNames()[0]}
+			updateClusterNames = []string{framework.ClusterNames()[1]}
 
 			policyName = deploymentNamePrefix + rand.String(RandomStrLength)
 			deploymentName = policyName

--- a/test/e2e/fieldselector_test.go
+++ b/test/e2e/fieldselector_test.go
@@ -56,7 +56,7 @@ var _ = ginkgo.Describe("propagation with fieldSelector testing", func() {
 			originalClusterRegionInfo = make(map[string]string)
 			desiredProvider = []string{"huaweicloud"}
 			undesiredRegion = []string{"cn-north-1"}
-			desiredScheduleResult = "member1"
+			desiredScheduleResult = framework.ClusterNames()[0]
 
 			// desire to schedule to clusters of huaweicloud but not in cn-north-1 region
 			filedSelector = &policyv1alpha1.FieldSelector{

--- a/test/e2e/karmadactl_test.go
+++ b/test/e2e/karmadactl_test.go
@@ -60,7 +60,7 @@ var _ = ginkgo.Describe("Karmadactl promote testing", func() {
 	var member1Client kubernetes.Interface
 
 	ginkgo.BeforeEach(func() {
-		member1 = "member1"
+		member1 = framework.ClusterNames()[0]
 		member1Client = framework.GetClusterClient(member1)
 		defaultConfigFlags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag().WithDiscoveryBurst(300).WithDiscoveryQPS(50.0)
 		defaultConfigFlags.Context = &karmadaContext
@@ -616,7 +616,7 @@ var _ = ginkgo.Describe("Karmadactl logs testing", func() {
 	var member1Client kubernetes.Interface
 
 	ginkgo.BeforeEach(func() {
-		member1 = "member1"
+		member1 = framework.ClusterNames()[0]
 		member1Client = framework.GetClusterClient(member1)
 	})
 
@@ -794,7 +794,7 @@ var _ = ginkgo.Describe("Karmadactl get testing", func() {
 	var member1Client kubernetes.Interface
 
 	ginkgo.BeforeEach(func() {
-		member1 = "member1"
+		member1 = framework.ClusterNames()[0]
 		member1Client = framework.GetClusterClient(member1)
 	})
 
@@ -898,7 +898,7 @@ var _ = ginkgo.Describe("Karmadactl describe testing", func() {
 	var member1Client kubernetes.Interface
 
 	ginkgo.BeforeEach(func() {
-		member1 = "member1"
+		member1 = framework.ClusterNames()[0]
 		member1Client = framework.GetClusterClient(member1)
 	})
 

--- a/test/e2e/lazy_activation_policy_test.go
+++ b/test/e2e/lazy_activation_policy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package e2e
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -113,7 +114,7 @@ var _ = ginkgo.Describe("Lazy activation policy testing", func() {
 				waitDeploymentPresentOnCluster(originalCluster, namespace, deploymentName)
 			})
 
-			ginkgo.By("step 2: after policy updated (cluster=member2, remove lazy activationPreference field), the propagation of deployment changed", func() {
+			ginkgo.By(fmt.Sprintf("step 2: after policy updated (cluster=%s, remove lazy activationPreference field), the propagation of deployment changed", modifiedCluster), func() {
 				// 1. remove lazy activationPreference field
 				policy.Spec.ActivationPreference = ""
 				// 2. update policy placement with clusterAffinities
@@ -137,7 +138,7 @@ var _ = ginkgo.Describe("Lazy activation policy testing", func() {
 					waitDeploymentPresentOnCluster(originalCluster, namespace, deploymentName)
 				})
 
-				ginkgo.By("step 2: after policy updated (cluster=member2, activationPreference=lazy), the propagation of deployment unchanged", func() {
+				ginkgo.By(fmt.Sprintf("step 2: after policy updated (cluster=%s, activationPreference=lazy), the propagation of deployment unchanged", modifiedCluster), func() {
 					// 1. activationPreference=lazy
 					policy.Spec.ActivationPreference = policyv1alpha1.LazyActivation
 					// 2. update policy placement with clusterAffinities
@@ -166,7 +167,7 @@ var _ = ginkgo.Describe("Lazy activation policy testing", func() {
 				waitDeploymentPresentOnCluster(originalCluster, namespace, deploymentName)
 			})
 
-			ginkgo.By("step 2: create PP2 (match nginx, cluster=member2, not lazy, priority=2, preemption=true)", func() {
+			ginkgo.By(fmt.Sprintf("step 2: create PP2 (match nginx, cluster=%s, not lazy, priority=2, preemption=true)", modifiedCluster), func() {
 				policyHigherPriority.Spec.ActivationPreference = "" // remove lazy activationPreference field
 				framework.CreatePropagationPolicy(karmadaClient, policyHigherPriority)
 				waitDeploymentPresentOnCluster(modifiedCluster, namespace, deploymentName)
@@ -184,7 +185,7 @@ var _ = ginkgo.Describe("Lazy activation policy testing", func() {
 				waitDeploymentPresentOnCluster(originalCluster, namespace, deploymentName)
 			})
 
-			ginkgo.By("step 2: create PP2 (match nginx, cluster=member2, lazy, priority=2, preemption=true)", func() {
+			ginkgo.By(fmt.Sprintf("step 2: create PP2 (match nginx, cluster=%s, lazy, priority=2, preemption=true)", modifiedCluster), func() {
 				framework.CreatePropagationPolicy(karmadaClient, policyHigherPriority)
 				// 1. annotation of policy name changed
 				framework.WaitDeploymentFitWith(kubeClient, namespace, deploymentName, func(deployment *appsv1.Deployment) bool {

--- a/test/e2e/mcs_test.go
+++ b/test/e2e/mcs_test.go
@@ -46,8 +46,7 @@ import (
 )
 
 var (
-	serviceExportClusterName = "member1"
-	serviceImportClusterName = "member2"
+	serviceExportClusterName, serviceImportClusterName string
 
 	serviceExportResource = "serviceexports"
 	serviceImportResource = "serviceimports"
@@ -205,6 +204,8 @@ var _ = ginkgo.Describe("Multi-Cluster Service testing", func() {
 	var demoService corev1.Service
 
 	ginkgo.BeforeEach(func() {
+		serviceExportClusterName = framework.ClusterNames()[0]
+		serviceImportClusterName = framework.ClusterNames()[1]
 		serviceExportPolicyName = fmt.Sprintf("%s-%s-policy", serviceExportResource, rand.String(RandomStrLength))
 		serviceImportPolicyName = fmt.Sprintf("%s-%s-policy", serviceImportResource, rand.String(RandomStrLength))
 
@@ -529,7 +530,7 @@ var _ = ginkgo.Describe("CrossCluster MultiClusterService testing", func() {
 	})
 
 	// case 1: ProviderClusters field is [member1], ConsumerClusters field is [member2]
-	ginkgo.Context("ProviderClusters field is [member1], ConsumerClusters field is [member2]", func() {
+	ginkgo.Context(fmt.Sprintf("ProviderClusters field is [%s], ConsumerClusters field is [%s]", member1Name, member2Name), func() {
 		var mcs *networkingv1alpha1.MultiClusterService
 
 		ginkgo.BeforeEach(func() {
@@ -562,7 +563,7 @@ var _ = ginkgo.Describe("CrossCluster MultiClusterService testing", func() {
 	})
 
 	// case 2: ProviderClusters field is [member1,member2], ConsumerClusters field is [member2]
-	ginkgo.Context("ProviderClusters field is [member1,member2], ConsumerClusters field is [member2]", func() {
+	ginkgo.Context(fmt.Sprintf("ProviderClusters field is [%s,%s], ConsumerClusters field is [%s]", member1Name, member2Name, member2Name), func() {
 		var mcs *networkingv1alpha1.MultiClusterService
 
 		ginkgo.BeforeEach(func() {
@@ -642,7 +643,7 @@ var _ = ginkgo.Describe("CrossCluster MultiClusterService testing", func() {
 	})
 
 	// case 4: ProviderClusters field is empty, ConsumerClusters field is [member2]
-	ginkgo.Context("ProviderClusters field is empty, ConsumerClusters field is [member2]", func() {
+	ginkgo.Context(fmt.Sprintf("ProviderClusters field is empty, ConsumerClusters field is [%s]", member2Name), func() {
 		var mcs *networkingv1alpha1.MultiClusterService
 
 		ginkgo.BeforeEach(func() {
@@ -675,7 +676,7 @@ var _ = ginkgo.Describe("CrossCluster MultiClusterService testing", func() {
 	})
 
 	// case 5: ProviderClusters field is [member1], ConsumerClusters field is empty
-	ginkgo.Context("ProviderClusters field is [member1], ConsumerClusters field is empty", func() {
+	ginkgo.Context(fmt.Sprintf("ProviderClusters field is [%s], ConsumerClusters field is empty", member1Name), func() {
 		var mcs *networkingv1alpha1.MultiClusterService
 
 		ginkgo.BeforeEach(func() {

--- a/test/e2e/preemption_test.go
+++ b/test/e2e/preemption_test.go
@@ -29,8 +29,12 @@ import (
 )
 
 var _ = ginkgo.Describe("[Preemption] propagation policy preemption testing", func() {
-	preemptingClusterName := "member2"
-	preemptedClusterName := "member1"
+	var preemptingClusterName, preemptedClusterName string
+
+	ginkgo.BeforeEach(func() {
+		preemptingClusterName = framework.ClusterNames()[1]
+		preemptedClusterName = framework.ClusterNames()[0]
+	})
 
 	ginkgo.When("[PropagationPolicy Preemption] PropagationPolicy preempts another (Cluster)PropagationPolicy", func() {
 		ginkgo.Context("High-priority PropagationPolicy preempts low-priority PropagationPolicy", func() {

--- a/test/e2e/rescheduling_test.go
+++ b/test/e2e/rescheduling_test.go
@@ -269,7 +269,7 @@ var _ = ginkgo.Describe("[cluster joined] reschedule testing", func() {
 
 		ginkgo.Context("testing clusterAffinity of the policy", func() {
 			ginkgo.BeforeEach(func() {
-				initClusterNames = []string{"member1", "member2", newClusterName}
+				initClusterNames = []string{framework.ClusterNames()[0], framework.ClusterNames()[1], newClusterName}
 				policyNamespace = testNamespace
 				policyName = deploymentNamePrefix + rand.String(RandomStrLength)
 				deploymentNamespace = testNamespace
@@ -329,7 +329,7 @@ var _ = ginkgo.Describe("[cluster joined] reschedule testing", func() {
 
 				gomega.Eventually(func(gomega.Gomega) bool {
 					targetClusterNames := framework.ExtractTargetClustersFrom(controlPlaneClient, deployment)
-					return testhelper.IsExclude("member3", targetClusterNames)
+					return testhelper.IsExclude(framework.ClusterNames()[2], targetClusterNames)
 				}, pollTimeout, pollInterval).Should(gomega.BeTrue())
 
 			})

--- a/test/e2e/tainttoleration_test.go
+++ b/test/e2e/tainttoleration_test.go
@@ -51,7 +51,7 @@ var _ = framework.SerialDescribe("propagation with taint and toleration testing"
 			deploymentName = policyName
 			deployment = helper.NewDeployment(deploymentNamespace, deploymentName)
 			tolerationKey = "cluster-toleration.karmada.io"
-			tolerationValue = "member1"
+			tolerationValue = framework.ClusterNames()[0]
 
 			// set clusterTolerations to tolerate taints in member1.
 			clusterTolerations = []corev1.Toleration{


### PR DESCRIPTION
**Description**

Unify access to cluster members utilizing `framework.ClusterMembers()[i]`.

**What type of PR is this?**

/kind cleanup [not sure if this is the correct kind of PR!]

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**Which issue(s) this PR fixes**:

Motivated by @XiShanYongYe-Chang's comment:
https://github.com/karmada-io/karmada/pull/5195#discussion_r1680354650


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

