### PR TITLE
fix operatore ci fail for invalid crdtarball

### DIFF
--- a/hack/deploy-karmada-operator.sh
+++ b/hack/deploy-karmada-operator.sh
@@ -55,7 +55,7 @@ export REGISTRY="docker.io/karmada"
 make image-karmada-operator GOOS="linux" --directory=.
 
 # load the karmada-operator images
-kind load docker-image "${REGISTRY}/karmada-controller-manager:${VERSION}" --name="${CONTEXT_NAME}"
+kind load docker-image "${REGISTRY}/karmada-operator:${VERSION}" --name="${CONTEXT_NAME}"
 
 # create namespace `karmada-system`
 kubectl --kubeconfig="${KUBECONFIG}" --context="${CONTEXT_NAME}" apply -f "${REPO_ROOT}/artifacts/deploy/namespace.yaml"

--- a/hack/local-up-karmada-by-operator.sh
+++ b/hack/local-up-karmada-by-operator.sh
@@ -156,7 +156,7 @@ tar -zcvf ../../crds.tar.gz crds
 cd -
 
 # copy the local crds.tar.gz file to the specified path of the karmada-operator, so that the karmada-operator will skip the step of downloading CRDs.
-CRDTARBALL_URL="local"
+CRDTARBALL_URL="http://local"
 DATA_DIR="/var/lib/karmada"
 CRD_CACHE_DIR=$(getCrdsDir "${DATA_DIR}" "${CRDTARBALL_URL}")
 OPERATOR_POD_NAME=$(kubectl --kubeconfig="${MAIN_KUBECONFIG}" --context="${HOST_CLUSTER_NAME}" get pods -n ${KARMADA_SYSTEM_NAMESPACE} -l karmada-app=karmada-operator -o custom-columns=NAME:.metadata.name --no-headers)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Due to the merge of PR #5614, the URL for the crdtarball used by `local-up-karmada-by-operator.sh` has become invalid, causing CI failures.
Fix as follows:
- change url `local` to `http:local`
- correct the image name


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

