### PR TITLE
Add timeout for watch requests to member clusters to prevent request …

### DIFF
--- a/pkg/search/proxy/store/multi_cluster_cache.go
+++ b/pkg/search/proxy/store/multi_cluster_cache.go
@@ -334,15 +334,34 @@ func (c *MultiClusterCache) Watch(ctx context.Context, gvr schema.GroupVersionRe
 		if cache == nil {
 			continue
 		}
-		w, err := cache.Watch(ctx, options)
-		if err != nil {
-			return nil, err
-		}
 
-		mux.AddSource(w, func(e watch.Event) {
-			setObjectResourceVersionFunc(cluster, e.Object)
-			addCacheSourceAnnotation(e.Object, cluster)
-		})
+		// The following logic adds a 30-second timeout to prevent watch requests to member clusters from hanging,
+		// which could cause the client watch to hang.
+		watchChan := make(chan watch.Interface, 1)
+		errChan := make(chan error, 1)
+
+		go func() {
+			w, err := cache.Watch(ctx, options)
+			if err != nil {
+				errChan <- fmt.Errorf("failed to start watch for resource %v in cluster %q: %v", gvr.String(), cluster, err)
+				return
+			}
+			watchChan <- w
+		}()
+
+		select {
+		case w := <-watchChan:
+			mux.AddSource(w, func(e watch.Event) {
+				setObjectResourceVersionFunc(cluster, e.Object)
+				addCacheSourceAnnotation(e.Object, cluster)
+			})
+		case err := <-errChan:
+			// If the watch request fails, return the error, and the client will retry.
+			return nil, err
+		case <-time.After(30 * time.Second):
+			// If the watch request times out, return an error, and the client will retry.
+			return nil, fmt.Errorf("timeout waiting for watch for resource %v in cluster %q", gvr.String(), cluster)
+		}
 	}
 	mux.Start()
 	return mux, nil


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
When the federate-apiserver's watch request to the member cluster gets stuck, it will cause the watch request from the federated client to get stuck as well.

**Which issue(s) this PR fixes**:
Fixes # https://github.com/karmada-io/karmada/issues/5672

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

