### PR TITLE
perf request close

### DIFF
--- a/pkg/util/proxy/upgrader.go
+++ b/pkg/util/proxy/upgrader.go
@@ -150,7 +150,7 @@ func (h *UpgradeAwareHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 			code := response.StatusCode
 			if code >= 300 && code <= 399 && len(response.Header.Get("Location")) > 0 {
 				// close the original response
-				response.Body.Close()
+				defer response.Body.Close()
 				msg := "the backend attempted to redirect this request, which is not permitted"
 				// replace the response
 				*response = http.Response{


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Using defer to close the response body is a common and recommended practice because it ensures that the Close method will be called before the function exits, whether the function completes normally or returns early due to an error or other reasons

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

