### PR TITLE
Automated cherry pick of #5469: ci: add github token for update-krew-index

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,6 +202,8 @@ jobs:
       upload-assets: true
 
   update-krew-index:
+    env: 
+      GH_TOKEN: ${{ github.token }}
     needs: 
     - release-assests
     name: Update krew-index


### PR DESCRIPTION
Cherry pick of #5469 on release-1.11.
#5469: ci: add github token for update-krew-index
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
NONE
```