### PR TITLE
Add stateful application failover status injection feature gate

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -18291,7 +18291,7 @@
           "type": "string"
         },
         "statePreservation": {
-          "description": "StatePreservation defines the policy for preserving and restoring state data during failover events for stateful applications.\n\nWhen an application fails over from one cluster to another, this policy enables the extraction of critical data from the original resource configuration. Upon successful migration, the extracted data is then re-injected into the new resource, ensuring that the application can resume operation with its previous state intact. This is particularly useful for stateful applications where maintaining data consistency across failover events is crucial. If not specified, means no state data will be preserved.",
+          "description": "StatePreservation defines the policy for preserving and restoring state data during failover events for stateful applications.\n\nWhen an application fails over from one cluster to another, this policy enables the extraction of critical data from the original resource configuration. Upon successful migration, the extracted data is then re-injected into the new resource, ensuring that the application can resume operation with its previous state intact. This is particularly useful for stateful applications where maintaining data consistency across failover events is crucial. If not specified, means no state data will be preserved.\n\nNote: This requires the StatefulFailoverInjection feature gate to be enabled, which is alpha.",
           "$ref": "#/definitions/com.github.karmada-io.karmada.pkg.apis.policy.v1alpha1.StatePreservation"
         }
       }

--- a/artifacts/deploy/karmada-controller-manager.yaml
+++ b/artifacts/deploy/karmada-controller-manager.yaml
@@ -30,7 +30,7 @@ spec:
             - --cluster-status-update-frequency=10s
             - --failover-eviction-timeout=30s
             - --controllers=*,hpaScaleTargetMarker,deploymentReplicasSyncer
-            - --feature-gates=PropagationPolicyPreemption=true,MultiClusterService=true
+            - --feature-gates=PropagationPolicyPreemption=true,MultiClusterService=true,StatefulFailoverInjection=true
             - --health-probe-bind-address=0.0.0.0:10357
             - --v=4
           livenessProbe:

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_clusterpropagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_clusterpropagationpolicies.yaml
@@ -177,6 +177,9 @@ spec:
                           This is particularly useful for stateful applications where maintaining data
                           consistency across failover events is crucial.
                           If not specified, means no state data will be preserved.
+
+                          Note: This requires the StatefulFailoverInjection feature gate to be enabled,
+                          which is alpha.
                         properties:
                           rules:
                             description: |-

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_propagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_propagationpolicies.yaml
@@ -174,6 +174,9 @@ spec:
                           This is particularly useful for stateful applications where maintaining data
                           consistency across failover events is crucial.
                           If not specified, means no state data will be preserved.
+
+                          Note: This requires the StatefulFailoverInjection feature gate to be enabled,
+                          which is alpha.
                         properties:
                           rules:
                             description: |-

--- a/charts/karmada/_crds/bases/work/work.karmada.io_clusterresourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work/work.karmada.io_clusterresourcebindings.yaml
@@ -339,6 +339,9 @@ spec:
                           This is particularly useful for stateful applications where maintaining data
                           consistency across failover events is crucial.
                           If not specified, means no state data will be preserved.
+
+                          Note: This requires the StatefulFailoverInjection feature gate to be enabled,
+                          which is alpha.
                         properties:
                           rules:
                             description: |-

--- a/charts/karmada/_crds/bases/work/work.karmada.io_resourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work/work.karmada.io_resourcebindings.yaml
@@ -339,6 +339,9 @@ spec:
                           This is particularly useful for stateful applications where maintaining data
                           consistency across failover events is crucial.
                           If not specified, means no state data will be preserved.
+
+                          Note: This requires the StatefulFailoverInjection feature gate to be enabled,
+                          which is alpha.
                         properties:
                           rules:
                             description: |-

--- a/pkg/apis/policy/v1alpha1/propagation_types.go
+++ b/pkg/apis/policy/v1alpha1/propagation_types.go
@@ -336,6 +336,9 @@ type ApplicationFailoverBehavior struct {
 	// This is particularly useful for stateful applications where maintaining data
 	// consistency across failover events is crucial.
 	// If not specified, means no state data will be preserved.
+	//
+	// Note: This requires the StatefulFailoverInjection feature gate to be enabled,
+	// which is alpha.
 	// +optional
 	StatePreservation *StatePreservation `json:"statePreservation,omitempty"`
 }

