### PR TITLE
Add the Ability to Specify the Namespace Used for Discovering Scheduler Estimator Services

### DIFF
--- a/cmd/descheduler/app/options/options.go
+++ b/cmd/descheduler/app/options/options.go
@@ -62,6 +62,8 @@ type Options struct {
 
 	// SchedulerEstimatorTimeout specifies the timeout period of calling the accurate scheduler estimator service.
 	SchedulerEstimatorTimeout metav1.Duration
+	// SchedulerEstimatorServiceNamespace specifies the namespace to be used for discovering scheduler estimator services.
+	SchedulerEstimatorServiceNamespace string
 	// SchedulerEstimatorServicePrefix presents the prefix of the accurate scheduler estimator service name.
 	SchedulerEstimatorServicePrefix string
 	// SchedulerEstimatorPort is the port that the accurate scheduler estimator server serves at.
@@ -129,6 +131,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.SchedulerEstimatorKeyFile, "scheduler-estimator-key-file", "", "SSL key file used to secure scheduler estimator communication.")
 	fs.StringVar(&o.SchedulerEstimatorCaFile, "scheduler-estimator-ca-file", "", "SSL Certificate Authority file used to secure scheduler estimator communication.")
 	fs.BoolVar(&o.InsecureSkipEstimatorVerify, "insecure-skip-estimator-verify", false, "Controls whether verifies the scheduler estimator's certificate chain and host name.")
+	fs.StringVar(&o.SchedulerEstimatorServiceNamespace, "scheduler-estimator-service-namespace", util.NamespaceKarmadaSystem, "The namespace to be used for discovering scheduler estimator services.")
 	fs.StringVar(&o.SchedulerEstimatorServicePrefix, "scheduler-estimator-service-prefix", "karmada-scheduler-estimator", "The prefix of scheduler estimator service name")
 	fs.DurationVar(&o.DeschedulingInterval.Duration, "descheduling-interval", defaultDeschedulingInterval, "Time interval between two consecutive descheduler executions. Setting this value instructs the descheduler to run in a continuous loop at the interval specified.")
 	fs.DurationVar(&o.UnschedulableThreshold.Duration, "unschedulable-threshold", defaultUnschedulableThreshold, "The period of pod unschedulable condition. This value is considered as a classification standard of unschedulable replicas.")

--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -81,6 +81,8 @@ type Options struct {
 	DisableSchedulerEstimatorInPullMode bool
 	// SchedulerEstimatorTimeout specifies the timeout period of calling the accurate scheduler estimator service.
 	SchedulerEstimatorTimeout metav1.Duration
+	// SchedulerEstimatorServiceNamespace specifies the namespace to be used for discovering scheduler estimator services.
+	SchedulerEstimatorServiceNamespace string
 	// SchedulerEstimatorServicePrefix presents the prefix of the accurate scheduler estimator service name.
 	SchedulerEstimatorServicePrefix string
 	// SchedulerEstimatorPort is the port that the accurate scheduler estimator server serves at.
@@ -164,6 +166,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.EnableSchedulerEstimator, "enable-scheduler-estimator", false, "Enable calling cluster scheduler estimator for adjusting replicas.")
 	fs.BoolVar(&o.DisableSchedulerEstimatorInPullMode, "disable-scheduler-estimator-in-pull-mode", false, "Disable the scheduler estimator for clusters in pull mode, which takes effect only when enable-scheduler-estimator is true.")
 	fs.DurationVar(&o.SchedulerEstimatorTimeout.Duration, "scheduler-estimator-timeout", 3*time.Second, "Specifies the timeout period of calling the scheduler estimator service.")
+	fs.StringVar(&o.SchedulerEstimatorServiceNamespace, "scheduler-estimator-service-namespace", util.NamespaceKarmadaSystem, "The namespace to be used for discovering scheduler estimator services.")
 	fs.StringVar(&o.SchedulerEstimatorServicePrefix, "scheduler-estimator-service-prefix", "karmada-scheduler-estimator", "The prefix of scheduler estimator service name")
 	fs.IntVar(&o.SchedulerEstimatorPort, "scheduler-estimator-port", defaultEstimatorPort, "The secure port on which to connect the accurate scheduler estimator.")
 	fs.StringVar(&o.SchedulerEstimatorCertFile, "scheduler-estimator-cert-file", "", "SSL certification file used to secure scheduler estimator communication.")

