### PR TITLE
charts/karmada: fix the creation condition of metrics-adapter related APIService

### DIFF
--- a/charts/karmada/templates/_karmada_apiservice.tpl
+++ b/charts/karmada/templates/_karmada_apiservice.tpl
@@ -32,6 +32,8 @@ metadata:
 spec:
   type: ExternalName
   externalName: {{ $name }}-aggregated-apiserver.{{ include "karmada.namespace" . }}.svc.{{ .Values.clusterDomain }}
+{{- end }}
+{{- if has "metricsAdapter" .Values.components }}
 ---
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

I did not enable the `metricsAdapter` component, so the metrics adapter-related deployment was not created:

https://github.com/karmada-io/karmada/blob/cd99897506a42b9398f5f958f1ffe6821414f419/charts/karmada/templates/karmada-metrics-adapter.yaml#L1

However, its `APIService` was still created, causing the controller-manager to continuously output the following error:

```
Discovery failed for some groups, 3 failing: unable to retrieve the complete list of server APIs: custom.metrics.k8s.io/v1beta1: stale GroupVersion discovery: custom.metrics.k8s.io/v1beta1, custom.metrics.k8s.io/v1beta2: stale GroupVersion discovery: custom.metrics.k8s.io/v1beta2, metrics.k8s.io/v1beta1: stale GroupVersion discovery: metrics.k8s.io/v1beta1
```

<img width="914" alt="Screenshot 2024-08-15 at 17 10 45" src="https://github.com/user-attachments/assets/93d77570-af0a-4dfa-ac09-401ce8e124bd">

This patch updates the creation condition of the related `APIService`, ensuring that they will be created together with the deployment.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Fix the creation condition of metrics-adapter related APIService.
```

