### PR TITLE
add CA data to local up generated karmada config for enhanced security

### DIFF
--- a/hack/deploy-karmada.sh
+++ b/hack/deploy-karmada.sh
@@ -265,7 +265,7 @@ else
 fi
 
 # write karmada api server config to kubeconfig file
-util::append_client_kubeconfig "${HOST_CLUSTER_KUBECONFIG}" "${CERT_DIR}/client.crt" "${CERT_DIR}/client.key" "${KARMADA_APISERVER_IP}" "${KARMADA_APISERVER_SECURE_PORT}" karmada-apiserver
+util::append_client_kubeconfig "${HOST_CLUSTER_KUBECONFIG}" "${ROOT_CA_FILE}" "${CERT_DIR}/client.crt" "${CERT_DIR}/client.key" "${KARMADA_APISERVER_IP}" "${KARMADA_APISERVER_SECURE_PORT}" karmada-apiserver
 
 # deploy kube controller manager
 cp "${REPO_ROOT}"/artifacts/deploy/kube-controller-manager.yaml "${TEMP_PATH_APISERVER}"/kube-controller-manager.yaml

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -258,13 +258,14 @@ EOF
 # util::append_client_kubeconfig creates a new context including a cluster and a user to the existed kubeconfig file
 function util::append_client_kubeconfig {
     local kubeconfig_path=$1
-    local client_certificate_file=$2
-    local client_key_file=$3
-    local api_host=$4
-    local api_port=$5
-    local client_id=$6
-    local token=${7:-}
-    kubectl config set-cluster "${client_id}" --server=https://"${api_host}:${api_port}" --insecure-skip-tls-verify=true --kubeconfig="${kubeconfig_path}"
+    local ca_file=$2
+    local client_certificate_file=$3
+    local client_key_file=$4
+    local api_host=$5
+    local api_port=$6
+    local client_id=$7
+    local token=${8:-}
+    kubectl config set-cluster "${client_id}" --server=https://"${api_host}:${api_port}" --embed-certs --certificate-authority="${ca_file}" --kubeconfig="${kubeconfig_path}"
     kubectl config set-credentials "${client_id}" --token="${token}" --client-certificate="${client_certificate_file}" --client-key="${client_key_file}" --embed-certs=true --kubeconfig="${kubeconfig_path}"
     kubectl config set-context "${client_id}" --cluster="${client_id}" --user="${client_id}" --kubeconfig="${kubeconfig_path}"
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Execute `karmadactl token create` command failed, because the cluster is set `insecure-skip-tls-verify=true` in karmada config, that is a insecure config.

So, this PR add CA data to local up generated karmada config for enhanced security.

**Which issue(s) this PR fixes**:

Fixes #5738

**Special notes for your reviewer**:

test report:

```shell
$ karmadactl token create --print-register-command --kubeconfig ~/.kube/karmada.config --karmada-context karmada-apiserver                                                                                
karmadactl register 172.18.0.4:5443 --token yqnbkt.muyyaah5omv1s24d --discovery-token-ca-cert-hash sha256:4f12a0f772cdaecfb7e150992f627485485d75922ddae5080bcb50a79bf22971
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`local up`: add CA data to generated karmada config for enhanced security
```

