### PR TITLE
karmada-search: support field selector for corev1 resources

### DIFF
--- a/pkg/search/proxy/framework/plugins/cache/apis/core/v1/conversion.go
+++ b/pkg/search/proxy/framework/plugins/cache/apis/core/v1/conversion.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// addConversionFuncs ensures that the cache plugin can handle the field selectors for corev1 resources.
+// It is copied from "k8s.io/kubernetes/pkg/apis/core/v1/conversion.go".
+func addConversionFuncs(scheme *runtime.Scheme) error {
+	// Add field conversion funcs.
+	err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("Pod"),
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name",
+				"metadata.namespace",
+				"spec.nodeName",
+				"spec.restartPolicy",
+				"spec.schedulerName",
+				"spec.serviceAccountName",
+				"spec.hostNetwork",
+				"status.phase",
+				"status.podIP",
+				"status.podIPs",
+				"status.nominatedNodeName":
+				return label, value, nil
+			// This is for backwards compatibility with old v1 clients which send spec.host
+			case "spec.host":
+				return "spec.nodeName", value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		},
+	)
+	if err != nil {
+		return err
+	}
+	err = scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("Node"),
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name":
+				return label, value, nil
+			case "spec.unschedulable":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		},
+	)
+	if err != nil {
+		return err
+	}
+	err = scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("ReplicationController"),
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name",
+				"metadata.namespace",
+				"status.replicas":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		return err
+	}
+	if err := AddFieldLabelConversionsForEvent(scheme); err != nil {
+		return err
+	}
+	if err := AddFieldLabelConversionsForNamespace(scheme); err != nil {
+		return err
+	}
+	if err := AddFieldLabelConversionsForSecret(scheme); err != nil {
+		return err
+	}
+	if err := AddFieldLabelConversionsForService(scheme); err != nil {
+		return err
+	}
+	return nil
+}
+
+// AddFieldLabelConversionsForEvent adds field label conversions for Event.
+func AddFieldLabelConversionsForEvent(scheme *runtime.Scheme) error {
+	return scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("Event"),
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "involvedObject.kind",
+				"involvedObject.namespace",
+				"involvedObject.name",
+				"involvedObject.uid",
+				"involvedObject.apiVersion",
+				"involvedObject.resourceVersion",
+				"involvedObject.fieldPath",
+				"reason",
+				"reportingComponent",
+				"source",
+				"type",
+				"metadata.namespace",
+				"metadata.name":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+}
+
+// AddFieldLabelConversionsForNamespace adds field label conversions for Namespace.
+func AddFieldLabelConversionsForNamespace(scheme *runtime.Scheme) error {
+	return scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("Namespace"),
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "status.phase",
+				"metadata.name":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+}
+
+// AddFieldLabelConversionsForSecret adds field label conversions for Secret.
+func AddFieldLabelConversionsForSecret(scheme *runtime.Scheme) error {
+	return scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("Secret"),
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "type",
+				"metadata.namespace",
+				"metadata.name":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+}
+
+// AddFieldLabelConversionsForService adds field label conversions for Service.
+func AddFieldLabelConversionsForService(scheme *runtime.Scheme) error {
+	return scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("Service"),
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.namespace",
+				"metadata.name",
+				"spec.clusterIP",
+				"spec.type":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+}

--- a/pkg/search/proxy/framework/plugins/cache/apis/core/v1/register.go
+++ b/pkg/search/proxy/framework/plugins/cache/apis/core/v1/register.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// SchemeGroupVersion is group version used to register these objects.
+var SchemeGroupVersion = corev1.SchemeGroupVersion
+
+var (
+	// SchemeBuilder points to a list of functions added to Scheme.
+	SchemeBuilder = runtime.NewSchemeBuilder(addConversionFuncs)
+	// AddToScheme applies all the stored functions to the scheme.
+	AddToScheme = SchemeBuilder.AddToScheme
+)

--- a/pkg/search/proxy/framework/plugins/cache/cache.go
+++ b/pkg/search/proxy/framework/plugins/cache/cache.go
@@ -110,7 +110,7 @@ func (c *Cache) Connect(_ context.Context, request framework.ProxyRequest) (http
 			ClusterScoped: mapping.Scope.Name() == meta.RESTScopeNameRoot,
 		},
 		Serializer:       scheme.Codecs.WithoutConversion(),
-		Convertor:        runtime.NewScheme(),
+		Convertor:        cacheScheme,
 		Subresource:      requestInfo.Subresource,
 		MetaGroupVersion: metav1.SchemeGroupVersion,
 		TableConvertor:   r.tableConvertor,

--- a/pkg/search/proxy/framework/plugins/cache/scheme.go
+++ b/pkg/search/proxy/framework/plugins/cache/scheme.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	corev1 "github.com/karmada-io/karmada/pkg/search/proxy/framework/plugins/cache/apis/core/v1"
+)
+
+var cacheScheme = runtime.NewScheme()
+
+func init() {
+	AddToScheme(cacheScheme)
+}
+
+// AddToScheme applies all the stored functions to the scheme.
+func AddToScheme(scheme *runtime.Scheme) {
+	utilruntime.Must(corev1.AddToScheme(scheme))
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
karmada-search: support field selector for corev1 resources.

This supports most scenarios that use fieldSelector, such as finding a list of pods by node name.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
without this patch:
```sh
 # kubectl get pod --kubeconfig karmada-search.config --field-selector="spec.nodeName=member1-worker"
Error from server (BadRequest): Unable to find "/v1, Resource=pods" that match label selector "", field selector "spec.nodeName=member1-worker": "spec.nodeName" is not a known field selector: only "metadata.name", "metadata.namespace"
```

with this patch:
```sh
 # kubectl get pod --kubeconfig karmada-search.config --field-selector="spec.nodeName=member1-worker"
example-app-6c847589df-xmjm5                2024-10-29T03:15:25Z
...
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-search: support field selector for corev1 resources.
```

