### PR TITLE
fix: `ClusterResourceBinding` scope in `MutatingWebhookConfiguration`

### DIFF
--- a/charts/karmada/templates/_karmada_webhook_configuration.tpl
+++ b/charts/karmada/templates/_karmada_webhook_configuration.tpl
@@ -72,7 +72,7 @@ webhooks:
         apiGroups: ["work.karmada.io"]
         apiVersions: ["*"]
         resources: ["clusterresourcebindings"]
-        scope: "Namespaced"
+        scope: "Cluster"
     clientConfig:
       url: https://{{ $name }}-webhook.{{ $namespace }}.svc:443/mutate-clusterresourcebinding
       {{- include "karmada.webhook.caBundle" . | nindent 6 }}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

We've been having a lot of issues with karmada deleting cluster-level resources such as ClusterRole and ClusterRoleBinding.

After debugging, we realized that the label `clusterresourcebinding.karmada.io/permanent-id` was missing from those ClusterResourceBinding and that the webhook is responsible for populating that. Given that this was empty, all resource propagated to the member cluster also had an empty value for the id (i.e. `clusterresourcebinding.karmada.io/permanent-id: ""`) which is then identified as orphaned work and is deleted in the cluster.

This must have broke after the "63 char limit issue" because all of our CRBs prior to that release are fine and do not cause orphan work issues:

(note 79 days ago is good, but all recent ones are not)

```
❯ kubectl get crb -L clusterresourcebinding.karmada.io/permanent-id

NAME                                                                                          SCHEDULED   FULLYAPPLIED   AGE     PERMANENT-ID
access-admin-clusterrole                                                                      True        True           150d    49baa1bb-c6e5-40fb-a913-3721314d736e
access-admin-clusterrolebinding                                                               True        True           150d    cfd8e53f-52fb-4613-8244-9a8084959b54
aggregate-olm-edit-clusterrole                                                                True        False          13d
aggregate-olm-view-clusterrole                                                                True        False          13d
aggregate-to-restricted-edit-clusterrole                                                      True        False          13d
amir-namespace                                                                                True        True           125d    fca50359-b88b-4647-bf33-9f25ffd82d02
analytics-admin-clusterrole                                                                   True        True           150d    ce2aefef-3251-45bf-8082-b816913b66cc
applications.argoproj.io-customresourcedefinition                                             True        True           79d     f5e35e32-20ac-4b2d-94b3-1e3a94e387f1
applicationsets.argoproj.io-customresourcedefinition                                          True        True           79d     d6f33b7d-1dd4-467d-b753-b60d0d70d473
appprojects.argoproj.io-customresourcedefinition                                              True        True           79d     50c92fea-e201-44fd-ba34-a717c90ed2e2
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
fix: `ClusterResourceBinding` scope in `MutatingWebhookConfiguration`
```

