### PR TITLE
hasResource should return whether resource is matched not cached

### DIFF
--- a/pkg/search/proxy/controller.go
+++ b/pkg/search/proxy/controller.go
@@ -186,7 +186,7 @@ func (ctl *Controller) reconcile(util.QueueKey) error {
 	if err != nil {
 		return err
 	}
-
+	registeredResources := make(map[schema.GroupVersionResource]struct{})
 	resourcesByClusters := make(map[string]map[schema.GroupVersionResource]*store.MultiNamespace)
 	for _, registry := range registries {
 		matchedResources := make(map[schema.GroupVersionResource]*store.MultiNamespace, len(registry.Spec.ResourceSelectors))
@@ -203,8 +203,8 @@ func (ctl *Controller) reconcile(util.QueueKey) error {
 				matchedResources[gvr] = nsSelector
 			}
 			nsSelector.Add(selector.Namespace)
+			registeredResources[gvr] = struct{}{}
 		}
-
 		if len(matchedResources) == 0 {
 			continue
 		}
@@ -238,7 +238,7 @@ func (ctl *Controller) reconcile(util.QueueKey) error {
 		}
 	}
 
-	return ctl.store.UpdateCache(resourcesByClusters)
+	return ctl.store.UpdateCache(resourcesByClusters, registeredResources)
 }
 
 type errorHTTPHandler struct {

--- a/pkg/search/proxy/controller_test.go
+++ b/pkg/search/proxy/controller_test.go
@@ -293,7 +293,7 @@ func TestController_reconcile(t *testing.T) {
 				clusterLister:  karmadaFactory.Cluster().V1alpha1().Clusters().Lister(),
 				registryLister: karmadaFactory.Search().V1alpha1().ResourceRegistries().Lister(),
 				store: &proxytest.MockStore{
-					UpdateCacheFunc: func(m map[string]map[schema.GroupVersionResource]*store.MultiNamespace) error {
+					UpdateCacheFunc: func(m map[string]map[schema.GroupVersionResource]*store.MultiNamespace, _ map[schema.GroupVersionResource]struct{}) error {
 						for clusterName, resources := range m {
 							resourceNames := make([]string, 0, len(resources))
 							for resource := range resources {

--- a/pkg/search/proxy/testing/mock_store.go
+++ b/pkg/search/proxy/testing/mock_store.go
@@ -30,7 +30,7 @@ import (
 
 // MockStore is a mock for store.Store interface
 type MockStore struct {
-	UpdateCacheFunc          func(resourcesByCluster map[string]map[schema.GroupVersionResource]*store.MultiNamespace) error
+	UpdateCacheFunc          func(resourcesByCluster map[string]map[schema.GroupVersionResource]*store.MultiNamespace, registeredResources map[schema.GroupVersionResource]struct{}) error
 	HasResourceFunc          func(resource schema.GroupVersionResource) bool
 	GetResourceFromCacheFunc func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string) (runtime.Object, string, error)
 	StopFunc                 func()
@@ -42,11 +42,11 @@ type MockStore struct {
 var _ store.Store = &MockStore{}
 
 // UpdateCache implements store.Store interface
-func (c *MockStore) UpdateCache(resourcesByCluster map[string]map[schema.GroupVersionResource]*store.MultiNamespace) error {
+func (c *MockStore) UpdateCache(resourcesByCluster map[string]map[schema.GroupVersionResource]*store.MultiNamespace, registeredResources map[schema.GroupVersionResource]struct{}) error {
 	if c.UpdateCacheFunc == nil {
 		panic("implement me")
 	}
-	return c.UpdateCacheFunc(resourcesByCluster)
+	return c.UpdateCacheFunc(resourcesByCluster, registeredResources)
 }
 
 // HasResource implements store.Store interface


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

For detailed information of in tree plugins' execution order, please see:
// https://github.com/karmada-io/karmada/tree/master/docs/proposals/resource-aggregation-proxy#request-routing

![image](https://github.com/user-attachments/assets/e785382c-2328-4c7c-9af6-318614d79358)

But in fact, I found that if the requested resource is defined in ResourceRegistry but there is no cluster, the query is the resource of the karmada apiserver


![image](https://github.com/user-attachments/assets/94ff07e9-2548-4198-8d31-2438961b3e03)


```
apiVersion: search.karmada.io/v1alpha1
kind: ResourceRegistry
metadata:
  name: test
spec:
  resourceSelectors:
  - apiVersion: v1
    kind: Node
  - apiVersion: v1
    kind: Pod
  - apiVersion: v1
    kind: Namespace
```


This will cause two problems

case1.When there is no cluster registered, the query resource comes from karmada-apiserver

case2.When using watch, after deleting all clusters, watch will fail


![image](https://github.com/user-attachments/assets/37f06508-404a-49e0-ba56-2a8abd3d6bef)


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-search`: Modify the logic of checking whether the resource is registered when selecting the plugin .
```

