### PR TITLE
fix the error lstat /github/workspace: no such file or directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,7 @@ jobs:
         scan-type: 'fs'
         format: 'spdx'
         output: 'sbom-karmada.spdx'
-        scan-ref: "/github/workspace/"
+        scan-ref: "${{ github.workspace }}/"
     - name: Tar the sbom files
       run: |
         tar -zcf sbom.tar.gz *.spdx


### PR DESCRIPTION
**What type of PR is this?**
failed ci link:
https://github.com/karmada-io/karmada/actions/runs/11399514762/job/31718886970

refer to https://github.com/aquasecurity/trivy-action/issues/404#issuecomment-2406987466, replacing `scan-ref: /github/workspace/` with `scan-ref: ${{ github.workspace }}/` to fix the problem.



<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
local verification：
https://github.com/zhzhuang-zju/karmada/actions/runs/11400139818/job/31720357994

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

