### PR TITLE
repair the test for rb status controller

### DIFF
--- a/pkg/controllers/status/crb_status_controller_test.go
+++ b/pkg/controllers/status/crb_status_controller_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/resourceinterpreter/default/native"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 )
@@ -98,8 +99,11 @@ func TestCRBStatusController_Reconcile(t *testing.T) {
 			name: "failed in syncBindingStatus",
 			binding: &workv1alpha2.ClusterResourceBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "binding",
-					Namespace:         "default",
+					Name:      "binding",
+					Namespace: "default",
+					// finalizers field is required when deletionTimestamp is defined, otherwise will encounter the
+					// error: `refusing to create obj binding with metadata.deletionTimestamp but no finalizers`.
+					Finalizers:        []string{"test"},
 					DeletionTimestamp: &preTime,
 				},
 				Spec: workv1alpha2.ResourceBindingSpec{
@@ -119,6 +123,7 @@ func TestCRBStatusController_Reconcile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := generateCRBStatusController()
+			c.ResourceInterpreter = FakeResourceInterpreter{DefaultInterpreter: native.NewDefaultInterpreter()}
 
 			// Prepare req
 			req := controllerruntime.Request{
@@ -130,9 +135,7 @@ func TestCRBStatusController_Reconcile(t *testing.T) {
 
 			// Prepare binding and create it in client
 			if tt.binding != nil {
-				if err := c.Client.Create(context.Background(), tt.binding); err != nil {
-					t.Fatalf("Failed to create binding: %v", err)
-				}
+				c.Client = fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(tt.binding).WithStatusSubresource(tt.binding).Build()
 			}
 
 			res, err := c.Reconcile(context.Background(), req)
@@ -192,6 +195,7 @@ func TestCRBStatusController_syncBindingStatus(t *testing.T) {
 			c := generateCRBStatusController()
 			c.DynamicClient = dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: tt.podNameInDynamicClient, Namespace: "default"}})
+			c.ResourceInterpreter = FakeResourceInterpreter{DefaultInterpreter: native.NewDefaultInterpreter()}
 
 			binding := &workv1alpha2.ClusterResourceBinding{
 				ObjectMeta: metav1.ObjectMeta{
@@ -204,9 +208,7 @@ func TestCRBStatusController_syncBindingStatus(t *testing.T) {
 			}
 
 			if tt.resourceExistInClient {
-				if err := c.Client.Create(context.Background(), binding); err != nil {
-					t.Fatalf("Failed to create binding: %v", err)
-				}
+				c.Client = fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(binding).WithStatusSubresource(binding).Build()
 			}
 
 			err := c.syncBindingStatus(context.Background(), binding)

--- a/pkg/controllers/status/rb_status_controller_test.go
+++ b/pkg/controllers/status/rb_status_controller_test.go
@@ -34,6 +34,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/resourceinterpreter"
+	"github.com/karmada-io/karmada/pkg/resourceinterpreter/default/native"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 )
@@ -98,8 +100,11 @@ func TestRBStatusController_Reconcile(t *testing.T) {
 			name: "failed in syncBindingStatus",
 			binding: &workv1alpha2.ResourceBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "binding",
-					Namespace:         "default",
+					Name:      "binding",
+					Namespace: "default",
+					// finalizers field is required when deletionTimestamp is defined, otherwise will encounter the
+					// error: `refusing to create obj binding with metadata.deletionTimestamp but no finalizers`.
+					Finalizers:        []string{"test"},
 					DeletionTimestamp: &preTime,
 				},
 				Spec: workv1alpha2.ResourceBindingSpec{
@@ -119,6 +124,7 @@ func TestRBStatusController_Reconcile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := generateRBStatusController()
+			c.ResourceInterpreter = FakeResourceInterpreter{DefaultInterpreter: native.NewDefaultInterpreter()}
 
 			// Prepare req
 			req := controllerruntime.Request{
@@ -130,9 +136,7 @@ func TestRBStatusController_Reconcile(t *testing.T) {
 
 			// Prepare binding and create it in client
 			if tt.binding != nil {
-				if err := c.Client.Create(context.Background(), tt.binding); err != nil {
-					t.Fatalf("Failed to create binding: %v", err)
-				}
+				c.Client = fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(tt.binding).WithStatusSubresource(tt.binding).Build()
 			}
 
 			res, err := c.Reconcile(context.Background(), req)
@@ -192,6 +196,7 @@ func TestRBStatusController_syncBindingStatus(t *testing.T) {
 			c := generateRBStatusController()
 			c.DynamicClient = dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: tt.podNameInDynamicClient, Namespace: "default"}})
+			c.ResourceInterpreter = FakeResourceInterpreter{DefaultInterpreter: native.NewDefaultInterpreter()}
 
 			binding := &workv1alpha2.ResourceBinding{
 				ObjectMeta: metav1.ObjectMeta{
@@ -204,9 +209,7 @@ func TestRBStatusController_syncBindingStatus(t *testing.T) {
 			}
 
 			if tt.resourceExistInClient {
-				if err := c.Client.Create(context.Background(), binding); err != nil {
-					t.Fatalf("Failed to create binding: %v", err)
-				}
+				c.Client = fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(binding).WithStatusSubresource(binding).Build()
 			}
 
 			err := c.syncBindingStatus(context.Background(), binding)
@@ -218,4 +221,14 @@ func TestRBStatusController_syncBindingStatus(t *testing.T) {
 			}
 		})
 	}
+}
+
+var _ resourceinterpreter.ResourceInterpreter = &FakeResourceInterpreter{}
+
+type FakeResourceInterpreter struct {
+	*native.DefaultInterpreter
+}
+
+func (f FakeResourceInterpreter) Start(_ context.Context) (err error) {
+	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

repair the test for rb status controller:

In the UT of `RBStatusController`, here is a fake client, as:

```go
c.Client = fake.NewClientBuilder().WithScheme(gclient.NewSchema()).Build(),
```

the ut function wants to preset some resource by the fake client, such as:

```go
if err := c.Client.Create(context.Background(), binding); err != nil {
    t.Fatalf("Failed to create binding: %v", err)
}
```

then it wants to update the status of that resource, such as:

```go
if err := c.Client.Status().Update(context.Background(), binding); err != nil {
    t.Fatalf("Failed to update status of binding: %v", err)
}
```

Actually, the update function will failed with `Error: resourcebindings.work.karmada.io "binding" not found`.

the preset resource doesn't have subresource `status`, so update status will failed, a feasible way is like:

```go
c.Client = fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(binding).WithStatusSubresource(binding).Build()
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

