### PR TITLE
standardize the naming of karmada secrets in local up method

### DIFF
--- a/artifacts/deploy/karmada-aggregated-apiserver.yaml
+++ b/artifacts/deploy/karmada-aggregated-apiserver.yaml
@@ -30,11 +30,11 @@ spec:
             - --authentication-kubeconfig=/etc/karmada/config/karmada.config
             - --authorization-kubeconfig=/etc/karmada/config/karmada.config
             - --etcd-servers=https://etcd-client.karmada-system.svc.cluster.local:2379
-            - --etcd-cafile=/etc/karmada/pki/etcd-ca.crt
-            - --etcd-certfile=/etc/karmada/pki/etcd-client.crt
-            - --etcd-keyfile=/etc/karmada/pki/etcd-client.key
-            - --tls-cert-file=/etc/karmada/pki/karmada.crt
-            - --tls-private-key-file=/etc/karmada/pki/karmada.key
+            - --etcd-cafile=/etc/karmada/pki/etcd-client/ca.crt
+            - --etcd-certfile=/etc/karmada/pki/etcd-client/tls.crt
+            - --etcd-keyfile=/etc/karmada/pki/etcd-client/tls.key
+            - --tls-cert-file=/etc/karmada/pki/server/tls.crt
+            - --tls-private-key-file=/etc/karmada/pki//server/tls.key
             - --audit-log-path=-
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
@@ -61,16 +61,22 @@ spec:
           volumeMounts:
             - name: karmada-config
               mountPath: /etc/karmada/config
-            - name: karmada-certs
-              mountPath: /etc/karmada/pki
+            - name: server-cert
+              mountPath: /etc/karmada/pki/server
+              readOnly: true
+            - name: etcd-client-cert
+              mountPath: /etc/karmada/pki/etcd-client
               readOnly: true
       volumes:
         - name: karmada-config
           secret:
             secretName: karmada-aggregated-apiserver-config
-        - name: karmada-certs
+        - name: server-cert
           secret:
-            secretName: karmada-cert-secret
+            secretName: karmada-aggregated-apiserver-cert
+        - name: etcd-client-cert
+          secret:
+            secretName: karmada-aggregated-apiserver-etcd-client-cert
 ---
 apiVersion: v1
 kind: Service

--- a/artifacts/deploy/karmada-apiserver.yaml
+++ b/artifacts/deploy/karmada-apiserver.yaml
@@ -36,29 +36,29 @@ spec:
             - kube-apiserver
             - --allow-privileged=true
             - --authorization-mode=Node,RBAC
-            - --client-ca-file=/etc/karmada/pki/ca.crt
             - --enable-bootstrap-token-auth=true
-            - --etcd-cafile=/etc/karmada/pki/etcd-ca.crt
-            - --etcd-certfile=/etc/karmada/pki/etcd-client.crt
-            - --etcd-keyfile=/etc/karmada/pki/etcd-client.key
+            - --etcd-cafile=/etc/karmada/pki/etcd-client/ca.crt
+            - --etcd-certfile=/etc/karmada/pki/etcd-client/tls.crt
+            - --etcd-keyfile=/etc/karmada/pki/etcd-client/tls.key
             - --etcd-servers=https://etcd-client.karmada-system.svc.cluster.local:2379
             - --bind-address=0.0.0.0
             - --disable-admission-plugins=StorageObjectInUseProtection,ServiceAccount
             - --runtime-config=
             - --secure-port=5443
             - --service-account-issuer=https://kubernetes.default.svc.cluster.local
-            - --service-account-key-file=/etc/karmada/pki/karmada.key
-            - --service-account-signing-key-file=/etc/karmada/pki/karmada.key
+            - --service-account-key-file=/etc/karmada/pki/service-account-key-pair/sa.pub
+            - --service-account-signing-key-file=/etc/karmada/pki/service-account-key-pair/sa.key
             - --service-cluster-ip-range=10.96.0.0/12
-            - --proxy-client-cert-file=/etc/karmada/pki/front-proxy-client.crt
-            - --proxy-client-key-file=/etc/karmada/pki/front-proxy-client.key
+            - --proxy-client-cert-file=/etc/karmada/pki/front-proxy-client/tls.crt
+            - --proxy-client-key-file=/etc/karmada/pki/front-proxy-client/tls.key
+            - --requestheader-client-ca-file=/etc/karmada/pki/front-proxy-client/ca.crt
             - --requestheader-allowed-names=front-proxy-client
