### PR TITLE
Avoid treating PVC managed by VolumeClaimTemplate as dependencies

### DIFF
--- a/pkg/resourceinterpreter/default/native/dependencies_test.go
+++ b/pkg/resourceinterpreter/default/native/dependencies_test.go
@@ -861,6 +861,39 @@ func Test_getStatefulSetDependencies(t *testing.T) {
 			want:    testPairs[2].dependentObjectReference,
 			wantErr: false,
 		},
+		{
+			name: "statefulset with partial dependencies 4",
+			object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "StatefulSet",
+					"metadata": map[string]interface{}{
+						"name":      "fake-statefulset",
+						"namespace": namespace,
+					},
+					"spec": map[string]interface{}{
+						"serviceName": "fake-service",
+						"selector": map[string]interface{}{
+							"matchLabels": map[string]interface{}{
+								"app": "fake",
+							},
+						},
+						"template": map[string]interface{}{
+							"spec": testPairs[0].podSpecsWithDependencies.Object,
+						},
+						"volumeClaimTemplates": []interface{}{
+							map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"name": "test-pvc",
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    testPairs[0].dependentObjectReference[:3], // remove the pvc dependency because it was found in the volumeClaimTemplates
+			wantErr: false,
+		},
 	}
 
 	for i := range tests {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
It was incorrectly handling PVCs when it belongs to the StatefulSet VolumeClaimTemplates.
If you set the claim name in the to match the StatefulSet VolumeClaimTemplate the StatefulSet controller would replace it for the pod, so the name isn't a backed by a real pvc.

create the following statefulset, and note the pod created has a claim with name `www-web-0`
```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: web
spec:
  selector:
    matchLabels:
      app: nginx # has to match .spec.template.metadata.labels
  serviceName: "nginx"
  replicas: 3 # by default is 1
  minReadySeconds: 10 # by default is 0
  template:
    metadata:
      labels:
        app: nginx # has to match .spec.selector.matchLabels
    spec:
      volumes:
      - name: www
        persistentVolumeClaim:
          claimName: www
      terminationGracePeriodSeconds: 10
      containers:
      - name: nginx
        image: registry.k8s.io/nginx-slim:0.24
        ports:
        - containerPort: 80
          name: web
        volumeMounts:
        - name: www
          mountPath: /usr/share/nginx/html
  volumeClaimTemplates:
  - metadata:
      name: www
    spec:
      accessModes: [ "ReadWriteOnce" ]
      storageClassName: "my-storage-class"
      resources:
        requests:
          storage: 1Gi

``` 

**Which issue(s) this PR fixes**:
Fixes # n/a

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
fixed StatefulSet Dependencies with PVCs created via the VolumeClaimTemplates.
```

