### PR TITLE
Stop bump krew for release-1.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,11 +98,3 @@ jobs:
       with:
         files: |
           sbom.tar.gz
-  update-krew-index:
-    needs: release-assests
-    name: Update krew-index
-    runs-on: ubuntu-22.04
-    steps:
-    - uses: actions/checkout@v4
-    - name: Update new version in krew-index
-      uses: rajatjindal/krew-release-bot@v0.0.46


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Stop krew update on branch release-1.10, see #4703 for more details.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Thanks to @liangyuanpeng for his excellent effort on #5224. We don't need to do the same thing on release 1.11 and the following release, either.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

