### PR TITLE
fix ut failed in federatedresourcequota

### DIFF
--- a/pkg/webhook/federatedresourcequota/validating_test.go
+++ b/pkg/webhook/federatedresourcequota/validating_test.go
@@ -78,9 +78,11 @@ func (f *fakeValidationDecoder) DecodeRaw(_ runtime.RawExtension, obj runtime.Ob
 	return nil
 }
 
-// sortAndJoinMessages sorts and joins error message parts to ensure consistent ordering.
+// normalizedMessages trim the square brackets, and sorted error message parts to ensure consistent ordering.
 // This prevents test flakiness caused by varying error message order.
-func sortAndJoinMessages(message string) string {
+func normalizedMessages(message string) string {
+	message = strings.TrimLeft(message, "[")
+	message = strings.TrimRight(message, "]")
 	parts := strings.Split(message, ", ")
 	sort.Strings(parts)
 	return strings.Join(parts, ", ")
@@ -421,8 +423,8 @@ func TestValidatingAdmission_Handle(t *testing.T) {
 				Decoder: tt.decoder,
 			}
 			got := v.Handle(context.Background(), tt.req)
-			got.Result.Message = sortAndJoinMessages(got.Result.Message)
-			tt.want.Message = sortAndJoinMessages(tt.want.Message)
+			got.Result.Message = normalizedMessages(got.Result.Message)
+			tt.want.Message = normalizedMessages(tt.want.Message)
 
 			// Extract type and message from the actual response.
 			gotType := extractResponseType(got)

--- a/pkg/webhook/multiclusteringress/validating_test.go
+++ b/pkg/webhook/multiclusteringress/validating_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Karmada Authors.
+Copyright 2024 The Karmada Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

An intermittent error was found on the master branch, 

```log
=== FAIL: pkg/webhook/federatedresourcequota TestValidatingAdmission_Handle/Handle_ExceedResourceLimits_ResourceLimitsExceeded (0.00s)
E0921 06:46:06.951602   28812 validating.go:55] [spec.overall[memory]: Invalid value: "5Gi": overall is less than assignments spec.overall[cpu]: Invalid value: "5": overall is less than assignments]
    validating_test.go:432: Handle() = {Type: Denied, Message: [spec.overall[memory]: Invalid value: "5Gi": overall is less than assignments, spec.overall[cpu]: Invalid value: "5": overall is less than assignments]}, want {Type: Denied, Message: spec.overall[cpu]: Invalid value: "5": overall is less than assignments, spec.overall[memory]: Invalid value: "5Gi": overall is less than assignments}
    --- FAIL: TestValidatingAdmission_Handle/Handle_ExceedResourceLimits_ResourceLimitsExceeded (0.00s)

=== FAIL: pkg/webhook/federatedresourcequota TestValidatingAdmission_Handle (0.00s)
```

related to the sorting of error messages, and it has been fixed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

