### PR TITLE
cleanup: Remove redundant e2e testing steps

### DIFF
--- a/test/e2e/karmadactl_test.go
+++ b/test/e2e/karmadactl_test.go
@@ -524,12 +524,6 @@ var _ = ginkgo.Describe("Karmadactl exec testing", func() {
 	})
 
 	ginkgo.It("Test exec command", func() {
-		waitForPodReady := func(namespace, podName string) {
-			framework.WaitPodPresentOnClusterFitWith(framework.ClusterNames()[0], namespace, podName, func(pod *corev1.Pod) bool {
-				return pod.Status.Phase == corev1.PodRunning
-			})
-		}
-		waitForPodReady(pod.Namespace, pod.Name)
 		framework.WaitPodPresentOnClustersFitWith(framework.ClusterNames(), pod.Namespace, pod.Name,
 			func(pod *corev1.Pod) bool {
 				return pod.Status.Phase == corev1.PodRunning
@@ -543,7 +537,7 @@ var _ = ginkgo.Describe("Karmadactl exec testing", func() {
 	})
 })
 
-var _ = ginkgo.Describe("Karmadactl top testing", ginkgo.Labels{NeedCreateCluster}, func() {
+var _ = ginkgo.Describe("Karmadactl top testing", func() {
 	ginkgo.Context("Karmadactl top pod which does not exist", func() {
 		ginkgo.It("Karmadactl top pod which does not exist", func() {
 			podName := podNamePrefix + rand.String(RandomStrLength)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
- After waiting for all member clusters' pods to reach the running state, there's no need to wait for member cluster member1's pod to reach the running state again.

- The `top pod` test does not require creating a new cluster, so remove the `ginkgo.Labels{NeedCreateCluster}` label.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

