### PR TITLE
Fix `karmadactl addon` failed to install karmada-scheduler-estimator due to unknown flag

### DIFF
--- a/cmd/scheduler-estimator/app/options/options.go
+++ b/cmd/scheduler-estimator/app/options/options.go
@@ -90,7 +90,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.GrpcAuthCertFile, "grpc-auth-cert-file", "", "SSL certification file used for grpc SSL/TLS connections.")
 	fs.StringVar(&o.GrpcAuthKeyFile, "grpc-auth-key-file", "", "SSL key file used for grpc SSL/TLS connections.")
 	fs.BoolVar(&o.InsecureSkipGrpcClientVerify, "insecure-skip-grpc-client-verify", false, "If set to true, the estimator will not verify the grpc client's certificate chain and host name. When the relevant certificates are not configured, it will not take effect.")
-	fs.StringVar(&o.GrpcClientCaFile, "grpc-client-ca-file", "", "SSL Certificate Authority file used to verify grpc client certificates on incoming requests if --client-cert-auth flag is set.")
+	fs.StringVar(&o.GrpcClientCaFile, "grpc-client-ca-file", "", "SSL Certificate Authority file used to verify grpc client certificates on incoming requests.")
 	fs.IntVar(&o.SecurePort, "secure-port", defaultHealthzPort, "The secure port on which to serve HTTPS.")
 	fs.Float32Var(&o.ClusterAPIQPS, "kube-api-qps", 20.0, "QPS to use while talking with apiserver.")
 	fs.IntVar(&o.ClusterAPIBurst, "kube-api-burst", 30, "Burst to use while talking with apiserver.")

--- a/pkg/karmadactl/addons/estimator/manifests.go
+++ b/pkg/karmadactl/addons/estimator/manifests.go
@@ -50,7 +50,6 @@ spec:
             - --cluster-name={{ .MemberClusterName}}
             - --grpc-auth-cert-file=/etc/karmada/pki/karmada.crt
             - --grpc-auth-key-file=/etc/karmada/pki/karmada.key
-            - --client-cert-auth=true
             - --grpc-client-ca-file=/etc/karmada/pki/ca.crt
             - --metrics-bind-address=0.0.0.0:10351
             - --health-probe-bind-address=0.0.0.0:10351


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

fix launch arguments when install estimator by karmadactl which caused its installation failure

```shell
$ kubectl get pods -o wide -n karmada-system
...
karmada-system       karmada-scheduler-estimator-member4-774fd8d76c-skjj9            0/1     Error     1 (9s ago)   10s   10.91.0.17   karmada-karmadactl-host-control-plane   <none>           <none>
...

$ kubectl logs -f  karmada-scheduler-estimator-member4-774fd8d76c-skjj9 -n karmada-system                                                    
Usage:
  karmada-scheduler-estimator [flags]
...
Error: unknown flag: --client-cert-auth
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: Fixed the issue that karmadactl addon failed to install karmada-scheduler-estimator due to unknown flag.
```

