### PR TITLE
feat: Added 's' shorthand to operation-scope flags

### DIFF
--- a/pkg/karmadactl/apiresources/apiresources.go
+++ b/pkg/karmadactl/apiresources/apiresources.go
@@ -71,7 +71,7 @@ func NewCmdAPIResources(f util.Factory, parentCommand string, ioStreams generici
 	}
 
 	o.OperationScope = options.KarmadaControlPlane
-	cmd.Flags().Var(&o.OperationScope, "operation-scope", "Used to control the operation scope of the command. The optional values are karmada and members. Defaults to karmada.")
+	cmd.Flags().VarP(&o.OperationScope, "operation-scope", "s", "Used to control the operation scope of the command. The optional values are karmada and members. Defaults to karmada.")
 	cmd.Flags().StringVar(&o.Cluster, "cluster", "", "Used to specify a target member cluster and only takes effect when the command's operation scope is members, for example: --operation-scope=members --cluster=member1")
 	cmd.Flags().BoolVar(&o.NoHeaders, "no-headers", o.NoHeaders, "When using the default or custom-column output format, don't print headers (default print headers).")
 	cmd.Flags().StringVarP(&o.Output, "output", "o", o.Output, `Output format. One of: (wide, name).`)

--- a/pkg/karmadactl/apiresources/apiversions.go
+++ b/pkg/karmadactl/apiresources/apiversions.go
@@ -59,7 +59,7 @@ func NewCmdAPIVersions(f util.Factory, parentCommand string, ioStreams genericio
 	}
 
 	o.OperationScope = options.KarmadaControlPlane
-	cmd.Flags().Var(&o.OperationScope, "operation-scope", "Used to control the operation scope of the command. The optional values are karmada and members. Defaults to karmada.")
+	cmd.Flags().VarP(&o.OperationScope, "operation-scope", "s", "Used to control the operation scope of the command. The optional values are karmada and members. Defaults to karmada.")
 	cmd.Flags().StringVar(&o.Cluster, "cluster", "", "Used to specify a target member cluster and only takes effect when the command's operation scope is members, for example: --operation-scope=members --cluster=member1")
 	return cmd
 }

--- a/pkg/karmadactl/attach/attach.go
+++ b/pkg/karmadactl/attach/attach.go
@@ -83,7 +83,7 @@ func NewCmdAttach(f util.Factory, parentCommand string, streams genericiooptions
 	cmd.Flags().BoolVarP(&o.TTY, "tty", "t", o.TTY, "Stdin is a TTY")
 	cmd.Flags().BoolVarP(&o.Quiet, "quiet", "q", o.Quiet, "Only print output from the remote session")
 	cmd.Flags().StringVarP(options.DefaultConfigFlags.Namespace, "namespace", "n", *options.DefaultConfigFlags.Namespace, "If present, the namespace scope for this CLI request")
-	cmd.Flags().Var(&o.OperationScope, "operation-scope", "Used to control the operation scope of the command. The optional values are karmada and members. Defaults to karmada.")
+	cmd.Flags().VarP(&o.OperationScope, "operation-scope", "s", "Used to control the operation scope of the command. The optional values are karmada and members. Defaults to karmada.")
 	cmd.Flags().StringVar(&o.Cluster, "cluster", "", "Used to specify a target member cluster and only takes effect when the command's operation scope is members, for example: --operation-scope=members --cluster=member1")
 	return cmd
 }

