### PR TITLE
Restrict supported service types of Karamda APIServer supported by karmada-operator

### DIFF
--- a/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
+++ b/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
@@ -2539,9 +2539,15 @@ spec:
                           Defaults to "10.96.0.0/12".
                         type: string
                       serviceType:
+                        default: ClusterIP
                         description: |-
-                          ServiceType represents the service type of karmada apiserver.
-                          it is ClusterIP by default.
+                          ServiceType represents the service type of Karmada API server.
+                          Valid options are: "ClusterIP", "NodePort", "LoadBalancer".
+                          Defaults to "ClusterIP".
+                        enum:
+                        - ClusterIP
+                        - NodePort
+                        - LoadBalancer
                         type: string
                     type: object
                   karmadaAggregatedAPIServer:

--- a/operator/config/crds/operator.karmada.io_karmadas.yaml
+++ b/operator/config/crds/operator.karmada.io_karmadas.yaml
@@ -2539,9 +2539,15 @@ spec:
                           Defaults to "10.96.0.0/12".
                         type: string
                       serviceType:
+                        default: ClusterIP
                         description: |-
-                          ServiceType represents the service type of karmada apiserver.
-                          it is ClusterIP by default.
+                          ServiceType represents the service type of Karmada API server.
+                          Valid options are: "ClusterIP", "NodePort", "LoadBalancer".
+                          Defaults to "ClusterIP".
+                        enum:
+                        - ClusterIP
+                        - NodePort
+                        - LoadBalancer
                         type: string
                     type: object
                   karmadaAggregatedAPIServer:

--- a/operator/pkg/apis/operator/v1alpha1/type.go
+++ b/operator/pkg/apis/operator/v1alpha1/type.go
@@ -277,8 +277,12 @@ type KarmadaAPIServer struct {
 	// +optional
 	ServiceSubnet *string `json:"serviceSubnet,omitempty"`
 
-	// ServiceType represents the service type of karmada apiserver.
-	// it is ClusterIP by default.
+	// ServiceType represents the service type of Karmada API server.
+	// Valid options are: "ClusterIP", "NodePort", "LoadBalancer".
+	// Defaults to "ClusterIP".
+	//
+	// +kubebuilder:default="ClusterIP"
+	// +kubebuilder:validation:Enum=ClusterIP;NodePort;LoadBalancer
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind api-change

**What this PR does / why we need it**:
This PR restrics the service types supported by karmada-operator.

**Which issue(s) this PR fixes**:
Part of #5767 

**Special notes for your reviewer**:
This PR introduces validation rules which narrow down the range of acceptable configuration, but this has no impact on users who are currently using `ClusterIP` and `NodePort`.  And for `Loadbalancer` and `ExternalName`, currently not supported. (We are considering introduce the support of `Loadbalancer` to address the use case reported at #4634).

**Does this PR introduce a user-facing change?**:
```release-note
API change: The ServiceType of Karmada API server now has been restrict to `ClusterIP`, `NodePort` and `LoadBalancer`.
```

