### PR TITLE
External `etcd` Support for Karmada Operator - Part 1

### DIFF
--- a/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
+++ b/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
@@ -65,12 +65,14 @@ spec:
                             description: |-
                               CAData is an SSL Certificate Authority file used to secure etcd communication.
                               Required if using a TLS connection.
+                              Deprecated: This field is deprecated and will be removed in a future version. Use SecretRef for providing client connection credentials.
                             format: byte
                             type: string
                           certData:
                             description: |-
                               CertData is an SSL certification file used to secure etcd communication.
                               Required if using a TLS connection.
+                              Deprecated: This field is deprecated and will be removed in a future version. Use SecretRef for providing client connection credentials.
                             format: byte
                             type: string
                           endpoints:
@@ -82,13 +84,29 @@ spec:
                             description: |-
                               KeyData is an SSL key file used to secure etcd communication.
                               Required if using a TLS connection.
+                              Deprecated: This field is deprecated and will be removed in a future version. Use SecretRef for providing client connection credentials.
                             format: byte
                             type: string
+                          secretRef:
+                            description: |-
+                              SecretRef references a Kubernetes secret containing the etcd connection credentials.
+                              The secret must contain the following data keys:
+                              ca.crt: The Certificate Authority (CA) certificate data.
+                              tls.crt: The TLS certificate data used for verifying the etcd server's certificate.
+                              tls.key: The TLS private key.
+                              Required to configure the connection to an external etcd cluster.
+                            properties:
+                              name:
+                                description: Name is the name of resource being referenced.
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace for the resource
+                                  being referenced.
+                                type: string
+                            type: object
                         required:
-                        - caData
-                        - certData
                         - endpoints
-                        - keyData
+                        - secretRef
                         type: object
                       local:
                         description: |-

--- a/operator/config/crds/operator.karmada.io_karmadas.yaml
+++ b/operator/config/crds/operator.karmada.io_karmadas.yaml
@@ -65,12 +65,14 @@ spec:
                             description: |-
                               CAData is an SSL Certificate Authority file used to secure etcd communication.
                               Required if using a TLS connection.
+                              Deprecated: This field is deprecated and will be removed in a future version. Use SecretRef for providing client connection credentials.
                             format: byte
                             type: string
                           certData:
                             description: |-
                               CertData is an SSL certification file used to secure etcd communication.
                               Required if using a TLS connection.
+                              Deprecated: This field is deprecated and will be removed in a future version. Use SecretRef for providing client connection credentials.
                             format: byte
                             type: string
                           endpoints:
@@ -82,13 +84,29 @@ spec:
                             description: |-
                               KeyData is an SSL key file used to secure etcd communication.
                               Required if using a TLS connection.
+                              Deprecated: This field is deprecated and will be removed in a future version. Use SecretRef for providing client connection credentials.
                             format: byte
                             type: string
+                          secretRef:
+                            description: |-
+                              SecretRef references a Kubernetes secret containing the etcd connection credentials.
+                              The secret must contain the following data keys:
+                              ca.crt: The Certificate Authority (CA) certificate data.
+                              tls.crt: The TLS certificate data used for verifying the etcd server's certificate.
+                              tls.key: The TLS private key.
+                              Required to configure the connection to an external etcd cluster.
+                            properties:
+                              name:
+                                description: Name is the name of resource being referenced.
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace for the resource
+                                  being referenced.
+                                type: string
+                            type: object
                         required:
-                        - caData
-                        - certData
                         - endpoints
-                        - keyData
+                        - secretRef
                         type: object
                       local:
                         description: |-

--- a/operator/pkg/apis/operator/v1alpha1/type.go
+++ b/operator/pkg/apis/operator/v1alpha1/type.go
@@ -239,19 +239,32 @@ type VolumeData struct {
 // operator has no knowledge of where certificate files live, and they must be supplied.
 type ExternalEtcd struct {
 	// Endpoints of etcd members. Required for ExternalEtcd.
+	// +required
 	Endpoints []string `json:"endpoints"`
 
 	// CAData is an SSL Certificate Authority file used to secure etcd communication.
 	// Required if using a TLS connection.
-	CAData []byte `json:"caData"`
+	// Deprecated: This field is deprecated and will be removed in a future version. Use SecretRef for providing client connection credentials.
+	CAData []byte `json:"caData,omitempty"`
 
 	// CertData is an SSL certification file used to secure etcd communication.
 	// Required if using a TLS connection.
-	CertData []byte `json:"certData"`
+	// Deprecated: This field is deprecated and will be removed in a future version. Use SecretRef for providing client connection credentials.
+	CertData []byte `json:"certData,omitempty"`
 
 	// KeyData is an SSL key file used to secure etcd communication.
 	// Required if using a TLS connection.
-	KeyData []byte `json:"keyData"`
+	// Deprecated: This field is deprecated and will be removed in a future version. Use SecretRef for providing client connection credentials.
+	KeyData []byte `json:"keyData,omitempty"`
+
+	// SecretRef references a Kubernetes secret containing the etcd connection credentials.
+	// The secret must contain the following data keys:
+	// ca.crt: The Certificate Authority (CA) certificate data.
+	// tls.crt: The TLS certificate data used for verifying the etcd server's certificate.
+	// tls.key: The TLS private key.
+	// Required to configure the connection to an external etcd cluster.
+	// +required
+	SecretRef LocalSecretReference `json:"secretRef"`
 }
 
 // KarmadaAPIServer holds settings to kube-apiserver component of the kubernetes.

--- a/operator/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -139,6 +139,7 @@ func (in *ExternalEtcd) DeepCopyInto(out *ExternalEtcd) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
+	out.SecretRef = in.SecretRef
 	return
 }
 

