### PR TITLE
Improve test coverage of pkg/controllers/context

### DIFF
--- a/pkg/controllers/context/context_test.go
+++ b/pkg/controllers/context/context_test.go
@@ -49,15 +49,15 @@ func TestContext_IsControllerEnabled(t *testing.T) {
 		{
 			name:                         "on by default",
 			controllerName:               "alpha",
-			disabledByDefaultControllers: []string{"delta", "echo"}, // --controllers=*
-			controllers:                  []string{"*"},
+			disabledByDefaultControllers: []string{"delta", "echo"},
+			controllers:                  []string{"*"}, // --controllers=*
 			expected:                     true,
 		},
 		{
 			name:                         "off by default",
 			controllerName:               "delta",
-			disabledByDefaultControllers: []string{"delta", "echo"}, // --controllers=*
-			controllers:                  []string{"*"},
+			disabledByDefaultControllers: []string{"delta", "echo"},
+			controllers:                  []string{"*"}, // --controllers=*
 			expected:                     false,
 		},
 		{

--- a/pkg/controllers/context/context_test.go
+++ b/pkg/controllers/context/context_test.go
@@ -61,6 +61,13 @@ func TestContext_IsControllerEnabled(t *testing.T) {
 			expected:                     false,
 		},
 		{
+			name:                         "on by star, not in disabled list",
+			controllerName:               "foxtrot",
+			disabledByDefaultControllers: []string{"delta", "echo"},
+			controllers:                  []string{"*"}, // --controllers=*
+			expected:                     true,
+		},
+		{
 			name:                         "on by star, not off by name",
 			controllerName:               "alpha",
 			disabledByDefaultControllers: []string{"delta", "echo"},
@@ -80,13 +87,6 @@ func TestContext_IsControllerEnabled(t *testing.T) {
 			disabledByDefaultControllers: []string{"delta", "echo"},
 			controllers:                  []string{"alpha", "bravo", "-charlie"}, // --controllers=alpha,bravo,-charlie
 			expected:                     false,
-		},
-		{
-			name:                         "on by star, not in disabled list",
-			controllerName:               "foxtrot",
-			disabledByDefaultControllers: []string{"delta", "echo"},
-			controllers:                  []string{"*"}, // --controllers=*
-			expected:                     true,
 		},
 		{
 			name:                         "empty controllers list",

--- a/pkg/controllers/context/context_test.go
+++ b/pkg/controllers/context/context_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Karmada Authors.
+Copyright 2024 The Karmada Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ limitations under the License.
 package context
 
 import (
+	"errors"
+	"reflect"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -34,49 +36,63 @@ func TestContext_IsControllerEnabled(t *testing.T) {
 			name:                         "on by name",
 			controllerName:               "bravo",
 			disabledByDefaultControllers: []string{"delta", "echo"},
-			controllers:                  []string{"alpha", "bravo", "-charlie"}, // --controllers=alpha,bravo,-charlie
+			controllers:                  []string{"alpha", "bravo", "-charlie"},
 			expected:                     true,
 		},
 		{
 			name:                         "off by name",
 			controllerName:               "charlie",
 			disabledByDefaultControllers: []string{"delta", "echo"},
-			controllers:                  []string{"alpha", "bravo", "-charlie"}, // --controllers=alpha,bravo,-charlie
+			controllers:                  []string{"alpha", "bravo", "-charlie"},
 			expected:                     false,
 		},
 		{
 			name:                         "on by default",
 			controllerName:               "alpha",
 			disabledByDefaultControllers: []string{"delta", "echo"},
-			controllers:                  []string{"*"}, // --controllers=*
+			controllers:                  []string{"*"},
 			expected:                     true,
 		},
 		{
 			name:                         "off by default",
 			controllerName:               "delta",
 			disabledByDefaultControllers: []string{"delta", "echo"},
-			controllers:                  []string{"*"}, // --controllers=*
+			controllers:                  []string{"*"},
 			expected:                     false,
 		},
 		{
 			name:                         "on by star, not off by name",
 			controllerName:               "alpha",
 			disabledByDefaultControllers: []string{"delta", "echo"},
-			controllers:                  []string{"*", "-charlie"}, // --controllers=*,-charlie
+			controllers:                  []string{"*", "-charlie"},
 			expected:                     true,
 		},
 		{
 			name:                         "off by name with star",
 			controllerName:               "charlie",
 			disabledByDefaultControllers: []string{"delta", "echo"},
-			controllers:                  []string{"*", "-charlie"}, // --controllers=*,-charlie
+			controllers:                  []string{"*", "-charlie"},
 			expected:                     false,
 		},
 		{
 			name:                         "off by default implicit, no star",
 			controllerName:               "foxtrot",
 			disabledByDefaultControllers: []string{"delta", "echo"},
-			controllers:                  []string{"alpha", "bravo", "-charlie"}, // --controllers=alpha,bravo,-charlie
+			controllers:                  []string{"alpha", "bravo", "-charlie"},
+			expected:                     false,
+		},
+		{
+			name:                         "on by star, not in disabled list",
+			controllerName:               "foxtrot",
+			disabledByDefaultControllers: []string{"delta", "echo"},
+			controllers:                  []string{"*"},
+			expected:                     true,
+		},
+		{
+			name:                         "empty controllers list",
+			controllerName:               "alpha",
+			disabledByDefaultControllers: []string{"delta", "echo"},
+			controllers:                  []string{},
 			expected:                     false,
 		},
 	}
@@ -89,6 +105,87 @@ func TestContext_IsControllerEnabled(t *testing.T) {
 			}
 			if got := c.IsControllerEnabled(tt.controllerName, sets.New(tt.disabledByDefaultControllers...)); got != tt.expected {
 				t.Errorf("expected %v, but got %v", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestInitializers_ControllerNames(t *testing.T) {
+	initializers := Initializers{
+		"controller1": func(_ Context) (bool, error) { return true, nil },
+		"controller2": func(_ Context) (bool, error) { return true, nil },
+		"controller3": func(_ Context) (bool, error) { return true, nil },
+	}
+
+	expected := []string{"controller1", "controller2", "controller3"}
+	result := initializers.ControllerNames()
+
+	if !reflect.DeepEqual(sets.New(result...), sets.New(expected...)) {
+		t.Errorf("expected %v, but got %v", expected, result)
+	}
+}
+
+func TestInitializers_StartControllers(t *testing.T) {
+	tests := []struct {
+		name                         string
+		initializers                 Initializers
+		enabledControllers           []string
+		disabledByDefaultControllers []string
+		expectedError                bool
+	}{
+		{
+			name: "all controllers enabled and started successfully",
+			initializers: Initializers{
+				"controller1": func(_ Context) (bool, error) { return true, nil },
+				"controller2": func(_ Context) (bool, error) { return true, nil },
+			},
+			enabledControllers:           []string{"*"},
+			disabledByDefaultControllers: []string{},
+			expectedError:                false,
+		},
+		{
+			name: "some controllers disabled",
+			initializers: Initializers{
+				"controller1": func(_ Context) (bool, error) { return true, nil },
+				"controller2": func(_ Context) (bool, error) { return true, nil },
+				"controller3": func(_ Context) (bool, error) { return true, nil },
+			},
+			enabledControllers:           []string{"controller1", "controller2"},
+			disabledByDefaultControllers: []string{"controller3"},
+			expectedError:                false,
+		},
+		{
+			name: "controller returns error",
+			initializers: Initializers{
+				"controller1": func(_ Context) (bool, error) { return true, nil },
+				"controller2": func(_ Context) (bool, error) { return false, errors.New("test error") },
+			},
+			enabledControllers:           []string{"*"},
+			disabledByDefaultControllers: []string{},
+			expectedError:                true,
+		},
+		{
+			name: "controller not started",
+			initializers: Initializers{
+				"controller1": func(_ Context) (bool, error) { return true, nil },
+				"controller2": func(_ Context) (bool, error) { return false, nil },
+			},
+			enabledControllers:           []string{"*"},
+			disabledByDefaultControllers: []string{},
+			expectedError:                false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := Context{
+				Opts: Options{
+					Controllers: tt.enabledControllers,
+				},
+			}
+			err := tt.initializers.StartControllers(ctx, sets.New(tt.disabledByDefaultControllers...))
+			if (err != nil) != tt.expectedError {
+				t.Errorf("expected error: %v, but got: %v", tt.expectedError, err)
 			}
 		})
 	}

--- a/pkg/controllers/context/context_test.go
+++ b/pkg/controllers/context/context_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Karmada Authors.
+Copyright 2022 The Karmada Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -36,27 +36,27 @@ func TestContext_IsControllerEnabled(t *testing.T) {
 			name:                         "on by name",
 			controllerName:               "bravo",
 			disabledByDefaultControllers: []string{"delta", "echo"},
-			controllers:                  []string{"alpha", "bravo", "-charlie"},
+			controllers:                  []string{"alpha", "bravo", "-charlie"}, // --controllers=alpha,bravo,-charlie
 			expected:                     true,
 		},
 		{
 			name:                         "off by name",
 			controllerName:               "charlie",
 			disabledByDefaultControllers: []string{"delta", "echo"},
-			controllers:                  []string{"alpha", "bravo", "-charlie"},
+			controllers:                  []string{"alpha", "bravo", "-charlie"}, // --controllers=alpha,bravo,-charlie
 			expected:                     false,
 		},
 		{
 			name:                         "on by default",
 			controllerName:               "alpha",
-			disabledByDefaultControllers: []string{"delta", "echo"},
+			disabledByDefaultControllers: []string{"delta", "echo"}, // --controllers=*
 			controllers:                  []string{"*"},
 			expected:                     true,
 		},
 		{
 			name:                         "off by default",
 			controllerName:               "delta",
-			disabledByDefaultControllers: []string{"delta", "echo"},
+			disabledByDefaultControllers: []string{"delta", "echo"}, // --controllers=*
 			controllers:                  []string{"*"},
 			expected:                     false,
 		},
@@ -64,35 +64,35 @@ func TestContext_IsControllerEnabled(t *testing.T) {
 			name:                         "on by star, not off by name",
 			controllerName:               "alpha",
 			disabledByDefaultControllers: []string{"delta", "echo"},
-			controllers:                  []string{"*", "-charlie"},
+			controllers:                  []string{"*", "-charlie"}, // --controllers=*,-charlie
 			expected:                     true,
 		},
 		{
 			name:                         "off by name with star",
 			controllerName:               "charlie",
 			disabledByDefaultControllers: []string{"delta", "echo"},
-			controllers:                  []string{"*", "-charlie"},
+			controllers:                  []string{"*", "-charlie"}, // --controllers=*,-charlie
 			expected:                     false,
 		},
 		{
 			name:                         "off by default implicit, no star",
 			controllerName:               "foxtrot",
 			disabledByDefaultControllers: []string{"delta", "echo"},
-			controllers:                  []string{"alpha", "bravo", "-charlie"},
+			controllers:                  []string{"alpha", "bravo", "-charlie"}, // --controllers=alpha,bravo,-charlie
 			expected:                     false,
 		},
 		{
 			name:                         "on by star, not in disabled list",
 			controllerName:               "foxtrot",
 			disabledByDefaultControllers: []string{"delta", "echo"},
-			controllers:                  []string{"*"},
+			controllers:                  []string{"*"}, // --controllers=*
 			expected:                     true,
 		},
 		{
 			name:                         "empty controllers list",
 			controllerName:               "alpha",
 			disabledByDefaultControllers: []string{"delta", "echo"},
-			controllers:                  []string{},
+			controllers:                  []string{}, // No controllers
 			expected:                     false,
 		},
 	}


### PR DESCRIPTION
**Description**:
This PR enhances the test coverage for the pkg/controllers/context package, increasing its test coverage from 42.3% to 100%. The new tests are designed to ensure the functionality and reliability of the package, improving its overall maintainability.

**Implemented Tests**:
1. TestInitializers_ControllerNames: Checks that ControllerNames() correctly returns all controller names.
2. TestInitializers_StartControllers: Tests the StartControllers() method under different conditions, including successful starts, error handling, and scenarios with disabled controllers.

**Test Coverage**:
Implementing this tests increased it's test coverage from 42.3% to 100%. This can be verified in the file directory i.e. pkg/controllers/context using command
`go test -coverprofile=coverage.out`

**What type of PR is this**?
/kind failing-test
/kind feature

**What this PR does / why we need it**:
The tests introduced in this PR will:
Improve test coverage of pkg/controllers/context from 42.3% to 100%
Help catch potential issues in future changes

**Which issue(s) this PR fixes**:
Fixes a part #5236 

**Special notes for your reviewer**:
These commits are part of my introduction to the Karmada project and provide me with hands-on experience in implementing unit tests within the project. I look forward to implement more unit tests in the LFX Mentorship program.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

