### PR TITLE
charts/karmada: automatically clean up the static-resource Job after it completes

### DIFF
--- a/charts/karmada/templates/karmada-static-resource-job.yaml
+++ b/charts/karmada/templates/karmada-static-resource-job.yaml
@@ -11,6 +11,9 @@ metadata:
 spec:
   parallelism: 1
   completions: 1
+  {{- if semverCompare ">=1.23.0-0" .Capabilities.KubeVersion.GitVersion }}
+  ttlSecondsAfterFinished: {{ .Values.staticResourceJob.ttlSecondsAfterFinished }}
+  {{- end }}
   template:
     metadata:
       name: {{ $name }}

--- a/charts/karmada/templates/post-install-job.yaml
+++ b/charts/karmada/templates/post-install-job.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare "<1.23.0-0" .Capabilities.KubeVersion.GitVersion }}
 {{- $name := include "karmada.name" . -}}
 {{- $namespace := include "karmada.namespace" . -}}
 {{- if eq .Values.installMode "host" }}
@@ -51,8 +52,8 @@ spec:
           bash <<'EOF'
           set -ex
 
-          # The `post-install hook job` may be applied before all karmada components are ready that rely on `static-resource job` and `hook-job secret`.
-          # So, we have to postpone the deletion of the `static-resource job` and `hook-job secret` until all karmada components are up and running.
+          # The `post-install hook job` may be applied before all karmada components are ready that rely on `static-resource job`.
+          # So, we have to postpone the deletion of the `static-resource job` until all karmada components are up and running.
           while [[ $(kubectl get pods -n {{ $namespace }} --field-selector=status.phase!=Running,status.phase!=Succeeded -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep -v static-resource | wc -l) > 0 ]];
           do
             echo "waiting for all pods of karmada control plane ready..."; sleep 1;
@@ -60,4 +61,5 @@ spec:
 
           kubectl delete job {{ $name }}-static-resource -n {{ $namespace }}
           EOF
+{{- end }}
 {{- end }}

--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -102,6 +102,9 @@ preInstallJob:
 staticResourceJob:
   tolerations: []
   nodeSelector: {}
+  ## Set a TTL for the static-resource Job, the Job will be automatically cleaned up after this time.
+  ## This only works on Kubernetes version 1.23 or higher.
+  ttlSecondsAfterFinished: 10
 
 ## post-install job config
 postInstallJob:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

After #5305, we can now delete the static-resource job directly after its completion.

The new [`ttlSecondsAfterFinished` feature](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/) can handle this task elegantly. However, this feature only reached GA in version 1.23. Before this version, the feature requires manually enabling the feature gate, and we cannot assume that users' clusters have this feature gate enabled. Therefore, unlike the https://github.com/karmada-io/karmada/pull/5305#issuecomment-2313929232, considering that Karmada needs to run on various versions of Kubernetes, we cannot directly remove the post-install Job. The current strategy is:

1. For Kubernetes versions 1.23 or higher, use `ttlSecondsAfterFinished` for cleanup.
2. For Kubernetes versions lower than 1.23, continue using the post-install Job for cleanup.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
none
```

/cc @chaosi-zju @RainbowMango 
