### PR TITLE
ci: add github token for update-krew-index

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,6 +202,8 @@ jobs:
       upload-assets: true
 
   update-krew-index:
+    env: 
+      GH_TOKEN: ${{ github.token }}
     needs: 
     - release-assests
     name: Update krew-index


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind cleanup
**What this PR does / why we need it**:

https://github.com/karmada-io/karmada/actions/runs/10645084310/job/29510560441
```shell
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```
github action has made some updates. If you use the gh command, you must pass the GH_TOKEN env

/hold 
Let me test the whole process in the fork repo
/assign @RainbowMango @zhzhuang-zju 



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

