### PR TITLE
charts/karmada: ignore the static-resource Pod in the post-install check

### DIFF
--- a/charts/karmada/templates/post-install-job.yaml
+++ b/charts/karmada/templates/post-install-job.yaml
@@ -53,7 +53,8 @@ spec:
 
           # The `post-install hook job` may be applied before all karmada components are ready that rely on `static-resource job` and `hook-job secret`.
           # So, we have to postpone the deletion of the `static-resource job` and `hook-job secret` until all karmada components are up and running.
-          while [[ $(kubectl get pods -n {{ $namespace }} --field-selector=status.phase!=Running,status.phase!=Succeeded -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | wc -l) > 0 ]]; do
+          while [[ $(kubectl get pods -n {{ $namespace }} --field-selector=status.phase!=Running,status.phase!=Succeeded -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep -v static-resource | wc -l) > 0 ]];
+          do
             echo "waiting for all pods of karmada control plane ready..."; sleep 1;
           done
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

I encountered the following situation: the `static-resource` Job failed during execution, so it retried once. The retry was successful, and although the Job eventually completed successfully, the initial failure resulted in a failed Pod. Because of this failed Pod, the post-install check script kept running, even though all Karmada components were already running. This patch makes the post-install script ignore Pods related to `static-resource`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
none
```

