### PR TITLE
Remove deprecated `--bind-address` and `--bind-address` from `karmada-scheduler-estimator`

### DIFF
--- a/artifacts/deploy/karmada-scheduler-estimator.yaml
+++ b/artifacts/deploy/karmada-scheduler-estimator.yaml
@@ -30,7 +30,7 @@ spec:
             - --grpc-auth-cert-file=/etc/karmada/pki/karmada.crt
             - --grpc-auth-key-file=/etc/karmada/pki/karmada.key
             - --grpc-client-ca-file=/etc/karmada/pki/ca.crt
-            - --metrics-bind-address=0.0.0.0:10351
+            - --metrics-bind-address=0.0.0.0:8080
             - --health-probe-bind-address=0.0.0.0:10351
           livenessProbe:
             httpGet:
@@ -42,7 +42,7 @@ spec:
             periodSeconds: 15
             timeoutSeconds: 5
           ports:
-            - containerPort: 10351
+            - containerPort: 8080
               name: metrics
               protocol: TCP
           volumeMounts:

--- a/charts/karmada/templates/karmada-scheduler-estimator.yaml
+++ b/charts/karmada/templates/karmada-scheduler-estimator.yaml
@@ -51,7 +51,7 @@ spec:
             - --grpc-auth-cert-file=/etc/karmada/pki/karmada.crt
             - --grpc-auth-key-file=/etc/karmada/pki/karmada.key
             - --grpc-client-ca-file=/etc/karmada/pki/server-ca.crt
-            - --metrics-bind-address=0.0.0.0:10351
+            - --metrics-bind-address=0.0.0.0:8080
             - --health-probe-bind-address=0.0.0.0:10351
             {{- with (include "karmada.schedulerEstimator.featureGates" (dict "featureGatesArg" $.Values.schedulerEstimator.featureGates)) }}
             - {{ . }}
@@ -66,7 +66,7 @@ spec:
             periodSeconds: 15
             timeoutSeconds: 5
           ports:
-            - containerPort: 10351
+            - containerPort: 8080
               name: metrics
               protocol: TCP
           volumeMounts:

