### PR TITLE
[UT] cancel concurrent test for SetupWithManager

### DIFF
--- a/pkg/controllers/remediation/remedy_controller_test.go
+++ b/pkg/controllers/remediation/remedy_controller_test.go
@@ -148,12 +148,6 @@ func TestSetupWithManager(t *testing.T) {
 				return &RemedyController{Client: createFakeClient(scheme)}
 			},
 		},
-		{
-			name: "setup with nil client",
-			controllerSetup: func() *RemedyController {
-				return &RemedyController{Client: nil}
-			},
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Cancel the concurrent execution of SetupWithManager tests, because when the SetupWithManager method is executed more than once, an error will be reported if the same controller name is used. In addition, the concurrent execution of the SetupWithManager test case is of little significance. The concurrency we usually refer to is the concurrency of its internal queue execution, not the controller itself. Therefore, the test case was deleted.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

@anujagrawal699 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