--- a/cmd/scheduler/app/scheduler.go
+++ b/cmd/scheduler/app/scheduler.go
@@ -171,6 +171,7 @@ func run(opts *options.Options, stopChan <-chan struct{}, registryOptions ...Opt
 		scheduler.WithOutOfTreeRegistry(outOfTreeRegistry),
 		scheduler.WithEnableSchedulerEstimator(opts.EnableSchedulerEstimator),
 		scheduler.WithDisableSchedulerEstimatorInPullMode(opts.DisableSchedulerEstimatorInPullMode),
+		scheduler.WithSchedulerEstimatorServiceNamespace(opts.SchedulerEstimatorServiceNamespace),
 		scheduler.WithSchedulerEstimatorServicePrefix(opts.SchedulerEstimatorServicePrefix),
 		scheduler.WithSchedulerEstimatorConnection(opts.SchedulerEstimatorPort, opts.SchedulerEstimatorCertFile, opts.SchedulerEstimatorKeyFile, opts.SchedulerEstimatorCaFile, opts.InsecureSkipEstimatorVerify),
 		scheduler.WithSchedulerEstimatorTimeout(opts.SchedulerEstimatorTimeout),

--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -64,10 +64,11 @@ type Descheduler struct {
 
 	eventRecorder record.EventRecorder
 
-	schedulerEstimatorCache         *estimatorclient.SchedulerEstimatorCache
-	schedulerEstimatorServicePrefix string
-	schedulerEstimatorClientConfig  *grpcconnection.ClientConfig
-	schedulerEstimatorWorker        util.AsyncWorker
+	schedulerEstimatorCache            *estimatorclient.SchedulerEstimatorCache
+	schedulerEstimatorServiceNamespace string
+	schedulerEstimatorServicePrefix    string
+	schedulerEstimatorClientConfig     *grpcconnection.ClientConfig
+	schedulerEstimatorWorker           util.AsyncWorker
 
 	unschedulableThreshold time.Duration
 	deschedulingInterval   time.Duration
@@ -93,9 +94,10 @@ func NewDescheduler(karmadaClient karmadaclientset.Interface, kubeClient kuberne
 			KeyFile:                  opts.SchedulerEstimatorKeyFile,
 			TargetPort:               opts.SchedulerEstimatorPort,
 		},
-		schedulerEstimatorServicePrefix: opts.SchedulerEstimatorServicePrefix,
-		unschedulableThreshold:          opts.UnschedulableThreshold.Duration,
-		deschedulingInterval:            opts.DeschedulingInterval.Duration,
+		schedulerEstimatorServiceNamespace: opts.SchedulerEstimatorServiceNamespace,
+		schedulerEstimatorServicePrefix:    opts.SchedulerEstimatorServicePrefix,
+		unschedulableThreshold:             opts.UnschedulableThreshold.Duration,
+		deschedulingInterval:               opts.DeschedulingInterval.Duration,
 	}
 	// ignore the error here because the informers haven't been started
 	_ = desched.bindingInformer.SetTransform(fedinformer.StripUnusedFields)
@@ -284,7 +286,12 @@ func (d *Descheduler) establishEstimatorConnections() {
 		return
 	}
 	for i := range clusterList.Items {
-		if err = estimatorclient.EstablishConnection(d.KubeClient, clusterList.Items[i].Name, d.schedulerEstimatorCache, d.schedulerEstimatorServicePrefix, d.schedulerEstimatorClientConfig); err != nil {
+		serviceInfo := estimatorclient.SchedulerEstimatorServiceInfo{
+			Name:       clusterList.Items[i].Name,
+			Namespace:  d.schedulerEstimatorServiceNamespace,
+			NamePrefix: d.schedulerEstimatorServicePrefix,
+		}
+		if err = estimatorclient.EstablishConnection(d.KubeClient, serviceInfo, d.schedulerEstimatorCache, d.schedulerEstimatorClientConfig); err != nil {
 			klog.Error(err)
 		}
 	}
@@ -304,7 +311,12 @@ func (d *Descheduler) reconcileEstimatorConnection(key util.QueueKey) error {
 		}
 		return err
 	}
-	return estimatorclient.EstablishConnection(d.KubeClient, name, d.schedulerEstimatorCache, d.schedulerEstimatorServicePrefix, d.schedulerEstimatorClientConfig)
+	serviceInfo := estimatorclient.SchedulerEstimatorServiceInfo{
+		Name:       name,
+		Namespace:  d.schedulerEstimatorServiceNamespace,
+		NamePrefix: d.schedulerEstimatorServicePrefix,
+	}
+	return estimatorclient.EstablishConnection(d.KubeClient, serviceInfo, d.schedulerEstimatorCache, d.schedulerEstimatorClientConfig)
 }
 
 func (d *Descheduler) recordDescheduleResultEventForResourceBinding(rb *workv1alpha2.ResourceBinding, message string, err error) {

--- a/pkg/estimator/client/cache.go
+++ b/pkg/estimator/client/cache.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/klog/v2"
 
 	estimatorservice "github.com/karmada-io/karmada/pkg/estimator/service"
-	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/grpcconnection"
 	"github.com/karmada-io/karmada/pkg/util/names"
 )