--- a/pkg/controllers/applicationfailover/common.go
+++ b/pkg/controllers/applicationfailover/common.go
@@ -192,18 +192,20 @@ func buildTaskOptions(failoverBehavior *policyv1alpha1.ApplicationFailoverBehavi
 	taskOpts = append(taskOpts, workv1alpha2.WithReason(workv1alpha2.EvictionReasonApplicationFailure))
 	taskOpts = append(taskOpts, workv1alpha2.WithPurgeMode(failoverBehavior.PurgeMode))
 
-	if failoverBehavior.StatePreservation != nil && len(failoverBehavior.StatePreservation.Rules) != 0 {
-		targetStatusItem, exist := findTargetStatusItemByCluster(aggregatedStatus, cluster)
-		if !exist || targetStatusItem.Status == nil || targetStatusItem.Status.Raw == nil {
-			return nil, fmt.Errorf("the application status has not yet been collected from Cluster(%s)", cluster)
-		}
-		preservedLabelState, err := buildPreservedLabelState(failoverBehavior.StatePreservation, targetStatusItem.Status.Raw)
-		if err != nil {
-			return nil, err
-		}
-		if preservedLabelState != nil {
-			taskOpts = append(taskOpts, workv1alpha2.WithPreservedLabelState(preservedLabelState))
-			taskOpts = append(taskOpts, workv1alpha2.WithClustersBeforeFailover(clustersBeforeFailover))
+	if features.FeatureGate.Enabled(features.StatefulFailoverInjection) {
+		if failoverBehavior.StatePreservation != nil && len(failoverBehavior.StatePreservation.Rules) != 0 {
+			targetStatusItem, exist := findTargetStatusItemByCluster(aggregatedStatus, cluster)
+			if !exist || targetStatusItem.Status == nil || targetStatusItem.Status.Raw == nil {
+				return nil, fmt.Errorf("the application status has not yet been collected from Cluster(%s)", cluster)
+			}
+			preservedLabelState, err := buildPreservedLabelState(failoverBehavior.StatePreservation, targetStatusItem.Status.Raw)
+			if err != nil {
+				return nil, err
+			}
+			if preservedLabelState != nil {
+				taskOpts = append(taskOpts, workv1alpha2.WithPreservedLabelState(preservedLabelState))
+				taskOpts = append(taskOpts, workv1alpha2.WithClustersBeforeFailover(clustersBeforeFailover))
+			}
 		}
 	}
 

--- a/pkg/controllers/applicationfailover/common_test.go
+++ b/pkg/controllers/applicationfailover/common_test.go
@@ -30,6 +30,7 @@ import (
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/features"
 )
 
 func TestTimeStampProcess(t *testing.T) {
@@ -645,6 +646,8 @@ func Test_buildTaskOptions(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		err := features.FeatureGate.Set(fmt.Sprintf("%s=%t", features.StatefulFailoverInjection, true))
+		assert.NoError(t, err)
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := buildTaskOptions(tt.args.failoverBehavior, tt.args.aggregatedStatus, tt.args.cluster, tt.args.producer, tt.args.clustersBeforeFailover)
 			if !tt.wantErr(t, err, fmt.Sprintf("buildTaskOptions(%v, %v, %v, %v, %v)", tt.args.failoverBehavior, tt.args.aggregatedStatus, tt.args.cluster, tt.args.producer, tt.args.clustersBeforeFailover)) {

--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -31,6 +31,7 @@ import (
 	configv1alpha1 "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/features"
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/helper"
@@ -113,9 +114,11 @@ func ensureWork(
 			return err
 		}
 
-		// we need to figure out if the targetCluster is in the cluster we are going to migrate application to.
-		// If yes, we have to inject the preserved label state to clonedWorkload with the label.
-		clonedWorkload = injectReservedLabelState(bindingSpec, targetCluster, clonedWorkload, len(targetClusters))
+		if features.FeatureGate.Enabled(features.StatefulFailoverInjection) {
+			// we need to figure out if the targetCluster is in the cluster we are going to migrate application to.
+			// If yes, we have to inject the preserved label state to the clonedWorkload.
+			clonedWorkload = injectReservedLabelState(bindingSpec, targetCluster, clonedWorkload, len(targetClusters))
+		}
 
 		workMeta := metav1.ObjectMeta{
 			Name:        names.GenerateWorkName(clonedWorkload.GetKind(), clonedWorkload.GetName(), clonedWorkload.GetNamespace()),

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -43,6 +43,15 @@ const (
 
 	// ResourceQuotaEstimate indicates if enable resource quota check in estimator
 	ResourceQuotaEstimate featuregate.Feature = "ResourceQuotaEstimate"
+
+	// StatefulFailoverInjection controls whether Karmada collects state information
+	// from the source cluster during a failover event for stateful applications and
+	// injects this information into the application configuration when it is moved
+	// to the target cluster.
+	//
+	// owner: @mszacillo, @XiShanYongYe-Chang
+	// alpha: v1.12
+	StatefulFailoverInjection featuregate.Feature = "StatefulFailoverInjection"
 )
 
 var (
@@ -58,6 +67,7 @@ var (
 		PolicyPreemption:                  {Default: false, PreRelease: featuregate.Alpha},
 		MultiClusterService:               {Default: false, PreRelease: featuregate.Alpha},
 		ResourceQuotaEstimate:             {Default: false, PreRelease: featuregate.Alpha},
+		StatefulFailoverInjection:         {Default: false, PreRelease: featuregate.Alpha},
 	}
 )
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -3515,7 +3515,7 @@ func schema_pkg_apis_policy_v1alpha1_ApplicationFailoverBehavior(ref common.Refe
 					},
 					"statePreservation": {
 						SchemaProps: spec.SchemaProps{
-							Description: "StatePreservation defines the policy for preserving and restoring state data during failover events for stateful applications.\n\nWhen an application fails over from one cluster to another, this policy enables the extraction of critical data from the original resource configuration. Upon successful migration, the extracted data is then re-injected into the new resource, ensuring that the application can resume operation with its previous state intact. This is particularly useful for stateful applications where maintaining data consistency across failover events is crucial. If not specified, means no state data will be preserved.",
+							Description: "StatePreservation defines the policy for preserving and restoring state data during failover events for stateful applications.\n\nWhen an application fails over from one cluster to another, this policy enables the extraction of critical data from the original resource configuration. Upon successful migration, the extracted data is then re-injected into the new resource, ensuring that the application can resume operation with its previous state intact. This is particularly useful for stateful applications where maintaining data consistency across failover events is crucial. If not specified, means no state data will be preserved.\n\nNote: This requires the StatefulFailoverInjection feature gate to be enabled, which is alpha.",
 							Ref:         ref("github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1.StatePreservation"),
 						},
 					},


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds a feature gate `StatefulFailoverInjection` which controls whether Karmada collects state information from the source cluster during a failover event for stateful applications and injects this information into the application configuration when it is moved to the target cluster.

**Which issue(s) this PR fixes**:
Part of #5788

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Introduced feature gate `StatefulFailoverInjection` to control whether Karmada collects and injects state information during a failover event for stateful application.
```

