### PR TITLE
feat: Implement group score calculation

### DIFF
--- a/pkg/scheduler/core/spreadconstraint/group_clusters.go
+++ b/pkg/scheduler/core/spreadconstraint/group_clusters.go
@@ -18,6 +18,8 @@ package spreadconstraint
 
 import (
 	"k8s.io/utils/ptr"
+	"math"
+	"sort"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
@@ -34,13 +36,16 @@ type GroupClustersInfo struct {
 	// Clusters from global view, sorted by cluster.Score descending.
 	Clusters []ClusterDetailInfo
 
+	// The average score of all cluster.
+	averageScore int64
+
 	calAvailableReplicasFunc func(clusters []*clusterv1alpha1.Cluster, spec *workv1alpha2.ResourceBindingSpec) []workv1alpha2.TargetCluster
 }
 
 // ProviderInfo indicate the provider information
 type ProviderInfo struct {
 	Name              string
-	Score             int64 // the highest score in all clusters of the provider
+	Score             int64 // the comprehensive score in all clusters of the provider
 	AvailableReplicas int64
 
 	// Regions under this provider
@@ -54,7 +59,7 @@ type ProviderInfo struct {
 // RegionInfo indicate the region information
 type RegionInfo struct {
 	Name              string
-	Score             int64 // the highest score in all clusters of the region
+	Score             int64 // the comprehensive score in all clusters of the region
 	AvailableReplicas int64
 
 	// Zones under this provider
@@ -66,7 +71,7 @@ type RegionInfo struct {
 // ZoneInfo indicate the zone information
 type ZoneInfo struct {
 	Name              string
-	Score             int64 // the highest score in all clusters of the zone
+	Score             int64 // the comprehensive score in all clusters of the zone
 	AvailableReplicas int64
 
 	// Clusters under this zone, sorted by cluster.Score descending.
@@ -109,9 +114,9 @@ func groupClustersBasedTopology(
 	}
 	groupClustersInfo.calAvailableReplicasFunc = calAvailableReplicasFunc
 	groupClustersInfo.generateClustersInfo(clustersScore, rbSpec)
-	groupClustersInfo.generateZoneInfo(spreadConstraints)
-	groupClustersInfo.generateRegionInfo(spreadConstraints)
-	groupClustersInfo.generateProviderInfo(spreadConstraints)
+	groupClustersInfo.generateZoneInfo(spreadConstraints, rbSpec)
+	groupClustersInfo.generateRegionInfo(spreadConstraints, rbSpec)
+	groupClustersInfo.generateProviderInfo(spreadConstraints, rbSpec)
 
 	return groupClustersInfo
 }
@@ -128,9 +133,87 @@ func groupClustersIgnoringTopology(
 	return groupClustersInfo
 }
 
+func (info *GroupClustersInfo) calcGroupScore(clusters []ClusterDetailInfo, rbSpec *workv1alpha2.ResourceBindingSpec) int64 {
+	// sort clusters by Score, from high score to low score.
+	sort.Slice(clusters, func(i, j int) bool {
+		if clusters[i].Score != clusters[j].Score {
+			return clusters[i].Score > clusters[j].Score
+		}
+		// if Score same，sort by Name.
+		return clusters[i].Name < clusters[j].Name
+	})
+	var highScoreSum, selectedNum int64
+	midIndex := (len(clusters) - 1) / 2
+	// The same applies to both odd and even numbers.
+	for i, cluster := range clusters {
+		if i > midIndex {
+			break
+		}
+		highScoreSum += cluster.Score
+		selectedNum++
+	}
+	var baseScore, bonusScore int64
+	baseScore = highScoreSum/selectedNum - (clusters[0].Score - clusters[len(clusters)-1].Score)
+	bonusScore = 0
+
+	// if duplicate =>
+	if rbSpec.Placement == nil ||
+		rbSpec.Placement.ReplicaScheduling == nil ||
+		rbSpec.Placement.ReplicaScheduling.ReplicaSchedulingType == policyv1alpha1.ReplicaSchedulingTypeDuplicated {
+		var goodNum int
+		for _, cluster := range clusters {
+			if cluster.AvailableReplicas >= int64(rbSpec.Replicas) {
+				goodNum++
+			}
+		}
+		bonusRatio := float64(goodNum) / float64(len(clusters))
+		bonusScore = int64(float64(baseScore) * bonusRatio)
+		return baseScore + bonusScore
+	}
+
+	// if static weight =>
+	if rbSpec.Placement != nil && rbSpec.Placement.ReplicaScheduling != nil &&
+		rbSpec.Placement.ReplicaScheduling.ReplicaSchedulingType == policyv1alpha1.ReplicaSchedulingTypeDivided &&
+		rbSpec.Placement.ReplicaScheduling.ReplicaDivisionPreference == policyv1alpha1.ReplicaDivisionPreferenceWeighted &&
+		(rbSpec.Placement.ReplicaScheduling.WeightPreference == nil ||
+			len(rbSpec.Placement.ReplicaScheduling.WeightPreference.StaticWeightList) != 0 && rbSpec.Placement.ReplicaScheduling.WeightPreference.DynamicWeight == "") {
+		return baseScore
+	}
+
+	// if Aggregated or dynamic weight =>
+	// Record the score ranking.
+	scoreSortedMap := make(map[string]int)
+	for i, cluster := range clusters {
+		scoreSortedMap[cluster.Name] = i
+	}
+
+	// sort clusters by AvailableReplicas, from high score to low score.
+	sort.Slice(clusters, func(i, j int) bool {
+		if clusters[i].AvailableReplicas != clusters[j].AvailableReplicas {
+			return clusters[i].AvailableReplicas > clusters[j].AvailableReplicas
+		}
+		// if AvailableReplicas same，sort by Name.
+		return clusters[i].Name < clusters[j].Name
+	})
+	var sumDistance int64
+	// the index of high score should be closed to the index of high AvailableReplicas.
+	// then the sumDistance will be lowed.
+	for i, cluster := range clusters {
+		sortedIndex := scoreSortedMap[cluster.Name]
+		sumDistance += int64(math.Abs(float64(sortedIndex - i)))
+	}
+
+	avgDistance := sumDistance / int64(len(clusters))
+	bonusScore = -avgDistance * info.averageScore
+
+	return baseScore + bonusScore
+}
+
 func (info *GroupClustersInfo) generateClustersInfo(clustersScore framework.ClusterScoreList, rbSpec *workv1alpha2.ResourceBindingSpec) {
 	var clusters []*clusterv1alpha1.Cluster
+	var totalScore int64
 	for _, clusterScore := range clustersScore {
+		totalScore += clusterScore.Score
 		clusterInfo := ClusterDetailInfo{}
 		clusterInfo.Name = clusterScore.Cluster.Name
 		clusterInfo.Score = clusterScore.Score
@@ -138,6 +221,7 @@ func (info *GroupClustersInfo) generateClustersInfo(clustersScore framework.Clus
 		info.Clusters = append(info.Clusters, clusterInfo)
 		clusters = append(clusters, clusterScore.Cluster)
 	}
+	info.averageScore = totalScore / int64(len(clusters))
 
 	clustersReplicas := info.calAvailableReplicasFunc(clusters, rbSpec)
 	for i, clustersReplica := range clustersReplicas {
@@ -153,7 +237,7 @@ func (info *GroupClustersInfo) generateClustersInfo(clustersScore framework.Clus
 	})
 }
 
-func (info *GroupClustersInfo) generateZoneInfo(spreadConstraints []policyv1alpha1.SpreadConstraint) {
+func (info *GroupClustersInfo) generateZoneInfo(spreadConstraints []policyv1alpha1.SpreadConstraint, rbSpec *workv1alpha2.ResourceBindingSpec) {
 	if !IsSpreadConstraintExisted(spreadConstraints, policyv1alpha1.SpreadByFieldZone) {
 		return
 	}
@@ -179,12 +263,12 @@ func (info *GroupClustersInfo) generateZoneInfo(spreadConstraints []policyv1alph
 	}
 
 	for zone, zoneInfo := range info.Zones {
-		zoneInfo.Score = zoneInfo.Clusters[0].Score
+		zoneInfo.Score = info.calcGroupScore(zoneInfo.Clusters, rbSpec)
 		info.Zones[zone] = zoneInfo
 	}
 }
 
-func (info *GroupClustersInfo) generateRegionInfo(spreadConstraints []policyv1alpha1.SpreadConstraint) {
+func (info *GroupClustersInfo) generateRegionInfo(spreadConstraints []policyv1alpha1.SpreadConstraint, rbSpec *workv1alpha2.ResourceBindingSpec) {
 	if !IsSpreadConstraintExisted(spreadConstraints, policyv1alpha1.SpreadByFieldRegion) {
 		return
 	}
@@ -213,12 +297,12 @@ func (info *GroupClustersInfo) generateRegionInfo(spreadConstraints []policyv1al
 	}
 
 	for region, regionInfo := range info.Regions {
-		regionInfo.Score = regionInfo.Clusters[0].Score
+		regionInfo.Score = info.calcGroupScore(regionInfo.Clusters, rbSpec)
 		info.Regions[region] = regionInfo
 	}
 }
 
-func (info *GroupClustersInfo) generateProviderInfo(spreadConstraints []policyv1alpha1.SpreadConstraint) {
+func (info *GroupClustersInfo) generateProviderInfo(spreadConstraints []policyv1alpha1.SpreadConstraint, rbSpec *workv1alpha2.ResourceBindingSpec) {
 	if !IsSpreadConstraintExisted(spreadConstraints, policyv1alpha1.SpreadByFieldProvider) {
 		return
 	}
@@ -253,7 +337,7 @@ func (info *GroupClustersInfo) generateProviderInfo(spreadConstraints []policyv1
 	}
 
 	for provider, providerInfo := range info.Providers {
-		providerInfo.Score = providerInfo.Clusters[0].Score
+		providerInfo.Score = info.calcGroupScore(providerInfo.Clusters, rbSpec)
 		info.Providers[provider] = providerInfo
 	}
 }

--- a/pkg/scheduler/core/spreadconstraint/group_clusters_test.go
+++ b/pkg/scheduler/core/spreadconstraint/group_clusters_test.go
@@ -395,7 +395,6 @@ func generateClusterScores() [][]ClusterDetailInfo {
 }
 
 func Test_CalcGroupScore(t *testing.T) {
-
 	rbSpecs := generateRbSpec()
 	scores := generateClusterScores()
 

--- a/pkg/scheduler/core/spreadconstraint/group_clusters_test.go
+++ b/pkg/scheduler/core/spreadconstraint/group_clusters_test.go
@@ -219,3 +219,233 @@ func Test_GroupClustersWithScore(t *testing.T) {
 		})
 	}
 }
+
+func generateRbSpec() []*workv1alpha2.ResourceBindingSpec {
+	rbspecDuplicated := &workv1alpha2.ResourceBindingSpec{
+		Replicas: 20,
+		Placement: &policyv1alpha1.Placement{
+			ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+				ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDuplicated,
+			},
+		},
+	}
+	rbspecAggregated := &workv1alpha2.ResourceBindingSpec{
+		Replicas: 20,
+		Placement: &policyv1alpha1.Placement{
+			ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+				ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
+				ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceAggregated,
+			},
+		},
+	}
+	rbspecDynamicWeight := &workv1alpha2.ResourceBindingSpec{
+		Replicas: 20,
+		Placement: &policyv1alpha1.Placement{
+			ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+				ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
+				ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceWeighted,
+				WeightPreference: &policyv1alpha1.ClusterPreferences{
+					DynamicWeight: "AvailableReplicas",
+				},
+			},
+		},
+	}
+	rbspecStaticWeight := &workv1alpha2.ResourceBindingSpec{
+		Replicas: 20,
+		Placement: &policyv1alpha1.Placement{
+			ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+				ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
+				ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceWeighted,
+				WeightPreference: &policyv1alpha1.ClusterPreferences{
+					StaticWeightList: []policyv1alpha1.StaticClusterWeight{
+						{
+							TargetCluster: policyv1alpha1.ClusterAffinity{},
+							Weight:        20,
+						},
+					},
+				},
+			},
+		},
+	}
+	return []*workv1alpha2.ResourceBindingSpec{rbspecDuplicated, rbspecAggregated, rbspecDynamicWeight, rbspecStaticWeight}
+}
+
+func generateClusterScores() [][]ClusterDetailInfo {
+	// score: [20, 40, 60, 80, 100]
+	// available: [20, 40, 60, 80, 100]
+	info1 := []ClusterDetailInfo{
+		{
+			Name:              "member1",
+			Score:             20,
+			AvailableReplicas: 20,
+		},
+		{
+			Name:              "member2",
+			Score:             40,
+			AvailableReplicas: 40,
+		},
+		{
+			Name:              "member3",
+			Score:             60,
+			AvailableReplicas: 60,
+		},
+		{
+			Name:              "member4",
+			Score:             80,
+			AvailableReplicas: 80,
+		},
+		{
+			Name:              "member5",
+			Score:             100,
+			AvailableReplicas: 100,
+		},
+	}
+
+	// score: [100, 10, 10, 10, 10]
+	// available: [20, 20, 20, 20, 20]
+	info2 := []ClusterDetailInfo{
+		{
+			Name:              "member1",
+			Score:             100,
+			AvailableReplicas: 20,
+		},
+		{
+			Name:              "member2",
+			Score:             10,
+			AvailableReplicas: 20,
+		},
+		{
+			Name:              "member3",
+			Score:             10,
+			AvailableReplicas: 20,
+		},
+		{
+			Name:              "member4",
+			Score:             10,
+			AvailableReplicas: 20,
+		},
+		{
+			Name:              "member5",
+			Score:             10,
+			AvailableReplicas: 20,
+		},
+	}
+
+	// score: [60, 60, 60, 60, 60]
+	// available: [20, 20, 20, 20, 20]
+	info3 := []ClusterDetailInfo{
+		{
+			Name:              "member1",
+			Score:             60,
+			AvailableReplicas: 20,
+		},
+		{
+			Name:              "member2",
+			Score:             60,
+			AvailableReplicas: 20,
+		},
+		{
+			Name:              "member3",
+			Score:             60,
+			AvailableReplicas: 20,
+		},
+		{
+			Name:              "member4",
+			Score:             60,
+			AvailableReplicas: 20,
+		},
+		{
+			Name:              "member5",
+			Score:             60,
+			AvailableReplicas: 20,
+		},
+	}
+
+	// score: [120, 100, 80, 60, 40]
+	// available: [20, 40, 60, 80, 100]
+	info4 := []ClusterDetailInfo{
+		{
+			Name:              "member1",
+			Score:             120,
+			AvailableReplicas: 20,
+		},
+		{
+			Name:              "member2",
+			Score:             100,
+			AvailableReplicas: 40,
+		},
+		{
+			Name:              "member3",
+			Score:             80,
+			AvailableReplicas: 60,
+		},
+		{
+			Name:              "member4",
+			Score:             60,
+			AvailableReplicas: 80,
+		},
+		{
+			Name:              "member5",
+			Score:             40,
+			AvailableReplicas: 100,
+		},
+	}
+
+	return [][]ClusterDetailInfo{info1, info2, info3, info4}
+}
+
+func Test_CalcGroupScore(t *testing.T) {
+
+	rbSpecs := generateRbSpec()
+	scores := generateClusterScores()
+
+	type args struct {
+		clusters1 []ClusterDetailInfo
+		clusters2 []ClusterDetailInfo
+		rbSpec    *workv1alpha2.ResourceBindingSpec
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "avoid extreme cases",
+			args: args{
+				clusters1: scores[1],
+				clusters2: scores[2],
+				rbSpec:    rbSpecs[3],
+			},
+			want: false,
+		},
+		{
+			name: "the index of high score should be closed to the index of high AvailableReplicas.",
+			args: args{
+				clusters1: scores[0],
+				clusters2: scores[3],
+				rbSpec:    rbSpecs[2],
+			},
+			want: true,
+		},
+	}
+
+	groupClustersInfo := &GroupClustersInfo{
+		Providers: make(map[string]ProviderInfo),
+		Regions:   make(map[string]RegionInfo),
+		Zones:     make(map[string]ZoneInfo),
+
+		averageScore: 20,
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score1 := groupClustersInfo.calcGroupScore(tt.args.clusters1, tt.args.rbSpec)
+			score2 := groupClustersInfo.calcGroupScore(tt.args.clusters2, tt.args.rbSpec)
+			t.Logf("test %s : score1 = %v, score2 = %v, score1 > score 2 res: %v", tt.name, score1, score2, score1 > score2)
+			if tt.want != (score1 > score2) {
+				t.Errorf("test %s : score1 = %v, score2 = %v, score1 > score 2 want %v, but not", tt.name, score1, score2, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind api-change

**What this PR does / why we need it**:
Optimize the scoring mechanism used for distribution constraints. Currently, the score of a region is determined by the highest score of the clusters within the region, which is not reasonable. We need a scoring method that reflects the overall situation of the region.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
@whitewindmills 

**Does this PR introduce a user-facing change?**:

```release-note
`karmada-scheduler`: implement group score calculation instead of take the highest score of clusters
```

