### PR TITLE
feat: skip collection of resource status to Karmada control plane

### DIFF
--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -370,26 +370,28 @@ func startBindingController(ctx controllerscontext.Context) (enabled bool, err e
 
 func startBindingStatusController(ctx controllerscontext.Context) (enabled bool, err error) {
 	rbStatusController := &status.RBStatusController{
-		Client:              ctx.Mgr.GetClient(),
-		DynamicClient:       ctx.DynamicClientSet,
-		InformerManager:     ctx.ControlPlaneInformerManager,
-		ResourceInterpreter: ctx.ResourceInterpreter,
-		EventRecorder:       ctx.Mgr.GetEventRecorderFor(status.RBStatusControllerName),
-		RESTMapper:          ctx.Mgr.GetRESTMapper(),
-		RateLimiterOptions:  ctx.Opts.RateLimiterOptions,
+		Client:               ctx.Mgr.GetClient(),
+		DynamicClient:        ctx.DynamicClientSet,
+		InformerManager:      ctx.ControlPlaneInformerManager,
+		ResourceInterpreter:  ctx.ResourceInterpreter,
+		EventRecorder:        ctx.Mgr.GetEventRecorderFor(status.RBStatusControllerName),
+		RESTMapper:           ctx.Mgr.GetRESTMapper(),
+		RateLimiterOptions:   ctx.Opts.RateLimiterOptions,
+		SkipStatusCollection: ctx.Opts.SkipStatusCollection,
 	}
 	if err := rbStatusController.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err
 	}
 
 	crbStatusController := &status.CRBStatusController{
-		Client:              ctx.Mgr.GetClient(),
-		DynamicClient:       ctx.DynamicClientSet,
-		InformerManager:     ctx.ControlPlaneInformerManager,
-		ResourceInterpreter: ctx.ResourceInterpreter,
-		EventRecorder:       ctx.Mgr.GetEventRecorderFor(status.CRBStatusControllerName),
-		RESTMapper:          ctx.Mgr.GetRESTMapper(),
-		RateLimiterOptions:  ctx.Opts.RateLimiterOptions,
+		Client:               ctx.Mgr.GetClient(),
+		DynamicClient:        ctx.DynamicClientSet,
+		InformerManager:      ctx.ControlPlaneInformerManager,
+		ResourceInterpreter:  ctx.ResourceInterpreter,
+		EventRecorder:        ctx.Mgr.GetEventRecorderFor(status.CRBStatusControllerName),
+		RESTMapper:           ctx.Mgr.GetRESTMapper(),
+		RateLimiterOptions:   ctx.Opts.RateLimiterOptions,
+		SkipStatusCollection: ctx.Opts.SkipStatusCollection,
 	}
 	if err := crbStatusController.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err
@@ -810,6 +812,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 			GracefulEvictionTimeout:           opts.GracefulEvictionTimeout,
 			EnableClusterResourceModeling:     opts.EnableClusterResourceModeling,
 			HPAControllerConfiguration:        opts.HPAControllerConfiguration,
+			SkipStatusCollection:              opts.SkipStatusCollection,
 		},
 		StopChan:                    stopChan,
 		DynamicClientSet:            dynamicClientSet,

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -157,6 +157,10 @@ type Options struct {
 	// in scenario of dynamic replica assignment based on cluster free resources.
 	// Disable if it does not fit your cases for better performance.
 	EnableClusterResourceModeling bool
+	// SkipStatusCollection specifies whether to bypass the aggregation and collection of resource statuses.
+	// By default, it is set to false, meaning resource statuses will reflect in the federated control-plane.
+	// When set to true, the aggregated resource statuses will not reflect.
+	SkipStatusCollection bool
 }
 
 // NewOptions builds an empty options.
