### PR TITLE
pkg/webhook: unit test override policy

### DIFF
--- a/pkg/webhook/overridepolicy/mutating_test.go
+++ b/pkg/webhook/overridepolicy/mutating_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package overridepolicy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"reflect"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+)
+
+type fakeMutationDecoder struct {
+	err error
+	obj runtime.Object
+}
+
+// Decode mocks the Decode method of admission.Decoder.
+func (f *fakeMutationDecoder) Decode(_ admission.Request, obj runtime.Object) error {
+	if f.err != nil {
+		return f.err
+	}
+	if f.obj != nil {
+		reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(f.obj).Elem())
+	}
+	return nil
+}
+
+// DecodeRaw mocks the DecodeRaw method of admission.Decoder.
+func (f *fakeMutationDecoder) DecodeRaw(_ runtime.RawExtension, obj runtime.Object) error {
+	if f.err != nil {
+		return f.err
+	}
+	if f.obj != nil {
+		reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(f.obj).Elem())
+	}
+	return nil
+}
+
+func TestMutatingAdmission_Handle(t *testing.T) {
+	tests := []struct {
+		name    string
+		decoder admission.Decoder
+		req     admission.Request
+		want    admission.Response
+	}{
+		{
+			name: "Handle_DecodeError_DeniesAdmission",
+			decoder: &fakeValidationDecoder{
+				err: errors.New("decode error"),
+			},
+			req:  admission.Request{},
+			want: admission.Errored(http.StatusBadRequest, errors.New("decode error")),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := MutatingAdmission{
+				Decoder: tt.decoder,
+			}
+			got := m.Handle(context.Background(), tt.req)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Handle() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMutatingAdmission_Handle_FullCoverage(t *testing.T) {
+	// Define the op name and namespace to be used in the test.
+	policyName := "test-override-policy"
+	namespace := "test-namespace"
+
+	// Mock a request with a specific namespace.
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Namespace: namespace,
+			Operation: admissionv1.Create,
+		},
+	}
+
+	// Create the initial op with default values for testing.
+	op := &policyv1alpha1.OverridePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: policyName,
+		},
+		Spec: policyv1alpha1.OverrideSpec{
+			ResourceSelectors: []policyv1alpha1.ResourceSelector{
+				{Namespace: ""},
+				{Namespace: ""},
+			},
+		},
+	}
+
+	// Define the expected op after mutations.
+	wantOP := &policyv1alpha1.OverridePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: policyName,
+		},
+		Spec: policyv1alpha1.OverrideSpec{
+			ResourceSelectors: []policyv1alpha1.ResourceSelector{
+				{Namespace: namespace},
+				{Namespace: namespace},
+			},
+		},
+	}
+
+	// Mock decoder that decodes the request into the policy object.
+	decoder := &fakeMutationDecoder{
+		obj: op,
+	}
+
+	// Marshal the expected op to simulate the final mutated object.
+	wantBytes, err := json.Marshal(wantOP)
+	if err != nil {
+		t.Fatalf("Failed to marshal expected override policy: %v", err)
+	}
+	req.Object.Raw = wantBytes
+
+	// Instantiate the mutating handler.
+	mutatingHandler := MutatingAdmission{
+		Decoder: decoder,
+	}
+
+	// Call the Handle function.
+	got := mutatingHandler.Handle(context.Background(), req)
+
+	// Check if there are any patches applied. There should be no patches if the override policy is handled correctly.
+	if len(got.Patches) > 0 {
+		t.Errorf("Handle() returned patches, but no patches were expected. Got patches: %v", got.Patches)
+	}
+
+	// Check if the admission request was allowed.
+	if !got.Allowed {
+		t.Errorf("Handle() got.Allowed = false, want true")
+	}
+}

