### PR TITLE
Align federated helmreleases.helm.toolkit.fluxcd.io observedGeneration semantics with its native

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/helm.toolkit.fluxcd.io/v2beta1/HelmRelease/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/helm.toolkit.fluxcd.io/v2beta1/HelmRelease/customizations.yaml
@@ -22,51 +22,76 @@ spec:
     statusAggregation:
       luaScript: >
         function AggregateStatus(desiredObj, statusItems)
+          if desiredObj.status == nil then
+            desiredObj.status = {}
+          end
+          if desiredObj.metadata.generation == nil then
+            desiredObj.metadata.generation = 0
+          end
+          if desiredObj.status.observedGeneration == nil then
+            desiredObj.status.observedGeneration = 0
+          end
+
+          -- Initialize status fields if status doest not exist
+          -- If the Kustomization is not spread to any cluster, its status also should be aggregated
           if statusItems == nil then
+            desiredObj.status.observedGeneration = desiredObj.metadata.generation
+            desiredObj.status.lastAttemptedRevision = ''
+            desiredObj.status.lastAppliedRevision = ''
+            desiredObj.status.lastAttemptedValuesChecksum = ''
+            desiredObj.status.helmChart = ''
+            desiredObj.status.lastReleaseRevision = ''
+            desiredObj.status.failures = 0
+            desiredObj.status.upgradeFailures = 0
+            desiredObj.status.installFailures = 0
+            desiredObj.status.conditions = {}
             return desiredObj
           end
-          desiredObj.status = {}
-          desiredObj.status.conditions = {}
-          conditions = {}
+
+          local conditions = {}
+          local generation = desiredObj.metadata.generation
+          local lastAttemptedRevision = desiredObj.status.lastAttemptedRevision
+          local lastAppliedRevision = desiredObj.status.lastAppliedRevision
+          local lastAttemptedValuesChecksum = desiredObj.status.lastAttemptedValuesChecksum
+          local helmChart = desiredObj.status.helmChart
+          local lastReleaseRevision = desiredObj.status.lastReleaseRevision
+          local failures = desiredObj.status.failures
+          local upgradeFailures = desiredObj.status.upgradeFailures
+          local installFailures = desiredObj.status.installFailures
+
+          -- Count all members that their status is updated to the latest generation
+          local observedResourceTemplateGenerationCount = 0
+
           local conditionsIndex = 1
           for i = 1, #statusItems do
             if statusItems[i].status ~= nil and statusItems[i].status.lastAttemptedRevision ~= nil and statusItems[i].status.lastAttemptedRevision ~= '' then
-              desiredObj.status.lastAttemptedRevision = statusItems[i].status.lastAttemptedRevision
+              lastAttemptedRevision = statusItems[i].status.lastAttemptedRevision
             end
             if statusItems[i].status ~= nil and statusItems[i].status.lastAppliedRevision ~= nil and statusItems[i].status.lastAppliedRevision ~= '' then
-              desiredObj.status.lastAppliedRevision = statusItems[i].status.lastAppliedRevision
+              lastAppliedRevision = statusItems[i].status.lastAppliedRevision
             end        
-            if statusItems[i].status ~= nil and statusItems[i].status.lastHandledReconcileAt ~= nil and statusItems[i].status.lastHandledReconcileAt ~= '' then
-              desiredObj.status.lastHandledReconcileAt = statusItems[i].status.lastHandledReconcileAt
-            end
             if statusItems[i].status ~= nil and statusItems[i].status.lastAttemptedValuesChecksum ~= nil and statusItems[i].status.lastAttemptedValuesChecksum ~= '' then
-              desiredObj.status.lastAttemptedValuesChecksum = statusItems[i].status.lastAttemptedValuesChecksum
+              lastAttemptedValuesChecksum = statusItems[i].status.lastAttemptedValuesChecksum
             end
             if statusItems[i].status ~= nil and statusItems[i].status.helmChart ~= nil and statusItems[i].status.helmChart ~= '' then
-              desiredObj.status.helmChart = statusItems[i].status.helmChart
+              helmChart = statusItems[i].status.helmChart
             end
             if statusItems[i].status ~= nil and statusItems[i].status.lastReleaseRevision ~= nil then
-              desiredObj.status.lastReleaseRevision = statusItems[i].status.lastReleaseRevision
+              lastReleaseRevision = statusItems[i].status.lastReleaseRevision
             end
             if statusItems[i].status ~= nil and statusItems[i].status.failures ~= nil then
               if desiredObj.status.failures ~= nil then
-                desiredObj.status.failures = desiredObj.status.failures + statusItems[i].status.failures
-              else
-                desiredObj.status.failures = statusItems[i].status.failures
+                failures = failures + statusItems[i].status.failures
               end
             end
             if statusItems[i].status ~= nil and statusItems[i].status.upgradeFailures ~= nil then
               if desiredObj.status.upgradeFailures ~= nil then
-                desiredObj.status.upgradeFailures = desiredObj.status.upgradeFailures + statusItems[i].status.upgradeFailures
-              else
-                desiredObj.status.upgradeFailures = statusItems[i].status.upgradeFailures
+                upgradeFailures = upgradeFailures + statusItems[i].status.upgradeFailures
               end
             end
             if statusItems[i].status ~= nil and statusItems[i].status.installFailures ~= nil then
               if desiredObj.status.installFailures ~= nil then
-                desiredObj.status.installFailures = desiredObj.status.installFailures + statusItems[i].status.installFailures
-              else
-                desiredObj.status.installFailures = statusItems[i].status.installFailures
+                installFailures = installFailures + statusItems[i].status.installFailures
               end
             end
             if statusItems[i].status ~= nil and statusItems[i].status.conditions ~= nil then
@@ -86,9 +111,41 @@ spec:
                 end
               end
             end