@@ -35,6 +34,13 @@ import (
 type SchedulerEstimatorCache struct {
 	lock      sync.RWMutex
 	estimator map[string]*clientWrapper
+}
+
+// SchedulerEstimatorServiceInfo contains information needed to discover and connect to a scheduler estimator service.
+type SchedulerEstimatorServiceInfo struct {
+	Name       string
+	NamePrefix string
+	Namespace  string
 }
 
 // NewSchedulerEstimatorCache returns an accurate scheduler estimator cache.
@@ -97,25 +103,25 @@ func (c *SchedulerEstimatorCache) GetClient(name string) (estimatorservice.Estim
 }
 
 // EstablishConnection establishes a new gRPC connection with the specified cluster scheduler estimator.
-func EstablishConnection(kubeClient kubernetes.Interface, name string, estimatorCache *SchedulerEstimatorCache, estimatorServicePrefix string, grpcConfig *grpcconnection.ClientConfig) error {
-	if estimatorCache.IsEstimatorExist(name) {
+func EstablishConnection(kubeClient kubernetes.Interface, serviceInfo SchedulerEstimatorServiceInfo, estimatorCache *SchedulerEstimatorCache, grpcConfig *grpcconnection.ClientConfig) error {
+	if estimatorCache.IsEstimatorExist(serviceInfo.Name) {
 		return nil
 	}
 
-	serverAddr, err := resolveCluster(kubeClient, util.NamespaceKarmadaSystem,
-		names.GenerateEstimatorServiceName(estimatorServicePrefix, name), int32(grpcConfig.TargetPort))
+	serverAddr, err := resolveCluster(kubeClient, serviceInfo.Namespace,
+		names.GenerateEstimatorServiceName(serviceInfo.NamePrefix, serviceInfo.Name), int32(grpcConfig.TargetPort))
 	if err != nil {
 		return err
 	}
 
-	klog.Infof("Start dialing estimator server(%s) of cluster(%s).", serverAddr, name)
+	klog.Infof("Start dialing estimator server(%s) of cluster(%s).", serverAddr, serviceInfo.Name)
 	cc, err := grpcConfig.DialWithTimeOut(serverAddr, 5*time.Second)
 	if err != nil {
-		klog.Errorf("Failed to dial cluster(%s): %v.", name, err)
+		klog.Errorf("Failed to dial cluster(%s): %v.", serviceInfo.Name, err)
 		return err
 	}
 	c := estimatorservice.NewEstimatorClient(cc)
-	estimatorCache.AddCluster(name, cc, c)
-	klog.Infof("Connection with estimator server(%s) of cluster(%s) has been established.", serverAddr, name)
+	estimatorCache.AddCluster(serviceInfo.Name, cc, c)
+	klog.Infof("Connection with estimator server(%s) of cluster(%s) has been established.", serverAddr, serviceInfo.Name)
 	return nil
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -40,6 +40,7 @@ func TestCreateScheduler(t *testing.T) {
 	karmadaClient := karmadafake.NewSimpleClientset()
 	kubeClient := fake.NewSimpleClientset()
 	port := 10025
+	serviceNamespace := "tenant1"
 	servicePrefix := "test-service-prefix"
 	schedulerName := "test-scheduler"
 	timeout := metav1.Duration{Duration: 5 * time.Second}
@@ -51,6 +52,7 @@ func TestCreateScheduler(t *testing.T) {
 		schedulerEstimatorPort              int
 		disableSchedulerEstimatorInPullMode bool
 		schedulerEstimatorTimeout           metav1.Duration
+		schedulerEstimatorServiceNamespace  string
 		schedulerEstimatorServicePrefix     string
 		schedulerName                       string
 		schedulerEstimatorClientConfig      *grpcconnection.ClientConfig
@@ -102,6 +104,17 @@ func TestCreateScheduler(t *testing.T) {
 			schedulerEstimatorServicePrefix: servicePrefix,
 		},
 		{
+			name: "scheduler with custom SchedulerEstimatorServiceNamespace set",
+			opts: []Option{
+				WithEnableSchedulerEstimator(true),
+				WithSchedulerEstimatorConnection(port, "", "", "", false),
+				WithSchedulerEstimatorServiceNamespace(serviceNamespace),
+			},
+			enableSchedulerEstimator:           true,
+			schedulerEstimatorPort:             port,
+			schedulerEstimatorServiceNamespace: serviceNamespace,
+		},
+		{
 			name: "scheduler with SchedulerName enabled",
 			opts: []Option{
 				WithSchedulerName(schedulerName),
@@ -145,6 +158,10 @@ func TestCreateScheduler(t *testing.T) {
 
 			if tc.disableSchedulerEstimatorInPullMode != sche.disableSchedulerEstimatorInPullMode {
 				t.Errorf("unexpected disableSchedulerEstimatorInPullMode want %v, got %v", tc.disableSchedulerEstimatorInPullMode, sche.disableSchedulerEstimatorInPullMode)
+			}
+
+			if tc.schedulerEstimatorServiceNamespace != sche.schedulerEstimatorServiceNamespace {
+				t.Errorf("unexpected schedulerEstimatorServiceNamespace want %v, got %v", tc.schedulerEstimatorServiceNamespace, sche.schedulerEstimatorServiceNamespace)
 			}
 
 			if tc.schedulerEstimatorServicePrefix != sche.schedulerEstimatorServicePrefix {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When the scheduler estimator feature is enabled for the Karmada scheduler component, we can then provision scheduler estimator instances for member clusters that will provide the scheduler with more accurate information regarding resources for those member clusters. 

To gain that information, given some member cluster, the scheduler needs to contact the service for that member cluster's scheduler estimator deployment. As of today, it uses a naming convention for discovering those services. By default, given some member cluster `m1`, it will look for a service named `karmada-scheduler-estimator-m1` in the `karmada-system` namespace.
The service name prefix is [configurable](https://github.com/karmada-io/karmada/blob/release-1.10/cmd/scheduler/app/options/options.go#L139), but the namespace is [not](https://github.com/karmada-io/karmada/blob/release-1.10/pkg/estimator/client/cache.go#L104). This feature request is for providing the ability to configure the namespace in which the scheduler should try to discover the service.

At Bloomberg, we're currently building a managed Karmada platform and want to use the Karmada operator to manage the entire lifecycle of managed Karmada instances. Each tenant's control plane will live in a namespace in our host/management cluster. As such, we would also like to keep scheduler estimator instances scoped to their respective tenancy's namespace to avoid polluting the `karmada-system` namespace with instances across all managed tenancies.

**Which issue(s) this PR fixes**:
Fixes #5448

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
The `scheduler-estimator-service-namespace` flag is introduced for the `scheduler` and `descheduler` components. That new flag can be  used to explicitly specify the namespace that should be used to discover scheduler estimator services. For backwards compatibility, when not explicitly set, the default value of `karmada-system` is retained.
```

