### PR TITLE
standardize the naming of karmada secrets in karmadactl method

### DIFF
--- a/pkg/karmadactl/addons/descheduler/manifests.go
+++ b/pkg/karmadactl/addons/descheduler/manifests.go
@@ -49,8 +49,8 @@ spec:
             - --health-probe-bind-address=0.0.0.0:10358
             - --leader-elect-resource-namespace={{ .Namespace }}
             - --scheduler-estimator-ca-file=/etc/karmada/pki/ca.crt
-            - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada.crt
-            - --scheduler-estimator-key-file=/etc/karmada/pki/karmada.key
+            - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada-client.crt
+            - --scheduler-estimator-key-file=/etc/karmada/pki/karmada-client.key
             - --v=4
           livenessProbe:
             httpGet:
@@ -66,19 +66,19 @@ spec:
               name: metrics
               protocol: TCP
           volumeMounts:
-            - name: k8s-certs
+            - name: karmada-certs
               mountPath: /etc/karmada/pki
               readOnly: true
-            - name: kubeconfig
+            - name: karmada-kubeconfig
               subPath: kubeconfig
               mountPath: /etc/kubeconfig
       volumes:
-        - name: k8s-certs
+        - name: karmada-certs
           secret:
-            secretName: karmada-cert
-        - name: kubeconfig
+            secretName: karmada-certs
+        - name: karmada-kubeconfig
           secret:
