### PR TITLE
test: unify access to cluster members utilizing `framework.ClusterMembers()` as input parameter

### DIFF
--- a/test/e2e/federatedresourcequota_test.go
+++ b/test/e2e/federatedresourcequota_test.go
@@ -46,7 +46,7 @@ var _ = framework.SerialDescribe("FederatedResourceQuota auto-provision testing"
 	ginkgo.BeforeEach(func() {
 		frqNamespace = testNamespace
 		frqName = federatedResourceQuotaPrefix + rand.String(RandomStrLength)
-		federatedResourceQuota = helper.NewFederatedResourceQuota(frqNamespace, frqName)
+		federatedResourceQuota = helper.NewFederatedResourceQuota(frqNamespace, frqName, framework.ClusterNames())
 
 		defaultConfigFlags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag().WithDiscoveryBurst(300).WithDiscoveryQPS(50.0)
 		defaultConfigFlags.Context = &karmadaContext
@@ -163,7 +163,7 @@ var _ = framework.SerialDescribe("[FederatedResourceQuota] status collection tes
 	ginkgo.BeforeEach(func() {
 		frqNamespace = testNamespace
 		frqName = federatedResourceQuotaPrefix + rand.String(RandomStrLength)
-		federatedResourceQuota = helper.NewFederatedResourceQuota(frqNamespace, frqName)
+		federatedResourceQuota = helper.NewFederatedResourceQuota(frqNamespace, frqName, framework.ClusterNames())
 	})
 
 	ginkgo.Context("collect federatedResourceQuota status", func() {

--- a/test/helper/policy.go
+++ b/test/helper/policy.go
@@ -161,7 +161,7 @@ func NewClusterOverridePolicyByOverrideRules(policyName string, rsSelectors []po
 }
 
 // NewFederatedResourceQuota will build a demo FederatedResourceQuota object.
-func NewFederatedResourceQuota(ns, name string) *policyv1alpha1.FederatedResourceQuota {
+func NewFederatedResourceQuota(ns, name string, clusterNames []string) *policyv1alpha1.FederatedResourceQuota {
 	return &policyv1alpha1.FederatedResourceQuota{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
@@ -174,14 +174,14 @@ func NewFederatedResourceQuota(ns, name string) *policyv1alpha1.FederatedResourc
 			},
 			StaticAssignments: []policyv1alpha1.StaticClusterAssignment{
 				{
-					ClusterName: "member1",
+					ClusterName: clusterNames[0],
 					Hard: map[corev1.ResourceName]resource.Quantity{
 						"cpu":    resource.MustParse("1"),
 						"memory": resource.MustParse("2Gi"),
 					},
 				},
 				{
-					ClusterName: "member2",
+					ClusterName: clusterNames[1],
 					Hard: map[corev1.ResourceName]resource.Quantity{
 						"cpu":    resource.MustParse("1"),
 						"memory": resource.MustParse("2Gi"),


### PR DESCRIPTION
**Description**

In this commit, we unify access to cluster members in `test/helper` by passing `clusterNames` as an input parameter to the function `NewFederatedResourceQuota`. This commit is also a follow-up of this PR #5226.

**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**Which issue(s) this PR fixes**:

Motivated by @XiShanYongYe-Chang's comment:
https://github.com/karmada-io/karmada/pull/5226#issuecomment-2238613211

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```