### PR TITLE
Show more debug logs when failed to build resource model due to `getIndex` fails

### DIFF
--- a/pkg/modeling/modeling.go
+++ b/pkg/modeling/modeling.go
@@ -163,7 +163,7 @@ func (rs *ResourceSummary) clusterResourceNodeComparator(a, b interface{}) int {
 func (rs *ResourceSummary) AddToResourceSummary(crn ClusterResourceNode) {
 	index := rs.getIndex(crn)
 	if index == -1 {
-		klog.Error("ClusterResource can not add to resource summary: index is invalid.")
+		klog.Errorf("Failed to add node to resource summary due to no appropriate grade. ClusterResourceNode:%v", crn)
 		return
 	}
 	modeling := &(*rs).RMs[index]


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
when the "getIndex" fails, display more data details in logs.

**Which issue(s) this PR fixes**:
Fixes # add more details in the log.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

