### PR TITLE
pkg/webhook: unit test Federated HPA

### DIFF
--- a/pkg/webhook/federatedhpa/mutating_test.go
+++ b/pkg/webhook/federatedhpa/mutating_test.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package federatedhpa
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"reflect"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	autoscalingv1alpha1 "github.com/karmada-io/karmada/pkg/apis/autoscaling/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/util/lifted"
+)
+
+type fakeMutationDecoder struct {
+	err error
+	obj runtime.Object
+}
+
+// Decode mocks the Decode method of admission.Decoder.
+func (f *fakeMutationDecoder) Decode(_ admission.Request, obj runtime.Object) error {
+	if f.err != nil {
+		return f.err
+	}
+	if f.obj != nil {
+		reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(f.obj).Elem())
+	}
+	return nil
+}
+
+// DecodeRaw mocks the DecodeRaw method of admission.Decoder.
+func (f *fakeMutationDecoder) DecodeRaw(_ runtime.RawExtension, obj runtime.Object) error {
+	if f.err != nil {
+		return f.err
+	}
+	if f.obj != nil {
+		reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(f.obj).Elem())
+	}
+	return nil
+}
+
+func TestMutatingAdmission_Handle(t *testing.T) {
+	tests := []struct {
+		name    string
+		decoder admission.Decoder
+		req     admission.Request
+		want    admission.Response
+	}{
+		{
+			name: "Handle_DecodeError_DeniesAdmission",
+			decoder: &fakeValidationDecoder{
+				err: errors.New("decode error"),
+			},
+			req:  admission.Request{},
+			want: admission.Errored(http.StatusBadRequest, errors.New("decode error")),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := MutatingAdmission{
+				Decoder: tt.decoder,
+			}
+			got := m.Handle(context.Background(), tt.req)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Handle() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMutatingAdmission_Handle_FullCoverage(t *testing.T) {
+	// Define the federatedhpa object name and namespace to be used in the test.
+	name := "test-app"
+	namespace := "test-namespace"
+
+	// Mock an admission request request.
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Create,
+		},
+	}
+
+	// Create the initial federatedhpa with default values for testing.
+	federatedHPAObj := &autoscalingv1alpha1.FederatedHPA{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: autoscalingv1alpha1.FederatedHPASpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       name,
+			},
+			MinReplicas: nil,
+			MaxReplicas: 10,
+			Behavior:    &autoscalingv2.HorizontalPodAutoscalerBehavior{},
+			Metrics:     []autoscalingv2.MetricSpec{},
+		},
+	}
+
+	// Define the expected federatedhpa object after mutations.
+	wantFederatedHPAObj := &autoscalingv1alpha1.FederatedHPA{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: autoscalingv1alpha1.FederatedHPASpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       name,
+			},
+			MinReplicas: ptr.To[int32](1),
+			MaxReplicas: 10,
+			Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
+				ScaleUp: &autoscalingv2.HPAScalingRules{
+					StabilizationWindowSeconds: ptr.To[int32](0),
+					SelectPolicy:               ptr.To[autoscalingv2.ScalingPolicySelect](autoscalingv2.MaxChangePolicySelect),
+					Policies: []autoscalingv2.HPAScalingPolicy{
+						{
+							Type:          autoscalingv2.PodsScalingPolicy,
+							Value:         4,
+							PeriodSeconds: 15,
+						},
+						{
+							Type:          autoscalingv2.PercentScalingPolicy,
+							Value:         100,
+							PeriodSeconds: 15,
+						},
+					},
+				},
+				ScaleDown: &autoscalingv2.HPAScalingRules{
+					StabilizationWindowSeconds: nil,
+					SelectPolicy:               ptr.To[autoscalingv2.ScalingPolicySelect](autoscalingv2.MaxChangePolicySelect),
+					Policies: []autoscalingv2.HPAScalingPolicy{
+						{
+							Type:          autoscalingv2.PercentScalingPolicy,
+							Value:         100,
+							PeriodSeconds: 15,
+						},
+					},
+				},
+			},
+			Metrics: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceCPU,
+						Target: autoscalingv2.MetricTarget{
+							Type:               autoscalingv2.UtilizationMetricType,
+							AverageUtilization: ptr.To[int32](lifted.DefaultCPUUtilization),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Mock decoder that decodes the request into the federatedhpa object.
+	decoder := &fakeMutationDecoder{
+		obj: federatedHPAObj,
+	}
+
+	// Marshal the expected federatedhpa object to simulate the final mutated object.
+	wantBytes, err := json.Marshal(wantFederatedHPAObj)
+	if err != nil {
+		t.Fatalf("Failed to marshal expected federatedHPA object: %v", err)
+	}
+	req.Object.Raw = wantBytes
+
+	// Instantiate the mutating handler.
+	mutatingHandler := MutatingAdmission{
+		Decoder: decoder,
+	}
+
+	// Call the Handle function.
+	got := mutatingHandler.Handle(context.Background(), req)
+
+	// Check if there are any patches applied. There should be no patches if the federatedhpa object is handled correctly.
+	if len(got.Patches) > 0 {
+		t.Errorf("Handle() returned patches, but no patches were expected. Got patches: %v", got.Patches)
+	}
+
+	// Check if the admission request was allowed.
+	if !got.Allowed {
+		t.Errorf("Handle() got.Allowed = false, want true")
+	}
+}

