### PR TITLE
standardize the naming of karmada config in karmadactl method

### DIFF
--- a/pkg/karmadactl/addons/descheduler/manifests.go
+++ b/pkg/karmadactl/addons/descheduler/manifests.go
@@ -44,7 +44,7 @@ spec:
           imagePullPolicy: IfNotPresent
           command:
             - /bin/karmada-descheduler
-            - --kubeconfig=/etc/kubeconfig
+            - --kubeconfig=/etc/karmada/config/karmada.config
             - --metrics-bind-address=0.0.0.0:8080
             - --health-probe-bind-address=0.0.0.0:10358
             - --leader-elect-resource-namespace={{ .Namespace }}
@@ -66,19 +66,18 @@ spec:
               name: metrics
               protocol: TCP
           volumeMounts:
+            - name: karmada-config
+              mountPath: /etc/karmada/config
             - name: k8s-certs
               mountPath: /etc/karmada/pki
               readOnly: true
-            - name: kubeconfig
-              subPath: kubeconfig
-              mountPath: /etc/kubeconfig
       volumes:
+        - name: karmada-config
+          secret:
+            secretName: karmada-descheduler-config
         - name: k8s-certs
           secret:
             secretName: karmada-cert
-        - name: kubeconfig
-          secret:
-            secretName: kubeconfig
 `
 
 // DeploymentReplace is a struct to help to concrete

--- a/pkg/karmadactl/addons/metricsadapter/manifests.go
+++ b/pkg/karmadactl/addons/metricsadapter/manifests.go
@@ -43,19 +43,12 @@ spec:
         - name: karmada-metrics-adapter
           image: {{ .Image }}
           imagePullPolicy: IfNotPresent
-          volumeMounts:
-            - name: k8s-certs
-              mountPath: /etc/karmada/pki
-              readOnly: true
-            - name: kubeconfig
-              subPath: kubeconfig
-              mountPath: /etc/kubeconfig
           command:
             - /bin/karmada-metrics-adapter
-            - --kubeconfig=/etc/kubeconfig
             - --metrics-bind-address=:8080
-            - --authentication-kubeconfig=/etc/kubeconfig
-            - --authorization-kubeconfig=/etc/kubeconfig
+            - --kubeconfig=/etc/karmada/config/karmada.config
+            - --authentication-kubeconfig=/etc/karmada/config/karmada.config
+            - --authorization-kubeconfig=/etc/karmada/config/karmada.config
             - --client-ca-file=/etc/karmada/pki/ca.crt
             - --tls-cert-file=/etc/karmada/pki/karmada.crt
             - --tls-private-key-file=/etc/karmada/pki/karmada.key
@@ -84,13 +77,19 @@ spec:
           resources:
             requests:
               cpu: 100m
+          volumeMounts:
+            - name: karmada-config
+              mountPath: /etc/karmada/config
+            - name: k8s-certs
+              mountPath: /etc/karmada/pki
+              readOnly: true
       volumes:
+        - name: karmada-config
+          secret:
+            secretName: karmada-metrics-adapter-config
         - name: k8s-certs
           secret:
             secretName: karmada-cert
-        - name: kubeconfig
-          secret:
-            secretName: kubeconfig
 `
 
 	karmadaMetricsAdapterService = `

--- a/pkg/karmadactl/addons/search/manifests.go
+++ b/pkg/karmadactl/addons/search/manifests.go
@@ -43,18 +43,11 @@ spec:
         - name: karmada-search
           image: {{ .Image }}
           imagePullPolicy: IfNotPresent
-          volumeMounts:
-            - name: k8s-certs
-              mountPath: /etc/karmada/pki
-              readOnly: true
-            - name: kubeconfig
-              subPath: kubeconfig
-              mountPath: /etc/kubeconfig
           command:
             - /bin/karmada-search
-            - --kubeconfig=/etc/kubeconfig
-            - --authentication-kubeconfig=/etc/kubeconfig
-            - --authorization-kubeconfig=/etc/kubeconfig
+            - --kubeconfig=/etc/karmada/config/karmada.config
+            - --authentication-kubeconfig=/etc/karmada/config/karmada.config
+            - --authorization-kubeconfig=/etc/karmada/config/karmada.config
             - --etcd-servers={{ .ETCDSevers }}
             - --etcd-cafile=/etc/karmada/pki/etcd-ca.crt
             - --etcd-certfile=/etc/karmada/pki/etcd-client.crt
@@ -78,13 +71,19 @@ spec:
           resources:
             requests:
               cpu: 100m
+          volumeMounts:
+            - name: karmada-config
+              mountPath: /etc/karmada/config
+            - name: k8s-certs
+              mountPath: /etc/karmada/pki
+              readOnly: true
       volumes:
+        - name: karmada-config
+          secret:
+            secretName: karmada-search-config
         - name: k8s-certs
           secret:
             secretName: karmada-cert
-        - name: kubeconfig
-          secret:
-            secretName: kubeconfig
 `
 
 	karmadaSearchService = `

--- a/pkg/karmadactl/util/global.go
+++ b/pkg/karmadactl/util/global.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2022 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+const (
+	// KarmadaConfigFieldName the field stores karmada config in karmada config secret
+	KarmadaConfigFieldName = "karmada.config"
+)
+
+// KarmadaConfigName returns the name of karmada config secret
+func KarmadaConfigName(component string) string {
+	return component + "-config"
+}

--- a/pkg/util/names/names.go
+++ b/pkg/util/names/names.go
@@ -65,6 +65,9 @@ const (
 
 	// KarmadaControllerManagerComponentName is the name of the Karmada Controller Manager component.
 	KarmadaControllerManagerComponentName = "karmada-controller-manager"
+
+	// KubeControllerManagerComponentName is the name of the Kube Controller Manager component.
+	KubeControllerManagerComponentName = "kube-controller-manager"
 )
 
 // ExecutionSpacePrefix is the prefix of execution space


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

In karmada, here are two important secrets, which is mount by most karmada components. One is karmada-cert, which contains a series of cert files like ca.crt, apiserver.crt and so on; another is karmada-kubeconfig, which contains a kubeconfig of karmada-apiserver.

However, in different installation methods, we used inconsistent secret naming or file path naming, which can potentially cause some unnecessary problems, detail refer to https://github.com/karmada-io/karmada/issues/5363.

This PR aims to standardize the naming of karmada config in `karmadactl` installation method.

**Which issue(s) this PR fixes**:

Fixes part of #6051

**Special notes for your reviewer**:

karmada-agent is a bit different, this PR doesn't include the rename of karmada-agent

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: standardize the naming of karmada config in karmadactl installation method
```
