### PR TITLE
Remove deprecated --bind-address and --secure-port from karmada-descheduler

### DIFF
--- a/artifacts/deploy/karmada-descheduler.yaml
+++ b/artifacts/deploy/karmada-descheduler.yaml
@@ -26,7 +26,7 @@ spec:
           command:
             - /bin/karmada-descheduler
             - --kubeconfig=/etc/kubeconfig
-            - --metrics-bind-address=0.0.0.0:10358
+            - --metrics-bind-address=0.0.0.0:8080
             - --health-probe-bind-address=0.0.0.0:10358
             - --scheduler-estimator-ca-file=/etc/karmada/pki/ca.crt
             - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada.crt
@@ -42,7 +42,7 @@ spec:
             periodSeconds: 15
             timeoutSeconds: 5
           ports:
-            - containerPort: 10358
+            - containerPort: 8080
               name: metrics
               protocol: TCP
           volumeMounts:

--- a/charts/karmada/templates/karmada-descheduler.yaml
+++ b/charts/karmada/templates/karmada-descheduler.yaml
@@ -50,7 +50,7 @@ spec:
           command:
             - /bin/karmada-descheduler
             - --kubeconfig=/etc/kubeconfig
-            - --metrics-bind-address=0.0.0.0:10358
+            - --metrics-bind-address=0.0.0.0:8080
             - --health-probe-bind-address=0.0.0.0:10358
             - --leader-elect-resource-namespace={{ $systemNamespace }}
             - --scheduler-estimator-ca-file=/etc/karmada/pki/server-ca.crt
@@ -67,7 +67,7 @@ spec:
             periodSeconds: 15
             timeoutSeconds: 5
           ports:
-            - containerPort: 10358
+            - containerPort: 8080
               name: metrics
               protocol: TCP
           volumeMounts:

