### PR TITLE
standardize the naming of karmada secrets in operator method

### DIFF
--- a/operator/pkg/certs/certs.go
+++ b/operator/pkg/certs/certs.go
@@ -90,8 +90,8 @@ func GetDefaultCertList() []*CertConfig {
 	return []*CertConfig{
 		// karmada cert config.
 		KarmadaCertRootCA(),
-		KarmadaCertAdmin(),
-		KarmadaCertApiserver(),
+		KarmadaCertServer(),
+		KarmadaCertClient(),
 		// front proxy cert config.
 		KarmadaCertFrontProxyCA(),
 		KarmadaCertFrontProxyClient(),
@@ -112,37 +112,23 @@ func KarmadaCertRootCA() *CertConfig {
 	}
 }
 
-// KarmadaCertAdmin returns karmada client cert config.
-func KarmadaCertAdmin() *CertConfig {
+// KarmadaCertServer returns karmada-server cert config.
+func KarmadaCertServer() *CertConfig {
 	return &CertConfig{
-		Name:   constants.KarmadaCertAndKeyName,
+		Name:   constants.KarmadaServerCertAndKeyName,
 		CAName: constants.CaCertAndKeyName,
 		Config: certutil.Config{
-			CommonName:   "system:admin",
-			Organization: []string{"system:masters"},
-			Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
-		},
-		AltNamesMutatorFunc: makeAltNamesMutator(apiServerAltNamesMutator),
-	}
-}
-
-// KarmadaCertApiserver returns karmada apiserver cert config.
-func KarmadaCertApiserver() *CertConfig {
-	return &CertConfig{
-		Name:   constants.ApiserverCertAndKeyName,
-		CAName: constants.CaCertAndKeyName,
-		Config: certutil.Config{
-			CommonName: "karmada-apiserver",
+			CommonName: "karmada-server",
 			Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		},
 		AltNamesMutatorFunc: makeAltNamesMutator(apiServerAltNamesMutator),
 	}
 }
 
-// KarmadaCertClient returns karmada client cert config.
+// KarmadaCertClient returns karmada-client cert config.
 func KarmadaCertClient() *CertConfig {
 	return &CertConfig{
-		Name:   "karmada-client",
+		Name:   constants.KarmadaClientCertAndKeyName,
 		CAName: constants.CaCertAndKeyName,
 		Config: certutil.Config{
 			CommonName:   "system:admin",
@@ -180,7 +166,7 @@ func KarmadaCertEtcdCA() *CertConfig {
 	return &CertConfig{
 		Name: constants.EtcdCaCertAndKeyName,
 		Config: certutil.Config{
-			CommonName: "karmada-etcd-ca",
+			CommonName: "etcd-ca",
 		},
 	}
 }
@@ -191,7 +177,7 @@ func KarmadaCertEtcdServer() *CertConfig {
 		Name:   constants.EtcdServerCertAndKeyName,
 		CAName: constants.EtcdCaCertAndKeyName,
 		Config: certutil.Config{
-			CommonName: "karmada-etcd-server",
+			CommonName: "etcd-server",
 			Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		},
 		AltNamesMutatorFunc: makeAltNamesMutator(etcdServerAltNamesMutator),
@@ -204,7 +190,7 @@ func KarmadaCertEtcdClient() *CertConfig {
 		Name:   constants.EtcdClientCertAndKeyName,
 		CAName: constants.EtcdCaCertAndKeyName,
 		Config: certutil.Config{
-			CommonName: "karmada-etcd-client",
+			CommonName: "etcd-client",
 			Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		},
 	}

--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -88,14 +88,16 @@ const (
 	EtcdServerCertAndKeyName = "etcd-server"
 	// EtcdClientCertAndKeyName etcd client certificate key name
 	EtcdClientCertAndKeyName = "etcd-client"
-	// KarmadaCertAndKeyName karmada certificate key name
-	KarmadaCertAndKeyName = "karmada"
-	// ApiserverCertAndKeyName karmada apiserver certificate key name
-	ApiserverCertAndKeyName = "apiserver"
+	// KarmadaServerCertAndKeyName karmada apiserver certificate key name
+	KarmadaServerCertAndKeyName = "karmada-server"
+	// KarmadaClientCertAndKeyName karmada certificate key name
+	KarmadaClientCertAndKeyName = "karmada-client"
 	// FrontProxyCaCertAndKeyName front-proxy-client  certificate key name
 	FrontProxyCaCertAndKeyName = "front-proxy-ca"
 	// FrontProxyClientCertAndKeyName front-proxy-client  certificate key name
 	FrontProxyClientCertAndKeyName = "front-proxy-client"
+	// KarmadaKubeconfigSecretSubpath subPath name of the KarmadaKubeconfigSecret
+	KarmadaKubeconfigSecretSubpath = "kubeconfig"
 	// ClusterName karmada cluster name
 	ClusterName = "karmada-apiserver"
 	// UserName karmada cluster user name

--- a/operator/pkg/controller/karmada/planner.go
+++ b/operator/pkg/controller/karmada/planner.go
@@ -159,7 +159,7 @@ func (p *Planner) afterRunJob() error {
 				return fmt.Errorf("error when creating cluster client to install karmada, err: %w", err)
 			}
 
-			secret, err := remoteClient.CoreV1().Secrets(p.karmada.GetNamespace()).Get(context.TODO(), util.AdminKubeconfigSecretName(p.karmada.GetName()), metav1.GetOptions{})
+			secret, err := remoteClient.CoreV1().Secrets(p.karmada.GetNamespace()).Get(context.TODO(), util.KarmadaKubeconfigName, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
@@ -167,7 +167,7 @@ func (p *Planner) afterRunJob() error {
 			_, err = localClusterClient.CoreV1().Secrets(p.karmada.GetNamespace()).Create(context.TODO(), &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: p.karmada.GetNamespace(),
-					Name:      util.AdminKubeconfigSecretName(p.karmada.GetName()),
+					Name:      util.KarmadaKubeconfigName,
 				},
 				Data: secret.Data,
 			}, metav1.CreateOptions{})
@@ -178,7 +178,7 @@ func (p *Planner) afterRunJob() error {
 
 		p.karmada.Status.SecretRef = &operatorv1alpha1.LocalSecretReference{
 			Namespace: p.karmada.GetNamespace(),
-			Name:      util.AdminKubeconfigSecretName(p.karmada.GetName()),
+			Name:      util.KarmadaKubeconfigName,
 		}
 		return p.Client.Status().Update(context.TODO(), p.karmada)
 	}

--- a/operator/pkg/controlplane/apiserver/apiserver.go
+++ b/operator/pkg/controlplane/apiserver/apiserver.go
@@ -53,20 +53,20 @@ func EnsureKarmadaAggregatedAPIServer(client clientset.Interface, cfg *operatorv
 func installKarmadaAPIServer(client clientset.Interface, cfg *operatorv1alpha1.KarmadaAPIServer, name, namespace string, _ map[string]bool) error {
 	apiserverDeploymentBytes, err := util.ParseTemplate(KarmadaApiserverDeployment, struct {
 		DeploymentName, Namespace, Image, ImagePullPolicy, EtcdClientService string
-		ServiceSubnet, KarmadaCertsSecret, EtcdCertsSecret                   string
+		ServiceSubnet, KarmadaCertsSecret, KarmadaEtcdCertSecret             string
 		Replicas                                                             *int32
 		EtcdListenClientPort                                                 int32
 	}{
-		DeploymentName:       util.KarmadaAPIServerName(name),
-		Namespace:            namespace,
-		Image:                cfg.Image.Name(),
-		ImagePullPolicy:      string(cfg.ImagePullPolicy),
-		EtcdClientService:    util.KarmadaEtcdClientName(name),
-		ServiceSubnet:        *cfg.ServiceSubnet,
-		KarmadaCertsSecret:   util.KarmadaCertSecretName(name),
-		EtcdCertsSecret:      util.EtcdCertSecretName(name),
-		Replicas:             cfg.Replicas,
-		EtcdListenClientPort: constants.EtcdListenClientPort,
+		DeploymentName:        util.KarmadaAPIServerName(name),
+		Namespace:             namespace,
+		Image:                 cfg.Image.Name(),
+		ImagePullPolicy:       string(cfg.ImagePullPolicy),
+		EtcdClientService:     util.KarmadaEtcdClientName(name),
+		ServiceSubnet:         *cfg.ServiceSubnet,
+		KarmadaCertsSecret:    util.KarmadaCertsName,
+		KarmadaEtcdCertSecret: util.KarmadaEtcdCertName,
+		Replicas:              cfg.Replicas,
+		EtcdListenClientPort:  constants.EtcdListenClientPort,
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing karmadaApiserver deployment template: %w", err)
@@ -115,20 +115,20 @@ func createKarmadaAPIServerService(client clientset.Interface, cfg *operatorv1al
 func installKarmadaAggregatedAPIServer(client clientset.Interface, cfg *operatorv1alpha1.KarmadaAggregatedAPIServer, name, namespace string, featureGates map[string]bool) error {
 	aggregatedAPIServerDeploymentBytes, err := util.ParseTemplate(KarmadaAggregatedAPIServerDeployment, struct {
 		DeploymentName, Namespace, Image, ImagePullPolicy, EtcdClientService string
-		KubeconfigSecret, KarmadaCertsSecret, EtcdCertsSecret                string
+		KarmadaCertsSecret, KarmadaEtcdCertSecret, KarmadaKubeconfigSecret   string
 		Replicas                                                             *int32
 		EtcdListenClientPort                                                 int32
 	}{
-		DeploymentName:       util.KarmadaAggregatedAPIServerName(name),
-		Namespace:            namespace,
-		Image:                cfg.Image.Name(),
-		ImagePullPolicy:      string(cfg.ImagePullPolicy),
-		EtcdClientService:    util.KarmadaEtcdClientName(name),
-		KubeconfigSecret:     util.AdminKubeconfigSecretName(name),
-		KarmadaCertsSecret:   util.KarmadaCertSecretName(name),
-		EtcdCertsSecret:      util.EtcdCertSecretName(name),
-		Replicas:             cfg.Replicas,
-		EtcdListenClientPort: constants.EtcdListenClientPort,
+		DeploymentName:          util.KarmadaAggregatedAPIServerName(name),
+		Namespace:               namespace,
+		Image:                   cfg.Image.Name(),
+		ImagePullPolicy:         string(cfg.ImagePullPolicy),
+		EtcdClientService:       util.KarmadaEtcdClientName(name),
+		KarmadaCertsSecret:      util.KarmadaCertsName,
+		KarmadaEtcdCertSecret:   util.KarmadaEtcdCertName,
+		KarmadaKubeconfigSecret: util.KarmadaKubeconfigName,
+		Replicas:                cfg.Replicas,
+		EtcdListenClientPort:    constants.EtcdListenClientPort,
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing karmadaAggregatedAPIServer deployment template: %w", err)

--- a/operator/pkg/controlplane/controlplane.go
+++ b/operator/pkg/controlplane/controlplane.go
@@ -85,16 +85,16 @@ func getComponentManifests(name, namespace string, featureGates map[string]bool,
 func getKubeControllerManagerManifest(name, namespace string, cfg *operatorv1alpha1.KubeControllerManager) (*appsv1.Deployment, error) {
 	kubeControllerManagerBytes, err := util.ParseTemplate(KubeControllerManagerDeployment, struct {
 		DeploymentName, Namespace, Image, ImagePullPolicy string
-		KarmadaCertsSecret, KubeconfigSecret              string
+		KarmadaCertsSecret, KarmadaKubeconfigSecret       string
 		Replicas                                          *int32
 	}{
-		DeploymentName:     util.KubeControllerManagerName(name),
-		Namespace:          namespace,
-		Image:              cfg.Image.Name(),
-		ImagePullPolicy:    string(cfg.ImagePullPolicy),
-		KarmadaCertsSecret: util.KarmadaCertSecretName(name),
-		KubeconfigSecret:   util.AdminKubeconfigSecretName(name),
-		Replicas:           cfg.Replicas,
+		DeploymentName:          util.KubeControllerManagerName(name),
+		Namespace:               namespace,
+		Image:                   cfg.Image.Name(),
+		ImagePullPolicy:         string(cfg.ImagePullPolicy),
+		KarmadaCertsSecret:      util.KarmadaCertsName,
+		KarmadaKubeconfigSecret: util.KarmadaKubeconfigName,
+		Replicas:                cfg.Replicas,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error when parsing kube-controller-manager deployment template: %w", err)
@@ -112,17 +112,17 @@ func getKubeControllerManagerManifest(name, namespace string, cfg *operatorv1alp
 
 func getKarmadaControllerManagerManifest(name, namespace string, featureGates map[string]bool, cfg *operatorv1alpha1.KarmadaControllerManager) (*appsv1.Deployment, error) {
 	karmadaControllerManagerBytes, err := util.ParseTemplate(KamradaControllerManagerDeployment, struct {
-		Replicas                                   *int32
-		DeploymentName, Namespace, SystemNamespace string
-		Image, ImagePullPolicy, KubeconfigSecret   string
+		Replicas                                        *int32
+		DeploymentName, Namespace, SystemNamespace      string
+		Image, ImagePullPolicy, KarmadaKubeconfigSecret string
 	}{
-		DeploymentName:   util.KarmadaControllerManagerName(name),
-		Namespace:        namespace,
-		SystemNamespace:  constants.KarmadaSystemNamespace,
-		Image:            cfg.Image.Name(),
-		ImagePullPolicy:  string(cfg.ImagePullPolicy),
-		KubeconfigSecret: util.AdminKubeconfigSecretName(name),
-		Replicas:         cfg.Replicas,
+		DeploymentName:          util.KarmadaControllerManagerName(name),
+		Namespace:               namespace,
+		SystemNamespace:         constants.KarmadaSystemNamespace,
+		Image:                   cfg.Image.Name(),
+		ImagePullPolicy:         string(cfg.ImagePullPolicy),
+		KarmadaKubeconfigSecret: util.KarmadaKubeconfigName,
+		Replicas:                cfg.Replicas,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error when parsing karmada-controller-manager deployment template: %w", err)
@@ -140,18 +140,18 @@ func getKarmadaControllerManagerManifest(name, namespace string, featureGates ma
 
 func getKarmadaSchedulerManifest(name, namespace string, featureGates map[string]bool, cfg *operatorv1alpha1.KarmadaScheduler) (*appsv1.Deployment, error) {
 	karmadaSchedulerBytes, err := util.ParseTemplate(KarmadaSchedulerDeployment, struct {
-		Replicas                                                     *int32
-		DeploymentName, Namespace, SystemNamespace                   string
-		Image, ImagePullPolicy, KubeconfigSecret, KarmadaCertsSecret string
+		Replicas                                                            *int32
+		DeploymentName, Namespace, SystemNamespace                          string
+		Image, ImagePullPolicy, KarmadaKubeconfigSecret, KarmadaCertsSecret string
 	}{
-		DeploymentName:     util.KarmadaSchedulerName(name),
-		Namespace:          namespace,
-		SystemNamespace:    constants.KarmadaSystemNamespace,
-		Image:              cfg.Image.Name(),
-		ImagePullPolicy:    string(cfg.ImagePullPolicy),
-		KubeconfigSecret:   util.AdminKubeconfigSecretName(name),
-		KarmadaCertsSecret: util.KarmadaCertSecretName(name),
-		Replicas:           cfg.Replicas,
+		DeploymentName:          util.KarmadaSchedulerName(name),
+		Namespace:               namespace,
+		SystemNamespace:         constants.KarmadaSystemNamespace,
+		Image:                   cfg.Image.Name(),
+		ImagePullPolicy:         string(cfg.ImagePullPolicy),
+		KarmadaKubeconfigSecret: util.KarmadaKubeconfigName,
+		KarmadaCertsSecret:      util.KarmadaCertsName,
+		Replicas:                cfg.Replicas,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error when parsing karmada-scheduler deployment template: %w", err)
@@ -169,18 +169,18 @@ func getKarmadaSchedulerManifest(name, namespace string, featureGates map[string
 
 func getKarmadaDeschedulerManifest(name, namespace string, featureGates map[string]bool, cfg *operatorv1alpha1.KarmadaDescheduler) (*appsv1.Deployment, error) {
 	karmadaDeschedulerBytes, err := util.ParseTemplate(KarmadaDeschedulerDeployment, struct {
-		Replicas                                                     *int32
-		DeploymentName, Namespace, SystemNamespace                   string
-		Image, ImagePullPolicy, KubeconfigSecret, KarmadaCertsSecret string
+		Replicas                                                            *int32
+		DeploymentName, Namespace, SystemNamespace                          string
+		Image, ImagePullPolicy, KarmadaKubeconfigSecret, KarmadaCertsSecret string
 	}{
-		DeploymentName:     util.KarmadaDeschedulerName(name),
-		Namespace:          namespace,
-		SystemNamespace:    constants.KarmadaSystemNamespace,
-		Image:              cfg.Image.Name(),
-		ImagePullPolicy:    string(cfg.ImagePullPolicy),
-		KubeconfigSecret:   util.AdminKubeconfigSecretName(name),
-		KarmadaCertsSecret: util.KarmadaCertSecretName(name),
-		Replicas:           cfg.Replicas,
+		DeploymentName:          util.KarmadaDeschedulerName(name),
+		Namespace:               namespace,
+		SystemNamespace:         constants.KarmadaSystemNamespace,
+		Image:                   cfg.Image.Name(),
+		ImagePullPolicy:         string(cfg.ImagePullPolicy),
+		KarmadaKubeconfigSecret: util.KarmadaKubeconfigName,
+		KarmadaCertsSecret:      util.KarmadaCertsName,
+		Replicas:                cfg.Replicas,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error when parsing karmada-descheduler deployment template: %w", err)

--- a/operator/pkg/controlplane/etcd/etcd.go
+++ b/operator/pkg/controlplane/etcd/etcd.go
@@ -63,23 +63,23 @@ func installKarmadaEtcd(client clientset.Interface, name, namespace string, cfg 
 
 	etcdStatefulSetBytes, err := util.ParseTemplate(KarmadaEtcdStatefulSet, struct {
 		StatefulSetName, Namespace, Image, ImagePullPolicy, EtcdClientService string
-		CertsSecretName, EtcdPeerServiceName                                  string
+		KarmadaEtcdCertSecret, EtcdPeerServiceName                            string
 		InitialCluster, EtcdDataVolumeName, EtcdCipherSuites                  string
 		Replicas, EtcdListenClientPort, EtcdListenPeerPort                    int32
 	}{
-		StatefulSetName:      util.KarmadaEtcdName(name),
-		Namespace:            namespace,
-		Image:                cfg.Image.Name(),
-		ImagePullPolicy:      string(cfg.ImagePullPolicy),
-		EtcdClientService:    util.KarmadaEtcdClientName(name),
-		CertsSecretName:      util.EtcdCertSecretName(name),
-		EtcdPeerServiceName:  util.KarmadaEtcdName(name),
-		EtcdDataVolumeName:   constants.EtcdDataVolumeName,
-		InitialCluster:       strings.Join(initialClusters, ","),
-		EtcdCipherSuites:     genEtcdCipherSuites(),
-		Replicas:             *cfg.Replicas,
-		EtcdListenClientPort: constants.EtcdListenClientPort,
-		EtcdListenPeerPort:   constants.EtcdListenPeerPort,
+		StatefulSetName:       util.KarmadaEtcdName(name),
+		Namespace:             namespace,
+		Image:                 cfg.Image.Name(),
+		ImagePullPolicy:       string(cfg.ImagePullPolicy),
+		EtcdClientService:     util.KarmadaEtcdClientName(name),
+		KarmadaEtcdCertSecret: util.KarmadaEtcdCertName,
+		EtcdPeerServiceName:   util.KarmadaEtcdName(name),
+		EtcdDataVolumeName:    constants.EtcdDataVolumeName,
+		InitialCluster:        strings.Join(initialClusters, ","),
+		EtcdCipherSuites:      genEtcdCipherSuites(),
+		Replicas:              *cfg.Replicas,
+		EtcdListenClientPort:  constants.EtcdListenClientPort,
+		EtcdListenPeerPort:    constants.EtcdListenPeerPort,
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing Etcd statefuelset template: %w", err)

--- a/operator/pkg/controlplane/etcd/mainfests.go
+++ b/operator/pkg/controlplane/etcd/mainfests.go
@@ -55,9 +55,9 @@ spec:
         - --initial-cluster={{ .InitialCluster }}
         - --initial-cluster-state=new
         - --client-cert-auth=true
-        - --trusted-ca-file=/etc/karmada/pki/etcd/etcd-ca.crt
-        - --cert-file=/etc/karmada/pki/etcd/etcd-server.crt
-        - --key-file=/etc/karmada/pki/etcd/etcd-server.key
+        - --trusted-ca-file=/etc/etcd/pki/etcd-ca.crt
+        - --cert-file=/etc/etcd/pki/etcd-server.crt
+        - --key-file=/etc/etcd/pki/etcd-server.key
         - --data-dir=/var/lib/etcd
         - --snapshot-count=10000
         - --log-level=debug
@@ -73,7 +73,7 @@ spec:
             command:
             - /bin/sh
             - -ec
-            - etcdctl get /registry --prefix --keys-only --endpoints https://127.0.0.1:{{ .EtcdListenClientPort }} --cacert=/etc/karmada/pki/etcd/etcd-ca.crt --cert=/etc/karmada/pki/etcd/etcd-server.crt --key=/etc/karmada/pki/etcd/etcd-server.key
+            - etcdctl get /registry --prefix --keys-only --endpoints https://127.0.0.1:{{ .EtcdListenClientPort }} --cacert=/etc/etcd/pki/etcd-ca.crt --cert=/etc/etcd/pki/etcd-client.crt --key=/etc/etcd/pki/etcd-client.key
           failureThreshold: 3
           initialDelaySeconds: 600
           periodSeconds: 60
@@ -89,12 +89,12 @@ spec:
         volumeMounts:
         - mountPath: /var/lib/etcd
           name: {{ .EtcdDataVolumeName }}
-        - mountPath: /etc/karmada/pki/etcd
-          name: etcd-cert
+        - mountPath: /etc/etcd/pki
+          name: karmada-etcd-cert
       volumes:
-      - name: etcd-cert
+      - name: karmada-etcd-cert
         secret:
-          secretName: {{ .CertsSecretName }}
+          secretName: {{ .KarmadaEtcdCertSecret }}
 `
 
 	// KarmadaEtcdClientService is karmada etcd client service manifest

--- a/operator/pkg/controlplane/manifests.go
+++ b/operator/pkg/controlplane/manifests.go
@@ -55,9 +55,9 @@ spec:
         command:
         - kube-controller-manager
         - --allocate-node-cidrs=true
-        - --kubeconfig=/etc/karmada/kubeconfig
-        - --authentication-kubeconfig=/etc/karmada/kubeconfig
-        - --authorization-kubeconfig=/etc/karmada/kubeconfig
+        - --kubeconfig=/etc/kubeconfig
+        - --authentication-kubeconfig=/etc/kubeconfig
+        - --authorization-kubeconfig=/etc/kubeconfig
         - --bind-address=0.0.0.0
         - --client-ca-file=/etc/karmada/pki/ca.crt
         - --cluster-cidr=10.244.0.0/16
@@ -68,7 +68,7 @@ spec:
         - --leader-elect=true
         - --node-cidr-mask-size=24
         - --root-ca-file=/etc/karmada/pki/ca.crt
-        - --service-account-private-key-file=/etc/karmada/pki/karmada.key
+        - --service-account-private-key-file=/etc/karmada/pki/karmada-client.key
         - --service-cluster-ip-range=10.96.0.0/12
         - --use-service-account-credentials=true
         - --v=4
@@ -86,16 +86,16 @@ spec:
         - name: karmada-certs
           mountPath: /etc/karmada/pki
           readOnly: true
-        - name: kubeconfig
-          mountPath: /etc/karmada/kubeconfig
+        - name: karmada-kubeconfig
+          mountPath: /etc/kubeconfig
           subPath: kubeconfig
       volumes:
         - name: karmada-certs
           secret:
             secretName: {{ .KarmadaCertsSecret }}
-        - name: kubeconfig
+        - name: karmada-kubeconfig
           secret:
-            secretName: {{ .KubeconfigSecret }}
+            secretName: {{ .KarmadaKubeconfigSecret }}
 `
 	// KamradaControllerManagerDeployment is karmada controllerManager Deployment manifest
 	KamradaControllerManagerDeployment = `
@@ -127,7 +127,7 @@ spec:
         imagePullPolicy: {{ .ImagePullPolicy }}
         command:
         - /bin/karmada-controller-manager
-        - --kubeconfig=/etc/karmada/kubeconfig
+        - --kubeconfig=/etc/kubeconfig
         - --metrics-bind-address=:8080
         - --cluster-status-update-frequency=10s
         - --failover-eviction-timeout=30s
@@ -148,13 +148,13 @@ spec:
           name: metrics
           protocol: TCP
         volumeMounts:
-        - name: kubeconfig
+        - name: karmada-kubeconfig
           subPath: kubeconfig
-          mountPath: /etc/karmada/kubeconfig
+          mountPath: /etc/kubeconfig
       volumes:
-      - name: kubeconfig
+      - name: karmada-kubeconfig
         secret:
-          secretName: {{ .KubeconfigSecret }}
+          secretName: {{ .KarmadaKubeconfigSecret }}
 `
 
 	// KarmadaSchedulerDeployment is KarmadaScheduler Deployment manifest
@@ -187,14 +187,14 @@ spec:
         imagePullPolicy: {{ .ImagePullPolicy }}
         command:
         - /bin/karmada-scheduler
-        - --kubeconfig=/etc/karmada/kubeconfig
+        - --kubeconfig=/etc/kubeconfig
         - --metrics-bind-address=0.0.0.0:10351
         - --health-probe-bind-address=0.0.0.0:10351
         - --enable-scheduler-estimator=true
         - --leader-elect-resource-namespace={{ .SystemNamespace }}
         - --scheduler-estimator-ca-file=/etc/karmada/pki/ca.crt
-        - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada.crt
-        - --scheduler-estimator-key-file=/etc/karmada/pki/karmada.key
+        - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada-client.crt
+        - --scheduler-estimator-key-file=/etc/karmada/pki/karmada-client.key
         - --v=4
         livenessProbe:
           httpGet:
@@ -213,16 +213,16 @@ spec:
         - name: karmada-certs
           mountPath: /etc/karmada/pki
           readOnly: true
-        - name: kubeconfig
+        - name: karmada-kubeconfig
           subPath: kubeconfig
-          mountPath: /etc/karmada/kubeconfig
+          mountPath: /etc/kubeconfig
       volumes:
         - name: karmada-certs
           secret:
             secretName: {{ .KarmadaCertsSecret }}
-        - name: kubeconfig
+        - name: karmada-kubeconfig
           secret:
-            secretName: {{ .KubeconfigSecret }}
+            secretName: {{ .KarmadaKubeconfigSecret }}
 `
 
 	// KarmadaDeschedulerDeployment is KarmadaDescheduler Deployment manifest
@@ -255,13 +255,13 @@ spec:
         imagePullPolicy: {{ .ImagePullPolicy }}
         command:
         - /bin/karmada-descheduler
-        - --kubeconfig=/etc/karmada/kubeconfig
+        - --kubeconfig=/etc/kubeconfig
         - --metrics-bind-address=0.0.0.0:10358
         - --health-probe-bind-address=0.0.0.0:10358
         - --leader-elect-resource-namespace={{ .SystemNamespace }}
         - --scheduler-estimator-ca-file=/etc/karmada/pki/ca.crt
-        - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada.crt
-        - --scheduler-estimator-key-file=/etc/karmada/pki/karmada.key
+        - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada-client.crt
+        - --scheduler-estimator-key-file=/etc/karmada/pki/karmada-client.key
         - --v=4
         livenessProbe:
           httpGet:
@@ -280,15 +280,15 @@ spec:
         - name: karmada-certs
           mountPath: /etc/karmada/pki
           readOnly: true
-        - name: kubeconfig
+        - name: karmada-kubeconfig
           subPath: kubeconfig
-          mountPath: /etc/karmada/kubeconfig
+          mountPath: /etc/kubeconfig
       volumes:
         - name: karmada-certs
           secret:
             secretName: {{ .KarmadaCertsSecret }}
-        - name: kubeconfig
+        - name: karmada-kubeconfig
           secret:
-            secretName: {{ .KubeconfigSecret }}
+            secretName: {{ .KarmadaKubeconfigSecret }}
 `
 )

--- a/operator/pkg/controlplane/metricsadapter/mainfests.go
+++ b/operator/pkg/controlplane/metricsadapter/mainfests.go
@@ -47,21 +47,21 @@ spec:
         imagePullPolicy: {{ .ImagePullPolicy }}
         command:
         - /bin/karmada-metrics-adapter
-        - --kubeconfig=/etc/karmada/kubeconfig
-        - --authentication-kubeconfig=/etc/karmada/kubeconfig
-        - --authorization-kubeconfig=/etc/karmada/kubeconfig
+        - --kubeconfig=/etc/kubeconfig
+        - --authentication-kubeconfig=/etc/kubeconfig
+        - --authorization-kubeconfig=/etc/kubeconfig
         - --client-ca-file=/etc/karmada/pki/ca.crt
-        - --tls-cert-file=/etc/karmada/pki/karmada.crt
-        - --tls-private-key-file=/etc/karmada/pki/karmada.key
+        - --tls-cert-file=/etc/karmada/pki/karmada-server.crt
+        - --tls-private-key-file=/etc/karmada/pki/karmada-server.key
         - --tls-min-version=VersionTLS13
         - --audit-log-path=-
         - --audit-log-maxage=0
         - --audit-log-maxbackup=0
         volumeMounts:
-        - name: kubeconfig
+        - name: karmada-kubeconfig
           subPath: kubeconfig
-          mountPath: /etc/karmada/kubeconfig
-        - name: karmada-cert
+          mountPath: /etc/kubeconfig
+        - name: karmada-certs
           mountPath: /etc/karmada/pki
           readOnly: true
         readinessProbe:
@@ -86,10 +86,10 @@ spec:
           requests:
             cpu: 100m
       volumes:
-      - name: kubeconfig
+      - name: karmada-kubeconfig
         secret:
-          secretName: {{ .KubeconfigSecret }}
-      - name: karmada-cert
+          secretName: {{ .KarmadaKubeconfigSecret }}
+      - name: karmada-certs
         secret:
           secretName: {{ .KarmadaCertsSecret }}
 `

--- a/operator/pkg/controlplane/metricsadapter/metricsadapter.go
+++ b/operator/pkg/controlplane/metricsadapter/metricsadapter.go
@@ -43,16 +43,16 @@ func EnsureKarmadaMetricAdapter(client clientset.Interface, cfg *operatorv1alpha
 func installKarmadaMetricAdapter(client clientset.Interface, cfg *operatorv1alpha1.KarmadaMetricsAdapter, name, namespace string) error {
 	metricAdapterBytes, err := util.ParseTemplate(KarmadaMetricsAdapterDeployment, struct {
 		DeploymentName, Namespace, Image, ImagePullPolicy string
-		KubeconfigSecret, KarmadaCertsSecret              string
+		KarmadaKubeconfigSecret, KarmadaCertsSecret       string
 		Replicas                                          *int32
 	}{
-		DeploymentName:     util.KarmadaMetricsAdapterName(name),
-		Namespace:          namespace,
-		Image:              cfg.Image.Name(),
-		ImagePullPolicy:    string(cfg.ImagePullPolicy),
-		Replicas:           cfg.Replicas,
-		KubeconfigSecret:   util.AdminKubeconfigSecretName(name),
-		KarmadaCertsSecret: util.KarmadaCertSecretName(name),
+		DeploymentName:          util.KarmadaMetricsAdapterName(name),
+		Namespace:               namespace,
+		Image:                   cfg.Image.Name(),
+		ImagePullPolicy:         string(cfg.ImagePullPolicy),
+		Replicas:                cfg.Replicas,
+		KarmadaKubeconfigSecret: util.KarmadaKubeconfigName,
+		KarmadaCertsSecret:      util.KarmadaCertsName,
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing KarmadaMetricAdapter Deployment template: %w", err)

--- a/operator/pkg/controlplane/search/mainfests.go
+++ b/operator/pkg/controlplane/search/mainfests.go
@@ -46,10 +46,13 @@ spec:
           image: {{ .Image }}
           imagePullPolicy: {{ .ImagePullPolicy }}
           volumeMounts:
-            - name: k8s-certs
+            - name: karmada-certs
               mountPath: /etc/karmada/pki
               readOnly: true
-            - name: kubeconfig
+            - name: karmada-etcd-cert
+              mountPath: /etc/etcd/pki
+              readOnly: true
+            - name: karmada-kubeconfig
               subPath: kubeconfig
               mountPath: /etc/kubeconfig
           command:
@@ -58,11 +61,11 @@ spec:
             - --authentication-kubeconfig=/etc/kubeconfig
             - --authorization-kubeconfig=/etc/kubeconfig
             - --etcd-servers=https://{{ .EtcdClientService }}.{{ .Namespace }}.svc.cluster.local:{{ .EtcdListenClientPort }}
-            - --etcd-cafile=/etc/karmada/pki/etcd-ca.crt
-            - --etcd-certfile=/etc/karmada/pki/etcd-client.crt
-            - --etcd-keyfile=/etc/karmada/pki/etcd-client.key
-            - --tls-cert-file=/etc/karmada/pki/karmada.crt
-            - --tls-private-key-file=/etc/karmada/pki/karmada.key
+            - --etcd-cafile=/etc/etcd/pki/etcd-ca.crt
+            - --etcd-certfile=/etc/etcd/pki/etcd-client.crt
+            - --etcd-keyfile=/etc/etcd/pki/etcd-client.key
+            - --tls-cert-file=/etc/karmada/pki/karmada-server.crt
+            - --tls-private-key-file=/etc/karmada/pki/karmada-server.key
             - --tls-min-version=VersionTLS13
             - --audit-log-path=-
             - --audit-log-maxage=0
@@ -80,12 +83,15 @@ spec:
             requests:
               cpu: 100m
       volumes:
-        - name: k8s-certs
+        - name: karmada-certs
           secret:
             secretName: {{ .KarmadaCertsSecret }}
-        - name: kubeconfig
+        - name: karmada-etcd-cert
           secret:
-            secretName: {{ .KubeconfigSecret }}
+            secretName: {{ .KarmadaEtcdCertSecret }}
+        - name: karmada-kubeconfig
+          secret:
+            secretName: {{ .KarmadaKubeconfigSecret }}
 `
 
 	// KarmadaSearchService is karmada-search service manifest

--- a/operator/pkg/controlplane/search/search.go
+++ b/operator/pkg/controlplane/search/search.go
@@ -43,20 +43,21 @@ func EnsureKarmadaSearch(client clientset.Interface, cfg *operatorv1alpha1.Karma
 
 func installKarmadaSearch(client clientset.Interface, cfg *operatorv1alpha1.KarmadaSearch, name, namespace string, _ map[string]bool) error {
 	searchDeploymentSetBytes, err := util.ParseTemplate(KarmadaSearchDeployment, struct {
-		DeploymentName, Namespace, Image, ImagePullPolicy, KarmadaCertsSecret string
-		KubeconfigSecret, EtcdClientService                                   string
-		Replicas                                                              *int32
-		EtcdListenClientPort                                                  int32
+		DeploymentName, Namespace, Image, ImagePullPolicy, EtcdClientService string
+		KarmadaCertsSecret, KarmadaEtcdCertSecret, KarmadaKubeconfigSecret   string
+		Replicas                                                             *int32
+		EtcdListenClientPort                                                 int32
 	}{
-		DeploymentName:       util.KarmadaSearchName(name),
-		Namespace:            namespace,
-		Image:                cfg.Image.Name(),
-		ImagePullPolicy:      string(cfg.ImagePullPolicy),
-		KarmadaCertsSecret:   util.KarmadaCertSecretName(name),
-		Replicas:             cfg.Replicas,
-		KubeconfigSecret:     util.AdminKubeconfigSecretName(name),
-		EtcdClientService:    util.KarmadaEtcdClientName(name),
-		EtcdListenClientPort: constants.EtcdListenClientPort,
+		DeploymentName:          util.KarmadaSearchName(name),
+		Namespace:               namespace,
+		Image:                   cfg.Image.Name(),
+		ImagePullPolicy:         string(cfg.ImagePullPolicy),
+		Replicas:                cfg.Replicas,
+		KarmadaCertsSecret:      util.KarmadaCertsName,
+		KarmadaEtcdCertSecret:   util.KarmadaEtcdCertName,
+		KarmadaKubeconfigSecret: util.KarmadaKubeconfigName,
+		EtcdClientService:       util.KarmadaEtcdClientName(name),
+		EtcdListenClientPort:    constants.EtcdListenClientPort,
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing KarmadaSearch Deployment template: %w", err)

--- a/operator/pkg/controlplane/webhook/mainfests.go
+++ b/operator/pkg/controlplane/webhook/mainfests.go
@@ -47,13 +47,13 @@ spec:
         imagePullPolicy: {{ .ImagePullPolicy }}
         command:
         - /bin/karmada-webhook
-        - --kubeconfig=/etc/karmada/kubeconfig
+        - --kubeconfig=/etc/kubeconfig
         - --bind-address=0.0.0.0
         - --metrics-bind-address=:8080
         - --default-not-ready-toleration-seconds=30
         - --default-unreachable-toleration-seconds=30
         - --secure-port=8443
-        - --cert-dir=/var/serving-cert
+        - --cert-dir=/etc/karmada/pki
         - --v=4
         ports:
         - containerPort: 8443
@@ -61,11 +61,11 @@ spec:
           name: metrics
           protocol: TCP
         volumeMounts:
-        - name: kubeconfig
+        - name: karmada-kubeconfig
           subPath: kubeconfig
-          mountPath: /etc/karmada/kubeconfig
-        - name: cert
-          mountPath: /var/serving-cert
+          mountPath: /etc/kubeconfig
+        - name: karmada-webhook-cert
+          mountPath: /etc/karmada/pki
           readOnly: true
         readinessProbe:
           httpGet:
@@ -73,12 +73,12 @@ spec:
             port: 8443
             scheme: HTTPS
       volumes:
-      - name: kubeconfig
+      - name: karmada-kubeconfig
         secret:
-          secretName: {{ .KubeconfigSecret }}
-      - name: cert
+          secretName: {{ .KarmadaKubeconfigSecret }}
+      - name: karmada-webhook-cert
         secret:
-          secretName: {{ .WebhookCertsSecret }}
+          secretName: {{ .KarmadaWebhookCertSecret }}
 `
 
 	// KarmadaWebhookService is karmada webhook service manifest

--- a/operator/pkg/controlplane/webhook/webhook.go
+++ b/operator/pkg/controlplane/webhook/webhook.go
@@ -43,16 +43,16 @@ func EnsureKarmadaWebhook(client clientset.Interface, cfg *operatorv1alpha1.Karm
 func installKarmadaWebhook(client clientset.Interface, cfg *operatorv1alpha1.KarmadaWebhook, name, namespace string, _ map[string]bool) error {
 	webhookDeploymentSetBytes, err := util.ParseTemplate(KarmadaWebhookDeployment, struct {
 		DeploymentName, Namespace, Image, ImagePullPolicy string
-		KubeconfigSecret, WebhookCertsSecret              string
+		KarmadaKubeconfigSecret, KarmadaWebhookCertSecret string
 		Replicas                                          *int32
 	}{
-		DeploymentName:     util.KarmadaWebhookName(name),
-		Namespace:          namespace,
-		Image:              cfg.Image.Name(),
-		ImagePullPolicy:    string(cfg.ImagePullPolicy),
-		Replicas:           cfg.Replicas,
-		KubeconfigSecret:   util.AdminKubeconfigSecretName(name),
-		WebhookCertsSecret: util.WebhookCertSecretName(name),
+		DeploymentName:           util.KarmadaWebhookName(name),
+		Namespace:                namespace,
+		Image:                    cfg.Image.Name(),
+		ImagePullPolicy:          string(cfg.ImagePullPolicy),
+		Replicas:                 cfg.Replicas,
+		KarmadaKubeconfigSecret:  util.KarmadaKubeconfigName,
+		KarmadaWebhookCertSecret: util.KarmadaWebhookCertName,
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing KarmadaWebhook Deployment template: %w", err)

--- a/operator/pkg/tasks/deinit/cert.go
+++ b/operator/pkg/tasks/deinit/cert.go
@@ -35,9 +35,9 @@ func NewCleanupCertTask() workflow.Task {
 		Run:         runCleanupCert,
 		RunSubTasks: true,
 		Tasks: []workflow.Task{
-			newCleanupCertSubTask("karmada", util.KarmadaCertSecretName),
-			newCleanupCertSubTask("etcd", util.EtcdCertSecretName),
-			newCleanupCertSubTask("webhook", util.WebhookCertSecretName),
+			newCleanupCertSubTask("karmada", util.KarmadaCertsName),
+			newCleanupCertSubTask("etcd", util.KarmadaEtcdCertName),
+			newCleanupCertSubTask("webhook", util.KarmadaWebhookCertName),
 		},
 	}
 }
@@ -52,14 +52,14 @@ func runCleanupCert(r workflow.RunData) error {
 	return nil
 }
 
-func newCleanupCertSubTask(owner string, secretNameFunc util.Namefunc) workflow.Task {
+func newCleanupCertSubTask(owner, secretName string) workflow.Task {
 	return workflow.Task{
 		Name: fmt.Sprintf("cleanup-%s-cert", owner),
-		Run:  runCleanupCertSubTask(owner, secretNameFunc),
+		Run:  runCleanupCertSubTask(owner, secretName),
 	}
 }
 
-func runCleanupCertSubTask(owner string, secretNameFunc util.Namefunc) func(r workflow.RunData) error {
+func runCleanupCertSubTask(owner, secretName string) func(r workflow.RunData) error {
 	return func(r workflow.RunData) error {
 		data, ok := r.(DeInitData)
 		if !ok {
@@ -68,7 +68,7 @@ func runCleanupCertSubTask(owner string, secretNameFunc util.Namefunc) func(r wo
 
 		err := apiclient.DeleteSecretIfHasLabels(
 			data.RemoteClient(),
-			secretNameFunc(data.GetName()),
+			secretName,
 			data.GetNamespace(),
 			constants.KarmadaOperatorLabel,
 		)

--- a/operator/pkg/tasks/deinit/kubeconfig.go
+++ b/operator/pkg/tasks/deinit/kubeconfig.go
@@ -46,7 +46,7 @@ func runCleanupKubeconfig(r workflow.RunData) error {
 
 	err := apiclient.DeleteSecretIfHasLabels(
 		data.RemoteClient(),
-		util.AdminKubeconfigSecretName(data.GetName()),
+		util.KarmadaKubeconfigName,
 		data.GetNamespace(),
 		constants.KarmadaOperatorLabel,
 	)

--- a/operator/pkg/util/kubeconfig.go
+++ b/operator/pkg/util/kubeconfig.go
@@ -40,8 +40,8 @@ func CreateWithCerts(serverURL, clusterName, userName string, caCert []byte, cli
 
 // CreateBasic creates a basic, general KubeConfig object that then can be extended
 func CreateBasic(serverURL, clusterName, userName string, caCert []byte) *clientcmdapi.Config {
-	// Use the cluster and the username as the context name
-	contextName := fmt.Sprintf("%s@%s", userName, clusterName)
+	// Use the clusterName as the context name
+	contextName := clusterName
 
 	return &clientcmdapi.Config{
 		Clusters: map[string]*clientcmdapi.Cluster{

--- a/operator/pkg/util/naming.go
+++ b/operator/pkg/util/naming.go
@@ -21,28 +21,22 @@ import (
 	"strings"
 )
 
+const (
+	// KarmadaCertsName secret name of karmada-certs
+	KarmadaCertsName = "karmada-certs"
+
+	// KarmadaEtcdCertName secret name of karmada-etcd-cert
+	KarmadaEtcdCertName = "karmada-etcd-cert"
+
+	// KarmadaWebhookCertName secret name of karmada-webhook-cert
+	KarmadaWebhookCertName = "karmada-webhook-cert"
+
+	// KarmadaKubeconfigName secret name of karmada-kubeconfig
+	KarmadaKubeconfigName = "karmada-kubeconfig"
+)
+
 // Namefunc defines a function to generate resource name according to karmada resource name.
 type Namefunc func(karmada string) string
-
-// AdminKubeconfigSecretName returns secret name of karmada-admin kubeconfig
-func AdminKubeconfigSecretName(karmada string) string {
-	return generateResourceName(karmada, "admin-config")
-}
-
-// KarmadaCertSecretName returns secret name of karmada certs
-func KarmadaCertSecretName(karmada string) string {
-	return generateResourceName(karmada, "cert")
-}
-
-// EtcdCertSecretName returns secret name of etcd cert
-func EtcdCertSecretName(karmada string) string {
-	return generateResourceName(karmada, "etcd-cert")
-}
-
-// WebhookCertSecretName returns secret name of karmada-webhook cert
-func WebhookCertSecretName(karmada string) string {
-	return generateResourceName(karmada, "webhook-cert")
-}
 
 // KarmadaAPIServerName returns secret name of karmada-apiserver
 func KarmadaAPIServerName(karmada string) string {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

In karmada, here are two important secrets, which is mount by most karmada components. One is karmada-cert, which contains a series of cert files like ca.crt, apiserver.crt and so on; another is karmada-kubeconfig, which contains a kubeconfig of karmada-apiserver.

However, in different installation methods, we used inconsistent secret naming or file path naming, which can potentially cause some unnecessary problems, detail refer to https://github.com/karmada-io/karmada/issues/5363.

This PR aims to standardize the naming of karmada secrets in operator installation method.

**Which issue(s) this PR fixes**:

Fixes part of #5363

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-operator: standardize the naming of karmada secrets in operator installation method
```

