### PR TITLE
Standardize the health probe and metrics arguments of scheduler-estimator

### DIFF
--- a/artifacts/deploy/karmada-scheduler-estimator.yaml
+++ b/artifacts/deploy/karmada-scheduler-estimator.yaml
@@ -30,6 +30,8 @@ spec:
             - --grpc-auth-cert-file=/etc/karmada/pki/karmada.crt
             - --grpc-auth-key-file=/etc/karmada/pki/karmada.key
             - --grpc-client-ca-file=/etc/karmada/pki/ca.crt
+            - --metrics-bind-address=0.0.0.0:10351
+            - --health-probe-bind-address=0.0.0.0:10351
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/karmada/templates/karmada-scheduler-estimator.yaml
+++ b/charts/karmada/templates/karmada-scheduler-estimator.yaml
@@ -51,6 +51,8 @@ spec:
             - --grpc-auth-cert-file=/etc/karmada/pki/karmada.crt
             - --grpc-auth-key-file=/etc/karmada/pki/karmada.key
             - --grpc-client-ca-file=/etc/karmada/pki/server-ca.crt
+            - --metrics-bind-address=0.0.0.0:10351
+            - --health-probe-bind-address=0.0.0.0:10351
             {{- with (include "karmada.schedulerEstimator.featureGates" (dict "featureGatesArg" $.Values.schedulerEstimator.featureGates)) }}
             - {{ . }}
             {{- end}}

--- a/cmd/scheduler-estimator/app/options/options.go
+++ b/cmd/scheduler-estimator/app/options/options.go
@@ -17,6 +17,9 @@ limitations under the License.
 package options
 
 import (
+	"net"
+	"strconv"
+
 	"github.com/spf13/pflag"
 
 	"github.com/karmada-io/karmada/pkg/features"
@@ -35,8 +38,10 @@ type Options struct {
 	Master      string
 	ClusterName string
 	// BindAddress is the IP address on which to listen for the --secure-port port.
+	// Deprecated: To specify the TCP addresse for serving health probes, use HealthProbeBindAddress instead. To specify the TCP addresse for serving prometheus metrics, use MetricsBindAddress instead. This will be removed in release 1.12+.
 	BindAddress string
 	// SecurePort is the port that the server serves at.
+	// Deprecated: To specify the TCP addresse for serving health probes, use HealthProbeBindAddress instead. To specify the TCP addresse for serving prometheus metrics, use MetricsBindAddress instead. This will be removed in release 1.12+.
 	SecurePort int
 	// ServerPort is the port that the server gRPC serves at.
 	ServerPort int
@@ -55,6 +60,16 @@ type Options struct {
 	// Parallelism defines the amount of parallelism in algorithms for estimating. Must be greater than 0. Defaults to 16.
 	Parallelism int
 	ProfileOpts profileflag.Options
+	// MetricsBindAddress is the TCP address that the server should bind to
+	// for serving prometheus metrics.
+	// It can be set to "0" to disable the metrics serving.
+	// Defaults to ":10351".
+	MetricsBindAddress string
+	// HealthProbeBindAddress is the TCP address that the server should bind to
+	// for serving health probes
+	// It can be set to "0" to disable serving the health probe.
+	// Defaults to ":10351".
+	HealthProbeBindAddress string
 }
 
 // NewOptions builds an empty options.
@@ -80,7 +95,24 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.Float32Var(&o.ClusterAPIQPS, "kube-api-qps", 20.0, "QPS to use while talking with apiserver.")
 	fs.IntVar(&o.ClusterAPIBurst, "kube-api-burst", 30, "Burst to use while talking with apiserver.")
 	fs.IntVar(&o.Parallelism, "parallelism", o.Parallelism, "Parallelism defines the amount of parallelism in algorithms for estimating. Must be greater than 0. Defaults to 16.")
+	// nolint: errcheck
+	fs.MarkDeprecated("bind-address", "This flag is deprecated and will be removed in release 1.12+. Use --health-probe-bind-address and --metrics-bind-address instead. Note: In release 1.12+, these two addresses cannot be the same.")
+	// nolint: errcheck
+	fs.MarkDeprecated("secure-port", "This flag is deprecated and will be removed in release 1.12+. Use --health-probe-bind-address and --metrics-bind-address instead. Note: In release 1.12+, these two addresses cannot be the same.")
+	fs.StringVar(&o.MetricsBindAddress, "metrics-bind-address", "", "The TCP address that the server should bind to for serving prometheus metrics(e.g. 127.0.0.1:10351, :10351). It can be set to \"0\" to disable the metrics serving. Defaults to 0.0.0.0:10351.")
+	fs.StringVar(&o.HealthProbeBindAddress, "health-probe-bind-address", "", "The TCP address that the server should bind to for serving health probes(e.g. 127.0.0.1:10351, :10351). It can be set to \"0\" to disable serving the health probe. Defaults to 0.0.0.0:10351.")
 	features.FeatureGate.AddFlag(fs)
 
 	o.ProfileOpts.AddFlags(fs)
+}
+
+// Complete ensures that options are valid and marshals them if necessary.
+func (o *Options) Complete() error {
+	if len(o.HealthProbeBindAddress) == 0 {
+		o.HealthProbeBindAddress = net.JoinHostPort(o.BindAddress, strconv.Itoa(o.SecurePort))
+	}
+	if len(o.MetricsBindAddress) == 0 {
+		o.MetricsBindAddress = net.JoinHostPort(o.BindAddress, strconv.Itoa(o.SecurePort))
+	}
+	return nil
 }

--- a/cmd/scheduler-estimator/app/options/validation.go
+++ b/cmd/scheduler-estimator/app/options/validation.go
@@ -17,8 +17,6 @@ limitations under the License.
 package options
 
 import (
-	"net"
-
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -31,16 +29,8 @@ func (o *Options) Validate() field.ErrorList {
 		errs = append(errs, field.Invalid(newPath.Child("ClusterName"), o.ClusterName, "clusterName cannot be empty"))
 	}
 
-	if net.ParseIP(o.BindAddress) == nil {
-		errs = append(errs, field.Invalid(newPath.Child("BindAddress"), o.BindAddress, "not a valid textual representation of an IP address"))
-	}
-
 	if o.ServerPort < 0 || o.ServerPort > 65535 {
 		errs = append(errs, field.Invalid(newPath.Child("ServerPort"), o.ServerPort, "must be a valid port between 0 and 65535 inclusive"))
-	}
-
-	if o.SecurePort < 0 || o.SecurePort > 65535 {
-		errs = append(errs, field.Invalid(newPath.Child("SecurePort"), o.SecurePort, "must be a valid port between 0 and 65535 inclusive"))
 	}
 
 	return errs

--- a/cmd/scheduler-estimator/app/options/validation_test.go
+++ b/cmd/scheduler-estimator/app/options/validation_test.go
@@ -29,8 +29,6 @@ type ModifyOptions func(option *Options)
 func New(modifyOptions ModifyOptions) Options {
 	option := Options{
 		ClusterName: "testCluster",
-		BindAddress: "0.0.0.0",
-		SecurePort:  10100,
 		ServerPort:  8088,
 	}
 
@@ -60,18 +58,6 @@ func TestValidateKarmadaSchedulerEstimator(t *testing.T) {
 				option.ClusterName = ""
 			}),
 			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("ClusterName"), "", "clusterName cannot be empty")},
