### PR TITLE
add new command 

### DIFF
--- a/pkg/karmadactl/karmadactl.go
+++ b/pkg/karmadactl/karmadactl.go
@@ -48,6 +48,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/karmadactl/label"
 	"github.com/karmada-io/karmada/pkg/karmadactl/logs"
 	"github.com/karmada-io/karmada/pkg/karmadactl/options"
+	"github.com/karmada-io/karmada/pkg/karmadactl/patch"
 	"github.com/karmada-io/karmada/pkg/karmadactl/promote"
 	"github.com/karmada-io/karmada/pkg/karmadactl/register"
 	"github.com/karmada-io/karmada/pkg/karmadactl/taint"
@@ -137,6 +138,7 @@ func NewKarmadaCtlCommand(cmdUse, parentCommand string) *cobra.Command {
 				apply.NewCmdApply(f, parentCommand, ioStreams),
 				promote.NewCmdPromote(f, parentCommand),
 				top.NewCmdTop(f, parentCommand, ioStreams),
+				patch.NewCmdPatch(f, parentCommand, ioStreams),
 			},
 		},
 		{

--- a/pkg/karmadactl/karmadactl.go
+++ b/pkg/karmadactl/karmadactl.go
@@ -49,6 +49,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/karmadactl/logs"
 	"github.com/karmada-io/karmada/pkg/karmadactl/options"
 	"github.com/karmada-io/karmada/pkg/karmadactl/patch"
+	"github.com/karmada-io/karmada/pkg/karmadactl/portforward"
 	"github.com/karmada-io/karmada/pkg/karmadactl/promote"
 	"github.com/karmada-io/karmada/pkg/karmadactl/register"
 	"github.com/karmada-io/karmada/pkg/karmadactl/taint"
@@ -130,6 +131,7 @@ func NewKarmadaCtlCommand(cmdUse, parentCommand string) *cobra.Command {
 				exec.NewCmdExec(f, parentCommand, ioStreams),
 				describe.NewCmdDescribe(f, parentCommand, ioStreams),
 				interpret.NewCmdInterpret(f, parentCommand, ioStreams),
+				portforward.NewCmdPortForWard(f, parentCommand, ioStreams),
 			},
 		},
 		{

--- a/pkg/karmadactl/patch/patch.go
+++ b/pkg/karmadactl/patch/patch.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2024 The Karmada Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	kubectlpatch "k8s.io/kubectl/pkg/cmd/patch"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	"github.com/karmada-io/karmada/pkg/karmadactl/util"
+)
+
+var (
+	patchExample = templates.Examples(`
+		# Partially update a deployment using a strategic merge patch, specifying the patch as JSON
+		[1]%s patch deployment nginx-deployment -p '{"spec":{"replicas":2}}'
+
+		# Partially update a deployment using a strategic merge patch, specifying the patch as YAML
+		[1]%s patch deployment nginx-deployment -p $'spec:\n replicas: 2'
+
+		# Partially update a deployment identified by the type and name specified in "deployment.json" using strategic merge patch
+		[1]%s patch -f deployment.json -p '{"spec":{"replicas":2}}'
+
+		# Update a propagationpolicy's conflictResolution using a JSON patch with positional arrays
+		[1]%s patch pp nginx-propagation --type='json' -p='[{"op": "replace", "path": "/spec/conflictResolution", "value":"Overwrite"}]'
+
+		# Update a deployment's replicas through the 'scale' subresource using a merge patch
+		[1]%s patch deployment nginx-deployment --subresource='scale' --type='merge' -p '{"spec":{"replicas":2}}'`)
+)
+
+// NewCmdPatch returns new initialized instance of patch sub command
+func NewCmdPatch(f util.Factory, parentCommand string, ioStreams genericiooptions.IOStreams) *cobra.Command {
+	cmd := kubectlpatch.NewCmdPatch(f, ioStreams)
+	cmd.Example = fmt.Sprintf(patchExample, parentCommand)
+	return cmd
+}

