### PR TITLE
add commandGroup annotation to ctl command

### DIFF
--- a/hack/tools/genkarmadactldocs/gen_karmadactl_docs.go
+++ b/hack/tools/genkarmadactldocs/gen_karmadactl_docs.go
@@ -71,7 +71,7 @@ func GenMarkdownTreeForIndex(cmd *cobra.Command, dir string) error {
 		return err
 	}
 
-	for _, tp := range []string{util.GroupBasic, util.GroupClusterRegistration, util.GroupClusterManagement, util.GroupClusterTroubleshootingAndDebugging, util.GroupAdvancedCommands} {
+	for _, tp := range []string{util.GroupBasic, util.GroupClusterRegistration, util.GroupClusterManagement, util.GroupClusterTroubleshootingAndDebugging, util.GroupAdvancedCommands, util.GroupSettingsCommands, util.GroupOtherCommands} {
 		// write header of type
 		_, err = io.WriteString(f, "## "+tp+"\n\n")
 		if err != nil {

--- a/pkg/karmadactl/annotate/annotate.go
+++ b/pkg/karmadactl/annotate/annotate.go
@@ -51,5 +51,8 @@ var (
 func NewCmdAnnotate(f util.Factory, parentCommand string, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	cmd := kubectlannotate.NewCmdAnnotate(parentCommand, f, ioStreams)
 	cmd.Example = fmt.Sprintf(annotateExample, parentCommand)
+	cmd.Annotations = map[string]string{
+		util.TagCommandGroup: util.GroupSettingsCommands,
+	}
 	return cmd
 }

--- a/pkg/karmadactl/apiresources/apiresources.go
+++ b/pkg/karmadactl/apiresources/apiresources.go
@@ -65,6 +65,9 @@ func NewCmdAPIResources(f util.Factory, parentCommand string, ioStreams generici
 			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.RunAPIResources())
 		},
+		Annotations: map[string]string{
+			util.TagCommandGroup: util.GroupOtherCommands,
+		},
 	}
 
 	o.OperationScope = options.KarmadaControlPlane

--- a/pkg/karmadactl/apiresources/apiversions.go
+++ b/pkg/karmadactl/apiresources/apiversions.go
@@ -53,6 +53,9 @@ func NewCmdAPIVersions(f util.Factory, parentCommand string, ioStreams genericio
 			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.RunAPIVersions())
 		},
+		Annotations: map[string]string{
+			util.TagCommandGroup: util.GroupOtherCommands,
+		},
 	}
 
 	o.OperationScope = options.KarmadaControlPlane

--- a/pkg/karmadactl/attach/attach.go
+++ b/pkg/karmadactl/attach/attach.go
@@ -70,6 +70,9 @@ func NewCmdAttach(f util.Factory, parentCommand string, streams genericiooptions
 			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.Run())
 		},
+		Annotations: map[string]string{
+			util.TagCommandGroup: util.GroupClusterTroubleshootingAndDebugging,
+		},
 	}
 
 	cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodAttachTimeout)

--- a/pkg/karmadactl/create/create.go
+++ b/pkg/karmadactl/create/create.go
@@ -49,5 +49,8 @@ func NewCmdCreate(f util.Factory, parentCommnd string, ioStreams genericiooption
 	cmd := kubectlcreate.NewCmdCreate(f, ioStreams)
 	cmd.Long = fmt.Sprintf(createLong, parentCommnd)
 	cmd.Example = fmt.Sprintf(createExample, parentCommnd)
+	cmd.Annotations = map[string]string{
+		util.TagCommandGroup: util.GroupBasic,
+	}
 	return cmd
 }

--- a/pkg/karmadactl/delete/delete.go
+++ b/pkg/karmadactl/delete/delete.go
@@ -92,5 +92,8 @@ func NewCmdDelete(f util.Factory, parentCommnd string, ioStreams genericiooption
 	cmd := kubectldelete.NewCmdDelete(f, ioStreams)
 	cmd.Long = fmt.Sprintf(deleteLong, parentCommnd)
 	cmd.Example = fmt.Sprintf(deleteExample, parentCommnd)
+	cmd.Annotations = map[string]string{
+		util.TagCommandGroup: util.GroupBasic,
+	}
 	return cmd
 }

--- a/pkg/karmadactl/edit/edit.go
+++ b/pkg/karmadactl/edit/edit.go
@@ -50,5 +50,8 @@ var (
 func NewCmdEdit(f util.Factory, parentCommand string, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	cmd := kubectledit.NewCmdEdit(f, ioStreams)
 	cmd.Example = fmt.Sprintf(editExample, parentCommand)
+	cmd.Annotations = map[string]string{
+		util.TagCommandGroup: util.GroupBasic,
+	}
 	return cmd
 }

--- a/pkg/karmadactl/explain/explain.go
+++ b/pkg/karmadactl/explain/explain.go
@@ -74,6 +74,9 @@ func NewCmdExplain(f util.Factory, parentCommand string, streams genericiooption
 			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.Run())
 		},
+		Annotations: map[string]string{
+			util.TagCommandGroup: util.GroupBasic,
+		},
 	}
 
 	flags := cmd.Flags()

--- a/pkg/karmadactl/label/label.go
+++ b/pkg/karmadactl/label/label.go
@@ -50,5 +50,8 @@ var (
 func NewCmdLabel(f util.Factory, parentCommand string, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	cmd := kubectllabel.NewCmdLabel(f, ioStreams)
 	cmd.Example = fmt.Sprintf(labelExample, parentCommand)
+	cmd.Annotations = map[string]string{
+		util.TagCommandGroup: util.GroupSettingsCommands,
+	}
 	return cmd
 }

--- a/pkg/karmadactl/patch/patch.go
+++ b/pkg/karmadactl/patch/patch.go
@@ -46,5 +46,8 @@ var (
 func NewCmdPatch(f util.Factory, parentCommand string, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	cmd := kubectlpatch.NewCmdPatch(f, ioStreams)
 	cmd.Example = fmt.Sprintf(patchExample, parentCommand)
+	cmd.Annotations = map[string]string{
+		util.TagCommandGroup: util.GroupAdvancedCommands,
+	}
 	return cmd
 }

--- a/pkg/karmadactl/top/top.go
+++ b/pkg/karmadactl/top/top.go
@@ -58,6 +58,9 @@ func NewCmdTop(f util.Factory, parentCommand string, streams genericiooptions.IO
 		Short: "Display resource (CPU/memory) usage of member clusters",
 		Long:  topLong,
 		Run:   cmdutil.DefaultSubCommandRun(streams.ErrOut),
+		Annotations: map[string]string{
+			util.TagCommandGroup: util.GroupAdvancedCommands,
+		},
 	}
 
 	// create subcommands

--- a/pkg/karmadactl/util/command_group.go
+++ b/pkg/karmadactl/util/command_group.go
@@ -36,4 +36,10 @@ const (
 
 	// GroupAdvancedCommands means the command belongs to Group "Advanced Commands"
 	GroupAdvancedCommands = "Advanced Commands"
+
+	// GroupSettingsCommands means the command belongs to Group "Settings Commands"
+	GroupSettingsCommands = "Settings Commands"
+
+	// GroupOtherCommands means the command belongs to Group "Other Commands"
+	GroupOtherCommands = "Other Commands"
 )


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
The `commandGroup` annotation for the ctl command is used for filtering commands when generating the [karmadactl index doc](https://karmada.io/docs/reference/karmadactl/karmadactl-commands/karmadactl_index). Therefore, the appropriate annotations need to be added to the ctl command to prevent the generated documentation from missing relevant sections.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