-            - --requestheader-client-ca-file=/etc/karmada/pki/front-proxy-ca.crt
             - --requestheader-extra-headers-prefix=X-Remote-Extra-
             - --requestheader-group-headers=X-Remote-Group
             - --requestheader-username-headers=X-Remote-User
-            - --tls-cert-file=/etc/karmada/pki/apiserver.crt
-            - --tls-private-key-file=/etc/karmada/pki/apiserver.key
+            - --tls-cert-file=/etc/karmada/pki/server/tls.crt
+            - --tls-private-key-file=/etc/karmada/pki/server/tls.key
+            - --client-ca-file=/etc/karmada/pki/server/ca.crt
             - --tls-min-version=VersionTLS13
           name: karmada-apiserver
           image: registry.k8s.io/kube-apiserver:{{karmada_apiserver_version}}
@@ -88,9 +88,31 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
-            - mountPath: /etc/karmada/pki
-              name: karmada-certs
+            - name: server-cert
+              mountPath: /etc/karmada/pki/server
               readOnly: true
+            - name: etcd-client-cert
+              mountPath: /etc/karmada/pki/etcd-client
+              readOnly: true
+            - name: front-proxy-client-cert
+              mountPath: /etc/karmada/pki/front-proxy-client
+              readOnly: true
+            - name: service-account-key-pair
+              mountPath: /etc/karmada/pki/service-account-key-pair
+              readOnly: true
+      volumes:
+        - name: server-cert
+          secret:
+            secretName: karmada-apiserver-cert
+        - name: etcd-client-cert
+          secret:
+            secretName: karmada-apiserver-etcd-client-cert
+        - name: front-proxy-client-cert
+          secret:
+            secretName: karmada-apiserver-front-proxy-client-cert
+        - name: service-account-key-pair
+          secret:
+            secretName: karmada-apiserver-service-account-key-pair
       dnsPolicy: ClusterFirstWithHostNet
       enableServiceLinks: true
       hostNetwork: true
@@ -104,10 +126,6 @@ spec:
       tolerations:
         - effect: NoExecute
           operator: Exists
-      volumes:
-        - name: karmada-certs
-          secret:
-            secretName: karmada-cert-secret
 ---
 apiVersion: v1
 kind: Service

--- a/artifacts/deploy/karmada-ca-cert-secret.yaml
+++ b/artifacts/deploy/karmada-ca-cert-secret.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: webhook-cert
+  name: ${component}-ca-cert
   namespace: karmada-system
 type: kubernetes.io/tls
 data:
   tls.crt: |
-    {{server_certificate}}
+    ${ca_crt}
   tls.key: |
-    {{server_key}}
+    ${ca_key}

--- a/artifacts/deploy/karmada-cert-secret.yaml
+++ b/artifacts/deploy/karmada-cert-secret.yaml
@@ -1,35 +1,13 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: karmada-cert-secret
+  name: ${name}-cert
   namespace: karmada-system
-type: Opaque
+type: kubernetes.io/tls
 data:
   ca.crt: |
-    {{ca_crt}}
-  ca.key: |
-    {{ca_key}}
-  karmada.crt: |
-    {{client_crt}}
-  karmada.key: |
-    {{client_key}}
-  apiserver.crt: |
-    {{apiserver_crt}}
-  apiserver.key: |
-    {{apiserver_key}}
-  front-proxy-ca.crt: |
-    {{front_proxy_ca_crt}}
-  front-proxy-client.crt: |
-    {{front_proxy_client_crt}}
-  front-proxy-client.key: |
-    {{front_proxy_client_key}}
-  etcd-ca.crt: |
-    {{etcd_ca_crt}}
-  etcd-server.crt: |
-    {{etcd_server_crt}}
-  etcd-server.key: |
-    {{etcd_server_key}}
-  etcd-client.crt: |
-    {{etcd_client_crt}}
-  etcd-client.key: |
-    {{etcd_client_key}}
+    ${ca_crt}
+  tls.crt: |
+    ${tls_crt}
+  tls.key: |
+    ${tls_key}

--- a/artifacts/deploy/karmada-descheduler.yaml
+++ b/artifacts/deploy/karmada-descheduler.yaml
@@ -28,9 +28,9 @@ spec:
             - --kubeconfig=/etc/karmada/config/karmada.config
             - --metrics-bind-address=0.0.0.0:8080
             - --health-probe-bind-address=0.0.0.0:10358
