### PR TITLE
fix(cluster):  remove related metrics label when cluster is deleted

### DIFF
--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -135,6 +135,7 @@ func (c *ClusterStatusController) Reconcile(ctx context.Context, req controllerr
 			c.GenericInformerManager.Stop(req.NamespacedName.Name)
 			c.TypedInformerManager.Stop(req.NamespacedName.Name)
 			c.clusterConditionCache.delete(req.NamespacedName.Name)
+			metrics.CleanupMetricsForCluster(req.NamespacedName.Name)
 
 			// stop lease controller after the cluster is gone.
 			// only used for clusters in Pull mode because no need to set up lease syncing for Push clusters.

--- a/pkg/metrics/cluster.go
+++ b/pkg/metrics/cluster.go
@@ -135,6 +135,20 @@ func RecordClusterSyncStatusDuration(cluster *v1alpha1.Cluster, startTime time.T
 	clusterSyncStatusDuration.WithLabelValues(cluster.Name).Observe(utilmetrics.DurationInSeconds(startTime))
 }
 
+// CleanupMetricsForCluster removes the cluster status metrics after the cluster is deleted.
+func CleanupMetricsForCluster(clusterName string) {
+	clusterReadyGauge.DeleteLabelValues(clusterName)
+	clusterTotalNodeNumberGauge.DeleteLabelValues(clusterName)
+	clusterReadyNodeNumberGauge.DeleteLabelValues(clusterName)
+	clusterMemoryAllocatableGauge.DeleteLabelValues(clusterName)
+	clusterCPUAllocatableGauge.DeleteLabelValues(clusterName)
+	clusterPodAllocatableGauge.DeleteLabelValues(clusterName)
+	clusterMemoryAllocatedGauge.DeleteLabelValues(clusterName)
+	clusterCPUAllocatedGauge.DeleteLabelValues(clusterName)
+	clusterPodAllocatedGauge.DeleteLabelValues(clusterName)
+	clusterSyncStatusDuration.DeleteLabelValues(clusterName)
+}
+
 // ClusterCollectors returns the collectors about clusters.
 func ClusterCollectors() []prometheus.Collector {
 	return []prometheus.Collector{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/karmada/issues/5843

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`Instrumentation`: The cluster status-related metrics, emitting from `karmada-controller-manager`, will be cleaned up after the cluster is removed.
```