--- a/cmd/scheduler-estimator/app/options/options.go
+++ b/cmd/scheduler-estimator/app/options/options.go
@@ -17,9 +17,6 @@ limitations under the License.
 package options
 
 import (
-	"net"
-	"strconv"
-
 	"github.com/spf13/pflag"
 
 	"github.com/karmada-io/karmada/pkg/features"
@@ -27,9 +24,7 @@ import (
 )
 
 const (
-	defaultBindAddress = "0.0.0.0"
-	defaultServerPort  = 10352
-	defaultHealthzPort = 10351
+	defaultServerPort = 10352
 )
 
 // Options contains everything necessary to create and run scheduler-estimator.
@@ -37,12 +32,6 @@ type Options struct {
 	KubeConfig  string
 	Master      string
 	ClusterName string
-	// BindAddress is the IP address on which to listen for the --secure-port port.
-	// Deprecated: To specify the TCP address for serving health probes, use HealthProbeBindAddress instead. To specify the TCP address for serving prometheus metrics, use MetricsBindAddress instead. This will be removed in release 1.12+.
-	BindAddress string
-	// SecurePort is the port that the server serves at.
-	// Deprecated: To specify the TCP address for serving health probes, use HealthProbeBindAddress instead. To specify the TCP address for serving prometheus metrics, use MetricsBindAddress instead. This will be removed in release 1.12+.
-	SecurePort int
 	// ServerPort is the port that the server gRPC serves at.
 	ServerPort int
 	// InsecureSkipGrpcClientVerify controls whether verifies the grpc client's certificate chain and host name.
@@ -63,7 +52,7 @@ type Options struct {
 	// MetricsBindAddress is the TCP address that the server should bind to
 	// for serving prometheus metrics.
 	// It can be set to "0" to disable the metrics serving.
-	// Defaults to ":10351".
+	// Defaults to ":8080".
 	MetricsBindAddress string
 	// HealthProbeBindAddress is the TCP address that the server should bind to
 	// for serving health probes
@@ -85,34 +74,17 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.KubeConfig, "kubeconfig", o.KubeConfig, "Path to member cluster's kubeconfig file.")
 	fs.StringVar(&o.Master, "master", o.Master, "The address of the member Kubernetes API server. Overrides any value in KubeConfig. Only required if out-of-cluster.")
 	fs.StringVar(&o.ClusterName, "cluster-name", o.ClusterName, "Name of member cluster that the estimator serves for.")
-	fs.StringVar(&o.BindAddress, "bind-address", defaultBindAddress, "The IP address on which to listen for the --secure-port port.")
 	fs.IntVar(&o.ServerPort, "server-port", defaultServerPort, "The secure port on which to serve gRPC.")
 	fs.StringVar(&o.GrpcAuthCertFile, "grpc-auth-cert-file", "", "SSL certification file used for grpc SSL/TLS connections.")
 	fs.StringVar(&o.GrpcAuthKeyFile, "grpc-auth-key-file", "", "SSL key file used for grpc SSL/TLS connections.")
 	fs.BoolVar(&o.InsecureSkipGrpcClientVerify, "insecure-skip-grpc-client-verify", false, "If set to true, the estimator will not verify the grpc client's certificate chain and host name. When the relevant certificates are not configured, it will not take effect.")
 	fs.StringVar(&o.GrpcClientCaFile, "grpc-client-ca-file", "", "SSL Certificate Authority file used to verify grpc client certificates on incoming requests.")
-	fs.IntVar(&o.SecurePort, "secure-port", defaultHealthzPort, "The secure port on which to serve HTTPS.")
 	fs.Float32Var(&o.ClusterAPIQPS, "kube-api-qps", 20.0, "QPS to use while talking with apiserver.")
 	fs.IntVar(&o.ClusterAPIBurst, "kube-api-burst", 30, "Burst to use while talking with apiserver.")
 	fs.IntVar(&o.Parallelism, "parallelism", o.Parallelism, "Parallelism defines the amount of parallelism in algorithms for estimating. Must be greater than 0. Defaults to 16.")
-	// nolint: errcheck
-	fs.MarkDeprecated("bind-address", "This flag is deprecated and will be removed in release 1.12+. Use --health-probe-bind-address and --metrics-bind-address instead. Note: In release 1.12+, these two addresses cannot be the same.")
-	// nolint: errcheck
-	fs.MarkDeprecated("secure-port", "This flag is deprecated and will be removed in release 1.12+. Use --health-probe-bind-address and --metrics-bind-address instead. Note: In release 1.12+, these two addresses cannot be the same.")
-	fs.StringVar(&o.MetricsBindAddress, "metrics-bind-address", "", "The TCP address that the server should bind to for serving prometheus metrics(e.g. 127.0.0.1:10351, :10351). It can be set to \"0\" to disable the metrics serving. Defaults to 0.0.0.0:10351.")
-	fs.StringVar(&o.HealthProbeBindAddress, "health-probe-bind-address", "", "The TCP address that the server should bind to for serving health probes(e.g. 127.0.0.1:10351, :10351). It can be set to \"0\" to disable serving the health probe. Defaults to 0.0.0.0:10351.")
+	fs.StringVar(&o.MetricsBindAddress, "metrics-bind-address", ":8080", "The TCP address that the server should bind to for serving prometheus metrics(e.g. 127.0.0.1:8080, :8080). It can be set to \"0\" to disable the metrics serving. Defaults to 0.0.0.0:8080.")
+	fs.StringVar(&o.HealthProbeBindAddress, "health-probe-bind-address", ":10351", "The TCP address that the server should bind to for serving health probes(e.g. 127.0.0.1:10351, :10351). It can be set to \"0\" to disable serving the health probe. Defaults to 0.0.0.0:10351.")
 	features.FeatureGate.AddFlag(fs)
 
 	o.ProfileOpts.AddFlags(fs)
-}
-
-// Complete ensures that options are valid and marshals them if necessary.
-func (o *Options) Complete() error {
-	if len(o.HealthProbeBindAddress) == 0 {
-		o.HealthProbeBindAddress = net.JoinHostPort(o.BindAddress, strconv.Itoa(o.SecurePort))
-	}
-	if len(o.MetricsBindAddress) == 0 {
-		o.MetricsBindAddress = net.JoinHostPort(o.BindAddress, strconv.Itoa(o.SecurePort))
-	}
-	return nil
 }

--- a/cmd/scheduler-estimator/app/scheduler-estimator.go
+++ b/cmd/scheduler-estimator/app/scheduler-estimator.go
@@ -81,11 +81,6 @@ func NewSchedulerEstimatorCommand(ctx context.Context) *cobra.Command {
 		Long: `The karmada-scheduler-estimator runs an accurate scheduler estimator of a cluster. It 
 provides the scheduler with more accurate cluster resource information.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			// complete options
-			if err := opts.Complete(); err != nil {
-				return err
-			}
-
 			// validate options
 			if errs := opts.Validate(); len(errs) != 0 {
 				return errs.ToAggregate()

--- a/pkg/karmadactl/addons/estimator/manifests.go
+++ b/pkg/karmadactl/addons/estimator/manifests.go
@@ -51,7 +51,7 @@ spec:
             - --grpc-auth-cert-file=/etc/karmada/pki/karmada.crt
             - --grpc-auth-key-file=/etc/karmada/pki/karmada.key
             - --grpc-client-ca-file=/etc/karmada/pki/ca.crt
-            - --metrics-bind-address=0.0.0.0:10351
+            - --metrics-bind-address=0.0.0.0:8080
             - --health-probe-bind-address=0.0.0.0:10351
           livenessProbe:
             httpGet:
@@ -63,7 +63,7 @@ spec:
             periodSeconds: 15
             timeoutSeconds: 5
           ports:
-            - containerPort: 10351
+            - containerPort: 8080
               name: metrics
               protocol: TCP
           volumeMounts:

--- a/pkg/karmadactl/cmdinit/utils/examples.go
+++ b/pkg/karmadactl/cmdinit/utils/examples.go
@@ -140,7 +140,7 @@ spec:
             - /bin/karmada-scheduler-estimator
             - --kubeconfig=/etc/{{member_cluster_name}}-kubeconfig
             - --cluster-name={{member_cluster_name}}
-            - --metrics-bind-address=0.0.0.0:10351
+            - --metrics-bind-address=0.0.0.0:8080
             - --health-probe-bind-address=0.0.0.0:10351
           volumeMounts:
             - name: member-kubeconfig


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:

Which issue(s) this PR fixes:
part of https://github.com/karmada-io/karmada/issues/5547

Special notes for your reviewer:
Based on this [comment](https://github.com/karmada-io/karmada/pull/5273#discussion_r1732080241), I assign different default values to `--metrics-bind-address` and `--health-probe-bind-address`. I've chosen to align with other components by using `8080` as the default for `--metrics-bind-address`.

Does this PR introduce a user-facing change?:
```
`karmada-scheduler-estimator`: Removed `--bind-address` and `--secure-port` flags which were deprecated in release-1.11 and replaced by `--health-probe-bind-address` and `--metrics-bind-address`.
```