### PR TITLE
fix unexpected interference between different e2e use cases

### DIFF
--- a/test/e2e/clusterpropagationpolicy_test.go
+++ b/test/e2e/clusterpropagationpolicy_test.go
@@ -570,6 +570,7 @@ var _ = ginkgo.Describe("[ImplicitPriority] propagation testing", func() {
 					APIVersion: deployment.APIVersion,
 					Kind:       deployment.Kind,
 					Name:       deployment.Name,
+					Namespace:  deployment.Namespace,
 				},
 			}, policyv1alpha1.Placement{
 				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
@@ -580,6 +581,7 @@ var _ = ginkgo.Describe("[ImplicitPriority] propagation testing", func() {
 				{
 					APIVersion:    deployment.APIVersion,
 					Kind:          deployment.Kind,
+					Namespace:     deployment.Namespace,
 					LabelSelector: metav1.SetAsLabelSelector(labels.Set{implicitPriorityLabelKey: implicitPriorityLabelValue}),
 				},
 			}, policyv1alpha1.Placement{
@@ -591,6 +593,7 @@ var _ = ginkgo.Describe("[ImplicitPriority] propagation testing", func() {
 				{
 					APIVersion: deployment.APIVersion,
 					Kind:       deployment.Kind,
+					Namespace:  deployment.Namespace,
 				},
 			}, policyv1alpha1.Placement{
 				ClusterAffinity: &policyv1alpha1.ClusterAffinity{


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

The scope of some Policy's resourceSelector in E2E use case is too large to affect other use cases.

detail refer to #5256

**Which issue(s) this PR fixes**:

Fixes #5256

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

