### PR TITLE
fix: kustomize syntax for webhook caBundle

### DIFF
--- a/charts/karmada/_crds/patches/webhook_in_clusterresourcebindings.yaml
+++ b/charts/karmada/_crds/patches/webhook_in_clusterresourcebindings.yaml
@@ -10,5 +10,5 @@ spec:
     webhook:
       clientConfig:
         url: https://karmada-webhook.karmada-system.svc:443/convert
-        caBundle: {{caBundle}}
+        caBundle: "{{caBundle}}"
       conversionReviewVersions: ["v1"]

--- a/charts/karmada/_crds/patches/webhook_in_resourcebindings.yaml
+++ b/charts/karmada/_crds/patches/webhook_in_resourcebindings.yaml
@@ -10,5 +10,5 @@ spec:
     webhook:
       clientConfig:
         url: https://karmada-webhook.karmada-system.svc:443/convert
-        caBundle: {{caBundle}}
+        caBundle: "{{caBundle}}"
       conversionReviewVersions: ["v1"]


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
The current syntax does not work for kustomize
```
❯ kustomize build charts/karmada/_crds/
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
Error: wrong node kind: expected ScalarNode but got MappingNode: node contents:
{? {caBundle: ''} : ''}
```

Adding quotes around it makes it work for kustomize build while still working for helm charts. This is a no risk change for those that prefer using kustomize.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

