### PR TITLE
Added tests pkg/util/fedinformer

### DIFF
--- a/pkg/util/fedinformer/handlers_test.go
+++ b/pkg/util/fedinformer/handlers_test.go
@@ -1,0 +1,248 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fedinformer
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+type TestObject struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+	Spec string
+}
+
+func (in *TestObject) DeepCopyObject() runtime.Object {
+	return &TestObject{
+		TypeMeta:   in.TypeMeta,
+		ObjectMeta: in.ObjectMeta,
+		Spec:       in.Spec,
+	}
+}
+
+type CustomResourceEventHandler struct {
+	handler cache.ResourceEventHandler
+}
+
+func (c *CustomResourceEventHandler) OnAdd(obj interface{}, isInInitialList bool) {
+	if h, ok := c.handler.(interface{ OnAdd(interface{}, bool) }); ok {
+		h.OnAdd(obj, isInInitialList)
+	} else {
+		c.handler.OnAdd(obj, false)
+	}
+}
+
+func (c *CustomResourceEventHandler) OnUpdate(oldObj, newObj interface{}) {
+	c.handler.OnUpdate(oldObj, newObj)
+}
+
+func (c *CustomResourceEventHandler) OnDelete(obj interface{}) {
+	c.handler.OnDelete(obj)
+}
+
+func TestNewHandlerOnAllEvents(t *testing.T) {
+	testCases := []struct {
+		name     string
+		event    string
+		input    interface{}
+		expected runtime.Object
+	}{
+		{
+			name:     "Add event",
+			event:    "add",
+			input:    &TestObject{ObjectMeta: metav1.ObjectMeta{Name: "test-obj-add"}, Spec: "add"},
+			expected: &TestObject{ObjectMeta: metav1.ObjectMeta{Name: "test-obj-add"}, Spec: "add"},
+		},
+		{
+			name:     "Update event",
+			event:    "update",
+			input:    &TestObject{ObjectMeta: metav1.ObjectMeta{Name: "test-obj-update"}, Spec: "update"},
+			expected: &TestObject{ObjectMeta: metav1.ObjectMeta{Name: "test-obj-update"}, Spec: "update"},
+		},
+		{
+			name:     "Delete event",
+			event:    "delete",
+			input:    &TestObject{ObjectMeta: metav1.ObjectMeta{Name: "test-obj-delete"}, Spec: "delete"},
+			expected: &TestObject{ObjectMeta: metav1.ObjectMeta{Name: "test-obj-delete"}, Spec: "delete"},
+		},
+		{
+			name:     "Delete event with DeletedFinalStateUnknown",
+			event:    "delete",
+			input:    cache.DeletedFinalStateUnknown{Obj: &TestObject{ObjectMeta: metav1.ObjectMeta{Name: "test-obj-delete-unknown"}, Spec: "delete-unknown"}},
+			expected: &TestObject{ObjectMeta: metav1.ObjectMeta{Name: "test-obj-delete-unknown"}, Spec: "delete-unknown"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var calledWith runtime.Object
+			fn := func(obj interface{}) {
+				calledWith = obj.(runtime.Object)
+			}
+
+			handler := &CustomResourceEventHandler{NewHandlerOnAllEvents(fn)}
+
+			switch tc.event {
+			case "add":
+				handler.OnAdd(tc.input, false)
+			case "update":
+				oldObj := &TestObject{ObjectMeta: metav1.ObjectMeta{Name: "old-obj"}, Spec: "old"}
+				handler.OnUpdate(oldObj, tc.input)
+			case "delete":
+				handler.OnDelete(tc.input)
+			}
+
+			if !reflect.DeepEqual(calledWith, tc.expected) {
+				t.Errorf("expected %v, got %v", tc.expected, calledWith)
+			}
+		})
+	}
+}
+
+func TestNewHandlerOnEvents(t *testing.T) {
+	testCases := []struct {
+		name  string
+		event string
+	}{
+		{"Add event", "add"},
+		{"Update event", "update"},
+		{"Delete event", "delete"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var addCalled, updateCalled, deleteCalled bool
+			addFunc := func(_ interface{}) { addCalled = true }
+			updateFunc := func(_, _ interface{}) { updateCalled = true }
+			deleteFunc := func(_ interface{}) { deleteCalled = true }
+
+			handler := &CustomResourceEventHandler{NewHandlerOnEvents(addFunc, updateFunc, deleteFunc)}
+
+			testObj := &TestObject{ObjectMeta: metav1.ObjectMeta{Name: "test-obj"}}
+
+			switch tc.event {
+			case "add":
+				handler.OnAdd(testObj, false)
+				if !addCalled {
+					t.Error("AddFunc was not called")
+				}
+			case "update":
+				handler.OnUpdate(testObj, testObj)
+				if !updateCalled {
+					t.Error("UpdateFunc was not called")
+				}
+			case "delete":
+				handler.OnDelete(testObj)
+				if !deleteCalled {
+					t.Error("DeleteFunc was not called")
+				}
+			}
+		})
+	}
+}
+
+func TestNewFilteringHandlerOnAllEvents(t *testing.T) {
+	testCases := []struct {
+		name           string
+		event          string
+		input          interface{}
+		expectedAdd    bool
+		expectedUpdate bool
+		expectedDelete bool
+	}{
+		{
+			name:           "Add passing object",
+			event:          "add",
+			input:          &TestObject{ObjectMeta: metav1.ObjectMeta{Name: "passing-obj"}, Spec: "pass"},
+			expectedAdd:    true,
+			expectedUpdate: false,
+			expectedDelete: false,
+		},
+		{
+			name:           "Add failing object",
+			event:          "add",
+			input:          &TestObject{ObjectMeta: metav1.ObjectMeta{Name: "failing-obj"}, Spec: "fail"},
+			expectedAdd:    false,
+			expectedUpdate: false,
+			expectedDelete: false,
+		},
+		{
+			name:           "Update to passing object",
+			event:          "update",
+			input:          &TestObject{ObjectMeta: metav1.ObjectMeta{Name: "passing-obj"}, Spec: "pass"},
+			expectedAdd:    false,
+			expectedUpdate: true,
+			expectedDelete: false,
+		},
+		{
+			name:           "Update to failing object",
+			event:          "update",
+			input:          &TestObject{ObjectMeta: metav1.ObjectMeta{Name: "failing-obj"}, Spec: "fail"},
+			expectedAdd:    false,
+			expectedUpdate: false,
+			expectedDelete: true,
+		},
+		{
+			name:           "Delete passing object",
+			event:          "delete",
+			input:          &TestObject{ObjectMeta: metav1.ObjectMeta{Name: "passing-obj"}, Spec: "pass"},
+			expectedAdd:    false,
+			expectedUpdate: false,
+			expectedDelete: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var addCalled, updateCalled, deleteCalled bool
+			addFunc := func(_ interface{}) { addCalled = true }
+			updateFunc := func(_, _ interface{}) { updateCalled = true }
+			deleteFunc := func(_ interface{}) { deleteCalled = true }
+
+			filterFunc := func(obj interface{}) bool {
+				testObj := obj.(*TestObject)
+				return testObj.Spec == "pass"
+			}
+
+			handler := NewFilteringHandlerOnAllEvents(filterFunc, addFunc, updateFunc, deleteFunc)
+
+			switch tc.event {
+			case "add":
+				handler.OnAdd(tc.input, false)
+			case "update":
+				handler.OnUpdate(&TestObject{Spec: "pass"}, tc.input)
+			case "delete":
+				handler.OnDelete(tc.input)
+			}
+
+			if addCalled != tc.expectedAdd {
+				t.Errorf("AddFunc called: %v, expected: %v", addCalled, tc.expectedAdd)
+			}
+			if updateCalled != tc.expectedUpdate {
+				t.Errorf("UpdateFunc called: %v, expected: %v", updateCalled, tc.expectedUpdate)
+			}
+			if deleteCalled != tc.expectedDelete {
+				t.Errorf("DeleteFunc called: %v, expected: %v", deleteCalled, tc.expectedDelete)
+			}
+		})
+	}
+}

