### PR TITLE
Expose metrics port for operator installation

### DIFF
--- a/operator/pkg/controlplane/manifests.go
+++ b/operator/pkg/controlplane/manifests.go
@@ -128,6 +128,7 @@ spec:
         command:
         - /bin/karmada-controller-manager
         - --kubeconfig=/etc/karmada/kubeconfig
+        - --metrics-bind-address=:8080
         - --cluster-status-update-frequency=10s
         - --failover-eviction-timeout=30s
         - --leader-elect-resource-namespace={{ .SystemNamespace }}
@@ -142,6 +143,10 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 15
           timeoutSeconds: 5
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
         volumeMounts:
         - name: kubeconfig
           subPath: kubeconfig
@@ -200,6 +205,10 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 15
           timeoutSeconds: 5
+        ports:
+        - containerPort: 10351
+          name: metrics
+          protocol: TCP
         volumeMounts:
         - name: karmada-certs
           mountPath: /etc/karmada/pki
@@ -263,6 +272,10 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 15
           timeoutSeconds: 5
+        ports:
+        - containerPort: 10358
+          name: metrics
+          protocol: TCP
         volumeMounts:
         - name: karmada-certs
           mountPath: /etc/karmada/pki

--- a/operator/pkg/controlplane/webhook/mainfests.go
+++ b/operator/pkg/controlplane/webhook/mainfests.go
@@ -49,6 +49,7 @@ spec:
         - /bin/karmada-webhook
         - --kubeconfig=/etc/karmada/kubeconfig
         - --bind-address=0.0.0.0
+        - --metrics-bind-address=:8080
         - --default-not-ready-toleration-seconds=30
         - --default-unreachable-toleration-seconds=30
         - --secure-port=8443
@@ -56,6 +57,9 @@ spec:
         - --v=4
         ports:
         - containerPort: 8443
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
         volumeMounts:
         - name: kubeconfig
           subPath: kubeconfig


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Expose metrics port for operator installation

**Which issue(s) this PR fixes**:

Fixes part of #5166

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Expose the metrics port for the karmada-controller-manager, scheduler、karmada-webhook and descheduler in operator installation.
```

