### PR TITLE
Automated cherry pick of #5865: let rb status controller onCreate predicate return true

### DIFF
--- a/pkg/controllers/status/common.go
+++ b/pkg/controllers/status/common.go
@@ -43,7 +43,13 @@ import (
 )
 
 var bindingPredicateFn = builder.WithPredicates(predicate.Funcs{
-	CreateFunc: func(event.CreateEvent) bool { return false },
+	CreateFunc: func(event.CreateEvent) bool {
+		// Although we don't need to process the ResourceBinding immediately upon its creation,
+		// but it's necessary to ensure that all existing ResourceBindings are processed
+		// uniformly once when the component restarts.
+		// This guarantees that no ResourceBinding is missed after a controller restart.
+		return true
+	},
 	UpdateFunc: func(e event.UpdateEvent) bool {
 		var oldResourceVersion, newResourceVersion string
 


### PR DESCRIPTION
Cherry pick of #5865 on release-1.11.
#5865: let rb status controller onCreate predicate return true
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`: Fixed the corner case where the reconciliation of aggregating status might be missed in case of component restart.
```