### PR TITLE
only generate json patch for status filed when patchBindingStatus

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -828,7 +828,7 @@ func patchBindingStatusWithAffinityName(karmadaClient karmadaclientset.Interface
 }
 
 func patchBindingStatus(karmadaClient karmadaclientset.Interface, rb, updateRB *workv1alpha2.ResourceBinding) error {
-	patchBytes, err := helper.GenMergePatch(rb, updateRB)
+	patchBytes, err := helper.GenFieldMergePatch("status", rb.Status, updateRB.Status)
 	if err != nil {
 		return err
 	}
@@ -879,7 +879,7 @@ func patchClusterBindingStatusWithAffinityName(karmadaClient karmadaclientset.In
 }
 
 func patchClusterResourceBindingStatus(karmadaClient karmadaclientset.Interface, crb, updateCRB *workv1alpha2.ClusterResourceBinding) error {
-	patchBytes, err := helper.GenMergePatch(crb, updateCRB)
+	patchBytes, err := helper.GenFieldMergePatch("status", crb.Status, updateCRB.Status)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/helper/patch.go
+++ b/pkg/util/helper/patch.go
@@ -67,6 +67,24 @@ func GenMergePatch(originalObj interface{}, modifiedObj interface{}) ([]byte, er
 	return patchBytes, nil
 }
 
+// GenFieldMergePatch will return a merge patch document capable of converting the
+// original field to the modified field.
+// The merge patch format is primarily intended for use with the HTTP PATCH method
+// as a means of describing a set of modifications to a target resource's content.
+func GenFieldMergePatch(fieldName string, originField interface{}, modifiedField interface{}) ([]byte, error) {
+	patchBytes, err := GenMergePatch(originField, modifiedField)
+	if err != nil {
+		return nil, err
+	}
+	if len(patchBytes) == 0 {
+		return nil, nil
+	}
+
+	patchBytes = append(patchBytes, '}')
+	patchBytes = append([]byte(`{"`+fieldName+`":`), patchBytes...)
+	return patchBytes, nil
+}
+
 // GenReplaceFieldJSONPatch returns the RFC6902 JSONPatch array as []byte, which is used to simply
 // add/replace/delete certain JSON **Object** field.
 func GenReplaceFieldJSONPatch(path string, originalFieldValue, newFieldValue interface{}) ([]byte, error) {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

only generate json patch for status filed when patchBindingStatus

**Which issue(s) this PR fixes**:

Fixes #5203

**Special notes for your reviewer**:

Test report of **Benchmark**:

**1）** test code:

<details>
<summary>benchmark_test.go</summary>

```go
var now = metav1.Now()
var bindSpec = workv1alpha2.ResourceBindingSpec{
	PropagateDeps:         true,
	ReplicaRequirements: &workv1alpha2.ReplicaRequirements{
		ResourceRequest: util.EmptyResource().ResourceList(),
	},
	Replicas:              10,
	Placement: &policyv1alpha1.Placement{
		ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
			ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
			ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceAggregated,
		},
	},
	GracefulEvictionTasks: nil,
	RequiredBy: []workv1alpha2.BindingSnapshot{
		{
			Clusters: []workv1alpha2.TargetCluster{
				{
					Name:     "member3",
					Replicas: 2,
				},
			},
		},
	},
	SchedulerName:         "default",
	Resource: workv1alpha2.ObjectReference{
		APIVersion: "v1",
		Kind:       "Pod",
		Namespace:  "default",
		Name:       "pod",
	},
	Failover: &policyv1alpha1.FailoverBehavior{
		Application: &policyv1alpha1.ApplicationFailoverBehavior{
			DecisionConditions: policyv1alpha1.DecisionConditions{
				TolerationSeconds: pointer.Int32(1),
			},
		},
	},
	Clusters: []workv1alpha2.TargetCluster{
		{
			Name:     "member1",
			Replicas: 1,
		},
		{
			Name:     "member1",
			Replicas: 2,
		},
	},
	ConflictResolution:    workv1alpha2.ResourceConflictResolutionOverwrite,
	RescheduleTriggeredAt: &now,
}
var successCondition = util.NewCondition(workv1alpha2.Scheduled, workv1alpha2.BindingReasonSuccess, successfulSchedulingMessage, metav1.ConditionTrue)

var rb = &workv1alpha2.ResourceBinding{
	ObjectMeta: metav1.ObjectMeta{Name: "rb-4", Namespace: "default"},
	Spec:       bindSpec,
	Status:     workv1alpha2.ResourceBindingStatus{},
}
var updateRB = &workv1alpha2.ResourceBinding{
	ObjectMeta: metav1.ObjectMeta{Name: "rb-4", Namespace: "default"},
	Spec:       bindSpec,
	Status:     workv1alpha2.ResourceBindingStatus{Conditions: []metav1.Condition{successCondition}},
}

func BenchmarkPatchBindingStatusOld(b *testing.B) {
	for i := 0; i < b.N; i++ {
		patchBytes, err := helper.GenMergePatch(rb, updateRB)
		if err != nil {
			b.Fatal(err)
		}
		if len(patchBytes) == 0 {
			b.Fatal(err)
		}
	}
}

func BenchmarkPatchBindingStatus(b *testing.B) {
	for i := 0; i < b.N; i++ {
		patchBytes, err := helper.GenMergePatch(rb.Status, updateRB.Status)
		if err != nil {
			b.Fatal(err)
		}
		if len(patchBytes) == 0 {
			b.Fatal(err)
		}
		patchBytes = append(patchBytes, '}')
		patchBytes = append([]byte("{\"status\":"), patchBytes...)
	}
}
```
</details>

**2）** test result

* BenchmarkPatchBindingStatusOld

```shell
goos: windows
goarch: amd64
pkg: github.com/karmada-io/karmada/pkg/scheduler
cpu: Intel(R) Xeon(R) Gold 6278C CPU @ 2.60GHz
BenchmarkPatchBindingStatusOld
BenchmarkPatchBindingStatusOld-4           19429             64816 ns/op
PASS
```

* BenchmarkPatchBindingStatus

```shell
goos: windows
goarch: amd64
pkg: github.com/karmada-io/karmada/pkg/scheduler
cpu: Intel(R) Xeon(R) Gold 6278C CPU @ 2.60GHz
BenchmarkPatchBindingStatus
BenchmarkPatchBindingStatus-4             125234              9259 ns/op
PASS
```

So, here is about a 6x performance increase.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

