### PR TITLE
feat: strategytype should be duplicated, add default case for Replica…

### DIFF
--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_clusterpropagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_clusterpropagationpolicies.yaml
@@ -485,7 +485,7 @@ spec:
                         - Weighted
                         type: string
                       replicaSchedulingType:
-                        default: Divided
+                        default: Duplicated
                         description: |-
                           ReplicaSchedulingType determines how the replicas is scheduled when karmada propagating
                           a resource. Valid options are Duplicated and Divided.

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_propagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_propagationpolicies.yaml
@@ -482,7 +482,7 @@ spec:
                         - Weighted
                         type: string
                       replicaSchedulingType:
-                        default: Divided
+                        default: Duplicated
                         description: |-
                           ReplicaSchedulingType determines how the replicas is scheduled when karmada propagating
                           a resource. Valid options are Duplicated and Divided.

--- a/charts/karmada/_crds/bases/work/work.karmada.io_clusterresourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work/work.karmada.io_clusterresourcebindings.yaml
@@ -737,7 +737,7 @@ spec:
                         - Weighted
                         type: string
                       replicaSchedulingType:
-                        default: Divided
+                        default: Duplicated
                         description: |-
                           ReplicaSchedulingType determines how the replicas is scheduled when karmada propagating
                           a resource. Valid options are Duplicated and Divided.

--- a/charts/karmada/_crds/bases/work/work.karmada.io_resourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work/work.karmada.io_resourcebindings.yaml
@@ -737,7 +737,7 @@ spec:
                         - Weighted
                         type: string
                       replicaSchedulingType:
-                        default: Divided
+                        default: Duplicated
                         description: |-
                           ReplicaSchedulingType determines how the replicas is scheduled when karmada propagating
                           a resource. Valid options are Duplicated and Divided.

--- a/pkg/apis/policy/v1alpha1/propagation_types.go
+++ b/pkg/apis/policy/v1alpha1/propagation_types.go
@@ -443,7 +443,7 @@ type ReplicaSchedulingStrategy struct {
 	// "Divided" divides replicas into parts according to number of valid candidate member
 	// clusters, and exact replicas for each cluster are determined by ReplicaDivisionPreference.
 	// +kubebuilder:validation:Enum=Duplicated;Divided
-	// +kubebuilder:default=Divided
+	// +kubebuilder:default=Duplicated
 	// +optional
 	ReplicaSchedulingType ReplicaSchedulingType `json:"replicaSchedulingType,omitempty"`
 

--- a/pkg/scheduler/core/assignment.go
+++ b/pkg/scheduler/core/assignment.go
@@ -103,6 +103,8 @@ func newAssignState(candidates []*clusterv1alpha1.Cluster, spec *workv1alpha2.Re
 			} else {
 				strategyType = StaticWeightStrategy
 			}
+		default:
+			strategyType = AggregatedStrategy
 		}
 	}
 


### PR DESCRIPTION
…DivisionPreference

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind feature

**What this PR does / why we need it**:
According to this snippet of code, default ReplicaSchedulingType should be Duplicated.
```
func (p *Placement) ReplicaSchedulingType() ReplicaSchedulingType {
	if p.ReplicaScheduling == nil {
		return ReplicaSchedulingTypeDuplicated
	}

	return p.ReplicaScheduling.ReplicaSchedulingType
}
```
And in case that ReplicaSchedulingType is divided and ReplicaDivisionPreference is not defined, default ReplicaDivisionPreference should be added. I think Aggregated is more appropriate.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

