### PR TITLE
skip cleanup when the poliy claim metadata changed

### DIFF
--- a/pkg/detector/claim.go
+++ b/pkg/detector/claim.go
@@ -75,3 +75,17 @@ func CleanupCPPClaimMetadata(obj metav1.Object) {
 	util.RemoveLabels(obj, clusterPropagationPolicyClaimLabels...)
 	util.RemoveAnnotations(obj, clusterPropagationPolicyClaimAnnotations...)
 }
+
+// NeedCleanupClaimMetadata determines whether the object's claim metadata needs to be cleaned up.
+// We need to ensure that the claim metadata being deleted belong to the current PropagationPolicy/ClusterPropagationPolicy,
+// otherwise, there is a risk of mistakenly deleting the ones belonging to another PropagationPolicy/ClusterPropagationPolicy.
+// This situation could occur during the rapid deletion and creation of PropagationPolicy(s)/ClusterPropagationPolicy(s).
+// More info can refer to https://github.com/karmada-io/karmada/issues/5307.
+func NeedCleanupClaimMetadata(obj metav1.Object, targetClaimMetadata map[string]string) bool {
+	for k, v := range targetClaimMetadata {
+		if obj.GetLabels()[k] != v {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/detector/claim_test.go
+++ b/pkg/detector/claim_test.go
@@ -167,3 +167,44 @@ func TestCleanupCPPClaimMetadata(t *testing.T) {
 		})
 	}
 }
+
+func TestNeedCleanupClaimMetadata(t *testing.T) {
+	tests := []struct {
+		name                string
+		obj                 metav1.Object
+		targetClaimMetadata map[string]string
+		needCleanup         bool
+	}{
+		{
+			name: "need cleanup",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels":      map[string]interface{}{policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel: "f2507cgb-f3f3-4a4b-b289-5691a4fef979"},
+						"annotations": map[string]interface{}{policyv1alpha1.ClusterPropagationPolicyAnnotation: "cpp-example"},
+					},
+				},
+			},
+			targetClaimMetadata: map[string]string{policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel: "f2507cgb-f3f3-4a4b-b289-5691a4fef979"},
+			needCleanup:         true,
+		},
+		{
+			name: "no need cleanup",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels":      map[string]interface{}{policyv1alpha1.PropagationPolicyPermanentIDLabel: "b0907cgb-f3f3-4a4b-b289-5691a4fef979"},
+						"annotations": map[string]interface{}{policyv1alpha1.PropagationPolicyNamespaceAnnotation: "default", policyv1alpha1.PropagationPolicyNameAnnotation: "pp-example"},
+					},
+				},
+			},
+			targetClaimMetadata: map[string]string{policyv1alpha1.PropagationPolicyPermanentIDLabel: "f2507cgb-f3f3-4a4b-b289-5691a4fef979"},
+			needCleanup:         false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.needCleanup, NeedCleanupClaimMetadata(tt.obj, tt.targetClaimMetadata))
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Refer to #5307, there is a chance that poliy marks be lost when deleting the old pp/cpp and binding a new one. When performing a clean up of marks on rb/crb, we can compare the value of the label `policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel/policyv1alpha1.PolicyPermanentIDLabel` on the cb/crb with the policyId value of the deleted CPP/PP. If they are not the same, it indicates that the rb/crb has already claimed to a new CPP/PP, and there is no need to clean up the label/annotation.

**Which issue(s) this PR fixes**:
Fixes #5307

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Fixed an issue that policy claim metadata might be lost during the rapid deletion and creation of PropagationPolicy(s)/ClusterPropagationPolicy(s)
```