-            - --scheduler-estimator-ca-file=/etc/karmada/pki/ca.crt
-            - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada.crt
-            - --scheduler-estimator-key-file=/etc/karmada/pki/karmada.key
+            - --scheduler-estimator-ca-file=/etc/karmada/pki/scheduler-estimator-client/ca.crt
+            - --scheduler-estimator-cert-file=/etc/karmada/pki/scheduler-estimator-client/tls.crt
+            - --scheduler-estimator-key-file=/etc/karmada/pki/scheduler-estimator-client/tls.key
             - --v=4
           livenessProbe:
             httpGet:
@@ -48,13 +48,13 @@ spec:
           volumeMounts:
             - name: karmada-config
               mountPath: /etc/karmada/config
-            - name: karmada-certs
-              mountPath: /etc/karmada/pki
+            - name: scheduler-estimator-client-cert
+              mountPath: /etc/karmada/pki/scheduler-estimator-client
               readOnly: true
       volumes:
         - name: karmada-config
           secret:
             secretName: karmada-descheduler-config
-        - name: karmada-certs
+        - name: scheduler-estimator-client-cert
           secret:
-            secretName: karmada-cert-secret
+            secretName: karmada-descheduler-scheduler-estimator-client-cert

--- a/artifacts/deploy/karmada-etcd.yaml
+++ b/artifacts/deploy/karmada-etcd.yaml
@@ -40,7 +40,7 @@ spec:
               command:
                 - /bin/sh
                 - -ec
-                - 'etcdctl get /registry --prefix --keys-only  --endpoints https://127.0.0.1:2379  --cacert /etc/karmada/pki/etcd-ca.crt --cert /etc/karmada/pki/etcd-server.crt --key /etc/karmada/pki/etcd-server.key'
+                - 'etcdctl get /registry --prefix --keys-only  --endpoints https://127.0.0.1:2379  --cacert /etc/karmada/pki/etcd-client/ca.crt --cert /etc/karmada/pki/etcd-client/tls.crt --key /etc/karmada/pki/etcd-client/tls.key'
             failureThreshold: 3
             initialDelaySeconds: 600
             periodSeconds: 60
@@ -53,11 +53,6 @@ spec:
             - containerPort: 2380
               name: server
               protocol: TCP
-          volumeMounts:
-            - mountPath: /var/lib/etcd
-              name: etcd-data
-            - mountPath: /etc/karmada/pki
-              name: etcd-certs
           resources:
             requests:
               cpu: 100m
@@ -76,24 +71,34 @@ spec:
             - etcd0=http://etcd-0.etcd.karmada-system.svc.cluster.local:2380
             - --initial-cluster-state
             - new
-            - --cert-file=/etc/karmada/pki/etcd-server.crt
             - --client-cert-auth=true
-            - --key-file=/etc/karmada/pki/etcd-server.key
-            - --trusted-ca-file=/etc/karmada/pki/etcd-ca.crt
+            - --cert-file=/etc/karmada/pki/server/tls.crt
+            - --key-file=/etc/karmada/pki/server/tls.key
+            - --trusted-ca-file=/etc/karmada/pki/server/ca.crt
             - --data-dir=/var/lib/etcd
             - --snapshot-count=10000
             # Setting Golang's secure cipher suites as etcd's cipher suites.
             # They are obtained by the return value of the function CipherSuites() under the go/src/crypto/tls/cipher_suites.go package.
             # Consistent with the Preferred values of k8s’s default cipher suites.
             - --cipher-suites=TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+          volumeMounts:
+            - name: etcd-data
+              mountPath: /var/lib/etcd
+            - name: server-cert
+              mountPath: /etc/karmada/pki/server
+            - name: etcd-client-cert
+              mountPath: /etc/karmada/pki/etcd-client
       volumes:
-        - hostPath:
+        - name: etcd-data
+          hostPath:
             path: /var/lib/karmada-etcd
             type: DirectoryOrCreate
-          name: etcd-data
-        - name: etcd-certs
+        - name: server-cert
           secret:
-            secretName: karmada-cert-secret
+            secretName: etcd-cert
+        - name: etcd-client-cert
+          secret:
+            secretName: etcd-etcd-client-cert
 ---
 
 apiVersion: v1

--- a/artifacts/deploy/karmada-key-pair-secret.yaml
+++ b/artifacts/deploy/karmada-key-pair-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${component}-service-account-key-pair
+  namespace: karmada-system
+type: Opaque
+data:
+  sa.pub: |
+    ${sa_pub}
+  sa.key: |
+    ${sa_key}

