### PR TITLE
Cleanup works from cluster if purgemode is immediately

### DIFF
--- a/pkg/util/helper/binding.go
+++ b/pkg/util/helper/binding.go
@@ -186,7 +186,11 @@ func ObtainBindingSpecExistingClusters(bindingSpec workv1alpha2.ResourceBindingS
 	}
 
 	for _, task := range bindingSpec.GracefulEvictionTasks {
-		clusterNames.Insert(task.FromCluster)
+		// EvictionTasks with Immediately PurgeMode should not be treated as existing clusters
+		// Work on those clusters should be removed immediately and treated as orphans
+		if task.PurgeMode != policyv1alpha1.Immediately {
+			clusterNames.Insert(task.FromCluster)
+		}
 	}
 
 	return clusterNames

--- a/pkg/util/helper/binding_test.go
+++ b/pkg/util/helper/binding_test.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
@@ -334,6 +335,36 @@ func TestObtainBindingSpecExistingClusters(t *testing.T) {
 				},
 			},
 			want: sets.New("member1", "member2", "member3"),
+		},
+		{
+			name: "unique cluster names with GracefulEvictionTasks with PurgeMode Immediately",
+			bindingSpec: workv1alpha2.ResourceBindingSpec{
+				Clusters: []workv1alpha2.TargetCluster{
+					{
+						Name:     "member1",
+						Replicas: 2,
+					},
+					{
+						Name:     "member2",
+						Replicas: 3,
+					},
+				},
+				GracefulEvictionTasks: []workv1alpha2.GracefulEvictionTask{
+					{
+						FromCluster: "member3",
+						PurgeMode:   policyv1alpha1.Immediately,
+					},
+					{
+						FromCluster: "member4",
+						PurgeMode:   policyv1alpha1.Graciously,
+					},
+					{
+						FromCluster: "member5",
+						PurgeMode:   policyv1alpha1.Never,
+					},
+				},
+			},
+			want: sets.New("member1", "member2", "member4", "member5"),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Within the [binding controller](https://github.com/karmada-io/karmada/blob/38ee277de7aaaf4f93fec42d49bfc71cc4b0be76/pkg/controllers/binding/binding_controller.go#L145-L164) and [cluster binding controller](https://github.com/karmada-io/karmada/blob/38ee277de7aaaf4f93fec42d49bfc71cc4b0be76/pkg/controllers/binding/cluster_resource_binding_controller.go#L144-L160) we find and remove orphan works by checking the works against the existing clusters.

Existing clusters are populated by joining the resource binding's `spec.Clusters` field with any clusters that are found in the GracefulEvictionTasks. With the addition of PurgeMode, we should now check that the PurgeMode is not Immediately when populating the existing clusters. 

If the cluster has an eviction task with Immediately purgeMode, we should treat the work on that cluster as an orphan and evict it.

**Which issue(s) this PR fixes**:
Part of #5788 

**Does this PR introduce a user-facing change?**:
```release-note
Cleanup works from clusters with eviction task when purge mode is immediately
```