### PR TITLE
karmadactl init: add CRDs archive verification to enhance file system robustness

### DIFF
--- a/pkg/karmadactl/cmdinit/utils/util.go
+++ b/pkg/karmadactl/cmdinit/utils/util.go
@@ -157,3 +157,17 @@ func ListFiles(path string) []string {
 	}
 	return files
 }
+
+// PathExists check whether the path is exist
+func PathExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	return false, err
+}

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -721,7 +721,7 @@ func TestValidateApplicationFailover(t *testing.T) {
 	}
 }
 
-func TestCheckOperatorCrdsTar(t *testing.T) {
+func TestValidateCrdsTarBall(t *testing.T) {
 	testItems := []struct {
 		name        string
 		header      *tar.Header


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
`karmadactl init` provides a custom download path for CRDs files. Before processing the files, it's necessary to validate the CRDs archive to enhance system robustness.

- check if its file name includes unclean paths.

- check if the CRDs archive has the expected directory structure.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