@@ -246,6 +250,7 @@ func (o *Options) AddFlags(flags *pflag.FlagSet, allControllers, disabledByDefau
 	flags.BoolVar(&o.EnableClusterResourceModeling, "enable-cluster-resource-modeling", true, "Enable means controller would build resource modeling for each cluster by syncing Nodes and Pods resources.\n"+
 		"The resource modeling might be used by the scheduler to make scheduling decisions in scenario of dynamic replica assignment based on cluster free resources.\n"+
 		"Disable if it does not fit your cases for better performance.")
+	flags.BoolVar(&o.SkipStatusCollection, "skip-status-collection", false, "Skip status collection. By default, it is false which means that resource status will be reflected in federated control-plane.")
 
 	o.RateLimiterOpts.AddFlags(flags)
 	o.ProfileOpts.AddFlags(flags)

--- a/pkg/controllers/context/context.go
+++ b/pkg/controllers/context/context.go
@@ -99,6 +99,10 @@ type Options struct {
 	KarmadaKubeconfigNamespace string
 	// HPAControllerConfiguration is the config of federatedHPA-controller.
 	HPAControllerConfiguration config.HPAControllerConfiguration
+	// SkipStatusCollection specifies whether to bypass the aggregation and collection of resource statuses.
+	// By default, it is set to false, meaning resource statuses will reflect in the federated control-plane.
+	// When set to true, the aggregated resource statuses will not reflect.
+	SkipStatusCollection bool
 }
 
 // Context defines the context object for controller.

--- a/pkg/controllers/status/crb_status_controller_test.go
+++ b/pkg/controllers/status/crb_status_controller_test.go
@@ -156,6 +156,7 @@ func TestCRBStatusController_syncBindingStatus(t *testing.T) {
 		podNameInDynamicClient string
 		resourceExistInClient  bool
 		expectedError          bool
+		skipStatusCollection   bool
 	}{
 		{
 			name: "failed in FetchResourceTemplate, err is NotFound",
@@ -188,6 +189,19 @@ func TestCRBStatusController_syncBindingStatus(t *testing.T) {
 			resourceExistInClient:  false,
 			expectedError:          true,
 		},
+		{
+			name: "skip status collection",
+			resource: workv1alpha2.ObjectReference{
+				APIVersion: "v1",
+				Kind:       "Pod",
+				Namespace:  "default",
+				Name:       "pod",
+			},
+			podNameInDynamicClient: "pod",
+			resourceExistInClient:  true,
+			skipStatusCollection:   true,
+			expectedError:          false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -196,6 +210,7 @@ func TestCRBStatusController_syncBindingStatus(t *testing.T) {
 			c.DynamicClient = dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: tt.podNameInDynamicClient, Namespace: "default"}})
 			c.ResourceInterpreter = FakeResourceInterpreter{DefaultInterpreter: native.NewDefaultInterpreter()}
+			c.SkipStatusCollection = tt.skipStatusCollection
 
 			binding := &workv1alpha2.ClusterResourceBinding{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/status/rb_status_controller_test.go
+++ b/pkg/controllers/status/rb_status_controller_test.go
@@ -157,6 +157,7 @@ func TestRBStatusController_syncBindingStatus(t *testing.T) {
 		podNameInDynamicClient string
 		resourceExistInClient  bool
 		expectedError          bool
+		skipStatusCollection   bool
 	}{
 		{
 			name: "failed in FetchResourceTemplate, err is NotFound",
@@ -189,6 +190,19 @@ func TestRBStatusController_syncBindingStatus(t *testing.T) {
 			resourceExistInClient:  false,
 			expectedError:          true,
 		},
+		{
+			name: "skips collecting status",
+			resource: workv1alpha2.ObjectReference{
+				APIVersion: "v1",
+				Kind:       "Pod",
+				Namespace:  "default",
+				Name:       "pod",
+			},
+			podNameInDynamicClient: "pod",
+			resourceExistInClient:  true,
+			skipStatusCollection:   true,
+			expectedError:          false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -197,6 +211,7 @@ func TestRBStatusController_syncBindingStatus(t *testing.T) {
 			c.DynamicClient = dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
 				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: tt.podNameInDynamicClient, Namespace: "default"}})
 			c.ResourceInterpreter = FakeResourceInterpreter{DefaultInterpreter: native.NewDefaultInterpreter()}
+			c.SkipStatusCollection = tt.skipStatusCollection
 
 			binding := &workv1alpha2.ResourceBinding{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/karmada/issues/5489

**Special notes for your reviewer**:

While this does not represent a regular karmada setup (i.e. federated control-plane and member clusters), it doesn't introduce any regression or complexity of retaining that. It also enables using karmada in different setup mechanisms where it can be installed on a "source" cluster with existing resources/controllers.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

