### PR TITLE
Remove deprecated --bind-address and --secure-port from karmada-scheduler

### DIFF
--- a/artifacts/deploy/karmada-scheduler.yaml
+++ b/artifacts/deploy/karmada-scheduler.yaml
@@ -33,14 +33,13 @@ spec:
             periodSeconds: 15
             timeoutSeconds: 5
           ports:
-            - containerPort: 10351
+            - containerPort: 8080
               name: metrics
               protocol: TCP
           command:
             - /bin/karmada-scheduler
             - --kubeconfig=/etc/kubeconfig
-            - --bind-address=0.0.0.0
-            - --metrics-bind-address=0.0.0.0:10351
+            - --metrics-bind-address=0.0.0.0:8080
             - --health-probe-bind-address=0.0.0.0:10351
             - --enable-scheduler-estimator=true
             - --scheduler-estimator-ca-file=/etc/karmada/pki/ca.crt

--- a/charts/karmada/templates/karmada-scheduler.yaml
+++ b/charts/karmada/templates/karmada-scheduler.yaml
@@ -50,8 +50,8 @@ spec:
           command:
             - /bin/karmada-scheduler
             - --kubeconfig=/etc/kubeconfig
-            - --bind-address=0.0.0.0
-            - --secure-port=10351
+            - --metrics-bind-address=0.0.0.0:8080
+            - --health-probe-bind-address=0.0.0.0:10351
             - --leader-elect-resource-namespace={{ $systemNamespace }}
             - --scheduler-estimator-ca-file=/etc/karmada/pki/server-ca.crt
             - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada.crt
@@ -66,8 +66,9 @@ spec:
             periodSeconds: 15
             timeoutSeconds: 5
           ports:
-            - containerPort: 10351
-              name: http
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
           volumeMounts:
             - name: karmada-certs
               mountPath: /etc/karmada/pki

--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -35,8 +35,6 @@ import (
 )
 
 const (
-	defaultBindAddress   = "0.0.0.0"
-	defaultPort          = 10351
 	defaultEstimatorPort = 10352
 )
 
@@ -51,17 +49,11 @@ type Options struct {
 	LeaderElection componentbaseconfig.LeaderElectionConfiguration
 	KubeConfig     string
 	Master         string
-	// BindAddress is the IP address on which to listen for the --secure-port port.
-	// Deprecated: To specify the TCP address for serving health probes, use HealthProbeBindAddress instead. To specify the TCP address for serving prometheus metrics, use MetricsBindAddress instead. This will be removed in release 1.12+.
-	BindAddress string
-	// SecurePort is the port that the server serves at.
-	// Deprecated: To specify the TCP address for serving health probes, use HealthProbeBindAddress instead. To specify the TCP address for serving prometheus metrics, use MetricsBindAddress instead. This will be removed in release 1.12+.
-	SecurePort int
 
 	// MetricsBindAddress is the TCP address that the controller should bind to
 	// for serving prometheus metrics.
 	// It can be set to "0" to disable the metrics serving.
-	// Defaults to ":10351".
+	// Defaults to ":8080".
 	MetricsBindAddress string
 
 	// HealthProbeBindAddress is the TCP address that the controller should bind to
@@ -153,14 +145,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 		"of a leadership. This is only applicable if leader election is enabled.")
 	fs.StringVar(&o.KubeConfig, "kubeconfig", o.KubeConfig, "Path to karmada control plane kubeconfig file.")
 	fs.StringVar(&o.Master, "master", o.Master, "The address of the Kubernetes API server. Overrides any value in KubeConfig. Only required if out-of-cluster.")
-	fs.StringVar(&o.BindAddress, "bind-address", defaultBindAddress, "The IP address on which to listen for the --secure-port port.")
-	fs.IntVar(&o.SecurePort, "secure-port", defaultPort, "The secure port on which to serve HTTPS.")
-	// nolint: errcheck
-	fs.MarkDeprecated("bind-address", "This flag is deprecated and will be removed in release 1.12+. Use --health-probe-bind-address and --metrics-bind-address instead. Note: In release 1.12+, these two addresses cannot be the same.")
-	// nolint: errcheck
-	fs.MarkDeprecated("secure-port", "This flag is deprecated and will be removed in release 1.12+. Use --health-probe-bind-address and --metrics-bind-address instead. Note: In release 1.12+, these two addresses cannot be the same.")
-	fs.StringVar(&o.MetricsBindAddress, "metrics-bind-address", "", "The TCP address that the server should bind to for serving prometheus metrics(e.g. 127.0.0.1:9000, :10351). It can be set to \"0\" to disable the metrics serving. Defaults to 0.0.0.0:10351.")
-	fs.StringVar(&o.HealthProbeBindAddress, "health-probe-bind-address", "", "The TCP address that the server should bind to for serving health probes(e.g. 127.0.0.1:9000, :10351). It can be set to \"0\" to disable serving the health probe. Defaults to 0.0.0.0:10351.")
+	fs.StringVar(&o.MetricsBindAddress, "metrics-bind-address", ":8080", "The TCP address that the server should bind to for serving prometheus metrics(e.g. 127.0.0.1:8080, :8080). It can be set to \"0\" to disable the metrics serving. Defaults to 0.0.0.0:8080.")
+	fs.StringVar(&o.HealthProbeBindAddress, "health-probe-bind-address", ":10351", "The TCP address that the server should bind to for serving health probes(e.g. 127.0.0.1:10351, :10351). It can be set to \"0\" to disable serving the health probe. Defaults to 0.0.0.0:10351.")
 	fs.Float32Var(&o.KubeAPIQPS, "kube-api-qps", 40.0, "QPS to use while talking with karmada-apiserver.")
 	fs.IntVar(&o.KubeAPIBurst, "kube-api-burst", 60, "Burst to use while talking with karmada-apiserver.")
 	fs.BoolVar(&o.EnableSchedulerEstimator, "enable-scheduler-estimator", false, "Enable calling cluster scheduler estimator for adjusting replicas.")

