### PR TITLE
Standardize the naming conventions for karmada system roles

### DIFF
--- a/artifacts/deploy/admin-clusterrole-aggregation.yaml
+++ b/artifacts/deploy/admin-clusterrole-aggregation.yaml
@@ -4,13 +4,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    # refer to https://kubernetes.io/docs/reference/access-authn-authz/rbac/#auto-reconciliation
-    # and https://kubernetes.io/docs/reference/access-authn-authz/rbac/#kubectl-auth-reconcile
-    rbac.authorization.kubernetes.io/autoupdate: "true"
   labels:
-    # refer to https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
-    kubernetes.io/bootstrapping: rbac-defaults
+    karmada.io/bootstrapping: rbac-defaults
     # used to aggregate rules to view clusterrole
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: karmada-view
@@ -73,13 +68,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    # refer to https://kubernetes.io/docs/reference/access-authn-authz/rbac/#auto-reconciliation
-    # and https://kubernetes.io/docs/reference/access-authn-authz/rbac/#kubectl-auth-reconcile
-    rbac.authorization.kubernetes.io/autoupdate: "true"
   labels:
-    # refer to https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
-    kubernetes.io/bootstrapping: rbac-defaults
+    karmada.io/bootstrapping: rbac-defaults
     # used to aggregate rules to view clusterrole
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: karmada-edit

--- a/artifacts/deploy/bootstrap-token-configuration.yaml
+++ b/artifacts/deploy/bootstrap-token-configuration.yaml
@@ -16,7 +16,9 @@ data:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: karmada:bootstrap-signer-clusterinfo
+  labels:
+    karmada.io/bootstrapping: rbac-defaults
+  name: system:karmada:bootstrap-signer-clusterinfo
   namespace: kube-public
 rules:
 - apiGroups:
@@ -32,12 +34,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: karmada:bootstrap-signer-clusterinfo
+  labels:
+    karmada.io/bootstrapping: rbac-defaults
+  name: system:karmada:bootstrap-signer-clusterinfo
   namespace: kube-public
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: karmada:bootstrap-signer-clusterinfo
+  name: system:karmada:bootstrap-signer-clusterinfo
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
@@ -47,7 +51,9 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: karmada:agent-bootstrap
+  labels:
+    karmada.io/bootstrapping: rbac-defaults
+  name: system:karmada:agent-bootstrap
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -61,7 +67,9 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: karmada:agent-autoapprove-bootstrap
+  labels:
+    karmada.io/bootstrapping: rbac-defaults
+  name: system:karmada:agent-autoapprove-bootstrap
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -75,7 +83,9 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: karmada:agent-autoapprove-certificate-rotation
+  labels:
+    karmada.io/bootstrapping: rbac-defaults
+  name: system:karmada:agent-autoapprove-certificate-rotation
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -89,6 +99,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    karmada.io/bootstrapping: rbac-defaults
   name: system:karmada:agent
 rules:
 - apiGroups:
@@ -176,6 +188,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    karmada.io/bootstrapping: rbac-defaults
   name: system:karmada:agent
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/karmada/templates/_karmada_bootstrap_token_configuration.tpl
+++ b/charts/karmada/templates/_karmada_bootstrap_token_configuration.tpl
@@ -23,7 +23,7 @@ data:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: karmada:bootstrap-signer-clusterinfo
+  name: system:karmada:bootstrap-signer-clusterinfo
   namespace: kube-public
   {{- if "karmada.commonLabels" }}
   labels:
@@ -42,7 +42,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: karmada:bootstrap-signer-clusterinfo
+  name: system:karmada:bootstrap-signer-clusterinfo
   namespace: kube-public
   {{- if "karmada.commonLabels" }}
   labels:
@@ -51,7 +51,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: karmada:bootstrap-signer-clusterinfo
+  name: system:karmada:bootstrap-signer-clusterinfo
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
@@ -60,7 +60,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: karmada:agent-bootstrap
+  name: system:karmada:agent-bootstrap
   {{- if "karmada.commonLabels" }}
   labels:
     {{- include "karmada.commonLabels" . | nindent 4 }}
