### PR TITLE
rename webhooks to be clearly identifiable as from karmada

### DIFF
--- a/artifacts/deploy/webhook-configuration.yaml
+++ b/artifacts/deploy/webhook-configuration.yaml
@@ -1,9 +1,9 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: mutating-config
+  name: karmada-mutations
   labels:
-    app: mutating-config
+    app: karmada-webhook
 webhooks:
   - name: propagationpolicy.karmada.io
     rules:
@@ -121,9 +121,9 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: validating-config
+  name: karmada-validations
   labels:
-    app: validating-config
+    app: karmada-webhook
 webhooks:
   - name: propagationpolicy.karmada.io
     rules:

--- a/charts/karmada/templates/_karmada_webhook_configuration.tpl
+++ b/charts/karmada/templates/_karmada_webhook_configuration.tpl
@@ -5,9 +5,9 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: mutating-config
+  name: karmada-mutations
   labels:
-    app: mutating-config
+    app: karmada-webhook
     {{- include "karmada.commonLabels" . | nindent 4 }}
 webhooks:
   - name: propagationpolicy.karmada.io
@@ -126,9 +126,9 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: validating-config
+  name: karmada-validations
   labels:
-    app: validating-config
+    app: karmada-webhook
     {{- include "karmada.commonLabels" . | nindent 4 }}
 webhooks:
   - name: propagationpolicy.karmada.io

--- a/operator/pkg/karmadaresource/webhookconfiguration/manifests.go
+++ b/operator/pkg/karmadaresource/webhookconfiguration/manifests.go
@@ -22,9 +22,9 @@ const (
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: mutating-config
+  name: karmada-mutations
   labels:
-    app: mutating-config
+    app: karmada-webhook
 webhooks:
   - name: propagationpolicy.karmada.io
     rules:
@@ -145,9 +145,9 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: validating-config
+  name: karmada-validations
   labels:
-    app: validating-config
+    app: karmada-webhook
 webhooks:
   - name: propagationpolicy.karmada.io
     rules:

--- a/pkg/karmadactl/cmdinit/karmada/deploy.go
+++ b/pkg/karmadactl/cmdinit/karmada/deploy.go
@@ -105,12 +105,12 @@ func InitKarmadaResources(dir, caBase64, systemNamespace string) error {
 
 	// create webhook configuration
 	// https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/webhook-configuration.yaml
-	klog.Info("Create MutatingWebhookConfiguration mutating-config.")
+	klog.Info("Create MutatingWebhookConfiguration karmada-mutations.")
 	if err = createOrUpdateMutatingWebhookConfiguration(clientSet, mutatingConfig(caBase64, systemNamespace)); err != nil {
 		klog.Exitln(err)
 	}
 
-	klog.Info("Create ValidatingWebhookConfiguration validating-config.")
+	klog.Info("Create ValidatingWebhookConfiguration karmada-validations.")
 	if err = createOrUpdateValidatingWebhookConfiguration(clientSet, validatingConfig(caBase64, systemNamespace)); err != nil {
 		klog.Exitln(err)
 	}

--- a/pkg/karmadactl/cmdinit/karmada/webhook_configuration.go
+++ b/pkg/karmadactl/cmdinit/karmada/webhook_configuration.go
@@ -34,9 +34,9 @@ func mutatingConfig(caBundle string, systemNamespace string) string {
 	return fmt.Sprintf(`apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: mutating-config
+  name: karmada-mutations
   labels:
-    app: mutating-config
+    app: karmada-webhook
 webhooks:
   - name: propagationpolicy.karmada.io
     rules:
@@ -156,9 +156,9 @@ func validatingConfig(caBundle string, systemNamespace string) string {
 	return fmt.Sprintf(`apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: validating-config
+  name: karmada-validations
   labels:
-    app: validating-config
+    app: karmada-webhook
 webhooks:
   - name: propagationpolicy.karmada.io
     rules:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind deprecation

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/karmada/issues/5231

**Special notes for your reviewer**:

I used `app: karmada-webhook` since that is where the requests are sent to, made more sense to me then declaring 2 apps that only have the hooks

**Does this PR introduce a user-facing change?**:
```release-note
- after deploying delete the mutating-config MutatingWebhookConfiguration and validating-config ValidatingWebhookConfiguration (they were renamed)
```

TODO:
- [ ] merge label change and rebase
- [ ] add helm clenup job
