### PR TITLE
Automated cherry pick of #5662: HasResource should return whether resource is registered not

### DIFF
--- a/pkg/search/proxy/controller.go
+++ b/pkg/search/proxy/controller.go
@@ -186,7 +186,7 @@ func (ctl *Controller) reconcile(util.QueueKey) error {
 	if err != nil {
 		return err
 	}
-
+	registeredResources := make(map[schema.GroupVersionResource]struct{})
 	resourcesByClusters := make(map[string]map[schema.GroupVersionResource]*store.MultiNamespace)
 	for _, registry := range registries {
 		matchedResources := make(map[schema.GroupVersionResource]*store.MultiNamespace, len(registry.Spec.ResourceSelectors))
@@ -203,8 +203,8 @@ func (ctl *Controller) reconcile(util.QueueKey) error {
 				matchedResources[gvr] = nsSelector
 			}
 			nsSelector.Add(selector.Namespace)
+			registeredResources[gvr] = struct{}{}
 		}
-
 		if len(matchedResources) == 0 {
 			continue
 		}
@@ -238,7 +238,7 @@ func (ctl *Controller) reconcile(util.QueueKey) error {
 		}
 	}
 
-	return ctl.store.UpdateCache(resourcesByClusters)
+	return ctl.store.UpdateCache(resourcesByClusters, registeredResources)
 }
 
 type errorHTTPHandler struct {

--- a/pkg/search/proxy/controller_test.go
+++ b/pkg/search/proxy/controller_test.go
@@ -293,7 +293,7 @@ func TestController_reconcile(t *testing.T) {
 				clusterLister:  karmadaFactory.Cluster().V1alpha1().Clusters().Lister(),
 				registryLister: karmadaFactory.Search().V1alpha1().ResourceRegistries().Lister(),
 				store: &proxytest.MockStore{
-					UpdateCacheFunc: func(m map[string]map[schema.GroupVersionResource]*store.MultiNamespace) error {
+					UpdateCacheFunc: func(m map[string]map[schema.GroupVersionResource]*store.MultiNamespace, _ map[schema.GroupVersionResource]struct{}) error {
 						for clusterName, resources := range m {
 							resourceNames := make([]string, 0, len(resources))
 							for resource := range resources {

--- a/pkg/search/proxy/testing/mock_store.go
+++ b/pkg/search/proxy/testing/mock_store.go
@@ -30,7 +30,7 @@ import (
 
 // MockStore is a mock for store.Store interface
 type MockStore struct {
-	UpdateCacheFunc          func(resourcesByCluster map[string]map[schema.GroupVersionResource]*store.MultiNamespace) error
+	UpdateCacheFunc          func(resourcesByCluster map[string]map[schema.GroupVersionResource]*store.MultiNamespace, registeredResources map[schema.GroupVersionResource]struct{}) error
 	HasResourceFunc          func(resource schema.GroupVersionResource) bool
 	GetResourceFromCacheFunc func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string) (runtime.Object, string, error)
 	StopFunc                 func()
@@ -42,11 +42,11 @@ type MockStore struct {
 var _ store.Store = &MockStore{}
 
 // UpdateCache implements store.Store interface
-func (c *MockStore) UpdateCache(resourcesByCluster map[string]map[schema.GroupVersionResource]*store.MultiNamespace) error {
+func (c *MockStore) UpdateCache(resourcesByCluster map[string]map[schema.GroupVersionResource]*store.MultiNamespace, registeredResources map[schema.GroupVersionResource]struct{}) error {
 	if c.UpdateCacheFunc == nil {
 		panic("implement me")
 	}
-	return c.UpdateCacheFunc(resourcesByCluster)
+	return c.UpdateCacheFunc(resourcesByCluster, registeredResources)
 }
 
 // HasResource implements store.Store interface


### PR DESCRIPTION
Cherry pick of #5662 on release-1.10.
#5662: HasResource should return whether resource is registered not
Part of https://github.com/karmada-io/karmada/issues/5718
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-search`: Modify the logic of checking whether the resource is registered when selecting the plugin .
```