### PR TITLE
feat(stateful failover support) Introduce PurgeMode to GracefulEvictionTask in ResourceBinding

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -20054,6 +20054,10 @@
           "type": "string",
           "default": ""
         },
+        "purgeMode": {
+          "description": "PurgeMode represents how to deal with the legacy applications on the cluster from which the application is migrated. Valid options are \"Immediately\", \"Graciously\" and \"Never\".",
+          "type": "string"
+        },
         "reason": {
           "description": "Reason contains a programmatic identifier indicating the reason for the eviction. Producers may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
           "type": "string",

--- a/charts/karmada/_crds/bases/work/work.karmada.io_clusterresourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work/work.karmada.io_clusterresourcebindings.yaml
@@ -381,6 +381,16 @@ spec:
                       description: Producer indicates the controller who triggered
                         the eviction.
                       type: string
+                    purgeMode:
+                      description: |-
+                        PurgeMode represents how to deal with the legacy applications on the
+                        cluster from which the application is migrated.
+                        Valid options are "Immediately", "Graciously" and "Never".
+                      enum:
+                      - Immediately
+                      - Graciously
+                      - Never
+                      type: string
                     reason:
                       description: |-
                         Reason contains a programmatic identifier indicating the reason for the eviction.

--- a/charts/karmada/_crds/bases/work/work.karmada.io_resourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work/work.karmada.io_resourcebindings.yaml
@@ -381,6 +381,16 @@ spec:
                       description: Producer indicates the controller who triggered
                         the eviction.
                       type: string
+                    purgeMode:
+                      description: |-
+                        PurgeMode represents how to deal with the legacy applications on the
+                        cluster from which the application is migrated.
+                        Valid options are "Immediately", "Graciously" and "Never".
+                      enum:
+                      - Immediately
+                      - Graciously
+                      - Never
+                      type: string
                     reason:
                       description: |-
                         Reason contains a programmatic identifier indicating the reason for the eviction.

--- a/pkg/apis/work/v1alpha2/binding_types.go
+++ b/pkg/apis/work/v1alpha2/binding_types.go
@@ -240,6 +240,13 @@ type GracefulEvictionTask struct {
 	// +required
 	FromCluster string `json:"fromCluster"`
 
+	// PurgeMode represents how to deal with the legacy applications on the
+	// cluster from which the application is migrated.
+	// Valid options are "Immediately", "Graciously" and "Never".
+	// +kubebuilder:validation:Enum=Immediately;Graciously;Never
+	// +optional
+	PurgeMode policyv1alpha1.PurgeMode `json:"purgeMode,omitempty"`
+
 	// Replicas indicates the number of replicas should be evicted.
 	// Should be ignored for resource type that doesn't have replica.
 	// +optional

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -6832,6 +6832,13 @@ func schema_pkg_apis_work_v1alpha2_GracefulEvictionTask(ref common.ReferenceCall
 							Format:      "",
 						},
 					},
+					"purgeMode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PurgeMode represents how to deal with the legacy applications on the cluster from which the application is migrated. Valid options are \"Immediately\", \"Graciously\" and \"Never\".",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"replicas": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Replicas indicates the number of replicas should be evicted. Should be ignored for resource type that doesn't have replica.",


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
Part of #5788. This small PR adds PurgeMode to the GracefulEvictionTask as a prerequisite for ensuring scheduler skips clusters which triggered the failover.

**Does this PR introduce a user-facing change?**:
```release-note
Introduce PurgeMode to GracefulEvictionTask in ResourceBinding
```

