### PR TITLE
operator+pkg:  depend on `clientset.Interface` instead of `*clientset.Clientset`

### DIFF
--- a/operator/pkg/util/kubeconfig.go
+++ b/operator/pkg/util/kubeconfig.go
@@ -67,7 +67,7 @@ func IsInCluster(hostCluster *operatorv1alpha1.HostCluster) bool {
 }
 
 // BuildClientFromSecretRef builds a clientset from the secret reference.
-func BuildClientFromSecretRef(client *clientset.Clientset, ref *operatorv1alpha1.LocalSecretReference) (*clientset.Clientset, error) {
+func BuildClientFromSecretRef(client clientset.Interface, ref *operatorv1alpha1.LocalSecretReference) (clientset.Interface, error) {
 	secret, err := client.CoreV1().Secrets(ref.Namespace).Get(context.TODO(), ref.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -81,7 +81,7 @@ func BuildClientFromSecretRef(client *clientset.Clientset, ref *operatorv1alpha1
 	return newClientSetForConfig(kubeconfigBytes)
 }
 
-func newClientSetForConfig(kubeconfig []byte) (*clientset.Clientset, error) {
+func newClientSetForConfig(kubeconfig []byte) (clientset.Interface, error) {
 	clientConfig, err := clientcmd.NewClientConfigFromBytes(kubeconfig)
 	if err != nil {
 		return nil, err

--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -451,9 +451,9 @@ func getClusterHealthStatus(clusterClient *util.ClusterClient) (online, healthy 
 	return true, true
 }
 
-func healthEndpointCheck(client *clientset.Clientset, path string) (int, error) {
+func healthEndpointCheck(client clientset.Interface, path string) (int, error) {
 	var healthStatus int
-	resp := client.DiscoveryClient.RESTClient().Get().AbsPath(path).Do(context.TODO()).StatusCode(&healthStatus)
+	resp := client.Discovery().RESTClient().Get().AbsPath(path).Do(context.TODO()).StatusCode(&healthStatus)
 	return healthStatus, resp.Error()
 }
 

--- a/pkg/karmadactl/cmdinit/karmada/deploy.go
+++ b/pkg/karmadactl/cmdinit/karmada/deploy.go
@@ -221,7 +221,7 @@ func crdPatchesResources(filename, caBundle string) ([]byte, error) {
 }
 
 // createCRDs create crd resource
-func createCRDs(crdClient *clientset.Clientset, filename string) error {
+func createCRDs(crdClient clientset.Interface, filename string) error {
 	obj := apiextensionsv1.CustomResourceDefinition{}
 	data, err := os.ReadFile(filename)
 	if err != nil {
@@ -252,7 +252,7 @@ func createCRDs(crdClient *clientset.Clientset, filename string) error {
 }
 
 // patchCRDs patch crd resource
-func patchCRDs(crdClient *clientset.Clientset, caBundle, filename string) error {
+func patchCRDs(crdClient clientset.Interface, caBundle, filename string) error {
 	data, err := crdPatchesResources(filename, caBundle)
 	if err != nil {
 		return err

--- a/pkg/karmadactl/util/apiclient/apiclient.go
+++ b/pkg/karmadactl/util/apiclient/apiclient.go
@@ -98,7 +98,7 @@ func NewClientSet(c *rest.Config) (*kubernetes.Clientset, error) {
 }
 
 // NewCRDsClient is to create a clientset ClientSet
-func NewCRDsClient(c *rest.Config) (*clientset.Clientset, error) {
+func NewCRDsClient(c *rest.Config) (clientset.Interface, error) {
 	return clientset.NewForConfig(c)
 }
 


### PR DESCRIPTION
**Description**

In this commit, we apply the Dependency Inversion Principle by depending on an interface instead of a concrete type. This improves flexibility and testability.

**Motivation and Context**

While testing the Karmada Init and DeInit in the operator package (#5613), I found it difficult to mock `*clientset.Clientset`, complicating unit tests. By refactoring to depend on an interface, we improve flexibility and testability, allowing for the integration of a fake clientset since it implements that interface.

**What type of PR is this?**

/kind cleanup

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```