### PR TITLE
test/e2e: unfiy random string length generation

### DIFF
--- a/test/e2e/federatedresourcequota_test.go
+++ b/test/e2e/federatedresourcequota_test.go
@@ -84,7 +84,7 @@ var _ = framework.SerialDescribe("FederatedResourceQuota auto-provision testing"
 		var clusterContext string
 
 		ginkgo.BeforeEach(func() {
-			clusterName = "member-e2e-" + rand.String(3)
+			clusterName = "member-e2e-" + rand.String(RandomStrLength)
 			homeDir = os.Getenv("HOME")
 			kubeConfigPath = fmt.Sprintf("%s/.kube/%s.config", homeDir, clusterName)
 			controlPlane = fmt.Sprintf("%s-control-plane", clusterName)

--- a/test/e2e/karmadactl_test.go
+++ b/test/e2e/karmadactl_test.go
@@ -281,7 +281,7 @@ var _ = framework.SerialDescribe("Karmadactl join/unjoin testing", ginkgo.Labels
 		var policy *policyv1alpha1.PropagationPolicy
 
 		ginkgo.BeforeEach(func() {
-			clusterName = "member-e2e-" + rand.String(3)
+			clusterName = "member-e2e-" + rand.String(RandomStrLength)
 			homeDir = os.Getenv("HOME")
 			kubeConfigPath = fmt.Sprintf("%s/.kube/%s.config", homeDir, clusterName)
 			clusterContext = fmt.Sprintf("kind-%s", clusterName)
@@ -402,7 +402,7 @@ var _ = framework.SerialDescribe("Karmadactl cordon/uncordon testing", ginkgo.La
 	var f cmdutil.Factory
 
 	ginkgo.BeforeEach(func() {
-		clusterName = "member-e2e-" + rand.String(3)
+		clusterName = "member-e2e-" + rand.String(RandomStrLength)
 		homeDir = os.Getenv("HOME")
 		kubeConfigPath = fmt.Sprintf("%s/.kube/%s.config", homeDir, clusterName)
 		controlPlane = fmt.Sprintf("%s-control-plane", clusterName)
@@ -1164,7 +1164,7 @@ var _ = framework.SerialDescribe("Karmadactl taint testing", ginkgo.Labels{NeedC
 		)
 
 		ginkgo.BeforeEach(func() {
-			newClusterName = "member-e2e-" + rand.String(3)
+			newClusterName = "member-e2e-" + rand.String(RandomStrLength)
 			homeDir = os.Getenv("HOME")
 			kubeConfigPath = fmt.Sprintf("%s/.kube/%s.config", homeDir, newClusterName)
 			controlPlane = fmt.Sprintf("%s-control-plane", newClusterName)

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -45,7 +45,7 @@ var _ = ginkgo.Describe("[namespace auto-provision] namespace auto-provision tes
 	var f cmdutil.Factory
 
 	ginkgo.BeforeEach(func() {
-		namespaceName = "karmada-e2e-ns-" + rand.String(3)
+		namespaceName = "karmada-e2e-ns-" + rand.String(RandomStrLength)
 		namespace = helper.NewNamespace(namespaceName)
 
 		defaultConfigFlags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag().WithDiscoveryBurst(300).WithDiscoveryQPS(50.0)
@@ -86,7 +86,7 @@ var _ = ginkgo.Describe("[namespace auto-provision] namespace auto-provision tes
 		var clusterContext string
 
 		ginkgo.BeforeEach(func() {
-			clusterName = "member-e2e-" + rand.String(3)
+			clusterName = "member-e2e-" + rand.String(RandomStrLength)
 			homeDir = os.Getenv("HOME")
 			kubeConfigPath = fmt.Sprintf("%s/.kube/%s.config", homeDir, clusterName)
 			controlPlane = fmt.Sprintf("%s-control-plane", clusterName)

--- a/test/e2e/rescheduling_test.go
+++ b/test/e2e/rescheduling_test.go
@@ -52,7 +52,7 @@ var _ = ginkgo.Describe("[cluster unjoined] reschedule testing", func() {
 		var f cmdutil.Factory
 
 		ginkgo.BeforeEach(func() {
-			newClusterName = "member-e2e-" + rand.String(3)
+			newClusterName = "member-e2e-" + rand.String(RandomStrLength)
 			homeDir = os.Getenv("HOME")
 			kubeConfigPath = fmt.Sprintf("%s/.kube/%s.config", homeDir, newClusterName)
 			controlPlane = fmt.Sprintf("%s-control-plane", newClusterName)
@@ -173,7 +173,7 @@ var _ = ginkgo.Describe("[cluster joined] reschedule testing", func() {
 		var f cmdutil.Factory
 
 		ginkgo.BeforeEach(func() {
-			newClusterName = "member-e2e-" + rand.String(3)
+			newClusterName = "member-e2e-" + rand.String(RandomStrLength)
 			homeDir = os.Getenv("HOME")
 			kubeConfigPath = fmt.Sprintf("%s/.kube/%s.config", homeDir, newClusterName)
 			controlPlane = fmt.Sprintf("%s-control-plane", newClusterName)


### PR DESCRIPTION
### Description

This commit standardizes the generation of random string lengths by utilizing the `RandomStrLength` global constant.

### Motivation and Context

The motivation for this change arose from observing that `RandomStrLength` was already being used to create clusters in [`test/e2e/aggregatedapi_test.go`](https://github.com/karmada-io/karmada/blob/37488bd1093a2c5cf808b6cf87d601caab07a05f/test/e2e/aggregatedapi_test.go#L69). This presented a good opportunity to unify cluster name generation using the `RandomStrLength` constant across the codebase. Please let me know if this is a valid improvement! 🙏

### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

### Does this PR introduce a user-facing change?

```release-note
NONE
```