### PR TITLE
pkg+test: unify the usage of policyv1alpha1 operators

### DIFF
--- a/pkg/controllers/namespace/namespace_sync_controller_test.go
+++ b/pkg/controllers/namespace/namespace_sync_controller_test.go
@@ -287,7 +287,7 @@ func TestController_buildWorks(t *testing.T) {
 						Plaintext: []policyv1alpha1.PlaintextOverrider{
 							{
 								Path:     "/metadata/labels/overridden",
-								Operator: "add",
+								Operator: policyv1alpha1.OverriderOpAdd,
 								Value: apiextensionsv1.JSON{
 									Raw: []byte(`"true"`),
 								},

--- a/pkg/util/overridemanager/commandargsoverride_test.go
+++ b/pkg/util/overridemanager/commandargsoverride_test.go
@@ -260,13 +260,13 @@ func TestParseJSONPatchesByCommandOverrider(t *testing.T) {
 				rawObj: generateTestCommandDeploymentYaml(),
 				CommandArgsOverrider: &policyv1alpha1.CommandArgsOverrider{
 					ContainerName: "nginx",
-					Operator:      "add",
+					Operator:      policyv1alpha1.OverriderOpAdd,
 					Value:         []string{"&& echo 'hello karmada'"},
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/command",
 					Value: []string{"nginx", "-v", "-t", "&& echo 'hello karmada'"},
 				},
@@ -278,13 +278,13 @@ func TestParseJSONPatchesByCommandOverrider(t *testing.T) {
 				rawObj: generateTestCommandDeploymentYaml(),
 				CommandArgsOverrider: &policyv1alpha1.CommandArgsOverrider{
 					ContainerName: "nginx",
-					Operator:      "remove",
+					Operator:      policyv1alpha1.OverriderOpRemove,
 					Value:         []string{"-t"},
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/command",
 					Value: []string{"nginx", "-v"},
 				},
@@ -296,13 +296,13 @@ func TestParseJSONPatchesByCommandOverrider(t *testing.T) {
 				rawObj: generateTestCommandDeploymentYaml(),
 				CommandArgsOverrider: &policyv1alpha1.CommandArgsOverrider{
 					ContainerName: "nginx",
-					Operator:      "remove",
+					Operator:      policyv1alpha1.OverriderOpRemove,
 					Value:         []string{},
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/command",
 					Value: []string{"nginx", "-v", "-t"},
 				},
@@ -314,13 +314,13 @@ func TestParseJSONPatchesByCommandOverrider(t *testing.T) {
 				rawObj: generateTestCommandDeploymentYamlWithTwoContainer(),
 				CommandArgsOverrider: &policyv1alpha1.CommandArgsOverrider{
 					ContainerName: "nginx",
-					Operator:      "add",
+					Operator:      policyv1alpha1.OverriderOpAdd,
 					Value:         []string{"echo 'hello karmada'"},
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/command",
 					Value: []string{"nginx", "-v", "-t", "echo 'hello karmada'"},
 				},
@@ -332,13 +332,13 @@ func TestParseJSONPatchesByCommandOverrider(t *testing.T) {
 				rawObj: generateTestCommandDeploymentYamlWithTwoContainer(),
 				CommandArgsOverrider: &policyv1alpha1.CommandArgsOverrider{
 					ContainerName: "nginx",
-					Operator:      "remove",
+					Operator:      policyv1alpha1.OverriderOpRemove,
 					Value:         []string{"-t"},
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/command",
 					Value: []string{"nginx", "-v"},
 				},
@@ -350,13 +350,13 @@ func TestParseJSONPatchesByCommandOverrider(t *testing.T) {
 				rawObj: generateTestCommandPodYaml(),
 				CommandArgsOverrider: &policyv1alpha1.CommandArgsOverrider{
 					ContainerName: "nginx",
-					Operator:      "add",
+					Operator:      policyv1alpha1.OverriderOpAdd,
 					Value:         []string{"echo 'hello karmada'"},
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/containers/0/command",
 					Value: []string{"nginx", "-v", "-t", "echo 'hello karmada'"},
 				},
@@ -368,13 +368,13 @@ func TestParseJSONPatchesByCommandOverrider(t *testing.T) {
 				rawObj: generateTestCommandStatefulSetYaml(),
 				CommandArgsOverrider: &policyv1alpha1.CommandArgsOverrider{
 					ContainerName: "nginx",
-					Operator:      "add",
+					Operator:      policyv1alpha1.OverriderOpAdd,
 					Value:         []string{"echo 'hello karmada'"},
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/command",
 					Value: []string{"nginx", "-v", "-t", "echo 'hello karmada'"},
 				},
@@ -386,13 +386,13 @@ func TestParseJSONPatchesByCommandOverrider(t *testing.T) {
 				rawObj: generateTestCommandReplicaSetYaml(),
 				CommandArgsOverrider: &policyv1alpha1.CommandArgsOverrider{
 					ContainerName: "nginx",
-					Operator:      "remove",
+					Operator:      policyv1alpha1.OverriderOpRemove,
 					Value:         []string{"-t"},
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/command",
 					Value: []string{"nginx", "-v"},
 				},
@@ -404,13 +404,13 @@ func TestParseJSONPatchesByCommandOverrider(t *testing.T) {
 				rawObj: generateTestCommandDaemonSetYaml(),
 				CommandArgsOverrider: &policyv1alpha1.CommandArgsOverrider{
 					ContainerName: "nginx",
-					Operator:      "remove",
+					Operator:      policyv1alpha1.OverriderOpRemove,
 					Value:         []string{"-t"},
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/command",
 					Value: []string{"nginx", "-v"},
 				},
@@ -449,13 +449,13 @@ func TestParseJSONPatchesByArgsOverrider(t *testing.T) {
 				rawObj: generateTestArgsDeploymentYaml(),
 				CommandArgsOverrider: &policyv1alpha1.CommandArgsOverrider{
 					ContainerName: "nginx",
-					Operator:      "add",
+					Operator:      policyv1alpha1.OverriderOpAdd,
 					Value:         []string{"&& echo 'hello karmada'"},
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/args",
 					Value: []string{"nginx", "-v", "-t", "&& echo 'hello karmada'"},
 				},
@@ -467,13 +467,13 @@ func TestParseJSONPatchesByArgsOverrider(t *testing.T) {
 				rawObj: generateTestArgsDeploymentYaml(),
 				CommandArgsOverrider: &policyv1alpha1.CommandArgsOverrider{
 					ContainerName: "nginx",
-					Operator:      "remove",
+					Operator:      policyv1alpha1.OverriderOpRemove,
 					Value:         []string{"-t"},
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/args",
 					Value: []string{"nginx", "-v"},
 				},
@@ -485,13 +485,13 @@ func TestParseJSONPatchesByArgsOverrider(t *testing.T) {
 				rawObj: generateTestCommandDeploymentYaml(),
 				CommandArgsOverrider: &policyv1alpha1.CommandArgsOverrider{
 					ContainerName: "nginx",
-					Operator:      "add",
+					Operator:      policyv1alpha1.OverriderOpAdd,
 					Value:         []string{"-t"},
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "add",
+					Op:    string(policyv1alpha1.OverriderOpAdd),
 					Path:  "/spec/template/spec/containers/0/args",
 					Value: []string{"-t"},
 				},

--- a/pkg/util/overridemanager/imageoverride_test.go
+++ b/pkg/util/overridemanager/imageoverride_test.go
@@ -240,13 +240,13 @@ func TestParseJSONPatchesByImageOverrider(t *testing.T) {
 				rawObj: generateJobYaml(),
 				imageOverrider: &policyv1alpha1.ImageOverrider{
 					Component: "Registry",
-					Operator:  "add",
+					Operator:  policyv1alpha1.OverriderOpAdd,
 					Value:     "registry.k8s.io",
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/image",
 					Value: "registry.k8s.io/perl:5.34.0",
 				},
@@ -262,13 +262,13 @@ func TestParseJSONPatchesByImageOverrider(t *testing.T) {
 						Path: "/spec/template/spec/containers/0/image",
 					},
 					Component: "Registry",
-					Operator:  "add",
+					Operator:  policyv1alpha1.OverriderOpAdd,
 					Value:     "registry.k8s.io",
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/image",
 					Value: "registry.k8s.io/perl:5.34.0",
 				},
@@ -281,13 +281,13 @@ func TestParseJSONPatchesByImageOverrider(t *testing.T) {
 				rawObj: generateDeploymentYaml(),
 				imageOverrider: &policyv1alpha1.ImageOverrider{
 					Component: "Registry",
-					Operator:  "add",
+					Operator:  policyv1alpha1.OverriderOpAdd,
 					Value:     ".test",
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/image",
 					Value: "fictional.registry.example.test/imagename:v1.0.0",
 				},
@@ -300,13 +300,13 @@ func TestParseJSONPatchesByImageOverrider(t *testing.T) {
 				rawObj: generateDeploymentYaml(),
 				imageOverrider: &policyv1alpha1.ImageOverrider{
 					Component: "Registry",
-					Operator:  "replace",
+					Operator:  policyv1alpha1.OverriderOpReplace,
 					Value:     "fictional.registry.us",
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/image",
 					Value: "fictional.registry.us/imagename:v1.0.0",
 				},
@@ -319,13 +319,13 @@ func TestParseJSONPatchesByImageOverrider(t *testing.T) {
 				rawObj: generateDeploymentYaml(),
 				imageOverrider: &policyv1alpha1.ImageOverrider{
 					Component: "Registry",
-					Operator:  "remove",
+					Operator:  policyv1alpha1.OverriderOpRemove,
 					Value:     "fictional.registry.us",
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/image",
 					Value: "imagename:v1.0.0",
 				},
@@ -338,13 +338,13 @@ func TestParseJSONPatchesByImageOverrider(t *testing.T) {
 				rawObj: generateDeploymentYaml(),
 				imageOverrider: &policyv1alpha1.ImageOverrider{
 					Component: "Repository",
-					Operator:  "add",
+					Operator:  policyv1alpha1.OverriderOpAdd,
 					Value:     "/nginx",
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/image",
 					Value: "fictional.registry.example/imagename/nginx:v1.0.0",
 				},
@@ -357,13 +357,13 @@ func TestParseJSONPatchesByImageOverrider(t *testing.T) {
 				rawObj: generateDeploymentYaml(),
 				imageOverrider: &policyv1alpha1.ImageOverrider{
 					Component: "Repository",
-					Operator:  "replace",
+					Operator:  policyv1alpha1.OverriderOpReplace,
 					Value:     "nginx",
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/image",
 					Value: "fictional.registry.example/nginx:v1.0.0",
 				},
@@ -376,13 +376,13 @@ func TestParseJSONPatchesByImageOverrider(t *testing.T) {
 				rawObj: generateDeploymentYaml(),
 				imageOverrider: &policyv1alpha1.ImageOverrider{
 					Component: "Repository",
-					Operator:  "remove",
+					Operator:  policyv1alpha1.OverriderOpRemove,
 					Value:     "nginx",
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/image",
 					Value: "fictional.registry.example/:v1.0.0",
 				},
@@ -395,13 +395,13 @@ func TestParseJSONPatchesByImageOverrider(t *testing.T) {
 				rawObj: generateDeploymentYaml(),
 				imageOverrider: &policyv1alpha1.ImageOverrider{
 					Component: "Tag",
-					Operator:  "add",
+					Operator:  policyv1alpha1.OverriderOpAdd,
 					Value:     "sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c",
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/image",
 					Value: "fictional.registry.example/imagename:v1.0.0", // only one of tag and digest is valid.
 				},
@@ -414,13 +414,13 @@ func TestParseJSONPatchesByImageOverrider(t *testing.T) {
 				rawObj: generateDeploymentYaml(),
 				imageOverrider: &policyv1alpha1.ImageOverrider{
 					Component: "Tag",
-					Operator:  "replace",
+					Operator:  policyv1alpha1.OverriderOpReplace,
 					Value:     "sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c",
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/image",
 					Value: "fictional.registry.example/imagename@sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c",
 				},
@@ -433,13 +433,13 @@ func TestParseJSONPatchesByImageOverrider(t *testing.T) {
 				rawObj: generateDeploymentYaml(),
 				imageOverrider: &policyv1alpha1.ImageOverrider{
 					Component: "Tag",
-					Operator:  "remove",
+					Operator:  policyv1alpha1.OverriderOpRemove,
 					Value:     "sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c",
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/image",
 					Value: "fictional.registry.example/imagename",
 				},
@@ -452,13 +452,13 @@ func TestParseJSONPatchesByImageOverrider(t *testing.T) {
 				rawObj: generatePodYaml(),
 				imageOverrider: &policyv1alpha1.ImageOverrider{
 					Component: "Repository",
-					Operator:  "replace",
+					Operator:  policyv1alpha1.OverriderOpReplace,
 					Value:     "nginx",
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/containers/0/image",
 					Value: "fictional.registry.example/nginx:v1.0.0",
 				},
@@ -471,13 +471,13 @@ func TestParseJSONPatchesByImageOverrider(t *testing.T) {
 				rawObj: generateStatefulSetYaml(),
 				imageOverrider: &policyv1alpha1.ImageOverrider{
 					Component: "Repository",
-					Operator:  "replace",
+					Operator:  policyv1alpha1.OverriderOpReplace,
 					Value:     "nginx",
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/image",
 					Value: "fictional.registry.example/nginx:v1.0.0",
 				},
@@ -490,13 +490,13 @@ func TestParseJSONPatchesByImageOverrider(t *testing.T) {
 				rawObj: generateReplicaSetYaml(),
 				imageOverrider: &policyv1alpha1.ImageOverrider{
 					Component: "Repository",
-					Operator:  "replace",
+					Operator:  policyv1alpha1.OverriderOpReplace,
 					Value:     "nginx",
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/image",
 					Value: "fictional.registry.example/nginx:v1.0.0",
 				},
@@ -509,13 +509,13 @@ func TestParseJSONPatchesByImageOverrider(t *testing.T) {
 				rawObj: generateDaemonSetYaml(),
 				imageOverrider: &policyv1alpha1.ImageOverrider{
 					Component: "Repository",
-					Operator:  "replace",
+					Operator:  policyv1alpha1.OverriderOpReplace,
 					Value:     "nginx",
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/image",
 					Value: "fictional.registry.example/nginx:v1.0.0",
 				},
@@ -528,18 +528,18 @@ func TestParseJSONPatchesByImageOverrider(t *testing.T) {
 				rawObj: generateDeploymentYamlWithTwoContainer(),
 				imageOverrider: &policyv1alpha1.ImageOverrider{
 					Component: "Repository",
-					Operator:  "replace",
+					Operator:  policyv1alpha1.OverriderOpReplace,
 					Value:     "nginx",
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/image",
 					Value: "fictional.registry.example/nginx:v1.0.0",
 				},
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/1/image",
 					Value: "registry.k8s.io/nginx:0.8",
 				},
@@ -555,13 +555,13 @@ func TestParseJSONPatchesByImageOverrider(t *testing.T) {
 						Path: "/spec/template/spec/containers/0/image",
 					},
 					Component: "Repository",
-					Operator:  "replace",
+					Operator:  policyv1alpha1.OverriderOpReplace,
 					Value:     "nginx",
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/0/image",
 					Value: "fictional.registry.example/nginx:v1.0.0",
 				},
@@ -577,13 +577,13 @@ func TestParseJSONPatchesByImageOverrider(t *testing.T) {
 						Path: "/spec/template/spec/containers/1/image",
 					},
 					Component: "Repository",
-					Operator:  "replace",
+					Operator:  policyv1alpha1.OverriderOpReplace,
 					Value:     "nginx",
 				},
 			},
 			want: []overrideOption{
 				{
-					Op:    "replace",
+					Op:    string(policyv1alpha1.OverriderOpReplace),
 					Path:  "/spec/template/spec/containers/1/image",
 					Value: "registry.k8s.io/nginx:0.8",
 				},

--- a/pkg/util/overridemanager/overridemanager_test.go
+++ b/pkg/util/overridemanager/overridemanager_test.go
@@ -258,7 +258,7 @@ func TestGetMatchingOverridePolicies(t *testing.T) {
 		Plaintext: []policyv1alpha1.PlaintextOverrider{
 			{
 				Path:     "/metadata/annotations",
-				Operator: "add",
+				Operator: policyv1alpha1.OverriderOpAdd,
 				Value:    apiextensionsv1.JSON{Raw: []byte(`"foo: bar"`)},
 			},
 		},
@@ -267,7 +267,7 @@ func TestGetMatchingOverridePolicies(t *testing.T) {
 		Plaintext: []policyv1alpha1.PlaintextOverrider{
 			{
 				Path:     "/metadata/annotations",
-				Operator: "add",
+				Operator: policyv1alpha1.OverriderOpAdd,
 				Value:    apiextensionsv1.JSON{Raw: []byte(`"aaa: bbb"`)},
 			},
 		},
@@ -276,7 +276,7 @@ func TestGetMatchingOverridePolicies(t *testing.T) {
 		Plaintext: []policyv1alpha1.PlaintextOverrider{
 			{
 				Path:     "/metadata/annotations",
-				Operator: "add",
+				Operator: policyv1alpha1.OverriderOpAdd,
 				Value:    apiextensionsv1.JSON{Raw: []byte(`"hello: world"`)},
 			},
 		},

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -133,7 +133,7 @@ func TestValidateOverrideSpec(t *testing.T) {
 						Overriders: policyv1alpha1.Overriders{
 							AnnotationsOverrider: []policyv1alpha1.LabelAnnotationOverrider{
 								{
-									Operator: "add",
+									Operator: policyv1alpha1.OverriderOpAdd,
 									Value:    map[string]string{"testannotation~projectId": "c-m-lfx9lk92p-v86cf"},
 								},
 							},
@@ -154,7 +154,7 @@ func TestValidateOverrideSpec(t *testing.T) {
 						Overriders: policyv1alpha1.Overriders{
 							LabelsOverrider: []policyv1alpha1.LabelAnnotationOverrider{
 								{
-									Operator: "add",
+									Operator: policyv1alpha1.OverriderOpAdd,
 									Value:    map[string]string{"testannotation~projectId": "c-m-lfx9lk92p-v86cf"},
 								},
 							},
@@ -277,14 +277,14 @@ func TestEmptyOverrides(t *testing.T) {
 				ImageOverrider: []policyv1alpha1.ImageOverrider{
 					{
 						Component: "Registry",
-						Operator:  "remove",
+						Operator:  policyv1alpha1.OverriderOpRemove,
 						Value:     "fictional.registry.us",
 					},
 				},
 				CommandOverrider: []policyv1alpha1.CommandArgsOverrider{
 					{
 						ContainerName: "nginx",
-						Operator:      "add",
+						Operator:      policyv1alpha1.OverriderOpAdd,
 						Value:         []string{"echo 'hello karmada'"},
 					},
 				},

--- a/test/e2e/clusteroverridepolicy_test.go
+++ b/test/e2e/clusteroverridepolicy_test.go
@@ -154,7 +154,7 @@ var _ = framework.SerialDescribe("The ClusterOverridePolicy with nil resourceSel
 								Path: "/spec/template/spec/containers/0/image",
 							},
 							Component: "Registry",
-							Operator:  "replace",
+							Operator:  policyv1alpha1.OverriderOpReplace,
 							Value:     "fictional.registry.us",
 						},
 					},

--- a/test/e2e/failover_test.go
+++ b/test/e2e/failover_test.go
@@ -354,7 +354,7 @@ var _ = framework.SerialDescribe("failover testing", func() {
 							ImageOverrider: []policyv1alpha1.ImageOverrider{
 								{
 									Component: "Registry",
-									Operator:  "replace",
+									Operator:  policyv1alpha1.OverriderOpReplace,
 									Value:     "fake",
 								},
 							},
@@ -405,7 +405,7 @@ var _ = framework.SerialDescribe("failover testing", func() {
 				// modify gracePeriodSeconds to create a time difference with tolerationSecond to avoid cluster interference
 				patch := []map[string]interface{}{
 					{
-						"op":    "replace",
+						"op":    policyv1alpha1.OverriderOpReplace,
 						"path":  "/spec/failover/application/gracePeriodSeconds",
 						"value": ptr.To[int32](gracePeriodSeconds),
 					},
@@ -432,7 +432,7 @@ var _ = framework.SerialDescribe("failover testing", func() {
 							ImageOverrider: []policyv1alpha1.ImageOverrider{
 								{
 									Component: "Registry",
-									Operator:  "replace",
+									Operator:  policyv1alpha1.OverriderOpReplace,
 									Value:     "fake",
 								},
 							},
@@ -545,7 +545,7 @@ var _ = framework.SerialDescribe("failover testing", func() {
 							ImageOverrider: []policyv1alpha1.ImageOverrider{
 								{
 									Component: "Registry",
-									Operator:  "replace",
+									Operator:  policyv1alpha1.OverriderOpReplace,
 									Value:     "fake",
 								},
 							},

--- a/test/e2e/overridepolicy_test.go
+++ b/test/e2e/overridepolicy_test.go
@@ -74,20 +74,20 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 			}, policyv1alpha1.Overriders{
 				LabelsOverrider: []policyv1alpha1.LabelAnnotationOverrider{
 					{
-						Operator: "replace",
+						Operator: policyv1alpha1.OverriderOpReplace,
 						Value: map[string]string{
 							"foo":       "exist",
 							"non-exist": "non-exist",
 						},
 					},
 					{
-						Operator: "add",
+						Operator: policyv1alpha1.OverriderOpAdd,
 						Value: map[string]string{
 							"app": "nginx",
 						},
 					},
 					{
-						Operator: "remove",
+						Operator: policyv1alpha1.OverriderOpRemove,
 						Value: map[string]string{
 							"bar": "bar",
 						},
@@ -159,20 +159,20 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 			}, policyv1alpha1.Overriders{
 				AnnotationsOverrider: []policyv1alpha1.LabelAnnotationOverrider{
 					{
-						Operator: "replace",
+						Operator: policyv1alpha1.OverriderOpReplace,
 						Value: map[string]string{
 							"foo":       "exist",
 							"non-exist": "non-exist",
 						},
 					},
 					{
-						Operator: "add",
+						Operator: policyv1alpha1.OverriderOpAdd,
 						Value: map[string]string{
 							"app": "nginx",
 						},
 					},
 					{
-						Operator: "remove",
+						Operator: policyv1alpha1.OverriderOpRemove,
 						Value: map[string]string{
 							"bar": "bar",
 						},
@@ -241,17 +241,17 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 				ImageOverrider: []policyv1alpha1.ImageOverrider{
 					{
 						Component: "Registry",
-						Operator:  "replace",
+						Operator:  policyv1alpha1.OverriderOpReplace,
 						Value:     "fictional.registry.us",
 					},
 					{
 						Component: "Repository",
-						Operator:  "replace",
+						Operator:  policyv1alpha1.OverriderOpReplace,
 						Value:     "busybox",
 					},
 					{
 						Component: "Tag",
-						Operator:  "replace",
+						Operator:  policyv1alpha1.OverriderOpReplace,
 						Value:     "1.0",
 					},
 				},
@@ -319,17 +319,17 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 				ImageOverrider: []policyv1alpha1.ImageOverrider{
 					{
 						Component: "Registry",
-						Operator:  "replace",
+						Operator:  policyv1alpha1.OverriderOpReplace,
 						Value:     "fictional.registry.us",
 					},
 					{
 						Component: "Repository",
-						Operator:  "replace",
+						Operator:  policyv1alpha1.OverriderOpReplace,
 						Value:     "busybox",
 					},
 					{
 						Component: "Tag",
-						Operator:  "replace",
+						Operator:  policyv1alpha1.OverriderOpReplace,
 						Value:     "1.0",
 					},
 				},
@@ -399,7 +399,7 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 							Path: "/spec/template/spec/containers/0/image",
 						},
 						Component: "Registry",
-						Operator:  "replace",
+						Operator:  policyv1alpha1.OverriderOpReplace,
 						Value:     "fictional.registry.us",
 					},
 				},
@@ -464,7 +464,7 @@ var _ = framework.SerialDescribe("OverridePolicy with nil resourceSelector testi
 						Path: "/spec/template/spec/containers/0/image",
 					},
 					Component: "Registry",
-					Operator:  "replace",
+					Operator:  policyv1alpha1.OverriderOpReplace,
 					Value:     "fictional.registry.us",
 				},
 			},
@@ -538,17 +538,17 @@ var _ = ginkgo.Describe("[OverrideRules] apply overriders testing", func() {
 						ImageOverrider: []policyv1alpha1.ImageOverrider{
 							{
 								Component: "Registry",
-								Operator:  "replace",
+								Operator:  policyv1alpha1.OverriderOpReplace,
 								Value:     "fictional.registry.us",
 							},
 							{
 								Component: "Repository",
-								Operator:  "replace",
+								Operator:  policyv1alpha1.OverriderOpReplace,
 								Value:     "busybox",
 							},
 							{
 								Component: "Tag",
-								Operator:  "replace",
+								Operator:  policyv1alpha1.OverriderOpReplace,
 								Value:     "1.0",
 							},
 						},
@@ -621,17 +621,17 @@ var _ = ginkgo.Describe("[OverrideRules] apply overriders testing", func() {
 						ImageOverrider: []policyv1alpha1.ImageOverrider{
 							{
 								Component: "Registry",
-								Operator:  "replace",
+								Operator:  policyv1alpha1.OverriderOpReplace,
 								Value:     "fictional.registry.us",
 							},
 							{
 								Component: "Repository",
-								Operator:  "replace",
+								Operator:  policyv1alpha1.OverriderOpReplace,
 								Value:     "busybox",
 							},
 							{
 								Component: "Tag",
-								Operator:  "replace",
+								Operator:  policyv1alpha1.OverriderOpReplace,
 								Value:     "1.0",
 							},
 						},
@@ -706,7 +706,7 @@ var _ = ginkgo.Describe("[OverrideRules] apply overriders testing", func() {
 									Path: "/spec/template/spec/containers/0/image",
 								},
 								Component: "Registry",
-								Operator:  "replace",
+								Operator:  policyv1alpha1.OverriderOpReplace,
 								Value:     "fictional.registry.us",
 							},
 						},
@@ -777,7 +777,7 @@ var _ = framework.SerialDescribe("OverrideRules with nil resourceSelector testin
 								Path: "/spec/template/spec/containers/0/image",
 							},
 							Component: "Registry",
-							Operator:  "replace",
+							Operator:  policyv1alpha1.OverriderOpReplace,
 							Value:     "fictional.registry.us",
 						},
 					},


### PR DESCRIPTION
**Description**

In this commit, we unify the usage of `policyv1alpha1` operators, specifically `OverriderOpAdd`, `OverriderOpRemove`, and `OverriderOpReplace`.

**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**Additional Context**

While testing the override policy (#5495), I identified an opportunity to improve consistency by unifying the operators, leading to this submission.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
