### PR TITLE
relabel webhooks to make it obvious they belong to karmada

### DIFF
--- a/artifacts/deploy/webhook-configuration.yaml
+++ b/artifacts/deploy/webhook-configuration.yaml
@@ -3,7 +3,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-config
   labels:
-    app: mutating-config
+    app: karmada-webhook
 webhooks:
   - name: propagationpolicy.karmada.io
     rules:
@@ -123,7 +123,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-config
   labels:
-    app: validating-config
+    app: karmada-webhook
 webhooks:
   - name: propagationpolicy.karmada.io
     rules:

--- a/charts/karmada/templates/_karmada_webhook_configuration.tpl
+++ b/charts/karmada/templates/_karmada_webhook_configuration.tpl
@@ -7,7 +7,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-config
   labels:
-    app: mutating-config
+    app: karmada-webhook
     {{- include "karmada.commonLabels" . | nindent 4 }}
 webhooks:
   - name: propagationpolicy.karmada.io
@@ -128,7 +128,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-config
   labels:
-    app: validating-config
+    app: karmada-webhook
     {{- include "karmada.commonLabels" . | nindent 4 }}
 webhooks:
   - name: propagationpolicy.karmada.io

--- a/operator/pkg/karmadaresource/webhookconfiguration/manifests.go
+++ b/operator/pkg/karmadaresource/webhookconfiguration/manifests.go
@@ -24,7 +24,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-config
   labels:
-    app: mutating-config
+    app: karmada-webhook
 webhooks:
   - name: propagationpolicy.karmada.io
     rules:
@@ -147,7 +147,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-config
   labels:
-    app: validating-config
+    app: karmada-webhook
 webhooks:
   - name: propagationpolicy.karmada.io
     rules:

--- a/pkg/karmadactl/cmdinit/karmada/webhook_configuration.go
+++ b/pkg/karmadactl/cmdinit/karmada/webhook_configuration.go
@@ -36,7 +36,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-config
   labels:
-    app: mutating-config
+    app: karmada-webhook
 webhooks:
   - name: propagationpolicy.karmada.io
     rules:
@@ -158,7 +158,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-config
   labels:
-    app: validating-config
+    app: karmada-webhook
 webhooks:
   - name: propagationpolicy.karmada.io
     rules:


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

spilling out a part of https://github.com/karmada-io/karmada/pull/5240

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
- karmada-webhook: changed "app" label from mutating-config/validating-config to karmada-webhook to make them identifiyable
```