--- a/pkg/util/fedinformer/keys/keys_test.go
+++ b/pkg/util/fedinformer/keys/keys_test.go
@@ -73,6 +73,38 @@ var (
 			Name:      "bar",
 		},
 	}
+	podWithEmptyGroup = &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+			Name:      "bar",
+		},
+	}
+
+	podWithEmptyKind = &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+			Name:      "bar",
+		},
+	}
+
+	secretWithEmptyNamespace = &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "",
+			Name:      "bar",
+		},
+	}
 )
 
 func TestClusterWideKeyFunc(t *testing.T) {
@@ -120,6 +152,22 @@ func TestClusterWideKeyFunc(t *testing.T) {
 			name:      "non APIVersion and kind runtime object should be error",
 			object:    deploymentObj,
 			expectErr: true,
+		},
+		{
+			name:      "resource with empty group",
+			object:    podWithEmptyGroup,
+			expectErr: true,
+		},
+		{
+			name:      "resource with empty kind",
+			object:    podWithEmptyKind,
+			expectErr: true,
+		},
+		{
+			name:         "resource with empty namespace",
+			object:       secretWithEmptyNamespace,
+			expectErr:    false,
+			expectKeyStr: "v1, kind=Secret, bar",
 		},
 	}
 

--- a/pkg/util/fedinformer/typedmanager/multi-cluster-manager_test.go
+++ b/pkg/util/fedinformer/typedmanager/multi-cluster-manager_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package typedmanager
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/karmada-io/karmada/pkg/util/fedinformer"
+)
+
+func TestMultiClusterInformerManager(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	transforms := map[schema.GroupVersionResource]cache.TransformFunc{
+		nodeGVR: fedinformer.NodeTransformFunc,
+		podGVR:  fedinformer.PodTransformFunc,
+	}
+
+	manager := NewMultiClusterInformerManager(stopCh, transforms)
+
+	t.Run("ForCluster", func(_ *testing.T) {
+		cluster := "test-cluster"
+		client := fake.NewSimpleClientset()
+		resync := 10 * time.Second
+
+		singleManager := manager.ForCluster(cluster, client, resync)
+		if singleManager == nil {
+			t.Fatalf("ForCluster() returned nil")
+		}
+
+		if !manager.IsManagerExist(cluster) {
+			t.Fatalf("IsManagerExist() returned false for existing cluster")
+		}
+	})
+
+	t.Run("GetSingleClusterManager", func(t *testing.T) {
+		cluster := "test-cluster"
+		singleManager := manager.GetSingleClusterManager(cluster)
+		if singleManager == nil {
+			t.Fatalf("GetSingleClusterManager() returned nil for existing cluster")
+		}
+
+		nonExistentCluster := "non-existent-cluster"
+		singleManager = manager.GetSingleClusterManager(nonExistentCluster)
+		if singleManager != nil {
+			t.Fatalf("GetSingleClusterManager() returned non-nil for non-existent cluster")
+		}
+	})
+
+	t.Run("Start and Stop", func(t *testing.T) {
+		cluster := "test-cluster-2"
+		client := fake.NewSimpleClientset()
+		resync := 10 * time.Second
+
+		manager.ForCluster(cluster, client, resync)
+		manager.Start(cluster)
+
+		manager.Stop(cluster)
+
+		if manager.IsManagerExist(cluster) {
+			t.Fatalf("IsManagerExist() returned true after Stop()")
+		}
+	})
+
+	t.Run("WaitForCacheSync", func(t *testing.T) {
+		cluster := "test-cluster-3"
+		client := fake.NewSimpleClientset()
+		resync := 10 * time.Millisecond
+		singleManager := manager.ForCluster(cluster, client, resync)
+		manager.Start(cluster)
+
+		_, _ = singleManager.Lister(podGVR)
+		_, _ = singleManager.Lister(nodeGVR)
+
+		time.Sleep(100 * time.Millisecond)
+
+		result := manager.WaitForCacheSync(cluster)
+		if result == nil {
+			t.Fatalf("WaitForCacheSync() returned nil result")
+		}
+
+		for gvr, synced := range result {
+			t.Logf("Resource %v synced: %v", gvr, synced)
+		}
+
+		manager.Stop(cluster)
+	})
+
+	t.Run("WaitForCacheSyncWithTimeout", func(t *testing.T) {
+		cluster := "test-cluster-4"
+		client := fake.NewSimpleClientset()
+		resync := 10 * time.Millisecond
+		singleManager := manager.ForCluster(cluster, client, resync)
+		manager.Start(cluster)
+
+		_, _ = singleManager.Lister(podGVR)
+		_, _ = singleManager.Lister(nodeGVR)
+
+		timeout := 100 * time.Millisecond
+		result := manager.WaitForCacheSyncWithTimeout(cluster, timeout)
+		if result == nil {
+			t.Fatalf("WaitForCacheSyncWithTimeout() returned nil result")
+		}
+
+		for gvr, synced := range result {
+			t.Logf("Resource %v synced: %v", gvr, synced)
+		}
+
+		manager.Stop(cluster)
+	})
+
+	t.Run("WaitForCacheSync and WaitForCacheSyncWithTimeout with non-existent cluster", func(t *testing.T) {
+		nonExistentCluster := "non-existent-cluster"
+
+		result1 := manager.WaitForCacheSync(nonExistentCluster)
+		if result1 != nil {
+			t.Fatalf("WaitForCacheSync() returned non-nil for non-existent cluster")
+		}
+
+		result2 := manager.WaitForCacheSyncWithTimeout(nonExistentCluster, 1*time.Second)
+		if result2 != nil {
+			t.Fatalf("WaitForCacheSyncWithTimeout() returned non-nil for non-existent cluster")
+		}
+	})
+}
+
+func TestGetInstance(t *testing.T) {
+	instance1 := GetInstance()
+	instance2 := GetInstance()
+
+	if instance1 != instance2 {
+		t.Fatalf("GetInstance() returned different instances")
+	}
+}
+
+func TestStopInstance(_ *testing.T) {
+	StopInstance()
+	// Ensure StopInstance doesn't panic
+	StopInstance()
+}

