### PR TITLE
Add tests for deploying Karmada services using the configuration file with the karmadactl init --config command.

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -62,3 +62,45 @@ jobs:
           name: karmadactl_test_logs_${{ matrix.k8s }}
           path: ${{ github.workspace }}/karmadactl-test-logs/${{ matrix.k8s }}/
 
+  init-config:
+    name: init with config file
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        # Latest three minor releases of Kubernetes
+        k8s: [ v1.29.0, v1.30.0, v1.31.0 ]
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: run karmadactl init with config file test
+        run: |
+          export CLUSTER_VERSION=kindest/node:${{ matrix.k8s }}
+          
+          # Run custom test for workload configuration deployment
+          hack/cli-testing-init-with-config.sh
+          
+          # run a single e2e
+          export KUBECONFIG=${HOME}/karmada/karmada-apiserver.config
+          GO111MODULE=on go install github.com/onsi/ginkgo/v2/ginkgo
+          ginkgo -v --race --trace -p  --focus="[BasicPropagation] propagation testing deployment propagation testing"  ./test/e2e/
+      - name: export logs for config test
+        if: always()
+        run: |
+          export ARTIFACTS_PATH=${{ github.workspace }}/karmadactl-test-logs/${{ matrix.k8s }}/config
+          mkdir -p $ARTIFACTS_PATH
+          
+          mkdir -p $ARTIFACTS_PATH/karmada-host
+          kind export logs --name=karmada-host $ARTIFACTS_PATH/karmada-host
+      - name: upload config test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: karmadactl_config_test_logs_${{ matrix.k8s }}
+          path: ${{ github.workspace }}/karmadactl-test-logs/${{ matrix.k8s }}/config/

