### PR TITLE
Ensure controller names are unique when emitting metrics

### DIFF
--- a/operator/pkg/controller/karmada/controller.go
+++ b/operator/pkg/controller/karmada/controller.go
@@ -45,7 +45,7 @@ import (
 )
 
 const (
-	// ControllerName is the controller name that will be used when reporting events.
+	// ControllerName is the controller name that will be used when reporting events and metrics.
 	ControllerName = "karmada-operator-controller"
 
 	// ControllerFinalizerName is the name of the karmada controller finalizer
@@ -185,6 +185,7 @@ func (ctrl *Controller) ensureKarmada(ctx context.Context, karmada *operatorv1al
 // SetupWithManager creates a controller and register to controller manager.
 func (ctrl *Controller) SetupWithManager(mgr controllerruntime.Manager) error {
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(ControllerName).
 		For(&operatorv1alpha1.Karmada{},
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc: ctrl.onKarmadaUpdate,

--- a/pkg/controllers/applicationfailover/crb_application_failover_controller.go
+++ b/pkg/controllers/applicationfailover/crb_application_failover_controller.go
@@ -45,7 +45,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/helper"
 )
 
-// CRBApplicationFailoverControllerName is the controller name that will be used when reporting events.
+// CRBApplicationFailoverControllerName is the controller name that will be used when reporting events and metrics.
 const CRBApplicationFailoverControllerName = "cluster-resource-binding-application-failover-controller"
 
 // CRBApplicationFailoverController is to sync ClusterResourceBinding's application failover behavior.
@@ -230,6 +230,7 @@ func (c *CRBApplicationFailoverController) SetupWithManager(mgr controllerruntim
 	}
 
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(CRBApplicationFailoverControllerName).
 		For(&workv1alpha2.ClusterResourceBinding{}, builder.WithPredicates(clusterResourceBindingPredicateFn)).
 		WithOptions(controller.Options{RateLimiter: ratelimiterflag.DefaultControllerRateLimiter(c.RateLimiterOptions)}).
 		Complete(c)

--- a/pkg/controllers/applicationfailover/rb_application_failover_controller.go
+++ b/pkg/controllers/applicationfailover/rb_application_failover_controller.go
@@ -45,7 +45,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/helper"
 )
 
-// RBApplicationFailoverControllerName is the controller name that will be used when reporting events.
+// RBApplicationFailoverControllerName is the controller name that will be used when reporting events and metrics.
 const RBApplicationFailoverControllerName = "resource-binding-application-failover-controller"
 
 // RBApplicationFailoverController is to sync ResourceBinding's application failover behavior.
@@ -232,6 +232,7 @@ func (c *RBApplicationFailoverController) SetupWithManager(mgr controllerruntime
 	}
 
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(RBApplicationFailoverControllerName).
 		For(&workv1alpha2.ResourceBinding{}, builder.WithPredicates(resourceBindingPredicateFn)).
 		WithOptions(controller.Options{RateLimiter: ratelimiterflag.DefaultControllerRateLimiter(c.RateLimiterOptions)}).
 		Complete(c)

--- a/pkg/controllers/binding/binding_controller.go
+++ b/pkg/controllers/binding/binding_controller.go
@@ -49,7 +49,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/overridemanager"
 )
 
-// ControllerName is the controller name that will be used when reporting events.
+// ControllerName is the controller name that will be used when reporting events and metrics.
 const ControllerName = "binding-controller"
 
 // ResourceBindingController is to sync ResourceBinding.
@@ -165,7 +165,9 @@ func (c *ResourceBindingController) removeOrphanWorks(ctx context.Context, bindi
 
 // SetupWithManager creates a controller and register to controller manager.
 func (c *ResourceBindingController) SetupWithManager(mgr controllerruntime.Manager) error {
-	return controllerruntime.NewControllerManagedBy(mgr).For(&workv1alpha2.ResourceBinding{}).
+	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(ControllerName).
+		For(&workv1alpha2.ResourceBinding{}).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Watches(&policyv1alpha1.OverridePolicy{}, handler.EnqueueRequestsFromMapFunc(c.newOverridePolicyFunc())).
 		Watches(&policyv1alpha1.ClusterOverridePolicy{}, handler.EnqueueRequestsFromMapFunc(c.newOverridePolicyFunc())).

--- a/pkg/controllers/binding/cluster_resource_binding_controller.go
+++ b/pkg/controllers/binding/cluster_resource_binding_controller.go
@@ -49,7 +49,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/overridemanager"
 )
 
-// ClusterResourceBindingControllerName is the controller name that will be used when reporting events.
+// ClusterResourceBindingControllerName is the controller name that will be used when reporting events and metrics.
 const ClusterResourceBindingControllerName = "cluster-resource-binding-controller"
 
 // ClusterResourceBindingController is to sync ClusterResourceBinding.
@@ -161,7 +161,9 @@ func (c *ClusterResourceBindingController) removeOrphanWorks(ctx context.Context
 
 // SetupWithManager creates a controller and register to controller manager.
 func (c *ClusterResourceBindingController) SetupWithManager(mgr controllerruntime.Manager) error {
-	return controllerruntime.NewControllerManagedBy(mgr).For(&workv1alpha2.ClusterResourceBinding{}).
+	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(ClusterResourceBindingControllerName).
+		For(&workv1alpha2.ClusterResourceBinding{}).
 		Watches(&policyv1alpha1.ClusterOverridePolicy{}, handler.EnqueueRequestsFromMapFunc(c.newOverridePolicyFunc())).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		WithOptions(controller.Options{RateLimiter: ratelimiterflag.DefaultControllerRateLimiter(c.RateLimiterOptions)}).

--- a/pkg/controllers/certificate/cert_rotation_controller.go
+++ b/pkg/controllers/certificate/cert_rotation_controller.go
@@ -50,7 +50,7 @@ import (
 )
 
 const (
-	// CertRotationControllerName is the controller name that will be used when reporting events.
+	// CertRotationControllerName is the controller name that will be used when reporting events and metrics.
 	CertRotationControllerName = "cert-rotation-controller"
 
 	// SignerName defines the signer name for csr, 'kubernetes.io/kube-apiserver-client-kubelet' can sign the csr automatically
@@ -129,6 +129,7 @@ func (c *CertRotationController) Reconcile(ctx context.Context, req controllerru
 // SetupWithManager creates a controller and register to controller manager.
 func (c *CertRotationController) SetupWithManager(mgr controllerruntime.Manager) error {
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(CertRotationControllerName).
 		For(&clusterv1alpha1.Cluster{}, builder.WithPredicates(c.PredicateFunc)).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		WithOptions(controller.Options{

--- a/pkg/controllers/cluster/cluster_controller.go
+++ b/pkg/controllers/cluster/cluster_controller.go
@@ -51,7 +51,7 @@ import (
 )
 
 const (
-	// ControllerName is the controller name that will be used when reporting events.
+	// ControllerName is the controller name that will be used when reporting events and metrics.
 	ControllerName = "cluster-controller"
 	// MonitorRetrySleepTime is the amount of time the cluster controller that should
 	// sleep between retrying cluster health updates.
@@ -215,7 +215,7 @@ func (c *Controller) Start(ctx context.Context) error {
 func (c *Controller) SetupWithManager(mgr controllerruntime.Manager) error {
 	c.clusterHealthMap = newClusterHealthMap()
 	return utilerrors.NewAggregate([]error{
-		controllerruntime.NewControllerManagedBy(mgr).For(&clusterv1alpha1.Cluster{}).Complete(c),
+		controllerruntime.NewControllerManagedBy(mgr).Named(ControllerName).For(&clusterv1alpha1.Cluster{}).Complete(c),
 		mgr.Add(c),
 	})
 }

--- a/pkg/controllers/cluster/taint_manager.go
+++ b/pkg/controllers/cluster/taint_manager.go
@@ -39,7 +39,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/helper"
 )
 
-// TaintManagerName is the controller name that will be used for taint management.
+// TaintManagerName is the controller name that will be used when reporting events and metrics.
 const TaintManagerName = "taint-manager"
 
 // NoExecuteTaintManager listens to Taint/Toleration changes and is responsible for removing objects
@@ -291,7 +291,7 @@ func (tc *NoExecuteTaintManager) needEviction(clusterName string, annotations ma
 // SetupWithManager creates a controller and register to controller manager.
 func (tc *NoExecuteTaintManager) SetupWithManager(mgr controllerruntime.Manager) error {
 	return utilerrors.NewAggregate([]error{
-		controllerruntime.NewControllerManagedBy(mgr).For(&clusterv1alpha1.Cluster{}).Complete(tc),
+		controllerruntime.NewControllerManagedBy(mgr).Named(TaintManagerName).For(&clusterv1alpha1.Cluster{}).Complete(tc),
 		mgr.Add(tc),
 	})
 }

--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_controller.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_controller.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	// ControllerName is the controller name that will be used when reporting events.
+	// ControllerName is the controller name that will be used when reporting events and metrics.
 	ControllerName = "cronfederatedhpa-controller"
 )
 
@@ -118,6 +118,7 @@ func (c *CronFHPAController) Reconcile(ctx context.Context, req controllerruntim
 func (c *CronFHPAController) SetupWithManager(mgr controllerruntime.Manager) error {
 	c.CronHandler = NewCronHandler(mgr.GetClient(), mgr.GetEventRecorderFor(ControllerName))
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(ControllerName).
 		For(&autoscalingv1alpha1.CronFederatedHPA{}).
 		WithOptions(controller.Options{RateLimiter: ratelimiterflag.DefaultControllerRateLimiter(c.RateLimiterOptions)}).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).

--- a/pkg/controllers/deploymentreplicassyncer/deployment_replicas_syncer_controller.go
+++ b/pkg/controllers/deploymentreplicassyncer/deployment_replicas_syncer_controller.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	// ControllerName is the controller name that will be used when reporting events.
+	// ControllerName is the controller name that will be used when reporting events and metrics.
 	ControllerName = "deployment-replicas-syncer"
 
 	waitDeploymentStatusInterval = 1 * time.Second

--- a/pkg/controllers/execution/execution_controller.go
+++ b/pkg/controllers/execution/execution_controller.go
@@ -53,7 +53,7 @@ import (
 )
 
 const (
-	// ControllerName is the controller name that will be used when reporting events.
+	// ControllerName is the controller name that will be used when reporting events and metrics.
 	ControllerName = "execution-controller"
 	// WorkSuspendDispatchingConditionMessage is the condition and event message when dispatching is suspended.
 	WorkSuspendDispatchingConditionMessage = "Work dispatching is in a suspended state."
@@ -133,6 +133,7 @@ func (c *Controller) Reconcile(ctx context.Context, req controllerruntime.Reques
 // SetupWithManager creates a controller and register to controller manager.
 func (c *Controller) SetupWithManager(mgr controllerruntime.Manager) error {
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(ControllerName).
 		For(&workv1alpha1.Work{}, builder.WithPredicates(c.PredicateFunc)).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		WithOptions(controller.Options{

--- a/pkg/controllers/federatedhpa/federatedhpa_controller.go
+++ b/pkg/controllers/federatedhpa/federatedhpa_controller.go
@@ -62,7 +62,7 @@ import (
 // FederatedHPA-controller is borrowed from the HPA controller of Kubernetes.
 // The referenced code has been marked in the comment.
 
-// ControllerName is the controller name that will be used when reporting events.
+// ControllerName is the controller name that will be used when reporting events and metrics.
 const ControllerName = "federatedHPA-controller"
 
 var (
@@ -128,6 +128,7 @@ func (c *FHPAController) SetupWithManager(mgr controllerruntime.Manager) error {
 	c.hpaSelectors = selectors.NewBiMultimap()
 	c.monitor = monitor.New()
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(ControllerName).
 		For(&autoscalingv1alpha1.FederatedHPA{}).
 		WithOptions(controller.Options{RateLimiter: ratelimiterflag.DefaultControllerRateLimiter(c.RateLimiterOptions)}).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).

--- a/pkg/controllers/federatedresourcequota/federated_resource_quota_status_controller.go
+++ b/pkg/controllers/federatedresourcequota/federated_resource_quota_status_controller.go
@@ -48,7 +48,7 @@ import (
 )
 
 const (
-	// StatusControllerName is the controller name that will be used when reporting events.
+	// StatusControllerName is the controller name that will be used when reporting events and metrics.
 	StatusControllerName = "federated-resource-quota-status-controller"
 )
 
@@ -129,6 +129,7 @@ func (c *StatusController) SetupWithManager(mgr controllerruntime.Manager) error
 		},
 	})
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(StatusControllerName).
 		For(&policyv1alpha1.FederatedResourceQuota{}).
 		Watches(&workv1alpha1.Work{}, handler.EnqueueRequestsFromMapFunc(fn), workPredicate).
 		Complete(c)

--- a/pkg/controllers/federatedresourcequota/federated_resource_quota_sync_controller.go
+++ b/pkg/controllers/federatedresourcequota/federated_resource_quota_sync_controller.go
@@ -44,7 +44,7 @@ import (
 )
 
 const (
-	// SyncControllerName is the controller name that will be used when reporting events.
+	// SyncControllerName is the controller name that will be used when reporting events and metrics.
 	SyncControllerName = "federated-resource-quota-sync-controller"
 )
 
@@ -129,6 +129,7 @@ func (c *SyncController) SetupWithManager(mgr controllerruntime.Manager) error {
 	})
 
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(SyncControllerName).
 		For(&policyv1alpha1.FederatedResourceQuota{}).
 		Watches(&clusterv1alpha1.Cluster{}, handler.EnqueueRequestsFromMapFunc(fn), clusterPredicate).
 		Complete(c)

--- a/pkg/controllers/gracefuleviction/crb_graceful_eviction_controller.go
+++ b/pkg/controllers/gracefuleviction/crb_graceful_eviction_controller.go
@@ -37,7 +37,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/helper"
 )
 
-// CRBGracefulEvictionControllerName is the controller name that will be used when reporting events.
+// CRBGracefulEvictionControllerName is the controller name that will be used when reporting events and metrics.
 const CRBGracefulEvictionControllerName = "cluster-resource-binding-graceful-eviction-controller"
 
 // CRBGracefulEvictionController is to sync ClusterResourceBinding.spec.gracefulEvictionTasks.
@@ -125,6 +125,7 @@ func (c *CRBGracefulEvictionController) SetupWithManager(mgr controllerruntime.M
 	}
 
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(CRBGracefulEvictionControllerName).
 		For(&workv1alpha2.ClusterResourceBinding{}, builder.WithPredicates(clusterResourceBindingPredicateFn)).
 		WithOptions(controller.Options{RateLimiter: ratelimiterflag.DefaultControllerRateLimiter(c.RateLimiterOptions)}).
 		Complete(c)

--- a/pkg/controllers/gracefuleviction/rb_graceful_eviction_controller.go
+++ b/pkg/controllers/gracefuleviction/rb_graceful_eviction_controller.go
@@ -37,7 +37,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/helper"
 )
 
-// RBGracefulEvictionControllerName is the controller name that will be used when reporting events.
+// RBGracefulEvictionControllerName is the controller name that will be used when reporting events and metrics.
 const RBGracefulEvictionControllerName = "resource-binding-graceful-eviction-controller"
 
 // RBGracefulEvictionController is to sync ResourceBinding.spec.gracefulEvictionTasks.
@@ -125,6 +125,7 @@ func (c *RBGracefulEvictionController) SetupWithManager(mgr controllerruntime.Ma
 	}
 
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(RBGracefulEvictionControllerName).
 		For(&workv1alpha2.ResourceBinding{}, builder.WithPredicates(resourceBindingPredicateFn)).
 		WithOptions(controller.Options{RateLimiter: ratelimiterflag.DefaultControllerRateLimiter(c.RateLimiterOptions)}).
 		Complete(c)

--- a/pkg/controllers/hpascaletargetmarker/hpa_scale_target_marker_controller.go
+++ b/pkg/controllers/hpascaletargetmarker/hpa_scale_target_marker_controller.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	// ControllerName is the controller name that will be used when reporting events.
+	// ControllerName is the controller name that will be used when reporting events and metrics.
 	ControllerName = "hpa-scale-target-marker"
 	// scaleTargetWorkerNum is the async Worker number
 	scaleTargetWorkerNum = 1

--- a/pkg/controllers/mcs/endpointslice_controller.go
+++ b/pkg/controllers/mcs/endpointslice_controller.go
@@ -40,7 +40,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
-// EndpointSliceControllerName is the controller name that will be used when reporting events.
+// EndpointSliceControllerName is the controller name that will be used when reporting events and metrics.
 const EndpointSliceControllerName = "endpointslice-controller"
 
 // EndpointSliceController is to collect EndpointSlice which reported by member cluster from executionNamespace to serviceexport namespace.
@@ -115,7 +115,10 @@ func (c *EndpointSliceController) SetupWithManager(mgr controllerruntime.Manager
 			return false
 		},
 	}
-	return controllerruntime.NewControllerManagedBy(mgr).For(&workv1alpha1.Work{}, builder.WithPredicates(serviceImportPredicateFun)).Complete(c)
+	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(EndpointSliceControllerName).
+		For(&workv1alpha1.Work{}, builder.WithPredicates(serviceImportPredicateFun)).
+		Complete(c)
 }
 
 func (c *EndpointSliceController) collectEndpointSliceFromWork(ctx context.Context, work *workv1alpha1.Work) error {

--- a/pkg/controllers/mcs/service_export_controller.go
+++ b/pkg/controllers/mcs/service_export_controller.go
@@ -55,7 +55,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
-// ServiceExportControllerName is the controller name that will be used when reporting events.
+// ServiceExportControllerName is the controller name that will be used when reporting events and metrics.
 const ServiceExportControllerName = "service-export-controller"
 
 // ServiceExportController is to sync ServiceExport and report EndpointSlices of exported service to control-plane.
@@ -131,7 +131,7 @@ func (c *ServiceExportController) Reconcile(ctx context.Context, req controllerr
 
 // SetupWithManager creates a controller and register to controller manager.
 func (c *ServiceExportController) SetupWithManager(mgr controllerruntime.Manager) error {
-	return controllerruntime.NewControllerManagedBy(mgr).For(&workv1alpha1.Work{}, builder.WithPredicates(c.PredicateFunc)).Complete(c)
+	return controllerruntime.NewControllerManagedBy(mgr).Named(ServiceExportControllerName).For(&workv1alpha1.Work{}, builder.WithPredicates(c.PredicateFunc)).Complete(c)
 }
 
 // RunWorkQueue initializes worker and run it, worker will process resource asynchronously.

--- a/pkg/controllers/mcs/service_import_controller.go
+++ b/pkg/controllers/mcs/service_import_controller.go
@@ -35,7 +35,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
-// ServiceImportControllerName is the controller name that will be used when reporting events.
+// ServiceImportControllerName is the controller name that will be used when reporting events and metrics.
 const ServiceImportControllerName = "service-import-controller"
 
 // ServiceImportController is to sync derived service from ServiceImport.
@@ -71,7 +71,10 @@ func (c *ServiceImportController) Reconcile(ctx context.Context, req controllerr
 
 // SetupWithManager creates a controller and register to controller manager.
 func (c *ServiceImportController) SetupWithManager(mgr controllerruntime.Manager) error {
-	return controllerruntime.NewControllerManagedBy(mgr).For(&mcsv1alpha1.ServiceImport{}).Complete(c)
+	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(ServiceImportControllerName).
+		For(&mcsv1alpha1.ServiceImport{}).
+		Complete(c)
 }
 
 func (c *ServiceImportController) deleteDerivedService(ctx context.Context, svcImport types.NamespacedName) (controllerruntime.Result, error) {

--- a/pkg/controllers/multiclusterservice/endpointslice_collect_controller.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_collect_controller.go
@@ -74,6 +74,9 @@ var (
 	multiClusterServiceGVK = networkingv1alpha1.SchemeGroupVersion.WithKind("MultiClusterService")
 )
 
+// EndpointSliceCollectControllerName is the controller name that will be used when reporting events and metrics.
+const EndpointSliceCollectControllerName = "endpointslice-collect-controller"
+
 // Reconcile performs a full reconciliation for the object referred to by the Request.
 func (c *EndpointSliceCollectController) Reconcile(ctx context.Context, req controllerruntime.Request) (controllerruntime.Result, error) {
 	klog.V(4).Infof("Reconciling Work %s", req.NamespacedName.String())
@@ -115,6 +118,7 @@ func (c *EndpointSliceCollectController) Reconcile(ctx context.Context, req cont
 // SetupWithManager creates a controller and register to controller manager.
 func (c *EndpointSliceCollectController) SetupWithManager(mgr controllerruntime.Manager) error {
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(EndpointSliceCollectControllerName).
 		For(&workv1alpha1.Work{}, builder.WithPredicates(c.PredicateFunc)).Complete(c)
 }
 

--- a/pkg/controllers/multiclusterservice/endpointslice_dispatch_controller.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_dispatch_controller.go
@@ -49,7 +49,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
-// EndpointsliceDispatchControllerName is the controller name that will be used when reporting events.
+// EndpointsliceDispatchControllerName is the controller name that will be used when reporting events and metrics.
 const EndpointsliceDispatchControllerName = "endpointslice-dispatch-controller"
 
 // EndpointsliceDispatchController will reconcile a MultiClusterService object
@@ -160,7 +160,9 @@ func (c *EndpointsliceDispatchController) SetupWithManager(mgr controllerruntime
 			return false
 		},
 	}
-	return controllerruntime.NewControllerManagedBy(mgr).For(&workv1alpha1.Work{}, builder.WithPredicates(workPredicateFun)).
+	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(EndpointsliceDispatchControllerName).
+		For(&workv1alpha1.Work{}, builder.WithPredicates(workPredicateFun)).
 		Watches(&networkingv1alpha1.MultiClusterService{}, handler.EnqueueRequestsFromMapFunc(c.newMultiClusterServiceFunc())).
 		Watches(&clusterv1alpha1.Cluster{}, handler.EnqueueRequestsFromMapFunc(c.newClusterFunc())).
 		Complete(c)

--- a/pkg/controllers/multiclusterservice/mcs_controller.go
+++ b/pkg/controllers/multiclusterservice/mcs_controller.go
@@ -54,7 +54,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
-// ControllerName is the controller name that will be used when reporting events.
+// ControllerName is the controller name that will be used when reporting events and metrics.
 const ControllerName = "multiclusterservice-controller"
 
 // MCSController is to sync MultiClusterService.
@@ -600,6 +600,7 @@ func (c *MCSController) SetupWithManager(mgr controllerruntime.Manager) error {
 		})
 
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(ControllerName).
 		For(&networkingv1alpha1.MultiClusterService{}, builder.WithPredicates(mcsPredicateFunc)).
 		Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(svcMapFunc), builder.WithPredicates(svcPredicateFunc)).
 		Watches(&clusterv1alpha1.Cluster{}, handler.EnqueueRequestsFromMapFunc(c.clusterMapFunc())).

--- a/pkg/controllers/namespace/namespace_sync_controller.go
+++ b/pkg/controllers/namespace/namespace_sync_controller.go
@@ -48,7 +48,7 @@ import (
 )
 
 const (
-	// ControllerName is the controller name that will be used when reporting events.
+	// ControllerName is the controller name that will be used when reporting events and metrics.
 	ControllerName = "namespace-sync-controller"
 )
 
@@ -273,6 +273,7 @@ func (c *Controller) SetupWithManager(mgr controllerruntime.Manager) error {
 	})
 
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(ControllerName).
 		For(&corev1.Namespace{}).
 		Watches(&clusterv1alpha1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterNamespaceFn),

--- a/pkg/controllers/remediation/remedy_controller.go
+++ b/pkg/controllers/remediation/remedy_controller.go
@@ -34,7 +34,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/helper"
 )
 
-// ControllerName is the controller name that will be used when reporting events.
+// ControllerName is the controller name that will be used when reporting events and metrics.
 const ControllerName = "remedy-controller"
 
 // RemedyController is to sync Cluster resource, according to the cluster status

--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -58,7 +58,7 @@ import (
 )
 
 const (
-	// ControllerName is the controller name that will be used when reporting events.
+	// ControllerName is the controller name that will be used when reporting events and metrics.
 	ControllerName            = "cluster-status-controller"
 	clusterReady              = "ClusterReady"
 	clusterHealthy            = "cluster is healthy and ready to accept workloads"
@@ -171,6 +171,7 @@ func (c *ClusterStatusController) SetupWithManager(mgr controllerruntime.Manager
 		failureThreshold: c.ClusterFailureThreshold.Duration,
 	}
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(ControllerName).
 		For(&clusterv1alpha1.Cluster{}, builder.WithPredicates(c.PredicateFunc)).
 		WithOptions(controller.Options{
 			RateLimiter: ratelimiterflag.DefaultControllerRateLimiter(c.RateLimiterOptions),

--- a/pkg/controllers/status/crb_status_controller.go
+++ b/pkg/controllers/status/crb_status_controller.go
@@ -39,7 +39,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/helper"
 )
 
-// CRBStatusControllerName is the controller name that will be used when reporting events.
+// CRBStatusControllerName is the controller name that will be used when reporting events and metrics.
 const CRBStatusControllerName = "cluster-resource-binding-status-controller"
 
 // CRBStatusController is to sync status of ClusterResourceBinding
@@ -101,7 +101,8 @@ func (c *CRBStatusController) SetupWithManager(mgr controllerruntime.Manager) er
 			return requests
 		})
 
-	return controllerruntime.NewControllerManagedBy(mgr).Named("clusterResourceBinding_status_controller").
+	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(CRBStatusControllerName).
 		For(&workv1alpha2.ClusterResourceBinding{}, bindingPredicateFn).
 		Watches(&workv1alpha1.Work{}, handler.EnqueueRequestsFromMapFunc(workMapFunc), workPredicateFn).
 		WithOptions(controller.Options{RateLimiter: ratelimiterflag.DefaultControllerRateLimiter(c.RateLimiterOptions)}).

--- a/pkg/controllers/status/rb_status_controller.go
+++ b/pkg/controllers/status/rb_status_controller.go
@@ -39,7 +39,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/helper"
 )
 
-// RBStatusControllerName is the controller name that will be used when reporting events.
+// RBStatusControllerName is the controller name that will be used when reporting events and metrics.
 const RBStatusControllerName = "resource-binding-status-controller"
 
 // RBStatusController is to sync status of ResourceBinding
@@ -103,7 +103,8 @@ func (c *RBStatusController) SetupWithManager(mgr controllerruntime.Manager) err
 			return requests
 		})
 
-	return controllerruntime.NewControllerManagedBy(mgr).Named("resourceBinding_status_controller").
+	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(RBStatusControllerName).
 		For(&workv1alpha2.ResourceBinding{}, bindingPredicateFn).
 		Watches(&workv1alpha1.Work{}, handler.EnqueueRequestsFromMapFunc(workMapFunc), workPredicateFn).
 		WithOptions(controller.Options{RateLimiter: ratelimiterflag.DefaultControllerRateLimiter(c.RateLimiterOptions)}).

--- a/pkg/controllers/status/work_status_controller.go
+++ b/pkg/controllers/status/work_status_controller.go
@@ -55,7 +55,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/restmapper"
 )
 
-// WorkStatusControllerName is the controller name that will be used when reporting events.
+// WorkStatusControllerName is the controller name that will be used when reporting events and metrics.
 const WorkStatusControllerName = "work-status-controller"
 
 // WorkStatusController is to sync status of Work.
@@ -546,6 +546,7 @@ func (c *WorkStatusController) getSingleClusterManager(cluster *clusterv1alpha1.
 // SetupWithManager creates a controller and register to controller manager.
 func (c *WorkStatusController) SetupWithManager(mgr controllerruntime.Manager) error {
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(WorkStatusControllerName).
 		For(&workv1alpha1.Work{}, builder.WithPredicates(c.PredicateFunc)).
 		WithOptions(controller.Options{
 			RateLimiter: ratelimiterflag.DefaultControllerRateLimiter(c.RateLimiterOptions),

--- a/pkg/controllers/unifiedauth/unified_auth_controller.go
+++ b/pkg/controllers/unifiedauth/unified_auth_controller.go
@@ -44,7 +44,7 @@ import (
 )
 
 const (
-	// ControllerName is the controller name that will be used when reporting events.
+	// ControllerName is the controller name that will be used when reporting events and metrics.
 	ControllerName = "unified-auth-controller"
 
 	karmadaImpersonatorName = "karmada-impersonator"
@@ -255,6 +255,7 @@ func (c *Controller) SetupWithManager(mgr controllerruntime.Manager) error {
 	}
 
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(ControllerName).
 		For(&clusterv1alpha1.Cluster{}, builder.WithPredicates(clusterPredicateFunc)).
 		Watches(&rbacv1.ClusterRole{}, handler.EnqueueRequestsFromMapFunc(c.newClusterRoleMapFunc())).
 		Watches(&rbacv1.ClusterRoleBinding{}, handler.EnqueueRequestsFromMapFunc(c.newClusterRoleBindingMapFunc())).

--- a/pkg/controllers/workloadrebalancer/workloadrebalancer_controller.go
+++ b/pkg/controllers/workloadrebalancer/workloadrebalancer_controller.go
@@ -40,7 +40,7 @@ import (
 )
 
 const (
-	// ControllerName is the controller name that will be used when reporting events.
+	// ControllerName is the controller name that will be used when reporting events and metrics.
 	ControllerName = "workload-rebalancer"
 )
 

--- a/pkg/dependenciesdistributor/dependencies_distributor.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor.go
@@ -61,6 +61,11 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/restmapper"
 )
 
+const (
+	// ControllerName is the controller name that will be used when reporting events and metrics.
+	ControllerName = "dependencies-distributor"
+)
+
 // well-know labels
 const (
 	// dependedByLabelKeyPrefix is added to the attached binding, it is the
@@ -622,7 +627,9 @@ func (d *DependenciesDistributor) SetupWithManager(mgr controllerruntime.Manager
 	d.genericEvent = make(chan event.TypedGenericEvent[*workv1alpha2.ResourceBinding])
 	return utilerrors.NewAggregate([]error{
 		mgr.Add(d),
-		controllerruntime.NewControllerManagedBy(mgr).For(&workv1alpha2.ResourceBinding{}).
+		controllerruntime.NewControllerManagedBy(mgr).
+			Named(ControllerName).
+			For(&workv1alpha2.ResourceBinding{}).
 			WithEventFilter(predicate.Funcs{
 				CreateFunc: func(event event.CreateEvent) bool {
 					bindingObject := event.Object.(*workv1alpha2.ResourceBinding)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

set fixed names for each controller to prevent metrics conflicts

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
The controller-runtime will validate controller names starting v0.19.x. 
See https://github.com/kubernetes-sigs/controller-runtime/pull/2902 for reference.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Unique controller names and remove ambitions when reporting metrics.
```