--- a/cmd/descheduler/app/descheduler.go
+++ b/cmd/descheduler/app/descheduler.go
@@ -85,11 +85,6 @@ func NewDeschedulerCommand(stopChan <-chan struct{}) *cobra.Command {
 if they are failed to be scheduled for a period of time. It relies on 
 karmada-scheduler-estimator to get replica status.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			// complete options
-			if err := opts.Complete(); err != nil {
-				return err
-			}
-
 			// validate options
 			if errs := opts.Validate(); len(errs) != 0 {
 				return errs.ToAggregate()

--- a/cmd/descheduler/app/options/options.go
+++ b/cmd/descheduler/app/options/options.go
@@ -17,8 +17,6 @@ limitations under the License.
 package options
 
 import (
-	"net"
-	"strconv"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -31,8 +29,6 @@ import (
 )
 
 const (
-	defaultBindAddress            = "0.0.0.0"
-	defaultPort                   = 10358
 	defaultEstimatorPort          = 10352
 	defaultDeschedulingInterval   = 2 * time.Minute
 	defaultUnschedulableThreshold = 5 * time.Minute
@@ -49,12 +45,6 @@ type Options struct {
 	LeaderElection componentbaseconfig.LeaderElectionConfiguration
 	KubeConfig     string
 	Master         string
-	// BindAddress is the IP address on which to listen for the --secure-port port.
-	// Deprecated: To specify the TCP address for serving health probes, use HealthProbeBindAddress instead. To specify the TCP address for serving prometheus metrics, use MetricsBindAddress instead. This will be removed in release 1.12+.
-	BindAddress string
-	// SecurePort is the port that the server serves at.
-	// Deprecated: To specify the TCP address for serving health probes, use HealthProbeBindAddress instead. To specify the TCP address for serving prometheus metrics, use MetricsBindAddress instead. This will be removed in release 1.12+.
-	SecurePort int
 
 	KubeAPIQPS float32
 	// KubeAPIBurst is the burst to allow while talking with karmada-apiserver.
@@ -84,7 +74,7 @@ type Options struct {
 	// MetricsBindAddress is the TCP address that the server should bind to
 	// for serving prometheus metrics.
 	// It can be set to "0" to disable the metrics serving.
-	// Defaults to ":10358".
+	// Defaults to ":8080".
 	MetricsBindAddress string
 	// HealthProbeBindAddress is the TCP address that the server should bind to
 	// for serving health probes
@@ -117,12 +107,6 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.LeaderElection.ResourceNamespace, "leader-elect-resource-namespace", util.NamespaceKarmadaSystem, "The namespace of resource object that is used for locking during leader election.")
 	fs.StringVar(&o.KubeConfig, "kubeconfig", o.KubeConfig, "Path to karmada control plane kubeconfig file.")
 	fs.StringVar(&o.Master, "master", o.Master, "The address of the Kubernetes API server. Overrides any value in KubeConfig. Only required if out-of-cluster.")
-	fs.StringVar(&o.BindAddress, "bind-address", defaultBindAddress, "The IP address on which to listen for the --secure-port port.")
-	fs.IntVar(&o.SecurePort, "secure-port", defaultPort, "The secure port on which to serve HTTPS.")
-	// nolint: errcheck
-	fs.MarkDeprecated("bind-address", "This flag is deprecated and will be removed in release 1.12+. Use --health-probe-bind-address and --metrics-bind-address instead. Note: In release 1.12+, these two addresses cannot be the same.")
-	// nolint: errcheck
-	fs.MarkDeprecated("secure-port", "This flag is deprecated and will be removed in release 1.12+. Use --health-probe-bind-address and --metrics-bind-address instead. Note: In release 1.12+, these two addresses cannot be the same.")
 	fs.Float32Var(&o.KubeAPIQPS, "kube-api-qps", 40.0, "QPS to use while talking with karmada-apiserver.")
 	fs.IntVar(&o.KubeAPIBurst, "kube-api-burst", 60, "Burst to use while talking with karmada-apiserver.")
 	fs.DurationVar(&o.SchedulerEstimatorTimeout.Duration, "scheduler-estimator-timeout", 3*time.Second, "Specifies the timeout period of calling the scheduler estimator service.")
@@ -135,18 +119,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.SchedulerEstimatorServicePrefix, "scheduler-estimator-service-prefix", "karmada-scheduler-estimator", "The prefix of scheduler estimator service name")
 	fs.DurationVar(&o.DeschedulingInterval.Duration, "descheduling-interval", defaultDeschedulingInterval, "Time interval between two consecutive descheduler executions. Setting this value instructs the descheduler to run in a continuous loop at the interval specified.")
 	fs.DurationVar(&o.UnschedulableThreshold.Duration, "unschedulable-threshold", defaultUnschedulableThreshold, "The period of pod unschedulable condition. This value is considered as a classification standard of unschedulable replicas.")
-	fs.StringVar(&o.MetricsBindAddress, "metrics-bind-address", "", "The TCP address that the server should bind to for serving prometheus metrics(e.g. 127.0.0.1:10358, :10358). It can be set to \"0\" to disable the metrics serving. Defaults to 0.0.0.0:10358.")
-	fs.StringVar(&o.HealthProbeBindAddress, "health-probe-bind-address", "", "The TCP address that the server should bind to for serving health probes(e.g. 127.0.0.1:10358, :10358). It can be set to \"0\" to disable serving the health probe. Defaults to 0.0.0.0:10358.")
+	fs.StringVar(&o.MetricsBindAddress, "metrics-bind-address", ":8080", "The TCP address that the server should bind to for serving prometheus metrics(e.g. 127.0.0.1:8080, :8080). It can be set to \"0\" to disable the metrics serving. Defaults to 0.0.0.0:8080.")
+	fs.StringVar(&o.HealthProbeBindAddress, "health-probe-bind-address", ":10358", "The TCP address that the server should bind to for serving health probes(e.g. 127.0.0.1:10358, :10358). It can be set to \"0\" to disable serving the health probe. Defaults to 0.0.0.0:10358.")
 	o.ProfileOpts.AddFlags(fs)
-}
-
-// Complete ensures that options are valid and marshals them if necessary.
-func (o *Options) Complete() error {
-	if len(o.HealthProbeBindAddress) == 0 {
-		o.HealthProbeBindAddress = net.JoinHostPort(o.BindAddress, strconv.Itoa(o.SecurePort))
-	}
-	if len(o.MetricsBindAddress) == 0 {
-		o.MetricsBindAddress = net.JoinHostPort(o.BindAddress, strconv.Itoa(o.SecurePort))
-	}
-	return nil
 }

--- a/cmd/descheduler/app/options/validation_test.go
+++ b/cmd/descheduler/app/options/validation_test.go
@@ -59,8 +59,6 @@ func TestValidateKarmadaDescheduler(t *testing.T) {
 			LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
 				LeaderElect: false,
 			},
-			BindAddress:  "127.0.0.1",
-			SecurePort:   9000,
 			KubeAPIQPS:   40,
 			KubeAPIBurst: 30,
 		}}

--- a/operator/pkg/controlplane/manifests.go
+++ b/operator/pkg/controlplane/manifests.go
@@ -256,7 +256,7 @@ spec:
         command:
         - /bin/karmada-descheduler
         - --kubeconfig=/etc/karmada/kubeconfig
-        - --metrics-bind-address=0.0.0.0:10358
+        - --metrics-bind-address=0.0.0.0:8080
         - --health-probe-bind-address=0.0.0.0:10358
         - --leader-elect-resource-namespace={{ .SystemNamespace }}
         - --scheduler-estimator-ca-file=/etc/karmada/pki/ca.crt
@@ -273,7 +273,7 @@ spec:
           periodSeconds: 15
           timeoutSeconds: 5
         ports:
-        - containerPort: 10358
+        - containerPort: 8080
           name: metrics
           protocol: TCP
         volumeMounts:

--- a/pkg/karmadactl/addons/descheduler/manifests.go
+++ b/pkg/karmadactl/addons/descheduler/manifests.go
@@ -45,7 +45,7 @@ spec:
           command:
             - /bin/karmada-descheduler
             - --kubeconfig=/etc/kubeconfig
-            - --metrics-bind-address=0.0.0.0:10358
+            - --metrics-bind-address=0.0.0.0:8080
             - --health-probe-bind-address=0.0.0.0:10358
             - --leader-elect-resource-namespace={{ .Namespace }}
             - --scheduler-estimator-ca-file=/etc/karmada/pki/ca.crt
@@ -62,7 +62,7 @@ spec:
             periodSeconds: 15
             timeoutSeconds: 5
           ports:
-            - containerPort: 10358
+            - containerPort: 8080
               name: metrics
               protocol: TCP
           volumeMounts:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Remove deprecated --bind-address and --secure-port from karmada-descheduler

**Which issue(s) this PR fixes**:

Fixes part of #5547

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-descheduler`: Removed `--bind-address` and `--secure-port` flags which were deprecated in release-1.11 and replaced by `--health-probe-bind-address` and `--metrics-bind-address`.
```