--- a/artifacts/deploy/karmada-metrics-adapter.yaml
+++ b/artifacts/deploy/karmada-metrics-adapter.yaml
@@ -29,9 +29,9 @@ spec:
             - --kubeconfig=/etc/karmada/config/karmada.config
             - --authentication-kubeconfig=/etc/karmada/config/karmada.config
             - --authorization-kubeconfig=/etc/karmada/config/karmada.config
-            - --client-ca-file=/etc/karmada/pki/ca.crt
-            - --tls-cert-file=/etc/karmada/pki/karmada.crt
-            - --tls-private-key-file=/etc/karmada/pki/karmada.key
+            - --client-ca-file=/etc/karmada/pki/server/ca.crt
+            - --tls-cert-file=/etc/karmada/pki/server/tls.crt
+            - --tls-private-key-file=/etc/karmada/pki/server/tls.key
             - --audit-log-path=-
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
@@ -60,16 +60,16 @@ spec:
           volumeMounts:
             - name: karmada-config
               mountPath: /etc/karmada/config
-            - name: karmada-certs
-              mountPath: /etc/karmada/pki
+            - name: server-cert
+              mountPath: /etc/karmada/pki/server
               readOnly: true
       volumes:
         - name: karmada-config
           secret:
             secretName: karmada-metrics-adapter-config
-        - name: karmada-certs
+        - name: server-cert
           secret:
-            secretName: karmada-cert-secret
+            secretName: karmada-metrics-adapter-cert
 ---
 apiVersion: v1
 kind: Service

--- a/artifacts/deploy/karmada-scheduler-estimator.yaml
+++ b/artifacts/deploy/karmada-scheduler-estimator.yaml
@@ -27,9 +27,9 @@ spec:
             - /bin/karmada-scheduler-estimator
             - --kubeconfig=/etc/{{member_cluster_name}}-kubeconfig
             - --cluster-name={{member_cluster_name}}
-            - --grpc-auth-cert-file=/etc/karmada/pki/karmada.crt
-            - --grpc-auth-key-file=/etc/karmada/pki/karmada.key
-            - --grpc-client-ca-file=/etc/karmada/pki/ca.crt
+            - --grpc-auth-cert-file=/etc/karmada/pki/server/tls.crt
+            - --grpc-auth-key-file=/etc/karmada/pki/server/tls.key
+            - --grpc-client-ca-file=/etc/karmada/pki/server/ca.crt
             - --metrics-bind-address=0.0.0.0:8080
             - --health-probe-bind-address=0.0.0.0:10351
           livenessProbe:
@@ -46,16 +46,16 @@ spec:
               name: metrics
               protocol: TCP
           volumeMounts:
-            - name: karmada-certs
-              mountPath: /etc/karmada/pki
+            - name: server-cert
+              mountPath: /etc/karmada/pki/server
               readOnly: true
             - name: member-kubeconfig
               subPath: {{member_cluster_name}}-kubeconfig
               mountPath: /etc/{{member_cluster_name}}-kubeconfig
       volumes:
-        - name: karmada-certs
+        - name: server-cert
           secret:
-            secretName: karmada-cert-secret
+            secretName: karmada-metrics-adapter-cert
         - name: member-kubeconfig
           secret:
             secretName: {{member_cluster_name}}-kubeconfig

--- a/artifacts/deploy/karmada-scheduler.yaml
+++ b/artifacts/deploy/karmada-scheduler.yaml
@@ -42,20 +42,20 @@ spec:
             - --metrics-bind-address=0.0.0.0:8080
             - --health-probe-bind-address=0.0.0.0:10351
             - --enable-scheduler-estimator=true
-            - --scheduler-estimator-ca-file=/etc/karmada/pki/ca.crt
-            - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada.crt
-            - --scheduler-estimator-key-file=/etc/karmada/pki/karmada.key
+            - --scheduler-estimator-ca-file=/etc/karmada/pki/scheduler-estimator-client/ca.crt
+            - --scheduler-estimator-cert-file=/etc/karmada/pki/scheduler-estimator-client/tls.crt
+            - --scheduler-estimator-key-file=/etc/karmada/pki/scheduler-estimator-client/tls.key
             - --v=4
           volumeMounts:
             - name: karmada-config
               mountPath: /etc/karmada/config
