### PR TITLE
Automated cherry pick of #5568: Avoid treating PVC managed by VolumeClaimTemplate as dependencies

### DIFF
--- a/pkg/resourceinterpreter/default/native/dependencies_test.go
+++ b/pkg/resourceinterpreter/default/native/dependencies_test.go
@@ -860,6 +860,39 @@ func Test_getStatefulSetDependencies(t *testing.T) {
 			want:    testPairs[2].dependentObjectReference,
 			wantErr: false,
 		},
+		{
+			name: "statefulset with partial dependencies 4",
+			object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "StatefulSet",
+					"metadata": map[string]interface{}{
+						"name":      "fake-statefulset",
+						"namespace": namespace,
+					},
+					"spec": map[string]interface{}{
+						"serviceName": "fake-service",
+						"selector": map[string]interface{}{
+							"matchLabels": map[string]interface{}{
+								"app": "fake",
+							},
+						},
+						"template": map[string]interface{}{
+							"spec": testPairs[0].podSpecsWithDependencies.Object,
+						},
+						"volumeClaimTemplates": []interface{}{
+							map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"name": "test-pvc",
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    testPairs[0].dependentObjectReference[:3], // remove the pvc dependency because it was found in the volumeClaimTemplates
+			wantErr: false,
+		},
 	}
 
 	for i := range tests {


### PR DESCRIPTION
Cherry pick of #5568 on release-1.10.
#5568: fix sts pvc logic
Part of https://github.com/karmada-io/karmada/issues/5656
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`: Ignored StatefulSet Dependencies with PVCs created via the VolumeClaimTemplates.
```