### PR TITLE
Fixed cluster affinity scheduling evaluation order when scheduling is triggered via WorkloadRebalancer

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -631,6 +631,9 @@ func (s *Scheduler) scheduleResourceBindingWithClusterAffinities(rb *workv1alpha
 	)
 
 	affinityIndex := getAffinityIndex(rb.Spec.Placement.ClusterAffinities, rb.Status.SchedulerObservedAffinityName)
+	if util.RescheduleRequired(rb.Spec.RescheduleTriggeredAt, rb.Status.LastScheduledTime) {
+		affinityIndex = 0
+	}
 	updatedStatus := rb.Status.DeepCopy()
 	for affinityIndex < len(rb.Spec.Placement.ClusterAffinities) {
 		klog.V(4).Infof("Schedule ResourceBinding(%s/%s) with clusterAffiliates index(%d)", rb.Namespace, rb.Name, affinityIndex)
@@ -855,6 +858,9 @@ func (s *Scheduler) scheduleClusterResourceBindingWithClusterAffinities(crb *wor
 	)
 
 	affinityIndex := getAffinityIndex(crb.Spec.Placement.ClusterAffinities, crb.Status.SchedulerObservedAffinityName)
+	if util.RescheduleRequired(rb.Spec.RescheduleTriggeredAt, rb.Status.LastScheduledTime) {
+		affinityIndex = 0
+	}
 	updatedStatus := crb.Status.DeepCopy()
 	for affinityIndex < len(crb.Spec.Placement.ClusterAffinities) {
 		klog.V(4).Infof("Schedule ClusterResourceBinding(%s) with clusterAffiliates index(%d)", crb.Name, affinityIndex)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -858,7 +858,7 @@ func (s *Scheduler) scheduleClusterResourceBindingWithClusterAffinities(crb *wor
 	)
 
 	affinityIndex := getAffinityIndex(crb.Spec.Placement.ClusterAffinities, crb.Status.SchedulerObservedAffinityName)
-	if util.RescheduleRequired(rb.Spec.RescheduleTriggeredAt, rb.Status.LastScheduledTime) {
+	if util.RescheduleRequired(crb.Spec.RescheduleTriggeredAt, crb.Status.LastScheduledTime) {
 		affinityIndex = 0
 	}
 	updatedStatus := crb.Status.DeepCopy()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
As discussed in the community meet on 2024-07-09 , added the fix to evaluate the cluster affinities freshly when scheduling is triggered via WorkloadRebalancer. 

**Which issue(s) this PR fixes**:
Fixes #5070 

Progress

- [x]  share opinion in Community Meeting
- [ ] proposal
- [x] implementation
- [ ] UT test
- [ ] e2e test

**Special notes for your reviewer**:
Raising this PR to get early feedback on the implementation as it is still work in progress and tested manually by building the deploying the scheduler. There may be unit test failures which I will fix so please don't merge the PR until that's done. 

**Does this PR introduce a user-facing change?**:
```
`karmada-scheduler`: WorkloadRebalancer-triggered rescheduling now reevaluates multiple `clusterAffinities` in policy order starting from the first term.
```

