### PR TITLE
Nominates Amir and Chaosi as the owners of helm chart

### DIFF
--- a/charts/OWNERS
+++ b/charts/OWNERS
@@ -1,9 +1,12 @@
 reviewers:
+- a7i
 - chaosi-zju
 - calvin0327
 - jrkeen
 - pidb
 - Poor12
 approvers:
+- a7i
+- chaosi-zju
 - pidb
 - Poor12


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
This PR nominates @a7i and @chaosi-zju as the owners of the helm chart.

Both @a7i and @chaosi-zju have been contributing significantly to the helm chart for a long time. 
Their expertise are evident in every PR they sent and reviewed. Given their deep knowledge of the codebase and his commitment to the quality, I believe they are the perfect fit for this role.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