-            - name: karmada-certs
-              mountPath: /etc/karmada/pki
+            - name: scheduler-estimator-client-cert
+              mountPath: /etc/karmada/pki/scheduler-estimator-client
               readOnly: true
       volumes:
         - name: karmada-config
           secret:
             secretName: karmada-scheduler-config
-        - name: karmada-certs
+        - name: scheduler-estimator-client-cert
           secret:
-            secretName: karmada-cert-secret
+            secretName: karmada-scheduler-scheduler-estimator-client-cert

--- a/artifacts/deploy/karmada-search.yaml
+++ b/artifacts/deploy/karmada-search.yaml
@@ -30,11 +30,11 @@ spec:
             - --authentication-kubeconfig=/etc/karmada/config/karmada.config
             - --authorization-kubeconfig=/etc/karmada/config/karmada.config
             - --etcd-servers=https://etcd-client.karmada-system.svc.cluster.local:2379
-            - --etcd-cafile=/etc/karmada/pki/etcd-ca.crt
-            - --etcd-certfile=/etc/karmada/pki/etcd-client.crt
-            - --etcd-keyfile=/etc/karmada/pki/etcd-client.key
-            - --tls-cert-file=/etc/karmada/pki/karmada.crt
-            - --tls-private-key-file=/etc/karmada/pki/karmada.key
+            - --etcd-cafile=/etc/karmada/pki/etcd-client/ca.crt
+            - --etcd-certfile=/etc/karmada/pki/etcd-client/tls.crt
+            - --etcd-keyfile=/etc/karmada/pki/etcd-client/tls.key
+            - --tls-cert-file=/etc/karmada/pki/server/tls.crt
+            - --tls-private-key-file=/etc/karmada/pki/server/tls.key
             - --audit-log-path=-
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
@@ -54,16 +54,22 @@ spec:
           volumeMounts:
             - name: karmada-config
               mountPath: /etc/karmada/config
-            - name: karmada-certs
-              mountPath: /etc/karmada/pki
+            - name: server-cert
+              mountPath: /etc/karmada/pki/server
+              readOnly: true
+            - name: etcd-client-cert
+              mountPath: /etc/karmada/pki/etcd-client
               readOnly: true
       volumes:
         - name: karmada-config
           secret:
             secretName: karmada-search-config
-        - name: karmada-certs
+        - name: server-cert
           secret:
-            secretName: karmada-cert-secret
+            secretName: karmada-search-cert
+        - name: etcd-client-cert
+          secret:
+            secretName: karmada-search-etcd-client-cert
 ---
 apiVersion: v1
 kind: Service

--- a/artifacts/deploy/karmada-webhook.yaml
+++ b/artifacts/deploy/karmada-webhook.yaml
@@ -31,7 +31,7 @@ spec:
             - --default-not-ready-toleration-seconds=30
             - --default-unreachable-toleration-seconds=30
             - --secure-port=8443
-            - --cert-dir=/var/serving-cert
+            - --cert-dir=/etc/karmada/pki/server
             - --v=4
           ports:
             - containerPort: 8443
@@ -46,16 +46,16 @@ spec:
           volumeMounts:
             - name: karmada-config
               mountPath: /etc/karmada/config
-            - name: cert
-              mountPath: /var/serving-cert
+            - name: server-cert
+              mountPath: /etc/karmada/pki/server
               readOnly: true
       volumes:
         - name: karmada-config
           secret:
             secretName: karmada-webhook-config
-        - name: cert
+        - name: server-cert
           secret:
-            secretName: webhook-cert
+            secretName: karmada-webhook-cert
 ---
 apiVersion: v1
 kind: Service

--- a/artifacts/deploy/kube-controller-manager.yaml
+++ b/artifacts/deploy/kube-controller-manager.yaml
@@ -33,6 +33,9 @@ spec:
               topologyKey: kubernetes.io/hostname
       priorityClassName: system-node-critical
       containers:
+        # --client-ca-file verifies the cert of its client like kubelet and other controller
+        # --cluster-signing-key-file is used for signing certificates
+        # --root-ca-file is stored in service account type secret
         - command:
             - kube-controller-manager
             - --allocate-node-cidrs=true
@@ -40,16 +43,16 @@ spec:
             - --authentication-kubeconfig=/etc/karmada/config/karmada.config
             - --authorization-kubeconfig=/etc/karmada/config/karmada.config
             - --bind-address=0.0.0.0
