### PR TITLE
Keep preserveResourcesOnDeletion of the dependent resource consistent with that of the primary resource

### DIFF
--- a/pkg/dependenciesdistributor/dependencies_distributor.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor.go
@@ -546,6 +546,7 @@ func (d *DependenciesDistributor) removeScheduleResultFromAttachedBindings(bindi
 		delete(attachedBindings[index].Labels, bindingLabelKey)
 		updatedSnapshot := deleteBindingFromSnapshot(bindingNamespace, bindingName, attachedBindings[index].Spec.RequiredBy)
 		attachedBindings[index].Spec.RequiredBy = updatedSnapshot
+		attachedBindings[index].Spec.PreserveResourcesOnDeletion = nil
 		if err := d.Client.Update(context.TODO(), attachedBindings[index]); err != nil {
 			klog.Errorf("Failed to update binding(%s/%s): %v", binding.Namespace, binding.Name, err)
 			errs = append(errs, err)
@@ -563,6 +564,7 @@ func (d *DependenciesDistributor) createOrUpdateAttachedBinding(attachedBinding 
 		existBinding.Spec.RequiredBy = mergeBindingSnapshot(existBinding.Spec.RequiredBy, attachedBinding.Spec.RequiredBy)
 		existBinding.Labels = util.DedupeAndMergeLabels(existBinding.Labels, attachedBinding.Labels)
 		existBinding.Spec.Resource = attachedBinding.Spec.Resource
+		existBinding.Spec.PreserveResourcesOnDeletion = attachedBinding.Spec.PreserveResourcesOnDeletion
 
 		if err := d.Client.Update(context.TODO(), existBinding); err != nil {
 			klog.Errorf("Failed to update resourceBinding(%s): %v", bindingKey, err)
@@ -703,7 +705,8 @@ func buildAttachedBinding(independentBinding *workv1alpha2.ResourceBinding, obje
 				Name:            object.GetName(),
 				ResourceVersion: object.GetResourceVersion(),
 			},
-			RequiredBy: result,
+			RequiredBy:                  result,
+			PreserveResourcesOnDeletion: independentBinding.Spec.PreserveResourcesOnDeletion,
 		},
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

When users enable dependency distribution for a resource template, it will inherit the `PreserveResourcesOnDeletion` policy from the resource they are following. As a result, we can rollback the migration of dependency distributed resources.

**Which issue(s) this PR fixes**:
Part of #5577 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: keep preserveResourcesOnDeletion of the dependent resource consistent with that of the primary resource
```

