### PR TITLE
fix unexpected interference between different e2e use cases

### DIFF
--- a/test/e2e/clusterpropagationpolicy_test.go
+++ b/test/e2e/clusterpropagationpolicy_test.go
@@ -547,7 +547,8 @@ var _ = ginkgo.Describe("[AdvancedClusterPropagation] propagation testing", func
 })
 
 // ImplicitPriority more than one PP matches the object, we should choose the most suitable one.
-var _ = ginkgo.Describe("[ImplicitPriority] propagation testing", func() {
+// Set it to run sequentially to avoid affecting other test cases.
+var _ = framework.SerialDescribe("[ImplicitPriority] propagation testing", func() {
 	ginkgo.Context("priorityMatchName/priorityMatchLabel/priorityMatchAll propagation testing", func() {
 		var priorityMatchName, priorityMatchLabelSelector, priorityMatchAll string
 		var deploymentNamespace, deploymentName string

--- a/test/e2e/propagationpolicy_test.go
+++ b/test/e2e/propagationpolicy_test.go
@@ -514,7 +514,8 @@ var _ = ginkgo.Describe("[BasicPropagation] propagation testing", func() {
 })
 
 // ImplicitPriority more than one PP matches the object, we should choose the most suitable one.
-var _ = ginkgo.Describe("[ImplicitPriority] propagation testing", func() {
+// Set it to run sequentially to avoid affecting other test cases.
+var _ = framework.SerialDescribe("[ImplicitPriority] propagation testing", func() {
 	ginkgo.Context("priorityMatchName propagation testing", func() {
 		var policyNamespace, priorityMatchName, priorityMatchLabelSelector, priorityMatchAll string
 		var deploymentNamespace, deploymentName string


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

The `testNamespace` is initialized in the input function `allProcessBody` of `ginkgo.SynchronizedBeforeSuite`. The execution count of the `allProcessBody` function in `SynchronizedBeforeSuite` is related to the concurrency level. Therefore, it cannot be guaranteed that the `testNamespace` will be different for all test cases.

If a test case creates a `pp/cpp` with a `ResourceSelector` set to `testNamespace`, to ensure it does not affect other test cases, the test case should be set to run sequentially.



**Which issue(s) this PR fixes**:
Parts of #5256

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

