### PR TITLE
cluster proxy transport disable keepalive

### DIFF
--- a/pkg/util/proxy/proxy.go
+++ b/pkg/util/proxy/proxy.go
@@ -183,8 +183,9 @@ func constructLocation(cluster *clusterapis.Cluster) (*url.URL, error) {
 func createProxyTransport(cluster *clusterapis.Cluster, tlsConfig *tls.Config) (*http.Transport, error) {
 	var proxyDialerFn utilnet.DialFunc
 	trans := utilnet.SetTransportDefaults(&http.Transport{
-		DialContext:     proxyDialerFn,
-		TLSClientConfig: tlsConfig,
+		DialContext:       proxyDialerFn,
+		TLSClientConfig:   tlsConfig,
+		DisableKeepAlives: true,
 	})
 
 	if proxyURL := cluster.Spec.ProxyURL; proxyURL != "" {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

![image](https://github.com/user-attachments/assets/fcc44940-9e04-46fb-8400-d5e3b1221a59)

We can solve the problem of too many connections by setting DisableKeepAlives: true


test.sh:

```#!/bin/bash
KUBECONFIG="proxy.config"
SLEEP_INTERVAL=0.1
MAX_JOBS=100  
function run_karmadactl() {
  while true; do
    kubectl  --kubeconfig "$KUBECONFIG" get node
    sleep "$SLEEP_INTERVAL"
  done
}
for ((i = 1; i <= MAX_JOBS; i++)); do
  run_karmadactl &
done
wait
```

Monitor the number of TCP connections in the pod

```
#!/bin/bash

# Output total number of all TCP connections every 10 seconds
while true; do
  # Get the total number of all TCP connections
  tcp_count=$(ss -tn | wc -l)
  
  # Print current time and TCP connection count
  echo "$(date '+%Y-%m-%d %H:%M:%S') - Current total TCP connections: $((tcp_count - 1))"  # Subtract 1 for the header line
  
  # Wait for 10 seconds
  sleep 10
done

```

before fix

<img width="314" alt="0880c4c80710adb4c422" src="https://github.com/user-attachments/assets/d4373112-7985-46a7-9598-e3c305e24978">



after fix 

<img width="304" alt="0880c4c80710adf28a23" src="https://github.com/user-attachments/assets/34cc57a3-6c30-4ebc-bf8d-a937e1e82bc5">


**Which issue(s) this PR fixes**:
Fixes #5574

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