-            secretName: kubeconfig
+            secretName: karmada-kubeconfig
 `
 
 // DeploymentReplace is a struct to help to concrete

--- a/pkg/karmadactl/addons/estimator/manifests.go
+++ b/pkg/karmadactl/addons/estimator/manifests.go
@@ -48,8 +48,8 @@ spec:
             - /bin/karmada-scheduler-estimator
             - --kubeconfig=/etc/{{ .MemberClusterName}}-kubeconfig
             - --cluster-name={{ .MemberClusterName}}
-            - --grpc-auth-cert-file=/etc/karmada/pki/karmada.crt
-            - --grpc-auth-key-file=/etc/karmada/pki/karmada.key
+            - --grpc-auth-cert-file=/etc/karmada/pki/karmada-server.crt
+            - --grpc-auth-key-file=/etc/karmada/pki/karmada-server.key
             - --grpc-client-ca-file=/etc/karmada/pki/ca.crt
             - --metrics-bind-address=0.0.0.0:10351
             - --health-probe-bind-address=0.0.0.0:10351
@@ -67,16 +67,16 @@ spec:
               name: metrics
               protocol: TCP
           volumeMounts:
-            - name: k8s-certs
+            - name: karmada-certs
               mountPath: /etc/karmada/pki
               readOnly: true
             - name: member-kubeconfig
               subPath: {{ .MemberClusterName}}-kubeconfig
               mountPath: /etc/{{ .MemberClusterName}}-kubeconfig
       volumes:
-        - name: k8s-certs
+        - name: karmada-certs
           secret:
-            secretName: karmada-cert
+            secretName: karmada-certs
         - name: member-kubeconfig
           secret:
             secretName: {{ .MemberClusterName}}-kubeconfig

--- a/pkg/karmadactl/addons/metricsadapter/manifests.go
+++ b/pkg/karmadactl/addons/metricsadapter/manifests.go
@@ -44,10 +44,10 @@ spec:
           image: {{ .Image }}
           imagePullPolicy: IfNotPresent
           volumeMounts:
-            - name: k8s-certs
+            - name: karmada-certs
               mountPath: /etc/karmada/pki
               readOnly: true
-            - name: kubeconfig
+            - name: karmada-kubeconfig
               subPath: kubeconfig
               mountPath: /etc/kubeconfig
           command:
@@ -82,12 +82,12 @@ spec:
             requests:
               cpu: 100m
       volumes:
-        - name: k8s-certs
+        - name: karmada-certs
           secret:
-            secretName: karmada-cert
-        - name: kubeconfig
+            secretName: karmada-certs
+        - name: karmada-kubeconfig
           secret:
-            secretName: kubeconfig
+            secretName: karmada-kubeconfig
 `
 
 	karmadaMetricsAdapterService = `

--- a/pkg/karmadactl/addons/search/manifests.go
+++ b/pkg/karmadactl/addons/search/manifests.go
@@ -44,10 +44,13 @@ spec:
           image: {{ .Image }}
           imagePullPolicy: IfNotPresent
           volumeMounts:
-            - name: k8s-certs
+            - name: karmada-certs
               mountPath: /etc/karmada/pki
               readOnly: true
-            - name: kubeconfig
+            - name: karmada-etcd-cert
+              mountPath: /etc/etcd/pki
+              readOnly: true
+            - name: karmada-kubeconfig
               subPath: kubeconfig
               mountPath: /etc/kubeconfig
           command:
@@ -56,11 +59,11 @@ spec:
             - --authentication-kubeconfig=/etc/kubeconfig
             - --authorization-kubeconfig=/etc/kubeconfig
             - --etcd-servers={{ .ETCDSevers }}
-            - --etcd-cafile=/etc/karmada/pki/etcd-ca.crt
-            - --etcd-certfile=/etc/karmada/pki/etcd-client.crt
-            - --etcd-keyfile=/etc/karmada/pki/etcd-client.key
-            - --tls-cert-file=/etc/karmada/pki/karmada.crt
-            - --tls-private-key-file=/etc/karmada/pki/karmada.key
+            - --etcd-cafile=/etc/etcd/pki/etcd-ca.crt
+            - --etcd-certfile=/etc/etcd/pki/etcd-client.crt
+            - --etcd-keyfile=/etc/etcd/pki/etcd-client.key
+            - --tls-cert-file=/etc/karmada/pki/karmada-server.crt
+            - --tls-private-key-file=/etc/karmada/pki/karmada-server.key
             - --tls-min-version=VersionTLS13
             - --audit-log-path=-
             - --audit-log-maxage=0
@@ -79,12 +82,15 @@ spec:
             requests:
               cpu: 100m
       volumes:
-        - name: k8s-certs
+        - name: karmada-certs
           secret:
-            secretName: karmada-cert
-        - name: kubeconfig
+            secretName: karmada-certs
+        - name: karmada-etcd-cert
           secret:
-            secretName: kubeconfig
+            secretName: karmada-etcd-cert
+        - name: karmada-kubeconfig
+          secret:
+            secretName: karmada-kubeconfig
 `
 
 	karmadaSearchService = `

--- a/pkg/karmadactl/cmdinit/cert/cert.go
+++ b/pkg/karmadactl/cmdinit/cert/cert.go
@@ -276,7 +276,7 @@ func GenCerts(pkiPath, caCertFile, caKeyFile string, etcdServerCertCfg, etcdClie
 	if err != nil {
 		return err
 	}
-	if err = WriteCertAndKey(pkiPath, options.KarmadaCertAndKeyName, karmadaCert, &karmadaKey); err != nil {
+	if err = WriteCertAndKey(pkiPath, options.KarmadaClientCertAndKeyName, karmadaCert, &karmadaKey); err != nil {
 		return err
 	}
 
@@ -284,7 +284,7 @@ func GenCerts(pkiPath, caCertFile, caKeyFile string, etcdServerCertCfg, etcdClie
 	if err != nil {
 		return err
 	}
-	if err = WriteCertAndKey(pkiPath, options.ApiserverCertAndKeyName, apiserverCert, &apiserverKey); err != nil {
+	if err = WriteCertAndKey(pkiPath, options.KarmadaServerCertAndKeyName, apiserverCert, &apiserverKey); err != nil {
 		return err
 	}
 

--- a/pkg/karmadactl/cmdinit/cert/cert_test.go
+++ b/pkg/karmadactl/cmdinit/cert/cert_test.go
@@ -29,7 +29,9 @@ import (
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/klog/v2"
 
+	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/utils"
+	globaloptions "github.com/karmada-io/karmada/pkg/karmadactl/options"
 )
 
 const (
@@ -40,14 +42,22 @@ const (
 )
 
 var certFiles = []string{
-	"apiserver.crt", "apiserver.key",
-	"ca.crt", "ca.key",
-	"etcd-ca.crt", "etcd-ca.key",
-	"etcd-client.crt", "etcd-client.key",
-	"etcd-server.crt", "etcd-server.key",
-	"front-proxy-ca.crt", "front-proxy-ca.key",
-	"front-proxy-client.crt", "front-proxy-client.key",
-	"karmada.crt", "karmada.key",
+	fmt.Sprintf("%s.crt", globaloptions.CaCertAndKeyName),
+	fmt.Sprintf("%s.key", globaloptions.CaCertAndKeyName),
+	fmt.Sprintf("%s.crt", options.KarmadaServerCertAndKeyName),
+	fmt.Sprintf("%s.key", options.KarmadaServerCertAndKeyName),
+	fmt.Sprintf("%s.crt", options.KarmadaClientCertAndKeyName),
+	fmt.Sprintf("%s.key", options.KarmadaClientCertAndKeyName),
+	fmt.Sprintf("%s.crt", options.EtcdCaCertAndKeyName),
+	fmt.Sprintf("%s.key", options.EtcdCaCertAndKeyName),
+	fmt.Sprintf("%s.crt", options.EtcdClientCertAndKeyName),
+	fmt.Sprintf("%s.key", options.EtcdClientCertAndKeyName),
+	fmt.Sprintf("%s.crt", options.EtcdServerCertAndKeyName),
+	fmt.Sprintf("%s.key", options.EtcdServerCertAndKeyName),
+	fmt.Sprintf("%s.crt", options.FrontProxyCaCertAndKeyName),
+	fmt.Sprintf("%s.key", options.FrontProxyCaCertAndKeyName),
+	fmt.Sprintf("%s.crt", options.FrontProxyClientCertAndKeyName),
+	fmt.Sprintf("%s.key", options.FrontProxyClientCertAndKeyName),
 }
 
 func TestGenCerts(t *testing.T) {

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -51,15 +51,18 @@ var (
 		"cn":     "registry.cn-hangzhou.aliyuncs.com/google_containers",
 	}
 
-	certList = []string{
+	karmadaCertsList = []string{
 		globaloptions.CaCertAndKeyName,
+		options.KarmadaClientCertAndKeyName,
+		options.KarmadaServerCertAndKeyName,
+		options.FrontProxyCaCertAndKeyName,
+		options.FrontProxyClientCertAndKeyName,
+	}
+
+	etcdCertList = []string{
 		options.EtcdCaCertAndKeyName,
 		options.EtcdServerCertAndKeyName,
 		options.EtcdClientCertAndKeyName,
-		options.KarmadaCertAndKeyName,
-		options.ApiserverCertAndKeyName,
-		options.FrontProxyCaCertAndKeyName,
-		options.FrontProxyClientCertAndKeyName,
 	}
 
 	emptyByteSlice                 = make([]byte, 0)
@@ -314,8 +317,8 @@ func (i *CommandInitOption) genCerts() error {
 			DNSNames: etcdServerCertDNS,
 			IPs:      []net.IP{utils.StringToNetIP("127.0.0.1")},
 		}
-		etcdServerCertConfig = cert.NewCertConfig("karmada-etcd-server", []string{}, etcdServerAltNames, &notAfter)
-		etcdClientCertCfg = cert.NewCertConfig("karmada-etcd-client", []string{}, certutil.AltNames{}, &notAfter)
+		etcdServerCertConfig = cert.NewCertConfig("etcd-server", []string{}, etcdServerAltNames, &notAfter)
+		etcdClientCertCfg = cert.NewCertConfig("etcd-client", []string{}, certutil.AltNames{}, &notAfter)
 	}
 
 	karmadaDNS := []string{
@@ -353,12 +356,12 @@ func (i *CommandInitOption) genCerts() error {
 		DNSNames: karmadaDNS,
 		IPs:      karmadaIPs,
 	}
-	karmadaCertCfg := cert.NewCertConfig("system:admin", []string{"system:masters"}, karmadaAltNames, &notAfter)
+	karmadaClientCertCfg := cert.NewCertConfig("system:admin", []string{"system:masters"}, karmadaAltNames, &notAfter)
 
-	apiserverCertCfg := cert.NewCertConfig("karmada-apiserver", []string{""}, karmadaAltNames, &notAfter)
+	karmadaServerCertCfg := cert.NewCertConfig("karmada-apiserver", []string{""}, karmadaAltNames, &notAfter)
 
 	frontProxyClientCertCfg := cert.NewCertConfig("front-proxy-client", []string{}, certutil.AltNames{}, &notAfter)
-	if err = cert.GenCerts(i.KarmadaPkiPath, i.CaCertFile, i.CaKeyFile, etcdServerCertConfig, etcdClientCertCfg, karmadaCertCfg, apiserverCertCfg, frontProxyClientCertCfg); err != nil {
+	if err = cert.GenCerts(i.KarmadaPkiPath, i.CaCertFile, i.CaKeyFile, etcdServerCertConfig, etcdClientCertCfg, karmadaClientCertCfg, karmadaServerCertCfg, frontProxyClientCertCfg); err != nil {
 		return err
 	}
 	return nil
@@ -382,44 +385,46 @@ func (i *CommandInitOption) prepareCRD() error {
 }
 
 func (i *CommandInitOption) createCertsSecrets() error {
-	// Create kubeconfig Secret
+	// 1. Create karmada-kubeconfig Secret
 	karmadaServerURL := fmt.Sprintf("https://%s.%s.svc.%s:%v", karmadaAPIServerDeploymentAndServiceName, i.Namespace, i.HostClusterDomain, karmadaAPIServerContainerPort)
 	config := utils.CreateWithCerts(karmadaServerURL, options.UserName, options.UserName, i.CertAndKeyFileData[fmt.Sprintf("%s.crt", globaloptions.CaCertAndKeyName)],
-		i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaCertAndKeyName)], i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaCertAndKeyName)])
+		i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaClientCertAndKeyName)], i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaClientCertAndKeyName)])
 	configBytes, err := clientcmd.Write(*config)
 	if err != nil {
 		return fmt.Errorf("failure while serializing admin kubeConfig. %v", err)
 	}
 
-	kubeConfigSecret := i.SecretFromSpec(KubeConfigSecretAndMountName, corev1.SecretTypeOpaque, map[string]string{KubeConfigSecretAndMountName: string(configBytes)})
+	kubeConfigSecret := i.SecretFromSpec(KubeConfigSecretAndMountName, corev1.SecretTypeOpaque, map[string]string{kubeConfigSubPathName: string(configBytes)})
 	if err = util.CreateOrUpdateSecret(i.KubeClientSet, kubeConfigSecret); err != nil {
 		return err
 	}
-	// Create certs Secret
-	etcdCert := map[string]string{
-		fmt.Sprintf("%s.crt", options.EtcdCaCertAndKeyName):     string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.EtcdCaCertAndKeyName)]),
-		fmt.Sprintf("%s.key", options.EtcdCaCertAndKeyName):     string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.EtcdCaCertAndKeyName)]),
-		fmt.Sprintf("%s.crt", options.EtcdServerCertAndKeyName): string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.EtcdServerCertAndKeyName)]),
-		fmt.Sprintf("%s.key", options.EtcdServerCertAndKeyName): string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.EtcdServerCertAndKeyName)]),
+
+	// 2. Create karmada-certs Secret
+	karmadaCerts := map[string]string{}
+	for _, v := range karmadaCertsList {
+		karmadaCerts[fmt.Sprintf("%s.crt", v)] = string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", v)])
+		karmadaCerts[fmt.Sprintf("%s.key", v)] = string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", v)])
+	}
+	karmadaSecret := i.SecretFromSpec(globaloptions.KarmadaCertsName, corev1.SecretTypeOpaque, karmadaCerts)
+	if err := util.CreateOrUpdateSecret(i.KubeClientSet, karmadaSecret); err != nil {
+		return err
+	}
+
+	// 3. Create karmada-etcd-cert Secret
+	etcdCert := map[string]string{}
+	for _, v := range etcdCertList {
+		etcdCert[fmt.Sprintf("%s.crt", v)] = string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", v)])
+		etcdCert[fmt.Sprintf("%s.key", v)] = string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", v)])
 	}
 	etcdSecret := i.SecretFromSpec(etcdCertName, corev1.SecretTypeOpaque, etcdCert)
 	if err := util.CreateOrUpdateSecret(i.KubeClientSet, etcdSecret); err != nil {
 		return err
 	}
 
-	karmadaCert := map[string]string{}
-	for _, v := range certList {
-		karmadaCert[fmt.Sprintf("%s.crt", v)] = string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", v)])
-		karmadaCert[fmt.Sprintf("%s.key", v)] = string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", v)])
-	}
-	karmadaSecret := i.SecretFromSpec(globaloptions.KarmadaCertsName, corev1.SecretTypeOpaque, karmadaCert)
-	if err := util.CreateOrUpdateSecret(i.KubeClientSet, karmadaSecret); err != nil {
-		return err
-	}
-
+	// 4. Create karmada-webhook-cert Secret
 	karmadaWebhookCert := map[string]string{
-		"tls.crt": string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaCertAndKeyName)]),
-		"tls.key": string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaCertAndKeyName)]),
+		"tls.crt": string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaServerCertAndKeyName)]),
+		"tls.key": string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaServerCertAndKeyName)]),
 	}
 	karmadaWebhookSecret := i.SecretFromSpec(webhookCertsName, corev1.SecretTypeOpaque, karmadaWebhookCert)
 	if err := util.CreateOrUpdateSecret(i.KubeClientSet, karmadaWebhookSecret); err != nil {
@@ -533,6 +538,7 @@ func (i *CommandInitOption) RunInit(parentCommand string) error {
 
 	i.CertAndKeyFileData = map[string][]byte{}
 
+	certList := append(karmadaCertsList, etcdCertList...)
 	for _, v := range certList {
 		if isExternalEtcdCert, err := i.readExternalEtcdCert(v); err != nil {
 			return fmt.Errorf("read external etcd certificate failed, %s. %v", v, err)
@@ -606,8 +612,8 @@ func (i *CommandInitOption) createKarmadaConfig() error {
 		return err
 	}
 	if err := utils.WriteKubeConfigFromSpec(serverURL, options.UserName, options.ClusterName, i.KarmadaDataPath, options.KarmadaKubeConfigName,
-		i.CertAndKeyFileData[fmt.Sprintf("%s.crt", globaloptions.CaCertAndKeyName)], i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaCertAndKeyName)],
-		i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaCertAndKeyName)]); err != nil {
+		i.CertAndKeyFileData[fmt.Sprintf("%s.crt", globaloptions.CaCertAndKeyName)], i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaClientCertAndKeyName)],
+		i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaClientCertAndKeyName)]); err != nil {
 		return fmt.Errorf("failed to create karmada kubeconfig file. %v", err)
 	}
 	klog.Info("Create karmada kubeconfig success.")

--- a/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
@@ -45,8 +45,8 @@ const (
 	etcdConfigName                     = "etcd.conf"
 	etcdEnvPodName                     = "POD_NAME"
 	etcdEnvPodIP                       = "POD_IP"
-	//secrets name
-	etcdCertName = "etcd-cert"
+	etcdCertName                       = "karmada-etcd-cert"
+	etcdCertVolumeMountPath            = "/etc/etcd/pki"
 )
 
 var (
@@ -163,12 +163,12 @@ cipher-suites: %s
 `,
 			etcdContainerConfigDataMountPath, etcdConfigName,
 			etcdEnvPodName,
