### PR TITLE
replace hard-coded karmada config secret name with arguments in cert_rotation controller

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -423,6 +423,8 @@ func startCertRotationController(ctx controllerscontext.Context) (bool, error) {
 		CertRotationCheckingInterval:       ctx.Opts.CertRotationCheckingInterval,
 		CertRotationRemainingTimeThreshold: ctx.Opts.CertRotationRemainingTimeThreshold,
 		KarmadaKubeconfigNamespace:         ctx.Opts.KarmadaKubeconfigNamespace,
+		KarmadaKubeconfigName:              ctx.Opts.KarmadaKubeconfigName,
+		KarmadaKubeconfigField:             ctx.Opts.KarmadaKubeconfigField,
 	}
 	if err := certRotationController.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err

--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -139,6 +139,10 @@ type Options struct {
 	CertRotationRemainingTimeThreshold float64
 	// KarmadaKubeconfigNamespace is the namespace of the secret containing karmada-agent certificate.
 	KarmadaKubeconfigNamespace string
+	// KarmadaKubeconfigName is the name of the secret containing karmada-agent certificate.
+	KarmadaKubeconfigName string
+	// KarmadaKubeconfigFeild is the subfield name of the Karmada config secret containing karmada-agent certificate.
+	KarmadaKubeconfigFeild string
 }
 
 // NewOptions builds an default scheduler options.