-            - --client-ca-file=/etc/karmada/pki/ca.crt
+            - --client-ca-file=/etc/karmada/pki/ca/tls.crt
             - --cluster-cidr=10.244.0.0/16
             - --cluster-name=karmada
-            - --cluster-signing-cert-file=/etc/karmada/pki/ca.crt
-            - --cluster-signing-key-file=/etc/karmada/pki/ca.key
+            - --cluster-signing-cert-file=/etc/karmada/pki/ca/tls.crt
+            - --cluster-signing-key-file=/etc/karmada/pki/ca/tls.key
             - --controllers=namespace,garbagecollector,serviceaccount-token,ttl-after-finished,bootstrapsigner,tokencleaner,csrapproving,csrcleaner,csrsigning,clusterrole-aggregation
             - --leader-elect=true
             - --node-cidr-mask-size=24
-            - --root-ca-file=/etc/karmada/pki/ca.crt
-            - --service-account-private-key-file=/etc/karmada/pki/karmada.key
+            - --root-ca-file=/etc/karmada/pki/ca/tls.crt
+            - --service-account-private-key-file=/etc/karmada/pki/service-account-key-pair/sa.key
             - --service-cluster-ip-range=10.96.0.0/12
             - --use-service-account-credentials=true
             - --v=4
@@ -72,13 +75,19 @@ spec:
           volumeMounts:
             - name: karmada-config
               mountPath: /etc/karmada/config
-            - mountPath: /etc/karmada/pki
-              name: karmada-certs
+            - name: ca-cert
+              mountPath: /etc/karmada/pki/ca
+              readOnly: true
+            - name: service-account-key-pair
+              mountPath: /etc/karmada/pki/service-account-key-pair
               readOnly: true
       volumes:
         - name: karmada-config
           secret:
             secretName: kube-controller-manager-config
-        - name: karmada-certs
+        - name: ca-cert
           secret:
-            secretName: karmada-cert-secret
+            secretName: kube-controller-manager-ca-cert
+        - name: service-account-key-pair
+          secret:
+            secretName: kube-controller-manager-service-account-key-pair

--- a/examples/customresourceinterpreter/karmada-interpreter-webhook-example.yaml
+++ b/examples/customresourceinterpreter/karmada-interpreter-webhook-example.yaml
@@ -28,7 +28,7 @@ spec:
             - --kubeconfig=/etc/karmada/config/karmada.config
             - --bind-address=0.0.0.0
             - --secure-port=8445
-            - --cert-dir=/var/serving-cert
+            - --cert-dir=/etc/karmada/pki/server
             - --v=4
           ports:
             - containerPort: 8445
@@ -40,16 +40,16 @@ spec:
           volumeMounts:
             - name: karmada-config
               mountPath: /etc/karmada/config
-            - name: cert
-              mountPath: /var/serving-cert
+            - name: server-cert
+              mountPath: /etc/karmada/pki/server
               readOnly: true
       volumes:
         - name: karmada-config
           secret:
             secretName: karmada-interpreter-webhook-example-config
-        - name: cert
+        - name: server-cert
           secret:
-            secretName: webhook-cert
+            secretName: karmada-interpreter-webhook-example-cert
 ---
 apiVersion: v1
 kind: Service

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -243,6 +243,18 @@ function util::create_certkey {
 EOF
 }
 
+# util::create_key_pair generates a new public and private key pair.
+function util::create_key_pair {
+  local sudo=$1
+  local dest_dir=$2
+  local name=$3
+  ${sudo} /usr/bin/env bash -e <<EOF
+  cd ${dest_dir}
+  openssl genrsa -out ${name}.key 3072
+  openssl rsa -in ${name}.key -pubout -out ${name}.pub
+EOF
+}
+
 # util::append_client_kubeconfig creates a new context including a cluster and a user to the existed kubeconfig file
 function util::append_client_kubeconfig {
     local kubeconfig_path=$1


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

In karmada, here are two important secrets, which is mount by most karmada components. One is karmada-cert, which contains a series of cert files like ca.crt, apiserver.crt and so on; another is karmada-kubeconfig, which contains a kubeconfig of karmada-apiserver.

However, in different installation methods, we used inconsistent secret naming or file path naming, which can potentially cause some unnecessary problems, detail refer to #5363.

This PR aims to standardize the naming of karmada secrets in local up installation method.

**Which issue(s) this PR fixes**:

Fixes part of #5363

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
standardize the naming of karmada secrets in local up installation method
```

