### PR TITLE
Standardize the health probe argument of karmada-controller-manager

### DIFF
--- a/artifacts/deploy/karmada-controller-manager.yaml
+++ b/artifacts/deploy/karmada-controller-manager.yaml
@@ -26,12 +26,11 @@ spec:
           command:
             - /bin/karmada-controller-manager
             - --kubeconfig=/etc/kubeconfig
-            - --bind-address=0.0.0.0
             - --cluster-status-update-frequency=10s
-            - --secure-port=10357
             - --failover-eviction-timeout=30s
             - --controllers=*,hpaScaleTargetMarker,deploymentReplicasSyncer
             - --feature-gates=PropagationPolicyPreemption=true,MultiClusterService=true
+            - --health-probe-bind-address=0.0.0.0:10357
             - --v=4
           livenessProbe:
             httpGet:

--- a/charts/karmada/templates/karmada-controller-manager.yaml
+++ b/charts/karmada/templates/karmada-controller-manager.yaml
@@ -53,10 +53,9 @@ spec:
           command:
             - /bin/karmada-controller-manager
             - --kubeconfig=/etc/kubeconfig
-            - --bind-address=0.0.0.0
             - --cluster-status-update-frequency=10s
-            - --secure-port=10357
             - --leader-elect-resource-namespace={{ $systemNamespace }}
+            - --health-probe-bind-address=0.0.0.0:10357
             - --v=2
             {{- if .Values.controllerManager.controllers }}
             - --controllers={{ .Values.controllerManager.controllers }}

--- a/charts/karmada/templates/karmada-controller-manager.yaml
+++ b/charts/karmada/templates/karmada-controller-manager.yaml
@@ -53,9 +53,10 @@ spec:
           command:
             - /bin/karmada-controller-manager
             - --kubeconfig=/etc/kubeconfig
+            - --bind-address=0.0.0.0
             - --cluster-status-update-frequency=10s
+            - --secure-port=10357
             - --leader-elect-resource-namespace={{ $systemNamespace }}
-            - --health-probe-bind-address=0.0.0.0:10357
             - --v=2
             {{- if .Values.controllerManager.controllers }}
             - --controllers={{ .Values.controllerManager.controllers }}

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -19,8 +19,6 @@ package app
 import (
 	"context"
 	"flag"
-	"net"
-	"strconv"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -102,6 +100,10 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 The controllers watch Karmada objects and then talk to the underlying clusters' API servers
 to create regular Kubernetes resources.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
+			// complete options
+			if err := opts.Complete(); err != nil {
+				return err
+			}
 			// validate options
 			if errs := opts.Validate(); len(errs) != 0 {
 				return errs.ToAggregate()
@@ -156,7 +158,7 @@ func Run(ctx context.Context, opts *options.Options) error {
 		RenewDeadline:              &opts.LeaderElection.RenewDeadline.Duration,
 		RetryPeriod:                &opts.LeaderElection.RetryPeriod.Duration,
 		LeaderElectionResourceLock: opts.LeaderElection.ResourceLock,
-		HealthProbeBindAddress:     net.JoinHostPort(opts.BindAddress, strconv.Itoa(opts.SecurePort)),
+		HealthProbeBindAddress:     opts.HealthProbeBindAddress,
 		LivenessEndpointName:       "/healthz",
 		Metrics:                    metricsserver.Options{BindAddress: opts.MetricsBindAddress},
 		MapperProvider:             restmapper.MapperProvider,

--- a/cmd/controller-manager/app/options/validation.go
+++ b/cmd/controller-manager/app/options/validation.go
@@ -34,9 +34,6 @@ func (o *Options) Validate() field.ErrorList {
 	if err := skippedResourceConfig.Parse(o.SkippedPropagatingAPIs); err != nil {
 		errs = append(errs, field.Invalid(newPath.Child("SkippedPropagatingAPIs"), o.SkippedPropagatingAPIs, "Invalid API string"))
 	}
-	if o.SecurePort < 0 || o.SecurePort > 65535 {
-		errs = append(errs, field.Invalid(newPath.Child("SecurePort"), o.SecurePort, "must be between 0 and 65535 inclusive"))
-	}
 	if o.ClusterStatusUpdateFrequency.Duration <= 0 {
 		errs = append(errs, field.Invalid(newPath.Child("ClusterStatusUpdateFrequency"), o.ClusterStatusUpdateFrequency, "must be greater than 0"))
 	}

--- a/cmd/controller-manager/app/options/validation_test.go
+++ b/cmd/controller-manager/app/options/validation_test.go
@@ -31,7 +31,6 @@ type ModifyOptions func(option *Options)
 func New(modifyOptions ModifyOptions) Options {
 	option := Options{
 		SkippedPropagatingAPIs:       "cluster.karmada.io;policy.karmada.io;work.karmada.io",
-		SecurePort:                   8090,
 		ClusterStatusUpdateFrequency: metav1.Duration{Duration: 10 * time.Second},
 		ClusterLeaseDuration:         metav1.Duration{Duration: 10 * time.Second},
 		ClusterMonitorPeriod:         metav1.Duration{Duration: 10 * time.Second},
@@ -66,12 +65,6 @@ func TestValidateControllerManagerConfiguration(t *testing.T) {
 				options.SkippedPropagatingAPIs = "a/b/c/d?"
 			}),
 			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("SkippedPropagatingAPIs"), "a/b/c/d?", "Invalid API string")},
-		},
-		"invalid SecurePort": {
-			opt: New(func(options *Options) {
-				options.SecurePort = -10
-			}),
-			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("SecurePort"), -10, "must be between 0 and 65535 inclusive")},
 		},
 		"invalid ClusterStatusUpdateFrequency": {
 			opt: New(func(options *Options) {

--- a/operator/pkg/controlplane/manifests.go
+++ b/operator/pkg/controlplane/manifests.go
@@ -128,11 +128,10 @@ spec:
         command:
         - /bin/karmada-controller-manager
         - --kubeconfig=/etc/karmada/kubeconfig
-        - --bind-address=0.0.0.0
         - --cluster-status-update-frequency=10s
-        - --secure-port=10357
         - --failover-eviction-timeout=30s
         - --leader-elect-resource-namespace={{ .SystemNamespace }}
+        - --health-probe-bind-address=0.0.0.0:10357
         - --v=4
         livenessProbe:
           httpGet:

--- a/pkg/karmadactl/cmdinit/kubernetes/deployments.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deployments.go
@@ -591,10 +591,9 @@ func (i *CommandInitOption) makeKarmadaControllerManagerDeployment() *appsv1.Dep
 				Command: []string{
 					"/bin/karmada-controller-manager",
 					"--kubeconfig=/etc/kubeconfig",
-					"--bind-address=0.0.0.0",
 					"--metrics-bind-address=:8080",
+					"--health-probe-bind-address=0.0.0.0:10357",
 					"--cluster-status-update-frequency=10s",
-					"--secure-port=10357",
 					fmt.Sprintf("--leader-elect-resource-namespace=%s", i.Namespace),
 					"--v=4",
 				},


### PR DESCRIPTION
**What type of PR is this?**
/kind deprecation
/kind feature
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
part of https://github.com/karmada-io/karmada/issues/5219

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`:  Add health probe argument `health-probe-bind-address`, and deprecate `--bind-address` and `--secure-port` flag.
```

