### PR TITLE
refactor: introduce DefaultHistoryLimit constant for CronFederatedHPA

### DIFF
--- a/pkg/util/helper/cronfederatedhpa.go
+++ b/pkg/util/helper/cronfederatedhpa.go
@@ -22,6 +22,9 @@ import (
 	autoscalingv1alpha1 "github.com/karmada-io/karmada/pkg/apis/autoscaling/v1alpha1"
 )
 
+// DefaultHistoryLimit defines the default number of history entries to keep
+const DefaultHistoryLimit = 3
+
 // IsCronFederatedHPARuleSuspend returns true if the CronFederatedHPA is suspended.
 func IsCronFederatedHPARuleSuspend(rule autoscalingv1alpha1.CronFederatedHPARule) bool {
 	if rule.Suspend == nil {
@@ -33,7 +36,7 @@ func IsCronFederatedHPARuleSuspend(rule autoscalingv1alpha1.CronFederatedHPARule
 // GetCronFederatedHPASuccessHistoryLimits returns the successful history limits of the CronFederatedHPA.
 func GetCronFederatedHPASuccessHistoryLimits(rule autoscalingv1alpha1.CronFederatedHPARule) int {
 	if rule.SuccessfulHistoryLimit == nil {
-		return 3
+		return DefaultHistoryLimit
 	}
 	return int(*rule.SuccessfulHistoryLimit)
 }
@@ -41,7 +44,7 @@ func GetCronFederatedHPASuccessHistoryLimits(rule autoscalingv1alpha1.CronFedera
 // GetCronFederatedHPAFailedHistoryLimits returns the failed history limits of the CronFederatedHPA.
 func GetCronFederatedHPAFailedHistoryLimits(rule autoscalingv1alpha1.CronFederatedHPARule) int {
 	if rule.FailedHistoryLimit == nil {
-		return 3
+		return DefaultHistoryLimit
 	}
 	return int(*rule.FailedHistoryLimit)
 }

--- a/pkg/util/helper/cronfederatedhpa_test.go
+++ b/pkg/util/helper/cronfederatedhpa_test.go
@@ -68,19 +68,19 @@ func TestGetCronFederatedHPASuccessHistoryLimits(t *testing.T) {
 		expected int
 	}{
 		{
-			name:     "successful history limit is nil",
+			name:     "returns default limit when history limit is unspecified",
 			rule:     autoscalingv1alpha1.CronFederatedHPARule{},
-			expected: 3,
+			expected: DefaultHistoryLimit,
 		},
 		{
-			name: "successful history limit is set to 5",
+			name: "returns custom limit when specified",
 			rule: autoscalingv1alpha1.CronFederatedHPARule{
 				SuccessfulHistoryLimit: ptr.To[int32](5),
 			},
 			expected: 5,
 		},
 		{
-			name: "successful history limit is set to 0",
+			name: "returns zero when limit is explicitly set to zero",
 			rule: autoscalingv1alpha1.CronFederatedHPARule{
 				SuccessfulHistoryLimit: ptr.To[int32](0),
 			},
@@ -103,19 +103,19 @@ func TestGetCronFederatedHPAFailedHistoryLimits(t *testing.T) {
 		expected int
 	}{
 		{
-			name:     "failed history limit is nil",
+			name:     "returns default limit when history limit is unspecified",
 			rule:     autoscalingv1alpha1.CronFederatedHPARule{},
-			expected: 3,
+			expected: DefaultHistoryLimit,
 		},
 		{
-			name: "failed history limit is set to 5",
+			name: "returns custom limit when specified",
 			rule: autoscalingv1alpha1.CronFederatedHPARule{
 				FailedHistoryLimit: ptr.To[int32](5),
 			},
 			expected: 5,
 		},
 		{
-			name: "failed history limit is set to 0",
+			name: "returns zero when limit is explicitly set to zero",
 			rule: autoscalingv1alpha1.CronFederatedHPARule{
 				FailedHistoryLimit: ptr.To[int32](0),
 			},


### PR DESCRIPTION
**Description:**
This PR introduces a DefaultHistoryLimit constant to replace the magic number '3' in CronFederatedHPA history limits.

**Changes:**
- Added DefaultHistoryLimit constant (value: 3) to define default history entries
- Updated GetCronFederatedHPASuccessHistoryLimits to use the constant
- Updated GetCronFederatedHPAFailedHistoryLimits to use the constant
- Improved test case names for better clarity and maintainability

**What type of PR is this?**
/kind cleanup
/kind documentation

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
As suggested by @XiShanYongYe-Chang in #5768 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