--- a/pkg/karmadactl/portforward/portforward.go
+++ b/pkg/karmadactl/portforward/portforward.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2024 The Karmada Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+	kubectlportforward "k8s.io/kubectl/pkg/cmd/portforward"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/completion"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	"github.com/karmada-io/karmada/pkg/karmadactl/options"
+	"github.com/karmada-io/karmada/pkg/karmadactl/util"
+)
+
+const (
+	// Amount of time to wait until at least one pod is running
+	defaultPodPortForwardWaitTimeout = 60 * time.Second
+)
+
+var (
+	portforwardLong = templates.LongDesc(`
+                Forward one or more local ports to a pod.
+
+                Use resource type/name such as deployment/mydeployment to select a pod. Resource type defaults to 'pod' if omitted.
+
+                If there are multiple pods matching the criteria, a pod will be selected automatically. The
+                forwarding session ends when the selected pod terminates, and a rerun of the command is needed
+                to resume forwarding.`)
+
+	portforwardExample = templates.Examples(`
+		# Listen on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in the pod
+		%[1]s port-forward pod/mypod 5000 6000
+
+		# Listen on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in a pod selected by the deployment
+		%[1]s port-forward deployment/mydeployment 5000 6000
+
+		# Listen on port 8443 locally, forwarding to the targetPort of the service's port named "https" in a pod selected by the service
+		%[1]s port-forward service/myservice 8443:https
+
+		# Listen on port 8888 locally, forwarding to 5000 in the pod
+		%[1]s port-forward pod/mypod 8888:5000
+
+		# Listen on port 8888 on all addresses, forwarding to 5000 in the pod
+		%[1]s port-forward --address 0.0.0.0 pod/mypod 8888:5000
+
+		# Listen on port 8888 on localhost and selected IP, forwarding to 5000 in the pod
+		%[1]s port-forward --address localhost,10.19.21.23 pod/mypod 8888:5000
+
+		# Listen on a random port locally, forwarding to 5000 in the pod
+		%[1]s port-forward pod/mypod :5000`)
+)
+
+// NewCmdPortForWard new port-forward command.
+func NewCmdPortForWard(f util.Factory, parentCommand string, streams genericiooptions.IOStreams) *cobra.Command {
+	opts := &CommandPortForwardOptions{
+		KubectlPortForwardOptions: &kubectlportforward.PortForwardOptions{
+			PortForwarder: &defaultPortForwarder{
+				IOStreams: streams,
+			},
+		}}
+
+	cmd := &cobra.Command{
+		Use:                   "port-forward TYPE/NAME [options] [LOCAL_PORT:]REMOTE_PORT [...[LOCAL_PORT_N:]REMOTE_PORT_N]",
+		DisableFlagsInUseLine: true,
+		Short:                 "Forward one or more local ports to a pod",
+		Long:                  portforwardLong,
+		Example:               fmt.Sprintf(portforwardExample, parentCommand),
+		ValidArgsFunction:     completion.PodResourceNameCompletionFunc(f),
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(opts.PreCheck())
+			cmdutil.CheckErr(opts.Complete(f, cmd, args))
+			cmdutil.CheckErr(opts.Validate())
+			cmdutil.CheckErr(opts.Run(context.Background()))
+		},
+	}
+	cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodPortForwardWaitTimeout)
+	cmd.Flags().StringSliceVar(&opts.KubectlPortForwardOptions.Address, "address", []string{"localhost"}, "Addresses to listen on (comma separated). Only accepts IP addresses or localhost as a value. When localhost is supplied, kubectl will try to bind on both 127.0.0.1 and ::1 and will fail if neither of these addresses are available to bind.")
+	cmd.Flags().StringVarP(options.DefaultConfigFlags.Namespace, "namespace", "n", *options.DefaultConfigFlags.Namespace, "If present, the namespace scope for this CLI request")
+	opts.OperationScope = options.KarmadaControlPlane
+	cmd.Flags().Var(&opts.OperationScope, "operation-scope", "Used to control the operation scope of the command. The optional values are karmada and members. Defaults to karmada.")
+	cmd.Flags().StringVarP(&opts.Cluster, "cluster", "C", "", "Used to specify a target member cluster and only takes effect when the command's operation scope is members, for example: --operation-scope=members --cluster=member1")
+
+	return cmd
+}
+
+// CommandPortForwardOptions contains the input to the port-forward command.
+type CommandPortForwardOptions struct {
+	KubectlPortForwardOptions *kubectlportforward.PortForwardOptions
+	Cluster                   string
+	OperationScope            options.OperationScope
+}
+
+type defaultPortForwarder struct {
+	genericiooptions.IOStreams
+}
+
+// ForwardPorts port-forward to specify url.
+func (f *defaultPortForwarder) ForwardPorts(method string, url *url.URL, opts kubectlportforward.PortForwardOptions) error {
+	transport, upgrader, err := spdy.RoundTripperFor(opts.Config)
+	if err != nil {
+		return err
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, method, url)
+	fw, err := portforward.NewOnAddresses(dialer, opts.Address, opts.Ports, opts.StopChannel, opts.ReadyChannel, f.Out, f.ErrOut)
+	if err != nil {
+		return err
+	}
+	return fw.ForwardPorts()
+}
+
+// PreCheck precondition check operation-scope and other flags.
+func (o *CommandPortForwardOptions) PreCheck() error {
+	err := options.VerifyOperationScopeFlags(o.OperationScope, options.KarmadaControlPlane, options.Members)
+	if err != nil {
+		return err
+	}
+	if o.OperationScope == options.Members && len(o.Cluster) == 0 {
+		return fmt.Errorf("must specify a member cluster")
+	}
+	return nil
+}
+
+// Complete ensures that options are valid and marshals them if necessary
+func (o *CommandPortForwardOptions) Complete(f util.Factory, cmd *cobra.Command, args []string) error {
+	var portForwardFactory cmdutil.Factory = f
+	if o.OperationScope == options.KarmadaControlPlane {
+		portForwardFactory = f
+	}
+	if o.OperationScope == options.Members && len(o.Cluster) != 0 {
+		memberFactory, err := f.FactoryForMemberCluster(o.Cluster)
+		if err != nil {
+			return err
+		}
+		portForwardFactory = memberFactory
+	}
+
+	return o.KubectlPortForwardOptions.Complete(portForwardFactory, cmd, args)
+}
+
+// Validate checks if the parameters are valid
+func (o *CommandPortForwardOptions) Validate() error {
+	return o.KubectlPortForwardOptions.Validate()
+}
+
+// Run implements all the necessary functionality for port-forward cmd.
+// It ends portforwarding when an error is received from the backend, or an os.Interrupt
+// signal is received, or the provided context is done.
+func (o *CommandPortForwardOptions) Run(ctx context.Context) error {
+	return o.KubectlPortForwardOptions.RunPortForwardContext(ctx)
+}

