### PR TITLE
fix: remove extra slash when constructing member cluster URL if the apiEndpoint of the cluster object ends with a slash

### DIFF
--- a/pkg/registry/cluster/storage/aggregate.go
+++ b/pkg/registry/cluster/storage/aggregate.go
@@ -149,7 +149,7 @@ func requestWithResourceNameHandlerFunc(
 					klog.Errorf("failed to get impersonateToken for cluster %s: %v", cluster.Name, err)
 					return
 				}
-				statusCode, err := doClusterRequest(req.Method, requestURLStr(location.String(), proxyRequestInfo), transport, requester, impersonateToken)
+				statusCode, err := doClusterRequest(req.Method, requestURLStr(location, proxyRequestInfo), transport, requester, impersonateToken)
 				if err != nil {
 					klog.Errorf("failed to do request for cluster %s: %v", cluster.Name, err)
 					return
@@ -358,7 +358,7 @@ func doClusterRequest(
 }
 
 // requestURLStr returns the request resource url string.
-func requestURLStr(urlStr string, requestInfo *request.RequestInfo) string {
+func requestURLStr(location *url.URL, requestInfo *request.RequestInfo) string {
 	parts := []string{requestInfo.APIPrefix}
 	if requestInfo.APIGroup != "" {
 		parts = append(parts, requestInfo.APIGroup)
@@ -377,7 +377,7 @@ func requestURLStr(urlStr string, requestInfo *request.RequestInfo) string {
 		requestInfo.Subresource != "exec" && requestInfo.Subresource != "log" {
 		parts = append(parts, requestInfo.Subresource)
 	}
-	return fmt.Sprintf("%s/%s", urlStr, strings.Join(parts, "/"))
+	return location.ResolveReference(&url.URL{Path: strings.Join(parts, "/")}).String()
 }
 
 func setRequestHeader(req *http.Request, userInfo user.Info, impersonateToken string) {

--- a/pkg/registry/cluster/storage/aggregate_test.go
+++ b/pkg/registry/cluster/storage/aggregate_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2022 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/karmada-io/karmada/pkg/util/lifted"
+)
+
+func TestRequestURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		urlString string
+		request   http.Request
+		want      string
+	}{
+		{
+			name:      "without slash in the end",
+			urlString: "https://0.0.0.0:6443",
+			request: http.Request{
+				Method: "GET",
+				URL: &url.URL{
+					Path: "/api/v1/namespaces/test/pods/",
+				},
+			},
+			want: "https://0.0.0.0:6443/api/v1/namespaces/test/pods",
+		},
+		{
+			name:      "with slash in the end",
+			urlString: "https://0.0.0.0:6443/",
+			request: http.Request{
+				Method: "GET",
+				URL: &url.URL{
+					Path: "/api/v1/namespaces/test/pods/",
+				},
+			},
+			want: "https://0.0.0.0:6443/api/v1/namespaces/test/pods",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proxyRequestInfo := lifted.NewRequestInfo(&tt.request)
+			location, _ := url.Parse(tt.urlString)
+			requestURL := requestURLStr(location, proxyRequestInfo)
+			require.Equal(t, tt.want, requestURL)
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #5228 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
User can append a "/" at the end when configuring the cluster's apiEndpoint.
```

