### PR TITLE
operator/pkg/controlplane/etcd: remove redundant `EtcdPeerServiceName`

### DIFF
--- a/operator/pkg/controlplane/etcd/etcd.go
+++ b/operator/pkg/controlplane/etcd/etcd.go
@@ -62,10 +62,10 @@ func installKarmadaEtcd(client clientset.Interface, name, namespace string, cfg 
 	}
 
 	etcdStatefulSetBytes, err := util.ParseTemplate(KarmadaEtcdStatefulSet, struct {
-		KarmadaInstanceName, StatefulSetName, Namespace, Image, ImagePullPolicy, EtcdClientService string
-		CertsSecretName, EtcdPeerServiceName                                                       string
-		InitialCluster, EtcdDataVolumeName, EtcdCipherSuites                                       string
-		Replicas, EtcdListenClientPort, EtcdListenPeerPort                                         int32
+		KarmadaInstanceName, StatefulSetName, Namespace, Image string
+		ImagePullPolicy, EtcdClientService, CertsSecretName    string
+		InitialCluster, EtcdDataVolumeName, EtcdCipherSuites   string
+		Replicas, EtcdListenClientPort, EtcdListenPeerPort     int32
 	}{
 		KarmadaInstanceName:  name,
 		StatefulSetName:      util.KarmadaEtcdName(name),
@@ -74,7 +74,6 @@ func installKarmadaEtcd(client clientset.Interface, name, namespace string, cfg 
 		ImagePullPolicy:      string(cfg.ImagePullPolicy),
 		EtcdClientService:    util.KarmadaEtcdClientName(name),
 		CertsSecretName:      util.EtcdCertSecretName(name),
-		EtcdPeerServiceName:  util.KarmadaEtcdName(name),
 		EtcdDataVolumeName:   constants.EtcdDataVolumeName,
 		InitialCluster:       strings.Join(initialClusters, ","),
 		EtcdCipherSuites:     genEtcdCipherSuites(),


### PR DESCRIPTION
**Description**

In this commit, we remove the redundant field `EtcdPeerServiceName` in the function `installKarmadaEtcd` in `operator/pkg/controlplane/etcd` package. 

**What type of PR is this?**

/kind cleanup

**Which issue(s) this PR fixes**:
Fixes #5584

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```