### PR TITLE
chore: remove e2e tests for delete when suspended

### DIFF
--- a/test/e2e/propagationpolicy_test.go
+++ b/test/e2e/propagationpolicy_test.go
@@ -1213,29 +1213,6 @@ var _ = ginkgo.Describe("[Suspend] PropagationPolicy testing", func() {
 		})
 	})
 
-	ginkgo.Context("delete resource in the control plane", func() {
-		ginkgo.JustBeforeEach(func() {
-			framework.RemoveDeployment(kubeClient, deployment.Namespace, deployment.Name)
-		})
-
-		ginkgo.It("suspends deleting deployment in member cluster", func() {
-			framework.WaitDeploymentPresentOnClusterFitWith(targetMember, deployment.Namespace, deployment.Name, func(dep *appsv1.Deployment) bool {
-				return dep.GetDeletionTimestamp() == nil
-			})
-		})
-
-		ginkgo.When("propagation is resumed", func() {
-			ginkgo.JustBeforeEach(func() {
-				policy.Spec.Suspension = &policyv1alpha1.Suspension{}
-				framework.UpdatePropagationPolicyWithSpec(karmadaClient, policy.Namespace, policy.Name, policy.Spec)
-			})
-
-			ginkgo.It("deletes deployment in member cluster", func() {
-				framework.WaitDeploymentDisappearOnCluster(targetMember, deployment.Namespace, deployment.Name)
-			})
-		})
-	})
-
 	ginkgo.Context("update resource in the control plane", func() {
 		ginkgo.JustBeforeEach(func() {
 			framework.UpdateDeploymentReplicas(kubeClient, deployment, updateDeploymentReplicas)


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

In #5376 we no longer suspend deletion, as a result these tests do not make sense any longer.

/cc @chaosi-zju @XiShanYongYe-Chang 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

