### PR TITLE
`karmada-operator`: Grand proxy permission to system:admin

### DIFF
--- a/operator/pkg/karmadaresource/rbac/manifest.go
+++ b/operator/pkg/karmadaresource/rbac/manifest.go
@@ -167,4 +167,32 @@ rules:
       - patch
       - update
 `
+	// ClusterProxyAdminClusterRole role to proxy member clusters
+	ClusterProxyAdminClusterRole = `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-proxy-admin
+rules:
+- apiGroups:
+  - 'cluster.karmada.io'
+  resources:
+  - clusters/proxy
+  verbs:
+  - '*'
+`
+	// ClusterProxyAdminClusterRoleBinding authorize system:admin to proxy member clusters
+	ClusterProxyAdminClusterRoleBinding = `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-proxy-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-proxy-admin
+subjects:
+  - kind: User
+    name: "system:admin"
+`
 )


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

auto authorize system:admin to proxy member clusters in operation install method

**Which issue(s) this PR fixes**:

Fixes #5571

**Special notes for your reviewer**:

test report:

```shell
$ karmadactl --karmada-context karmada-apiserver get deploy --operation-scope members
NAME    CLUSTER   READY   UP-TO-DATE   AVAILABLE   AGE   ADOPTION
nginx   member1   1/1     1            1           9s    Y
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-operator`: Fixed `system:admin` can not proxy to member cluster issue.
```