--- a/pkg/webhook/overridepolicy/validating_test.go
+++ b/pkg/webhook/overridepolicy/validating_test.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package overridepolicy
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+)
+
+// ResponseType represents the type of admission response.
+type ResponseType string
+
+const (
+	Denied  ResponseType = "Denied"
+	Allowed ResponseType = "Allowed"
+	Errored ResponseType = "Errored"
+)
+
+// TestResponse is used to define expected response in a test case.
+type TestResponse struct {
+	Type    ResponseType
+	Message string
+}
+
+type fakeValidationDecoder struct {
+	err error
+	obj runtime.Object
+}
+
+// Decode mocks the Decode method of admission.Decoder.
+func (f *fakeValidationDecoder) Decode(_ admission.Request, obj runtime.Object) error {
+	if f.err != nil {
+		return f.err
+	}
+	if f.obj != nil {
+		reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(f.obj).Elem())
+	}
+	return nil
+}
+
+// DecodeRaw mocks the DecodeRaw method of admission.Decoder.
+func (f *fakeValidationDecoder) DecodeRaw(_ runtime.RawExtension, obj runtime.Object) error {
+	if f.err != nil {
+		return f.err
+	}
+	if f.obj != nil {
+		reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(f.obj).Elem())
+	}
+	return nil
+}
+
+func TestValidatingAdmission_Handle(t *testing.T) {
+	tests := []struct {
+		name    string
+		decoder admission.Decoder
+		req     admission.Request
+		want    TestResponse
+	}{
+		{
+			name: "Handle_DecodeError_DeniesAdmission",
+			decoder: &fakeValidationDecoder{
+				err: errors.New("decode error"),
+			},
+			req: admission.Request{},
+			want: TestResponse{
+				Type:    Errored,
+				Message: "decode error",
+			},
+		},
+		{
+			name: "Handle_ValidationOverrideSpecFails_DeniesAdmission",
+			decoder: &fakeValidationDecoder{
+				obj: &policyv1alpha1.OverridePolicy{
+					Spec: policyv1alpha1.OverrideSpec{
+						ResourceSelectors: []policyv1alpha1.ResourceSelector{
+							{APIVersion: "test-apiversion", Kind: "test"},
+						},
+						OverrideRules: []policyv1alpha1.RuleWithCluster{
+							{
+								TargetCluster: &policyv1alpha1.ClusterAffinity{
+									ClusterNames: []string{"member1"},
+								},
+								Overriders: policyv1alpha1.Overriders{
+									LabelsOverrider: []policyv1alpha1.LabelAnnotationOverrider{
+										{
+											Operator: policyv1alpha1.OverriderOpAdd,
+											Value:    map[string]string{"testannotation~projectId": "c-m-lfx9lk92p-v86cf"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			req: admission.Request{},
+			want: TestResponse{
+				Type:    Denied,
+				Message: "Invalid value: \"testannotation~projectId\"",
+			},
+		},
+		{
+			name: "Handle_ValidationSucceeds_AllowsAdmission",
+			decoder: &fakeValidationDecoder{
+				obj: &policyv1alpha1.OverridePolicy{
+					Spec: policyv1alpha1.OverrideSpec{
+						ResourceSelectors: []policyv1alpha1.ResourceSelector{
+							{APIVersion: "test-apiversion", Kind: "test"},
+						},
+						OverrideRules: []policyv1alpha1.RuleWithCluster{
+							{
+								TargetCluster: &policyv1alpha1.ClusterAffinity{
+									ClusterNames: []string{"member1"},
+								},
+								Overriders: policyv1alpha1.Overriders{
+									Plaintext: []policyv1alpha1.PlaintextOverrider{
+										{
+											Path:     "/spec/optional",
+											Operator: policyv1alpha1.OverriderOpRemove,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			req: admission.Request{},
+			want: TestResponse{
+				Type:    Allowed,
+				Message: "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &ValidatingAdmission{
+				Decoder: tt.decoder,
+			}
+			got := v.Handle(context.Background(), tt.req)
+
+			// Extract type and message from the actual response.
+			gotType := extractResponseType(got)
+			gotMessage := extractErrorMessage(got)
+
+			if gotType != tt.want.Type || !strings.Contains(gotMessage, tt.want.Message) {
+				t.Errorf("Handle() = {Type: %v, Message: %v}, want {Type: %v, Message: %v}", gotType, gotMessage, tt.want.Type, tt.want.Message)
+			}
+		})
+	}
+}
+
+// extractResponseType extracts the type of admission response.
+func extractResponseType(resp admission.Response) ResponseType {
+	if resp.Allowed {
+		return Allowed
+	}
+	if resp.Result != nil {
+		if resp.Result.Code == http.StatusBadRequest {
+			return Errored
+		}
+	}
+	return Denied
+}
+
+// extractErrorMessage extracts the error message from a Denied/Errored response.
+func extractErrorMessage(resp admission.Response) string {
+	if !resp.Allowed && resp.Result != nil {
+		return resp.Result.Message
+	}
+	return ""
+}


### PR DESCRIPTION
**Description**

In this commit, we introduce unit tests for both the `ValidationAdmission` and `MutatingAdmission` webhooks specifically for the `OverridePolicy` resource.

The tests include:

- Validation webhook tests:
  - Tests the behavior when decoding the request object fails, verifying that admission is denied with an appropriate error message.
  - Validates that the webhook denies admission when encountering invalid label values in the `OverridePolicy` spec, ensuring proper error messaging.
  - Confirms that valid `OverridePolicy` objects are admitted without errors.

- Mutation webhook tests:
  - Handles decode errors and denies admission when decoding fails.
  - Provides full coverage of policy mutation, including setting default namespaces and validating no unnecessary patches.

**What type of PR is this?**

/kind failing-test
/kind feature

**Which issue(s) this PR fixes**:
Part of #5491

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```