### PR TITLE
Bump kind dependencis from v0.24.0 to v0.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	sigs.k8s.io/cluster-api v1.7.1
 	sigs.k8s.io/controller-runtime v0.19.1
 	sigs.k8s.io/custom-metrics-apiserver v1.30.1-0.20241105195130-84dc8cfe2555
-	sigs.k8s.io/kind v0.24.0
+	sigs.k8s.io/kind v0.25.0
 	sigs.k8s.io/mcs-api v0.1.0
 	sigs.k8s.io/metrics-server v0.7.1
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1

--- a/go.sum
+++ b/go.sum
@@ -1488,8 +1488,8 @@ sigs.k8s.io/custom-metrics-apiserver v1.30.1-0.20241105195130-84dc8cfe2555/go.mo
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/kind v0.8.1/go.mod h1:oNKTxUVPYkV9lWzY6CVMNluVq8cBsyq+UgPJdvA3uu4=
-sigs.k8s.io/kind v0.24.0 h1:g4y4eu0qa+SCeKESLpESgMmVFBebL0BDa6f777OIWrg=
-sigs.k8s.io/kind v0.24.0/go.mod h1:t7ueEpzPYJvHA8aeLtI52rtFftNgUYUaCwvxjk7phfw=
+sigs.k8s.io/kind v0.25.0 h1:ugUvgesHKKA0yKmD6QtYTiEev+kPUpGxdTPbMGf8VTU=
+sigs.k8s.io/kind v0.25.0/go.mod h1:t7ueEpzPYJvHA8aeLtI52rtFftNgUYUaCwvxjk7phfw=
 sigs.k8s.io/kustomize/api v0.17.2 h1:E7/Fjk7V5fboiuijoZHgs4aHuexi5Y2loXlVOAVAG5g=
 sigs.k8s.io/kustomize/api v0.17.2/go.mod h1:UWTz9Ct+MvoeQsHcJ5e+vziRRkwimm3HytpZgIYqye0=
 sigs.k8s.io/kustomize/kyaml v0.17.1 h1:TnxYQxFXzbmNG6gOINgGWQt09GghzgTP6mIurOgrLCQ=

--- a/hack/cli-testing-environment.sh
+++ b/hack/cli-testing-environment.sh
@@ -35,7 +35,7 @@ BUILD_PATH=${BUILD_PATH:-"_output/bin/linux/amd64"}
 
 
 # install kind and kubectl
-kind_version=v0.22.0
+kind_version=v0.25.0
 echo -n "Preparing: 'kind' existence check - "
 if util::cmd_exist kind; then
   echo "passed"

--- a/hack/cli-testing-init-with-config.sh
+++ b/hack/cli-testing-init-with-config.sh
@@ -35,7 +35,7 @@ BUILD_PATH=${BUILD_PATH:-"_output/bin/linux/amd64"}
 CONFIG_FILE_PATH=${CONFIG_FILE_PATH:-"/tmp/karmada-config.yaml"}
 
 # install kind and kubectl
-kind_version=v0.24.0
+kind_version=v0.25.0
 echo -n "Preparing: 'kind' existence check - "
 if util::cmd_exist kind; then
   echo "passed"

--- a/hack/local-up-karmada-by-operator.sh
+++ b/hack/local-up-karmada-by-operator.sh
@@ -87,7 +87,7 @@ util::verify_go_version
 util::cmd_must_exist "docker"
 
 # install kind and kubectl
-kind_version=v0.24.0
+kind_version=v0.25.0
 echo -n "Preparing: 'kind' existence check - "
 if util::cmd_exist kind; then
   echo "passed"

--- a/hack/local-up-karmada.sh
+++ b/hack/local-up-karmada.sh
@@ -80,7 +80,7 @@ util::verify_go_version
 util::verify_docker
 
 # install kind and kubectl
