### PR TITLE
e2e: clusterresourcebinding permanent-id label

### DIFF
--- a/test/e2e/clusterresourcebinding_test.go
+++ b/test/e2e/clusterresourcebinding_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo/v2"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/util/helper"
+	"github.com/karmada-io/karmada/pkg/util/names"
+	"github.com/karmada-io/karmada/test/e2e/framework"
+	testhelper "github.com/karmada-io/karmada/test/helper"
+)
+
+var _ = ginkgo.Describe("ClusterResourceBinding test", func() {
+	ginkgo.Context("permanent id label testing", func() {
+		var (
+			policy                  *policyv1alpha1.ClusterPropagationPolicy
+			clusterRole             *rbacv1.ClusterRole
+			bindingName             string
+			hasPermanentIDLabelFunc = func(labels map[string]string) bool {
+				return len(labels) > 0 && labels[workv1alpha2.ClusterResourceBindingPermanentIDLabel] != ""
+			}
+		)
+		ginkgo.BeforeEach(func() {
+			policyName := clusterRoleNamePrefix + rand.String(RandomStrLength)
+			clusterRoleName := fmt.Sprintf("system:test-%s", policyName)
+
+			clusterRole = testhelper.NewClusterRole(clusterRoleName, nil)
+			policy = testhelper.NewClusterPropagationPolicy(policyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: clusterRole.APIVersion,
+					Kind:       clusterRole.Kind,
+					Name:       clusterRole.Name,
+				},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: framework.ClusterNames(),
+				},
+			})
+
+			bindingName = names.GenerateBindingName(clusterRole.Kind, clusterRole.Name)
+		})
+
+		ginkgo.BeforeEach(func() {
+			framework.CreateClusterPropagationPolicy(karmadaClient, policy)
+			framework.CreateClusterRole(kubeClient, clusterRole)
+			ginkgo.DeferCleanup(func() {
+				framework.RemoveClusterPropagationPolicy(karmadaClient, policy.Name)
+				framework.RemoveClusterRole(kubeClient, clusterRole.Name)
+				framework.WaitClusterRoleDisappearOnClusters(framework.ClusterNames(), clusterRole.Name)
+			})
+		})
+
+		ginkgo.BeforeEach(func() {
+			framework.WaitClusterResourceBindingFitWith(karmadaClient, bindingName, func(clusterResourceBinding *workv1alpha2.ClusterResourceBinding) bool {
+				return hasPermanentIDLabelFunc(clusterResourceBinding.Labels)
+			})
+		})
+
+		ginkgo.It("creates work with permanent ID label", func() {
+			framework.WaitClusterResourceBindingFitWith(karmadaClient, bindingName, func(clusterResourceBinding *workv1alpha2.ClusterResourceBinding) bool {
+				workList, err := helper.GetWorksByBindingID(controlPlaneClient, clusterResourceBinding.Labels[workv1alpha2.ClusterResourceBindingPermanentIDLabel], false)
+				if err != nil {
+					return false
+				}
+
+				return workList != nil && len(workList.Items) == len(framework.ClusterNames())
+			})
+		})
+
+		ginkgo.It("propagates resource with permanent ID label", func() {
+			framework.WaitClusterRolePresentOnClustersFitWith(framework.ClusterNames(), clusterRole.Name, func(clusterRole *rbacv1.ClusterRole) bool {
+				return hasPermanentIDLabelFunc(clusterRole.Labels)
+			})
+		})
+	})
+})


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

As described in linked PR, if the label is not set, it could lead to cluster resources being identified as orphaned work and deleted in member clusters. This PR attempts to prevent regressions from happening.

**Which issue(s) this PR fixes**:
Request in PR https://github.com/karmada-io/karmada/pull/5252#issuecomment-2252336961

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

