### PR TITLE
use single source for go version

### DIFF
--- a/.github/workflows/ci-image-scanning.yaml
+++ b/.github/workflows/ci-image-scanning.yaml
@@ -32,6 +32,10 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v4
+      - name: install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - name: Build an image from Dockerfile
         run: |
           export VERSION="latest"

--- a/.github/workflows/dockerhub-latest-chart.yml
+++ b/.github/workflows/dockerhub-latest-chart.yml
@@ -22,6 +22,10 @@ jobs:
           # 0 indicates all history for all branches and tags.
           # for `git describe --tags` in Makefile.
           fetch-depth: 0
+      - name: install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - name: login to DockerHub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/dockerhub-released-chart.yml
+++ b/.github/workflows/dockerhub-released-chart.yml
@@ -17,6 +17,10 @@ jobs:
           # 0 indicates all history for all branches and tags.
           # for `git describe --tags` in Makefile.
           fetch-depth: 0
+      - name: install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - name: login to DockerHub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/lint-chart.yaml
+++ b/.github/workflows/lint-chart.yaml
@@ -29,6 +29,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
The setup-go action is the recommended way of [using Go with GitHub Actions](https://docs.github.com/en/actions/use-cases-and-examples/building-and-testing/building-and-testing-go#specifying-a-go-version), because it helps ensure consistent behavior across different runners and different versions of Go. At present, we still have the following workflows for which the Go version has not been specified：
- .github/workflows/ci-image-scanning.yaml
- .github/workflows/dockerhub-latest-chart.yml
- .github/workflows/dockerhub-released-chart.yml
- .github/workflows/lint-chart.yaml


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
When the Go version is not specified, the Go version in the CI environment may not match the one in the `go.mod` file. For example, recent vulnerability scans for the release-1.10 version did not properly identify vulnerabilities in `gobinary`. Upon investigation, it was found that the inconsistency between the Go version in the CI environment and the one specified in the `go.mod` file caused this issue.
[image-scan-with-set-up-go](https://github.com/zhzhuang-zju/karmada/actions/runs/10365848027/job/28693829118)
[image-scan-without-set-up-go](https://github.com/zhzhuang-zju/karmada/actions/runs/10365787713/job/28693635788)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

