### PR TITLE
feat: add fieldoverrider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/emirpasic/gods v1.18.1
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/go-co-op/gocron v1.30.1
+	github.com/go-openapi/jsonpointer v0.20.2
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.5.0
@@ -90,7 +91,6 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
-	github.com/go-openapi/jsonpointer v0.20.2 // indirect
 	github.com/go-openapi/jsonreference v0.20.4 // indirect
 	github.com/go-openapi/swag v0.22.7 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect

--- a/pkg/util/overridemanager/overridemanager_test.go
+++ b/pkg/util/overridemanager/overridemanager_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/karmada-io/karmada/test/helper"
 )
 
-func Test_overrideManagerImpl_ApplyOverridePolicies(t *testing.T) {
+func Test_overrideManagerImpl_ApplyLabelAnnotationOverriderPolicies(t *testing.T) {
 	deployment := helper.NewDeployment(metav1.NamespaceDefault, "test1")
 	deployment.Labels = map[string]string{
 		"testLabel": "testLabel",
@@ -438,6 +438,245 @@ func TestGetMatchingOverridePolicies(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := m.getOverridersFromOverridePolicies(tt.policies, tt.resource, tt.cluster); !reflect.DeepEqual(got, tt.wantedOverriders) {
 				t.Errorf("getOverridersFromOverridePolicies() = %v, want %v", got, tt.wantedOverriders)
+			}
+		})
+	}
+}
+
+func Test_overrideManagerImpl_ApplyFieldOverriderPolicies_YAML(t *testing.T) {
+	configmap := helper.NewConfigMap(metav1.NamespaceDefault, "test1", map[string]string{
+		"test.yaml": `
+key: 
+  key1: value
+`,
+	})
+	configmapObj, _ := utilhelper.ToUnstructured(configmap)
+
+	type fields struct {
+		Client        client.Client
+		EventRecorder record.EventRecorder
+	}
+	type args struct {
+		rawObj      *unstructured.Unstructured
+		clusterName string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantCOP *AppliedOverrides
+		wantOP  *AppliedOverrides
+		wantErr bool
+	}{
+		{
+			name: "test yaml overridePolicies",
+			fields: fields{
+				Client: fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(helper.NewCluster("test1"),
+					&policyv1alpha1.OverridePolicy{
+						ObjectMeta: metav1.ObjectMeta{Name: "test1", Namespace: metav1.NamespaceDefault},
+						Spec: policyv1alpha1.OverrideSpec{
+							ResourceSelectors: []policyv1alpha1.ResourceSelector{
+								{
+									APIVersion: "v1",
+									Kind:       "ConfigMap",
+									Namespace:  "default",
+									Name:       "test1",
+								},
+							},
+							OverrideRules: []policyv1alpha1.RuleWithCluster{
+								{
+									TargetCluster: &policyv1alpha1.ClusterAffinity{ClusterNames: []string{"test1"}},
+									Overriders: policyv1alpha1.Overriders{
+										FieldOverrider: []policyv1alpha1.FieldOverrider{
+											{
+												FieldPath: "/data/test.yaml",
+												YAML: []policyv1alpha1.YAMLPatchOperation{
+													{
+														SubPath:  "/key/key1",
+														Operator: policyv1alpha1.OverriderOpReplace,
+														Value:    apiextensionsv1.JSON{Raw: []byte(`"updated_value"`)},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				).Build(),
+				EventRecorder: &record.FakeRecorder{},
+			},
+			args: args{
+				rawObj:      configmapObj,
+				clusterName: "test1",
+			},
+			wantCOP: nil,
+			wantOP: &AppliedOverrides{
+				AppliedItems: []OverridePolicyShadow{
+					{
+						PolicyName: "test1",
+						Overriders: policyv1alpha1.Overriders{
+							FieldOverrider: []policyv1alpha1.FieldOverrider{
+								{
+									FieldPath: "/data/test.yaml",
+									YAML: []policyv1alpha1.YAMLPatchOperation{
+										{
+											SubPath:  "/key/key1",
+											Operator: policyv1alpha1.OverriderOpReplace,
+											Value:    apiextensionsv1.JSON{Raw: []byte(`"updated_value"`)},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &overrideManagerImpl{
+				Client:        tt.fields.Client,
+				EventRecorder: tt.fields.EventRecorder,
+			}
+			gotCOP, gotOP, err := o.ApplyOverridePolicies(tt.args.rawObj, tt.args.clusterName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ApplyOverridePolicies() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotCOP, tt.wantCOP) {
+				t.Errorf("ApplyOverridePolicies() gotCOP = %v, wantCOP %v", gotCOP, tt.wantCOP)
+			}
+			if !reflect.DeepEqual(gotOP, tt.wantOP) {
+				t.Errorf("ApplyOverridePolicies() gotOP = %v, wantOP %v", gotOP, tt.wantOP)
+			}
+			wantData := map[string]interface{}{
+				"test.yaml": `key:
+  key1: updated_value
+`,
+			}
+			if !reflect.DeepEqual(tt.args.rawObj.Object["data"], wantData) {
+				t.Errorf("ApplyOverridePolicies() gotData = %v, wantData %v", tt.args.rawObj.Object["data"], wantData)
+			}
+		})
+	}
+}
+
+func Test_overrideManagerImpl_ApplyJSONOverridePolicies_JSON(t *testing.T) {
+	configmap := helper.NewConfigMap(metav1.NamespaceDefault, "test1", map[string]string{
+		"test.json": `{"key":{"key1":"value"}}`,
+	})
+	configmapObj, _ := utilhelper.ToUnstructured(configmap)
+
+	type fields struct {
+		Client        client.Client
+		EventRecorder record.EventRecorder
+	}
+	type args struct {
+		rawObj      *unstructured.Unstructured
+		clusterName string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantCOP *AppliedOverrides
+		wantOP  *AppliedOverrides
+		wantErr bool
+	}{
+		{
+			name: "test yaml overridePolicies",
+			fields: fields{
+				Client: fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(helper.NewCluster("test1"),
+					&policyv1alpha1.OverridePolicy{
+						ObjectMeta: metav1.ObjectMeta{Name: "test1", Namespace: metav1.NamespaceDefault},
+						Spec: policyv1alpha1.OverrideSpec{
+							ResourceSelectors: []policyv1alpha1.ResourceSelector{
+								{
+									APIVersion: "v1",
+									Kind:       "ConfigMap",
+									Namespace:  "default",
+									Name:       "test1",
+								},
+							},
+							OverrideRules: []policyv1alpha1.RuleWithCluster{
+								{
+									TargetCluster: &policyv1alpha1.ClusterAffinity{ClusterNames: []string{"test1"}},
+									Overriders: policyv1alpha1.Overriders{
+										FieldOverrider: []policyv1alpha1.FieldOverrider{
+											{
+												FieldPath: "/data/test.json",
+												JSON: []policyv1alpha1.JSONPatchOperation{
+													{
+														SubPath:  "/key/key1",
+														Operator: policyv1alpha1.OverriderOpReplace,
+														Value:    apiextensionsv1.JSON{Raw: []byte(`"updated_value"`)},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				).Build(),
+				EventRecorder: &record.FakeRecorder{},
+			},
+			args: args{
+				rawObj:      configmapObj,
+				clusterName: "test1",
+			},
+			wantCOP: nil,
+			wantOP: &AppliedOverrides{
+				AppliedItems: []OverridePolicyShadow{
+					{
+						PolicyName: "test1",
+						Overriders: policyv1alpha1.Overriders{
+							FieldOverrider: []policyv1alpha1.FieldOverrider{
+								{
+									FieldPath: "/data/test.json",
+									JSON: []policyv1alpha1.JSONPatchOperation{
+										{
+											SubPath:  "/key/key1",
+											Operator: policyv1alpha1.OverriderOpReplace,
+											Value:    apiextensionsv1.JSON{Raw: []byte(`"updated_value"`)},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &overrideManagerImpl{
+				Client:        tt.fields.Client,
+				EventRecorder: tt.fields.EventRecorder,
+			}
+			gotCOP, gotOP, err := o.ApplyOverridePolicies(tt.args.rawObj, tt.args.clusterName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ApplyOverridePolicies() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotCOP, tt.wantCOP) {
+				t.Errorf("ApplyOverridePolicies() gotCOP = %v, wantCOP %v", gotCOP, tt.wantCOP)
+			}
+			if !reflect.DeepEqual(gotOP, tt.wantOP) {
+				t.Errorf("ApplyOverridePolicies() gotOP = %v, wantOP %v", gotOP, tt.wantOP)
+			}
+			wantData := map[string]interface{}{
+				"test.json": `{"key":{"key1":"updated_value"}}`,
+			}
+			if !reflect.DeepEqual(tt.args.rawObj.Object["data"], wantData) {
+				t.Errorf("ApplyOverridePolicies() gotData = %v, wantData %v", tt.args.rawObj.Object["data"], wantData)
 			}
 		})
 	}

--- a/test/e2e/coverage_docs/overridepolicy_test.md
+++ b/test/e2e/coverage_docs/overridepolicy_test.md
@@ -8,6 +8,8 @@
 | Check if the OverridePolicy will update the deployment's image value                                                                                    | deployment imageOverride testing        |                                                                                     |
 | Check if the OverridePolicy will update the pod's image value                                                                                           | pod imageOverride testing               |                                                                                     |
 | Check if the OverridePolicy will update the specific image value                                                                                        | deployment imageOverride testing        |                                                                                     |
+| Check if the OverridePolicy will update the value inside JSON                                                                                           | deployment fieldOverride testing        |                                                                                     |
+| Check if the OverridePolicy will update the value inside YAML                                                                                           | deployment fieldOverride testing        |                                                                                     |
 
 #### OverridePolicy with nil resourceSelector testing
 | Test Case                                                                                                                                               | E2E Describe Text                       | Comments                                                                            |

--- a/test/e2e/overridepolicy_test.go
+++ b/test/e2e/overridepolicy_test.go
@@ -17,9 +17,13 @@ limitations under the License.
 package e2e
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/onsi/ginkgo/v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/klog/v2"
 
@@ -425,6 +429,221 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 				})
 		})
 	})
+
+	ginkgo.Context("[FieldOverrider] apply field overrider testing to update JSON values in ConfigMap", func() {
+		var configMapNamespace, configMapName string
+		var configMap *corev1.ConfigMap
+
+		ginkgo.BeforeEach(func() {
+			configMapNamespace = testNamespace
+			configMapName = configMapNamePrefix + rand.String(RandomStrLength)
+			propagationPolicyNamespace = testNamespace
+			propagationPolicyName = configMapName
+			overridePolicyNamespace = testNamespace
+			overridePolicyName = configMapName
+
+			configMapData := map[string]string{
+				"deploy.json": fmt.Sprintf(`{
+				"apiVersion": "apps/v1",
+				"kind": "Deployment",
+				"metadata": {
+					"name": "nginx-deploy",
+					"namespace": "%s"
+				},
+				"spec": {
+					"replicas": 3,
+					"selector": {
+						"matchLabels": {
+							"app": "nginx"
+						}
+					},
+					"template": {
+						"metadata": {
+							"labels": {
+								"app": "nginx"
+							}
+						},
+						"spec": {
+							"containers": [
+								{
+									"name": "nginx",
+									"image": "nginx:1.19.0"
+								}
+							]
+						}
+					}
+				}
+			}`, configMapNamespace),
+			}
+
+			configMap = helper.NewConfigMap(configMapNamespace, configMapName, configMapData)
+			propagationPolicy = helper.NewPropagationPolicy(propagationPolicyNamespace, propagationPolicyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: configMap.APIVersion,
+					Kind:       configMap.Kind,
+					Name:       configMap.Name,
+				},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: framework.ClusterNames(),
+				},
+			})
+
+			overridePolicy = helper.NewOverridePolicy(overridePolicyNamespace, overridePolicyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: configMap.APIVersion,
+					Kind:       configMap.Kind,
+					Name:       configMap.Name,
+				},
+			}, policyv1alpha1.ClusterAffinity{
+				ClusterNames: framework.ClusterNames(),
+			}, policyv1alpha1.Overriders{
+				FieldOverrider: []policyv1alpha1.FieldOverrider{
+					{
+						FieldPath: "/data/deploy.json",
+						JSON: []policyv1alpha1.JSONPatchOperation{
+							{
+								SubPath:  "/spec/replicas",
+								Operator: policyv1alpha1.OverriderOpReplace,
+								Value:    apiextensionsv1.JSON{Raw: []byte(`5`)},
+							},
+							{
+								SubPath:  "/spec/template/spec/containers/-",
+								Operator: policyv1alpha1.OverriderOpAdd,
+								Value:    apiextensionsv1.JSON{Raw: []byte(`{"name": "nginx-helper", "image": "nginx:1.19.1"}`)},
+							},
+							{
+								SubPath:  "/spec/template/spec/containers/0/image",
+								Operator: policyv1alpha1.OverriderOpRemove,
+							},
+						},
+					},
+				},
+			})
+		})
+
+		ginkgo.BeforeEach(func() {
+			framework.CreatePropagationPolicy(karmadaClient, propagationPolicy)
+			framework.CreateOverridePolicy(karmadaClient, overridePolicy)
+			framework.CreateConfigMap(kubeClient, configMap)
+			ginkgo.DeferCleanup(func() {
+				framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
+				framework.RemoveOverridePolicy(karmadaClient, overridePolicy.Namespace, overridePolicy.Name)
+				framework.RemoveConfigMap(kubeClient, configMap.Namespace, configMap.Name)
+			})
+		})
+
+		ginkgo.It("should override JSON field in ConfigMap", func() {
+			klog.Infof("check if configMap present on member clusters has the correct JSON field value.")
+			framework.WaitConfigMapPresentOnClustersFitWith(framework.ClusterNames(), configMap.Namespace, configMap.Name,
+				func(cm *corev1.ConfigMap) bool {
+					return strings.Contains(cm.Data["deploy.json"], `"replicas":5`) &&
+						strings.Contains(cm.Data["deploy.json"], `"name":"nginx-helper"`) &&
+						!strings.Contains(cm.Data["deploy.json"], `"image":"nginx:1.19.0"`)
+				})
+		})
+	})
+
+	ginkgo.Context("[FieldOverrider] apply field overrider testing to update YAML values in ConfigMap", func() {
+		var configMapNamespace, configMapName string
+		var configMap *corev1.ConfigMap
+
+		ginkgo.BeforeEach(func() {
+			configMapNamespace = testNamespace
+			configMapName = configMapNamePrefix + rand.String(RandomStrLength)
+			propagationPolicyNamespace = testNamespace
+			propagationPolicyName = configMapName
+			overridePolicyNamespace = testNamespace
+			overridePolicyName = configMapName
+
+			// Define the ConfigMap data
+			configMapData := map[string]string{
+				"nginx.yaml": `
+server:
+  listen: 80
+  server_name: localhost
+  location /:
+    root: /usr/share/nginx/html
+    index: 
+      - index.html
+      - index.htm
+  error_page:
+    - code: 500
+    - code: 502
+    - code: 503
+    - code: 504
+  location /50x.html:
+    root: /usr/share/nginx/html
+`,
+			}
+			configMap = helper.NewConfigMap(configMapNamespace, configMapName, configMapData)
+			propagationPolicy = helper.NewPropagationPolicy(propagationPolicyNamespace, propagationPolicyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: configMap.APIVersion,
+					Kind:       configMap.Kind,
+					Name:       configMap.Name,
+				},
+			}, policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: framework.ClusterNames(),
+				},
+			})
+
+			overridePolicy = helper.NewOverridePolicy(overridePolicyNamespace, overridePolicyName, []policyv1alpha1.ResourceSelector{
+				{
+					APIVersion: configMap.APIVersion,
+					Kind:       configMap.Kind,
+					Name:       configMap.Name,
+				},
+			}, policyv1alpha1.ClusterAffinity{
+				ClusterNames: framework.ClusterNames(),
+			}, policyv1alpha1.Overriders{
+				FieldOverrider: []policyv1alpha1.FieldOverrider{
+					{
+						FieldPath: "/data/nginx.yaml",
+						YAML: []policyv1alpha1.YAMLPatchOperation{
+							{
+								SubPath:  "/server/location ~1/root",
+								Operator: policyv1alpha1.OverriderOpReplace,
+								Value:    apiextensionsv1.JSON{Raw: []byte(`"/var/www/html"`)},
+							},
+							{
+								SubPath:  "/server/error_page/-",
+								Operator: policyv1alpha1.OverriderOpAdd,
+								Value:    apiextensionsv1.JSON{Raw: []byte(`{"code": 400}`)},
+							},
+							{
+								SubPath:  "/server/location ~1/index",
+								Operator: policyv1alpha1.OverriderOpRemove,
+							},
+						},
+					},
+				},
+			})
+		})
+
+		ginkgo.BeforeEach(func() {
+			framework.CreatePropagationPolicy(karmadaClient, propagationPolicy)
+			framework.CreateOverridePolicy(karmadaClient, overridePolicy)
+			framework.CreateConfigMap(kubeClient, configMap)
+			ginkgo.DeferCleanup(func() {
+				framework.RemovePropagationPolicy(karmadaClient, propagationPolicy.Namespace, propagationPolicy.Name)
+				framework.RemoveOverridePolicy(karmadaClient, overridePolicy.Namespace, overridePolicy.Name)
+				framework.RemoveConfigMap(kubeClient, configMap.Namespace, configMap.Name)
+			})
+		})
+
+		ginkgo.It("should override YAML field in ConfigMap", func() {
+			klog.Infof("check if configMap present on member clusters has the correct YAML field value.")
+			framework.WaitConfigMapPresentOnClustersFitWith(framework.ClusterNames(), configMap.Namespace, configMap.Name,
+				func(cm *corev1.ConfigMap) bool {
+					return strings.Contains(cm.Data["nginx.yaml"], "root: /var/www/html") &&
+						strings.Contains(cm.Data["nginx.yaml"], "code: 400") &&
+						!strings.Contains(cm.Data["nginx.yaml"], "- index.html")
+				})
+		})
+	})
+
 })
 
 var _ = framework.SerialDescribe("OverridePolicy with nil resourceSelector testing", func() {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

The proposal introduces a new feature that allows users to partially override values inside  JSON and YAML fields. This is achieved using JSON patch operation. This design enables users to to override the values within JSON/YAML fields partially, rather than replacing a whole JSON/YAML fields with `PlaintextOverrider`. Currently, `PlaintextOverrider`  applies JSON patch operations to whole fields, rather than specific values within fields, making it unsuitable for cases where users need to override individual values within those fields.

**Which issue(s) this PR fixes**:
Fixes #5330

**Special notes for your reviewer**:
Proposal: #5449 
Related PR: #5329, #5581

**Does this PR introduce a user-facing change?**:

```release-note
Introduced `FieldOverrider`  for overriding values in JSON and YAML.
```
