### PR TITLE
operator/pkg/certs: validate X509 Cert key types and improve error handling

### DIFF
--- a/pkg/karmadactl/cmdinit/cert/cert.go
+++ b/pkg/karmadactl/cmdinit/cert/cert.go
@@ -54,13 +54,20 @@ const (
 // NewPrivateKey returns a new private key.
 var NewPrivateKey = GeneratePrivateKey
 
-// GeneratePrivateKey Generate CA Private Key
+// GeneratePrivateKey generates a certificate key. It supports both
+// ECDSA (using the P-256 elliptic curve) and RSA algorithms. For RSA,
+// the key is generated with a size of 3072 bits. If the keyType is
+// x509.UnknownPublicKeyAlgorithm, the function defaults to generating
+// an RSA key.
 func GeneratePrivateKey(keyType x509.PublicKeyAlgorithm) (crypto.Signer, error) {
-	if keyType == x509.ECDSA {
+	switch keyType {
+	case x509.ECDSA:
 		return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	case x509.RSA, x509.UnknownPublicKeyAlgorithm:
+		return rsa.GenerateKey(rand.Reader, rsaKeySize)
+	default:
+		return nil, fmt.Errorf("unsupported key type: %T, supported key types are RSA and ECDSA", keyType)
 	}
-
-	return rsa.GenerateKey(rand.Reader, rsaKeySize)
 }
 
 // CertsConfig is a wrapper around certutil.Config extending it with PublicKeyAlgorithm.


### PR DESCRIPTION
**Description**
In this commit, we enhance the `GeneratePrivateKey` and `ParsePrivateKeyPEM` functions:

- Added validation for unsupported key types and provided a more descriptive error message. This function supports ECDSA (using P-256) and RSA (with a key size of 3072 bits) algorithms. It returns an error for unsupported key types.
- Improved error handling to include the type of the unsupported key format in the error message. This function now provides more informative feedback when the private key format is neither RSA nor ECDSA.

**Motivation and Context**
During the testing of the Certificate Manager and Karmada Store (#5559), it was observed that when unsupported key types such as `UnknownPublicKeyAlgorithm`, `DSA`, or `Ed25519` (as documented in the [Go standard library crypto package](https://pkg.go.dev/crypto/x509#PublicKeyAlgorithm)) are passed to the `GeneratePrivateKey` function, the function incorrectly returns an `RSA` key. Instead, it should return an error when encountering unsupported key types.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```