### PR TITLE
cleanup: change *kubeclient.Clientset to kubeclient.Interface in unregister module

### DIFF
--- a/pkg/karmadactl/unregister/unregister.go
+++ b/pkg/karmadactl/unregister/unregister.go
@@ -128,10 +128,10 @@ type CommandUnregisterOption struct {
 	DryRun bool
 
 	// ControlPlaneClient control plane client set
-	ControlPlaneClient *karmadaclientset.Clientset
+	ControlPlaneClient karmadaclientset.Interface
 
 	// MemberClusterClient member cluster client set
-	MemberClusterClient *kubeclient.Clientset
+	MemberClusterClient kubeclient.Interface
 }
 
 // AddFlags adds flags to the specified FlagSet.

--- a/pkg/karmadactl/util/cluster.go
+++ b/pkg/karmadactl/util/cluster.go
@@ -30,7 +30,7 @@ import (
 )
 
 // DeleteClusterObject deletes the cluster object from the Karmada control plane.
-func DeleteClusterObject(controlPlaneKarmadaClient *karmadaclientset.Clientset, clusterName string,
+func DeleteClusterObject(controlPlaneKarmadaClient karmadaclientset.Interface, clusterName string,
 	timeout time.Duration, dryRun bool) error {
 	if dryRun {
 		return nil


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

cleanup: change `*kubeclient.Clientset` to `kubeclient.Interface` in unregister module

* Improved Abstraction: By using the interface, we enhance the code's flexibility, making it easier to swap out implementations or mock dependencies for testing.
* Easier Testing: Interfaces facilitate unit testing by allowing the use of mock clients, thereby improving test coverage and reliability.
* Code Maintainability: This change promotes better software design principles, making the codebase easier to understand and maintain.

**Which issue(s) this PR fixes**:

Part of #5380

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

