### PR TITLE
Add test coverage for revisereplica and retain in pkg/resourceinterpr…

### DIFF
--- a/pkg/resourceinterpreter/default/native/retain_test.go
+++ b/pkg/resourceinterpreter/default/native/retain_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package native
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,88 +25,145 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/helper"
+	"github.com/karmada-io/karmada/pkg/util/lifted"
 )
 
 func Test_retainK8sWorkloadReplicas(t *testing.T) {
 	desiredNum, observedNum := int32(2), int32(4)
-	observed, _ := helper.ToUnstructured(&appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "nginx",
-		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: &observedNum,
-		},
-	})
-	desired, _ := helper.ToUnstructured(&appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "nginx",
-			Labels: map[string]string{
-				util.RetainReplicasLabel: util.RetainReplicasValue,
-			},
-		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: &desiredNum,
-		},
-	})
-	want, _ := helper.ToUnstructured(&appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "nginx",
-			Labels: map[string]string{
-				util.RetainReplicasLabel: util.RetainReplicasValue,
-			},
-		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: &observedNum,
-		},
-	})
-	desired2, _ := helper.ToUnstructured(&appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "nginx",
-		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: &desiredNum,
-		},
-	})
 	type args struct {
-		desired  *unstructured.Unstructured
-		observed *unstructured.Unstructured
+		desired  interface{}
+		observed interface{}
 	}
 	tests := []struct {
 		name    string
 		args    args
-		want    *unstructured.Unstructured
+		want    interface{}
 		wantErr bool
 	}{
 		{
 			name: "deployment is control by hpa",
 			args: args{
-				desired:  desired,
-				observed: observed,
+				desired: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nginx",
+						Labels: map[string]string{
+							util.RetainReplicasLabel: util.RetainReplicasValue,
+						},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: &desiredNum,
+					},
+				},
+				observed: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nginx",
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: &observedNum,
+					},
+				},
 			},
-			want:    want,
+			want: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nginx",
+					Labels: map[string]string{
+						util.RetainReplicasLabel: util.RetainReplicasValue,
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &observedNum,
+				},
+			},
 			wantErr: false,
 		},
 		{
 			name: "deployment is not control by hpa",
 			args: args{
-				desired:  desired2,
-				observed: observed,
+				desired: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nginx",
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: &desiredNum,
+					},
+				},
+				observed: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nginx",
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: &observedNum,
+					},
+				},
 			},
-			want:    desired2,
+			want: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nginx",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &desiredNum,
+				},
+			},
 			wantErr: false,
+		},
+		{
+			name: "empty observed replicas",
+			args: args{
+				desired: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nginx",
+						Labels: map[string]string{
+							util.RetainReplicasLabel: util.RetainReplicasValue,
+						},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: &desiredNum,
+					},
+				},
+				observed: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nginx",
+					},
+					Spec: appsv1.DeploymentSpec{},
+				},
+			},
+			want:    nil,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := retainWorkloadReplicas(tt.args.desired, tt.args.observed)
+			unstructuredDesiredObj, err := helper.ToUnstructured(tt.args.desired)
+			if err != nil {
+				klog.Errorf("Failed to transform desired, error: %v", err)
+				return
+			}
+
+			unstructuredObservedObj, err := helper.ToUnstructured(tt.args.observed)
+			if err != nil {
+				klog.Errorf("Failed to transform observed, error: %v", err)
+				return
+			}
+			got, err := retainWorkloadReplicas(unstructuredDesiredObj, unstructuredObservedObj)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("retainWorkloadReplicas() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			assert.Equalf(t, tt.want, got, "retainDeploymentFields(%v, %v)", tt.args.desired, tt.args.observed)
+
+			unstructuredWantObj := (*unstructured.Unstructured)(nil)
+			if tt.want != nil {
+				unstructuredWantObj, err = helper.ToUnstructured(tt.want)
+				if err != nil {
+					klog.Errorf("Failed to transform want, error: %v", err)
+					return
+				}
+			}
+			assert.Equalf(t, unstructuredWantObj, got, "retainWorkloadReplicas(%v, %v)", unstructuredDesiredObj, unstructuredObservedObj)
 		})
 	}
 }
