### PR TITLE
Automated cherry pick of #5685: add ResourceSummary deep copy in general-estimator

### DIFF
--- a/pkg/estimator/client/general.go
+++ b/pkg/estimator/client/general.go
@@ -54,7 +54,8 @@ func (ge *GeneralEstimator) MaxAvailableReplicas(_ context.Context, clusters []*
 }
 
 func (ge *GeneralEstimator) maxAvailableReplicas(cluster *clusterv1alpha1.Cluster, replicaRequirements *workv1alpha2.ReplicaRequirements) int32 {
-	resourceSummary := cluster.Status.ResourceSummary
+	//Note: resourceSummary must be deep-copied before using in the function to avoid modifying the original data structure.
+	resourceSummary := cluster.Status.ResourceSummary.DeepCopy()
 	if resourceSummary == nil {
 		return 0
 	}


### PR DESCRIPTION
Cherry pick of #5685 on release-1.9.
#5685: add ResourceSummary deep copy in general-estimator
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-scheduler`: Fixed unexpected modification of original `ResourceSummary` due to lack of deep copy.
```