### PR TITLE
Redact sensitive information from the karmadactl init command output

### DIFF
--- a/pkg/karmadactl/cmdinit/karmada/deploy.go
+++ b/pkg/karmadactl/cmdinit/karmada/deploy.go
@@ -47,7 +47,6 @@ import (
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/utils"
 	"github.com/karmada-io/karmada/pkg/karmadactl/util"
 	"github.com/karmada-io/karmada/pkg/karmadactl/util/apiclient"
-	tokenutil "github.com/karmada-io/karmada/pkg/karmadactl/util/bootstraptoken"
 )
 
 const (
@@ -126,38 +125,6 @@ func InitKarmadaResources(dir, caBase64, systemNamespace string) error {
 	}
 
 	return nil
-}
-
-// InitKarmadaBootstrapToken create initial bootstrap token
-func InitKarmadaBootstrapToken(dir string) (string, error) {
-	restConfig, err := apiclient.RestConfig("", filepath.Join(dir, options.KarmadaKubeConfigName))
-	if err != nil {
-		return "", err
-	}
-
-	clientSet, err := apiclient.NewClientSet(restConfig)
-	if err != nil {
-		return "", err
-	}
-	// Create initial bootstrap token
-	klog.Info("Initialize karmada bootstrap token")
-	bootstrapToken, err := tokenutil.GenerateRandomBootstrapToken(&metav1.Duration{Duration: tokenutil.DefaultTokenDuration}, "", tokenutil.DefaultGroups, tokenutil.DefaultUsages)
-	if err != nil {
-		return "", err
-	}
-
-	if err := tokenutil.CreateNewToken(clientSet, bootstrapToken); err != nil {
-		return "", err
-	}
-
-	tokenStr := bootstrapToken.Token.ID + "." + bootstrapToken.Token.Secret
-
-	registerCommand, err := tokenutil.GenerateRegisterCommand(filepath.Join(dir, options.KarmadaKubeConfigName), "", tokenStr, "")
-	if err != nil {
-		return "", fmt.Errorf("failed to get register command, err: %w", err)
-	}
-
-	return registerCommand, nil
 }
 
 func createExtraResources(clientSet *kubernetes.Clientset, dir string) error {

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -599,18 +599,12 @@ func (i *CommandInitOption) RunInit(parentCommand string) error {
 		return err
 	}
 
-	// Create bootstrap token in karmada
-	registerCommand, err := karmada.InitKarmadaBootstrapToken(i.KarmadaDataPath)
-	if err != nil {
-		return err
-	}
-
 	// install karmada Component
 	if err := i.initKarmadaComponent(); err != nil {
 		return err
 	}
 
-	utils.GenExamples(i.KarmadaDataPath, parentCommand, registerCommand)
+	utils.GenExamples(i.KarmadaDataPath, parentCommand)
 	return nil
 }
 

--- a/pkg/karmadactl/cmdinit/utils/examples.go
+++ b/pkg/karmadactl/cmdinit/utils/examples.go
@@ -168,7 +168,7 @@ spec:
 )
 
 // GenExamples Generate sample files
-func GenExamples(path, parentCommand, printRegisterCommand string) {
+func GenExamples(path, parentCommand string) {
 	karmadaAgentStr := fmt.Sprintf(karmadaAgent, options.ClusterName)
 	if err := BytesToFile(path, "karmada-agent.yaml", []byte(karmadaAgentStr)); err != nil {
 		klog.Warning(err)
@@ -206,11 +206,22 @@ Step 2: Show members of karmada
 
 Register cluster with 'Pull' mode
 
-Step 1: Use "%[2]s register" command to register the cluster to Karmada control plane. "--cluster-name" is set to cluster of current-context by default.
-(In member cluster)~# %[2]s%[3]s
+Step 1: Create bootstrap token and generate the '%[2]s register' command which will be used later.
+~# %[2]s token create --print-register-command --kubeconfig=%[1]s/karmada-apiserver.config
+This command will generate a registration command similar to:
 
-Step 2: Show members of karmada
-(In karmada)~# kubectl --kubeconfig %[1]s/karmada-apiserver.config get clusters
+%[2]s register 172.18.0.5:5443 --token t8xfio.640u9gp9obc72v5d --discovery-token-ca-cert-hash sha256:9cfa542ff48f43793d1816b1dd0a78ad574e349d8f6e005e6e32e8ab528e4244
 
-`, path, parentCommand, printRegisterCommand)
+Step 2: Use the output from Step 1 to register the cluster to the Karmada control plane. 
+You need to specify the target member cluster by flag '--kubeconfig'
+~# %[2]s register 172.18.0.5:5443 --token t8xfio.640u9gp9obc72v5d --discovery-token-ca-cert-hash sha256:9cfa542ff48f43793d1816b1dd0a78ad574e349d8f6e005e6e32e8ab528e4244 --kubeconfig=<path-to-member-cluster-kubeconfig>
+
+Step 3: Show members of Karmada.
+~# %[2]s --kubeconfig=%[1]s/karmada-apiserver.config get clusters
+
+The %[2]s register command has several optional parameters for setting the properties of the member cluster. For more details, run:
+
+~# %[2]s register --help
+
+`, path, parentCommand)
 }

--- a/pkg/karmadactl/cmdinit/utils/examples_test.go
+++ b/pkg/karmadactl/cmdinit/utils/examples_test.go
@@ -19,5 +19,5 @@ package utils
 import "testing"
 
 func TestGenExamples(_ *testing.T) {
-	GenExamples("/tmp", "kubectl karmada", " register")
+	GenExamples("/tmp", "kubectl karmada")
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
The `karmadactl init` command, at the end of the initializtaion, writes some sensitive information in the stdout, like token, in its `karmadactl register` example. This will bring up two issues：
- data leak, for instance in CI/CD logs
![image](https://github.com/user-attachments/assets/35f5b4f4-431a-41e9-b101-bc06e56f6d1c)

- The token's validity period is one day. Users may not join the pull mode member clusters immediately after installing Karmada, causing the secret to expire.

I hope the command output to be how to do rather than what to do. Users can follow the steps in the command output as needed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Modified command output:
```bash
Register cluster with 'Pull' mode

Step 1: Create bootstrap tokens and get the full 'karmadactl register' flag needed to register the member cluster using the token.
(In karmada)~# karmadactl token create --print-register-command --kubeconfig /etc/init/members/karmada-apiserver.config
karmadactl register [karmada-apiserver-endpoint] --token [token] --discovery-token-ca-cert-hash [ca-cert-hash]

Step 2: Use the output result from step 1 to register the cluster to Karmada control plane. "--cluster-name" is set to cluster of current-context by default.
(In member cluster)~# karmadactl register [karmada-apiserver-endpoint] --token [token] --discovery-token-ca-cert-hash [ca-cert-hash]

Step 3: Show members of karmada
(In karmada)~# karmadactl --kubeconfig /etc/init/members/karmada-apiserver.config get clusters
```


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

