### PR TITLE
standardize the naming of karmada secrets in helm method

### DIFF
--- a/charts/karmada/templates/_helpers.tpl
+++ b/charts/karmada/templates/_helpers.tpl
@@ -110,17 +110,40 @@ app: {{- include "karmada.name" .}}-kube-controller-manager
 {{- end }}
 {{- end -}}
 
-{{- define "karmada.kubeconfig.volume" -}}
-{{- $name := include "karmada.name" . -}}
-- name: kubeconfig-secret
+{{- define "karmada.karmada-certs.volume" -}}
+- name: karmada-certs
   secret:
-    secretName: {{ $name }}-kubeconfig
+    secretName: karmada-certs
+{{- end -}}
+
+{{- define "karmada.karmada-certs.volumeMount" -}}
+- name: karmada-certs
+  mountPath: /etc/karmada/pki
+  readOnly: true
+{{- end -}}
+
+{{- define "karmada.kubeconfig.volume" -}}
+- name: karmada-kubeconfig
+  secret:
+    secretName: karmada-kubeconfig
 {{- end -}}
 
 {{- define "karmada.kubeconfig.volumeMount" -}}
-- name: kubeconfig-secret
+- name: karmada-kubeconfig
   subPath: kubeconfig
   mountPath: /etc/kubeconfig
+{{- end -}}
+
+{{- define "karmada.etcd-cert.volume" -}}
+- name: karmada-etcd-cert
+  secret:
+    secretName: karmada-etcd-cert
+{{- end -}}
+
+{{- define "karmada.etcd-cert.volumeMount" -}}
+- name: karmada-etcd-cert
+  mountPath: /etc/etcd/pki
+  readOnly: true
 {{- end -}}
 
 {{- define "karmada.kubeconfig.caData" -}}
@@ -193,20 +216,6 @@ app: {{$name}}
 {{- end }}
 {{- end }}
 {{- end -}}
-
-{{- define "karmada.descheduler.kubeconfig.volume" -}}
-{{ $name :=  include "karmada.name" . }}
-{{- if eq .Values.installMode "host" -}}
-- name: kubeconfig-secret
-  secret:
-    secretName: {{ $name }}-kubeconfig
-{{- else -}}
-- name: kubeconfig-secret
-  secret:
-    secretName: {{ .Values.descheduler.kubeconfig }}
-{{- end -}}
-{{- end -}}
-
 
 {{- define "karmada.webhook.labels" -}}
 {{ $name :=  include "karmada.name" .}}
@@ -316,44 +325,6 @@ app: {{- include "karmada.name" .}}-search
 
 {{- define "karmada.postDeleteJob.labels" -}}
 {{- include "karmada.commonLabels" . -}}