-		},
-		"invalid BindAddress": {
-			opt: New(func(option *Options) {
-				option.BindAddress = "127.0.0.1:8082"
-			}),
-			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("BindAddress"), "127.0.0.1:8082", "not a valid textual representation of an IP address")},
-		},
-		"invalid SecurePort": {
-			opt: New(func(option *Options) {
-				option.SecurePort = 908188
-			}),
-			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("SecurePort"), 908188, "must be a valid port between 0 and 65535 inclusive")},
 		},
 		"invalid ServerPort": {
 			opt: New(func(option *Options) {

--- a/pkg/karmadactl/addons/estimator/manifests.go
+++ b/pkg/karmadactl/addons/estimator/manifests.go
@@ -48,12 +48,12 @@ spec:
             - /bin/karmada-scheduler-estimator
             - --kubeconfig=/etc/{{ .MemberClusterName}}-kubeconfig
             - --cluster-name={{ .MemberClusterName}}
-            - --bind-address=0.0.0.0
-            - --secure-port=10351
             - --grpc-auth-cert-file=/etc/karmada/pki/karmada.crt
             - --grpc-auth-key-file=/etc/karmada/pki/karmada.key
             - --client-cert-auth=true
             - --grpc-client-ca-file=/etc/karmada/pki/ca.crt
+            - --metrics-bind-address=0.0.0.0:10351
+            - --health-probe-bind-address=0.0.0.0:10351
           livenessProbe:
             httpGet:
               path: /healthz

--- a/pkg/karmadactl/cmdinit/utils/examples.go
+++ b/pkg/karmadactl/cmdinit/utils/examples.go
@@ -140,6 +140,8 @@ spec:
             - /bin/karmada-scheduler-estimator
             - --kubeconfig=/etc/{{member_cluster_name}}-kubeconfig
             - --cluster-name={{member_cluster_name}}
+            - --metrics-bind-address=0.0.0.0:10351
+            - --health-probe-bind-address=0.0.0.0:10351
           volumeMounts:
             - name: member-kubeconfig
               subPath: {{member_cluster_name}}-kubeconfig


### PR DESCRIPTION
**What type of PR is this?**
/kind deprecation
/kind feature
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
part of https://github.com/karmada-io/karmada/issues/5219

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-scheduler-estimator`:  Add health probe argument `health-probe-bind-address` and metrics argument `metrics-bind-address`. Deprecate `--bind-address` and `--secure-port` flags.
```