--- a/pkg/util/fedinformer/typedmanager/single-cluster-manager_test.go
+++ b/pkg/util/fedinformer/typedmanager/single-cluster-manager_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package typedmanager
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestSingleClusterInformerManager(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	manager := NewSingleClusterInformerManager(client, 0, stopCh, nil)
+
+	t.Run("ForResource", func(t *testing.T) {
+		handler := &testResourceEventHandler{}
+		err := manager.ForResource(podGVR, handler)
+		require.NoError(t, err, "ForResource failed")
+
+		assert.True(t, manager.IsHandlerExist(podGVR, handler), "Handler should exist for podGVR")
+	})
+
+	t.Run("Lister", func(t *testing.T) {
+		lister, err := manager.Lister(podGVR)
+		require.NoError(t, err, "Lister failed")
+		assert.NotNil(t, lister, "Lister should not be nil")
+	})
+
+	t.Run("Start and Stop", func(_ *testing.T) {
+		manager.Start()
+		// Sleep to allow informers to start
+		time.Sleep(100 * time.Millisecond)
+		manager.Stop()
+	})
+
+	t.Run("WaitForCacheSync", func(t *testing.T) {
+		manager.Start()
+		defer manager.Stop()
+
+		synced := manager.WaitForCacheSync()
+		assert.NotEmpty(t, synced, "WaitForCacheSync should return non-empty map")
+	})
+
+	t.Run("WaitForCacheSyncWithTimeout", func(t *testing.T) {
+		manager.Start()
+		defer manager.Stop()
+
+		synced := manager.WaitForCacheSyncWithTimeout(5 * time.Second)
+		assert.NotEmpty(t, synced, "WaitForCacheSyncWithTimeout should return non-empty map")
+	})
+
+	t.Run("Context", func(t *testing.T) {
+		ctx := manager.Context()
+		assert.NotNil(t, ctx, "Context should not be nil")
+	})
+
+	t.Run("GetClient", func(t *testing.T) {
+		c := manager.GetClient()
+		assert.NotNil(t, c, "GetClient should not return nil")
+	})
+}
+
+func TestSingleClusterInformerManagerWithTransformFunc(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	transformFunc := func(i interface{}) (interface{}, error) {
+		return i, nil
+	}
+
+	transformFuncs := map[schema.GroupVersionResource]cache.TransformFunc{
+		podGVR: transformFunc,
+	}
+
+	manager := NewSingleClusterInformerManager(client, 0, stopCh, transformFuncs)
+
+	t.Run("ForResourceWithTransform", func(t *testing.T) {
+		handler := &testResourceEventHandler{}
+		err := manager.ForResource(podGVR, handler)
+		require.NoError(t, err, "ForResource with transform failed")
+	})
+}
+
+func TestSingleClusterInformerManagerMultipleHandlers(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	manager := NewSingleClusterInformerManager(client, 0, stopCh, nil)
+
+	handler1 := &testResourceEventHandler{}
+	handler2 := &testResourceEventHandler{}
+
+	t.Run("MultipleHandlers", func(t *testing.T) {
+		err := manager.ForResource(podGVR, handler1)
+		require.NoError(t, err, "ForResource failed for handler1")
+
+		err = manager.ForResource(podGVR, handler2)
+		require.NoError(t, err, "ForResource failed for handler2")
+
+		assert.True(t, manager.IsHandlerExist(podGVR, handler1), "Handler1 should exist for podGVR")
+		assert.True(t, manager.IsHandlerExist(podGVR, handler2), "Handler2 should exist for podGVR")
+	})
+}
+
+func TestSingleClusterInformerManagerDifferentResources(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	manager := NewSingleClusterInformerManager(client, 0, stopCh, nil)
+
+	t.Run("DifferentResources", func(t *testing.T) {
+		podHandler := &testResourceEventHandler{}
+		err := manager.ForResource(podGVR, podHandler)
+		require.NoError(t, err, "ForResource failed for podGVR")
+
+		nodeHandler := &testResourceEventHandler{}
+		err = manager.ForResource(nodeGVR, nodeHandler)
+		require.NoError(t, err, "ForResource failed for nodeGVR")
+
+		assert.True(t, manager.IsHandlerExist(podGVR, podHandler), "PodHandler should exist for podGVR")
+		assert.True(t, manager.IsHandlerExist(nodeGVR, nodeHandler), "NodeHandler should exist for nodeGVR")
+	})
+}
+
+func TestIsInformerSynced(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	manager := NewSingleClusterInformerManager(client, 0, stopCh, nil)
+
+	assert.False(t, manager.IsInformerSynced(podGVR))
+	assert.False(t, manager.IsInformerSynced(nodeGVR))
+
+	handler := &testResourceEventHandler{}
+	err := manager.ForResource(podGVR, handler)
+	require.NoError(t, err)
+	err = manager.ForResource(nodeGVR, handler)
+	require.NoError(t, err)
+
+	manager.Start()
+	defer manager.Stop()
+
+	synced := manager.WaitForCacheSyncWithTimeout(5 * time.Second)
+
+	assert.True(t, synced[podGVR], "Pod informer should be synced")
+	assert.True(t, synced[nodeGVR], "Node informer should be synced")
+
+	time.Sleep(100 * time.Millisecond)
+
+	assert.True(t, manager.IsInformerSynced(podGVR), "Pod informer should be reported as synced")
+	assert.True(t, manager.IsInformerSynced(nodeGVR), "Node informer should be reported as synced")
+}
+
+type testResourceEventHandler struct{}
+
+func (t *testResourceEventHandler) OnAdd(_ interface{}, _ bool) {}
+func (t *testResourceEventHandler) OnUpdate(_, _ interface{})   {}
+func (t *testResourceEventHandler) OnDelete(_ interface{})      {}


### PR DESCRIPTION
**Description**:
This PR adds 3 new test files for pkg/util/fedinformer and enhances its code coverage and reliability of a critical component of the project. These new additions have increased its test coverage significantly.

**Additions:**
3 new test files are implemented in this PR.
1.  pkg/util/fedinformer/handlers_test.go
2.  pkg/util/fedinformer/typedmanager/multi-cluster-manager_test.go
3.  pkg/util/fedinformer/typedmanager/single-cluster-manager_test.go

**What type of PR is this?**
/kind failing-test
/kind feature

**What this PR does / why we need it**:
This PR improves the test coverage and reliability of the fedinformer package, which is critical for the functionality of the project. Enhanced testing ensures better stability and performance.

**Which issue(s) this PR fixes**:
Fixes a part of #5235 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

