### PR TITLE
operator/pkg/certs: mitigate potential null pointer dereference in AltNames Mutators for both the `APIServer` and `EtcdServer`

### DIFF
--- a/operator/pkg/certs/certs.go
+++ b/operator/pkg/certs/certs.go
@@ -455,7 +455,7 @@ func etcdServerAltNamesMutator(cfg *AltNamesMutatorConfig) (*certutil.AltNames, 
 		IPs:      []net.IP{net.IPv4(127, 0, 0, 1)},
 	}
 
-	if cfg.Components.Etcd.Local != nil {
+	if cfg.Components != nil && cfg.Components.Etcd != nil && cfg.Components.Etcd.Local != nil {
 		appendSANsToAltNames(altNames, cfg.Components.Etcd.Local.ServerCertSANs)
 	}
 
@@ -488,7 +488,7 @@ func apiServerAltNamesMutator(cfg *AltNamesMutatorConfig) (*certutil.AltNames, e
 			fmt.Sprintf("*.%s.svc", cfg.Namespace)})
 	}
 
-	if len(cfg.Components.KarmadaAPIServer.CertSANs) > 0 {
+	if cfg.Components != nil && cfg.Components.KarmadaAPIServer != nil && len(cfg.Components.KarmadaAPIServer.CertSANs) > 0 {
 		appendSANsToAltNames(altNames, cfg.Components.KarmadaAPIServer.CertSANs)
 	}
 	if len(cfg.ControlplaneAddress) > 0 {


### PR DESCRIPTION
**Description**

In this commit, we fix the null pointer dereference issue that happens in altnames mutators for both Karmada APIServer and EtcdServer when accessing the `Components` field on `AltNamesMutatorConfig` struct.

**Motivation and Context**

In testing the Certificate Manager and Karmada Store (#5559), empty `Components` in [AltNamesMutatorConfig struct](https://github.com/karmada-io/karmada/blob/4c8bcd4af157ce68bc000da4974ec4d07a4b27fc/operator/pkg/certs/certs.go#L56) triggered a null pointer dereference in both APIServer and EtcdServer AltNames mutators. This PR resolves that issue.

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```