### PR TITLE
let rb status controller onCreate predicate return true

### DIFF
--- a/pkg/controllers/status/common.go
+++ b/pkg/controllers/status/common.go
@@ -43,7 +43,13 @@ import (
 )
 
 var bindingPredicateFn = builder.WithPredicates(predicate.Funcs{
-	CreateFunc: func(event.CreateEvent) bool { return false },
+	CreateFunc: func(event.CreateEvent) bool {
+		// Although we don't need to process the ResourceBinding immediately upon its creation,
+		// but it's necessary to ensure that all existing ResourceBindings are processed
+		// uniformly once when the component restarts.
+		// This guarantees that no ResourceBinding is missed after a controller restart.
+		return true
+	},
 	UpdateFunc: func(e event.UpdateEvent) bool {
 		var oldResourceVersion, newResourceVersion string
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind bug


**What this PR does / why we need it**:

Currently, the rb/crb status controller watchs rb/crb and work, but the predicates for creating events are all false, which means that if the work status is up to date, but the queue of the rb/crb status controller is not cleared, and it crashes, these unprocessed items will not be requeued after the next restart, and the status of rb/crb and workload will not be updated, until the relevant member cluster objects update the status again, triggering the work status controller and rb/crb status controller to process again.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Fixed the corner case where the reconciliation of aggregating status might be missed in case of component restart.
```

