### PR TITLE
enhance karmadactl exec command

### DIFF
--- a/test/e2e/karmadactl_test.go
+++ b/test/e2e/karmadactl_test.go
@@ -529,7 +529,7 @@ var _ = ginkgo.Describe("Karmadactl exec testing", func() {
 			})
 
 		for _, clusterName := range framework.ClusterNames() {
-			cmd := framework.NewKarmadactlCommand(kubeconfig, karmadaContext, karmadactlPath, pod.Namespace, karmadactlTimeout, "exec", pod.Name, "-C", clusterName, "--", "echo", "hello")
+			cmd := framework.NewKarmadactlCommand(kubeconfig, karmadaContext, karmadactlPath, pod.Namespace, karmadactlTimeout, "exec", pod.Name, "--operation-scope", "members", "--cluster", clusterName, "--", "echo", "hello")
 			_, err := cmd.ExecOrDie()
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
enhance karmadactl exec command

Given that the Karmada control plane has a deployment named `nginx`, which is propagated to member1, member2 and member3.
```bash
$ karmadactl get pods --operation-scope all
NAME    CLUSTER   READY   STATUS    RESTARTS   AGE
nginx   Karmada   3/1     Running   0          26m
nginx   member1   1/1     Running   0          26m
nginx   member2   1/1     Running   0          26m
nginx   member3   1/1     Running   0          26m
$ karmadactl exec -it  nginx --operation-scope=members --cluster=member1 -- echo "hello"
hello
$ karmadactl exec -it  nginx --operation-scope=members --cluster=member2 -- echo "hello"
hello
$ karmadactl exec -it  nginx --operation-scope=members --cluster=member3 -- echo "hello"
hello
$ karmadactl exec -it  nginx --operation-scope=members -- echo "hello" 
error: must specify a member cluster
```

**Which issue(s) this PR fixes**:
Parts of #5249

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: The `exec` command can execute a command in a Karmada container now.
```

