### PR TITLE
Disable a single resource multi dependency distribution

### DIFF
--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -762,6 +762,7 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 		ConcurrentClusterPropagationPolicySyncs: opts.ConcurrentClusterPropagationPolicySyncs,
 		ConcurrentResourceTemplateSyncs:         opts.ConcurrentResourceTemplateSyncs,
 		RateLimiterOptions:                      opts.RateLimiterOpts,
+		DisableMultiDependencyDistribution:      opts.DisableMultiDependencyDistribution,
 	}
 
 	if err := mgr.Add(resourceDetector); err != nil {
@@ -769,13 +770,14 @@ func setupControllers(mgr controllerruntime.Manager, opts *options.Options, stop
 	}
 	if features.FeatureGate.Enabled(features.PropagateDeps) {
 		dependenciesDistributor := &dependenciesdistributor.DependenciesDistributor{
-			Client:              mgr.GetClient(),
-			DynamicClient:       dynamicClientSet,
-			InformerManager:     controlPlaneInformerManager,
-			ResourceInterpreter: resourceInterpreter,
-			RESTMapper:          mgr.GetRESTMapper(),
-			EventRecorder:       mgr.GetEventRecorderFor("dependencies-distributor"),
-			RateLimiterOptions:  opts.RateLimiterOpts,
+			Client:                             mgr.GetClient(),
+			DynamicClient:                      dynamicClientSet,
+			InformerManager:                    controlPlaneInformerManager,
+			ResourceInterpreter:                resourceInterpreter,
+			RESTMapper:                         mgr.GetRESTMapper(),
+			EventRecorder:                      mgr.GetEventRecorderFor("dependencies-distributor"),
+			RateLimiterOptions:                 opts.RateLimiterOpts,
+			DisableMultiDependencyDistribution: opts.DisableMultiDependencyDistribution,
 		}
 		if err := dependenciesDistributor.SetupWithManager(mgr); err != nil {
 			klog.Fatalf("Failed to setup dependencies distributor: %v", err)

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -143,6 +143,17 @@ type Options struct {
 	// in scenario of dynamic replica assignment based on cluster free resources.
 	// Disable if it does not fit your cases for better performance.
 	EnableClusterResourceModeling bool
+
+	// DisableMultiDependencyDistribution indicates disable the ability to a resource from being depended on by multiple
+	// resources or being distributed by PropagationPolicy/ClusterPropagationPolicy while being depended on.
+	//
+	// Before v1.12, this capability is allowed by default. If you still wish to enable this capability, you can set
+	// this flag to false. However, you will need to bear some side effects that come with it.
+	// For example, you can refer to https://github.com/karmada-io/karmada/pull/5717. When the primary resource is deleted,
+	// it does not consider other resources that currently depend on the resource or any PropagationPolicy associated with it.
+	//
+	// It is recommended that you adapt your business accordingly to avoid continued use.
+	DisableMultiDependencyDistribution bool
 }
 
 // NewOptions builds an empty options.
@@ -224,6 +235,9 @@ func (o *Options) AddFlags(flags *pflag.FlagSet, allControllers, disabledByDefau
 	flags.BoolVar(&o.EnableClusterResourceModeling, "enable-cluster-resource-modeling", true, "Enable means controller would build resource modeling for each cluster by syncing Nodes and Pods resources.\n"+
 		"The resource modeling might be used by the scheduler to make scheduling decisions in scenario of dynamic replica assignment based on cluster free resources.\n"+
 		"Disable if it does not fit your cases for better performance.")
+	flags.BoolVar(&o.DisableMultiDependencyDistribution, "disable-multi-dependency-distribution", true, "True value means disable the ability to a resource from being depended on by multiple resources or being distributed by PropagationPolicy/ClusterPropagationPolicy while being depended on.\n"+
+		"Before v1.12, this capability is allowed by default. If you still wish to enable this capability, you can set this flag to false. However, you will need to bear some side effects that come with it. For example, you can refer to https://github.com/karmada-io/karmada/pull/5717. When the primary resource is deleted, it does not consider other resources that currently depend on the resource or any PropagationPolicy associated with it.\n"+
+		"It is recommended that you adapt your business accordingly to avoid continued use.")
 
 	o.RateLimiterOpts.AddFlags(flags)
 	o.ProfileOpts.AddFlags(flags)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

From the majority of user feedback received so far, there are no scenarios where a single resource is depended on by multiple resources, or where a resource is both depended on by other resources and also distributed through PropagationPolicy/ClusterPropagationPolicy. Therefore, we have decided to restrict the above usage in the Karmada system, with the ultimate goal of ensuring that a resource can only be subject to distribution decisions by one PropagationPolicy/ClusterPropagationPolicy. 

By imposing such a restriction, we can make the behavior of the Karmada system more explicit and also facilitate the iteration of the follow-on distribution feature.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The current PR is far from the end. In order to complete the entire restriction activity, I plan to carry out the following tasks:

1. Add events for the target resources to describe the restriction operations performed by the Karmada system.
2. In the next version (v1.13), deprecate the DisableMultiDependencyDistribution switch and clean up the existing code, no longer considering the situation where a resource is depended on by multiple resources. For example, labels with the prefix resourcebinding.karmada.io/depended-by- will be deprecated.
3. Optimize the restriction logic so that when a resource is depended on by another resource and an attachedBinding is generated, an annotation or label is added to the resource to record its depender, thus avoiding the need to query the corresponding resourceBinding object during restriction judgment. Additionally, this information may also be processed through karmadactl for further extensions.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-controller-manager: disable a single resource multi dependency distribution
```

