### PR TITLE
e2e suspend: ensure proper cleanup after each run 

### DIFF
--- a/test/e2e/clusterpropagationpolicy_test.go
+++ b/test/e2e/clusterpropagationpolicy_test.go
@@ -1034,7 +1034,7 @@ var _ = ginkgo.Describe("[Suspend] clusterPropagation testing", func() {
 	ginkgo.BeforeEach(func() {
 		targetMember = framework.ClusterNames()[0]
 		policyName := clusterRoleNamePrefix + rand.String(RandomStrLength)
-		clusterRoleName := fmt.Sprintf("system:test-%s", policyName)
+		clusterRoleName := fmt.Sprintf("system:test-suspend-%s", policyName)
 
 		clusterRole = testhelper.NewClusterRole(clusterRoleName, nil)
 		resourceBindingName = names.GenerateBindingName(clusterRole.Kind, clusterRole.Name)
@@ -1057,6 +1057,7 @@ var _ = ginkgo.Describe("[Suspend] clusterPropagation testing", func() {
 		ginkgo.DeferCleanup(func() {
 			framework.RemoveClusterPropagationPolicy(karmadaClient, policy.Name)
 			framework.RemoveClusterRole(kubeClient, clusterRole.Name)
+			framework.WaitClusterRoleBindingDisappearOnCluster(targetMember, clusterRole.Name)
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this?**
/kidn failing-test
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
ClusterRole and CPP are cluster-level resources so we need to ensure that we use a unique name. Otherwise, the randomness is bound to have collisions here and there.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

