### PR TITLE
charts/karmada: remove duplicate app label config in scheduler-estimator

### DIFF
--- a/.github/workflows/lint-chart.yaml
+++ b/.github/workflows/lint-chart.yaml
@@ -3,6 +3,7 @@ name: Chart Lint
 
 env:
   HELM_VERSION: v3.11.2
+  KUSTOMIZE_VERSION: 5.4.3
   KIND_VERSION: v0.22.0
   KIND_NODE_IMAGE: kindest/node:v1.29.0
   K8S_VERSION: v1.29.0
@@ -39,13 +40,37 @@ jobs:
         with:
           version: ${{ env.HELM_VERSION }}
 
+      - name: Set up Kustomize
+        uses: syntaqx/setup-kustomize@v1
+        with:
+          kustomize-version: ${{ env.KUSTOMIZE_VERSION }}
+
       - name: Run chart-testing (template)
         run: |
-          helm template --set components={"search,descheduler,schedulerEstimator"} --dependency-update ./charts/karmada --debug > /dev/null
-          helm template --set components={"search,descheduler,schedulerEstimator"},certs.mode=custom --dependency-update ./charts/karmada --debug > /dev/null
-          helm template --set components={"search,descheduler,schedulerEstimator"},installMode=component --dependency-update ./charts/karmada --debug > /dev/null
-          helm template --set installMode=agent --dependency-update ./charts/karmada --debug > /dev/null
-          helm template --dependency-update ./charts/karmada-operator --debug > /dev/null   
+          cat <<EOF > post-render.sh
+          #!/bin/sh
+          # save helm stdout to file, kustomize will read this
+          cat > all.yaml
+          kustomize build
+          EOF
+
+          chmod +x post-render.sh
+
+          cat <<EOF > kustomization.yaml
+          resources:
+            - all.yaml
+          EOF
+
+          helm template --set components={"search,descheduler,schedulerEstimator"} --dependency-update ./charts/karmada \
+            --post-renderer ./post-render.sh --debug > /dev/null
+          helm template --set components={"search,descheduler,schedulerEstimator"},certs.mode=custom --dependency-update \
+            ./charts/karmada --post-renderer ./post-render.sh --debug > /dev/null
+          helm template --set components={"search,descheduler,schedulerEstimator"},installMode=component --dependency-update \
+            ./charts/karmada --post-renderer ./post-render.sh --debug > /dev/null
+          helm template --set installMode=agent --dependency-update ./charts/karmada --post-renderer ./post-render.sh --debug > /dev/null
+          helm template --dependency-update ./charts/karmada-operator --post-renderer ./post-render.sh --debug > /dev/null
+
+          rm post-render.sh all.yaml kustomization.yaml
 
       # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
       # yamllint (https://github.com/adrienverge/yamllint) which require Python

--- a/charts/karmada/templates/karmada-scheduler-estimator.yaml
+++ b/charts/karmada/templates/karmada-scheduler-estimator.yaml
@@ -17,7 +17,7 @@ spec:
   replicas: {{  $member.replicaCount }}
   selector:
     matchLabels:
-      app: karmada-scheduler-estimator-{{ $clusterName }}
+      cluster: {{ $clusterName }}
       {{- include "karmada.schedulerEstimator.labels" $ | nindent 6 }}
   {{- with $.Values.schedulerEstimator.strategy }}
   strategy:
@@ -30,7 +30,7 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        app: karmada-scheduler-estimator-{{ $clusterName }}
+        cluster: {{ $clusterName }}
         {{- include "karmada.schedulerEstimator.labels" $ | nindent 8 }}
         {{- include "karmada.schedulerEstimator.podLabels" $ | nindent 8 }}
     spec:
@@ -91,7 +91,7 @@ metadata:
     cluster: {{ $clusterName }}
 spec:
   selector:
-    app: karmada-scheduler-estimator-{{ $clusterName }}
+    cluster: {{ $clusterName }}
     {{- include "karmada.schedulerEstimator.labels" $ | nindent 4 }}
   ports:
     - protocol: TCP
@@ -138,7 +138,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: karmada-scheduler-estimator-{{ $clusterName }}
+      cluster: {{ $clusterName }}
       {{- include "karmada.schedulerEstimator.labels" $ | nindent 6 }}
   {{ toYaml $.Values.schedulerEstimator.podDisruptionBudget | nindent 2 }}
 {{- end -}}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The scheduler-estimator Pod already has an app label configured:

https://github.com/karmada-io/karmada/blob/e5b12986081bf878bf4b70f3db2f8500e0bceb02/charts/karmada/templates/karmada-scheduler-estimator.yaml#L33-L35

And we also have a default app label value in the `values.yaml`:

https://github.com/karmada-io/karmada/blob/e5b12986081bf878bf4b70f3db2f8500e0bceb02/charts/karmada/values.yaml#L801-L802

This results in duplicate app labels in the scheduler-estimator Pod:

```yaml
labels:
  app: karmada-scheduler-estimator-xx
  app: karmada-scheduler-estimator
```

 This doesn't affect the helm installation, but it prevents kustomize from building it:

```
mapping key "app" already defined
```

This patch removes the default scheduler-estimator label config in `values.yaml` to make kustomize happy.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
none
```
