### PR TITLE
operator/pkg: depend on `aggregator.Interface` instead of `*aggregator.Clientset`

### DIFF
--- a/operator/pkg/karmadaresource/apiservice/apiservice.go
+++ b/operator/pkg/karmadaresource/apiservice/apiservice.go
@@ -46,7 +46,7 @@ func init() {
 }
 
 // EnsureAggregatedAPIService creates aggregated APIService and a service
-func EnsureAggregatedAPIService(aggregatorClient *aggregator.Clientset, client clientset.Interface, karmadaControlPlaneServiceName, karmadaControlPlaneNamespace, hostClusterServiceName, hostClusterNamespace, caBundle string) error {
+func EnsureAggregatedAPIService(aggregatorClient aggregator.Interface, client clientset.Interface, karmadaControlPlaneServiceName, karmadaControlPlaneNamespace, hostClusterServiceName, hostClusterNamespace, caBundle string) error {
 	if err := aggregatedApiserverService(client, karmadaControlPlaneServiceName, karmadaControlPlaneNamespace, hostClusterServiceName, hostClusterNamespace); err != nil {
 		return err
 	}
@@ -54,7 +54,7 @@ func EnsureAggregatedAPIService(aggregatorClient *aggregator.Clientset, client c
 	return aggregatedAPIService(aggregatorClient, karmadaControlPlaneServiceName, karmadaControlPlaneNamespace, caBundle)
 }
 
-func aggregatedAPIService(client *aggregator.Clientset, karmadaControlPlaneServiceName, karmadaControlPlaneNamespace, caBundle string) error {
+func aggregatedAPIService(client aggregator.Interface, karmadaControlPlaneServiceName, karmadaControlPlaneNamespace, caBundle string) error {
 	apiServiceBytes, err := util.ParseTemplate(KarmadaAggregatedAPIService, struct {
 		Namespace   string
 		ServiceName string
@@ -101,7 +101,7 @@ func aggregatedApiserverService(client clientset.Interface, karmadaControlPlaneS
 }
 
 // EnsureMetricsAdapterAPIService creates APIService and a service for karmada-metrics-adapter
-func EnsureMetricsAdapterAPIService(aggregatorClient *aggregator.Clientset, client clientset.Interface, karmadaControlPlaneServiceName, karmadaControlPlaneNamespace, hostClusterServiceName, hostClusterNamespace, caBundle string) error {
+func EnsureMetricsAdapterAPIService(aggregatorClient aggregator.Interface, client clientset.Interface, karmadaControlPlaneServiceName, karmadaControlPlaneNamespace, hostClusterServiceName, hostClusterNamespace, caBundle string) error {
 	if err := karmadaMetricsAdapterService(client, karmadaControlPlaneServiceName, karmadaControlPlaneNamespace, hostClusterServiceName, hostClusterNamespace); err != nil {
 		return err
 	}
@@ -109,7 +109,7 @@ func EnsureMetricsAdapterAPIService(aggregatorClient *aggregator.Clientset, clie
 	return karmadaMetricsAdapterAPIService(aggregatorClient, karmadaControlPlaneServiceName, karmadaControlPlaneNamespace, caBundle)
 }
 
-func karmadaMetricsAdapterAPIService(client *aggregator.Clientset, karmadaControlPlaneServiceName, karmadaControlPlaneNamespace, caBundle string) error {
+func karmadaMetricsAdapterAPIService(client aggregator.Interface, karmadaControlPlaneServiceName, karmadaControlPlaneNamespace, caBundle string) error {
 	for _, gv := range constants.KarmadaMetricsAdapterAPIServices {
 		// The APIService name to metrics adapter is "$version.$group"
 		apiServiceName := fmt.Sprintf("%s.%s", gv.Version, gv.Group)
@@ -171,7 +171,7 @@ func karmadaMetricsAdapterService(client clientset.Interface, karmadaControlPlan
 }
 
 // EnsureSearchAPIService creates APIService and a service for karmada-metrics-adapter
-func EnsureSearchAPIService(aggregatorClient *aggregator.Clientset, client clientset.Interface, karmadaControlPlaneServiceName, karmadaControlPlaneNamespace, hostClusterServiceName, hostClusterNamespace, caBundle string) error {
+func EnsureSearchAPIService(aggregatorClient aggregator.Interface, client clientset.Interface, karmadaControlPlaneServiceName, karmadaControlPlaneNamespace, hostClusterServiceName, hostClusterNamespace, caBundle string) error {
 	if err := karmadaSearchService(client, karmadaControlPlaneServiceName, karmadaControlPlaneNamespace, hostClusterServiceName, hostClusterNamespace); err != nil {
 		return err
 	}
@@ -179,7 +179,7 @@ func EnsureSearchAPIService(aggregatorClient *aggregator.Clientset, client clien
 	return karmadaSearchAPIService(aggregatorClient, karmadaControlPlaneServiceName, karmadaControlPlaneNamespace, caBundle)
 }
 
-func karmadaSearchAPIService(client *aggregator.Clientset, karmadaControlPlaneServiceName, karmadaControlPlaneNamespace, caBundle string) error {
+func karmadaSearchAPIService(client aggregator.Interface, karmadaControlPlaneServiceName, karmadaControlPlaneNamespace, caBundle string) error {
 	apiServiceBytes, err := util.ParseTemplate(KarmadaSearchAPIService, struct {
 		ServiceName, Namespace string
 		CABundle               string

--- a/operator/pkg/util/apiclient/idempotency.go
+++ b/operator/pkg/util/apiclient/idempotency.go
@@ -49,7 +49,7 @@ func NewCRDsClient(c *rest.Config) (*crdsclient.Clientset, error) {
 }
 
 // NewAPIRegistrationClient is to create an apiregistration ClientSet
-func NewAPIRegistrationClient(c *rest.Config) (*aggregator.Clientset, error) {
+func NewAPIRegistrationClient(c *rest.Config) (aggregator.Interface, error) {
 	return aggregator.NewForConfig(c)
 }
 
@@ -183,7 +183,7 @@ func CreateOrUpdateValidatingWebhookConfiguration(client clientset.Interface, vw
 }
 
 // CreateOrUpdateAPIService creates a APIService if the target resource doesn't exist. If the resource exists already, this function will update the resource instead.
-func CreateOrUpdateAPIService(apiRegistrationClient *aggregator.Clientset, apiservice *apiregistrationv1.APIService) error {
+func CreateOrUpdateAPIService(apiRegistrationClient aggregator.Interface, apiservice *apiregistrationv1.APIService) error {
 	_, err := apiRegistrationClient.ApiregistrationV1().APIServices().Create(context.TODO(), apiservice, metav1.CreateOptions{})
 	if err != nil {
 		if !apierrors.IsAlreadyExists(err) {

--- a/pkg/karmadactl/addons/init/global.go
+++ b/pkg/karmadactl/addons/init/global.go
@@ -47,7 +47,7 @@ type GlobalCommandOptions struct {
 
 	KarmadaRestConfig *rest.Config
 
-	KarmadaAggregatorClientSet *aggregator.Clientset
+	KarmadaAggregatorClientSet aggregator.Interface
 }
 
 // AddFlags adds flags to the specified FlagSet.

--- a/pkg/karmadactl/cmdinit/karmada/check.go
+++ b/pkg/karmadactl/cmdinit/karmada/check.go
@@ -29,7 +29,7 @@ import (
 )
 
 // WaitAPIServiceReady wait the api service condition true
-func WaitAPIServiceReady(c *aggregator.Clientset, name string, timeout time.Duration) error {
+func WaitAPIServiceReady(c aggregator.Interface, name string, timeout time.Duration) error {
 	if err := wait.PollUntilContextTimeout(context.TODO(), time.Second, timeout, true, func(ctx context.Context) (done bool, err error) {
 		apiService, e := c.ApiregistrationV1().APIServices().Get(ctx, name, metav1.GetOptions{})
 		if e != nil {

--- a/pkg/karmadactl/util/apiclient/apiclient.go
+++ b/pkg/karmadactl/util/apiclient/apiclient.go
@@ -103,7 +103,7 @@ func NewCRDsClient(c *rest.Config) (*clientset.Clientset, error) {
 }
 
 // NewAPIRegistrationClient is to create an apiregistration ClientSet
-func NewAPIRegistrationClient(c *rest.Config) (*aggregator.Clientset, error) {
+func NewAPIRegistrationClient(c *rest.Config) (aggregator.Interface, error) {
 	return aggregator.NewForConfig(c)
 }
 

--- a/pkg/karmadactl/util/idempotency.go
+++ b/pkg/karmadactl/util/idempotency.go
@@ -96,7 +96,7 @@ func CreateOrUpdateDeployment(client kubernetes.Interface, deploy *appsv1.Deploy
 
 // CreateOrUpdateAPIService creates a ApiService if the target resource doesn't exist.
 // If the resource exists already, this function will update the resource instead.
-func CreateOrUpdateAPIService(apiRegistrationClient *aggregator.Clientset, apiservice *apiregistrationv1.APIService) error {
+func CreateOrUpdateAPIService(apiRegistrationClient aggregator.Interface, apiservice *apiregistrationv1.APIService) error {
 	if _, err := apiRegistrationClient.ApiregistrationV1().APIServices().Create(context.TODO(), apiservice, metav1.CreateOptions{}); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
 			return fmt.Errorf("unable to create APIService: %v", err)

--- a/pkg/karmadactl/util/validate.go
+++ b/pkg/karmadactl/util/validate.go
@@ -39,7 +39,7 @@ func VerifyClustersExist(input []string, clusters *clusterv1alpha1.ClusterList) 
 		}
 	}
 	if len(nonExistClusters) != 0 {
-		return fmt.Errorf("clusters don't exist: " + strings.Join(nonExistClusters, ","))
+		return fmt.Errorf("clusters don't exist: %s", strings.Join(nonExistClusters, ","))
 	}
 
 	return nil


### PR DESCRIPTION
**Description**

In this commit, we apply the Dependency Inversion Principle by depending on an interface instead of a concrete type. This improves flexibility and testability.

**Motivation and Context**

While testing the KarmadaResource API service operator package (#5596), I found it difficult to mock *aggregator.Clientset, complicating unit tests. By refactoring to depend on an interface, we improve flexibility and testability, allowing for the integration of a fake aggregator clientset since it implements that interface.


**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```