-kind_version=v0.24.0
+kind_version=v0.25.0
 echo -n "Preparing: 'kind' existence check - "
 if util::cmd_exist kind; then
   echo "passed"

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -39,7 +39,7 @@ KARMADA_GO_PACKAGE="github.com/karmada-io/karmada"
 
 MIN_Go_VERSION=go1.22.9
 
-DEFAULT_CLUSTER_VERSION="kindest/node:v1.31.0"
+DEFAULT_CLUSTER_VERSION="kindest/node:v1.31.2"
 
 KARMADA_TARGET_SOURCE=(
   karmada-aggregated-apiserver=cmd/aggregated-apiserver

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1868,7 +1868,7 @@ sigs.k8s.io/custom-metrics-apiserver/pkg/registry/external_metrics
 ## explicit; go 1.18
 sigs.k8s.io/json
 sigs.k8s.io/json/internal/golang/encoding/json
-# sigs.k8s.io/kind v0.24.0
+# sigs.k8s.io/kind v0.25.0
 ## explicit; go 1.17
 sigs.k8s.io/kind/pkg/apis/config/defaults
 sigs.k8s.io/kind/pkg/apis/config/v1alpha4

--- a/vendor/sigs.k8s.io/kind/pkg/apis/config/defaults/image.go
+++ b/vendor/sigs.k8s.io/kind/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865"
+const Image = "kindest/node:v1.31.2@sha256:18fbefc20a7113353c7b75b5c869d7145a6abd6269154825872dc59c1329912e"

--- a/vendor/sigs.k8s.io/kind/pkg/cluster/internal/providers/podman/provider.go
+++ b/vendor/sigs.k8s.io/kind/pkg/cluster/internal/providers/podman/provider.go
@@ -171,6 +171,15 @@ func (p *provider) DeleteNodes(n []nodes.Node) error {
 	return deleteVolumes(nodeVolumes)
 }
 
+// getHostIPOrDefault defaults HostIP to localhost if is not set
+// xref: https://github.com/kubernetes-sigs/kind/issues/3777
+func getHostIPOrDefault(hostIP string) string {
+	if hostIP == "" {
+		return "127.0.0.1"
+	}
+	return hostIP
+}
+
 // GetAPIServerEndpoint is part of the providers.Provider interface
 func (p *provider) GetAPIServerEndpoint(cluster string) (string, error) {
 	// locate the node that hosts this
@@ -266,7 +275,7 @@ func (p *provider) GetAPIServerEndpoint(cluster string) (string, error) {
 			}
 			for _, pm := range v {
 				if containerPort == common.APIServerInternalPort && protocol == "tcp" {
-					return net.JoinHostPort(pm.HostIP, pm.HostPort), nil
+					return net.JoinHostPort(getHostIPOrDefault(pm.HostIP), pm.HostPort), nil
 				}
 			}
 		}
@@ -278,7 +287,7 @@ func (p *provider) GetAPIServerEndpoint(cluster string) (string, error) {
 	}
 	for _, pm := range portMappings19 {
 		if pm.ContainerPort == common.APIServerInternalPort && pm.Protocol == "tcp" {
-			return net.JoinHostPort(pm.HostIP, strconv.Itoa(int(pm.HostPort))), nil
+			return net.JoinHostPort(getHostIPOrDefault(pm.HostIP), strconv.Itoa(int(pm.HostPort))), nil
 		}
 	}
 

--- a/vendor/sigs.k8s.io/kind/pkg/cmd/kind/version/version.go
+++ b/vendor/sigs.k8s.io/kind/pkg/cmd/kind/version/version.go
@@ -54,7 +54,7 @@ func DisplayVersion() string {
 }
 
 // versionCore is the core portion of the kind CLI version per Semantic Versioning 2.0.0
-const versionCore = "0.24.0"
+const versionCore = "0.25.0"
 
 // versionPreRelease is the base pre-release portion of the kind CLI version per
 // Semantic Versioning 2.0.0


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR updates sigs.k8s.io/kind to v0.25.0 whose default node image is Kubernetes v1.31.2.
Our E2E test uses kind to simulate clusters, and now we use the latest Kubernetes v1.31.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

