### PR TITLE
Add 100% test coverage for matcher, shadow, and names.go in pkg/util

### DIFF
--- a/pkg/util/interpreter/matcher_test.go
+++ b/pkg/util/interpreter/matcher_test.go
@@ -313,3 +313,135 @@ func TestExactOrWildcard(t *testing.T) {
 		})
 	}
 }
+
+func TestMatches(t *testing.T) {
+	tests := []struct {
+		name     string
+		matcher  *Matcher
+		expected bool
+	}{
+		{
+			name: "not equal operations, equal group version and kind",
+			matcher: &Matcher{
+				ObjGVK: schema.GroupVersionKind{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+				},
+				Operation: configv1alpha1.InterpreterOperationPrune,
+				Rule: configv1alpha1.RuleWithOperations{
+					Operations: []configv1alpha1.InterpreterOperation{
+						configv1alpha1.InterpreterOperationRetain,
+						configv1alpha1.InterpreterOperationInterpretReplica,
+					},
+					Rule: configv1alpha1.Rule{
+						APIGroups:   []string{"batch", "apps"},
+						APIVersions: []string{"v1", "v1beta1"},
+						Kinds:       []string{"Pod", "Deployment"},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "not equal group, equal operation version and kind",
+			matcher: &Matcher{
+				ObjGVK: schema.GroupVersionKind{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+				},
+				Operation: configv1alpha1.InterpreterOperationRetain,
+				Rule: configv1alpha1.RuleWithOperations{
+					Operations: []configv1alpha1.InterpreterOperation{
+						configv1alpha1.InterpreterOperationRetain,
+						configv1alpha1.InterpreterOperationInterpretReplica,
+					},
+					Rule: configv1alpha1.Rule{
+						APIGroups:   []string{"batch"},
+						APIVersions: []string{"v1", "v1beta1"},
+						Kinds:       []string{"Pod", "Deployment"},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "not equal version, equal operation group and kind",
+			matcher: &Matcher{
+				ObjGVK: schema.GroupVersionKind{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+				},
+				Operation: configv1alpha1.InterpreterOperationRetain,
+				Rule: configv1alpha1.RuleWithOperations{
+					Operations: []configv1alpha1.InterpreterOperation{
+						configv1alpha1.InterpreterOperationRetain,
+						configv1alpha1.InterpreterOperationInterpretReplica,
+					},
+					Rule: configv1alpha1.Rule{
+						APIGroups:   []string{"batch", "apps"},
+						APIVersions: []string{"v1beta1"},
+						Kinds:       []string{"Pod", "Deployment"},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "not equal kind, equal operation group and version",
+			matcher: &Matcher{
+				ObjGVK: schema.GroupVersionKind{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+				},
+				Operation: configv1alpha1.InterpreterOperationRetain,
+				Rule: configv1alpha1.RuleWithOperations{
+					Operations: []configv1alpha1.InterpreterOperation{
+						configv1alpha1.InterpreterOperationRetain,
+						configv1alpha1.InterpreterOperationInterpretReplica,
+					},
+					Rule: configv1alpha1.Rule{
+						APIGroups:   []string{"batch", "apps"},
+						APIVersions: []string{"v1", "v1beta1"},
+						Kinds:       []string{"Pod"},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "operation, object matches the rule",
+			matcher: &Matcher{
+				ObjGVK: schema.GroupVersionKind{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+				},
+				Operation: configv1alpha1.InterpreterOperationRetain,
+				Rule: configv1alpha1.RuleWithOperations{
+					Operations: []configv1alpha1.InterpreterOperation{
+						configv1alpha1.InterpreterOperationRetain,
+						configv1alpha1.InterpreterOperationInterpretReplica,
+					},
+					Rule: configv1alpha1.Rule{
+						APIGroups:   []string{"batch", "apps"},
+						APIVersions: []string{"v1", "v1beta1"},
+						Kinds:       []string{"Pod", "Deployment"},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := tt.matcher.Matches()
+			if res != tt.expected {
+				t.Errorf("Matches() = %v, want %v", res, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/util/overridemanager/shadow_test.go
+++ b/pkg/util/overridemanager/shadow_test.go
@@ -22,6 +22,14 @@ import (
 
 func TestAppliedOverrides_AscendOrder(t *testing.T) {
 	applied := AppliedOverrides{}
+	appliedEmptyBytes, er := applied.MarshalJSON()
+	if er != nil {
+		t.Fatalf("not expect error, but got: %v", er)
+	}
+	if appliedEmptyBytes != nil {
+		t.Fatalf("expect nil, but got: %s", string(appliedEmptyBytes))
+	}
+
 	item2 := OverridePolicyShadow{PolicyName: "bbb"}
 	item1 := OverridePolicyShadow{PolicyName: "aaa"}
 	item3 := OverridePolicyShadow{PolicyName: "ccc"}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind failing-test
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
The test case coverage for interpreter/matcher.go, overridemanager/shadow.go and names/names.go has been increased to 100%.

**Which issue(s) this PR fixes**:
Ref #5235 

**Special notes for your reviewer**:
To verify the changes in the pkg/util directory run the following commands:
```
go test ./... -coverprofile=coverage.out
go tool cover -html=coverage.out -o coverage.html
open coverage.html
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

