### PR TITLE
one cluster should have only one transport to reduce the number of TCP connections

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64
 	go.uber.org/mock v0.4.0
 	golang.org/x/net v0.24.0
+	golang.org/x/sync v0.7.0
 	golang.org/x/term v0.19.0
 	golang.org/x/text v0.14.0
 	golang.org/x/time v0.5.0
@@ -174,7 +175,6 @@ require (
 	golang.org/x/exp v0.0.0-20231226003508-02704c960a9b // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/oauth2 v0.18.0 // indirect
-	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto v0.0.0-20231212172506-995d672761c0 // indirect

--- a/pkg/util/proxy/proxy_test.go
+++ b/pkg/util/proxy/proxy_test.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/request"
 
@@ -68,7 +69,7 @@ func TestConnectCluster(t *testing.T) {
 			name: "apiEndpoint is empty",
 			args: args{
 				cluster: &clusterapis.Cluster{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cluster"},
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cluster", UID: uuid.NewUUID()},
 					Spec:       clusterapis.ClusterSpec{},
 				},
 				secretGetter: nil,
@@ -80,7 +81,7 @@ func TestConnectCluster(t *testing.T) {
 			name: "apiEndpoint is invalid",
 			args: args{
 				cluster: &clusterapis.Cluster{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cluster"},
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cluster", UID: uuid.NewUUID()},
 					Spec:       clusterapis.ClusterSpec{APIEndpoint: "h :/ invalid"},
 				},
 				secretGetter: nil,
@@ -92,7 +93,7 @@ func TestConnectCluster(t *testing.T) {
 			name: "ProxyURL is invalid",
 			args: args{
 				cluster: &clusterapis.Cluster{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cluster"},
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cluster", UID: uuid.NewUUID()},
 					Spec: clusterapis.ClusterSpec{
 						APIEndpoint: s.URL,
 						ProxyURL:    "h :/ invalid",
@@ -107,7 +108,7 @@ func TestConnectCluster(t *testing.T) {
 			name: "ImpersonatorSecretRef is nil",
 			args: args{
 				cluster: &clusterapis.Cluster{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cluster"},
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cluster", UID: uuid.NewUUID()},
 					Spec: clusterapis.ClusterSpec{
 						APIEndpoint: s.URL,
 						ProxyURL:    "http://proxy",
@@ -122,7 +123,7 @@ func TestConnectCluster(t *testing.T) {
 			name: "secret not found",
 			args: args{
 				cluster: &clusterapis.Cluster{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cluster"},
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cluster", UID: uuid.NewUUID()},
 					Spec: clusterapis.ClusterSpec{
 						APIEndpoint:           s.URL,
 						ImpersonatorSecretRef: &clusterapis.LocalSecretReference{Namespace: "ns", Name: "secret"},
@@ -139,7 +140,7 @@ func TestConnectCluster(t *testing.T) {
 			name: "SecretTokenKey not found",
 			args: args{
 				cluster: &clusterapis.Cluster{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cluster"},
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cluster", UID: uuid.NewUUID()},
 					Spec: clusterapis.ClusterSpec{
 						APIEndpoint:           s.URL,
 						ImpersonatorSecretRef: &clusterapis.LocalSecretReference{Namespace: "ns", Name: "secret"},
@@ -160,7 +161,7 @@ func TestConnectCluster(t *testing.T) {
 			args: args{
 				ctx: context.TODO(),
 				cluster: &clusterapis.Cluster{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cluster"},
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cluster", UID: uuid.NewUUID()},
 					Spec: clusterapis.ClusterSpec{
 						APIEndpoint:           s.URL,
 						ImpersonatorSecretRef: &clusterapis.LocalSecretReference{Namespace: "ns", Name: "secret"},
@@ -181,7 +182,7 @@ func TestConnectCluster(t *testing.T) {
 			args: args{
 				ctx: request.WithUser(request.NewContext(), &user.DefaultInfo{Name: testUser, Groups: []string{testGroup, user.AllAuthenticated, user.AllUnauthenticated}}),
 				cluster: &clusterapis.Cluster{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cluster"},
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cluster", UID: uuid.NewUUID()},
 					Spec: clusterapis.ClusterSpec{
 						APIEndpoint:                 s.URL,
 						ImpersonatorSecretRef:       &clusterapis.LocalSecretReference{Namespace: "ns", Name: "secret"},


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind feature

-->

**What this PR does / why we need it**:
It can solve the problem about too many tcp connection between aggregated apiserver and apiserver of  member's cluster
**Which issue(s) this PR fixes**:
Fixes #5574

**Special notes for your reviewer**:

<img width="581" alt="截屏2024-09-27 10 46 40" src="https://github.com/user-attachments/assets/f6a18d55-f1c6-4130-ad14-8b80146505e8">

test.sh
````
KUBECONFIG="/root/.kube/karmada.config"
SLEEP_INTERVAL=0.1
MAX_JOBS=100
function run_karmadactl() {
  for ((i = 1; i <= 50; i++)); do
    karmadactl  --kubeconfig "$KUBECONFIG" get node --operation-scope=members
    sleep "$SLEEP_INTERVAL"
  done
}
for ((i = 1; i <= MAX_JOBS; i++)); do
  run_karmadactl &
done
wait
````

result.sh
````
#!/bin/bash

while true
do
  tcp_count=$(netstat -anp | grep 6443| wc -l)
  sleep 1
  echo "$(date '+%Y-%m-%d %H:%M:%S') - Current total TCP connections: $((tcp_count))"
done
````

fix before
<img width="499" alt="企业微信截图_f9386612-1d3f-402c-8aee-243149a67406" src="https://github.com/user-attachments/assets/70296d79-6d5d-4e41-82e4-506da7dad631">


fix after
<img width="500" alt="企业微信截图_ace06070-69d8-4391-853f-ba3a488df8f2" src="https://github.com/user-attachments/assets/b7afe6ee-7751-4e3d-aa73-4617f0bb3ce3">

