### PR TITLE
fix pdb collection testing occasional failure

### DIFF
--- a/test/e2e/resource_test.go
+++ b/test/e2e/resource_test.go
@@ -571,9 +571,13 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 			pdbNamespace = testNamespace
 			pdbName = policyName
 			deploymentName := policyName
+			// use a special label value to prevent PDB from selecting pods of other parallel e2e cases.
+			matchLabels := map[string]string{"app": "nginx-" + rand.String(RandomStrLength)}
 
 			deployment = testhelper.NewDeployment(pdbNamespace, deploymentName)
-			pdb = testhelper.NewPodDisruptionBudget(pdbNamespace, pdbName, intstr.FromString("50%"))
+			deployment.Spec.Selector.MatchLabels = matchLabels
+			deployment.Spec.Template.Labels = matchLabels
+			pdb = testhelper.NewPodDisruptionBudget(pdbNamespace, pdbName, intstr.FromString("50%"), matchLabels)
 			policy = testhelper.NewPropagationPolicy(policyNamespace, policyName, []policyv1alpha1.ResourceSelector{
 				{
 					APIVersion: pdb.APIVersion,

--- a/test/helper/resource.go
+++ b/test/helper/resource.go
@@ -936,9 +936,7 @@ func NewIngress(namespace, name string) *networkingv1.Ingress {
 }
 
 // NewPodDisruptionBudget will build a new PodDisruptionBudget object.
-func NewPodDisruptionBudget(namespace, name string, maxUnAvailable intstr.IntOrString) *policyv1.PodDisruptionBudget {
-	podLabels := map[string]string{"app": "nginx"}
-
+func NewPodDisruptionBudget(namespace, name string, maxUnAvailable intstr.IntOrString, matchLabels map[string]string) *policyv1.PodDisruptionBudget {
 	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "policy/v1",
@@ -951,7 +949,7 @@ func NewPodDisruptionBudget(namespace, name string, maxUnAvailable intstr.IntOrS
 		Spec: policyv1.PodDisruptionBudgetSpec{
 			MaxUnavailable: &maxUnAvailable,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: podLabels,
+				MatchLabels: matchLabels,
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

these days, the e2e case [pdb status collection testing] often failed, such as:

https://github.com/karmada-io/karmada/actions/runs/10401933004/job/28805568396?pr=5378
https://github.com/karmada-io/karmada/actions/runs/10401933004/job/28811015421?pr=5378


1. `work` status of `deploment/nginx` in member1:
```yaml
"manifestStatuses": [
      {
        "identifier": {
          "ordinal": 0,
          "group": "apps",
          "version": "v1",
          "kind": "Deployment",
          "resource": "",
          "namespace": "karmadatest-tlftr",
          "name": "poddisruptionbudget-m472d"
        },
        "status": {
          "availableReplicas": 3,
          "generation": 1,
          "observedGeneration": 1,
          "readyReplicas": 3,
          "replicas": 3,
          "resourceTemplateGeneration": 2,
          "updatedReplicas": 3
        },
        "health": "Healthy"
      }
    ]
```

2. `work` status of `PodDisruptionBudget/nginx` in member1:

```yaml
"manifestStatuses": [
      {
        "identifier": {
          "ordinal": 0,
          "group": "policy",
          "version": "v1",
          "kind": "PodDisruptionBudget",
          "resource": "",
          "namespace": "karmadatest-tlftr",
          "name": "poddisruptionbudget-m472d"
        },
        "status": {
          "currentHealthy": 6,
          "desiredHealthy": 3,
          "disruptionsAllowed": 3,
          "expectedPods": 6
        },
        "health": "Healthy"
      }
```

so, the pdb selected more than 3 pods by `app:nginx`, it has selected another 3 pods created by other e2e cases.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

