### PR TITLE
Automated cherry pick of #5840: Fix: karmada-metrics-adapter use the correct certificate when

### DIFF
--- a/pkg/karmadactl/addons/metricsadapter/manifests.go
+++ b/pkg/karmadactl/addons/metricsadapter/manifests.go
@@ -56,6 +56,8 @@ spec:
             - --authentication-kubeconfig=/etc/kubeconfig
             - --authorization-kubeconfig=/etc/kubeconfig
             - --client-ca-file=/etc/karmada/pki/ca.crt
+            - --tls-cert-file=/etc/karmada/pki/karmada.crt
+            - --tls-private-key-file=/etc/karmada/pki/karmada.key
             - --audit-log-path=-
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0


### PR DESCRIPTION
Cherry pick of #5840 on release-1.11.
#5840: Fix: karmada-metrics-adapter use the correct certificate when
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmadactl`: Fixed `karmada-metrics-adapter` use the incorrect certificate issue when deployed via karmadactl `init`.
```