### PR TITLE
Added tests for cmd/scheduler

### DIFF
--- a/cmd/scheduler/app/options/options_test.go
+++ b/cmd/scheduler/app/options/options_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewOptions(t *testing.T) {
+	opts := NewOptions()
+
+	assert.True(t, opts.LeaderElection.LeaderElect, "Expected default LeaderElect to be true")
+	assert.Equal(t, "karmada-system", opts.LeaderElection.ResourceNamespace, "Unexpected default ResourceNamespace")
+	assert.Equal(t, 15*time.Second, opts.LeaderElection.LeaseDuration.Duration, "Unexpected default LeaseDuration")
+	assert.Equal(t, "karmada-scheduler", opts.LeaderElection.ResourceName, "Unexpected default ResourceName")
+}
+
+func TestAddFlags(t *testing.T) {
+	opts := NewOptions()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	opts.AddFlags(fs)
+
+	testCases := []struct {
+		name            string
+		expectedType    string
+		expectedDefault string
+	}{
+		{"kubeconfig", "string", ""},
+		{"leader-elect", "bool", "true"},
+		{"enable-scheduler-estimator", "bool", "false"},
+		{"scheduler-estimator-port", "int", "10352"},
+		{"plugins", "stringSlice", "[*]"},
+		{"scheduler-name", "string", "default-scheduler"},
+	}
+
+	for _, tc := range testCases {
+		flag := fs.Lookup(tc.name)
+		assert.NotNil(t, flag, "Flag %s not found", tc.name)
+		assert.Equal(t, tc.expectedType, flag.Value.Type(), "Unexpected type for flag %s", tc.name)
+		assert.Equal(t, tc.expectedDefault, flag.DefValue, "Unexpected default value for flag %s", tc.name)
+	}
+}
+
+func TestOptionsComplete(t *testing.T) {
+	testCases := []struct {
+		name            string
+		bindAddress     string
+		securePort      int
+		expectedMetrics string
+		expectedHealth  string
+	}{
+		{
+			name:            "Default values",
+			bindAddress:     defaultBindAddress,
+			securePort:      defaultPort,
+			expectedMetrics: "0.0.0.0:10351",
+			expectedHealth:  "0.0.0.0:10351",
+		},
+		{
+			name:            "Custom values",
+			bindAddress:     "127.0.0.1",
+			securePort:      8080,
+			expectedMetrics: "127.0.0.1:8080",
+			expectedHealth:  "127.0.0.1:8080",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := &Options{
+				BindAddress: tc.bindAddress,
+				SecurePort:  tc.securePort,
+			}
+			err := opts.Complete()
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedMetrics, opts.MetricsBindAddress)
+			assert.Equal(t, tc.expectedHealth, opts.HealthProbeBindAddress)
+		})
+	}
+}
+
+func TestOptionsFlagParsing(t *testing.T) {
+	opts := NewOptions()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	opts.AddFlags(fs)
+
+	testArgs := []string{
+		"--leader-elect=false",
+		"--enable-scheduler-estimator=true",
+		"--plugins=*,-foo,bar",
+		"--scheduler-name=custom-scheduler",
+	}
+
+	err := fs.Parse(testArgs)
+	assert.NoError(t, err)
+
+	assert.False(t, opts.LeaderElection.LeaderElect)
+	assert.True(t, opts.EnableSchedulerEstimator)
+	assert.Equal(t, []string{"*", "-foo", "bar"}, opts.Plugins)
+	assert.Equal(t, "custom-scheduler", opts.SchedulerName)
+}

--- a/cmd/scheduler/app/scheduler_test.go
+++ b/cmd/scheduler/app/scheduler_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/karmada-io/karmada/cmd/scheduler/app/options"
+)
+
+func TestNewSchedulerCommand(t *testing.T) {
+	stopCh := make(chan struct{})
+	cmd := NewSchedulerCommand(stopCh)
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "karmada-scheduler", cmd.Use)
+	assert.NotEmpty(t, cmd.Long)
+}
+
+func TestSchedulerCommandFlagParsing(t *testing.T) {
+	testCases := []struct {
+		name        string
+		args        []string
+		expectError bool
+	}{
+		{"Default flags", []string{}, false},
+		{"With custom health probe bind address", []string{"--health-probe-bind-address=127.0.0.1:8080"}, false},
+		{"With custom metrics bind address", []string{"--metrics-bind-address=127.0.0.1:8081"}, false},
+		{"With leader election enabled", []string{"--leader-elect=true"}, false},
+		{"With invalid flag", []string{"--invalid-flag=value"}, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			stopCh := make(chan struct{})
+			cmd := NewSchedulerCommand(stopCh)
+			cmd.SetArgs(tc.args)
+			err := cmd.ParseFlags(tc.args)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestServeHealthzAndMetrics(t *testing.T) {
+	healthAddress := "127.0.0.1:8082"
+	metricsAddress := "127.0.0.1:8083"
+
+	go serveHealthzAndMetrics(healthAddress, metricsAddress)
+
+	// For servers to start
+	time.Sleep(100 * time.Millisecond)
+
+	t.Run("Healthz endpoint", func(t *testing.T) {
+		resp, err := http.Get("http://" + healthAddress + "/healthz")
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("Metrics endpoint", func(t *testing.T) {
+		resp, err := http.Get("http://" + metricsAddress + "/metrics")
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}
+
+func TestSchedulerOptionsValidation(t *testing.T) {
+	testCases := []struct {
+		name        string
+		setupOpts   func(*options.Options)
+		expectError bool
+	}{
+		{
+			name: "Default options",
+			setupOpts: func(o *options.Options) {
+				o.SchedulerName = "default-scheduler"
+			},
+			expectError: false,
+		},
+		{
+			name: "Empty scheduler name",
+			setupOpts: func(o *options.Options) {
+				o.SchedulerName = ""
+			},
+			expectError: true,
+		},
+		{
+			name: "Invalid kube API QPS",
+			setupOpts: func(o *options.Options) {
+				o.KubeAPIQPS = -1
+			},
+			expectError: true,
+		},
+		{
+			name: "Invalid kube API burst",
+			setupOpts: func(o *options.Options) {
+				o.KubeAPIBurst = -1
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := options.NewOptions()
+			tc.setupOpts(opts)
+			errs := opts.Validate()
+			if tc.expectError {
+				assert.NotEmpty(t, errs)
+			} else {
+				assert.Empty(t, errs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description:**
This PR introduces tests for cmd/scheduler/app/scheduler.go and cmd/scheduler/app/options/options.go .

**What type of PR is this?**
/kind failing-test
/kind feature

**What this PR does / why we need it**:
This PR adds comprehensive tests for testing core functionality of cmd/scheduler .

**Which issue(s) this PR fixes**:
Fixes a part of #5236 

**Special notes for your reviewer**:
The additions in this PR are similar to implemented in #5445 .

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