--- a/vendor/k8s.io/kubectl/pkg/cmd/patch/patch.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/patch/patch.go
@@ -1,0 +1,364 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/tools/clientcmd"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/kubectl/pkg/util/completion"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/slice"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var patchTypes = map[string]types.PatchType{"json": types.JSONPatchType, "merge": types.MergePatchType, "strategic": types.StrategicMergePatchType}
+
+// PatchOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
+// referencing the cmd.Flags()
+type PatchOptions struct {
+	resource.FilenameOptions
+
+	RecordFlags *genericclioptions.RecordFlags
+	PrintFlags  *genericclioptions.PrintFlags
+	ToPrinter   func(string) (printers.ResourcePrinter, error)
+	Recorder    genericclioptions.Recorder
+
+	Local       bool
+	PatchType   string
+	Patch       string
+	PatchFile   string
+	Subresource string
+
+	namespace                    string
+	enforceNamespace             bool
+	dryRunStrategy               cmdutil.DryRunStrategy
+	outputFormat                 string
+	args                         []string
+	builder                      *resource.Builder
+	unstructuredClientForMapping func(mapping *meta.RESTMapping) (resource.RESTClient, error)
+	fieldManager                 string
+
+	genericiooptions.IOStreams
+}
+
+var (
+	patchLong = templates.LongDesc(i18n.T(`
+		Update fields of a resource using strategic merge patch, a JSON merge patch, or a JSON patch.
+
+		JSON and YAML formats are accepted.
+
+		Note: Strategic merge patch is not supported for custom resources.`))
+
+	patchExample = templates.Examples(i18n.T(`
+		# Partially update a node using a strategic merge patch, specifying the patch as JSON
+		kubectl patch node k8s-node-1 -p '{"spec":{"unschedulable":true}}'
+
+		# Partially update a node using a strategic merge patch, specifying the patch as YAML
+		kubectl patch node k8s-node-1 -p $'spec:\n unschedulable: true'
+
+		# Partially update a node identified by the type and name specified in "node.json" using strategic merge patch
+		kubectl patch -f node.json -p '{"spec":{"unschedulable":true}}'
+
+		# Update a container's image; spec.containers[*].name is required because it's a merge key
+		kubectl patch pod valid-pod -p '{"spec":{"containers":[{"name":"kubernetes-serve-hostname","image":"new image"}]}}'
+
+		# Update a container's image using a JSON patch with positional arrays
+		kubectl patch pod valid-pod --type='json' -p='[{"op": "replace", "path": "/spec/containers/0/image", "value":"new image"}]'
+
+		# Update a deployment's replicas through the 'scale' subresource using a merge patch
+		kubectl patch deployment nginx-deployment --subresource='scale' --type='merge' -p '{"spec":{"replicas":2}}'`))
+)
+
+var supportedSubresources = []string{"status", "scale"}
+
+func NewPatchOptions(ioStreams genericiooptions.IOStreams) *PatchOptions {
+	return &PatchOptions{
+		RecordFlags: genericclioptions.NewRecordFlags(),
+		Recorder:    genericclioptions.NoopRecorder{},
+		PrintFlags:  genericclioptions.NewPrintFlags("patched").WithTypeSetter(scheme.Scheme),
+		IOStreams:   ioStreams,
+	}
+}
+
+func NewCmdPatch(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
+	o := NewPatchOptions(ioStreams)
+
+	cmd := &cobra.Command{
+		Use:                   "patch (-f FILENAME | TYPE NAME) [-p PATCH|--patch-file FILE]",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Update fields of a resource"),
+		Long:                  patchLong,
+		Example:               patchExample,
+		ValidArgsFunction:     completion.ResourceTypeAndNameCompletionFunc(f),
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.Complete(f, cmd, args))
+			cmdutil.CheckErr(o.Validate())
+			cmdutil.CheckErr(o.RunPatch())
+		},
+	}
+
+	o.RecordFlags.AddFlags(cmd)
+	o.PrintFlags.AddFlags(cmd)
+
+	cmd.Flags().StringVarP(&o.Patch, "patch", "p", "", "The patch to be applied to the resource JSON file.")
+	cmd.Flags().StringVar(&o.PatchFile, "patch-file", "", "A file containing a patch to be applied to the resource.")
+	cmd.Flags().StringVar(&o.PatchType, "type", "strategic", fmt.Sprintf("The type of patch being provided; one of %v", sets.StringKeySet(patchTypes).List()))
+	cmdutil.AddDryRunFlag(cmd)
+	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, "identifying the resource to update")
+	cmd.Flags().BoolVar(&o.Local, "local", o.Local, "If true, patch will operate on the content of the file, not the server-side resource.")
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-patch")
+	cmdutil.AddSubresourceFlags(cmd, &o.Subresource, "If specified, patch will operate on the subresource of the requested object.", supportedSubresources...)
+
+	return cmd
+}
+
+func (o *PatchOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	var err error
+	o.RecordFlags.Complete(cmd)
+	o.Recorder, err = o.RecordFlags.ToRecorder()
+	if err != nil {
+		return err
+	}
+
+	o.outputFormat = cmdutil.GetFlagString(cmd, "output")
+	o.dryRunStrategy, err = cmdutil.GetDryRunStrategy(cmd)
+	if err != nil {
+		return err
+	}
+
+	cmdutil.PrintFlagsWithDryRunStrategy(o.PrintFlags, o.dryRunStrategy)
+	o.ToPrinter = func(operation string) (printers.ResourcePrinter, error) {
+		o.PrintFlags.NamePrintFlags.Operation = operation
+
+		return o.PrintFlags.ToPrinter()
+	}
+
+	o.namespace, o.enforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
+	if err != nil && !(o.Local && clientcmd.IsEmptyConfig(err)) {
+		return err
+	}
+	o.args = args
+	o.builder = f.NewBuilder()
+	o.unstructuredClientForMapping = f.UnstructuredClientForMapping
+
+	return nil
+}
+
+func (o *PatchOptions) Validate() error {
+	if len(o.Patch) > 0 && len(o.PatchFile) > 0 {
+		return fmt.Errorf("cannot specify --patch and --patch-file together")
+	}
+	if len(o.Patch) == 0 && len(o.PatchFile) == 0 {
+		return fmt.Errorf("must specify --patch or --patch-file containing the contents of the patch")
+	}
+	if o.Local && len(o.args) != 0 {
+		return fmt.Errorf("cannot specify --local and server resources")
+	}
+	if o.Local && o.dryRunStrategy == cmdutil.DryRunServer {
+		return fmt.Errorf("cannot specify --local and --dry-run=server - did you mean --dry-run=client?")
+	}
+	if len(o.PatchType) != 0 {
+		if _, ok := patchTypes[strings.ToLower(o.PatchType)]; !ok {
+			return fmt.Errorf("--type must be one of %v, not %q", sets.StringKeySet(patchTypes).List(), o.PatchType)
+		}
+	}
+	if len(o.Subresource) > 0 && !slice.ContainsString(supportedSubresources, o.Subresource, nil) {
+		return fmt.Errorf("invalid subresource value: %q. Must be one of %v", o.Subresource, supportedSubresources)
+	}
+	return nil
+}
+
+func (o *PatchOptions) RunPatch() error {
+	patchType := types.StrategicMergePatchType
+	if len(o.PatchType) != 0 {
+		patchType = patchTypes[strings.ToLower(o.PatchType)]
+	}
+
+	var patchBytes []byte
+	if len(o.PatchFile) > 0 {
+		var err error
+		patchBytes, err = os.ReadFile(o.PatchFile)
+		if err != nil {
+			return fmt.Errorf("unable to read patch file: %v", err)
+		}
+	} else {
+		patchBytes = []byte(o.Patch)
+	}
+
+	patchBytes, err := yaml.ToJSON(patchBytes)
+	if err != nil {
+		return fmt.Errorf("unable to parse %q: %v", o.Patch, err)
+	}
+
+	r := o.builder.
+		Unstructured().
+		ContinueOnError().
+		LocalParam(o.Local).
+		NamespaceParam(o.namespace).DefaultNamespace().
+		FilenameParam(o.enforceNamespace, &o.FilenameOptions).
+		Subresource(o.Subresource).
+		ResourceTypeOrNameArgs(false, o.args...).
+		Flatten().
+		Do()
+	err = r.Err()
+	if err != nil {
+		return err
+	}
+
+	count := 0
+	err = r.Visit(func(info *resource.Info, err error) error {
+		if err != nil {
+			return err
+		}
+		count++
+		name, namespace := info.Name, info.Namespace
+
+		if !o.Local && o.dryRunStrategy != cmdutil.DryRunClient {
+			mapping := info.ResourceMapping()
+			client, err := o.unstructuredClientForMapping(mapping)
+			if err != nil {
+				return err
+			}
+
+			helper := resource.
+				NewHelper(client, mapping).
+				DryRun(o.dryRunStrategy == cmdutil.DryRunServer).
+				WithFieldManager(o.fieldManager).
+				WithSubresource(o.Subresource)
+			patchedObj, err := helper.Patch(namespace, name, patchType, patchBytes, nil)
+			if err != nil {
+				if apierrors.IsUnsupportedMediaType(err) {
+					return errors.Wrap(err, fmt.Sprintf("%s is not supported by %s", patchType, mapping.GroupVersionKind))
+				}
+				return err
+			}
+
+			didPatch := !reflect.DeepEqual(info.Object, patchedObj)
+
+			// if the recorder makes a change, compute and create another patch
+			if mergePatch, err := o.Recorder.MakeRecordMergePatch(patchedObj); err != nil {
+				klog.V(4).Infof("error recording current command: %v", err)
+			} else if len(mergePatch) > 0 {
+				if recordedObj, err := helper.Patch(namespace, name, types.MergePatchType, mergePatch, nil); err != nil {
+					klog.V(4).Infof("error recording reason: %v", err)
+				} else {
+					patchedObj = recordedObj
+				}
+			}
+
+			printer, err := o.ToPrinter(patchOperation(didPatch))
+			if err != nil {
+				return err
+			}
+			return printer.PrintObj(patchedObj, o.Out)
+		}
+
+		originalObjJS, err := runtime.Encode(unstructured.UnstructuredJSONScheme, info.Object)
+		if err != nil {
+			return err
+		}
+
+		originalPatchedObjJS, err := getPatchedJSON(patchType, originalObjJS, patchBytes, info.Object.GetObjectKind().GroupVersionKind(), scheme.Scheme)
+		if err != nil {
+			return err
+		}
+
+		targetObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, originalPatchedObjJS)
+		if err != nil {
+			return err
+		}
+
+		didPatch := !reflect.DeepEqual(info.Object, targetObj)
+		printer, err := o.ToPrinter(patchOperation(didPatch))
+		if err != nil {
+			return err
+		}
+		return printer.PrintObj(targetObj, o.Out)
+	})
+	if err != nil {
+		return err
+	}
+	if count == 0 {
+		return fmt.Errorf("no objects passed to patch")
+	}
+	return nil
+}
+
+func getPatchedJSON(patchType types.PatchType, originalJS, patchJS []byte, gvk schema.GroupVersionKind, creater runtime.ObjectCreater) ([]byte, error) {
+	switch patchType {
+	case types.JSONPatchType:
+		patchObj, err := jsonpatch.DecodePatch(patchJS)
+		if err != nil {
+			return nil, err
+		}
+		bytes, err := patchObj.Apply(originalJS)
+		// TODO: This is pretty hacky, we need a better structured error from the json-patch
+		if err != nil && strings.Contains(err.Error(), "doc is missing key") {
+			msg := err.Error()
+			ix := strings.Index(msg, "key:")
+			key := msg[ix+5:]
+			return bytes, fmt.Errorf("Object to be patched is missing field (%s)", key)
+		}
+		return bytes, err
+
+	case types.MergePatchType:
+		return jsonpatch.MergePatch(originalJS, patchJS)
+
+	case types.StrategicMergePatchType:
+		// get a typed object for this GVK if we need to apply a strategic merge patch
+		obj, err := creater.New(gvk)
+		if err != nil {
+			return nil, fmt.Errorf("strategic merge patch is not supported for %s locally, try --type merge", gvk.String())
+		}
+		return strategicpatch.StrategicMergePatch(originalJS, patchJS, obj)
+
+	default:
+		// only here as a safety net - go-restful filters content-type
+		return nil, fmt.Errorf("unknown Content-Type header for patch: %v", patchType)
+	}
+}
+
+func patchOperation(didPatch bool) string {
+	if didPatch {
+		return "patched"
+	}
+	return "patched (no change)"
+}

