### PR TITLE
Support PurgeMode setting in evection tasks

### DIFF
--- a/pkg/apis/work/v1alpha2/binding_types_helper.go
+++ b/pkg/apis/work/v1alpha2/binding_types_helper.go
@@ -16,8 +16,11 @@ limitations under the License.
 
 package v1alpha2
 
+import policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+
 // TaskOptions represents options for GracefulEvictionTasks.
 type TaskOptions struct {
+	purgeMode          policyv1alpha1.PurgeMode
 	producer           string
 	reason             string
 	message            string
@@ -36,6 +39,13 @@ func NewTaskOptions(opts ...Option) *TaskOptions {
 	}
 
 	return &options
+}
+
+// WithPurgeMode sets the purgeMode for TaskOptions
+func WithPurgeMode(purgeMode policyv1alpha1.PurgeMode) Option {
+	return func(o *TaskOptions) {
+		o.purgeMode = purgeMode
+	}
 }
 
 // WithProducer sets the producer for TaskOptions
@@ -154,6 +164,7 @@ func (s *ResourceBindingSpec) GracefulEvictCluster(name string, options *TaskOpt
 	evictingCluster := evictCluster.DeepCopy()
 	evictionTask := GracefulEvictionTask{
 		FromCluster:        evictingCluster.Name,
+		PurgeMode:          options.purgeMode,
 		Reason:             options.reason,
 		Message:            options.message,
 		Producer:           options.producer,

--- a/pkg/apis/work/v1alpha2/binding_types_helper_test.go
+++ b/pkg/apis/work/v1alpha2/binding_types_helper_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"k8s.io/utils/ptr"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 )
 
 func TestResourceBindingSpec_TargetContains(t *testing.T) {
@@ -172,6 +174,7 @@ func TestResourceBindingSpec_GracefulEvictCluster(t *testing.T) {
 			},
 			EvictEvent: GracefulEvictionTask{
 				FromCluster: "m1",
+				PurgeMode:   policyv1alpha1.Immediately,
 				Reason:      EvictionReasonTaintUntolerated,
 				Message:     "graceful eviction",
 				Producer:    EvictionProducerTaintManager,
@@ -181,6 +184,7 @@ func TestResourceBindingSpec_GracefulEvictCluster(t *testing.T) {
 				GracefulEvictionTasks: []GracefulEvictionTask{
 					{
 						FromCluster: "m1",
+						PurgeMode:   policyv1alpha1.Immediately,
 						Replicas:    ptr.To[int32](1),
 						Reason:      EvictionReasonTaintUntolerated,
 						Message:     "graceful eviction",
@@ -196,6 +200,7 @@ func TestResourceBindingSpec_GracefulEvictCluster(t *testing.T) {
 			},
 			EvictEvent: GracefulEvictionTask{
 				FromCluster: "m2",
+				PurgeMode:   policyv1alpha1.Never,
 				Reason:      EvictionReasonTaintUntolerated,
 				Message:     "graceful eviction",
 				Producer:    EvictionProducerTaintManager,
@@ -205,6 +210,7 @@ func TestResourceBindingSpec_GracefulEvictCluster(t *testing.T) {
 				GracefulEvictionTasks: []GracefulEvictionTask{
 					{
 						FromCluster: "m2",
+						PurgeMode:   policyv1alpha1.Never,
 						Replicas:    ptr.To[int32](2),
 						Reason:      EvictionReasonTaintUntolerated,
 						Message:     "graceful eviction",
@@ -220,6 +226,7 @@ func TestResourceBindingSpec_GracefulEvictCluster(t *testing.T) {
 			},
 			EvictEvent: GracefulEvictionTask{
 				FromCluster: "m3",
+				PurgeMode:   policyv1alpha1.Graciously,
 				Reason:      EvictionReasonTaintUntolerated,
 				Message:     "graceful eviction",
 				Producer:    EvictionProducerTaintManager,
@@ -229,6 +236,7 @@ func TestResourceBindingSpec_GracefulEvictCluster(t *testing.T) {
 				GracefulEvictionTasks: []GracefulEvictionTask{
 					{
 						FromCluster: "m3",
+						PurgeMode:   policyv1alpha1.Graciously,
 						Replicas:    ptr.To[int32](3),
 						Reason:      EvictionReasonTaintUntolerated,
 						Message:     "graceful eviction",
@@ -245,6 +253,7 @@ func TestResourceBindingSpec_GracefulEvictCluster(t *testing.T) {
 			},
 			EvictEvent: GracefulEvictionTask{
 				FromCluster: "m3",
+				PurgeMode:   policyv1alpha1.Graciously,
 				Reason:      EvictionReasonTaintUntolerated,
 				Message:     "graceful eviction",
 				Producer:    EvictionProducerTaintManager,
@@ -257,6 +266,7 @@ func TestResourceBindingSpec_GracefulEvictCluster(t *testing.T) {
 					},
 					{
 						FromCluster: "m3",
+						PurgeMode:   policyv1alpha1.Graciously,
 						Replicas:    ptr.To[int32](3),
 						Reason:      EvictionReasonTaintUntolerated,
 						Message:     "graceful eviction",
@@ -286,6 +296,7 @@ func TestResourceBindingSpec_GracefulEvictCluster(t *testing.T) {
 			},
 			EvictEvent: GracefulEvictionTask{
 				FromCluster: "m1",
+				PurgeMode:   policyv1alpha1.Graciously,
 				Replicas:    ptr.To[int32](1),
 				Reason:      EvictionReasonTaintUntolerated,
 				Message:     "graceful eviction v2",
@@ -309,7 +320,11 @@ func TestResourceBindingSpec_GracefulEvictCluster(t *testing.T) {
 	for _, test := range tests {
 		tc := test
 		t.Run(tc.Name, func(t *testing.T) {
-			tc.InputSpec.GracefulEvictCluster(tc.EvictEvent.FromCluster, NewTaskOptions(WithProducer(tc.EvictEvent.Producer), WithReason(tc.EvictEvent.Reason), WithMessage(tc.EvictEvent.Message)))
+			tc.InputSpec.GracefulEvictCluster(tc.EvictEvent.FromCluster, NewTaskOptions(
+				WithPurgeMode(tc.EvictEvent.PurgeMode),
+				WithProducer(tc.EvictEvent.Producer),
+				WithReason(tc.EvictEvent.Reason),
+				WithMessage(tc.EvictEvent.Message)))
 
 			if !reflect.DeepEqual(tc.InputSpec.Clusters, tc.ExpectSpec.Clusters) {
 				t.Fatalf("expect clusters: %v, but got: %v", tc.ExpectSpec.Clusters, tc.InputSpec.Clusters)

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -7393,6 +7393,13 @@ func schema_pkg_apis_work_v1alpha2_TaskOptions(ref common.ReferenceCallback) com
 				Description: "TaskOptions represents options for GracefulEvictionTasks.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"purgeMode": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
 					"producer": {
 						SchemaProps: spec.SchemaProps{
 							Default: "",
@@ -7427,7 +7434,7 @@ func schema_pkg_apis_work_v1alpha2_TaskOptions(ref common.ReferenceCallback) com
 						},
 					},
 				},
-				Required: []string{"producer", "reason", "message", "gracePeriodSeconds", "suppressDeletion"},
+				Required: []string{"purgeMode", "producer", "reason", "message", "gracePeriodSeconds", "suppressDeletion"},
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

update GracefulEvictCluster() to set PurgeMode during eviction process

**Which issue(s) this PR fixes**:
Part of #5788

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
update GracefulEvictCluster() to set PurgeMode during eviction process
```

