### PR TITLE
operator/pkg: add test helpers

### DIFF
--- a/operator/pkg/tasks/deinit/test_helpers.go
+++ b/operator/pkg/tasks/deinit/test_helpers.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+// TestInterface defines the interface for retrieving test data.
+type TestInterface interface {
+	// Get returns the data from the test instance.
+	Get() string
+}
+
+// MyTestData is a struct that implements the TestInterface.
+type MyTestData struct {
+	Data string
+}
+
+// Get returns the data stored in the MyTestData struct.
+func (m *MyTestData) Get() string {
+	return m.Data
+}
+
+// TestDeInitData contains the configuration and state required to deinitialize Karmada components.
+type TestDeInitData struct {
+	name         string
+	namespace    string
+	remoteClient clientset.Interface
+}
+
+// Ensure TestDeInitData implements InitData interface at compile time.
+var _ DeInitData = &TestDeInitData{}
+
+// GetName returns the name of the current Karmada installation.
+func (t *TestDeInitData) GetName() string {
+	return t.name
+}
+
+// GetNamespace returns the namespace of the current Karmada installation.
+func (t *TestDeInitData) GetNamespace() string {
+	return t.namespace
+}
+
+// RemoteClient returns the Kubernetes client for remote interactions.
+func (t *TestDeInitData) RemoteClient() clientset.Interface {
+	return t.remoteClient
+}

--- a/operator/pkg/tasks/init/test_helpers.go
+++ b/operator/pkg/tasks/init/test_helpers.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	operatorv1alpha1 "github.com/karmada-io/karmada/operator/pkg/apis/operator/v1alpha1"
+	"github.com/karmada-io/karmada/operator/pkg/certs"
+)
+
+// TestInterface defines the interface for retrieving test data.
+type TestInterface interface {
+	// Get returns the data from the test instance.
+	Get() string
+}
+
+// MyTestData is a struct that implements the TestInterface.
+type MyTestData struct {
+	Data string
+}
+
+// Get returns the data stored in the MyTestData struct.
+func (m *MyTestData) Get() string {
+	return m.Data
+}
+
+// TestInitData contains the configuration and state required to initialize Karmada components.
+type TestInitData struct {
+	Name                   string
+	Namespace              string
+	ControlplaneConfigREST *rest.Config
+	DataDirectory          string
+	CrdTarballArchive      operatorv1alpha1.CRDTarball
+	KarmadaVersionRelease  string
+	ComponentsUnits        *operatorv1alpha1.KarmadaComponents
+	FeatureGatesOptions    map[string]bool
+	RemoteClientConnector  clientset.Interface
+	KarmadaClientConnector clientset.Interface
+	ControlplaneAddr       string
+	Certs                  []*certs.KarmadaCert
+}
+
+// Ensure TestInitData implements InitData interface at compile time.
+var _ InitData = &TestInitData{}
+
+// GetName returns the name of the current Karmada installation.
+func (t *TestInitData) GetName() string {
+	return t.Name
+}
+
+// GetNamespace returns the namespace of the current Karmada installation.
+func (t *TestInitData) GetNamespace() string {
+	return t.Namespace
+}
+
+// SetControlplaneConfig sets the control plane configuration for Karmada.
+func (t *TestInitData) SetControlplaneConfig(config *rest.Config) {
+	t.ControlplaneConfigREST = config
+}
+
+// ControlplaneConfig returns the control plane configuration.
+func (t *TestInitData) ControlplaneConfig() *rest.Config {
+	return t.ControlplaneConfigREST
+}
+
+// ControlplaneAddress returns the address of the control plane.
+func (t *TestInitData) ControlplaneAddress() string {
+	return t.ControlplaneAddr
+}
+
+// RemoteClient returns the Kubernetes client for remote interactions.
+func (t *TestInitData) RemoteClient() clientset.Interface {
+	return t.RemoteClientConnector
+}
+
+// KarmadaClient returns the Kubernetes client for interacting with Karmada.
+func (t *TestInitData) KarmadaClient() clientset.Interface {
+	return t.KarmadaClientConnector
+}
+
+// DataDir returns the data directory used by Karmada.
+func (t *TestInitData) DataDir() string {
+	return t.DataDirectory
+}
+
+// CrdTarball returns the CRD tarball used for Karmada installation.
+func (t *TestInitData) CrdTarball() operatorv1alpha1.CRDTarball {
+	return t.CrdTarballArchive
+}
+
+// KarmadaVersion returns the version of Karmada being used.
+func (t *TestInitData) KarmadaVersion() string {
+	return t.KarmadaVersionRelease
+}
+
+// Components returns the Karmada components used in the current installation.
+func (t *TestInitData) Components() *operatorv1alpha1.KarmadaComponents {
+	return t.ComponentsUnits
+}
+
+// FeatureGates returns the feature gates enabled for the current installation.
+func (t *TestInitData) FeatureGates() map[string]bool {
+	return t.FeatureGatesOptions
+}
+
+// AddCert adds a Karmada certificate to the TestInitData.
+func (t *TestInitData) AddCert(cert *certs.KarmadaCert) {
+	t.Certs = append(t.Certs, cert)
+}
+
+// GetCert retrieves a Karmada certificate by its name.
+func (t *TestInitData) GetCert(name string) *certs.KarmadaCert {
+	for _, cert := range t.Certs {
+		parts := strings.Split(cert.CertName(), ".")
+		if parts[0] == name {
+			return cert
+		}
+	}
+	return nil
+}
+
+// CertList returns a list of all Karmada certificates stored in TestInitData.
+func (t *TestInitData) CertList() []*certs.KarmadaCert {
+	return t.Certs
+}
+
+// LoadCertFromSecret loads a Karmada certificate from a Kubernetes secret.
+func (t *TestInitData) LoadCertFromSecret(secret *corev1.Secret) error {
+	if len(secret.Data) == 0 {
+		return fmt.Errorf("cert data is empty")
+	}
+
+	// Dummy implementation: load empty certificate.
+	cert := &certs.KarmadaCert{}
+	t.AddCert(cert)
+	return nil
+}


### PR DESCRIPTION
**Description**

Add test helpers that would be reused across tasks in the operator package.

**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```