### PR TITLE
Added tests for validateclustertaints.go and validatingmcs.go

### DIFF
--- a/pkg/util/lifted/validateclustertaints_test.go
+++ b/pkg/util/lifted/validateclustertaints_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifted
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateClusterTaintEffect(t *testing.T) {
+	tests := []struct {
+		name       string
+		effect     corev1.TaintEffect
+		allowEmpty bool
+		wantErrors int
+		errorMsg   string
+	}{
+		{
+			name:       "valid NoSchedule effect",
+			effect:     corev1.TaintEffectNoSchedule,
+			allowEmpty: false,
+			wantErrors: 0,
+		},
+		{
+			name:       "valid NoExecute effect",
+			effect:     corev1.TaintEffectNoExecute,
+			allowEmpty: false,
+			wantErrors: 0,
+		},
+		{
+			name:       "invalid effect",
+			effect:     corev1.TaintEffect("InvalidEffect"),
+			allowEmpty: false,
+			wantErrors: 1,
+			errorMsg:   "test: Unsupported value: \"InvalidEffect\": supported values: \"NoSchedule\", \"NoExecute\"",
+		},
+		{
+			name:       "empty effect not allowed",
+			effect:     corev1.TaintEffect(""),
+			allowEmpty: false,
+			wantErrors: 1,
+			errorMsg:   "test: Required value",
+		},
+		{
+			name:       "empty effect with allowEmpty true",
+			effect:     corev1.TaintEffect(""),
+			allowEmpty: true,
+			wantErrors: 1,
+			errorMsg:   "test: Unsupported value: \"\": supported values: \"NoSchedule\", \"NoExecute\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errors := validateClusterTaintEffect(&tt.effect, tt.allowEmpty, field.NewPath("test"))
+			assert.Len(t, errors, tt.wantErrors)
+
+			if tt.wantErrors == 0 {
+				assert.Empty(t, errors)
+			} else {
+				assert.NotEmpty(t, errors)
+				assert.Equal(t, tt.errorMsg, errors[0].Error())
+			}
+		})
+	}
+}
+func TestValidateClusterTaints(t *testing.T) {
+	tests := []struct {
+		name       string
+		taints     []corev1.Taint
+		wantErrors int
+	}{
+		{
+			name: "valid taints",
+			taints: []corev1.Taint{
+				{Key: "key1", Value: "value1", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "key2", Value: "value2", Effect: corev1.TaintEffectNoExecute},
+			},
+			wantErrors: 0,
+		},
+		{
+			name: "invalid taint key",
+			taints: []corev1.Taint{
+				{Key: "invalid key", Value: "value1", Effect: corev1.TaintEffectNoSchedule},
+			},
+			wantErrors: 1,
+		},
+		{
+			name: "invalid taint value",
+			taints: []corev1.Taint{
+				{Key: "key1", Value: "invalid value!", Effect: corev1.TaintEffectNoSchedule},
+			},
+			wantErrors: 1,
+		},
+		{
+			name: "invalid taint effect",
+			taints: []corev1.Taint{
+				{Key: "key1", Value: "value1", Effect: corev1.TaintEffect("InvalidEffect")},
+			},
+			wantErrors: 1,
+		},
+		{
+			name: "duplicate taints",
+			taints: []corev1.Taint{
+				{Key: "key1", Value: "value1", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "key1", Value: "value2", Effect: corev1.TaintEffectNoSchedule},
+			},
+			wantErrors: 1,
+		},
+		{
+			name: "multiple errors",
+			taints: []corev1.Taint{
+				{Key: "invalid key", Value: "invalid value!", Effect: corev1.TaintEffect("InvalidEffect")},
+				{Key: "key1", Value: "value1", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "key1", Value: "value2", Effect: corev1.TaintEffectNoSchedule},
+			},
+			wantErrors: 4,
+		},
+		{
+			name: "empty effect",
+			taints: []corev1.Taint{
+				{Key: "key1", Value: "value1", Effect: corev1.TaintEffect("")},
+			},
+			wantErrors: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errors := ValidateClusterTaints(tt.taints, field.NewPath("test"))
+			assert.Len(t, errors, tt.wantErrors)
+
+			if tt.wantErrors == 0 {
+				assert.Empty(t, errors)
+			} else {
+				assert.NotEmpty(t, errors)
+			}
+		})
+	}
+}

--- a/pkg/util/lifted/validatingmcs_test.go
+++ b/pkg/util/lifted/validatingmcs_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifted
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateLoadBalancerStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     *corev1.LoadBalancerStatus
+		wantErrors int
+	}{
+		{
+			name: "valid IP",
+			status: &corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{IP: "192.168.1.1"},
+				},
+			},
+			wantErrors: 0,
+		},
+		{
+			name: "valid hostname",
+			status: &corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{Hostname: "example.com"},
+				},
+			},
+			wantErrors: 0,
+		},
+		{
+			name: "invalid IP",
+			status: &corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{IP: "300.300.300.300"},
+				},
+			},
+			wantErrors: 1,
+		},
+		{
+			name: "invalid hostname",
+			status: &corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{Hostname: "invalid_hostname"},
+				},
+			},
+			wantErrors: 1,
+		},
+		{
+			name: "IP in hostname field",
+			status: &corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{Hostname: "192.168.1.1"},
+				},
+			},
+			wantErrors: 1,
+		},
+		{
+			name: "multiple valid entries",
+			status: &corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{IP: "192.168.1.1"},
+					{Hostname: "example.com"},
+				},
+			},
+			wantErrors: 0,
+		},
+		{
+			name: "multiple entries with errors",
+			status: &corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{IP: "300.300.300.300"},
+					{Hostname: "invalid_hostname"},
+					{Hostname: "192.168.1.1"},
+				},
+			},
+			wantErrors: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errors := ValidateLoadBalancerStatus(tt.status, field.NewPath("status"))
+			assert.Len(t, errors, tt.wantErrors)
+
+			if tt.wantErrors == 0 {
+				assert.Empty(t, errors)
+			} else {
+				assert.NotEmpty(t, errors)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description:**
This PR introduces unit tests for the cluster taints validation and MCS (Multi-Cluster Services) validation functions in the pkg/util/lifted package. These additions aim to increase code reliability, maintainability, and test coverage for the cluster taints and MCS validation logic.

**Additions:**
1. pkg/util/lifted/validateclustertaints_test.go
2. pkg/util/lifted/validatingmcs_test.go

**Test Coverage:**
1. pkg/util/lifted/validateclustertaints.go: 0.00% to 100%
2. pkg/util/lifted/validatingmcs.go: 0.00% to 100%

**What type of PR is this?**
/kind feature

**Which issue(s) this PR fixes**:
Fixes a part of #5470

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

