### PR TITLE
Automated cherry pick of #5252: fix: `ClusterResourceBinding` scope in

### DIFF
--- a/charts/karmada/templates/_karmada_webhook_configuration.tpl
+++ b/charts/karmada/templates/_karmada_webhook_configuration.tpl
@@ -72,7 +72,7 @@ webhooks:
         apiGroups: ["work.karmada.io"]
         apiVersions: ["*"]
         resources: ["clusterresourcebindings"]
-        scope: "Namespaced"
+        scope: "Cluster"
     clientConfig:
       url: https://{{ $name }}-webhook.{{ $namespace }}.svc:443/mutate-clusterresourcebinding
       {{- include "karmada.webhook.caBundle" . | nindent 6 }}


### PR DESCRIPTION
Cherry pick of #5252 on release-1.10.
#5252: fix: `ClusterResourceBinding` scope in
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
Helm: fix wrong `ClusterResourceBinding` scope in `MutatingWebhookConfiguration`.
```