--- a/vendor/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
@@ -1,0 +1,444 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/kubernetes/scheme"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/polymorphichelpers"
+	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+// PortForwardOptions contains all the options for running the port-forward cli command.
+type PortForwardOptions struct {
+	Namespace     string
+	PodName       string
+	RESTClient    restclient.Interface
+	Config        *restclient.Config
+	PodClient     corev1client.PodsGetter
+	Address       []string
+	Ports         []string
+	PortForwarder portForwarder
+	StopChannel   chan struct{}
+	ReadyChannel  chan struct{}
+}
+
+var (
+	portforwardLong = templates.LongDesc(i18n.T(`
+                Forward one or more local ports to a pod.
+
+                Use resource type/name such as deployment/mydeployment to select a pod. Resource type defaults to 'pod' if omitted.
+
+                If there are multiple pods matching the criteria, a pod will be selected automatically. The
+                forwarding session ends when the selected pod terminates, and a rerun of the command is needed
+                to resume forwarding.`))
+
+	portforwardExample = templates.Examples(i18n.T(`
+		# Listen on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in the pod
+		kubectl port-forward pod/mypod 5000 6000
+
+		# Listen on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in a pod selected by the deployment
+		kubectl port-forward deployment/mydeployment 5000 6000
+
+		# Listen on port 8443 locally, forwarding to the targetPort of the service's port named "https" in a pod selected by the service
+		kubectl port-forward service/myservice 8443:https
+
+		# Listen on port 8888 locally, forwarding to 5000 in the pod
+		kubectl port-forward pod/mypod 8888:5000
+
+		# Listen on port 8888 on all addresses, forwarding to 5000 in the pod
+		kubectl port-forward --address 0.0.0.0 pod/mypod 8888:5000
+
+		# Listen on port 8888 on localhost and selected IP, forwarding to 5000 in the pod
+		kubectl port-forward --address localhost,10.19.21.23 pod/mypod 8888:5000
+
+		# Listen on a random port locally, forwarding to 5000 in the pod
+		kubectl port-forward pod/mypod :5000`))
+)
+
+const (
+	// Amount of time to wait until at least one pod is running
+	defaultPodPortForwardWaitTimeout = 60 * time.Second
+)
+
+func NewCmdPortForward(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+	opts := NewDefaultPortForwardOptions(streams)
+	cmd := &cobra.Command{
+		Use:                   "port-forward TYPE/NAME [options] [LOCAL_PORT:]REMOTE_PORT [...[LOCAL_PORT_N:]REMOTE_PORT_N]",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Forward one or more local ports to a pod"),
+		Long:                  portforwardLong,
+		Example:               portforwardExample,
+		ValidArgsFunction:     completion.PodResourceNameCompletionFunc(f),
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(opts.Complete(f, cmd, args))
+			cmdutil.CheckErr(opts.Validate())
+			cmdutil.CheckErr(opts.RunPortForward())
+		},
+	}
+	cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodPortForwardWaitTimeout)
+	cmd.Flags().StringSliceVar(&opts.Address, "address", []string{"localhost"}, "Addresses to listen on (comma separated). Only accepts IP addresses or localhost as a value. When localhost is supplied, kubectl will try to bind on both 127.0.0.1 and ::1 and will fail if neither of these addresses are available to bind.")
+	// TODO support UID
+	return cmd
+}
+
+func NewDefaultPortForwardOptions(streams genericiooptions.IOStreams) *PortForwardOptions {
+	return &PortForwardOptions{
+		PortForwarder: &defaultPortForwarder{
+			IOStreams: streams,
+		},
+	}
+}
+
+type portForwarder interface {
+	ForwardPorts(method string, url *url.URL, opts PortForwardOptions) error
+}
+
+type defaultPortForwarder struct {
+	genericiooptions.IOStreams
+}
+
+func (f *defaultPortForwarder) ForwardPorts(method string, url *url.URL, opts PortForwardOptions) error {
+	transport, upgrader, err := spdy.RoundTripperFor(opts.Config)
+	if err != nil {
+		return err
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, method, url)
+	if cmdutil.PortForwardWebsockets.IsEnabled() {
+		tunnelingDialer, err := portforward.NewSPDYOverWebsocketDialer(url, opts.Config)
+		if err != nil {
+			return err
+		}
+		// First attempt tunneling (websocket) dialer, then fallback to spdy dialer.
+		dialer = portforward.NewFallbackDialer(tunnelingDialer, dialer, httpstream.IsUpgradeFailure)
+	}
+	fw, err := portforward.NewOnAddresses(dialer, opts.Address, opts.Ports, opts.StopChannel, opts.ReadyChannel, f.Out, f.ErrOut)
+	if err != nil {
+		return err
+	}
+	return fw.ForwardPorts()
+}
+
+// splitPort splits port string which is in form of [LOCAL PORT]:REMOTE PORT
+// and returns local and remote ports separately
+func splitPort(port string) (local, remote string) {
+	parts := strings.Split(port, ":")
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+
+	return parts[0], parts[0]
+}
+
+// Translates service port to target port
+// It rewrites ports as needed if the Service port declares targetPort.
+// It returns an error when a named targetPort can't find a match in the pod, or the Service did not declare
+// the port.
+func translateServicePortToTargetPort(ports []string, svc corev1.Service, pod corev1.Pod) ([]string, error) {
+	var translated []string
+	for _, port := range ports {
+		localPort, remotePort := splitPort(port)
+
+		portnum, err := strconv.Atoi(remotePort)
+		if err != nil {
+			svcPort, err := util.LookupServicePortNumberByName(svc, remotePort)
+			if err != nil {
+				return nil, err
+			}
+			portnum = int(svcPort)
+
+			if localPort == remotePort {
+				localPort = strconv.Itoa(portnum)
+			}
+		}
+		containerPort, err := util.LookupContainerPortNumberByServicePort(svc, pod, int32(portnum))
+		if err != nil {
+			// can't resolve a named port, or Service did not declare this port, return an error
+			return nil, err
+		}
+
+		// convert the resolved target port back to a string
+		remotePort = strconv.Itoa(int(containerPort))
+
+		if localPort != remotePort {
+			translated = append(translated, fmt.Sprintf("%s:%s", localPort, remotePort))
+		} else {
+			translated = append(translated, remotePort)
+		}
+	}
+	return translated, nil
+}
+
+// convertPodNamedPortToNumber converts named ports into port numbers
+// It returns an error when a named port can't be found in the pod containers
+func convertPodNamedPortToNumber(ports []string, pod corev1.Pod) ([]string, error) {
+	var converted []string
+	for _, port := range ports {
+		localPort, remotePort := splitPort(port)
+
+		containerPortStr := remotePort
+		_, err := strconv.Atoi(remotePort)
+		if err != nil {
+			containerPort, err := util.LookupContainerPortNumberByName(pod, remotePort)
+			if err != nil {
+				return nil, err
+			}
+
+			containerPortStr = strconv.Itoa(int(containerPort))
+		}
+
+		if localPort != remotePort {
+			converted = append(converted, fmt.Sprintf("%s:%s", localPort, containerPortStr))
+		} else {
+			converted = append(converted, containerPortStr)
+		}
+	}
+
+	return converted, nil
+}
+
+func checkUDPPorts(udpOnlyPorts sets.Int, ports []string, obj metav1.Object) error {
+	for _, port := range ports {
+		_, remotePort := splitPort(port)
+		portNum, err := strconv.Atoi(remotePort)
+		if err != nil {
+			switch v := obj.(type) {
+			case *corev1.Service:
+				svcPort, err := util.LookupServicePortNumberByName(*v, remotePort)
+				if err != nil {
+					return err
+				}
+				portNum = int(svcPort)
+
+			case *corev1.Pod:
+				ctPort, err := util.LookupContainerPortNumberByName(*v, remotePort)
+				if err != nil {
+					return err
+				}
+				portNum = int(ctPort)
+
+			default:
+				return fmt.Errorf("unknown object: %v", obj)
+			}
+		}
+		if udpOnlyPorts.Has(portNum) {
+			return fmt.Errorf("UDP protocol is not supported for %s", remotePort)
+		}
+	}
+	return nil
+}
+
+// checkUDPPortInService returns an error if remote port in Service is a UDP port
+// TODO: remove this check after #47862 is solved
+func checkUDPPortInService(ports []string, svc *corev1.Service) error {
+	udpPorts := sets.NewInt()
+	tcpPorts := sets.NewInt()
+	for _, port := range svc.Spec.Ports {
+		portNum := int(port.Port)
+		switch port.Protocol {
+		case corev1.ProtocolUDP:
+			udpPorts.Insert(portNum)
+		case corev1.ProtocolTCP:
+			tcpPorts.Insert(portNum)
+		}
+	}
+	return checkUDPPorts(udpPorts.Difference(tcpPorts), ports, svc)
+}
+
+// checkUDPPortInPod returns an error if remote port in Pod is a UDP port
+// TODO: remove this check after #47862 is solved
+func checkUDPPortInPod(ports []string, pod *corev1.Pod) error {
+	udpPorts := sets.NewInt()
+	tcpPorts := sets.NewInt()
+	for _, ct := range pod.Spec.Containers {
+		for _, ctPort := range ct.Ports {
+			portNum := int(ctPort.ContainerPort)
+			switch ctPort.Protocol {
+			case corev1.ProtocolUDP:
+				udpPorts.Insert(portNum)
+			case corev1.ProtocolTCP:
+				tcpPorts.Insert(portNum)
+			}
+		}
+	}
+	return checkUDPPorts(udpPorts.Difference(tcpPorts), ports, pod)
+}
+
+// Complete completes all the required options for port-forward cmd.
+func (o *PortForwardOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	var err error
+	if len(args) < 2 {
+		return cmdutil.UsageErrorf(cmd, "TYPE/NAME and list of ports are required for port-forward")
+	}
+
+	o.Namespace, _, err = f.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return err
+	}
+
+	builder := f.NewBuilder().
+		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
+		ContinueOnError().
+		NamespaceParam(o.Namespace).DefaultNamespace()
+
+	getPodTimeout, err := cmdutil.GetPodRunningTimeoutFlag(cmd)
+	if err != nil {
+		return cmdutil.UsageErrorf(cmd, err.Error())
+	}
+
+	resourceName := args[0]
+	builder.ResourceNames("pods", resourceName)
+
+	obj, err := builder.Do().Object()
+	if err != nil {
+		return err
+	}
+
+	forwardablePod, err := polymorphichelpers.AttachablePodForObjectFn(f, obj, getPodTimeout)
+	if err != nil {
+		return err
+	}
+
+	o.PodName = forwardablePod.Name
+
+	// handle service port mapping to target port if needed
+	switch t := obj.(type) {
+	case *corev1.Service:
+		err = checkUDPPortInService(args[1:], t)
+		if err != nil {
+			return err
+		}
+		o.Ports, err = translateServicePortToTargetPort(args[1:], *t, *forwardablePod)
+		if err != nil {
+			return err
+		}
+	default:
+		err = checkUDPPortInPod(args[1:], forwardablePod)
+		if err != nil {
+			return err
+		}
+		o.Ports, err = convertPodNamedPortToNumber(args[1:], *forwardablePod)
+		if err != nil {
+			return err
+		}
+	}
+
+	clientset, err := f.KubernetesClientSet()
+	if err != nil {
+		return err
+	}
+
+	o.PodClient = clientset.CoreV1()
+
+	o.Config, err = f.ToRESTConfig()
+	if err != nil {
+		return err
+	}
+	o.RESTClient, err = f.RESTClient()
+	if err != nil {
+		return err
+	}
+
+	o.StopChannel = make(chan struct{}, 1)
+	o.ReadyChannel = make(chan struct{})
+	return nil
+}
+
+// Validate validates all the required options for port-forward cmd.
+func (o PortForwardOptions) Validate() error {
+	if len(o.PodName) == 0 {
+		return fmt.Errorf("pod name or resource type/name must be specified")
+	}
+
+	if len(o.Ports) < 1 {
+		return fmt.Errorf("at least 1 PORT is required for port-forward")
+	}
+
+	if o.PortForwarder == nil || o.PodClient == nil || o.RESTClient == nil || o.Config == nil {
+		return fmt.Errorf("client, client config, restClient, and portforwarder must be provided")
+	}
+	return nil
+}
+
+// Deprecated: Use RunPortForwardContext instead, which allows canceling.
+// RunPortForward implements all the necessary functionality for port-forward cmd.
+func (o PortForwardOptions) RunPortForward() error {
+	return o.RunPortForwardContext(context.Background())
+}
+
+// RunPortForwardContext implements all the necessary functionality for port-forward cmd.
+// It ends portforwarding when an error is received from the backend, or an os.Interrupt
+// signal is received, or the provided context is done.
+func (o PortForwardOptions) RunPortForwardContext(ctx context.Context) error {
+	pod, err := o.PodClient.Pods(o.Namespace).Get(ctx, o.PodName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if pod.Status.Phase != corev1.PodRunning {
+		return fmt.Errorf("unable to forward port because pod is not running. Current status=%v", pod.Status.Phase)
+	}
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt)
+	defer signal.Stop(signals)
+
+	returnCtx, returnCtxCancel := context.WithCancel(ctx)
+	defer returnCtxCancel()
+
+	go func() {
+		select {
+		case <-signals:
+		case <-returnCtx.Done():
+		}
+		if o.StopChannel != nil {
+			close(o.StopChannel)
+		}
+	}()
+
+	req := o.RESTClient.Post().
+		Resource("pods").
+		Namespace(o.Namespace).
+		Name(pod.Name).
+		SubResource("portforward")
+
+	return o.PortForwarder.ForwardPorts("POST", req.URL(), o)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1695,6 +1695,7 @@ k8s.io/kubectl/pkg/cmd/get
 k8s.io/kubectl/pkg/cmd/label
 k8s.io/kubectl/pkg/cmd/logs
 k8s.io/kubectl/pkg/cmd/patch
+k8s.io/kubectl/pkg/cmd/portforward
 k8s.io/kubectl/pkg/cmd/testing
 k8s.io/kubectl/pkg/cmd/util
 k8s.io/kubectl/pkg/cmd/util/editor

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1694,6 +1694,7 @@ k8s.io/kubectl/pkg/cmd/explain
 k8s.io/kubectl/pkg/cmd/get
 k8s.io/kubectl/pkg/cmd/label
 k8s.io/kubectl/pkg/cmd/logs
+k8s.io/kubectl/pkg/cmd/patch
 k8s.io/kubectl/pkg/cmd/testing
 k8s.io/kubectl/pkg/cmd/util
 k8s.io/kubectl/pkg/cmd/util/editor


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
add new command `port-forward` to forward one or more local ports to a pod

**Which issue(s) this PR fixes**:
parts of  #5249

**Special notes for your reviewer**:
```shell
$ karmadactl port-forward --operation-scope members service/metrics-server 443 -nkube-system --cluster member1
Forwarding from 127.0.0.1:443 -> 4443
Forwarding from [::1]:443 -> 4443
```


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: add new command `port-forward` to forward one or more local ports to a pod
```

