### PR TITLE
fix the error of cluster status old condition update will overwrite the newest condition

### DIFF
--- a/pkg/controllers/status/cluster_status_controller_test.go
+++ b/pkg/controllers/status/cluster_status_controller_test.go
@@ -228,9 +228,7 @@ func TestClusterStatusController_syncClusterStatus(t *testing.T) {
 		if err := c.Client.Create(context.Background(), cluster); err != nil {
 			t.Fatalf("Failed to create cluster: %v", err)
 		}
-		res, err := c.syncClusterStatus(context.Background(), cluster)
-		expect := controllerruntime.Result{}
-		assert.Equal(t, expect, res)
+		err := c.syncClusterStatus(context.Background(), cluster)
 		assert.Empty(t, err)
 	})
 	t.Run("online is false, readyCondition.Status isn't true", func(t *testing.T) {
@@ -275,9 +273,7 @@ func TestClusterStatusController_syncClusterStatus(t *testing.T) {
 			t.Fatalf("Failed to create cluster: %v", err)
 		}
 
-		res, err := c.syncClusterStatus(context.Background(), cluster)
-		expect := controllerruntime.Result{}
-		assert.Equal(t, expect, res)
+		err := c.syncClusterStatus(context.Background(), cluster)
 		assert.Empty(t, err)
 	})
 
@@ -322,9 +318,7 @@ func TestClusterStatusController_syncClusterStatus(t *testing.T) {
 		if err := c.Client.Create(context.Background(), cluster); err != nil {
 			t.Fatalf("Failed to create cluster: %v", err)
 		}
-		res, err := c.syncClusterStatus(context.Background(), cluster)
-		expect := controllerruntime.Result{}
-		assert.Equal(t, expect, res)
+		err := c.syncClusterStatus(context.Background(), cluster)
 		assert.Empty(t, err)
 	})
 }
@@ -913,8 +907,7 @@ func TestClusterStatusController_updateStatusIfNeeded(t *testing.T) {
 			ClusterClientSetFunc: util.NewClusterClientSet,
 		}
 
-		actual, err := c.updateStatusIfNeeded(context.Background(), cluster, currentClusterStatus)
-		assert.Equal(t, controllerruntime.Result{}, actual)
+		err := c.updateStatusIfNeeded(context.Background(), cluster, currentClusterStatus)
 		assert.Empty(t, err, "updateStatusIfNeeded returns error")
 	})
 
@@ -978,9 +971,7 @@ func TestClusterStatusController_updateStatusIfNeeded(t *testing.T) {
 			ClusterClientSetFunc: util.NewClusterClientSet,
 		}
 
-		actual, err := c.updateStatusIfNeeded(context.Background(), cluster, currentClusterStatus)
-		expect := controllerruntime.Result{}
-		assert.Equal(t, expect, actual)
+		err := c.updateStatusIfNeeded(context.Background(), cluster, currentClusterStatus)
 		assert.NotEmpty(t, err, "updateStatusIfNeeded doesn't return error")
 	})
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind failing-test

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

During the cluster status update, due to the presence of an old Condition in the previous Cluster status, this Condition is incorrectly updated to the Cluster object during the status refresh. The expected Cluster status conditions should no longer include the old condition.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-controller-manager: fix the error of cluster status old condition update will overwrite the newest condition
```

