### PR TITLE
Added tests for pkg/util/hash

### DIFF
--- a/pkg/util/hash/hash_test.go
+++ b/pkg/util/hash/hash_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hash
+
+import (
+	"crypto/sha256"
+	"testing"
+)
+
+func TestDeepHashObject(t *testing.T) {
+	tests := []struct {
+		name   string
+		object interface{}
+	}{
+		{
+			name:   "simple string",
+			object: "test string",
+		},
+		{
+			name: "struct",
+			object: struct {
+				Name  string
+				Value int
+			}{
+				Name:  "Test",
+				Value: 42,
+			},
+		},
+		{
+			name: "nested struct",
+			object: struct {
+				Inner struct {
+					Name  string
+					Value int
+				}
+			}{
+				Inner: struct {
+					Name  string
+					Value int
+				}{
+					Name:  "InnerTest",
+					Value: 100,
+				},
+			},
+		},
+		{
+			name:   "slice",
+			object: []int{1, 2, 3, 4, 5},
+		},
+		{
+			name:   "map",
+			object: map[string]int{"a": 1, "b": 2, "c": 3},
+		},
+		{
+			name: "pointer to struct",
+			object: &struct {
+				Name  string
+				Value int
+			}{
+				Name:  "PtrTest",
+				Value: 42,
+			},
+		},
+		{
+			name:   "nil value",
+			object: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hasher := sha256.New()
+			DeepHashObject(hasher, tt.object)
+			hash1 := hasher.Sum(nil)
+			hasher.Reset()
+			DeepHashObject(hasher, tt.object)
+			hash2 := hasher.Sum(nil)
+
+			if string(hash1) != string(hash2) {
+				t.Errorf("hashes do not match for %s: %x != %x", tt.name, hash1, hash2)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description**:
This PR introduces unit tests for the hash package to ensure its functionality and maintainability. Currently, the package lacks unit tests, making it difficult to catch potential regressions and verify its behavior. By adding these tests, we aim to improve the reliability and code coverage of this critical component. The code coverage of the package is 100%.

**Implemented Test**:
TestDeepHashObject(): Verifies that the DeepHashObject function produces consistent hashes for various input types.

**What type of PR is this?**
/kind failing-test
/kind feature

**Test Coverage**:
The hash package lacked unit tests and thus implementing this tests increased it's test coverage from 0% to 100%. This can be verified in the file directory i.e. pkg/util/hash using command
go test -coverprofile=coverage.out

**What this PR does / why we need it**:
The tests introduced in this PR will:
Ensure the basic functionality of the hash package
Improve test coverage of the hash package
Serve as documentation for expected behavior
Help catch potential issues in future changes

**Which issue(s) this PR fixes**:
Fixes part of #5235 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

