### PR TITLE
fix: `ResourceBinding` to be `FullyApplied` only when `Work` Status items are considered `Healthy`

### DIFF
--- a/pkg/util/helper/workstatus.go
+++ b/pkg/util/helper/workstatus.go
@@ -283,6 +283,10 @@ func worksFullyApplied(aggregatedStatuses []workv1alpha2.AggregatedStatusItem, t
 			return false
 		}
 
+		if aggregatedStatusItem.Health != workv1alpha2.ResourceHealthy {
+			return false
+		}
+
 		if !targetClusters.Has(aggregatedStatusItem.ClusterName) {
 			return false
 		}


### PR DESCRIPTION
**What type of PR is this?**
/king bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Fixes ResouceBinding claiming to be fully applied before work status items are evaluated as Healthy

**Which issue(s) this PR fixes**:
Fixes #5867

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

