### PR TITLE
Added tests for pkg/util/membercluster_client_test.go

### DIFF
--- a/pkg/util/membercluster_client_test.go
+++ b/pkg/util/membercluster_client_test.go
@@ -21,12 +21,14 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/rest"
+	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -55,6 +57,218 @@ grw/ZQTTIVjjh4JBSW3WyWgNo/ikC1lrVxzl4iPUGptxT36Cr7Zk2Bsg0XqwbOvK
 5d+NTDREkSnUbie4GeutujmX3Dsx88UiV6UY/4lHJa6I5leHUNOHahRbpbWeOfs/
 WkBKOclmOV2xlTVuPw==
 -----END CERTIFICATE-----`)
+
+func TestNewClusterScaleClientSet(t *testing.T) {
+	type args struct {
+		clusterName string
+		client      client.Client
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "cluster not found",
+			args: args{
+				clusterName: "test",
+				client:      fakeclient.NewClientBuilder().WithScheme(gclient.NewSchema()).Build(),
+			},
+			wantErr: true,
+			errMsg:  "clusters.cluster.karmada.io \"test\" not found",
+		},
+		{
+			name: "APIEndpoint is empty",
+			args: args{
+				clusterName: "test",
+				client: fakeclient.NewClientBuilder().WithScheme(gclient.NewSchema()).
+					WithObjects(newCluster("test")).Build(),
+			},
+			wantErr: true,
+			errMsg:  "the api endpoint of cluster test is empty",
+		},
+		{
+			name: "SecretRef is empty",
+			args: args{
+				clusterName: "test",
+				client: fakeclient.NewClientBuilder().WithScheme(gclient.NewSchema()).
+					WithObjects(withAPIEndPoint(newCluster("test"), "https://127.0.0.1")).Build(),
+			},
+			wantErr: true,
+			errMsg:  "cluster test does not have a secret",
+		},
+		{
+			name: "Secret not found",
+			args: args{
+				clusterName: "test",
+				client: fakeclient.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(
+					&clusterv1alpha1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{Name: "test"},
+						Spec: clusterv1alpha1.ClusterSpec{
+							APIEndpoint: "https://127.0.0.1",
+							SecretRef:   &clusterv1alpha1.LocalSecretReference{Namespace: "default", Name: "secret1"},
+						},
+					}).Build(),
+			},
+			wantErr: true,
+			errMsg:  "secrets \"secret1\" not found",
+		},
+		{
+			name: "token not found",
+			args: args{
+				clusterName: "test",
+				client: fakeclient.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(
+					&clusterv1alpha1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{Name: "test"},
+						Spec: clusterv1alpha1.ClusterSpec{
+							APIEndpoint: "https://127.0.0.1",
+							SecretRef:   &clusterv1alpha1.LocalSecretReference{Namespace: "ns1", Name: "secret1"},
+						},
+					},
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "secret1"},
+					}).Build(),
+			},
+			wantErr: true,
+			errMsg:  "the secret for cluster test is missing a non-empty value for \"token\"",
+		},
+		{
+			name: "valid configuration",
+			args: args{
+				clusterName: "test",
+				client: fakeclient.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(
+					&clusterv1alpha1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{Name: "test"},
+						Spec: clusterv1alpha1.ClusterSpec{
+							APIEndpoint: "https://127.0.0.1",
+							SecretRef:   &clusterv1alpha1.LocalSecretReference{Namespace: "ns1", Name: "secret1"},
+						},
+					},
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "secret1"},
+						Data:       map[string][]byte{clusterv1alpha1.SecretTokenKey: []byte("token"), clusterv1alpha1.SecretCADataKey: testCA},
+					}).Build(),
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewClusterScaleClientSet(tt.args.clusterName, tt.args.client)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, got)
+				assert.Equal(t, tt.args.clusterName, got.ClusterName)
+				assert.NotNil(t, got.KubeClient)
+				assert.NotNil(t, got.ScaleClient)
+			}
+		})
+	}
+}
+
+func TestNewClusterClientSetForAgent(t *testing.T) {
+	type args struct {
+		clusterName  string
+		client       client.Client
+		clientOption *ClientOption
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "valid configuration",
+			args: args{
+				clusterName:  "test-agent",
+				client:       fakeclient.NewClientBuilder().WithScheme(gclient.NewSchema()).Build(),
+				clientOption: &ClientOption{QPS: 100, Burst: 200},
+			},
+			wantErr: false,
+		},
+	}
+
+	// Store the original GetConfig function
+	originalGetConfig := controllerruntime.GetConfig
+	// Defer its restoration
+	defer func() { controllerruntime.GetConfig = originalGetConfig }()
+
+	// Mock the GetConfig function
+	controllerruntime.GetConfig = func() (*rest.Config, error) {
+		return &rest.Config{
+			Host: "https://fake.example.com",
+		}, nil
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewClusterClientSetForAgent(tt.args.clusterName, tt.args.client, tt.args.clientOption)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, got)
+				assert.Equal(t, tt.args.clusterName, got.ClusterName)
+				assert.NotNil(t, got.KubeClient)
+			}
+		})
+	}
+}
+
+func TestNewClusterDynamicClientSetForAgent(t *testing.T) {
+	type args struct {
+		clusterName string
+		client      client.Client
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "valid configuration",
+			args: args{
+				clusterName: "test-agent-dynamic",
+				client:      fakeclient.NewClientBuilder().WithScheme(gclient.NewSchema()).Build(),
+			},
+			wantErr: false,
+		},
+	}
+
+	// Store the original GetConfig function
+	originalGetConfig := controllerruntime.GetConfig
+	// Defer its restoration
+	defer func() { controllerruntime.GetConfig = originalGetConfig }()
+
+	// Mock the GetConfig function
+	controllerruntime.GetConfig = func() (*rest.Config, error) {
+		return &rest.Config{
+			Host: "https://fake.example.com",
+		}, nil
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewClusterDynamicClientSetForAgent(tt.args.clusterName, tt.args.client)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, got)
+				assert.Equal(t, tt.args.clusterName, got.ClusterName)
+				assert.NotNil(t, got.DynamicClientSet)
+			}
+		})
+	}
+}
 
 func TestNewClusterClientSet(t *testing.T) {
 	type args struct {
@@ -217,25 +431,14 @@ func TestNewClusterClientSet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := NewClusterClientSet(tt.args.clusterName, tt.args.client, tt.args.clientOption)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NewClusterClientSet() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if err != nil {
-				return
-			}
-
-			if got == nil {
-				t.Error("NewClusterClientSet() got nil")
-				return
-			}
-			if got.ClusterName != tt.args.clusterName {
-				t.Errorf("NewClusterClientSet() got.ClusterName = %v, want %v", got.ClusterName, tt.args.clusterName)
-				return
-			}
-			if got.KubeClient == nil {
-				t.Error("NewClusterClientSet() got.KubeClient got nil")
-				return
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, got)
+				assert.Equal(t, tt.args.clusterName, got.ClusterName)
+				assert.NotNil(t, got.KubeClient)
 			}
 		})
 	}
@@ -270,24 +473,19 @@ func TestNewClusterClientSet_ClientWorks(t *testing.T) {
 		}).Build()
 
 	clusterClient, err := NewClusterClientSet(clusterName, hostClient, nil)
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	assert.NoError(t, err)
+	assert.NotNil(t, clusterClient)
+
 	got, err := clusterClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), "foo", metav1.GetOptions{})
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
 
 	want := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "foo",
 		},
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("got = %#v, want %#v", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestNewClusterDynamicClientSet(t *testing.T) {
@@ -441,25 +639,14 @@ func TestNewClusterDynamicClientSet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := NewClusterDynamicClientSet(tt.args.clusterName, tt.args.client)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NewClusterClientSet() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if err != nil {
-				return
-			}
-
-			if got == nil {
-				t.Error("NewClusterClientSet() got nil")
-				return
-			}
-			if got.ClusterName != tt.args.clusterName {
-				t.Errorf("NewClusterClientSet() got ClusterName = %v, want %v", got.ClusterName, tt.args.clusterName)
-				return
-			}
-			if got.DynamicClientSet == nil {
-				t.Error("NewClusterClientSet() got DynamicClientSet nil")
-				return
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, got)
+				assert.Equal(t, tt.args.clusterName, got.ClusterName)
+				assert.NotNil(t, got.DynamicClientSet)
 			}
 		})
 	}
@@ -494,23 +681,17 @@ func TestNewClusterDynamicClientSet_ClientWorks(t *testing.T) {
 		}).Build()
 
 	clusterClient, err := NewClusterDynamicClientSet(clusterName, hostClient)
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	assert.NoError(t, err)
+	assert.NotNil(t, clusterClient)
 
 	nodeGVR := corev1.SchemeGroupVersion.WithResource("nodes")
 	got, err := clusterClient.DynamicClientSet.Resource(nodeGVR).Get(context.TODO(), "foo", metav1.GetOptions{})
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
 
 	want := &unstructured.Unstructured{}
 	want.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Node"))
 	want.SetName("foo")
 
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("got = %#v, want %#v", got, want)
-	}
+	assert.Equal(t, want, got)
 }


### PR DESCRIPTION
**Description:** 
This PR enhances the unit tests for member cluster client functions in pkg/util/membercluster_client.go. It introduces new tests for previously uncovered functions and refactors existing tests to use the `assert` package from `testify`. These changes significantly improve test readability, and maintainability while ensuring comprehensive coverage of the member cluster client functionality.

**Improvements:**
1. pkg/util/membercluster_client_test.go:
   - Added new tests for `NewClusterScaleClientSet`, `NewClusterClientSetForAgent`, and `NewClusterDynamicClientSetForAgent`
   - Refactored existing tests to use `assert` for improved readability and better error messages

**Test Coverage:**
1. pkg/util/membercluster_client.go: 57% to 92.1%

**What type of PR is this?**
/kind feature

**Which issue(s) this PR fixes**:
Fixes a part of #5470 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