--- a/hack/cli-testing-init-with-config.sh
+++ b/hack/cli-testing-init-with-config.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Copyright 2024 The Karmada Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script starts a local karmada control plane with karmadactl and with a certain number of clusters joined.
+# This script depends on utils in: ${REPO_ROOT}/hack/util.sh
+# 1. used by developer to setup develop environment quickly.
+# 2. used by e2e testing to setup test environment automatically.
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${REPO_ROOT}"/hack/util.sh
+
+# variable define
+KUBECONFIG_PATH=${KUBECONFIG_PATH:-"${HOME}/.kube"}
+HOST_CLUSTER_NAME=${HOST_CLUSTER_NAME:-"karmada-host"}
+MEMBER_CLUSTER_1_NAME=${MEMBER_CLUSTER_1_NAME:-"config-member1"}
+MEMBER_CLUSTER_2_NAME=${MEMBER_CLUSTER_2_NAME:-"config-member2"}
+CLUSTER_VERSION=${CLUSTER_VERSION:-"${DEFAULT_CLUSTER_VERSION}"}
+BUILD_PATH=${BUILD_PATH:-"_output/bin/linux/amd64"}
+CONFIG_FILE_PATH=${CONFIG_FILE_PATH:-"/tmp/karmada-config.yaml"}
+
+# install kind and kubectl
+kind_version=v0.24.0
+echo -n "Preparing: 'kind' existence check - "
+if util::cmd_exist kind; then
+  echo "passed"
+else
+  echo "not pass"
+  util::install_tools "sigs.k8s.io/kind" $kind_version
+fi
+# get arch name and os name in bootstrap
+BS_ARCH=$(go env GOARCH)
+BS_OS=$(go env GOOS)
+# check arch and os name before installing
+util::install_environment_check "${BS_ARCH}" "${BS_OS}"
+echo -n "Preparing: 'kubectl' existence check - "
+if util::cmd_exist kubectl; then
+  echo "passed"
+else
+  echo "not pass"
+  util::install_kubectl "" "${BS_ARCH}" "${BS_OS}"
+fi
+
+# prepare the newest crds
+echo "Prepare the newest crds"
+cd  charts/karmada/
+cp -r _crds crds
+tar -zcvf ../../crds.tar.gz crds
+cd -
+
+# make images
+export VERSION="latest"
+export REGISTRY="docker.io/karmada"
+make images GOOS="linux" --directory="${REPO_ROOT}"
+
+# make karmadactl binary
+make karmadactl
+
+# create host/member1/member2 cluster
+echo "Start create clusters..."
+hack/create-cluster.sh ${HOST_CLUSTER_NAME} ${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config > /dev/null 2>&1 &
+hack/create-cluster.sh ${MEMBER_CLUSTER_1_NAME} ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_1_NAME}.config > /dev/null 2>&1 &
+hack/create-cluster.sh ${MEMBER_CLUSTER_2_NAME} ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_2_NAME}.config > /dev/null 2>&1 &
+
+# wait cluster ready
+echo "Wait clusters ready..."
+util::wait_file_exist ${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config 300
+util::wait_context_exist ${HOST_CLUSTER_NAME} ${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config 300
+kubectl wait --for=condition=Ready nodes --all --timeout=800s --kubeconfig=${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config
+util::wait_nodes_taint_disappear 800 ${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config
+
+util::wait_file_exist ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_1_NAME}.config 300
+util::wait_context_exist "${MEMBER_CLUSTER_1_NAME}" ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_1_NAME}.config 300
+kubectl wait --for=condition=Ready nodes --all --timeout=800s --kubeconfig=${KUBECONFIG_PATH}/${MEMBER_CLUSTER_1_NAME}.config
+util::wait_nodes_taint_disappear 800 ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_1_NAME}.config
+
+util::wait_file_exist ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_2_NAME}.config 300
+util::wait_context_exist "${MEMBER_CLUSTER_2_NAME}" ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_2_NAME}.config 300
+kubectl wait --for=condition=Ready nodes --all --timeout=800s --kubeconfig=${KUBECONFIG_PATH}/${MEMBER_CLUSTER_2_NAME}.config
+util::wait_nodes_taint_disappear 800 ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_2_NAME}.config
+
+# load components images to kind cluster
+kind load docker-image "${REGISTRY}/karmada-controller-manager:${VERSION}" --name="${HOST_CLUSTER_NAME}"
+kind load docker-image "${REGISTRY}/karmada-scheduler:${VERSION}" --name="${HOST_CLUSTER_NAME}"
+kind load docker-image "${REGISTRY}/karmada-webhook:${VERSION}" --name="${HOST_CLUSTER_NAME}"
+kind load docker-image "${REGISTRY}/karmada-aggregated-apiserver:${VERSION}" --name="${HOST_CLUSTER_NAME}"
+
+# Ensure the parent directory of CONFIG_FILE_PATH exists
+CONFIG_DIR=$(dirname "${CONFIG_FILE_PATH}")
+if [ ! -d "${CONFIG_DIR}" ]; then
+  echo "Creating directory ${CONFIG_DIR}..."
+  mkdir -p "${CONFIG_DIR}"
+fi
+
+# build Karmada init configuration file
+CONFIG_TEMPLATE=$(cat <<EOF
+apiVersion: config.karmada.io/v1alpha1
+kind: KarmadaInitConfig
+spec:
+  hostCluster:
+    kubeconfig: "${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config"
+  components:
+    karmadaControllerManager:
+      repository: "${REGISTRY}/karmada-controller-manager"
+      tag: "${VERSION}"
+    karmadaScheduler:
+      repository: "${REGISTRY}/karmada-scheduler"
+      tag: "${VERSION}"
+    karmadaWebhook:
+      repository: "${REGISTRY}/karmada-webhook"
+      tag: "${VERSION}"
+    karmadaAggregatedAPIServer:
+      repository: "${REGISTRY}/karmada-aggregated-apiserver"
+      tag: "${VERSION}"
+  karmadaDataPath: "${HOME}/karmada"
+  karmadaPkiPath: "${HOME}/karmada/pki"
+  karmadaCrds: "./crds.tar.gz"
+EOF
+)
+
+filled_config=$(echo "$CONFIG_TEMPLATE" | sed \
+  -e "s|\${KUBECONFIG_PATH}|${KUBECONFIG_PATH}|g" \
+  -e "s|\${HOST_CLUSTER_NAME}|${HOST_CLUSTER_NAME}|g" \
+  -e "s|\${REGISTRY}|${REGISTRY}|g" \
+  -e "s|\${VERSION}|${VERSION}|g" \
+  -e "s|\${HOME}|${HOME}|g")
+
+echo "${filled_config}" > ${CONFIG_FILE_PATH}
+
+echo "Karmada init config file generated at ${CONFIG_FILE_PATH}"
+
+# init Karmada control plane
+echo "Start init karmada control plane..."
+${BUILD_PATH}/karmadactl init --config=${CONFIG_FILE_PATH}
+
+# join cluster
+echo "Join member clusters..."
+${BUILD_PATH}/karmadactl --kubeconfig ${HOME}/karmada/karmada-apiserver.config  join ${MEMBER_CLUSTER_1_NAME} --cluster-kubeconfig=${KUBECONFIG_PATH}/${MEMBER_CLUSTER_1_NAME}.config
+${BUILD_PATH}/karmadactl --kubeconfig ${HOME}/karmada/karmada-apiserver.config  join ${MEMBER_CLUSTER_2_NAME} --cluster-kubeconfig=${KUBECONFIG_PATH}/${MEMBER_CLUSTER_2_NAME}.config
+kubectl wait --for=condition=Ready clusters --all --timeout=800s  --kubeconfig=${HOME}/karmada/karmada-apiserver.config


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
This PR is an additional test, based on the suggestion provided in [url](https://github.com/karmada-io/karmada/pull/5357#discussion_r1807568543).
**Which issue(s) this PR fixes**:
Part of [#5357](https://github.com/karmada-io/karmada/pull/5357)
It adds test cases for deploying Karmada services using the `karmadactl init --config` command with a configuration file, similar to the existing tests for `karmadactl init`.

**Special notes for your reviewer**:
@liangyuanpeng 
@RainbowMango 

~~This PR currently contains two commits because the test files depend on the new feature for deploying with a configuration file, introduced in [#5357](https://github.com/karmada-io/karmada/pull/5357). Once that PR is merged, this PR will be rebased, retaining only the commit for adding test cases. However, to save time, it is being submitted for review in advance.~~

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

