### PR TITLE
feat(dependenciesdistributor):  remove dependenciesdistributor concurrentreconciles

### DIFF
--- a/pkg/dependenciesdistributor/dependencies_distributor.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor.go
@@ -665,8 +665,7 @@ func (d *DependenciesDistributor) SetupWithManager(mgr controllerruntime.Manager
 				},
 			}).
 			WithOptions(controller.Options{
-				RateLimiter:             ratelimiterflag.DefaultControllerRateLimiter[controllerruntime.Request](d.RateLimiterOptions),
-				MaxConcurrentReconciles: 2,
+				RateLimiter: ratelimiterflag.DefaultControllerRateLimiter[controllerruntime.Request](d.RateLimiterOptions),
 			}).
 			WatchesRawSource(source.Channel(d.genericEvent, &handler.TypedEnqueueRequestForObject[*workv1alpha2.ResourceBinding]{})).
 			Complete(d),


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
set concurrentreconciles for dependencies-distributor controller, which previously was a fixed value of 2;
value same as --concurrent-resourcebinding-syncs flag.

**Which issue(s) this PR fixes**:
part of  https://github.com/karmada-io/karmada/issues/5790

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

