### PR TITLE
Fix: karmada-metrics-adapter use the correct certificate when deploye…

### DIFF
--- a/pkg/karmadactl/addons/metricsadapter/manifests.go
+++ b/pkg/karmadactl/addons/metricsadapter/manifests.go
@@ -56,6 +56,8 @@ spec:
             - --authentication-kubeconfig=/etc/kubeconfig
             - --authorization-kubeconfig=/etc/kubeconfig
             - --client-ca-file=/etc/karmada/pki/ca.crt
+            - --tls-cert-file=/etc/karmada/pki/karmada.crt
+            - --tls-private-key-file=/etc/karmada/pki/karmada.key
             - --audit-log-path=-
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
-->

/kind bug


**What this PR does / why we need it**:

Currently, karmadactl blundles its own manifest for the metrics-adapter component, which is lacking the TLS flags. Thus it generates a local self-signed certificate, which karmada-apiserver doesn't trust, therefore breaking the metrics endpoint (`kubectl top node` for example).

**Which issue(s) this PR fixes**:
Fixes #5805

**Special notes for your reviewer**:

NOTE: Ask asked in the #5827 PR, I'm submitting a new PR for the master branch specifically.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Fix: karmada-metrics-adapter use the correct certificate when deployed via karmadactl
```