--- a/pkg/webhook/federatedhpa/validating_test.go
+++ b/pkg/webhook/federatedhpa/validating_test.go
@@ -1,0 +1,276 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package federatedhpa
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	autoscalingv1alpha1 "github.com/karmada-io/karmada/pkg/apis/autoscaling/v1alpha1"
+)
+
+// ResponseType represents the type of admission response.
+type ResponseType string
+
+const (
+	Denied  ResponseType = "Denied"
+	Allowed ResponseType = "Allowed"
+	Errored ResponseType = "Errored"
+)
+
+// TestResponse is used to define expected response in a test case.
+type TestResponse struct {
+	Type    ResponseType
+	Message string
+}
+
+type fakeValidationDecoder struct {
+	err error
+	obj runtime.Object
+}
+
+// Decode mocks the Decode method of admission.Decoder.
+func (f *fakeValidationDecoder) Decode(_ admission.Request, obj runtime.Object) error {
+	if f.err != nil {
+		return f.err
+	}
+	if f.obj != nil {
+		reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(f.obj).Elem())
+	}
+	return nil
+}
+
+// DecodeRaw mocks the DecodeRaw method of admission.Decoder.
+func (f *fakeValidationDecoder) DecodeRaw(_ runtime.RawExtension, obj runtime.Object) error {
+	if f.err != nil {
+		return f.err
+	}
+	if f.obj != nil {
+		reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(f.obj).Elem())
+	}
+	return nil
+}
+
+func TestValidatingAdmission_Handle(t *testing.T) {
+	tests := []struct {
+		name    string
+		decoder admission.Decoder
+		req     admission.Request
+		want    TestResponse
+	}{
+		{
+			name: "Handle_DecodeError_DeniesAdmission",
+			decoder: &fakeValidationDecoder{
+				err: errors.New("decode error"),
+			},
+			req: admission.Request{},
+			want: TestResponse{
+				Type:    Errored,
+				Message: "decode error",
+			},
+		},
+		{
+			name: "Handle_ValidationFederatedHPASpecFails_DeniesAdmission",
+			decoder: &fakeValidationDecoder{
+				obj: &autoscalingv1alpha1.FederatedHPA{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-app",
+						Namespace: "test-namespace",
+					},
+					Spec: autoscalingv1alpha1.FederatedHPASpec{
+						ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+							APIVersion: "apps/v1",
+							Kind:       "Deployment",
+							Name:       "test-app",
+						},
+						MinReplicas: ptr.To[int32](0),
+						MaxReplicas: 10,
+						Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
+							ScaleUp: &autoscalingv2.HPAScalingRules{
+								StabilizationWindowSeconds: ptr.To[int32](0),
+								Policies: []autoscalingv2.HPAScalingPolicy{
+									{
+										PeriodSeconds: 15,
+										Type:          autoscalingv2.PodsScalingPolicy,
+										Value:         4,
+									},
+									{
+										PeriodSeconds: 15,
+										Type:          autoscalingv2.PercentScalingPolicy,
+										Value:         100,
+									},
+								},
+							},
+							ScaleDown: &autoscalingv2.HPAScalingRules{
+								StabilizationWindowSeconds: ptr.To[int32](300),
+								Policies: []autoscalingv2.HPAScalingPolicy{
+									{
+										PeriodSeconds: 15,
+										Type:          autoscalingv2.PercentScalingPolicy,
+										Value:         100,
+									},
+								},
+							},
+						},
+						Metrics: []autoscalingv2.MetricSpec{
+							{
+								Type: autoscalingv2.PodsMetricSourceType,
+								Pods: &autoscalingv2.PodsMetricSource{
+									Metric: autoscalingv2.MetricIdentifier{
+										Name: "http_requests",
+									},
+									Target: autoscalingv2.MetricTarget{
+										AverageValue: resource.NewMilliQuantity(700, resource.DecimalSI),
+										Type:         autoscalingv2.ValueMetricType,
+									},
+								},
+							},
+						},
+					},
+					Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+						CurrentReplicas: 2,
+						DesiredReplicas: 2,
+					},
+				},
+			},
+			req: admission.Request{},
+			want: TestResponse{
+				Type:    Denied,
+				Message: "spec.minReplicas: Invalid value: 0",
+			},
+		},
+		{
+			name: "Handle_ValidationSucceeds_AllowsAdmission",
+			decoder: &fakeValidationDecoder{
+				obj: &autoscalingv1alpha1.FederatedHPA{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-app",
+						Namespace: "test-namespace",
+					},
+					Spec: autoscalingv1alpha1.FederatedHPASpec{
+						ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+							APIVersion: "apps/v1",
+							Kind:       "Deployment",
+							Name:       "test-app",
+						},
+						MinReplicas: ptr.To[int32](1),
+						MaxReplicas: 10,
+						Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
+							ScaleUp: &autoscalingv2.HPAScalingRules{
+								StabilizationWindowSeconds: ptr.To[int32](0),
+								Policies: []autoscalingv2.HPAScalingPolicy{
+									{
+										PeriodSeconds: 15,
+										Type:          autoscalingv2.PodsScalingPolicy,
+										Value:         4,
+									},
+									{
+										PeriodSeconds: 15,
+										Type:          autoscalingv2.PercentScalingPolicy,
+										Value:         100,
+									},
+								},
+							},
+							ScaleDown: &autoscalingv2.HPAScalingRules{
+								StabilizationWindowSeconds: ptr.To[int32](300),
+								Policies: []autoscalingv2.HPAScalingPolicy{
+									{
+										PeriodSeconds: 15,
+										Type:          autoscalingv2.PercentScalingPolicy,
+										Value:         100,
+									},
+								},
+							},
+						},
+						Metrics: []autoscalingv2.MetricSpec{
+							{
+								Type: autoscalingv2.PodsMetricSourceType,
+								Pods: &autoscalingv2.PodsMetricSource{
+									Metric: autoscalingv2.MetricIdentifier{
+										Name: "http_requests",
+									},
+									Target: autoscalingv2.MetricTarget{
+										AverageValue: resource.NewMilliQuantity(700, resource.DecimalSI),
+										Type:         autoscalingv2.ValueMetricType,
+									},
+								},
+							},
+						},
+					},
+					Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+						CurrentReplicas: 2,
+						DesiredReplicas: 2,
+					},
+				},
+			},
+			req: admission.Request{},
+			want: TestResponse{
+				Type:    Allowed,
+				Message: "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &ValidatingAdmission{
+				Decoder: tt.decoder,
+			}
+			got := v.Handle(context.Background(), tt.req)
+
+			// Extract type and message from the actual response.
+			gotType := extractResponseType(got)
+			gotMessage := extractErrorMessage(got)
+
+			if gotType != tt.want.Type || !strings.Contains(gotMessage, tt.want.Message) {
+				t.Errorf("Handle() = {Type: %v, Message: %v}, want {Type: %v, Message: %v}", gotType, gotMessage, tt.want.Type, tt.want.Message)
+			}
+		})
+	}
+}
+
+// extractResponseType extracts the type of admission response.
+func extractResponseType(resp admission.Response) ResponseType {
+	if resp.Allowed {
+		return Allowed
+	}
+	if resp.Result != nil {
+		if resp.Result.Code == http.StatusBadRequest {
+			return Errored
+		}
+	}
+	return Denied
+}
+
+// extractErrorMessage extracts the error message from a Denied/Errored response.
+func extractErrorMessage(resp admission.Response) string {
+	if !resp.Allowed && resp.Result != nil {
+		return resp.Result.Message
+	}
+	return ""
+}


### PR DESCRIPTION
**Description**

In this commit, we introduce unit tests for both the `MutatingAdmission` and `ValidatingAdmission` webhooks specifically for the `FederatedHPA` resource.

The tests include:

- Validation webhook tests:
  - Verifies that admission is denied with an appropriate error message when decoding the request object fails.
  - Ensures admission is denied when the `FederatedHPA` spec contains invalid values, such as a `minReplicas` set to zero, and the correct error message is returned.
  - Confirms that a valid `FederatedHPA` object is allowed through without errors.

- Mutation webhook tests:
  - Verifies that admission is denied when decoding the request object fails, returning the appropriate error message.
  - Ensures that the `FederatedHPA` object is correctly mutated when provided with default values, including scale policies and CPU utilization.
  - Confirms that no patches are applied when the `FederatedHPA` object is handled correctly and that admission is allowed for valid `FederatedHPA` objects.

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**Which issue(s) this PR fixes**:
Part of #5491.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```