--- a/pkg/karmadactl/describe/describe.go
+++ b/pkg/karmadactl/describe/describe.go
@@ -97,7 +97,7 @@ func NewCmdDescribe(f util.Factory, parentCommand string, streams genericiooptio
 
 	options.AddKubeConfigFlags(flags)
 	o.OperationScope = options.KarmadaControlPlane
-	flags.Var(&o.OperationScope, "operation-scope", "Used to control the operation scope of the command. The optional values are karmada and members. Defaults to karmada.")
+	flags.VarP(&o.OperationScope, "operation-scope", "s", "Used to control the operation scope of the command. The optional values are karmada and members. Defaults to karmada.")
 	flags.StringVarP(options.DefaultConfigFlags.Namespace, "namespace", "n", *options.DefaultConfigFlags.Namespace, "If present, the namespace scope for this CLI request")
 	flags.StringVarP(&o.Cluster, "cluster", "C", "", "Used to specify a target member cluster and only takes effect when the command's operation scope is members, for example: --operation-scope=members --cluster=member1")
 

--- a/pkg/karmadactl/exec/exec.go
+++ b/pkg/karmadactl/exec/exec.go
@@ -109,7 +109,7 @@ func NewCmdExec(f util.Factory, parentCommand string, streams genericiooptions.I
 	flags.BoolVarP(&o.KubectlExecOptions.Stdin, "stdin", "i", o.KubectlExecOptions.Stdin, "Pass stdin to the container")
 	flags.BoolVarP(&o.KubectlExecOptions.TTY, "tty", "t", o.KubectlExecOptions.TTY, "Stdin is a TTY")
 	flags.BoolVarP(&o.KubectlExecOptions.Quiet, "quiet", "q", o.KubectlExecOptions.Quiet, "Only print output from the remote session")
-	flags.Var(&o.OperationScope, "operation-scope", "Used to control the operation scope of the command. The optional values are karmada and members. Defaults to karmada.")
+	flags.VarP(&o.OperationScope, "operation-scope", "s", "Used to control the operation scope of the command. The optional values are karmada and members. Defaults to karmada.")
 	flags.StringVar(&o.Cluster, "cluster", "", "Used to specify a target member cluster and only takes effect when the command's operation scope is members, for example: --operation-scope=members --cluster=member1")
 	return cmd
 }

--- a/pkg/karmadactl/explain/explain.go
+++ b/pkg/karmadactl/explain/explain.go
@@ -81,7 +81,7 @@ func NewCmdExplain(f util.Factory, parentCommand string, streams genericiooption
 
 	flags := cmd.Flags()
 	o.OperationScope = options.KarmadaControlPlane
-	flags.Var(&o.OperationScope, "operation-scope", "Used to control the operation scope of the command. The optional values are karmada and members. Defaults to karmada.")
+	flags.VarP(&o.OperationScope, "operation-scope", "s", "Used to control the operation scope of the command. The optional values are karmada and members. Defaults to karmada.")
 	flags.BoolVar(&o.Recursive, "recursive", o.Recursive, "When true, print the name of all the fields recursively. Otherwise, print the available fields with their description.")
 	flags.StringVar(&o.APIVersion, "api-version", o.APIVersion, "Use given api-version (group/version) of the resource.")
 

--- a/pkg/karmadactl/get/get.go
+++ b/pkg/karmadactl/get/get.go
@@ -150,7 +150,7 @@ func NewCmdGet(f util.Factory, parentCommand string, streams genericiooptions.IO
 	flags := cmd.Flags()
 	options.AddKubeConfigFlags(flags)
 	o.OperationScope = options.KarmadaControlPlane
-	flags.Var(&o.OperationScope, "operation-scope", "Used to control the operation scope of the command. The optional values are karmada, members, and all. Defaults to karmada.")
+	flags.VarP(&o.OperationScope, "operation-scope", "s", "Used to control the operation scope of the command. The optional values are karmada, members, and all. Defaults to karmada.")
 	flags.StringVarP(options.DefaultConfigFlags.Namespace, "namespace", "n", *options.DefaultConfigFlags.Namespace, "If present, the namespace scope for this CLI request")
 	flags.StringVarP(&o.LabelSelector, "labels", "l", "", "-l=label or -l label")
 	flags.StringSliceVarP(&o.Clusters, "clusters", "C", []string{}, "Used to specify target member clusters and only takes effect when the command's operation scope is members or all, for example: --operation-scope=all --clusters=member1,member2")


### PR DESCRIPTION

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
The operation-scope flag gets used a lot when examining resources on member clusters. The 's' shorthand was added to improve user QoL.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: Added shorthand letter `s` to 'operation-scope' flags across commands.
```

