### PR TITLE
Enable the deprecation check which was disabled for version upgrade

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,10 +82,6 @@ linters-settings:
       - name: unexported-return
       - name: time-naming
       - name: empty-block
-  staticcheck:
-    # TODO(@RainbowMango): Disable deprecation check temporary for Kubernetes dependency update.
-    # This is tracked by https://github.com/karmada-io/karmada/issues/5796.
-    checks: ["all", "-SA1019"]
 
 issues:
   # The list of ids of default excludes to include or disable. By default it's empty.

--- a/cmd/aggregated-apiserver/app/options/options.go
+++ b/cmd/aggregated-apiserver/app/options/options.go
@@ -130,11 +130,11 @@ func (o *Options) Run(ctx context.Context) error {
 	}
 
 	server.GenericAPIServer.AddPostStartHookOrDie("start-aggregated-server-informers", func(context genericapiserver.PostStartHookContext) error {
-		config.GenericConfig.SharedInformerFactory.Start(context.StopCh)
+		config.GenericConfig.SharedInformerFactory.Start(context.Done())
 		return nil
 	})
 
-	return server.GenericAPIServer.PrepareRun().Run(ctx.Done())
+	return server.GenericAPIServer.PrepareRun().RunWithContext(ctx)
 }
 
 // Config returns config for the api server given Options

--- a/cmd/karmada-search/app/karmada-search.go
+++ b/cmd/karmada-search/app/karmada-search.go
@@ -124,12 +124,12 @@ func run(ctx context.Context, o *options.Options, registryOptions ...Option) err
 	}
 
 	server.GenericAPIServer.AddPostStartHookOrDie("start-karmada-search-informers", func(context genericapiserver.PostStartHookContext) error {
-		config.GenericConfig.SharedInformerFactory.Start(context.StopCh)
+		config.GenericConfig.SharedInformerFactory.Start(context.Done())
 		return nil
 	})
 
 	server.GenericAPIServer.AddPostStartHookOrDie("start-karmada-informers", func(context genericapiserver.PostStartHookContext) error {
-		config.ExtraConfig.KarmadaSharedInformerFactory.Start(context.StopCh)
+		config.ExtraConfig.KarmadaSharedInformerFactory.Start(context.Done())
 		return nil
 	})
 
@@ -138,14 +138,14 @@ func run(ctx context.Context, o *options.Options, registryOptions ...Option) err
 	if config.ExtraConfig.Controller != nil {
 		server.GenericAPIServer.AddPostStartHookOrDie("start-karmada-search-controller", func(context genericapiserver.PostStartHookContext) error {
 			// start ResourceRegistry controller
-			config.ExtraConfig.Controller.Start(context.StopCh)
+			config.ExtraConfig.Controller.Start(context.Done())
 			return nil
 		})
 	}
 
 	if config.ExtraConfig.ProxyController != nil {
 		server.GenericAPIServer.AddPostStartHookOrDie("start-karmada-proxy-controller", func(context genericapiserver.PostStartHookContext) error {
-			config.ExtraConfig.ProxyController.Start(context.StopCh)
+			config.ExtraConfig.ProxyController.Start(context.Done())
 			return nil
 		})
 
@@ -155,7 +155,7 @@ func run(ctx context.Context, o *options.Options, registryOptions ...Option) err
 		})
 	}
 
-	return server.GenericAPIServer.PrepareRun().Run(ctx.Done())
+	return server.GenericAPIServer.PrepareRun().RunWithContext(ctx)
 }
 
 // `config` returns config for the api server given Options

--- a/cmd/metrics-adapter/app/options/options.go
+++ b/cmd/metrics-adapter/app/options/options.go
@@ -114,9 +114,9 @@ func (o *Options) Config(stopCh <-chan struct{}) (*metricsadapter.MetricsServer,
 
 	err = server.GenericAPIServer.AddPostStartHook("start-karmada-informers", func(context genericapiserver.PostStartHookContext) error {
 		kubeFactory.Core().V1().Secrets().Informer()
-		kubeFactory.Start(context.StopCh)
-		kubeFactory.WaitForCacheSync(context.StopCh)
-		factory.Start(context.StopCh)
+		kubeFactory.Start(context.Done())
+		kubeFactory.WaitForCacheSync(context.Done())
+		factory.Start(context.Done())
 		return nil
 	})
 	if err != nil {

--- a/pkg/util/grpcconnection/config.go
+++ b/pkg/util/grpcconnection/config.go
@@ -103,6 +103,8 @@ func (s *ServerConfig) NewServer() (*grpc.Server, error) {
 // DialWithTimeOut will attempt to create a client connection based on the given targets, one at a time, until a client connection is successfully established.
 func (c *ClientConfig) DialWithTimeOut(paths []string, timeout time.Duration) (*grpc.ClientConn, error) {
 	opts := []grpc.DialOption{
+		// grpc.WithBlock is deprecated. TODO: Perhaps need to reconsider the approach in a future PR
+		//nolint:staticcheck
 		grpc.WithBlock(),
 	}
 
@@ -155,6 +157,8 @@ func createGRPCConnection(path string, timeout time.Duration, opts ...grpc.DialO
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
+	// grpc.DialContext is deprecated. TODO: Perhaps need to reconsider the approach in a future PR
+	//nolint:staticcheck
 	cc, err := grpc.DialContext(ctx, path, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("dial %s error: %v", path, err)


### PR DESCRIPTION
**What type of PR is this?**
/kind deprecation
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Re-enable the deprecation check which was disabled for the version upgrade.

**Which issue(s) this PR fixes**:
Part of #5796 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Replace `PostStartHookContext.StopCh` with `PostStartHookContext.Done` since `StopCh` is deprecated.
Replace `Run(ctx.Done())` with `RunWithContext`.
```

