### PR TITLE
operator/pkg/util: unit test naming

### DIFF
--- a/operator/pkg/util/naming_test.go
+++ b/operator/pkg/util/naming_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import "testing"
+
+func TestGenerateResourceName(t *testing.T) {
+	tests := []struct {
+		name      string
+		component string
+		suffix    string
+		want      string
+	}{
+		{
+			name:      "GenerateResourceName_WithKarmada_SuffixImmediatelyAfter",
+			component: "karmada-demo",
+			suffix:    "search",
+			want:      "karmada-demo-search",
+		},
+		{
+			name:      "GenerateResourceName_WithoutKarmada_KarmadaInTheMiddle",
+			component: "test-demo",
+			suffix:    "search",
+			want:      "test-demo-karmada-search",
+		},
+	}
+	for _, test := range tests {
+		if got := generateResourceName(test.component, test.suffix); got != test.want {
+			t.Errorf("expected resource name generated to be %s, but got %s", test.want, got)
+		}
+	}
+}


### PR DESCRIPTION
**Description**

In this commit, we unit test naming `generateResourceName` utility on given karmada component name and suffix.

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**Which issue(s) this PR fixes**:
Part of #5491.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```