--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -125,6 +125,9 @@ const (
 
 	// APIServiceName defines the karmada aggregated apiserver APIService resource name.
 	APIServiceName = "v1alpha1.cluster.karmada.io"
+
+	// KarmadaApiserverEtcdClientCertNameSuffix defines the suffix for the Karmada API server etcd client cert name
+	KarmadaApiserverEtcdClientCertNameSuffix = "karmada-apiserver-etcd-client-cert"
 )
 
 var (

--- a/operator/pkg/controller/karmada/controller.go
+++ b/operator/pkg/controller/karmada/controller.go
@@ -18,11 +18,15 @@ package karmada
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strconv"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
@@ -36,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	operatorv1alpha1 "github.com/karmada-io/karmada/operator/pkg/apis/operator/v1alpha1"
+	"github.com/karmada-io/karmada/operator/pkg/constants"
 	operatorscheme "github.com/karmada-io/karmada/operator/pkg/scheme"
 )
 
@@ -48,6 +53,9 @@ const (
 
 	// DisableCascadingDeletionLabel is the label that determine whether to perform cascade deletion
 	DisableCascadingDeletionLabel = "operator.karmada.io/disable-cascading-deletion"
+
+	// ValidationErrorReason is the reason for a validation error
+	ValidationErrorReason = "ValidationError"
 )
 
 // Controller controls the Karmada resource.
@@ -77,6 +85,11 @@ func (ctrl *Controller) Reconcile(ctx context.Context, req controllerruntime.Req
 		return controllerruntime.Result{}, err
 	}
 
+	if err := ctrl.validateKarmada(karmada); err != nil {
+		klog.Error(err, "Validation failed for karmada")
+		return controllerruntime.Result{}, nil
+	}
+
 	// The object is being deleted
 	if !karmada.DeletionTimestamp.IsZero() {
 		val, ok := karmada.Labels[DisableCascadingDeletionLabel]
@@ -94,6 +107,31 @@ func (ctrl *Controller) Reconcile(ctx context.Context, req controllerruntime.Req
 	}
 
 	return controllerruntime.Result{}, ctrl.syncKarmada(karmada)
+}
+
+// validateKarmada ensures the Karmada resource adheres to validation rules
+func (ctrl *Controller) validateKarmada(karmada *operatorv1alpha1.Karmada) error {
+	if karmada.Spec.Components.Etcd != nil && karmada.Spec.Components.Etcd.External != nil {
+		expectedSecretName := fmt.Sprintf("%s-%s", karmada.Name, constants.KarmadaApiserverEtcdClientCertNameSuffix)
+		if karmada.Spec.Components.Etcd.External.SecretRef.Name != expectedSecretName {
+			errorMessage := fmt.Sprintf("Secret name for external etcd client must be %s, but got %s", expectedSecretName, karmada.Spec.Components.Etcd.External.SecretRef.Name)
+			ctrl.EventRecorder.Event(karmada, corev1.EventTypeWarning, ValidationErrorReason, errorMessage)
+
+			newCondition := metav1.Condition{
+				Type:               string(operatorv1alpha1.Ready),
+				Status:             metav1.ConditionFalse,
+				Reason:             ValidationErrorReason,
+				Message:            errorMessage,
+				LastTransitionTime: metav1.Now(),
+			}
+			meta.SetStatusCondition(&karmada.Status.Conditions, newCondition)
+			if err := ctrl.Status().Update(context.TODO(), karmada); err != nil {
+				return err
+			}
+			return fmt.Errorf(errorMessage)
+		}
+	}
+	return nil
 }
 
 func (ctrl *Controller) syncKarmada(karmada *operatorv1alpha1.Karmada) error {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
This is an implementation of this [proposal](https://github.com/karmada-io/karmada/pull/5260) for adding support to the Karmada operator for external etcd cluster connections.

**Which issue(s) this PR fixes**:
Fixes #5242

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
The new `SecretRef` field added as part of the configuration for connecting to an external etcd cluster can be 
used to reference a secret that contains credentials for connecting to an external etcd cluster.
```

