### PR TITLE
Add unit test for group score calc to assign replicas evenly

### DIFF
--- a/pkg/scheduler/core/spreadconstraint/group_clusters_test.go
+++ b/pkg/scheduler/core/spreadconstraint/group_clusters_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package spreadconstraint
 
 import (
+	"fmt"
 	"testing"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
@@ -215,6 +216,164 @@ func Test_GroupClustersWithScore(t *testing.T) {
 			}
 			if tt.want.providerCnt != len(groupInfo.Providers) {
 				t.Errorf("test %s : providerCnt = %v, want %v", tt.name, len(groupInfo.Providers), tt.want.providerCnt)
+			}
+		})
+	}
+}
+
+var duplicated = "duplicated"
+var aggregated = "aggregated"
+var dynamicWeight = "dynamicWeight"
+var staticWeight = "staticWeight"
+
+type RbSpecMap map[string]*workv1alpha2.ResourceBindingSpec
+
+func generateRbSpec(replica int32) RbSpecMap {
+	rbspecDuplicated := &workv1alpha2.ResourceBindingSpec{
+		Replicas: replica,
+		Placement: &policyv1alpha1.Placement{
+			ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+				ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDuplicated,
+			},
+		},
+	}
+	rbspecAggregated := &workv1alpha2.ResourceBindingSpec{
+		Replicas: replica,
+		Placement: &policyv1alpha1.Placement{
+			ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+				ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
+				ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceAggregated,
+			},
+		},
+	}
+	rbspecDynamicWeight := &workv1alpha2.ResourceBindingSpec{
+		Replicas: replica,
+		Placement: &policyv1alpha1.Placement{
+			ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+				ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
+				ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceWeighted,
+				WeightPreference: &policyv1alpha1.ClusterPreferences{
+					DynamicWeight: policyv1alpha1.DynamicWeightByAvailableReplicas,
+				},
+			},
+		},
+	}
+	rbspecStaticWeight := &workv1alpha2.ResourceBindingSpec{
+		Replicas: replica,
+		Placement: &policyv1alpha1.Placement{
+			ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+				ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
+				ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceWeighted,
+				WeightPreference: &policyv1alpha1.ClusterPreferences{
+					StaticWeightList: []policyv1alpha1.StaticClusterWeight{},
+				},
+			},
+		},
+	}
+	return RbSpecMap{
+		"duplicated":    rbspecDuplicated,
+		"aggregated":    rbspecAggregated,
+		"dynamicWeight": rbspecDynamicWeight,
+		"staticWeight":  rbspecStaticWeight,
+	}
+}
+
+func generateClusterScores(n int, scores []int64, replicas []int64) []ClusterDetailInfo {
+	info := make([]ClusterDetailInfo, n)
+	for i := 0; i < n; i++ {
+		info[i] = ClusterDetailInfo{
+			Name:              fmt.Sprintf("member%d", i+1),
+			Score:             scores[i],
+			AvailableReplicas: replicas[i],
+		}
+	}
+	return info
+}
+
+type GroupScoreArgs struct {
+	id          int
+	clusters1   []ClusterDetailInfo
+	clusters2   []ClusterDetailInfo
+	rbSpec      *workv1alpha2.ResourceBindingSpec
+	minGroups   int
+	group1Wins  bool
+	description string
+}
+
+func generateArgs() []GroupScoreArgs {
+	argsList := []GroupScoreArgs{
+		{
+			id:          1,
+			clusters1:   generateClusterScores(5, []int64{100, 100, 0, 0, 0}, []int64{30, 30, 30, 30, 30}),
+			clusters2:   generateClusterScores(5, []int64{100, 100, 100, 100, 100}, []int64{30, 30, 30, 10, 10}),
+			rbSpec:      generateRbSpec(20)[duplicated],
+			group1Wins:  true,
+			description: "clusters1 is better than clusters2, because Because clusters1 meets the replica requirements for a larger number of clusters.",
+		},
+		{
+			id:          2,
+			clusters1:   generateClusterScores(5, []int64{100, 100, 0, 0, 0}, []int64{30, 30, 30, 10, 10}),
+			clusters2:   generateClusterScores(5, []int64{100, 100, 100, 100, 100}, []int64{30, 30, 30, 10, 10}),
+			rbSpec:      generateRbSpec(20)[duplicated],
+			group1Wins:  false,
+			description: "clusters2 is better than clusters1, because clusters1 and clusters2 meet the replica requirements for the same number of clusters, but clusters2 has a higher score.",
+		},
+		{
+			id:          3,
+			clusters1:   generateClusterScores(5, []int64{100, 100, 0, 0, 0}, []int64{30, 30, 30, 10, 10}),
+			clusters2:   generateClusterScores(5, []int64{100, 100, 100, 100, 100}, []int64{10, 10, 10, 5, 5}),
+			rbSpec:      generateRbSpec(100)[aggregated],
+			minGroups:   2,
+			group1Wins:  true,
+			description: "clusters1 is better than clusters2, because clusters1 meets the replica requirements, but clusters2 does not meet.",
+		},
+		{
+			id:          4,
+			clusters1:   generateClusterScores(5, []int64{100, 100, 0, 0, 0}, []int64{10, 10, 10, 10, 5}),
+			clusters2:   generateClusterScores(5, []int64{100, 100, 100, 100, 100}, []int64{10, 10, 10, 5, 5}),
+			rbSpec:      generateRbSpec(100)[dynamicWeight],
+			minGroups:   2,
+			group1Wins:  true,
+			description: "clusters1 is better than clusters2, because clusters1's available replica is larger than clusters2.",
+		},
+		{
+			id:          5,
+			clusters1:   generateClusterScores(5, []int64{100, 100, 0, 0, 0}, []int64{10, 10, 10, 5, 5}),
+			clusters2:   generateClusterScores(5, []int64{100, 100, 100, 100, 100}, []int64{10, 10, 10, 5, 5}),
+			rbSpec:      generateRbSpec(100)[staticWeight],
+			minGroups:   2,
+			group1Wins:  false,
+			description: "clusters2 is better than clusters1, because clusters2's score is higher than clusters1.",
+		},
+		{
+			id:          6,
+			clusters1:   generateClusterScores(5, []int64{0, 0, 0, 0, 0}, []int64{100, 100, 100, 100, 100}),
+			clusters2:   generateClusterScores(5, []int64{100, 100, 100, 100, 100}, []int64{50, 50, 50, 50, 50}),
+			rbSpec:      generateRbSpec(100)[aggregated],
+			minGroups:   2,
+			group1Wins:  false,
+			description: "clusters2 is better than clusters1, because clusters2's score is higher than clusters1, although clusters2's available replica is less than clusters1.",
+		},
+	}
+
+	return argsList
+}
+
+func Test_CalcGroupScore(t *testing.T) {
+	tests := generateArgs()
+	groupClustersInfo := &GroupClustersInfo{
+		Providers: make(map[string]ProviderInfo),
+		Regions:   make(map[string]RegionInfo),
+		Zones:     make(map[string]ZoneInfo),
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			score1 := groupClustersInfo.calcGroupScore(tt.clusters1, tt.rbSpec, tt.minGroups)
+			score2 := groupClustersInfo.calcGroupScore(tt.clusters2, tt.rbSpec, tt.minGroups)
+			t.Logf("test ID: %v, score1 = %v, score2 = %v, score1 >= score 2 res: %v, the description => %v", tt.id, score1, score2, score1 > score2, tt.description)
+			if tt.group1Wins != (score1 >= score2) {
+				t.Errorf("test ID: %v, score1 = %v, score2 = %v, score1 >= score 2 want %v, but res is %v", tt.id, score1, score2, tt.group1Wins, score1 > score2)
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Optimize the score calculation method to better measure the pros and cons of the group. This PR added unit test for group score calc to assign replicas evenly.

**Which issue(s) this PR fixes**:
Part of #5159 

**Special notes for your reviewer**:
@whitewindmills 

**Does this PR introduce a user-facing change?**:
```release-note
None.
```