-			karmadaCertsVolumeMountPath, options.EtcdCaCertAndKeyName,
-			karmadaCertsVolumeMountPath, options.EtcdServerCertAndKeyName,
-			karmadaCertsVolumeMountPath, options.EtcdServerCertAndKeyName,
-			karmadaCertsVolumeMountPath, options.EtcdCaCertAndKeyName,
-			karmadaCertsVolumeMountPath, options.EtcdServerCertAndKeyName,
-			karmadaCertsVolumeMountPath, options.EtcdServerCertAndKeyName,
+			etcdCertVolumeMountPath, options.EtcdCaCertAndKeyName,
+			etcdCertVolumeMountPath, options.EtcdServerCertAndKeyName,
+			etcdCertVolumeMountPath, options.EtcdServerCertAndKeyName,
+			etcdCertVolumeMountPath, options.EtcdCaCertAndKeyName,
+			etcdCertVolumeMountPath, options.EtcdServerCertAndKeyName,
+			etcdCertVolumeMountPath, options.EtcdServerCertAndKeyName,
 			strings.TrimRight(etcdClusterConfig, ","),
 			etcdEnvPodIP, etcdContainerServerPort,
 			etcdEnvPodIP, etcdContainerClientPort, etcdContainerClientPort,
@@ -289,7 +289,7 @@ func (i *CommandInitOption) makeETCDStatefulSet() *appsv1.StatefulSet {
 					{
 						Name:      etcdCertName,
 						ReadOnly:  true,
-						MountPath: karmadaCertsVolumeMountPath,
+						MountPath: etcdCertVolumeMountPath,
 					},
 				},
 				LivenessProbe: livenesProbe,