@@ -210,6 +214,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, allControllers []string) {
 	fs.DurationVar(&o.CertRotationCheckingInterval, "cert-rotation-checking-interval", 5*time.Minute, "The interval of checking if the certificate need to be rotated. This is only applicable if cert rotation is enabled")
 	fs.Float64Var(&o.CertRotationRemainingTimeThreshold, "cert-rotation-remaining-time-threshold", 0.2, "The threshold of remaining time of the valid certificate. This is only applicable if cert rotation is enabled.")
 	fs.StringVar(&o.KarmadaKubeconfigNamespace, "karmada-kubeconfig-namespace", "karmada-system", "Namespace of the secret containing karmada-agent certificate. This is only applicable if cert rotation is enabled.")
+	fs.StringVar(&o.KarmadaKubeconfigName, "karmada-kubeconfig-name", "karmada-kubeconfig", "Name of the secret containing karmada-agent certificate. This is only applicable if cert rotation is enabled.")
+	fs.StringVar(&o.KarmadaKubeconfigFeild, "karmada-kubeconfig-field", "karmada-kubeconfig", "Field name of the karmada config secret containing karmada-agent certificate. This is only applicable if cert rotation is enabled.")
 	o.RateLimiterOpts.AddFlags(fs)
 	features.FeatureGate.AddFlag(fs)
 	o.ProfileOpts.AddFlags(fs)

--- a/pkg/controllers/certificate/cert_rotation_controller.go
+++ b/pkg/controllers/certificate/cert_rotation_controller.go
@@ -55,9 +55,6 @@ const (
 
 	// SignerName defines the signer name for csr, 'kubernetes.io/kube-apiserver-client-kubelet' can sign the csr automatically
 	SignerName = "kubernetes.io/kube-apiserver-client-kubelet"
-
-	// KarmadaKubeconfigName is the name of the secret containing karmada-agent certificate.
-	KarmadaKubeconfigName = "karmada-kubeconfig"
 )
 
 // CertRotationController is to rotate certificates.
@@ -78,6 +75,10 @@ type CertRotationController struct {
 	CertRotationCheckingInterval time.Duration
 	// KarmadaKubeconfigNamespace is the namespace of the secret containing karmada-agent certificate.
 	KarmadaKubeconfigNamespace string
+	// KarmadaKubeconfigName is the name of the secret containing karmada-agent certificate.
+	KarmadaKubeconfigName string
+	// KarmadaKubeconfigField is the field name of the karmada config secret containing karmada-agent certificate.
+	KarmadaKubeconfigField string
 	// CertRotationRemainingTimeThreshold defines the threshold of remaining time of the valid certificate.
 	// If the ratio of remaining time to total time is less than or equal to this threshold, the certificate rotation starts.
 	CertRotationRemainingTimeThreshold float64
@@ -112,7 +113,7 @@ func (c *CertRotationController) Reconcile(ctx context.Context, req controllerru
 		return controllerruntime.Result{}, err
 	}
 
-	secret, err := c.ClusterClient.KubeClient.CoreV1().Secrets(c.KarmadaKubeconfigNamespace).Get(ctx, KarmadaKubeconfigName, metav1.GetOptions{})
+	secret, err := c.ClusterClient.KubeClient.CoreV1().Secrets(c.KarmadaKubeconfigNamespace).Get(ctx, c.KarmadaKubeconfigName, metav1.GetOptions{})
 	if err != nil {
 		klog.Errorf("failed to get karmada kubeconfig secret: %v", err)
 		return controllerruntime.Result{}, err
@@ -138,7 +139,7 @@ func (c *CertRotationController) SetupWithManager(mgr controllerruntime.Manager)
 }
 
 func (c *CertRotationController) syncCertRotation(ctx context.Context, secret *corev1.Secret) error {
-	karmadaKubeconfig, err := getKubeconfigFromSecret(secret)
+	karmadaKubeconfig, err := c.getKubeconfigFromSecret(secret)
 	if err != nil {
 		return err
 	}
@@ -208,7 +209,7 @@ func (c *CertRotationController) syncCertRotation(ctx context.Context, secret *c
 		return fmt.Errorf("failed to serialize karmada-agent kubeConfig. %v", err)
 	}
 
-	secret.Data["karmada-kubeconfig"] = karmadaKubeconfigBytes
+	secret.Data[c.KarmadaKubeconfigField] = karmadaKubeconfigBytes
 	// Update the karmada-kubeconfig secret in the member cluster.
 	if _, err := c.ClusterClient.KubeClient.CoreV1().Secrets(secret.Namespace).Update(ctx, secret, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("unable to update secret, err: %w", err)
@@ -260,12 +261,12 @@ func (c *CertRotationController) createCSRInControlPlane(ctx context.Context, cl
 	return csrName, nil
 }
 
-func getKubeconfigFromSecret(secret *corev1.Secret) (*clientcmdapi.Config, error) {
+func (c *CertRotationController) getKubeconfigFromSecret(secret *corev1.Secret) (*clientcmdapi.Config, error) {
 	if secret.Data == nil {
 		return nil, fmt.Errorf("no client certificate found in secret %q", secret.Namespace+"/"+secret.Name)
 	}
 
-	karmadaKubeconfigData, ok := secret.Data[KarmadaKubeconfigName]
+	karmadaKubeconfigData, ok := secret.Data[c.KarmadaKubeconfigField]
 	if !ok {
 		return nil, fmt.Errorf("no karmada kubeconfig found in secret %q", secret.Namespace+"/"+secret.Name)
 	}

--- a/pkg/controllers/certificate/cert_rotation_controller_test.go
+++ b/pkg/controllers/certificate/cert_rotation_controller_test.go
@@ -91,6 +91,8 @@ func makeFakeCertRotationController(threshold float64) *CertRotationController {
 		CertRotationRemainingTimeThreshold: threshold,
 		ClusterClientSetFunc:               util.NewClusterClientSet,
 		KarmadaKubeconfigNamespace:         "karmada-system",
+		KarmadaKubeconfigName:              "karmada-kubeconfig",
+		KarmadaKubeconfigField:             "karmada-kubeconfig",
 	}
 }
 

--- a/pkg/controllers/context/context.go
+++ b/pkg/controllers/context/context.go
@@ -97,6 +97,10 @@ type Options struct {
 	CertRotationRemainingTimeThreshold float64
 	// KarmadaKubeconfigNamespace is the namespace of the secret containing karmada-agent certificate.
 	KarmadaKubeconfigNamespace string
+	// KarmadaKubeconfigName is the name of the secret containing karmada-agent certificate.
+	KarmadaKubeconfigName string
+	// KarmadaKubeconfigField is the field name of the karmada config secret containing karmada-agent certificate.
+	KarmadaKubeconfigField string
 	// HPAControllerConfiguration is the config of federatedHPA-controller.
 	HPAControllerConfiguration config.HPAControllerConfiguration
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

replace hard-coded karmada config secret name with arguments in cert_rotation controller

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-agent`: add two command arguments to specify karmada config secret name for cert rotation controller
```

