### PR TITLE
add karmada.io/system label to created clusterrole+bindings

### DIFF
--- a/operator/pkg/karmadaresource/rbac/rbac.go
+++ b/operator/pkg/karmadaresource/rbac/rbac.go
@@ -25,6 +25,7 @@ import (
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/karmada-io/karmada/operator/pkg/util/apiclient"
+	"github.com/karmada-io/karmada/pkg/util"
 )
 
 // EnsureKarmadaRBAC create karmada resource view and edit clusterrole
@@ -36,17 +37,19 @@ func EnsureKarmadaRBAC(client clientset.Interface) error {
 }
 
 func grantKarmadaResourceViewClusterrole(client clientset.Interface) error {
-	viewClusterrole := &rbacv1.ClusterRole{}
-	if err := kuberuntime.DecodeInto(clientsetscheme.Codecs.UniversalDecoder(), []byte(KarmadaResourceViewClusterRole), viewClusterrole); err != nil {
+	role := &rbacv1.ClusterRole{}
+	if err := kuberuntime.DecodeInto(clientsetscheme.Codecs.UniversalDecoder(), []byte(KarmadaResourceViewClusterRole), role); err != nil {
 		return fmt.Errorf("err when decoding Karmada view Clusterrole: %w", err)
 	}
-	return apiclient.CreateOrUpdateClusterRole(client, viewClusterrole)
+	util.MergeLabel(role, util.KarmadaSystemLabel, util.KarmadaSystemLabelValue)
+	return apiclient.CreateOrUpdateClusterRole(client, role)
 }
 
 func grantKarmadaResourceEditClusterrole(client clientset.Interface) error {
-	editClusterrole := &rbacv1.ClusterRole{}
-	if err := kuberuntime.DecodeInto(clientsetscheme.Codecs.UniversalDecoder(), []byte(KarmadaResourceEditClusterRole), editClusterrole); err != nil {
+	role := &rbacv1.ClusterRole{}
+	if err := kuberuntime.DecodeInto(clientsetscheme.Codecs.UniversalDecoder(), []byte(KarmadaResourceEditClusterRole), role); err != nil {
 		return fmt.Errorf("err when decoding Karmada edit Clusterrole: %w", err)
 	}
-	return apiclient.CreateOrUpdateClusterRole(client, editClusterrole)
+	util.MergeLabel(role, util.KarmadaSystemLabel, util.KarmadaSystemLabelValue)
+	return apiclient.CreateOrUpdateClusterRole(client, role)
 }

--- a/pkg/controllers/unifiedauth/unified_auth_controller.go
+++ b/pkg/controllers/unifiedauth/unified_auth_controller.go
@@ -176,6 +176,9 @@ func (c *Controller) buildImpersonationClusterRole(cluster *clusterv1alpha1.Clus
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: karmadaImpersonatorName,
+			Labels: map[string]string{
+				util.KarmadaSystemLabel: util.KarmadaSystemLabelValue,
+			},
 		},
 		Rules: rules,
 	}
@@ -197,6 +200,9 @@ func (c *Controller) buildImpersonationClusterRoleBinding(cluster *clusterv1alph
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: karmadaImpersonatorName,
+			Labels: map[string]string{
+				util.KarmadaSystemLabel: util.KarmadaSystemLabelValue,
+			},
 		},
 		Subjects: []rbacv1.Subject{
 			{

--- a/pkg/karmadactl/cmdinit/utils/rbac.go
+++ b/pkg/karmadactl/cmdinit/utils/rbac.go
@@ -19,11 +19,13 @@ package utils
 import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/karmada-io/karmada/pkg/util"
 )
 
 // ClusterRoleFromRules ClusterRole Rules
 func ClusterRoleFromRules(name string, rules []rbacv1.PolicyRule, annotations map[string]string, labels map[string]string) *rbacv1.ClusterRole {
-	return &rbacv1.ClusterRole{
+	cr := &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "rbac.authorization.k8s.io/v1",
 			Kind:       "ClusterRole",
@@ -35,11 +37,13 @@ func ClusterRoleFromRules(name string, rules []rbacv1.PolicyRule, annotations ma
 		},
 		Rules: rules,
 	}
+	util.MergeLabel(cr, util.KarmadaSystemLabel, util.KarmadaSystemLabelValue)
+	return cr
 }
 
 // ClusterRoleBindingFromSubjects ClusterRoleBinding Subjects
 func ClusterRoleBindingFromSubjects(clusterRoleBindingName, clusterRoleName string, sub []rbacv1.Subject, labels map[string]string) *rbacv1.ClusterRoleBinding {
-	return &rbacv1.ClusterRoleBinding{
+	crb := &rbacv1.ClusterRoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "rbac.authorization.k8s.io/v1",
 			Kind:       "ClusterRoleBinding",
@@ -55,4 +59,6 @@ func ClusterRoleBindingFromSubjects(clusterRoleBindingName, clusterRoleName stri
 		},
 		Subjects: sub,
 	}
+	util.MergeLabel(crb, util.KarmadaSystemLabel, util.KarmadaSystemLabelValue)
+	return crb
 }

--- a/pkg/karmadactl/cmdinit/utils/rbac_test.go
+++ b/pkg/karmadactl/cmdinit/utils/rbac_test.go
@@ -22,6 +22,8 @@ import (
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/karmada-io/karmada/pkg/util"
 )
 
 func TestClusterRoleFromRules(t *testing.T) {
@@ -58,7 +60,10 @@ func TestClusterRoleFromRules(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "foo",
 					Annotations: map[string]string{"foo": "bar"},
-					Labels:      map[string]string{"foo": "bar"},
+					Labels: map[string]string{
+						"foo":                   "bar",
+						util.KarmadaSystemLabel: util.KarmadaSystemLabelValue,
+					},
 				},
 				Rules: []rbacv1.PolicyRule{
 					{
@@ -111,8 +116,11 @@ func TestClusterRoleBindingFromSubjects(t *testing.T) {
 					Kind:       "ClusterRoleBinding",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "foo",
-					Labels: map[string]string{"foo": "bar"},
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":                   "bar",
+						util.KarmadaSystemLabel: util.KarmadaSystemLabelValue,
+					},
 				},
 				RoleRef: rbacv1.RoleRef{
 					APIGroup: "rbac.authorization.k8s.io",


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

similar to [namespaces](https://github.com/karmada-io/karmada/pull/5243/files) cluster-roles need to have an identifier so we can find them all (without having to guess based on names)
and allow-list them in our "are you allowed to create cluster-roles" auditing tooling

**Does this PR introduce a user-facing change?**:
```release-note
- add karmada.io/system=true label to internally created karmada cluster-roles and cluster-role-bindings
```