-{{- end -}}
-
-{{- define "karmada.search.kubeconfig.volume" -}}
-{{ $name :=  include "karmada.name" . }}
-{{- if eq .Values.installMode "host" -}}
-- name: k8s-certs
-  secret:
-    secretName: {{ $name }}-cert
-- name: kubeconfig-secret
-  secret:
-    secretName: {{ $name }}-kubeconfig
-{{- else -}}
-- name: k8s-certs
-  secret:
-    secretName: {{ .Values.search.certs }}
-- name: kubeconfig-secret
-  secret:
-    secretName: {{ .Values.search.kubeconfig }}
-{{- end -}}
-{{- end -}}
-
-{{- define "karmada.search.etcd.cert.volume" -}}
-{{ $name :=  include "karmada.name" . }}
-- name: etcd-certs
-  secret:
-  {{- if eq .Values.etcd.mode "internal" }}
-    secretName: {{ $name }}-cert
-  {{- end }}
-  {{- if eq .Values.etcd.mode "external" }}
-    secretName: {{ $name }}-external-etcd-cert
-  {{- end }}
-{{- end -}}
-
-{{- define "karmada.scheduler.cert.volume" -}}
-{{ $name :=  include "karmada.name" . }}
-- name: karmada-certs
-  secret:
-    secretName: {{ $name }}-cert
 {{- end -}}
 
 {{/*

--- a/charts/karmada/templates/etcd.yaml
+++ b/charts/karmada/templates/etcd.yaml
@@ -52,7 +52,7 @@ spec:
               command:
                 - /bin/sh
                 - -ec
-                - 'etcdctl get /registry --prefix --keys-only  --endpoints https://127.0.0.1:2379  --cacert /etc/kubernetes/pki/etcd/server-ca.crt --cert /etc/kubernetes/pki/etcd/karmada.crt --key /etc/kubernetes/pki/etcd/karmada.key'
+                - 'etcdctl get /registry --prefix --keys-only  --endpoints https://127.0.0.1:2379  --cacert /etc/etcd/pki/etcd-ca.crt --cert /etc/etcd/pki/etcd-client.crt --key /etc/etcd/pki/etcd-client.key'
             failureThreshold: 3
             initialDelaySeconds: 600
             periodSeconds: 60
@@ -73,11 +73,9 @@ spec:
           resources:
           {{- toYaml .Values.etcd.internal.resources | nindent 12 }}
           volumeMounts:
+            {{- include "karmada.etcd-cert.volumeMount" . | nindent 12 }}
             - mountPath: /var/lib/etcd
               name: etcd-data
-            - name: etcd-cert
-              mountPath: /etc/kubernetes/pki/etcd
-              readOnly: true
           command:
             - /usr/local/bin/etcd
             - --name
@@ -92,19 +90,17 @@ spec:
             - {{ include "etcd.initial.clusters" . }}
             - --initial-cluster-state
             - new
-            - --cert-file=/etc/kubernetes/pki/etcd/karmada.crt
+            - --cert-file=/etc/etcd/pki/etcd-server.crt
             - --client-cert-auth=true
-            - --key-file=/etc/kubernetes/pki/etcd/karmada.key
-            - --trusted-ca-file=/etc/kubernetes/pki/etcd/server-ca.crt
+            - --key-file=/etc/etcd/pki/etcd-server.key
+            - --trusted-ca-file=/etc/etcd/pki/etcd-ca.crt
             - --data-dir=/var/lib/etcd
             # Setting Golang's secure cipher suites as etcd's cipher suites.
             # They are obtained by the return value of the function CipherSuites() under the go/src/crypto/tls/cipher_suites.go package.
             # Consistent with the Preferred values of k8s’s default cipher suites.
             - --cipher-suites=TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
       volumes:
-        - name: etcd-cert
-          secret:
-            secretName: {{ include "karmada.name" . }}-cert
+        {{- include "karmada.etcd-cert.volume" . | nindent 8 }}
         {{- if eq .Values.etcd.internal.storageType "hostPath" }}
         - hostPath:
             path: /var/lib/{{ include "karmada.namespace" . }}/karmada-etcd

--- a/charts/karmada/templates/karmada-agent.yaml
+++ b/charts/karmada/templates/karmada-agent.yaml
@@ -33,7 +33,7 @@ subjects:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $name }}-kubeconfig
+  name: karmada-kubeconfig
   namespace: {{ include "karmada.namespace" . }}
 stringData:
   kubeconfig: |-
@@ -126,14 +126,14 @@ spec:
               name: metrics
               protocol: TCP
           volumeMounts:
-            - name: kubeconfig
+            - name: karmada-kubeconfig
               mountPath: /etc/kubeconfig
           resources:
           {{- toYaml .Values.agent.resources | nindent 12 }}
       volumes:
-        - name: kubeconfig
+        - name: karmada-kubeconfig
           secret:
-            secretName: {{ $name }}-kubeconfig
+            secretName: karmada-kubeconfig
 
 {{ if .Values.agent.podDisruptionBudget }}
 ---

--- a/charts/karmada/templates/karmada-aggregated-apiserver.yaml
+++ b/charts/karmada/templates/karmada-aggregated-apiserver.yaml
@@ -37,32 +37,25 @@ spec:
           imagePullPolicy: {{ .Values.aggregatedApiServer.image.pullPolicy }}
           volumeMounts:
             {{- include "karmada.kubeconfig.volumeMount" . | nindent 12 }}
-            - name: etcd-cert
-              mountPath: /etc/etcd/pki
-              readOnly: true
-            - name: apiserver-cert
-              mountPath: /etc/kubernetes/pki
-              readOnly: true
+            {{- include "karmada.karmada-certs.volumeMount" . | nindent 12 }}
+            {{- include "karmada.etcd-cert.volumeMount" . | nindent 12 }}
           command:
             - /bin/karmada-aggregated-apiserver
             - --kubeconfig=/etc/kubeconfig
             - --authentication-kubeconfig=/etc/kubeconfig
             - --authorization-kubeconfig=/etc/kubeconfig
+            - --etcd-cafile=/etc/etcd/pki/etcd-ca.crt
+            - --etcd-certfile=/etc/etcd/pki/etcd-client.crt
+            - --etcd-keyfile=/etc/etcd/pki/etcd-client.key
             {{- if eq .Values.etcd.mode "external" }}
-            - --etcd-cafile=/etc/etcd/pki/ca.crt
-            - --etcd-certfile=/etc/etcd/pki/tls.crt
-            - --etcd-keyfile=/etc/etcd/pki/tls.key
             - --etcd-servers={{ .Values.etcd.external.servers }}
             - --etcd-prefix={{ .Values.etcd.external.registryPrefix }}
             {{- end }}
             {{- if eq .Values.etcd.mode "internal" }}
-            - --etcd-cafile=/etc/etcd/pki/server-ca.crt
-            - --etcd-certfile=/etc/etcd/pki/karmada.crt
-            - --etcd-keyfile=/etc/etcd/pki/karmada.key
             - --etcd-servers=https://etcd-client.{{ include "karmada.namespace" . }}.svc.{{ .Values.clusterDomain }}:2379
             {{- end }}
-            - --tls-cert-file=/etc/kubernetes/pki/karmada.crt
-            - --tls-private-key-file=/etc/kubernetes/pki/karmada.key
+            - --tls-cert-file=/etc/karmada/pki/karmada-server.crt
+            - --tls-private-key-file=/etc/karmada/pki/karmada-server.key
             - --audit-log-path=-
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
@@ -99,17 +92,8 @@ spec:
       {{- end }}
       volumes:
         {{- include "karmada.kubeconfig.volume" . | nindent 8 }}
-        - name: apiserver-cert
-          secret:
-            secretName: {{ $name }}-cert
-        - name: etcd-cert
-          secret:
-          {{- if eq .Values.etcd.mode "internal" }}
-            secretName: {{ $name }}-cert
-          {{- end }}
-          {{- if eq .Values.etcd.mode "external" }}
-            secretName: {{ $name }}-external-etcd-cert
-          {{- end }}
+        {{- include "karmada.karmada-certs.volume" . | nindent 8 }}
+        {{- include "karmada.etcd-cert.volume" . | nindent 8 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/karmada/templates/karmada-apiserver.yaml
+++ b/charts/karmada/templates/karmada-apiserver.yaml
@@ -38,38 +38,35 @@ spec:
             - kube-apiserver
             - --allow-privileged=true
             - --authorization-mode=Node,RBAC
-            - --client-ca-file=/etc/kubernetes/pki/server-ca.crt
+            - --client-ca-file=/etc/karmada/pki/ca.crt
             - --disable-admission-plugins=StorageObjectInUseProtection,ServiceAccount
+            - --etcd-cafile=/etc/etcd/pki/etcd-ca.crt
+            - --etcd-certfile=/etc/etcd/pki/etcd-client.crt
+            - --etcd-keyfile=/etc/etcd/pki/etcd-client.key
             - --enable-bootstrap-token-auth=true
             {{- if eq .Values.etcd.mode "external" }}
-            - --etcd-cafile=/etc/etcd/pki/ca.crt
-            - --etcd-certfile=/etc/etcd/pki/tls.crt
-            - --etcd-keyfile=/etc/etcd/pki/tls.key
             - --etcd-servers={{ .Values.etcd.external.servers }}
             - --etcd-prefix={{ .Values.etcd.external.registryPrefix }}
             {{- end }}
             {{- if eq .Values.etcd.mode "internal" }}
-            - --etcd-cafile=/etc/etcd/pki/server-ca.crt
-            - --etcd-certfile=/etc/etcd/pki/karmada.crt
-            - --etcd-keyfile=/etc/etcd/pki/karmada.key
             - --etcd-servers=https://etcd-client.{{ include "karmada.namespace" . }}.svc.{{ .Values.clusterDomain }}:2379
             {{- end }}
             - --bind-address=0.0.0.0
             - --runtime-config=
             - --secure-port=5443
             - --service-account-issuer=https://kubernetes.default.svc.{{ .Values.clusterDomain }}
-            - --service-account-key-file=/etc/kubernetes/pki/karmada.key
-            - --service-account-signing-key-file=/etc/kubernetes/pki/karmada.key
+            - --service-account-key-file=/etc/karmada/pki/karmada-client.key
+            - --service-account-signing-key-file=/etc/karmada/pki/karmada-client.key
             - --service-cluster-ip-range={{ .Values.apiServer.serviceClusterIPRange }}
-            - --proxy-client-cert-file=/etc/kubernetes/pki/front-proxy-client.crt
-            - --proxy-client-key-file=/etc/kubernetes/pki/front-proxy-client.key
+            - --proxy-client-cert-file=/etc/karmada/pki/front-proxy-client.crt
+            - --proxy-client-key-file=/etc/karmada/pki/front-proxy-client.key
             - --requestheader-allowed-names=front-proxy-client
-            - --requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt
+            - --requestheader-client-ca-file=/etc/karmada/pki/front-proxy-ca.crt
             - --requestheader-extra-headers-prefix=X-Remote-Extra-
             - --requestheader-group-headers=X-Remote-Group
             - --requestheader-username-headers=X-Remote-User
-            - --tls-cert-file=/etc/kubernetes/pki/karmada.crt
-            - --tls-private-key-file=/etc/kubernetes/pki/karmada.key
+            - --tls-cert-file=/etc/karmada/pki/karmada-server.crt
+            - --tls-private-key-file=/etc/karmada/pki/karmada-server.key
             - --max-requests-inflight={{ .Values.apiServer.maxRequestsInflight }}
             - --max-mutating-requests-inflight={{ .Values.apiServer.maxMutatingRequestsInflight }}
             - --tls-min-version=VersionTLS13
@@ -102,12 +99,8 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
-            - name: apiserver-cert
-              mountPath: /etc/kubernetes/pki
-              readOnly: true
-            - name: etcd-cert
-              mountPath: /etc/etcd/pki
-              readOnly: true
+            {{- include "karmada.karmada-certs.volumeMount" . | nindent 12 }}
+            {{- include "karmada.etcd-cert.volumeMount" . | nindent 12 }}
       {{- if .Values.apiServer.hostNetwork }}
       dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
@@ -134,17 +127,8 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-        - name: apiserver-cert
-          secret:
-            secretName: {{ $name }}-cert
-        - name: etcd-cert
-          secret:
-          {{- if eq .Values.etcd.mode "internal" }}
-            secretName: {{ $name }}-cert
-          {{- end }}
-          {{- if eq .Values.etcd.mode "external" }}
-            secretName: {{ $name }}-external-etcd-cert
-          {{- end }}
+        {{- include "karmada.karmada-certs.volume" . | nindent 8 }}
+        {{- include "karmada.etcd-cert.volume" . | nindent 8 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/karmada/templates/karmada-cert.yaml
+++ b/charts/karmada/templates/karmada-cert.yaml
@@ -2,18 +2,22 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "karmada.name" . }}-cert
+  name: karmada-certs
   namespace: {{ include "karmada.namespace" . }}
 type: Opaque
 data:
-  server-ca.crt: |
+  ca.crt: |
     {{ b64enc .Values.certs.custom.caCrt }}
-  server-ca.key: |
+  ca.key: |
     {{ b64enc .Values.certs.custom.caKey }}
-  karmada.crt: |
-    {{ b64enc .Values.certs.custom.crt }}
-  karmada.key: |
-    {{ b64enc .Values.certs.custom.key }}
+  karmada-client.crt: |
+    {{ b64enc .Values.certs.custom.karmadaClientCrt }}
+  karmada-client.key: |
+    {{ b64enc .Values.certs.custom.karmadaClientKey }}
+  karmada-server.crt: |
+    {{ b64enc .Values.certs.custom.karmadaServerCrt }}
+  karmada-server.key: |
+    {{ b64enc .Values.certs.custom.karmadaServerKey }}
   front-proxy-ca.crt: |
     {{ b64enc .Values.certs.custom.frontProxyCaCrt }}
   front-proxy-client.crt: |
@@ -24,30 +28,31 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "karmada.name" . }}-webhook-cert
+  name: karmada-etcd-cert
+  namespace: {{ include "karmada.namespace" . }}
+type: Opaque
+data:
+  etcd-ca.crt: |
+    {{ b64enc .Values.certs.custom.etcdCaCrt }}
+  etcd-server.crt: |
+    {{ b64enc .Values.certs.custom.etcdServerCrt }}
+  etcd-server.key: |
+    {{ b64enc .Values.certs.custom.etcdServerKey }}
+  etcd-client.crt: |
+    {{ b64enc .Values.certs.custom.etcdClientCrt }}
+  etcd-client.key: |
+    {{ b64enc .Values.certs.custom.etcdClientKey }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: karmada-webhook-cert
   namespace: {{ include "karmada.namespace" . }}
 type: kubernetes.io/tls
 data:
   tls.crt: |
-    {{ b64enc .Values.certs.custom.crt }}
+    {{ b64enc .Values.certs.custom.karmadaServerCrt }}
   tls.key: |
-    {{ b64enc .Values.certs.custom.key }}
----
-{{- end }}
-
-{{- if and (eq .Values.installMode "host") (eq .Values.etcd.mode "external") }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "karmada.name" . }}-external-etcd-cert
-  namespace: {{ include "karmada.namespace" . }}
-type: Opaque
-data:
-  ca.crt: |
-    {{ b64enc .Values.etcd.external.certs.caCrt }}
-  tls.crt: |
-    {{ b64enc .Values.etcd.external.certs.crt }}
-  tls.key: |
-    {{ b64enc .Values.etcd.external.certs.key }}
+    {{ b64enc .Values.certs.custom.karmadaServerKey }}
 ---
 {{- end }}

--- a/charts/karmada/templates/karmada-descheduler.yaml
+++ b/charts/karmada/templates/karmada-descheduler.yaml
@@ -53,9 +53,9 @@ spec:
             - --metrics-bind-address=0.0.0.0:10358
             - --health-probe-bind-address=0.0.0.0:10358
             - --leader-elect-resource-namespace={{ $systemNamespace }}
-            - --scheduler-estimator-ca-file=/etc/karmada/pki/server-ca.crt
-            - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada.crt
-            - --scheduler-estimator-key-file=/etc/karmada/pki/karmada.key
+            - --scheduler-estimator-ca-file=/etc/karmada/pki/ca.crt
+            - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada-client.crt
+            - --scheduler-estimator-key-file=/etc/karmada/pki/karmada-client.key
             - --v=4
           livenessProbe:
             httpGet:
@@ -71,15 +71,13 @@ spec:
               name: metrics
               protocol: TCP
           volumeMounts:
-            - name: karmada-certs
-              mountPath: /etc/karmada/pki
-              readOnly: true
           {{- include "karmada.kubeconfig.volumeMount" . | nindent 12 }}
+          {{- include "karmada.karmada-certs.volumeMount" . | nindent 12 }}
           resources:
           {{- toYaml .Values.descheduler.resources | nindent 12 }}
       volumes:
-      {{- include "karmada.descheduler.kubeconfig.volume" . | nindent 8 }}
-      {{- include "karmada.scheduler.cert.volume" . | nindent 8 }}
+      {{- include "karmada.kubeconfig.volume" . | nindent 8 }}
+      {{- include "karmada.karmada-certs.volume" . | nindent 8 }}
 
 {{ if .Values.descheduler.podDisruptionBudget }}
 ---

--- a/charts/karmada/templates/karmada-kubeconfig.yaml
+++ b/charts/karmada/templates/karmada-kubeconfig.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $name }}-kubeconfig
+  name: karmada-kubeconfig
   namespace: {{ include "karmada.namespace" . }}
 stringData:
   kubeconfig: |-
@@ -17,8 +17,8 @@ stringData:
         name: {{ $name }}-apiserver
     users:
       - user:
-          client-certificate-data: {{ b64enc .Values.certs.custom.crt }}
-          client-key-data: {{ b64enc .Values.certs.custom.key }}
+          client-certificate-data: {{ b64enc .Values.certs.custom.karmadaClientCrt }}
+          client-key-data: {{ b64enc .Values.certs.custom.karmadaClientKey }}
         name: {{ $name }}-apiserver
     contexts:
       - context:

--- a/charts/karmada/templates/karmada-metrics-adapter.yaml
+++ b/charts/karmada/templates/karmada-metrics-adapter.yaml
@@ -38,16 +38,14 @@ spec:
           imagePullPolicy: {{ .Values.metricsAdapter.image.pullPolicy }}
           volumeMounts:
             {{- include "karmada.kubeconfig.volumeMount" . | nindent 12 }}
-            - name: apiserver-cert
-              mountPath: /etc/kubernetes/pki
-              readOnly: true
+            {{- include "karmada.karmada-certs.volumeMount" . | nindent 12 }}
           command:
             - /bin/karmada-metrics-adapter
             - --kubeconfig=/etc/kubeconfig
             - --authentication-kubeconfig=/etc/kubeconfig
             - --authorization-kubeconfig=/etc/kubeconfig
-            - --tls-cert-file=/etc/kubernetes/pki/karmada.crt
-            - --tls-private-key-file=/etc/kubernetes/pki/karmada.key
+            - --tls-cert-file=/etc/karmada/pki/karmada-server.crt
+            - --tls-private-key-file=/etc/karmada/pki/karmada-server.key
             - --audit-log-path=-
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
@@ -84,9 +82,8 @@ spec:
       {{- end }}
       volumes:
         {{- include "karmada.kubeconfig.volume" . | nindent 8 }}
-        - name: apiserver-cert
-          secret:
-            secretName: {{ $name }}-cert
+        {{- include "karmada.karmada-certs.volume" . | nindent 8 }}
+
 ---
 apiVersion: v1
 kind: Service

--- a/charts/karmada/templates/karmada-scheduler-estimator.yaml
+++ b/charts/karmada/templates/karmada-scheduler-estimator.yaml
@@ -48,9 +48,9 @@ spec:
             - /bin/karmada-scheduler-estimator
             - --kubeconfig=/etc/{{ $clusterName }}-kubeconfig
             - --cluster-name={{ $clusterName }}
-            - --grpc-auth-cert-file=/etc/karmada/pki/karmada.crt
-            - --grpc-auth-key-file=/etc/karmada/pki/karmada.key
-            - --grpc-client-ca-file=/etc/karmada/pki/server-ca.crt
+            - --grpc-auth-cert-file=/etc/karmada/pki/karmada-server.crt
+            - --grpc-auth-key-file=/etc/karmada/pki/karmada-server.key
+            - --grpc-client-ca-file=/etc/karmada/pki/ca.crt
             - --metrics-bind-address=0.0.0.0:8080
             - --health-probe-bind-address=0.0.0.0:10351
             {{- with (include "karmada.schedulerEstimator.featureGates" (dict "featureGatesArg" $.Values.schedulerEstimator.featureGates)) }}
@@ -70,16 +70,14 @@ spec:
               name: metrics
               protocol: TCP
           volumeMounts:
-            - name: karmada-certs
-              mountPath: /etc/karmada/pki
-              readOnly: true
+            {{- include "karmada.karmada-certs.volumeMount" . | nindent 12 }}
             - name: member-kubeconfig
               subPath: {{ $clusterName }}-kubeconfig
               mountPath: /etc/{{ $clusterName }}-kubeconfig
           resources:
           {{- toYaml $.Values.schedulerEstimator.resources | nindent 12 }}
       volumes:
-      {{- include "karmada.scheduler.cert.volume" $ | nindent 8 }}
+        {{- include "karmada.karmada-certs.volume" $ | nindent 8 }}
         - name: member-kubeconfig
           secret:
             secretName: {{ $clusterName }}-kubeconfig

--- a/charts/karmada/templates/karmada-scheduler.yaml
+++ b/charts/karmada/templates/karmada-scheduler.yaml
@@ -53,9 +53,9 @@ spec:
             - --bind-address=0.0.0.0
             - --secure-port=10351
             - --leader-elect-resource-namespace={{ $systemNamespace }}
-            - --scheduler-estimator-ca-file=/etc/karmada/pki/server-ca.crt
-            - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada.crt
-            - --scheduler-estimator-key-file=/etc/karmada/pki/karmada.key
+            - --scheduler-estimator-ca-file=/etc/karmada/pki/ca.crt
+            - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada-client.crt
+            - --scheduler-estimator-key-file=/etc/karmada/pki/karmada-client.key
           livenessProbe:
             httpGet:
               path: /healthz
@@ -69,15 +69,13 @@ spec:
             - containerPort: 10351
               name: http
           volumeMounts:
-            - name: karmada-certs
-              mountPath: /etc/karmada/pki
-              readOnly: true
           {{- include "karmada.kubeconfig.volumeMount" . | nindent 12 }}
+          {{- include "karmada.karmada-certs.volumeMount" . | nindent 12 }}
           resources:
           {{- toYaml .Values.scheduler.resources | nindent 12 }}
       volumes:
       {{- include "karmada.kubeconfig.volume" . | nindent 8 }}
-      {{- include "karmada.scheduler.cert.volume" . | nindent 8 }}
+      {{- include "karmada.karmada-certs.volume" . | nindent 8 }}
 
 {{ if .Values.scheduler.podDisruptionBudget }}
 ---

--- a/charts/karmada/templates/karmada-search.yaml
+++ b/charts/karmada/templates/karmada-search.yaml
@@ -47,35 +47,26 @@ spec:
           image: {{ template "karmada.search.image" . }}
           imagePullPolicy: {{ .Values.search.image.pullPolicy }}
           volumeMounts:
-            - name: k8s-certs
-              mountPath: /etc/kubernetes/pki
-              readOnly: true
-            - name: etcd-certs
-              mountPath: /etc/etcd/pki
-              readOnly: true
-            - name: kubeconfig-secret
-              subPath: kubeconfig
-              mountPath: /etc/kubeconfig
+            {{- include "karmada.kubeconfig.volumeMount" . | nindent 12 }}
+            {{- include "karmada.karmada-certs.volumeMount" . | nindent 12 }}
+            {{- include "karmada.etcd-cert.volumeMount" . | nindent 12 }}
           command:
             - /bin/karmada-search
             - --kubeconfig=/etc/kubeconfig
             - --authentication-kubeconfig=/etc/kubeconfig
             - --authorization-kubeconfig=/etc/kubeconfig
+            - --etcd-cafile=/etc/etcd/pki/etcd-ca.crt
+            - --etcd-certfile=/etc/etcd/pki/etcd-client.crt
+            - --etcd-keyfile=/etc/etcd/pki/etcd-client.key
             {{- if eq .Values.etcd.mode "external" }}
-            - --etcd-cafile=/etc/etcd/pki/ca.crt
-            - --etcd-certfile=/etc/etcd/pki/tls.crt
-            - --etcd-keyfile=/etc/etcd/pki/tls.key
             - --etcd-servers={{ .Values.etcd.external.servers }}
             - --etcd-prefix={{ .Values.etcd.external.registryPrefix }}
             {{- end }}
             {{- if eq .Values.etcd.mode "internal" }}
             - --etcd-servers=https://etcd-client.{{ include "karmada.namespace" . }}.svc.{{ .Values.clusterDomain }}:2379
-            - --etcd-cafile=/etc/etcd/pki/server-ca.crt
-            - --etcd-certfile=/etc/etcd/pki/karmada.crt
-            - --etcd-keyfile=/etc/etcd/pki/karmada.key
             {{- end }}
-            - --tls-cert-file=/etc/kubernetes/pki/karmada.crt
-            - --tls-private-key-file=/etc/kubernetes/pki/karmada.key
+            - --tls-cert-file=/etc/karmada/pki/karmada-server.crt
+            - --tls-private-key-file=/etc/karmada/pki/karmada-server.key
             - --audit-log-path=-
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
@@ -92,8 +83,9 @@ spec:
           resources:
           {{- toYaml .Values.apiServer.resources | nindent 12 }}
       volumes:
-      {{- include "karmada.search.kubeconfig.volume" . | nindent 8 }}
-      {{- include "karmada.search.etcd.cert.volume" . | nindent 8 }}
+      {{- include "karmada.kubeconfig.volume" . | nindent 8 }}
+      {{- include "karmada.karmada-certs.volume" . | nindent 8 }}
+      {{- include "karmada.etcd-cert.volume" . | nindent 8 }}
 ---
 apiVersion: v1
 kind: Service
@@ -169,8 +161,7 @@ spec:
         - name: {{ $name }}-search-apiservice
           configMap:
             name: {{ $name }}-search-apiservice
-        {{- include "karmada.search.kubeconfig.volume" . | nindent 8 }}
-        {{- include "karmada.search.etcd.cert.volume" . | nindent 8 }}
+        {{- include "karmada.kubeconfig.volume" . | nindent 8 }}
 {{- end }}
 
 {{ if .Values.search.podDisruptionBudget }}

--- a/charts/karmada/templates/karmada-webhook.yaml
+++ b/charts/karmada/templates/karmada-webhook.yaml
@@ -52,7 +52,7 @@ spec:
             - --kubeconfig=/etc/kubeconfig
             - --bind-address=0.0.0.0
             - --secure-port=8443
-            - --cert-dir=/var/serving-cert
+            - --cert-dir=/etc/karmada/pki
           ports:
             - containerPort: 8443
             - containerPort: 8080
@@ -60,8 +60,8 @@ spec:
               protocol: TCP
           volumeMounts:
           {{- include "karmada.kubeconfig.volumeMount" . | nindent 12 }}
-            - name: {{ $name }}-webhook-cert-secret
-              mountPath: /var/serving-cert
+            - name: karmada-webhook-cert
+              mountPath: /etc/karmada/pki
               readOnly: true
           readinessProbe:
             httpGet:
@@ -72,9 +72,9 @@ spec:
           {{- toYaml .Values.webhook.resources | nindent 12 }}
       volumes:
       {{- include "karmada.kubeconfig.volume" . | nindent 8 }}
-        - name: {{ $name }}-webhook-cert-secret
+        - name: karmada-webhook-cert
           secret:
-            secretName: {{ $name }}-webhook-cert
+            secretName: karmada-webhook-cert
 ---
 apiVersion: v1
 kind: Service

--- a/charts/karmada/templates/kube-controller-manager.yaml
+++ b/charts/karmada/templates/kube-controller-manager.yaml
@@ -50,17 +50,17 @@ spec:
             - --authentication-kubeconfig=/etc/kubeconfig
             - --authorization-kubeconfig=/etc/kubeconfig
             - --bind-address=0.0.0.0
-            - --client-ca-file=/etc/karmada/pki/server-ca.crt
+            - --client-ca-file=/etc/karmada/pki/ca.crt
             - --cluster-cidr={{ .Values.kubeControllerManager.clusterCIDR }}
             - --cluster-name=karmada
-            - --cluster-signing-cert-file=/etc/karmada/pki/server-ca.crt
-            - --cluster-signing-key-file=/etc/karmada/pki/server-ca.key
+            - --cluster-signing-cert-file=/etc/karmada/pki/ca.crt
+            - --cluster-signing-key-file=/etc/karmada/pki/ca.key
             - --controllers={{ .Values.kubeControllerManager.controllers }}
             - --kubeconfig=/etc/kubeconfig
             - --leader-elect=true
             - --node-cidr-mask-size=24
-            - --root-ca-file=/etc/karmada/pki/server-ca.crt
-            - --service-account-private-key-file=/etc/karmada/pki/karmada.key
+            - --root-ca-file=/etc/karmada/pki/ca.crt
+            - --service-account-private-key-file=/etc/karmada/pki/karmada-client.key
             - --service-cluster-ip-range={{ .Values.kubeControllerManager.serviceClusterIPRange }}
             - --use-service-account-credentials=true
             - --v=5
@@ -80,16 +80,12 @@ spec:
           resources:
           {{- toYaml .Values.kubeControllerManager.resources | nindent 12 }}
           volumeMounts:
-            - mountPath: /etc/karmada/pki
-              name: apisever-cert
-              readOnly: true
             {{- include "karmada.kubeconfig.volumeMount" . | nindent 12 }}
+            {{- include "karmada.karmada-certs.volumeMount" . | nindent 12 }}
       priorityClassName: system-node-critical
       volumes:
-        - name: apisever-cert
-          secret:
-            secretName: {{ $name }}-cert
         {{- include "karmada.kubeconfig.volume" . | nindent 8 }}
+        {{- include "karmada.karmada-certs.volume" . | nindent 8 }}
 
 {{ if .Values.kubeControllerManager.podDisruptionBudget }}
 ---

--- a/charts/karmada/templates/pre-install-job.yaml
+++ b/charts/karmada/templates/pre-install-job.yaml
@@ -249,41 +249,73 @@ data:
     apiVersion: v1
     kind: Secret
     metadata:
-      name: {{ $name }}-cert
+      name: karmada-certs
       namespace: {{ $namespace }}
     type: Opaque
     data:
-      server-ca.crt: |-
+      ca.crt: |-
         {{ print "{{ ca_crt }}" }}
-      server-ca.key: |-
+      ca.key: |-
         {{ print "{{ ca_key }}" }}
-      karmada.crt: |-
-        {{ print "{{ crt }}" }}
-      karmada.key: |-
-        {{ print "{{ key }}" }}
+      karmada-client.crt: |-
+        {{ print "{{ karmada_client_crt }}" }}
+      karmada-client.key: |-
+        {{ print "{{ karmada_client_key }}" }}
+      karmada-server.crt: |-
+        {{ print "{{ karmada_server_crt }}" }}
+      karmada-server.key: |-
+        {{ print "{{ karmada_server_key }}" }}
       front-proxy-ca.crt: |-
         {{ print "{{ front_proxy_ca_crt }}" }}
       front-proxy-client.crt: |-
         {{ print "{{ front_proxy_crt }}" }}
       front-proxy-client.key: |-
         {{ print "{{ front_proxy_key }}" }}
+  etcd-cert.yaml: |-
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: karmada-etcd-cert
+      namespace: {{ $namespace }}
+    type: Opaque
+    data:
+      {{- if eq .Values.etcd.mode "internal" }}
+      etcd-ca.crt: |-
+        {{ print "{{ etcd_ca_crt }}" }}
+      etcd-server.crt: |-
+        {{ print "{{ etcd_server_crt }}" }}
+      etcd-server.key: |-
+        {{ print "{{ etcd_server_key }}" }}
+      etcd-client.crt: |-
+        {{ print "{{ etcd_client_crt }}" }}
+      etcd-client.key: |-
+        {{ print "{{ etcd_client_key }}" }}
+      {{- end }}
+      {{- if eq .Values.etcd.mode "external" }}
+      etcd-ca.crt: |
+        {{ b64enc .Values.etcd.external.certs.caCrt }}
+      etcd-client.crt: |
+        {{ b64enc .Values.etcd.external.certs.etcdClientCrt }}
+      etcd-client.key: |
+        {{ b64enc .Values.etcd.external.certs.etcdClientKey }}
+      {{- end }}
   webhook-cert.yaml: |-
     apiVersion: v1
     kind: Secret
     metadata:
-      name: {{ $name }}-webhook-cert
+      name: karmada-webhook-cert
       namespace: {{ $namespace }}
     type: kubernetes.io/tls
     data:
       tls.crt: |-
-        {{ print "{{ crt }}" }}
+        {{ print "{{ karmada_server_crt }}" }}
       tls.key: |-
-        {{ print "{{ key }}" }}
+        {{ print "{{ karmada_server_key }}" }}
   kubeconfig.yaml: |-
     apiVersion: v1
     kind: Secret
     metadata:
-      name: {{ $name }}-kubeconfig
+      name: karmada-kubeconfig
       namespace: {{ $namespace }}
     stringData:
       kubeconfig: |-
@@ -296,8 +328,8 @@ data:
             name: {{ $name }}-apiserver
         users:
           - user:
-              client-certificate-data: {{ print "{{ crt }}" }}
-              client-key-data: {{ print "{{ key }}" }}
+              client-certificate-data: {{ print "{{ karmada_client_crt }}" }}
+              client-key-data: {{ print "{{ karmada_client_key }}" }}
             name: {{ $name }}-apiserver
         contexts:
           - context:
@@ -388,31 +420,71 @@ spec:
           mkdir -p /opt/configs
           mkdir -p /opt/certs
           cp -r -L /opt/mount/* /opt/configs/
-          openssl req -x509 -sha256 -new -nodes -days 365 -newkey rsa:{{ .Values.certs.auto.rsaSize }} -keyout "/opt/certs/server-ca.key" -out "/opt/certs/server-ca.crt" -subj "/C=xx/ST=x/L=x/O=x/OU=x/CN=ca/emailAddress=x/"
+
+          # create CA signers
+          openssl req -x509 -sha256 -new -nodes -days 365 -newkey rsa:{{ .Values.certs.auto.rsaSize }} -keyout "/opt/certs/ca.key" -out "/opt/certs/ca.crt" -subj "/C=xx/ST=x/L=x/O=x/OU=x/CN=ca/emailAddress=x/"
           openssl req -x509 -sha256 -new -nodes -days 365 -newkey rsa:{{ .Values.certs.auto.rsaSize }} -keyout "/opt/certs/front-proxy-ca.key" -out "/opt/certs/front-proxy-ca.crt" -subj "/C=xx/ST=x/L=x/O=x/OU=x/CN=ca/emailAddress=x/"
-          echo '{"signing":{"default":{"expiry":{{ printf `"%s"` .Values.certs.auto.expiry }},"usages":["signing","key encipherment","client auth","server auth"]}}}' > "/opt/certs/server-ca-config.json"
-          echo '{"CN":"system:admin","hosts":{{ tpl (toJson .Values.certs.auto.hosts) . }},"names":[{"O":"system:masters"}],"key":{"algo":"rsa","size":{{ .Values.certs.auto.rsaSize }}}}' | cfssl gencert -ca=/opt/certs/server-ca.crt -ca-key=/opt/certs/server-ca.key -config=/opt/certs/server-ca-config.json - | cfssljson -bare /opt/certs/karmada
+          openssl req -x509 -sha256 -new -nodes -days 365 -newkey rsa:{{ .Values.certs.auto.rsaSize }} -keyout "/opt/certs/etcd-ca.key" -out "/opt/certs/etcd-ca.crt" -subj "/C=xx/ST=x/L=x/O=x/OU=x/CN=ca/emailAddress=x/"
+
+          # signs certificates
+          echo '{"signing":{"default":{"expiry":{{ printf `"%s"` .Values.certs.auto.expiry }},"usages":["signing","key encipherment","client auth","server auth"]}}}' > "/opt/certs/ca-config.json"
+          echo '{"CN":"system:admin","hosts":{{ tpl (toJson .Values.certs.auto.hosts) . }},"names":[{"O":"system:masters"}],"key":{"algo":"rsa","size":{{ .Values.certs.auto.rsaSize }}}}' | cfssl gencert -ca=/opt/certs/ca.crt -ca-key=/opt/certs/ca.key -config=/opt/certs/ca-config.json - | cfssljson -bare /opt/certs/karmada-client
+          echo '{"CN":"karmada-server","hosts":{{ tpl (toJson .Values.certs.auto.hosts) . }},"names":[{"O":""}],"key":{"algo":"rsa","size":{{ .Values.certs.auto.rsaSize }}}}' | cfssl gencert -ca=/opt/certs/ca.crt -ca-key=/opt/certs/ca.key -config=/opt/certs/ca-config.json - | cfssljson -bare /opt/certs/karmada-server
+
           echo '{"signing":{"default":{"expiry":{{ printf `"%s"` .Values.certs.auto.expiry }},"usages":["signing","key encipherment","client auth","server auth"]}}}' > "/opt/certs/front-proxy-ca-config.json"
           echo '{"CN":"front-proxy-client","hosts":{{ tpl (toJson .Values.certs.auto.hosts) . }},"names":[{"O":"system:masters"}],"key":{"algo":"rsa","size":{{ .Values.certs.auto.rsaSize }}}}' | cfssl gencert -ca=/opt/certs/front-proxy-ca.crt -ca-key=/opt/certs/front-proxy-ca.key -config=/opt/certs/front-proxy-ca-config.json - | cfssljson -bare /opt/certs/front-proxy-client
-          karmada_ca=$(base64 /opt/certs/server-ca.crt | tr -d '\r\n')
-          karmada_ca_key=$(base64 /opt/certs/server-ca.key | tr -d '\r\n')
-          karmada_crt=$(base64 /opt/certs/karmada.pem | tr -d '\r\n')
-          karmada_key=$(base64 /opt/certs/karmada-key.pem | tr -d '\r\n')
+
+          {{- if eq .Values.etcd.mode "internal" }}
+          echo '{"signing":{"default":{"expiry":{{ printf `"%s"` .Values.certs.auto.expiry }},"usages":["signing","key encipherment","client auth","server auth"]}}}' > "/opt/certs/etcd-ca-config.json"
+          echo '{"CN":"etcd-server","hosts":{{ tpl (toJson .Values.certs.auto.hosts) . }},"names":[{"O":""}],"key":{"algo":"rsa","size":{{ .Values.certs.auto.rsaSize }}}}' | cfssl gencert -ca=/opt/certs/etcd-ca.crt -ca-key=/opt/certs/etcd-ca.key -config=/opt/certs/etcd-ca-config.json - | cfssljson -bare /opt/certs/etcd-server
+          echo '{"CN":"etcd-client","hosts":{{ tpl (toJson .Values.certs.auto.hosts) . }},"names":[{"O":""}],"key":{"algo":"rsa","size":{{ .Values.certs.auto.rsaSize }}}}' | cfssl gencert -ca=/opt/certs/etcd-ca.crt -ca-key=/opt/certs/etcd-ca.key -config=/opt/certs/etcd-ca-config.json - | cfssljson -bare /opt/certs/etcd-client
+          {{- end }}
+
+          # fill in secret karmada-certs
+          karmada_ca=$(base64 /opt/certs/ca.crt | tr -d '\r\n')
+          karmada_ca_key=$(base64 /opt/certs/ca.key | tr -d '\r\n')
+          karmada_server_crt=$(base64 /opt/certs/karmada-server.pem | tr -d '\r\n')
+          karmada_server_key=$(base64 /opt/certs/karmada-server-key.pem | tr -d '\r\n')
+          karmada_client_crt=$(base64 /opt/certs/karmada-client.pem | tr -d '\r\n')
+          karmada_client_key=$(base64 /opt/certs/karmada-client-key.pem | tr -d '\r\n')
           front_proxy_ca=$(base64 /opt/certs/front-proxy-ca.crt | tr -d '\r\n')
           front_proxy_client_crt=$(base64 /opt/certs/front-proxy-client.pem | tr -d '\r\n')
           front_proxy_client_key=$(base64 /opt/certs/front-proxy-client-key.pem | tr -d '\r\n')
+
           sed -i'' -e "s/{{ print "{{ ca_crt }}" }}/${karmada_ca}/g" /opt/configs/cert.yaml
           sed -i'' -e "s/{{ print "{{ ca_key }}" }}/${karmada_ca_key}/g" /opt/configs/cert.yaml
-          sed -i'' -e "s/{{ print "{{ crt }}" }}/${karmada_crt}/g" /opt/configs/cert.yaml
-          sed -i'' -e "s/{{ print "{{ key }}" }}/${karmada_key}/g" /opt/configs/cert.yaml
+          sed -i'' -e "s/{{ print "{{ karmada_server_crt }}" }}/${karmada_server_crt}/g" /opt/configs/cert.yaml
+          sed -i'' -e "s/{{ print "{{ karmada_server_key }}" }}/${karmada_server_key}/g" /opt/configs/cert.yaml
+          sed -i'' -e "s/{{ print "{{ karmada_client_crt }}" }}/${karmada_client_crt}/g" /opt/configs/cert.yaml
+          sed -i'' -e "s/{{ print "{{ karmada_client_key }}" }}/${karmada_client_key}/g" /opt/configs/cert.yaml
           sed -i'' -e "s/{{ print "{{ front_proxy_ca_crt }}" }}/${front_proxy_ca}/g" /opt/configs/cert.yaml
           sed -i'' -e "s/{{ print "{{ front_proxy_crt }}" }}/${front_proxy_client_crt}/g" /opt/configs/cert.yaml
           sed -i'' -e "s/{{ print "{{ front_proxy_key }}" }}/${front_proxy_client_key}/g" /opt/configs/cert.yaml
+
+          {{- if eq .Values.etcd.mode "internal" }}
+          # fill in secret karmada-etcd-cert
+          etcd_ca_crt=$(base64 /opt/certs/etcd-ca.crt | tr -d '\r\n')
+          etcd_server_crt=$(base64 /opt/certs/etcd-server.pem | tr -d '\r\n')
+          etcd_server_key=$(base64 /opt/certs/etcd-server-key.pem | tr -d '\r\n')
+          etcd_client_crt=$(base64 /opt/certs/etcd-client.pem | tr -d '\r\n')
+          etcd_client_key=$(base64 /opt/certs/etcd-client-key.pem | tr -d '\r\n')
+
+          sed -i'' -e "s/{{ print "{{ etcd_ca_crt }}" }}/${etcd_ca_crt}/g" /opt/configs/etcd-cert.yaml
+          sed -i'' -e "s/{{ print "{{ etcd_server_crt }}" }}/${etcd_server_crt}/g" /opt/configs/etcd-cert.yaml
+          sed -i'' -e "s/{{ print "{{ etcd_server_key }}" }}/${etcd_server_key}/g" /opt/configs/etcd-cert.yaml
+          sed -i'' -e "s/{{ print "{{ etcd_client_crt }}" }}/${etcd_client_crt}/g" /opt/configs/etcd-cert.yaml
+          sed -i'' -e "s/{{ print "{{ etcd_client_key }}" }}/${etcd_client_key}/g" /opt/configs/etcd-cert.yaml
+          {{- end }}
+
+          # fill in secret karmada-kubeconfig
           sed -i'' -e "s/{{ print "{{ ca_crt }}" }}/${karmada_ca}/g" /opt/configs/kubeconfig.yaml
-          sed -i'' -e "s/{{ print "{{ crt }}" }}/${karmada_crt}/g" /opt/configs/kubeconfig.yaml
-          sed -i'' -e "s/{{ print "{{ key }}" }}/${karmada_key}/g" /opt/configs/kubeconfig.yaml
-          sed -i'' -e "s/{{ print "{{ crt }}" }}/${karmada_crt}/g" /opt/configs/webhook-cert.yaml
-          sed -i'' -e "s/{{ print "{{ key }}" }}/${karmada_key}/g" /opt/configs/webhook-cert.yaml
+          sed -i'' -e "s/{{ print "{{ karmada_client_crt }}" }}/${karmada_client_crt}/g" /opt/configs/kubeconfig.yaml
+          sed -i'' -e "s/{{ print "{{ karmada_client_key }}" }}/${karmada_client_key}/g" /opt/configs/kubeconfig.yaml
+
+          # fill in secret karmada-webhook-cert
+          sed -i'' -e "s/{{ print "{{ karmada_server_crt }}" }}/${karmada_server_crt}/g" /opt/configs/webhook-cert.yaml
+          sed -i'' -e "s/{{ print "{{ karmada_server_key }}" }}/${karmada_server_key}/g" /opt/configs/webhook-cert.yaml
+
           sed -i'' -e "s/{{ print "{{ ca_crt }}" }}/${karmada_ca}/g" /opt/configs/static-resources-configmaps.yaml
           sed -i'' -e "s/{{ print "{{ ca_crt }}" }}/${karmada_ca}/g" /opt/configs/crds-patches-configmaps.yaml
           EOF

--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -123,8 +123,8 @@ postDeleteJob:
 ## karmada certificate config
 certs:
   ## @param certs.mode "auto" and "custom" are provided
-  ## "auto" means auto generate certificate
-  ## "custom" means use user certificate
+  ## "auto" means auto generate certificate (you can still customize etcd cert by `etcd.external.certs` when external etcd mode)
+  ## "custom" means all certificates are provided by user
   mode: auto
   auto:
     ## @param certs.auto.expiry expiry of the certificate
@@ -151,13 +151,26 @@ certs:
       -----BEGIN RSA PRIVATE KEY-----
       XXXXXXXXXXXXXXXXXXXXXXXXXXX
       -----END RSA PRIVATE KEY-----
-    ## @param certs.custom.crt crt of the certificate
-    crt: |
+    ## @param certs.custom.karmadaServerCrt crt of the karmada-server certificate
+    ## mainly used as server certificate for karmada components, such as karmada-apiserver,
+    ## karmada-search, karmada-metrics-adapter, etc.
+    karmadaServerCrt: |
       -----BEGIN CERTIFICATE-----
       XXXXXXXXXXXXXXXXXXXXXXXXXXX
       -----END CERTIFICATE-----
-    ## @param certs.custom.key key of the certificate
-    key: |
+    ## @param certs.custom.karmadaServerKey key of the karmada-server certificate
+    karmadaServerKey: |
+      -----BEGIN RSA PRIVATE KEY-----
+      XXXXXXXXXXXXXXXXXXXXXXXXXXX
+      -----END RSA PRIVATE KEY-----
+    ## @param certs.custom.karmadaClientCrt crt of the karmada-client certificate
+    ## mainly used to construct kubeconfig for other components to access karmada-apiserver.
+    karmadaClientCrt: |
+      -----BEGIN CERTIFICATE-----
+      XXXXXXXXXXXXXXXXXXXXXXXXXXX
+      -----END CERTIFICATE-----
+    ## @param certs.custom.karmadaClientKey key of the karmada-client certificate
+    karmadaClientKey: |
       -----BEGIN RSA PRIVATE KEY-----
       XXXXXXXXXXXXXXXXXXXXXXXXXXX
       -----END RSA PRIVATE KEY-----
@@ -173,6 +186,31 @@ certs:
       -----END CERTIFICATE-----
     ## @param certs.custom.frontProxyKey key of the front proxy certificate
     frontProxyKey: |
+      -----BEGIN RSA PRIVATE KEY-----
+      XXXXXXXXXXXXXXXXXXXXXXXXXXX
+      -----END RSA PRIVATE KEY-----
+    ## @param certs.custom.etcdCaCrt ca of the etcd certificate
+    etcdCaCrt: |
+      -----BEGIN CERTIFICATE-----
+      XXXXXXXXXXXXXXXXXXXXXXXXXXX
+      -----END CERTIFICATE-----
+    ## @param certs.custom.etcdServerCrt crt of the etcd-server certificate
+    etcdServerCrt: |
+      -----BEGIN CERTIFICATE-----
+      XXXXXXXXXXXXXXXXXXXXXXXXXXX
+      -----END CERTIFICATE-----
+    ## @param certs.custom.frontProxyKey key of the etcd-server certificate
+    etcdServerKey: |
+      -----BEGIN RSA PRIVATE KEY-----
+      XXXXXXXXXXXXXXXXXXXXXXXXXXX
+      -----END RSA PRIVATE KEY-----
+    ## @param certs.custom.etcdClientCrt crt of the etcd-client certificate
+    etcdClientCrt: |
+      -----BEGIN CERTIFICATE-----
+      XXXXXXXXXXXXXXXXXXXXXXXXXXX
+      -----END CERTIFICATE-----
+    ## @param certs.custom.etcdClientKey key of the etcd-client certificate
+    etcdClientKey: |
       -----BEGIN RSA PRIVATE KEY-----
       XXXXXXXXXXXXXXXXXXXXXXXXXXX
       -----END RSA PRIVATE KEY-----
@@ -641,19 +679,20 @@ etcd:
     servers: ""
     ## @param etcd.external.registryPrefix use to registry prefix of etcd
     registryPrefix: "/registry/karmada"
+    ## @certs define external etcd cert when certs.mode is auto
     certs:
       ## @param etcd.external.certs.caCrt ca of the certificate
       caCrt: |
         -----BEGIN CERTIFICATE-----
         XXXXXXXXXXXXXXXXXXXXXXXXXXX
         -----END CERTIFICATE-----
-      ## @param etcd.external.certs.crt crt of the certificate
-      crt: |
+      ## @param etcd.external.certs.etcdClientCrt crt of the etcd-client certificate
+      etcdClientCrt: |
         -----BEGIN CERTIFICATE-----
         XXXXXXXXXXXXXXXXXXXXXXXXXXX
         -----END CERTIFICATE-----
-      ## @param etcd.external.certs.key key of the certificate
-      key: |
+      ## @param etcd.external.certs.etcdClientKey key of the etcd-client certificate
+      etcdClientKey: |
         -----BEGIN RSA PRIVATE KEY-----
         XXXXXXXXXXXXXXXXXXXXXXXXXXX
         -----END RSA PRIVATE KEY-----
@@ -911,8 +950,6 @@ descheduler:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 50%
-  ## @param descheduler.kubeconfig kubeconfig of the descheduler
-  kubeconfig: karmada-kubeconfig
   ## @param apiServer.podDisruptionBudget
   podDisruptionBudget: *podDisruptionBudget
 
@@ -969,9 +1006,5 @@ search:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 50%
-  ## @param search.certs certs of the search
-  certs: karmada-cert
-  ## @param search.kubeconfig kubeconfig of the search
-  kubeconfig: karmada-kubeconfig
   ## @param apiServer.podDisruptionBudget
   podDisruptionBudget: *podDisruptionBudget


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

In karmada, here are two important secrets, which is mount by most karmada components. One is karmada-cert, which contains a series of cert files like ca.crt, apiserver.crt and so on; another is karmada-kubeconfig, which contains a kubeconfig of karmada-apiserver.

However, in different installation methods, we used inconsistent secret naming or file path naming, which can potentially cause some unnecessary problems, detail refer to #5363.

This PR aims to standardize the naming of karmada secrets in helm installation method.

**Which issue(s) this PR fixes**:

Fixes part of #5363

**Special notes for your reviewer**:

In `helm` method, if I install karmada by `helm install karmada-xxx ...`, it will create a secret naming `karmada-xxx-cert`. Then if I install the single `karmada-scheduler-estimator` component by `helm install karmada-scheduler-estimator-xxx --set installMode=component ...`, the component will look for secret naming `karmada-scheduler-estimator-xxx-cert`, the name is inconsistent. In this case, since we cannot reuse the same `.Release.Name` when executing helm install, so the secret name is not advised to be prefixed with `.Release.Name`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
helm chart: standardize the naming of karmada secrets in helm installation method
```