@@ -77,7 +77,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: karmada:agent-autoapprove-bootstrap
+  name: system:karmada:agent-autoapprove-bootstrap
   {{- if "karmada.commonLabels" }}
   labels:
     {{- include "karmada.commonLabels" . | nindent 4 }}
@@ -94,7 +94,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: karmada:agent-autoapprove-certificate-rotation
+  name: system:karmada:agent-autoapprove-certificate-rotation
   {{- if "karmada.commonLabels" }}
   labels:
     {{- include "karmada.commonLabels" . | nindent 4 }}

--- a/pkg/karmadactl/cmdinit/bootstraptoken/agent/tlsbootstrap.go
+++ b/pkg/karmadactl/cmdinit/bootstraptoken/agent/tlsbootstrap.go
@@ -29,13 +29,13 @@ const (
 	// KarmadaAgentBootstrapperClusterRoleName defines the name of the auto-bootstrapped ClusterRole for letting someone post a CSR
 	KarmadaAgentBootstrapperClusterRoleName = "system:node-bootstrapper"
 	// KarmadaAgentBootstrap defines the name of the ClusterRoleBinding that lets Karmada Agent post CSRs
-	KarmadaAgentBootstrap = "karmada:agent-bootstrap"
+	KarmadaAgentBootstrap = "system:karmada:agent-bootstrap"
 	// KarmadaAgentGroup defines the group of Karmada Agent
 	KarmadaAgentGroup = "system:nodes"
 	// KarmadaAgentAutoApproveBootstrapClusterRoleBinding defines the name of the ClusterRoleBinding that makes the csrapprover approve agent CSRs
-	KarmadaAgentAutoApproveBootstrapClusterRoleBinding = "karmada:agent-autoapprove-bootstrap"
+	KarmadaAgentAutoApproveBootstrapClusterRoleBinding = "system:karmada:agent-autoapprove-bootstrap"
 	// KarmadaAgentAutoApproveCertificateRotationClusterRoleBinding defines name of the ClusterRoleBinding that makes the csrapprover approve agent auto rotated CSRs
-	KarmadaAgentAutoApproveCertificateRotationClusterRoleBinding = "karmada:agent-autoapprove-certificate-rotation"
+	KarmadaAgentAutoApproveCertificateRotationClusterRoleBinding = "system:karmada:agent-autoapprove-certificate-rotation"
 	// CSRAutoApprovalClusterRoleName defines the name of the auto-bootstrapped ClusterRole for making the csrapprover controller auto-approve the CSR
 	CSRAutoApprovalClusterRoleName = "system:certificates.k8s.io:certificatesigningrequests:nodeclient"
 	// KarmadaAgentSelfCSRAutoApprovalClusterRoleName is a role for automatic CSR approvals for automatically rotated agent certificates

--- a/pkg/karmadactl/cmdinit/bootstraptoken/clusterinfo/clusterinfo.go
+++ b/pkg/karmadactl/cmdinit/bootstraptoken/clusterinfo/clusterinfo.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	// BootstrapSignerClusterRoleName sets the name for the ClusterRole that allows access to ConfigMaps in the kube-public ns
-	BootstrapSignerClusterRoleName = "karmada:bootstrap-signer-clusterinfo"
+	BootstrapSignerClusterRoleName = "system:karmada:bootstrap-signer-clusterinfo"
 )
 
 // CreateBootstrapConfigMapIfNotExists creates the kube-public ConfigMap if it doesn't exist already


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup 
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
refer to https://github.com/karmada-io/karmada/pull/5793#issuecomment-2484577844
- standardize the naming of Karmada system roles by prefixing them with `system:karmada`
- rename  label `kubernetes.io/bootstrapping: rbac-defaults` to `karmada.io/bootstrapping: rbac-defaults`
- remove annotation `rbac.authorization.kubernetes.io/autoupdate: "true"`
-  standardize the group for karmada bootstrapping bearer tokens  by prefixing them with `system:bootstrappers:karmada`


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

