### PR TITLE
Automated cherry pick of #5360: use single source for go version

### DIFF
--- a/.github/workflows/ci-image-scanning.yaml
+++ b/.github/workflows/ci-image-scanning.yaml
@@ -28,6 +28,10 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v4
+      - name: install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - name: Build an image from Dockerfile
         run: |
           export VERSION="latest"

--- a/.github/workflows/dockerhub-latest-chart.yml
+++ b/.github/workflows/dockerhub-latest-chart.yml
@@ -19,6 +19,10 @@ jobs:
           # 0 indicates all history for all branches and tags.
           # for `git describe --tags` in Makefile.
           fetch-depth: 0
+      - name: install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - name: login to DockerHub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/dockerhub-released-chart.yml
+++ b/.github/workflows/dockerhub-released-chart.yml
@@ -15,6 +15,10 @@ jobs:
           # 0 indicates all history for all branches and tags.
           # for `git describe --tags` in Makefile.
           fetch-depth: 0
+      - name: install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - name: login to DockerHub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/lint-chart.yaml
+++ b/.github/workflows/lint-chart.yaml
@@ -26,6 +26,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:


### PR DESCRIPTION
Cherry pick of #5360 on release-1.10.
#5360: use single source for go version
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
```