### PR TITLE
pkg/webhook: log mutating handlers in `OverridePolicy`, `ClusterPropagationPolicy`, and `MultiClusterService`

### DIFF
--- a/pkg/webhook/clusterpropagationpolicy/mutating.go
+++ b/pkg/webhook/clusterpropagationpolicy/mutating.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/uuid"
 	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -59,6 +60,7 @@ func (a *MutatingAdmission) Handle(_ context.Context, req admission.Request) adm
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
+	klog.V(2).Infof("Mutating ClusterPropagationPolicy(%s/%s) for request: %s", req.Namespace, policy.Name, req.Operation)
 
 	// Set default spread constraints if both 'SpreadByField' and 'SpreadByLabel' not set.
 	helper.SetDefaultSpreadConstraints(policy.Spec.Placement.SpreadConstraints)

--- a/pkg/webhook/multiclusterservice/mutating.go
+++ b/pkg/webhook/multiclusterservice/mutating.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	"github.com/google/uuid"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	networkingv1alpha1 "github.com/karmada-io/karmada/pkg/apis/networking/v1alpha1"
@@ -44,6 +45,7 @@ func (a *MutatingAdmission) Handle(_ context.Context, req admission.Request) adm
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
+	klog.V(2).Infof("Mutating MultiClusterService(%s/%s) for request: %s", req.Namespace, mcs.Name, req.Operation)
 
 	if util.GetLabelValue(mcs.Labels, networkingv1alpha1.MultiClusterServicePermanentIDLabel) == "" {
 		id := uuid.New().String()

--- a/pkg/webhook/overridepolicy/mutating.go
+++ b/pkg/webhook/overridepolicy/mutating.go
@@ -43,6 +43,7 @@ func (a *MutatingAdmission) Handle(_ context.Context, req admission.Request) adm
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
+	klog.V(2).Infof("Mutating OverridePolicy(%s/%s) for request: %s", req.Namespace, policy.Name, req.Operation)
 
 	// Set default namespace for all resource selector if not set.
 	// We need to get the default namespace from the request because for kube-apiserver < v1.24,


### PR DESCRIPTION
**Description**

In this commit, we log the mutating handlers for `OverridePolicy`, `ClusterPropagationPolicy`, and `MultiClusterService`. Specifically, it logs information about the mutation of these resources, including the namespace, name, and the operation type from the admission request.

**Motivation and Context**

During testing of the multi-cluster service webhook (#5517), I observed that all mutating webhook handlers include logging functionality, except for the handlers related to `OverridePolicy`, `ClusterPropagationPolicy`, and `MultiClusterService`. Adding logging to these handlers will improve debugging and enhance visibility into the operations they handle, which is the purpose of this PR.

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Log mutating webhook handlers for OverridePolicy, ClusterPropagationPolicy, and MultiClusterService webhooks.
```