### PR TITLE
Support multiple label selection ability in EtcdNodeSelectorLabels

### DIFF
--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -140,7 +140,7 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 	flags.StringVarP(&opts.EtcdInitImage, "etcd-init-image", "", kubernetes.DefaultInitImage, "etcd init container image")
 	flags.Int32VarP(&opts.EtcdReplicas, "etcd-replicas", "", 1, "etcd replica set, cluster 3,5...singular")
 	flags.StringVarP(&opts.EtcdHostDataPath, "etcd-data", "", "/var/lib/karmada-etcd", "etcd data path,valid in hostPath mode.")
-	flags.StringVarP(&opts.EtcdNodeSelectorLabels, "etcd-node-selector-labels", "", "", "etcd pod select the labels of the node. valid in hostPath mode ( e.g. --etcd-node-selector-labels karmada.io/etcd=true)")
+	flags.StringVarP(&opts.EtcdNodeSelectorLabels, "etcd-node-selector-labels", "", "", "the labels used for etcd pod to select nodes, valid in hostPath mode, and with each label separated by a comma. ( e.g. --etcd-node-selector-labels karmada.io/etcd=true,kubernetes.io/os=linux)")
 	flags.StringVarP(&opts.EtcdPersistentVolumeSize, "etcd-pvc-size", "", "5Gi", "etcd data path,valid in pvc mode.")
 	flags.StringVar(&opts.ExternalEtcdCACertPath, "external-etcd-ca-cert-path", "", "The path of CA certificate of the external etcd cluster in pem format.")
 	flags.StringVar(&opts.ExternalEtcdClientCertPath, "external-etcd-client-cert-path", "", "The path of client side certificate to the external etcd cluster in pem format.")

--- a/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
-	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/utils"
 )
 
 const (
@@ -300,11 +299,12 @@ func (i *CommandInitOption) makeETCDStatefulSet() *appsv1.StatefulSet {
 		Volumes: *Volumes,
 	}
 
-	if i.EtcdStorageMode == "hostPath" && i.EtcdNodeSelectorLabels != "" {
-		podSpec.NodeSelector = utils.StringToMap(i.EtcdNodeSelectorLabels)
-	}
-	if i.EtcdStorageMode == "hostPath" && i.EtcdNodeSelectorLabels == "" {
-		podSpec.NodeSelector = map[string]string{"karmada.io/etcd": ""}
+	if i.EtcdStorageMode == "hostPath" {
+		if i.EtcdNodeSelectorLabelsMap != nil {
+			podSpec.NodeSelector = i.EtcdNodeSelectorLabelsMap
+		} else {
+			podSpec.NodeSelector = map[string]string{"karmada.io/etcd": ""}
+		}
 	}
 
 	// InitContainers


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Supports the function of --etcd-node-selector-labels for multiple labels of nodes in the cluster
```release-note
user@virtual-machine:karmada/_output/bin/linux/amd64# ./karmadactl init --etcd-node-selector-labels karmada.io/etcd=true,kubernetes.io/os=linux
I0830 09:58:51.083493    7186 deploy.go:111] No default release version found. build version: version.Info{GitVersion:"", GitCommit:"0c4ff310f2d3bba4c54a513c62bc4110e5353b32", GitTreeState:"clean", BuildDate:"2024-08-30T01:35:17Z", GoVersion:"go1.22.6", Compiler:"gc", Platform:"linux/amd64"}
I0830 09:58:51.083581    7186 enable_option.go:85] No default release version found. build version: version.Info{GitVersion:"", GitCommit:"0c4ff310f2d3bba4c54a513c62bc4110e5353b32", GitTreeState:"clean", BuildDate:"2024-08-30T01:35:17Z", GoVersion:"go1.22.6", Compiler:"gc", Platform:"linux/amd64"}
......
I0830 10:01:43.161625    7186 deploy.go:502] Create karmada webhook Deployment
I0830 10:01:43.167256    7186 idempotency.go:296] Service karmada-system/karmada-webhook has been created or updated.

------------------------------------------------------------------------------------------------------
 █████   ████   █████████   ███████████   ██████   ██████   █████████   ██████████     █████████
░░███   ███░   ███░░░░░███ ░░███░░░░░███ ░░██████ ██████   ███░░░░░███ ░░███░░░░███   ███░░░░░███
 ░███  ███    ░███    ░███  ░███    ░███  ░███░█████░███  ░███    ░███  ░███   ░░███ ░███    ░███
 ░███████     ░███████████  ░██████████   ░███░░███ ░███  ░███████████  ░███    ░███ ░███████████
 ░███░░███    ░███░░░░░███  ░███░░░░░███  ░███ ░░░  ░███  ░███░░░░░███  ░███    ░███ ░███░░░░░███
 ░███ ░░███   ░███    ░███  ░███    ░███  ░███      ░███  ░███    ░███  ░███    ███  ░███    ░███
 █████ ░░████ █████   █████ █████   █████ █████     █████ █████   █████ ██████████   █████   █████
░░░░░   ░░░░ ░░░░░   ░░░░░ ░░░░░   ░░░░░ ░░░░░     ░░░░░ ░░░░░   ░░░░░ ░░░░░░░░░░   ░░░░░   ░░░░░
------------------------------------------------------------------------------------------------------
Karmada is installed successfully.

Register Kubernetes cluster to Karmada control plane.

Register cluster with 'Push' mode

Step 1: Use "karmadactl join" command to register the cluster to Karmada control plane. --cluster-kubeconfig is kubeconfig of the member cluster.
(In karmada)~# MEMBER_CLUSTER_NAME=$(cat ~/.kube/config  | grep current-context | sed 's/: /\n/g'| sed '1d')
(In karmada)~# karmadactl --kubeconfig /etc/karmada/karmada-apiserver.config  join ${MEMBER_CLUSTER_NAME} --cluster-kubeconfig=$HOME/.kube/config

Step 2: Show members of karmada
(In karmada)~# kubectl --kubeconfig /etc/karmada/karmada-apiserver.config get clusters


Register cluster with 'Pull' mode

Step 1: Use "karmadactl register" command to register the cluster to Karmada control plane. "--cluster-name" is set to cluster of current-context by default.
(In member cluster)~# karmadactl register 172.18.0.2:32443 --token ofc912.rk5yj36jfc9es9by --discovery-token-ca-cert-hash sha256:82c3150ef0593fe5f581078cb6ccfc597a0043a45ff2af028b302d1cd53ad9f9

Step 2: Show members of karmada
(In karmada)~# kubectl --kubeconfig /etc/karmada/karmada-apiserver.config get clusters

user@virtual-machine:karmada/_output/bin/linux/amd64#

```
**Which issue(s) this PR fixes**:
Fixes [#5320 ](https://github.com/karmada-io/karmada/issues/5320)
This PR is related to the documentation PR: https://github.com/karmada-io/karmada/pull/5277
**Special notes for your reviewer**:
@liangyuanpeng 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmadactl: support multiple label selection ability with flag EtcdNodeSelectorLabels.
```