--- a/cmd/scheduler/app/options/options_test.go
+++ b/cmd/scheduler/app/options/options_test.go
@@ -59,44 +59,6 @@ func TestAddFlags(t *testing.T) {
 	}
 }
 
-func TestOptionsComplete(t *testing.T) {
-	testCases := []struct {
-		name            string
-		bindAddress     string
-		securePort      int
-		expectedMetrics string
-		expectedHealth  string
-	}{
-		{
-			name:            "Default values",
-			bindAddress:     defaultBindAddress,
-			securePort:      defaultPort,
-			expectedMetrics: "0.0.0.0:10351",
-			expectedHealth:  "0.0.0.0:10351",
-		},
-		{
-			name:            "Custom values",
-			bindAddress:     "127.0.0.1",
-			securePort:      8080,
-			expectedMetrics: "127.0.0.1:8080",
-			expectedHealth:  "127.0.0.1:8080",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			opts := &Options{
-				BindAddress: tc.bindAddress,
-				SecurePort:  tc.securePort,
-			}
-			err := opts.Complete()
-			assert.NoError(t, err)
-			assert.Equal(t, tc.expectedMetrics, opts.MetricsBindAddress)
-			assert.Equal(t, tc.expectedHealth, opts.HealthProbeBindAddress)
-		})
-	}
-}
-
 func TestOptionsFlagParsing(t *testing.T) {
 	opts := NewOptions()
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)

--- a/cmd/scheduler/app/options/validation.go
+++ b/cmd/scheduler/app/options/validation.go
@@ -17,22 +17,8 @@ limitations under the License.
 package options
 
 import (
-	"net"
-	"strconv"
-
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
-
-// Complete ensures that options are valid and marshals them if necessary.
-func (o *Options) Complete() error {
-	if len(o.HealthProbeBindAddress) == 0 {
-		o.HealthProbeBindAddress = net.JoinHostPort(o.BindAddress, strconv.Itoa(o.SecurePort))
-	}
-	if len(o.MetricsBindAddress) == 0 {
-		o.MetricsBindAddress = net.JoinHostPort(o.BindAddress, strconv.Itoa(o.SecurePort))
-	}
-	return nil
-}
 
 // Validate checks Options and return a slice of found errs.
 func (o *Options) Validate() field.ErrorList {

--- a/cmd/scheduler/app/options/validation_test.go
+++ b/cmd/scheduler/app/options/validation_test.go
@@ -34,8 +34,6 @@ func New(modifyOptions ModifyOptions) Options {
 		LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
 			LeaderElect: false,
 		},
-		BindAddress:               "127.0.0.1",
-		SecurePort:                9000,
 		KubeAPIQPS:                40,
 		KubeAPIBurst:              30,
 		EnableSchedulerEstimator:  false,

--- a/cmd/scheduler/app/scheduler.go
+++ b/cmd/scheduler/app/scheduler.go
@@ -98,10 +98,6 @@ The scheduler determines which clusters are valid placements for each resource i
 constraints and available resources. The scheduler then ranks each valid cluster and binds the resource to
 the most suitable cluster.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			// complete options
-			if err := opts.Complete(); err != nil {
-				return err
-			}
 			// validate options
 			if errs := opts.Validate(); len(errs) != 0 {
 				return errs.ToAggregate()

--- a/operator/pkg/controlplane/manifests.go
+++ b/operator/pkg/controlplane/manifests.go
@@ -188,7 +188,7 @@ spec:
         command:
         - /bin/karmada-scheduler
         - --kubeconfig=/etc/karmada/kubeconfig
-        - --metrics-bind-address=0.0.0.0:10351
+        - --metrics-bind-address=0.0.0.0:8080
         - --health-probe-bind-address=0.0.0.0:10351
         - --enable-scheduler-estimator=true
         - --leader-elect-resource-namespace={{ .SystemNamespace }}
@@ -206,7 +206,7 @@ spec:
           periodSeconds: 15
           timeoutSeconds: 5
         ports:
-        - containerPort: 10351
+        - containerPort: 8080
           name: metrics
           protocol: TCP
         volumeMounts:

--- a/pkg/karmadactl/cmdinit/kubernetes/deployments.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deployments.go
@@ -449,7 +449,7 @@ func (i *CommandInitOption) makeKarmadaSchedulerDeployment() *appsv1.Deployment 
 				Command: []string{
 					"/bin/karmada-scheduler",
 					"--kubeconfig=/etc/kubeconfig",
-					"--metrics-bind-address=0.0.0.0:10351",
+					"--metrics-bind-address=0.0.0.0:8080",
 					"--health-probe-bind-address=0.0.0.0:10351",
 					"--enable-scheduler-estimator=true",
 					"--leader-elect=true",
@@ -463,7 +463,7 @@ func (i *CommandInitOption) makeKarmadaSchedulerDeployment() *appsv1.Deployment 
 				Ports: []corev1.ContainerPort{
 					{
 						Name:          metricsPortName,
-						ContainerPort: 10351,
+						ContainerPort: 8080,
 						Protocol:      corev1.ProtocolTCP,
 					},
 				},


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Remove deprecated --bind-address and --secure-port from karmada-scheduler

**Which issue(s) this PR fixes**:

Fixes part of #5547

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-scheduler`: Removed `--bind-address` and `--secure-port` flags which were deprecated in release-1.11 and replaced by `--health-probe-bind-address` and `--metrics-bind-address`.
```