+
+            -- Check if the member's status is updated to the latest generation
+            local resourceTemplateGeneration = 0
+            if statusItems[i].status ~= nil and statusItems[i].status.resourceTemplateGeneration ~= nil then 
+              resourceTemplateGeneration = statusItems[i].status.resourceTemplateGeneration
+            end
+            local memberGeneration = 0
+            if statusItems[i].status ~= nil and statusItems[i].status.generation ~= nil then
+              memberGeneration = statusItems[i].status.generation
+            end
+            local memberObservedGeneration = 0
+            if statusItems[i].status ~= nil and statusItems[i].status.observedGeneration ~= nil then
+              memberObservedGeneration = statusItems[i].status.observedGeneration
+            end
+            if resourceTemplateGeneration == generation and memberGeneration == memberObservedGeneration then
+              observedResourceTemplateGenerationCount = observedResourceTemplateGenerationCount + 1
+            end
           end
-          desiredObj.status.observedGeneration = desiredObj.metadata.generation
+
+          -- Update the observed generation based on the observedResourceTemplateGenerationCount
+          if observedResourceTemplateGenerationCount == #statusItems then
+            desiredObj.status.observedGeneration = generation
+          else
+            desiredObj.status.observedGeneration = observedGeneration 
+          end
+
           desiredObj.status.conditions = conditions
+          desiredObj.status.lastAttemptedRevision = lastAttemptedRevision
+          desiredObj.status.lastAppliedRevision = lastAppliedRevision
+          desiredObj.status.lastAttemptedValuesChecksum = lastAttemptedValuesChecksum
+          desiredObj.status.helmChart = helmChart
+          desiredObj.status.lastReleaseRevision = lastReleaseRevision
+          desiredObj.status.failures = failures
+          desiredObj.status.upgradeFailures = upgradeFailures
+          desiredObj.status.installFailures = installFailures
           return desiredObj
         end
     retention:
@@ -102,11 +159,37 @@ spec:
     statusReflection:
       luaScript: >
         function ReflectStatus (observedObj)
-          status = {}
-          if observedObj == nil or observedObj.status == nil then 
+          local status = {}
+          if observedObj == nil or observedObj.status == nil then
             return status
           end
-          return observedObj.status
+
+          status.conditions = observedObj.status.conditions
+          status.observedGeneration = observedObj.status.observedGeneration
+          status.lastAttemptedRevision = observedObj.status.lastAttemptedRevision
+          status.lastAppliedRevision = observedObj.status.lastAppliedRevision
+          status.lastAttemptedValuesChecksum = observedObj.status.lastAttemptedValuesChecksum
+          status.helmChart = observedObj.status.helmChart
+          status.lastReleaseRevision = observedObj.status.lastReleaseRevision
+          status.failures = observedObj.status.failures
+          status.upgradeFailures = observedObj.status.upgradeFailures
+          status.installFailures = observedObj.status.installFailures 
+
+          -- handle resource generation report
+          if observedObj.metadata == nil then
+            return status
+          end
+          status.generation = observedObj.metadata.generation
+
+          if observedObj.metadata.annotations == nil then
+            return status
+          end
+          local resourceTemplateGeneration = tonumber(observedObj.metadata.annotations["resourcetemplate.karmada.io/generation"])
+          if resourceTemplateGeneration ~= nil then
+              status.resourceTemplateGeneration = resourceTemplateGeneration
+          end
+
+          return status
         end
     dependencyInterpretation:
       luaScript: >

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/helm.toolkit.fluxcd.io/v2beta1/HelmRelease/testdata/desired-helmrelease.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/helm.toolkit.fluxcd.io/v2beta1/HelmRelease/testdata/desired-helmrelease.yaml
@@ -3,6 +3,7 @@ kind: HelmRelease
 metadata:
   name: sample
   namespace: default
+  generation: 1
 spec:
   interval: 5m
   chart:

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/helm.toolkit.fluxcd.io/v2beta1/HelmRelease/testdata/observed-helmrelease.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/helm.toolkit.fluxcd.io/v2beta1/HelmRelease/testdata/observed-helmrelease.yaml
@@ -1,8 +1,11 @@
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
+  annotations:
+    resourcetemplate.karmada.io/generation: "1"
   name: sample
   namespace: default
+  generation: 1
 spec:
   interval: 5m
   chart:

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/helm.toolkit.fluxcd.io/v2beta1/HelmRelease/testdata/status-file.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/helm.toolkit.fluxcd.io/v2beta1/HelmRelease/testdata/status-file.yaml
@@ -13,12 +13,14 @@ status:
     reason: InstallSucceeded
     status: "True"
     type: Released
+  generation: 1
   helmChart: test-helmrelease/test-helmrelease-sample
   lastAppliedRevision: 6.3.5
   lastAttemptedRevision: 6.3.5
   lastAttemptedValuesChecksum: da39a3ee5e6b4b0d3255bfef95601890afd80709      
   lastReleaseRevision: 1
   observedGeneration: 1
+  resourceTemplateGeneration: 1
 ---
 applied: true
 clusterName: member3
@@ -35,9 +37,11 @@ status:
     reason: InstallSucceeded
     status: "True"
     type: Released
+  generation: 1
   helmChart: test-helmrelease/test-helmrelease-sample
   lastAppliedRevision: 6.3.5
   lastAttemptedRevision: 6.3.5
   lastAttemptedValuesChecksum: da39a3ee5e6b4b0d3255bfef95601890afd80709
   lastReleaseRevision: 1
   observedGeneration: 1
+  resourceTemplateGeneration: 1


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of #4870 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Mark `.status.observedGeneration` of helmreleases.helm.toolkit.fluxcd.io with `.metadata.generation` only when all members' statuses are algined with its resource template generation.
```

