### PR TITLE
chore: update image tags for Karmada components to v1.11.1

### DIFF
--- a/operator/config/samples/karmada.yaml
+++ b/operator/config/samples/karmada.yaml
@@ -31,19 +31,19 @@ spec:
       serviceSubnet: 10.96.0.0/12
     karmadaAggregatedAPIServer:
       imageRepository: docker.io/karmada/karmada-aggregated-apiserver
-      imageTag: v1.8.0
+      imageTag: v1.11.1
       replicas: 1
     karmadaControllerManager:
       imageRepository: docker.io/karmada/karmada-controller-manager
-      imageTag: v1.8.0
+      imageTag: v1.11.1
       replicas: 1
     karmadaScheduler:
       imageRepository: docker.io/karmada/karmada-scheduler
-      imageTag: v1.8.0
+      imageTag: v1.11.1
       replicas: 1
     karmadaWebhook:
       imageRepository: docker.io/karmada/karmada-webhook
-      imageTag: v1.8.0
+      imageTag: v1.11.1
       replicas: 1
     kubeControllerManager:
       imageRepository: registry.k8s.io/kube-controller-manager
@@ -51,15 +51,15 @@ spec:
       replicas: 1
     karmadaMetricsAdapter:
       imageRepository: docker.io/karmada/karmada-metrics-adapter
-      imageTag: v1.8.0
+      imageTag: v1.11.1
       replicas: 2
     # karmadaSearch: # the component `Karmadasearch` is not installed by default, if you need to install it, uncomment it and note the formatting
       # imageRepository: docker.io/karmada/karmada-search
-      # imageTag: v1.8.0
+      # imageTag: v1.11.1
       # replicas: 1
     # karmadaDescheduler: # the component `KarmadaDescheduler` is not installed by default, if you need to install it, uncomment it and note the formatting
       # imageRepository: docker.io/karmada/karmada-descheduler
-      # imageTag: v1.8.0
+      # imageTag: v1.11.1
       # replicas: 1
   hostCluster:
     networking:


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
-->
/kind cleanup

**What this PR does / why we need it**:
This PR updates the image tags for Karmada components, etcd, and kube-apiserver in the sample file from `v1.8.0` to `v1.11.1`. Manual updates are necessary to reflect the latest version until dynamic configuration is implemented.

**Which issue(s) this PR fixes**:
Part of #5484 update [sample file of karmada operator](https://github.com/karmada-io/karmada/blob/master/operator/config/samples/karmada.yaml)

**Special notes for your reviewer**:
This is a temporary manual update, as future plans involve implementing dynamic configuration.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
