### PR TITLE
pkg/karmadactl/interpret/interpret.go: Reformat `karmadactl interpret --help` output

### DIFF
--- a/pkg/karmadactl/interpret/interpret.go
+++ b/pkg/karmadactl/interpret/interpret.go
@@ -44,13 +44,13 @@ var (
 	interpretLong = templates.LongDesc(`
         Validate, test and edit interpreter customization before applying it to the control plane.
 
-        1. Validate the ResourceInterpreterCustomization configuration as per API schema
+		1. Validate the ResourceInterpreterCustomization configuration as per API schema
            and try to load the scripts for syntax check.
 
-        2. Run the rules locally and test if the result is expected. Similar to the dry run.
+		2. Run the rules locally and test if the result is expected. Similar to the dry run.
 
 		3. Edit customization. Similar to the kubectl edit.
-`)
+	`)
 
 	interpretExample = templates.Examples(`
         # Check the customizations in file
@@ -82,7 +82,7 @@ var (
 
 		# Edit customization
 		%[1]s interpret -f customization.yml --edit
-`)
+	`)
 )
 
 const (


### PR DESCRIPTION
**Description**

In this commit, we reformat the output for `karmadactl interpret --help` command.

**Screenshots**

Before            |  After
:-------------------------:|:-------------------------:
![Before](https://github.com/user-attachments/assets/59484f51-7d69-49ee-a4dd-e306344cd40a) |  ![After](https://github.com/user-attachments/assets/c661f510-fbc1-4b6c-b3d9-c2381d725b43)


**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```