### PR TITLE
Expose metrics port for local-up installation

### DIFF
--- a/artifacts/agent/karmada-agent.yaml
+++ b/artifacts/agent/karmada-agent.yaml
@@ -31,6 +31,7 @@ spec:
             - --cluster-api-endpoint={{member_cluster_api_endpoint}}
             - --cluster-status-update-frequency=10s
             - --health-probe-bind-address=0.0.0.0:10357
+            - --metrics-bind-address=:8080
             - --feature-gates=CustomizedClusterResourceModeling=true,MultiClusterService=true
             - --v=4
           livenessProbe:
@@ -42,6 +43,10 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 15
             timeoutSeconds: 5
+          ports:
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
           volumeMounts:
             - name: kubeconfig
               mountPath: /etc/kubeconfig

--- a/artifacts/deploy/karmada-controller-manager.yaml
+++ b/artifacts/deploy/karmada-controller-manager.yaml
@@ -26,6 +26,8 @@ spec:
           command:
             - /bin/karmada-controller-manager
             - --kubeconfig=/etc/kubeconfig
+            - --bind-address=0.0.0.0
+            - --metrics-bind-address=:8080
             - --cluster-status-update-frequency=10s
             - --failover-eviction-timeout=30s
             - --controllers=*,hpaScaleTargetMarker,deploymentReplicasSyncer
@@ -41,6 +43,10 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 15
             timeoutSeconds: 5
+          ports:
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
           volumeMounts:
           - name: kubeconfig
             subPath: kubeconfig

--- a/artifacts/deploy/karmada-descheduler.yaml
+++ b/artifacts/deploy/karmada-descheduler.yaml
@@ -41,6 +41,10 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 15
             timeoutSeconds: 5
+          ports:
+            - containerPort: 10358
+              name: metrics
+              protocol: TCP
           volumeMounts:
             - name: karmada-certs
               mountPath: /etc/karmada/pki

--- a/artifacts/deploy/karmada-scheduler-estimator.yaml
+++ b/artifacts/deploy/karmada-scheduler-estimator.yaml
@@ -41,6 +41,10 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 15
             timeoutSeconds: 5
+          ports:
+            - containerPort: 10351
+              name: metrics
+              protocol: TCP
           volumeMounts:
             - name: karmada-certs
               mountPath: /etc/karmada/pki

--- a/artifacts/deploy/karmada-scheduler.yaml
+++ b/artifacts/deploy/karmada-scheduler.yaml
@@ -32,6 +32,10 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 15
             timeoutSeconds: 5
+          ports:
+            - containerPort: 10351
+              name: metrics
+              protocol: TCP
           command:
             - /bin/karmada-scheduler
             - --kubeconfig=/etc/kubeconfig

--- a/artifacts/deploy/karmada-webhook.yaml
+++ b/artifacts/deploy/karmada-webhook.yaml
@@ -27,6 +27,7 @@ spec:
             - /bin/karmada-webhook
             - --kubeconfig=/etc/kubeconfig
             - --bind-address=0.0.0.0
+            - --metrics-bind-address=:8080
             - --default-not-ready-toleration-seconds=30
             - --default-unreachable-toleration-seconds=30
             - --secure-port=8443
@@ -34,6 +35,9 @@ spec:
             - --v=4
           ports:
             - containerPort: 8443
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
           volumeMounts:
             - name: kubeconfig
               subPath: kubeconfig


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes part of #5166

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Expose the metrics port for the karmada-controller-manager, scheduler、agent、karmada-webhook、descheduler and scheduler-estimator in local-up-karmada.
```