--- a/pkg/karmadactl/cmdinit/options/global.go
+++ b/pkg/karmadactl/cmdinit/options/global.go
@@ -23,10 +23,10 @@ const (
 	EtcdServerCertAndKeyName = "etcd-server"
 	// EtcdClientCertAndKeyName etcd client certificate key name
 	EtcdClientCertAndKeyName = "etcd-client"
-	// KarmadaCertAndKeyName karmada certificate key name
-	KarmadaCertAndKeyName = "karmada"
-	// ApiserverCertAndKeyName karmada apiserver certificate key name
-	ApiserverCertAndKeyName = "apiserver"
+	// KarmadaClientCertAndKeyName karmada certificate key name
+	KarmadaClientCertAndKeyName = "karmada-client"
+	// KarmadaServerCertAndKeyName karmada apiserver certificate key name
+	KarmadaServerCertAndKeyName = "karmada-server"
 	// FrontProxyCaCertAndKeyName front-proxy-client  certificate key name
 	FrontProxyCaCertAndKeyName = "front-proxy-ca"
 	// FrontProxyClientCertAndKeyName front-proxy-client  certificate key name

--- a/pkg/karmadactl/options/global.go
+++ b/pkg/karmadactl/options/global.go
@@ -35,7 +35,7 @@ const DefaultKarmadactlCommandDuration = 60 * time.Second
 
 const (
 	// KarmadaCertsName the secret name of karmada certs
-	KarmadaCertsName = "karmada-cert"
+	KarmadaCertsName = "karmada-certs"
 	// CaCertAndKeyName ca certificate cert/key name in karmada certs secret
 	CaCertAndKeyName = "ca"
 )


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

In karmada, here are two important secrets, which is mount by most karmada components. One is karmada-cert, which contains a series of cert files like ca.crt, apiserver.crt and so on; another is karmada-kubeconfig, which contains a kubeconfig of karmada-apiserver.

However, in different installation methods, we used inconsistent secret naming or file path naming, which can potentially cause some unnecessary problems, detail refer to #5363.

This PR aims to standardize the naming of karmada secrets in karmadactl installation method.

**Which issue(s) this PR fixes**:

Fixes part of #5363

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmadactl: standardize the naming of karmada secrets in karmadactl installation method
```

