### PR TITLE
image-scanning: fix ratelimiting error when downloading vulnerability db from ghcr.io

### DIFF
--- a/.github/workflows/ci-image-scanning-on-schedule.yml
+++ b/.github/workflows/ci-image-scanning-on-schedule.yml
@@ -48,6 +48,9 @@ jobs:
           make image-${{ matrix.target }}
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.28.0
+        env:
+          ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:
           image-ref: 'docker.io/karmada/${{ matrix.target }}:${{ matrix.karmada-version }}'
           format: 'sarif'
@@ -56,6 +59,8 @@ jobs:
           output: '${{ matrix.target }}:${{ matrix.karmada-version }}.trivy-results.sarif'
       - name: display scan results
         uses: aquasecurity/trivy-action@0.28.0
+        env:
+          TRIVY_SKIP_DB_UPDATE: true # Avoid updating the vulnerability db as it was cached in the previous step.
         with:
           image-ref: 'docker.io/karmada/${{ matrix.target }}:${{ matrix.karmada-version }}'
           format: 'table'

--- a/.github/workflows/ci-image-scanning.yaml
+++ b/.github/workflows/ci-image-scanning.yaml
@@ -43,6 +43,9 @@ jobs:
           make image-${{ matrix.target }}
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.28.0
+        env:
+          ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:
           image-ref: 'docker.io/karmada/${{ matrix.target }}:latest'
           format: 'sarif'
@@ -51,6 +54,8 @@ jobs:
           output: 'trivy-results.sarif'
       - name: display scan results
         uses: aquasecurity/trivy-action@0.28.0
+        env:
+          TRIVY_SKIP_DB_UPDATE: true # Avoid updating the vulnerability db as it was cached in the previous step.
         with:
           image-ref: 'docker.io/karmada/${{ matrix.target }}:latest'
           format: 'table'


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Recently, the image-scanning CI encountered a rate-limiting error when downloading the vulnerability database from ghcr.io. See:
- https://github.com/karmada-io/karmada/actions/runs/11270619338

There is an issue  https://github.com/aquasecurity/trivy-action/issues/389 tracking this problem in the trivy-action repository. Released v0.26.0 which adds support for caching should alleviate some of the pain as caching should ensure DBs are reused if cache is available. 

In addition, the following have also been strengthened:
- specify multiple DB registries, which will try the default GitHub Registry, and if too many requests is reached, will use the aws mirror
- avoid repeatedly updating the Vulnerability DB







**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

