### PR TITLE
Provide detailed error message when the  e2e test fails

### DIFF
--- a/test/e2e/karmadactl_test.go
+++ b/test/e2e/karmadactl_test.go
@@ -546,7 +546,8 @@ var _ = ginkgo.Describe("Karmadactl top testing", func() {
 			for _, clusterName := range framework.ClusterNames() {
 				cmd := framework.NewKarmadactlCommand(kubeconfig, karmadaContext, karmadactlPath, "", karmadactlTimeout, "top", "pod", podName, "-n", testNamespace, "-C", clusterName)
 				_, err := cmd.ExecOrDie()
-				gomega.Expect(strings.Contains(err.Error(), fmt.Sprintf("pods \"%s\" not found", podName))).To(gomega.BeTrue(), "should not found")
+				gomega.Expect(err).Should(gomega.HaveOccurred())
+				gomega.Expect(strings.Contains(err.Error(), fmt.Sprintf("pods \"%s\" not found", podName))).To(gomega.BeTrue(), "should not found", fmt.Sprintf("errMsg: %s", err.Error()))
 			}
 		})
 	})


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
The e2e test `Karmadactl top testing Karmadactl top pod which does not exist [It] Karmadactl top pod which does not exist` has been intermittently failing recently, for example:
- https://github.com/karmada-io/karmada/actions/runs/10611034056/job/29409966885?pr=5454

Due to the lack of effective positioning information, it's difficult to identify the root cause. Therefore, we plan to add error messages to facilitate subsequent troubleshooting.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
None
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
None
```