@@ -254,5 +312,413 @@ func Test_retainPersistentVolumeClaimFields(t *testing.T) {
 			assert.Nil(t, err, "retainPersistentVolumeClaimFields() error = %v", err)
 			assert.Equalf(t, tt.want, got, "retainPersistentVolumeClaimFields(%v, %v)", tt.args.desired, tt.args.observed)
 		})
+	}
+}
+
+func Test_retainJobSelectorFields(t *testing.T) {
+	replicaNum := int32(2)
+	type args struct {
+		desired  interface{}
+		observed interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    interface{}
+		wantErr bool
+	}{
+		{
+			name: "matchLabels and templateLabels exists",
+			args: args{
+				desired: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nginx",
+					},
+					Spec: appsv1.DeploymentSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "nginx_v1"},
+						},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{"app": "nginx_v1"},
+							},
+						},
+						Replicas: &replicaNum,
+					},
+				},
+				observed: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nginx",
+					},
+					Spec: appsv1.DeploymentSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"name": "nginx"},
+						},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{"name": "nginx"},
+							},
+						},
+						Replicas: &replicaNum,
+					},
+				},
+			},
+			want: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nginx",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"name": "nginx"},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"name": "nginx"},
+						},
+					},
+					Replicas: &replicaNum,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "matchLabels does not exists",
+			args: args{
+				desired: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nginx",
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{"app": "nginx_v1"},
+							},
+						},
+						Replicas: &replicaNum,
+					},
+				},
+				observed: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nginx",
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{"name": "nginx"},
+							},
+						},
+						Replicas: &replicaNum,
+					},
+				},
+			},
+			want: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nginx",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"name": "nginx"},
+						},
+					},
+					Replicas: &replicaNum,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "templateLabels does not exists",
+			args: args{
+				desired: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nginx",
+					},
+					Spec: appsv1.DeploymentSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "nginx_v1"},
+						},
+						Replicas: &replicaNum,
+					},
+				},
+				observed: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nginx",
+					},
+					Spec: appsv1.DeploymentSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"name": "nginx"},
+						},
+						Replicas: &replicaNum,
+					},
+				},
+			},
+			want: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nginx",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"name": "nginx"},
+					},
+					Replicas: &replicaNum,
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unstructuredDesiredObj, err := helper.ToUnstructured(tt.args.desired)
+			if err != nil {
+				klog.Errorf("Failed to transform desired, error: %v", err)
+				return
+			}
+			unstructuredObservedObj, err := helper.ToUnstructured(tt.args.observed)
+			if err != nil {
+				klog.Errorf("Failed to transform observed, error: %v", err)
+				return
+			}
+			got, err := retainJobSelectorFields(unstructuredDesiredObj, unstructuredObservedObj)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("retainJobSelectorFields() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			unstructuredWantObj, err := helper.ToUnstructured(tt.want)
+			if err != nil {
+				klog.Errorf("Failed to transform want, error: %v", err)
+				return
+			}
+			assert.Equalf(t, unstructuredWantObj, got, "retainJobSelectorFields(%v, %v)", unstructuredDesiredObj, unstructuredObservedObj)
+		})
+	}
+}
+
+func Test_retainPodFields(t *testing.T) {
+	type args struct {
+		desired  interface{}
+		observed interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    interface{}
+		wantErr bool
+	}{
+		{
+			name: "retain observed pod fields",
+			args: args{
+				desired: &corev1.Pod{Spec: corev1.PodSpec{
+					NodeName:           "node2",
+					ServiceAccountName: "fake-desired-sa",
+					Volumes: []corev1.Volume{
+						{
+							Name: "fake-desired-volume",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "fake-desired-secret",
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{{
+						Name: "test",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "fake-desired-config",
+								ReadOnly:  false,
+								MountPath: "/etc/etcd/desired",
+							},
+						},
+					}, {
+						Name: "test-3",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "fake-desired-config-2",
+								ReadOnly:  false,
+								MountPath: "/etc/etcd/desired2",
+							},
+						},
+					}},
+					Containers: []corev1.Container{{
+						Name: "test",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "fake-desired-cert",
+								ReadOnly:  true,
+								MountPath: "/etc/karmada/desired",
+							},
+						},
+					}, {
+						Name: "test-3",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "fake-desired-cert-2",
+								ReadOnly:  true,
+								MountPath: "/etc/karmada/desired2",
+							},
+						},
+					}},
+				}},
+				observed: &corev1.Pod{Spec: corev1.PodSpec{
+					NodeName:           "node1",
+					ServiceAccountName: "fake-obersved-sa",
+					Volumes: []corev1.Volume{
+						{
+							Name: "fake-obersved-volume",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "fake-obersved-secret",
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{{
+						Name: "test",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "fake-observed-config",
+								ReadOnly:  false,
+								MountPath: "/etc/etcd/observed",
+							},
+						},
+					}, {
+						Name: "test-2",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "fake-observed-config-2",
+								ReadOnly:  false,
+								MountPath: "/etc/etcd/observed2",
+							},
+						},
+					}},
+					Containers: []corev1.Container{{
+						Name: "test",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "fake-observed-cert",
+								ReadOnly:  true,
+								MountPath: "/etc/karmada/observed",
+							},
+						},
+					}, {
+						Name: "test-2",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "fake-observed-cert-2",
+								ReadOnly:  true,
+								MountPath: "/etc/karmada/observed2",
+							},
+						},
+					}},
+				}},
+			},
+			want: &corev1.Pod{Spec: corev1.PodSpec{
+				NodeName:           "node1",
+				ServiceAccountName: "fake-obersved-sa",
+				Volumes: []corev1.Volume{
+					{
+						Name: "fake-obersved-volume",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "fake-obersved-secret",
+							},
+						},
+					},
+				},
+				InitContainers: []corev1.Container{{
+					Name: "test",
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "fake-observed-config",
+							ReadOnly:  false,
+							MountPath: "/etc/etcd/observed",
+						},
+					},
+				}, {
+					Name: "test-3",
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "fake-desired-config-2",
+							ReadOnly:  false,
+							MountPath: "/etc/etcd/desired2",
+						},
+					},
+				}},
+				Containers: []corev1.Container{{
+					Name: "test",
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "fake-observed-cert",
+							ReadOnly:  true,
+							MountPath: "/etc/karmada/observed",
+						},
+					},
+				}, {
+					Name: "test-3",
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "fake-desired-cert-2",
+							ReadOnly:  true,
+							MountPath: "/etc/karmada/desired2",
+						},
+					},
+				}},
+			}},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unstructuredDesiredObj, err := helper.ToUnstructured(tt.args.desired)
+			if err != nil {
+				klog.Errorf("Failed to transform desired, error: %v", err)
+				return
+			}
+			unstructuredObservedObj, err := helper.ToUnstructured(tt.args.observed)
+			if err != nil {
+				klog.Errorf("Failed to transform observed, error: %v", err)
+				return
+			}
+			got, err := retainPodFields(unstructuredDesiredObj, unstructuredObservedObj)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("retainPodFields() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			unstructuredWantObj, err := helper.ToUnstructured(tt.want)
+			if err != nil {
+				klog.Errorf("Failed to transform want, error: %v", err)
+				return
+			}
+			assert.Equalf(t, unstructuredWantObj, got, "retainPodFields(%v, %v)", unstructuredDesiredObj, unstructuredObservedObj)
+		})
+	}
+}
+
+func Test_getAllDefaultRetentionInterpreter(t *testing.T) {
+	expected := map[schema.GroupVersionKind]retentionInterpreter{
+		{Group: "apps", Version: "v1", Kind: "Deployment"}:        retainWorkloadReplicas,
+		{Group: "", Version: "v1", Kind: "Pod"}:                   retainPodFields,
+		{Group: "", Version: "v1", Kind: "Service"}:               lifted.RetainServiceFields,
+		{Group: "", Version: "v1", Kind: "ServiceAccount"}:        lifted.RetainServiceAccountFields,
+		{Group: "", Version: "v1", Kind: "PersistentVolumeClaim"}: retainPersistentVolumeClaimFields,
+		{Group: "", Version: "v1", Kind: "PersistentVolume"}:      retainPersistentVolumeFields,
+		{Group: "batch", Version: "v1", Kind: "Job"}:              retainJobSelectorFields,
+		{Group: "", Version: "v1", Kind: "Secret"}:                retainSecretServiceAccountToken,
+	}
+
+	got := getAllDefaultRetentionInterpreter()
+
+	if len(got) != len(expected) {
+		t.Errorf("getAllDefaultRetentionInterpreter() length = %d, want %d", len(got), len(expected))
+	}
+
+	for key, expectedValue := range expected {
+		if gotValue, exists := got[key]; !exists {
+			t.Errorf("getAllDefaultRetentionInterpreter() missing key %v", key)
+		} else if gotValue == nil {
+			t.Errorf("for key %v, getAllDefaultRetentionInterpreter()= %v want %v", key, gotValue, expectedValue)
+		} else if reflect.ValueOf(gotValue).Pointer() != reflect.ValueOf(expectedValue).Pointer() {
+			t.Errorf("getAllDefaultRetentionInterpreter() for key %v = %v, want %v", key, gotValue, expectedValue)
+		}
 	}
 }

