### PR TITLE
disable deepcopy for list action

### DIFF
--- a/pkg/controllers/binding/cluster_resource_binding_controller.go
+++ b/pkg/controllers/binding/cluster_resource_binding_controller.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -180,14 +181,14 @@ func (c *ClusterResourceBindingController) newOverridePolicyFunc() handler.MapFu
 			return nil
 		}
 
-		bindingList := &workv1alpha2.ClusterResourceBindingList{}
-		if err := c.Client.List(ctx, bindingList); err != nil {
+		readonlyBindingList := &workv1alpha2.ClusterResourceBindingList{}
+		if err := c.Client.List(ctx, readonlyBindingList, &client.ListOptions{UnsafeDisableDeepCopy: ptr.To(true)}); err != nil {
 			klog.Errorf("Failed to list clusterResourceBindings, error: %v", err)
 			return nil
 		}
 
 		var requests []reconcile.Request
-		for _, binding := range bindingList.Items {
+		for _, binding := range readonlyBindingList.Items {
 			// Nil resourceSelectors means matching all resources.
 			if len(overrideRS) == 0 {
 				klog.V(2).Infof("Enqueue ClusterResourceBinding(%s) as cluster override policy(%s) changes.", binding.Name, a.GetName())

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -366,7 +367,8 @@ func (d *ResourceDetector) LookForMatchedPolicy(object *unstructured.Unstructure
 	klog.V(2).Infof("Attempts to match policy for resource(%s)", objectKey)
 	policyList := &policyv1alpha1.PropagationPolicyList{}
 	err := d.Client.List(context.TODO(), policyList, &client.ListOptions{
-		Namespace: objectKey.Namespace,
+		Namespace:             objectKey.Namespace,
+		UnsafeDisableDeepCopy: ptr.To(true),
 	})
 	if err != nil {
 		klog.Errorf("Failed to list propagation policy: %v", err)
@@ -392,7 +394,9 @@ func (d *ResourceDetector) LookForMatchedPolicy(object *unstructured.Unstructure
 func (d *ResourceDetector) LookForMatchedClusterPolicy(object *unstructured.Unstructured, objectKey keys.ClusterWideKey) (*policyv1alpha1.ClusterPropagationPolicy, error) {
 	klog.V(2).Infof("Attempts to match cluster policy for resource(%s)", objectKey)
 	policyList := &policyv1alpha1.ClusterPropagationPolicyList{}
-	err := d.Client.List(context.TODO(), policyList)
+	err := d.Client.List(context.TODO(), policyList, &client.ListOptions{
+		UnsafeDisableDeepCopy: ptr.To(true),
+	})
 	if err != nil {
 		klog.Errorf("Failed to list cluster propagation policy: %v", err)
 		return nil, err

--- a/pkg/detector/policy.go
+++ b/pkg/detector/policy.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
@@ -283,7 +284,8 @@ func (d *ResourceDetector) removeResourceClaimMetadataIfNotMatched(objectReferen
 func (d *ResourceDetector) listPPDerivedRBs(policyID, policyNamespace, policyName string) (*workv1alpha2.ResourceBindingList, error) {
 	bindings := &workv1alpha2.ResourceBindingList{}
 	listOpt := &client.ListOptions{
-		Namespace: policyNamespace,
+		Namespace:             policyNamespace,
+		UnsafeDisableDeepCopy: ptr.To(true),
 		LabelSelector: labels.SelectorFromSet(labels.Set{
 			policyv1alpha1.PropagationPolicyPermanentIDLabel: policyID,
 		}),
@@ -302,7 +304,9 @@ func (d *ResourceDetector) listCPPDerivedRBs(policyID, policyName string) (*work
 	listOpt := &client.ListOptions{
 		LabelSelector: labels.SelectorFromSet(labels.Set{
 			policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel: policyID,
-		})}
+		}),
+		UnsafeDisableDeepCopy: ptr.To(true),
+	}
 	err := d.Client.List(context.TODO(), bindings, listOpt)
 	if err != nil {
 		klog.Errorf("Failed to list ResourceBinding with policy(%s), error: %v", policyName, err)
@@ -317,7 +321,9 @@ func (d *ResourceDetector) listCPPDerivedCRBs(policyID, policyName string) (*wor
 	listOpt := &client.ListOptions{
 		LabelSelector: labels.SelectorFromSet(labels.Set{
 			policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel: policyID,
-		})}
+		}),
+		UnsafeDisableDeepCopy: ptr.To(true),
+	}
 	err := d.Client.List(context.TODO(), bindings, listOpt)
 	if err != nil {
 		klog.Errorf("Failed to list ClusterResourceBinding with policy(%s), error: %v", policyName, err)

--- a/pkg/detector/preemption.go
+++ b/pkg/detector/preemption.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
@@ -254,7 +255,8 @@ func (d *ResourceDetector) HandleDeprioritizedPropagationPolicy(oldPolicy policy
 	klog.Infof("PropagationPolicy(%s/%s) priority changed from %d to %d", newPolicy.GetNamespace(), newPolicy.GetName(), *oldPolicy.Spec.Priority, *newPolicy.Spec.Priority)
 	policyList := &policyv1alpha1.PropagationPolicyList{}
 	err := d.Client.List(context.TODO(), policyList, &client.ListOptions{
-		Namespace: newPolicy.GetNamespace(),
+		Namespace:             newPolicy.GetNamespace(),
+		UnsafeDisableDeepCopy: ptr.To(true),
 	})
 	if err != nil {
 		klog.Errorf("Failed to list PropagationPolicy from namespace: %s, error: %v", newPolicy.GetNamespace(), err)
@@ -297,7 +299,9 @@ func (d *ResourceDetector) HandleDeprioritizedClusterPropagationPolicy(oldPolicy
 	klog.Infof("ClusterPropagationPolicy(%s) priority changed from %d to %d",
 		newPolicy.GetName(), *oldPolicy.Spec.Priority, *newPolicy.Spec.Priority)
 	policyList := &policyv1alpha1.ClusterPropagationPolicyList{}
-	err := d.Client.List(context.TODO(), policyList)
+	err := d.Client.List(context.TODO(), policyList, &client.ListOptions{
+		UnsafeDisableDeepCopy: ptr.To(true),
+	})
 	if err != nil {
 		klog.Errorf("Failed to list ClusterPropagationPolicy, error: %v", err)
 		return

--- a/pkg/util/overridemanager/overridemanager.go
+++ b/pkg/util/overridemanager/overridemanager.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -127,7 +128,7 @@ func (o *overrideManagerImpl) ApplyOverridePolicies(rawObj *unstructured.Unstruc
 func (o *overrideManagerImpl) applyClusterOverrides(rawObj *unstructured.Unstructured, cluster *clusterv1alpha1.Cluster) (*AppliedOverrides, error) {
 	// get all cluster-scoped override policies
 	policyList := &policyv1alpha1.ClusterOverridePolicyList{}
-	if err := o.Client.List(context.TODO(), policyList, &client.ListOptions{}); err != nil {
+	if err := o.Client.List(context.TODO(), policyList, &client.ListOptions{UnsafeDisableDeepCopy: ptr.To(true)}); err != nil {
 		klog.Errorf("Failed to list cluster override policies, error: %v", err)
 		return nil, err
 	}
@@ -165,7 +166,7 @@ func (o *overrideManagerImpl) applyClusterOverrides(rawObj *unstructured.Unstruc
 func (o *overrideManagerImpl) applyNamespacedOverrides(rawObj *unstructured.Unstructured, cluster *clusterv1alpha1.Cluster) (*AppliedOverrides, error) {
 	// get all namespace-scoped override policies
 	policyList := &policyv1alpha1.OverridePolicyList{}
-	if err := o.Client.List(context.TODO(), policyList, &client.ListOptions{Namespace: rawObj.GetNamespace()}); err != nil {
+	if err := o.Client.List(context.TODO(), policyList, &client.ListOptions{Namespace: rawObj.GetNamespace(), UnsafeDisableDeepCopy: ptr.To(true)}); err != nil {
 		klog.Errorf("Failed to list override policies from namespace: %s, error: %v", rawObj.GetNamespace(), err)
 		return nil, err
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

When the node CPU usage rate is almost over 90%, it seems that deepcopy cost the most time:

```
I1113 14:36:11.161745      18 overridemanager.go:181] applyNamespacedOverrides, list configmap-beta-moa-demo-prod-681,  cluster member-cluster1, cost: 0.980144234
I1113 14:36:12.445315      18 overridemanager.go:181] applyNamespacedOverrides, list configmap-beta-moa-demo-prod-681,  cluster member-cluster2, cost: 0.811084427
```
<img width="857" alt="image" src="https://github.com/user-attachments/assets/21da9976-f172-4807-8331-fe9a79238396">

After turning off list deepcopy, the list time is reduced to 0.1s or even lower.
```
I1113 15:43:39.212238      17 overridemanager.go:182] applyNamespacedOverrides, list beta-moa-demo-prod-283,  cluster member-cluster1, cost: 0.040210384
I1113 15:43:39.251189      17 overridemanager.go:182] applyNamespacedOverrides, list beta-moa-demo-prod-97,  cluster member-cluster2, cost: 0.018000362
I1113 15:43:39.314731      17 overridemanager.go:182] applyNamespacedOverrides, list beta-moa-demo-prod-283,  cluster member-cluster2, cost: 0.023638913
```
<img width="629" alt="image" src="https://github.com/user-attachments/assets/263a2099-de17-421b-b946-b8b7e876c8d6">

**Which issue(s) this PR fixes**:
part of  https://github.com/karmada-io/karmada/issues/5790

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`Performance`: `karmada-controller-manager`: Significant performance improvements have been achieved by reducing deepcopy operations during list processes:
- ​​Binding Controller​​: Response time reduced by 50%
​​- Dependencies Controller​​: Execution time improved 5× faster 
​​- Detector Controller​​: Processing time cut by 50% 
```

