### PR TITLE
operator/pkg: mitigate null pointer dereference for `opt.Karmada.Spec.HostCluster` in `newRunData()` function

### DIFF
--- a/operator/pkg/controller/karmada/validating.go
+++ b/operator/pkg/controller/karmada/validating.go
@@ -18,6 +18,7 @@ package karmada
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 
@@ -102,6 +103,10 @@ func validate(karmada *operatorv1alpha1.Karmada) error {
 }
 
 func (ctrl *Controller) validateKarmada(ctx context.Context, karmada *operatorv1alpha1.Karmada) error {
+	if karmada == nil {
+		return errors.New("karmada cannot be nil")
+	}
+
 	if err := validate(karmada); err != nil {
 		ctrl.EventRecorder.Event(karmada, corev1.EventTypeWarning, ValidationErrorReason, err.Error())
 

--- a/operator/pkg/init.go
+++ b/operator/pkg/init.go
@@ -166,6 +166,11 @@ func newRunData(opt *InitOptions) (*initData, error) {
 		}
 	}
 
+	var hostClusterDNSDomain string
+	if opt.Karmada.Spec.HostCluster != nil && opt.Karmada.Spec.HostCluster.Networking != nil && opt.Karmada.Spec.HostCluster.Networking.DNSDomain != nil {
+		hostClusterDNSDomain = *opt.Karmada.Spec.HostCluster.Networking.DNSDomain
+	}
+
 	return &initData{
 		name:                    opt.Name,
 		namespace:               opt.Namespace,
@@ -178,7 +183,7 @@ func newRunData(opt *InitOptions) (*initData, error) {
 		privateRegistry:         privateRegistry,
 		components:              opt.Karmada.Spec.Components,
 		featureGates:            opt.Karmada.Spec.FeatureGates,
-		dnsDomain:               *opt.Karmada.Spec.HostCluster.Networking.DNSDomain,
+		dnsDomain:               hostClusterDNSDomain,
 		CertStore:               certs.NewCertStore(),
 	}, nil
 }


### PR DESCRIPTION
**Description**

In this commit, we mitigate the null pointer dereference issue in the deinit operator pkg by adding defensive checks on 
`opt.Karmada.Spec.HostCluster` in `newRunData` func.

**Motivation and Context**

While unit testing the Karmada Init and DeInit in the operator package (#5613), deliberately passing empty components on those fields triggers a null pointer exception error. This PR resolves this issue by adding defensive checks. 


While testing 

**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```