--- a/pkg/resourceinterpreter/default/native/revisereplica_test.go
+++ b/pkg/resourceinterpreter/default/native/revisereplica_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestReviseDeploymentReplica(t *testing.T) {
@@ -246,5 +247,30 @@ func TestReviseStatefulSetReplica(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestGetAllDefaultReviseReplicaInterpreter(t *testing.T) {
+	expected := map[schema.GroupVersionKind]reviseReplicaInterpreter{
+		{Group: "apps", Version: "v1", Kind: "Deployment"}:  reviseDeploymentReplica,
+		{Group: "apps", Version: "v1", Kind: "StatefulSet"}: reviseStatefulSetReplica,
+		{Group: "batch", Version: "v1", Kind: "Job"}:        reviseJobReplica,
+	}
+
+	got := getAllDefaultReviseReplicaInterpreter()
+
+	if len(got) != len(expected) {
+		t.Errorf("getAllDefaultReviseReplicaInterpreter() returned map of length %v, want %v", len(got), len(expected))
+	}
+
+	for key, expectedValue := range expected {
+		gotValue, gotOk := got[key]
+		if !gotOk {
+			t.Errorf("expected key %v not found in got map", key)
+		} else if gotValue == nil {
+			t.Errorf("for key %v, getAllDefaultReviseReplicaInterpreter()= %v want %v", key, gotValue, expectedValue)
+		} else if reflect.ValueOf(gotValue).Pointer() != reflect.ValueOf(expectedValue).Pointer() {
+			t.Errorf("for key %v, getAllDefaultReviseReplicaInterpreter()= %v want %v", key, gotValue, expectedValue)
+		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind failing-test
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
The test case coverage for pkg/resourceinterpreter/default/native/revisereplica has been increased from 66.67% to 100% and  pkg/resourceinterpreter/default/native/retain has been increased from 21.11% to more than 80%.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
To verify the changes in the pkg/resourceinterpreter/default/native/ directory run the following commands:
```
go test ./... -coverprofile=coverage.out
go tool cover -html=coverage.out -o coverage.html
open coverage.html
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

