### PR TITLE
Fix mTLS Configuration for Karmada Scheduler & Descheduler Components

### DIFF
--- a/operator/pkg/controlplane/controlplane.go
+++ b/operator/pkg/controlplane/controlplane.go
@@ -140,17 +140,18 @@ func getKarmadaControllerManagerManifest(name, namespace string, featureGates ma
 
 func getKarmadaSchedulerManifest(name, namespace string, featureGates map[string]bool, cfg *operatorv1alpha1.KarmadaScheduler) (*appsv1.Deployment, error) {
 	karmadaSchedulerBytes, err := util.ParseTemplate(KarmadaSchedulerDeployment, struct {
-		Replicas                                   *int32
-		DeploymentName, Namespace, SystemNamespace string
-		Image, ImagePullPolicy, KubeconfigSecret   string
+		Replicas                                                     *int32
+		DeploymentName, Namespace, SystemNamespace                   string
+		Image, ImagePullPolicy, KubeconfigSecret, KarmadaCertsSecret string
 	}{
-		DeploymentName:   util.KarmadaSchedulerName(name),
-		Namespace:        namespace,
-		SystemNamespace:  constants.KarmadaSystemNamespace,
-		Image:            cfg.Image.Name(),
-		ImagePullPolicy:  string(cfg.ImagePullPolicy),
-		KubeconfigSecret: util.AdminKubeconfigSecretName(name),
-		Replicas:         cfg.Replicas,
+		DeploymentName:     util.KarmadaSchedulerName(name),
+		Namespace:          namespace,
+		SystemNamespace:    constants.KarmadaSystemNamespace,
+		Image:              cfg.Image.Name(),
+		ImagePullPolicy:    string(cfg.ImagePullPolicy),
+		KubeconfigSecret:   util.AdminKubeconfigSecretName(name),
+		KarmadaCertsSecret: util.KarmadaCertSecretName(name),
+		Replicas:           cfg.Replicas,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error when parsing karmada-scheduler deployment template: %w", err)
@@ -168,17 +169,18 @@ func getKarmadaSchedulerManifest(name, namespace string, featureGates map[string
 
 func getKarmadaDeschedulerManifest(name, namespace string, featureGates map[string]bool, cfg *operatorv1alpha1.KarmadaDescheduler) (*appsv1.Deployment, error) {
 	karmadaDeschedulerBytes, err := util.ParseTemplate(KarmadaDeschedulerDeployment, struct {
-		Replicas                                   *int32
-		DeploymentName, Namespace, SystemNamespace string
-		Image, ImagePullPolicy, KubeconfigSecret   string
+		Replicas                                                     *int32
+		DeploymentName, Namespace, SystemNamespace                   string
+		Image, ImagePullPolicy, KubeconfigSecret, KarmadaCertsSecret string
 	}{
-		DeploymentName:   util.KarmadaDeschedulerName(name),
-		Namespace:        namespace,
-		SystemNamespace:  constants.KarmadaSystemNamespace,
-		Image:            cfg.Image.Name(),
-		ImagePullPolicy:  string(cfg.ImagePullPolicy),
-		KubeconfigSecret: util.AdminKubeconfigSecretName(name),
-		Replicas:         cfg.Replicas,
+		DeploymentName:     util.KarmadaDeschedulerName(name),
+		Namespace:          namespace,
+		SystemNamespace:    constants.KarmadaSystemNamespace,
+		Image:              cfg.Image.Name(),
+		ImagePullPolicy:    string(cfg.ImagePullPolicy),
+		KubeconfigSecret:   util.AdminKubeconfigSecretName(name),
+		KarmadaCertsSecret: util.KarmadaCertSecretName(name),
+		Replicas:           cfg.Replicas,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error when parsing karmada-descheduler deployment template: %w", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

A recent change introduced new flags for configuring mTLS for the [Karmada Scheduler](https://github.com/karmada-io/karmada/blob/release-1.11/operator/pkg/controlplane/manifests.go#L195) & [Descheduler](https://github.com/karmada-io/karmada/blob/release-1.11/operator/pkg/controlplane/manifests.go#L262) components. As such, the manifest templates for those components were changed accordingly to reflect the new change. Configuration of the new flags now require that a volume be [mounted](https://github.com/karmada-io/karmada/blob/release-1.11/operator/pkg/controlplane/manifests.go#L222) to use as the source of the TLS data. However, it looks like there's one more change required that was missed.

**Which issue(s) this PR fixes**:
Fixes #5545 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-operator`: Fixed the issue where the manifests for the `karmada-scheduler` and `karmada-descheduler` components were not parsed correctly.
```

