### PR TITLE
cmd+hack+operator+pkg: unify addons constants

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -73,7 +73,7 @@ func NewAgentCommand(ctx context.Context) *cobra.Command {
 	opts := options.NewOptions()
 
 	cmd := &cobra.Command{
-		Use: "karmada-agent",
+		Use: names.KarmadaAgentComponentName,
 		Long: `The karmada-agent is the agent of member clusters. It can register a specific cluster to the Karmada control
 plane and sync manifests from the Karmada control plane to the member cluster. In addition, it also syncs the status of member
 cluster and manifests to the Karmada control plane.`,
@@ -107,7 +107,7 @@ cluster and manifests to the Karmada control plane.`,
 	logsFlagSet := fss.FlagSet("logs")
 	klogflag.Add(logsFlagSet)
 
-	cmd.AddCommand(sharedcommand.NewCmdVersion("karmada-agent"))
+	cmd.AddCommand(sharedcommand.NewCmdVersion(names.KarmadaAgentComponentName))
 	cmd.Flags().AddFlagSet(genericFlagSet)
 	cmd.Flags().AddFlagSet(logsFlagSet)
 

--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -30,6 +30,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/sharedcli/profileflag"
 	"github.com/karmada-io/karmada/pkg/sharedcli/ratelimiterflag"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 const (
@@ -147,7 +148,7 @@ func NewOptions() *Options {
 		LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
 			LeaderElect:       true,
 			ResourceLock:      resourcelock.LeasesResourceLock,
-			ResourceNamespace: util.NamespaceKarmadaSystem,
+			ResourceNamespace: names.NamespaceKarmadaSystem,
 		},
 	}
 }
@@ -163,7 +164,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, allControllers []string) {
 		strings.Join(allControllers, ", "),
 	))
 	fs.BoolVar(&o.LeaderElection.LeaderElect, "leader-elect", true, "Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.")
-	fs.StringVar(&o.LeaderElection.ResourceNamespace, "leader-elect-resource-namespace", util.NamespaceKarmadaSystem, "The namespace of resource object that is used for locking during leader election.")
+	fs.StringVar(&o.LeaderElection.ResourceNamespace, "leader-elect-resource-namespace", names.NamespaceKarmadaSystem, "The namespace of resource object that is used for locking during leader election.")
 	fs.DurationVar(&o.LeaderElection.LeaseDuration.Duration, "leader-elect-lease-duration", defaultElectionLeaseDuration.Duration, ""+
 		"The duration that non-leader candidates will wait after observing a leadership "+
 		"renewal until attempting to acquire leadership of a led but unrenewed leader "+

--- a/cmd/aggregated-apiserver/app/aggregated-apiserver.go
+++ b/cmd/aggregated-apiserver/app/aggregated-apiserver.go
@@ -26,6 +26,7 @@ import (
 	"github.com/karmada-io/karmada/cmd/aggregated-apiserver/app/options"
 	"github.com/karmada-io/karmada/pkg/sharedcli"
 	"github.com/karmada-io/karmada/pkg/sharedcli/klogflag"
+	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/pkg/version/sharedcommand"
 )
 
@@ -34,7 +35,7 @@ func NewAggregatedApiserverCommand(ctx context.Context) *cobra.Command {
 	opts := options.NewOptions()
 
 	cmd := &cobra.Command{
-		Use: "karmada-aggregated-apiserver",
+		Use: names.KarmadaAggregatedAPIServerComponentName,
 		Long: `The karmada-aggregated-apiserver starts an aggregated server. 
 It is responsible for registering the Cluster API and provides the ability to aggregate APIs, 
 allowing users to access member clusters from the control plane directly.`,
@@ -61,7 +62,7 @@ allowing users to access member clusters from the control plane directly.`,
 	logsFlagSet := fss.FlagSet("logs")
 	klogflag.Add(logsFlagSet)
 
-	cmd.AddCommand(sharedcommand.NewCmdVersion("karmada-aggregated-apiserver"))
+	cmd.AddCommand(sharedcommand.NewCmdVersion(names.KarmadaAggregatedAPIServerComponentName))
 	cmd.Flags().AddFlagSet(genericFlagSet)
 	cmd.Flags().AddFlagSet(logsFlagSet)
 

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -84,6 +84,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/typedmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	"github.com/karmada-io/karmada/pkg/util/helper"
+	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/pkg/util/objectwatcher"
 	"github.com/karmada-io/karmada/pkg/util/overridemanager"
 	"github.com/karmada-io/karmada/pkg/util/restmapper"
@@ -96,7 +97,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 	opts := options.NewOptions()
 
 	cmd := &cobra.Command{
-		Use: "karmada-controller-manager",
+		Use: names.KarmadaControllerManagerComponentName,
 		Long: `The karmada-controller-manager runs various controllers.
 The controllers watch Karmada objects and then talk to the underlying clusters' API servers
 to create regular Kubernetes resources.`,
@@ -124,7 +125,7 @@ to create regular Kubernetes resources.`,
 	logsFlagSet := fss.FlagSet("logs")
 	klogflag.Add(logsFlagSet)
 
-	cmd.AddCommand(sharedcommand.NewCmdVersion("karmada-controller-manager"))
+	cmd.AddCommand(sharedcommand.NewCmdVersion(names.KarmadaControllerManagerComponentName))
 	cmd.Flags().AddFlagSet(genericFlagSet)
 	cmd.Flags().AddFlagSet(logsFlagSet)
 

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -32,6 +32,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/sharedcli/profileflag"
 	"github.com/karmada-io/karmada/pkg/sharedcli/ratelimiterflag"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 var (
@@ -153,8 +154,8 @@ func NewOptions() *Options {
 		LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
 			LeaderElect:       true,
 			ResourceLock:      resourcelock.LeasesResourceLock,
-			ResourceNamespace: util.NamespaceKarmadaSystem,
-			ResourceName:      "karmada-controller-manager",
+			ResourceNamespace: names.NamespaceKarmadaSystem,
+			ResourceName:      names.KarmadaControllerManagerComponentName,
 		},
 	}
 }
@@ -168,7 +169,7 @@ func (o *Options) AddFlags(flags *pflag.FlagSet, allControllers, disabledByDefau
 	flags.DurationVar(&o.ClusterStatusUpdateFrequency.Duration, "cluster-status-update-frequency", 10*time.Second,
 		"Specifies how often karmada-controller-manager posts cluster status to karmada-apiserver.")
 	flags.BoolVar(&o.LeaderElection.LeaderElect, "leader-elect", true, "Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.")
-	flags.StringVar(&o.LeaderElection.ResourceNamespace, "leader-elect-resource-namespace", util.NamespaceKarmadaSystem, "The namespace of resource object that is used for locking during leader election.")
+	flags.StringVar(&o.LeaderElection.ResourceNamespace, "leader-elect-resource-namespace", names.NamespaceKarmadaSystem, "The namespace of resource object that is used for locking during leader election.")
 	flags.DurationVar(&o.LeaderElection.LeaseDuration.Duration, "leader-elect-lease-duration", defaultElectionLeaseDuration.Duration, ""+
 		"The duration that non-leader candidates will wait after observing a leadership "+
 		"renewal until attempting to acquire leadership of a led but unrenewed leader "+

--- a/cmd/descheduler/app/descheduler.go
+++ b/cmd/descheduler/app/descheduler.go
@@ -42,6 +42,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/sharedcli"
 	"github.com/karmada-io/karmada/pkg/sharedcli/klogflag"
 	"github.com/karmada-io/karmada/pkg/sharedcli/profileflag"
+	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/pkg/version"
 	"github.com/karmada-io/karmada/pkg/version/sharedcommand"
 )
@@ -80,7 +81,7 @@ func NewDeschedulerCommand(stopChan <-chan struct{}) *cobra.Command {
 	opts := options.NewOptions()
 
 	cmd := &cobra.Command{
-		Use: "karmada-descheduler",
+		Use: names.KarmadaDeschedulerComponentName,
 		Long: `The karmada-descheduler evicts replicas from member clusters
 if they are failed to be scheduled for a period of time. It relies on 
 karmada-scheduler-estimator to get replica status.`,
@@ -113,7 +114,7 @@ karmada-scheduler-estimator to get replica status.`,
 	logsFlagSet := fss.FlagSet("logs")
 	klogflag.Add(logsFlagSet)
 
-	cmd.AddCommand(sharedcommand.NewCmdVersion("karmada-descheduler"))
+	cmd.AddCommand(sharedcommand.NewCmdVersion(names.KarmadaDeschedulerComponentName))
 	cmd.Flags().AddFlagSet(genericFlagSet)
 	cmd.Flags().AddFlagSet(logsFlagSet)
 

--- a/cmd/descheduler/app/descheduler_test.go
+++ b/cmd/descheduler/app/descheduler_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/karmada-io/karmada/cmd/descheduler/app/options"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 func TestNewDeschedulerCommand(t *testing.T) {
@@ -32,7 +33,7 @@ func TestNewDeschedulerCommand(t *testing.T) {
 	cmd := NewDeschedulerCommand(stopCh)
 
 	assert.NotNil(t, cmd)
-	assert.Equal(t, "karmada-descheduler", cmd.Use)
+	assert.Equal(t, names.KarmadaDeschedulerComponentName, cmd.Use)
 	assert.NotEmpty(t, cmd.Long)
 }
 

--- a/cmd/descheduler/app/options/options.go
+++ b/cmd/descheduler/app/options/options.go
@@ -25,7 +25,7 @@ import (
 	componentbaseconfig "k8s.io/component-base/config"
 
 	"github.com/karmada-io/karmada/pkg/sharedcli/profileflag"
-	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 const (
@@ -89,8 +89,8 @@ func NewOptions() *Options {
 		LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
 			LeaderElect:       true,
 			ResourceLock:      resourcelock.LeasesResourceLock,
-			ResourceNamespace: util.NamespaceKarmadaSystem,
-			ResourceName:      "karmada-descheduler",
+			ResourceNamespace: names.NamespaceKarmadaSystem,
+			ResourceName:      names.KarmadaDeschedulerComponentName,
 			LeaseDuration:     defaultElectionLeaseDuration,
 			RenewDeadline:     defaultElectionRenewDeadline,
 			RetryPeriod:       defaultElectionRetryPeriod,
@@ -104,7 +104,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 		return
 	}
 	fs.BoolVar(&o.LeaderElection.LeaderElect, "leader-elect", true, "Enable leader election, which must be true when running multi instances.")
-	fs.StringVar(&o.LeaderElection.ResourceNamespace, "leader-elect-resource-namespace", util.NamespaceKarmadaSystem, "The namespace of resource object that is used for locking during leader election.")
+	fs.StringVar(&o.LeaderElection.ResourceNamespace, "leader-elect-resource-namespace", names.NamespaceKarmadaSystem, "The namespace of resource object that is used for locking during leader election.")
 	fs.DurationVar(&o.LeaderElection.LeaseDuration.Duration, "leader-elect-lease-duration", defaultElectionLeaseDuration.Duration, ""+
 		"The duration that non-leader candidates will wait after observing a leadership "+
 		"renewal until attempting to acquire leadership of a led but unrenewed leader "+
@@ -128,8 +128,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.SchedulerEstimatorKeyFile, "scheduler-estimator-key-file", "", "SSL key file used to secure scheduler estimator communication.")
 	fs.StringVar(&o.SchedulerEstimatorCaFile, "scheduler-estimator-ca-file", "", "SSL Certificate Authority file used to secure scheduler estimator communication.")
 	fs.BoolVar(&o.InsecureSkipEstimatorVerify, "insecure-skip-estimator-verify", false, "Controls whether verifies the scheduler estimator's certificate chain and host name.")
-	fs.StringVar(&o.SchedulerEstimatorServiceNamespace, "scheduler-estimator-service-namespace", util.NamespaceKarmadaSystem, "The namespace to be used for discovering scheduler estimator services.")
-	fs.StringVar(&o.SchedulerEstimatorServicePrefix, "scheduler-estimator-service-prefix", "karmada-scheduler-estimator", "The prefix of scheduler estimator service name")
+	fs.StringVar(&o.SchedulerEstimatorServiceNamespace, "scheduler-estimator-service-namespace", names.NamespaceKarmadaSystem, "The namespace to be used for discovering scheduler estimator services.")
+	fs.StringVar(&o.SchedulerEstimatorServicePrefix, "scheduler-estimator-service-prefix", names.KarmadaSchedulerEstimatorComponentName, "The prefix of scheduler estimator service name")
 	fs.DurationVar(&o.DeschedulingInterval.Duration, "descheduling-interval", defaultDeschedulingInterval, "Time interval between two consecutive descheduler executions. Setting this value instructs the descheduler to run in a continuous loop at the interval specified.")
 	fs.DurationVar(&o.UnschedulableThreshold.Duration, "unschedulable-threshold", defaultUnschedulableThreshold, "The period of pod unschedulable condition. This value is considered as a classification standard of unschedulable replicas.")
 	fs.StringVar(&o.MetricsBindAddress, "metrics-bind-address", ":8080", "The TCP address that the server should bind to for serving prometheus metrics(e.g. 127.0.0.1:8080, :8080). It can be set to \"0\" to disable the metrics serving. Defaults to 0.0.0.0:8080.")

--- a/cmd/karmada-search/app/karmada-search.go
+++ b/cmd/karmada-search/app/karmada-search.go
@@ -51,6 +51,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/sharedcli/klogflag"
 	"github.com/karmada-io/karmada/pkg/sharedcli/profileflag"
 	"github.com/karmada-io/karmada/pkg/util/lifted"
+	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/pkg/version"
 	"github.com/karmada-io/karmada/pkg/version/sharedcommand"
 )
@@ -63,7 +64,7 @@ func NewKarmadaSearchCommand(ctx context.Context, registryOptions ...Option) *co
 	opts := options.NewOptions()
 
 	cmd := &cobra.Command{
-		Use: "karmada-search",
+		Use: names.KarmadaSearchComponentName,
 		Long: `The karmada-search starts an aggregated server. It provides 
 capabilities such as global search and resource proxy in a multi-cloud environment.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
@@ -89,7 +90,7 @@ capabilities such as global search and resource proxy in a multi-cloud environme
 	logsFlagSet := fss.FlagSet("logs")
 	klogflag.Add(logsFlagSet)
 
-	cmd.AddCommand(sharedcommand.NewCmdVersion("karmada-search"))
+	cmd.AddCommand(sharedcommand.NewCmdVersion(names.KarmadaSearchComponentName))
 	cmd.Flags().AddFlagSet(genericFlagSet)
 	cmd.Flags().AddFlagSet(logsFlagSet)
 
@@ -173,7 +174,7 @@ func config(o *options.Options, outOfTreeRegistryOptions ...Option) (*search.Con
 		sets.NewString("attach", "exec", "proxy", "log", "portforward"))
 	serverConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(generatedopenapi.GetOpenAPIDefinitions, openapi.NewDefinitionNamer(searchscheme.Scheme))
 	serverConfig.OpenAPIV3Config = genericapiserver.DefaultOpenAPIV3Config(generatedopenapi.GetOpenAPIDefinitions, openapi.NewDefinitionNamer(searchscheme.Scheme))
-	serverConfig.OpenAPIConfig.Info.Title = "karmada-search"
+	serverConfig.OpenAPIConfig.Info.Title = names.KarmadaSearchComponentName
 	if err := o.ApplyTo(serverConfig); err != nil {
 		return nil, err
 	}

--- a/cmd/metrics-adapter/app/metrics-adapter.go
+++ b/cmd/metrics-adapter/app/metrics-adapter.go
@@ -27,6 +27,7 @@ import (
 	"github.com/karmada-io/karmada/cmd/metrics-adapter/app/options"
 	"github.com/karmada-io/karmada/pkg/sharedcli"
 	"github.com/karmada-io/karmada/pkg/sharedcli/klogflag"
+	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/pkg/version/sharedcommand"
 )
 
@@ -35,7 +36,7 @@ func NewMetricsAdapterCommand(ctx context.Context) *cobra.Command {
 	opts := options.NewOptions()
 
 	cmd := &cobra.Command{
-		Use:  "karmada-metrics-adapter",
+		Use:  names.KarmadaMetricsAdapterComponentName,
 		Long: `The karmada-metrics-adapter is a adapter to aggregate the metrics from member clusters.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := opts.Complete(); err != nil {
@@ -68,7 +69,7 @@ func NewMetricsAdapterCommand(ctx context.Context) *cobra.Command {
 	logsFlagSet := fss.FlagSet("logs")
 	klogflag.Add(logsFlagSet)
 
-	cmd.AddCommand(sharedcommand.NewCmdVersion("karmada-metrics-adapter"))
+	cmd.AddCommand(sharedcommand.NewCmdVersion(names.KarmadaMetricsAdapterComponentName))
 	cmd.Flags().AddFlagSet(genericFlagSet)
 	cmd.Flags().AddFlagSet(logsFlagSet)
 

--- a/cmd/metrics-adapter/app/options/options.go
+++ b/cmd/metrics-adapter/app/options/options.go
@@ -35,6 +35,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/metricsadapter"
 	"github.com/karmada-io/karmada/pkg/sharedcli/profileflag"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/pkg/version"
 )
 
@@ -96,7 +97,7 @@ func (o *Options) Config(stopCh <-chan struct{}) (*metricsadapter.MetricsServer,
 	metricsAdapter := metricsadapter.NewMetricsAdapter(metricsController, o.CustomMetricsAdapterServerOptions)
 	metricsAdapter.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(generatedopenapi.GetOpenAPIDefinitions, openapinamer.NewDefinitionNamer(api.Scheme))
 	metricsAdapter.OpenAPIV3Config = genericapiserver.DefaultOpenAPIV3Config(generatedopenapi.GetOpenAPIDefinitions, openapinamer.NewDefinitionNamer(api.Scheme))
-	metricsAdapter.OpenAPIConfig.Info.Title = "karmada-metrics-adapter"
+	metricsAdapter.OpenAPIConfig.Info.Title = names.KarmadaMetricsAdapterComponentName
 	metricsAdapter.OpenAPIConfig.Info.Version = "1.0.0"
 
 	// Explicitly specify the remote kubeconfig file here to solve the issue that metrics adapter requires to build

--- a/cmd/scheduler-estimator/app/scheduler-estimator.go
+++ b/cmd/scheduler-estimator/app/scheduler-estimator.go
@@ -39,6 +39,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/sharedcli"
 	"github.com/karmada-io/karmada/pkg/sharedcli/klogflag"
 	"github.com/karmada-io/karmada/pkg/sharedcli/profileflag"
+	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/pkg/version"
 	"github.com/karmada-io/karmada/pkg/version/sharedcommand"
 )
@@ -77,7 +78,7 @@ func NewSchedulerEstimatorCommand(ctx context.Context) *cobra.Command {
 	opts := options.NewOptions()
 
 	cmd := &cobra.Command{
-		Use: "karmada-scheduler-estimator",
+		Use: names.KarmadaSchedulerEstimatorComponentName,
 		Long: `The karmada-scheduler-estimator runs an accurate scheduler estimator of a cluster. It 
 provides the scheduler with more accurate cluster resource information.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
@@ -101,7 +102,7 @@ provides the scheduler with more accurate cluster resource information.`,
 	logsFlagSet := fss.FlagSet("logs")
 	klogflag.Add(logsFlagSet)
 
-	cmd.AddCommand(sharedcommand.NewCmdVersion("karmada-scheduler-estimator"))
+	cmd.AddCommand(sharedcommand.NewCmdVersion(names.KarmadaSchedulerEstimatorComponentName))
 	cmd.Flags().AddFlagSet(genericFlagSet)
 	cmd.Flags().AddFlagSet(logsFlagSet)
 

--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -31,7 +31,7 @@ import (
 	frameworkplugins "github.com/karmada-io/karmada/pkg/scheduler/framework/plugins"
 	"github.com/karmada-io/karmada/pkg/sharedcli/profileflag"
 	"github.com/karmada-io/karmada/pkg/sharedcli/ratelimiterflag"
-	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 const (
@@ -112,8 +112,8 @@ func NewOptions() *Options {
 		LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
 			LeaderElect:       true,
 			ResourceLock:      resourcelock.LeasesResourceLock,
-			ResourceNamespace: util.NamespaceKarmadaSystem,
-			ResourceName:      "karmada-scheduler",
+			ResourceNamespace: names.NamespaceKarmadaSystem,
+			ResourceName:      names.KarmadaSchedulerComponentName,
 			LeaseDuration:     defaultElectionLeaseDuration,
 			RenewDeadline:     defaultElectionRenewDeadline,
 			RetryPeriod:       defaultElectionRetryPeriod,
@@ -128,8 +128,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	}
 
 	fs.BoolVar(&o.LeaderElection.LeaderElect, "leader-elect", true, "Enable leader election, which must be true when running multi instances.")
-	fs.StringVar(&o.LeaderElection.ResourceName, "leader-elect-resource-name", "karmada-scheduler", "The name of resource object that is used for locking during leader election.")
-	fs.StringVar(&o.LeaderElection.ResourceNamespace, "leader-elect-resource-namespace", util.NamespaceKarmadaSystem, "The namespace of resource object that is used for locking during leader election.")
+	fs.StringVar(&o.LeaderElection.ResourceName, "leader-elect-resource-name", names.KarmadaSchedulerComponentName, "The name of resource object that is used for locking during leader election.")
+	fs.StringVar(&o.LeaderElection.ResourceNamespace, "leader-elect-resource-namespace", names.NamespaceKarmadaSystem, "The namespace of resource object that is used for locking during leader election.")
 	fs.DurationVar(&o.LeaderElection.LeaseDuration.Duration, "leader-elect-lease-duration", defaultElectionLeaseDuration.Duration, ""+
 		"The duration that non-leader candidates will wait after observing a leadership "+
 		"renewal until attempting to acquire leadership of a led but unrenewed leader "+
@@ -152,8 +152,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.EnableSchedulerEstimator, "enable-scheduler-estimator", false, "Enable calling cluster scheduler estimator for adjusting replicas.")
 	fs.BoolVar(&o.DisableSchedulerEstimatorInPullMode, "disable-scheduler-estimator-in-pull-mode", false, "Disable the scheduler estimator for clusters in pull mode, which takes effect only when enable-scheduler-estimator is true.")
 	fs.DurationVar(&o.SchedulerEstimatorTimeout.Duration, "scheduler-estimator-timeout", 3*time.Second, "Specifies the timeout period of calling the scheduler estimator service.")
-	fs.StringVar(&o.SchedulerEstimatorServiceNamespace, "scheduler-estimator-service-namespace", util.NamespaceKarmadaSystem, "The namespace to be used for discovering scheduler estimator services.")
-	fs.StringVar(&o.SchedulerEstimatorServicePrefix, "scheduler-estimator-service-prefix", "karmada-scheduler-estimator", "The prefix of scheduler estimator service name")
+	fs.StringVar(&o.SchedulerEstimatorServiceNamespace, "scheduler-estimator-service-namespace", names.NamespaceKarmadaSystem, "The namespace to be used for discovering scheduler estimator services.")
+	fs.StringVar(&o.SchedulerEstimatorServicePrefix, "scheduler-estimator-service-prefix", names.KarmadaSchedulerEstimatorComponentName, "The prefix of scheduler estimator service name")
 	fs.IntVar(&o.SchedulerEstimatorPort, "scheduler-estimator-port", defaultEstimatorPort, "The secure port on which to connect the accurate scheduler estimator.")
 	fs.StringVar(&o.SchedulerEstimatorCertFile, "scheduler-estimator-cert-file", "", "SSL certification file used to secure scheduler estimator communication.")
 	fs.StringVar(&o.SchedulerEstimatorKeyFile, "scheduler-estimator-key-file", "", "SSL key file used to secure scheduler estimator communication.")

--- a/cmd/scheduler/app/options/options_test.go
+++ b/cmd/scheduler/app/options/options_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 func TestNewOptions(t *testing.T) {
@@ -30,7 +32,7 @@ func TestNewOptions(t *testing.T) {
 	assert.True(t, opts.LeaderElection.LeaderElect, "Expected default LeaderElect to be true")
 	assert.Equal(t, "karmada-system", opts.LeaderElection.ResourceNamespace, "Unexpected default ResourceNamespace")
 	assert.Equal(t, 15*time.Second, opts.LeaderElection.LeaseDuration.Duration, "Unexpected default LeaseDuration")
-	assert.Equal(t, "karmada-scheduler", opts.LeaderElection.ResourceName, "Unexpected default ResourceName")
+	assert.Equal(t, names.KarmadaSchedulerComponentName, opts.LeaderElection.ResourceName, "Unexpected default ResourceName")
 }
 
 func TestAddFlags(t *testing.T) {

--- a/cmd/scheduler/app/scheduler.go
+++ b/cmd/scheduler/app/scheduler.go
@@ -44,6 +44,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/sharedcli"
 	"github.com/karmada-io/karmada/pkg/sharedcli/klogflag"
 	"github.com/karmada-io/karmada/pkg/sharedcli/profileflag"
+	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/pkg/version"
 	"github.com/karmada-io/karmada/pkg/version/sharedcommand"
 )
@@ -92,7 +93,7 @@ func NewSchedulerCommand(stopChan <-chan struct{}, registryOptions ...Option) *c
 	opts := options.NewOptions()
 
 	cmd := &cobra.Command{
-		Use: "karmada-scheduler",
+		Use: names.KarmadaSchedulerComponentName,
 		Long: `The karmada-scheduler is a control plane process which assigns resources to the clusters it manages.
 The scheduler determines which clusters are valid placements for each resource in the scheduling queue according to
 constraints and available resources. The scheduler then ranks each valid cluster and binds the resource to
@@ -125,7 +126,7 @@ the most suitable cluster.`,
 	// Set klog flags
 	logsFlagSet := fss.FlagSet("logs")
 	klogflag.Add(logsFlagSet)
-	cmd.AddCommand(sharedcommand.NewCmdVersion("karmada-scheduler"))
+	cmd.AddCommand(sharedcommand.NewCmdVersion(names.KarmadaSchedulerComponentName))
 
 	cmd.Flags().AddFlagSet(genericFlagSet)
 	cmd.Flags().AddFlagSet(logsFlagSet)

--- a/cmd/scheduler/app/scheduler_test.go
+++ b/cmd/scheduler/app/scheduler_test.go
@@ -25,13 +25,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/karmada-io/karmada/cmd/scheduler/app/options"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 func TestNewSchedulerCommand(t *testing.T) {
 	stopCh := make(chan struct{})
 	cmd := NewSchedulerCommand(stopCh)
 	assert.NotNil(t, cmd)
-	assert.Equal(t, "karmada-scheduler", cmd.Use)
+	assert.Equal(t, names.KarmadaSchedulerComponentName, cmd.Use)
 	assert.NotEmpty(t, cmd.Long)
 }
 

--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -39,6 +39,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/sharedcli/klogflag"
 	"github.com/karmada-io/karmada/pkg/sharedcli/profileflag"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
+	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/pkg/version"
 	"github.com/karmada-io/karmada/pkg/version/sharedcommand"
 	"github.com/karmada-io/karmada/pkg/webhook/clusteroverridepolicy"
@@ -63,7 +64,7 @@ func NewWebhookCommand(ctx context.Context) *cobra.Command {
 	opts := options.NewOptions()
 
 	cmd := &cobra.Command{
-		Use: "karmada-webhook",
+		Use: names.KarmadaWebhookComponentName,
 		Long: `The karmada-webhook starts a webhook server and manages policies about how to mutate and validate
 Karmada resources including 'PropagationPolicy', 'OverridePolicy' and so on.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
@@ -96,7 +97,7 @@ Karmada resources including 'PropagationPolicy', 'OverridePolicy' and so on.`,
 	logsFlagSet := fss.FlagSet("logs")
 	klogflag.Add(logsFlagSet)
 
-	cmd.AddCommand(sharedcommand.NewCmdVersion("karmada-webhook"))
+	cmd.AddCommand(sharedcommand.NewCmdVersion(names.KarmadaWebhookComponentName))
 	cmd.Flags().AddFlagSet(genericFlagSet)
 	cmd.Flags().AddFlagSet(logsFlagSet)
 

--- a/hack/tools/gencomponentdocs/gen_component_docs.go
+++ b/hack/tools/gencomponentdocs/gen_component_docs.go
@@ -34,6 +34,7 @@ import (
 	schapp "github.com/karmada-io/karmada/cmd/scheduler/app"
 	webhookapp "github.com/karmada-io/karmada/cmd/webhook/app"
 	"github.com/karmada-io/karmada/pkg/util/lifted"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 func main() {
@@ -57,31 +58,31 @@ func main() {
 	var cmd *cobra.Command
 
 	switch module {
-	case "karmada-controller-manager":
+	case names.KarmadaControllerManagerComponentName:
 		// generate docs for karmada-controller-manager
 		cmd = cmapp.NewControllerManagerCommand(context.TODO())
-	case "karmada-scheduler":
+	case names.KarmadaSchedulerComponentName:
 		// generate docs for karmada-scheduler
 		cmd = schapp.NewSchedulerCommand(nil)
-	case "karmada-agent":
+	case names.KarmadaAgentComponentName:
 		// generate docs for karmada-agent
 		cmd = agentapp.NewAgentCommand(context.TODO())
-	case "karmada-aggregated-apiserver":
+	case names.KarmadaAggregatedAPIServerComponentName:
 		// generate docs for karmada-aggregated-apiserver
 		cmd = aaapp.NewAggregatedApiserverCommand(context.TODO())
-	case "karmada-descheduler":
+	case names.KarmadaDeschedulerComponentName:
 		// generate docs for karmada-descheduler
 		cmd = deschapp.NewDeschedulerCommand(nil)
-	case "karmada-search":
+	case names.KarmadaSearchComponentName:
 		// generate docs for karmada-search
 		cmd = searchapp.NewKarmadaSearchCommand(context.TODO())
-	case "karmada-scheduler-estimator":
+	case names.KarmadaSchedulerEstimatorComponentName:
 		// generate docs for karmada-scheduler-estimator
 		cmd = estiapp.NewSchedulerEstimatorCommand(context.TODO())
-	case "karmada-webhook":
+	case names.KarmadaWebhookComponentName:
 		// generate docs for karmada-webhook
 		cmd = webhookapp.NewWebhookCommand(context.TODO())
-	case "karmada-metrics-adapter":
+	case names.KarmadaMetricsAdapterComponentName:
 		// generate docs for karmada-metrics-adapter
 		cmd = adapterapp.NewMetricsAdapterCommand(context.TODO())
 	default:

--- a/operator/pkg/apis/operator/v1alpha1/defaults.go
+++ b/operator/pkg/apis/operator/v1alpha1/defaults.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/karmada-io/karmada/operator/pkg/constants"
+	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/pkg/version"
 )
 
@@ -33,14 +34,14 @@ var (
 	DefaultKarmadaImageVersion                string
 	etcdImageRepository                       = fmt.Sprintf("%s/%s", constants.KubeDefaultRepository, constants.Etcd)
 	karmadaAPIServiceImageRepository          = fmt.Sprintf("%s/%s", constants.KubeDefaultRepository, constants.KubeAPIServer)
-	karmadaAggregatedAPIServerImageRepository = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, constants.KarmadaAggregatedAPIServer)
+	karmadaAggregatedAPIServerImageRepository = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, names.KarmadaAggregatedAPIServerComponentName)
 	kubeControllerManagerImageRepository      = fmt.Sprintf("%s/%s", constants.KubeDefaultRepository, constants.KubeControllerManager)
-	karmadaControllerManagerImageRepository   = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, constants.KarmadaControllerManager)
-	karmadaSchedulerImageRepository           = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, constants.KarmadaScheduler)
-	karmadaWebhookImageRepository             = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, constants.KarmadaWebhook)
-	karmadaDeschedulerImageRepository         = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, constants.KarmadaDescheduler)
-	karmadaMetricsAdapterImageRepository      = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, constants.KarmadaMetricsAdapter)
-	karmadaSearchImageRepository              = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, constants.KarmadaSearch)
+	karmadaControllerManagerImageRepository   = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, names.KarmadaControllerManagerComponentName)
+	karmadaSchedulerImageRepository           = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, names.KarmadaSchedulerComponentName)
+	karmadaWebhookImageRepository             = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, names.KarmadaWebhookComponentName)
+	karmadaDeschedulerImageRepository         = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, names.KarmadaDeschedulerComponentName)
+	karmadaMetricsAdapterImageRepository      = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, names.KarmadaMetricsAdapterComponentName)
+	karmadaSearchImageRepository              = fmt.Sprintf("%s/%s", constants.KarmadaDefaultRepository, names.KarmadaSearchComponentName)
 )
 
 func init() {

--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -45,22 +45,8 @@ const (
 	KarmadaAPIServer = "karmada-apiserver"
 	// KubeAPIServer defines the repository name of the kube apiserver
 	KubeAPIServer = "kube-apiserver"
-	// KarmadaAggregatedAPIServer defines the name of the karmada-aggregated-apiserver component
-	KarmadaAggregatedAPIServer = "karmada-aggregated-apiserver"
 	// KubeControllerManager defines the name of the kube-controller-manager component
 	KubeControllerManager = "kube-controller-manager"
-	// KarmadaControllerManager defines the name of the karmada-controller-manager component
-	KarmadaControllerManager = "karmada-controller-manager"
-	// KarmadaScheduler defines the name of the karmada-scheduler component
-	KarmadaScheduler = "karmada-scheduler"
-	// KarmadaWebhook defines the name of the karmada-webhook component
-	KarmadaWebhook = "karmada-webhook"
-	// KarmadaSearch defines the name of the karmada-search component
-	KarmadaSearch = "karmada-search"
-	// KarmadaDescheduler defines the name of the karmada-descheduler component
-	KarmadaDescheduler = "karmada-descheduler"
-	// KarmadaMetricsAdapter defines the name of the karmada-metrics-adapter component
-	KarmadaMetricsAdapter = "karmada-metrics-adapter"
 
 	// KarmadaSystemNamespace defines the leader selection namespace for karmada components
 	KarmadaSystemNamespace = "karmada-system"

--- a/operator/pkg/tasks/deinit/component_test.go
+++ b/operator/pkg/tasks/deinit/component_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/karmada-io/karmada/operator/pkg/util"
 	"github.com/karmada-io/karmada/operator/pkg/util/apiclient"
 	"github.com/karmada-io/karmada/operator/pkg/workflow"
+	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/test/helper"
 )
 
@@ -89,16 +90,16 @@ func TestRunRemoveComponentSubTask(t *testing.T) {
 	}{
 		{
 			name:      "RunRemoveComponentSubTask_InvalidTypeAssertion_TypeAssertionIsInvalid",
-			component: constants.KarmadaControllerManager,
+			component: names.KarmadaControllerManagerComponentName,
 			runData:   &MyTestData{Data: "test"},
 			prep:      func(workflow.RunData, *appsv1.Deployment, *corev1.Service) error { return nil },
 			verify:    func(workflow.RunData, *appsv1.Deployment, *corev1.Service) error { return nil },
 			wantErr:   true,
-			errMsg:    fmt.Sprintf("remove-%s task invoked with an invalid data struct", constants.KarmadaControllerManager),
+			errMsg:    fmt.Sprintf("remove-%s task invoked with an invalid data struct", names.KarmadaControllerManagerComponentName),
 		},
 		{
 			name:             "RunRemoveComponentSubTask_DeleteKarmadaControllerManagerDeploymentWithSecret_DeploymentAndSecretDeleted",
-			component:        constants.KarmadaControllerManager,
+			component:        names.KarmadaControllerManagerComponentName,
 			workloadNameFunc: util.KarmadaControllerManagerName,
 			deployment:       helper.NewDeployment(namespace, util.KarmadaControllerManagerName(name)),
 			service:          helper.NewService(namespace, util.KarmadaControllerManagerName(name), corev1.ServiceTypeClusterIP),

--- a/operator/pkg/tasks/init/wait.go
+++ b/operator/pkg/tasks/init/wait.go
@@ -27,6 +27,7 @@ import (
 	"github.com/karmada-io/karmada/operator/pkg/constants"
 	"github.com/karmada-io/karmada/operator/pkg/util/apiclient"
 	"github.com/karmada-io/karmada/operator/pkg/workflow"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 var (
@@ -41,12 +42,12 @@ var (
 
 	etcdLabels                       = labels.Set{"karmada-app": constants.Etcd}
 	karmadaApiserverLabels           = labels.Set{"karmada-app": constants.KarmadaAPIServer}
-	karmadaAggregatedAPIServerLabels = labels.Set{"karmada-app": constants.KarmadaAggregatedAPIServer}
+	karmadaAggregatedAPIServerLabels = labels.Set{"karmada-app": names.KarmadaAggregatedAPIServerComponentName}
 	kubeControllerManagerLabels      = labels.Set{"karmada-app": constants.KubeControllerManager}
-	karmadaControllerManagerLabels   = labels.Set{"karmada-app": constants.KarmadaControllerManager}
-	karmadaSchedulerLabels           = labels.Set{"karmada-app": constants.KarmadaScheduler}
-	karmadaWebhookLabels             = labels.Set{"karmada-app": constants.KarmadaWebhook}
-	karmadaMetricAdapterLabels       = labels.Set{"karmada-app": constants.KarmadaMetricsAdapter}
+	karmadaControllerManagerLabels   = labels.Set{"karmada-app": names.KarmadaControllerManagerComponentName}
+	karmadaSchedulerLabels           = labels.Set{"karmada-app": names.KarmadaSchedulerComponentName}
+	karmadaWebhookLabels             = labels.Set{"karmada-app": names.KarmadaWebhookComponentName}
+	karmadaMetricAdapterLabels       = labels.Set{"karmada-app": names.KarmadaMetricsAdapterComponentName}
 )
 
 // NewCheckApiserverHealthTask init wait-apiserver task

--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -46,6 +46,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	"github.com/karmada-io/karmada/pkg/util/grpcconnection"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 const (
@@ -131,7 +132,7 @@ func NewDescheduler(karmadaClient karmadaclientset.Interface, kubeClient kuberne
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartStructuredLogging(0)
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: kubeClient.CoreV1().Events(metav1.NamespaceAll)})
-	desched.eventRecorder = eventBroadcaster.NewRecorder(gclient.NewSchema(), corev1.EventSource{Component: "karmada-descheduler"})
+	desched.eventRecorder = eventBroadcaster.NewRecorder(gclient.NewSchema(), corev1.EventSource{Component: names.KarmadaDeschedulerComponentName})
 
 	return desched
 }

--- a/pkg/karmadactl/addons/descheduler/descheduler.go
+++ b/pkg/karmadactl/addons/descheduler/descheduler.go
@@ -30,18 +30,19 @@ import (
 	addoninit "github.com/karmada-io/karmada/pkg/karmadactl/addons/init"
 	addonutils "github.com/karmada-io/karmada/pkg/karmadactl/addons/utils"
 	cmdutil "github.com/karmada-io/karmada/pkg/karmadactl/util"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 // AddonDescheduler describe the descheduler addon command process
 var AddonDescheduler = &addoninit.Addon{
-	Name:    addoninit.DeschedulerResourceName,
+	Name:    names.KarmadaDeschedulerComponentName,
 	Status:  status,
 	Enable:  enableDescheduler,
 	Disable: disableDescheduler,
 }
 
 var status = func(opts *addoninit.CommandAddonsListOption) (string, error) {
-	deployment, err := opts.KubeClientSet.AppsV1().Deployments(opts.Namespace).Get(context.TODO(), addoninit.DeschedulerResourceName, metav1.GetOptions{})
+	deployment, err := opts.KubeClientSet.AppsV1().Deployments(opts.Namespace).Get(context.TODO(), names.KarmadaDeschedulerComponentName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return addoninit.AddonDisabledStatus, nil
@@ -87,7 +88,7 @@ var enableDescheduler = func(opts *addoninit.CommandAddonsEnableOption) error {
 var disableDescheduler = func(opts *addoninit.CommandAddonsDisableOption) error {
 	// uninstall karmada descheduler deployment on host cluster
 	deployClient := opts.KubeClientSet.AppsV1().Deployments(opts.Namespace)
-	if err := deployClient.Delete(context.TODO(), addoninit.DeschedulerResourceName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+	if err := deployClient.Delete(context.TODO(), names.KarmadaDeschedulerComponentName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 

--- a/pkg/karmadactl/addons/descheduler/descheduler_test.go
+++ b/pkg/karmadactl/addons/descheduler/descheduler_test.go
@@ -33,10 +33,11 @@ import (
 	addoninit "github.com/karmada-io/karmada/pkg/karmadactl/addons/init"
 	addonutils "github.com/karmada-io/karmada/pkg/karmadactl/addons/utils"
 	cmdutil "github.com/karmada-io/karmada/pkg/karmadactl/util"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 func TestStatus(t *testing.T) {
-	name, namespace := addoninit.DeschedulerResourceName, "test"
+	name, namespace := names.KarmadaDeschedulerComponentName, "test"
 	var replicas int32 = 2
 	tests := []struct {
 		name       string
@@ -126,7 +127,7 @@ func TestStatus(t *testing.T) {
 }
 
 func TestEnableDescheduler(t *testing.T) {
-	name, namespace := addoninit.DeschedulerResourceName, "test"
+	name, namespace := names.KarmadaDeschedulerComponentName, "test"
 	var replicas int32 = 2
 	tests := []struct {
 		name       string
@@ -174,7 +175,7 @@ func TestEnableDescheduler(t *testing.T) {
 }
 
 func TestDisableDescheduler(t *testing.T) {
-	name, namespace := addoninit.DeschedulerResourceName, "test"
+	name, namespace := names.KarmadaDeschedulerComponentName, "test"
 	client := fakeclientset.NewSimpleClientset()
 	var replicas int32 = 2
 	tests := []struct {

--- a/pkg/karmadactl/addons/estimator/estimator.go
+++ b/pkg/karmadactl/addons/estimator/estimator.go
@@ -37,7 +37,7 @@ import (
 
 // AddonEstimator describe the estimator addon command process
 var AddonEstimator = &addoninit.Addon{
-	Name:    addoninit.EstimatorResourceName,
+	Name:    names.KarmadaSchedulerEstimatorComponentName,
 	Status:  status,
 	Enable:  enableEstimator,
 	Disable: disableEstimator,
@@ -143,13 +143,13 @@ var disableEstimator = func(opts *addoninit.CommandAddonsDisableOption) error {
 
 	//delete deployment
 	deployClient := opts.KubeClientSet.AppsV1().Deployments(opts.Namespace)
-	if err := deployClient.Delete(context.TODO(), fmt.Sprintf("%s-%s", addoninit.EstimatorResourceName, opts.Cluster), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+	if err := deployClient.Delete(context.TODO(), fmt.Sprintf("%s-%s", names.KarmadaSchedulerEstimatorComponentName, opts.Cluster), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		klog.Exitln(err)
 	}
 
 	// delete service
 	serviceClient := opts.KubeClientSet.CoreV1().Services(opts.Namespace)
-	if err := serviceClient.Delete(context.TODO(), fmt.Sprintf("%s-%s", addoninit.EstimatorResourceName, opts.Cluster), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+	if err := serviceClient.Delete(context.TODO(), fmt.Sprintf("%s-%s", names.KarmadaSchedulerEstimatorComponentName, opts.Cluster), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		klog.Exitln(err)
 	}
 

--- a/pkg/karmadactl/addons/init/addon.go
+++ b/pkg/karmadactl/addons/init/addon.go
@@ -30,20 +30,6 @@ const (
 	AddonUnknownStatus = "unknown"
 )
 
-const (
-	// DeschedulerResourceName define Descheduler Addon and component installed name
-	DeschedulerResourceName = "karmada-descheduler"
-
-	// EstimatorResourceName define Estimator Addon and component installed name
-	EstimatorResourceName = "karmada-scheduler-estimator"
-
-	// SearchResourceName define Search Addon and component installed name
-	SearchResourceName = "karmada-search"
-
-	// MetricsAdapterResourceName define metrics-adapter Addon and component installed name
-	MetricsAdapterResourceName = "karmada-metrics-adapter"
-)
-
 // Addons hosts the optional components that support by karmada
 var Addons = map[string]*Addon{}
 

--- a/pkg/karmadactl/addons/init/disable_option.go
+++ b/pkg/karmadactl/addons/init/disable_option.go
@@ -23,8 +23,9 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/strings/slices"
 
-	"github.com/karmada-io/karmada/pkg/karmadactl/util"
+	cmdutil "github.com/karmada-io/karmada/pkg/karmadactl/util"
 	"github.com/karmada-io/karmada/pkg/karmadactl/util/apiclient"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 // CommandAddonsDisableOption options for addons list.
@@ -58,7 +59,7 @@ func (o *CommandAddonsDisableOption) Validate(args []string) error {
 		return err
 	}
 
-	if slices.Contains(args, EstimatorResourceName) && o.Cluster == "" {
+	if slices.Contains(args, names.KarmadaSchedulerEstimatorComponentName) && o.Cluster == "" {
 		return fmt.Errorf("member cluster and config is needed when disable karmada-scheduler-estimator,use `--cluster=member --member-kubeconfig /root/.kube/config --member-context member1` to disable karmada-scheduler-estimator")
 	}
 	return nil
@@ -67,7 +68,7 @@ func (o *CommandAddonsDisableOption) Validate(args []string) error {
 // Run start disable Karmada addons
 func (o *CommandAddonsDisableOption) Run(args []string) error {
 	fmt.Printf("Disable Karmada addon %s\n", args)
-	if !o.Force && !util.DeleteConfirmation() {
+	if !o.Force && !cmdutil.DeleteConfirmation() {
 		return nil
 	}
 

--- a/pkg/karmadactl/addons/init/enable_option.go
+++ b/pkg/karmadactl/addons/init/enable_option.go
@@ -28,6 +28,7 @@ import (
 
 	cmdinit "github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/kubernetes"
 	"github.com/karmada-io/karmada/pkg/karmadactl/util/apiclient"
+	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/pkg/version"
 )
 
@@ -156,11 +157,11 @@ func (o *CommandAddonsEnableOption) Validate(args []string) error {
 	}
 
 	if o.Cluster == "" {
-		if slices.Contains(args, EstimatorResourceName) {
+		if slices.Contains(args, names.KarmadaSchedulerEstimatorComponentName) {
 			return fmt.Errorf("member cluster is needed when enable karmada-scheduler-estimator,use `--cluster=member --member-kubeconfig /root/.kube/config --member-context member1` to enable karmada-scheduler-estimator")
 		}
 	} else {
-		if !slices.Contains(args, EstimatorResourceName) && !slices.Contains(args, "all") {
+		if !slices.Contains(args, names.KarmadaSchedulerEstimatorComponentName) && !slices.Contains(args, "all") {
 			return fmt.Errorf("cluster is needed only when enable karmada-scheduler-estimator or enable all")
 		}
 		if o.MemberKubeConfig == "" {

--- a/pkg/karmadactl/addons/install/install.go
+++ b/pkg/karmadactl/addons/install/install.go
@@ -22,12 +22,13 @@ import (
 	addonsinit "github.com/karmada-io/karmada/pkg/karmadactl/addons/init"
 	"github.com/karmada-io/karmada/pkg/karmadactl/addons/metricsadapter"
 	"github.com/karmada-io/karmada/pkg/karmadactl/addons/search"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 // Install install the karmada addons process in Addons
 func Install() {
-	addonsinit.Addons["karmada-descheduler"] = descheduler.AddonDescheduler
-	addonsinit.Addons["karmada-metrics-adapter"] = metricsadapter.AddonMetricsAdapter
-	addonsinit.Addons["karmada-scheduler-estimator"] = estimator.AddonEstimator
-	addonsinit.Addons["karmada-search"] = search.AddonSearch
+	addonsinit.Addons[names.KarmadaDeschedulerComponentName] = descheduler.AddonDescheduler
+	addonsinit.Addons[names.KarmadaMetricsAdapterComponentName] = metricsadapter.AddonMetricsAdapter
+	addonsinit.Addons[names.KarmadaSchedulerEstimatorComponentName] = estimator.AddonEstimator
+	addonsinit.Addons[names.KarmadaSearchComponentName] = search.AddonSearch
 }

--- a/pkg/karmadactl/addons/install/install_test.go
+++ b/pkg/karmadactl/addons/install/install_test.go
@@ -25,6 +25,7 @@ import (
 	addonsinit "github.com/karmada-io/karmada/pkg/karmadactl/addons/init"
 	"github.com/karmada-io/karmada/pkg/karmadactl/addons/metricsadapter"
 	"github.com/karmada-io/karmada/pkg/karmadactl/addons/search"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 func TestInstall(t *testing.T) {
@@ -38,22 +39,22 @@ func TestInstall(t *testing.T) {
 	}{
 		{
 			name:          "Install_WithKarmadaDeschedulerAddon_Installed",
-			key:           "karmada-descheduler",
+			key:           names.KarmadaDeschedulerComponentName,
 			expectedAddon: descheduler.AddonDescheduler,
 		},
 		{
 			name:          "Install_WithKarmadaMetricsAdapterAddon_Installed",
-			key:           "karmada-metrics-adapter",
+			key:           names.KarmadaMetricsAdapterComponentName,
 			expectedAddon: metricsadapter.AddonMetricsAdapter,
 		},
 		{
 			name:          "Install_WithKarmadaSchedulerEstimatorAddon_Installed",
-			key:           "karmada-scheduler-estimator",
+			key:           names.KarmadaSchedulerEstimatorComponentName,
 			expectedAddon: estimator.AddonEstimator,
 		},
 		{
 			name:          "Install_WithKarmadaSearchAddon_Installed",
-			key:           "karmada-search",
+			key:           names.KarmadaSearchComponentName,
 			expectedAddon: search.AddonSearch,
 		},
 	}

--- a/pkg/karmadactl/addons/metricsadapter/metricsadapter.go
+++ b/pkg/karmadactl/addons/metricsadapter/metricsadapter.go
@@ -38,6 +38,7 @@ import (
 	initkarmada "github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/karmada"
 	"github.com/karmada-io/karmada/pkg/karmadactl/options"
 	cmdutil "github.com/karmada-io/karmada/pkg/karmadactl/util"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 // aaAPIServiceName define apiservice name install on karmada control plane
@@ -49,7 +50,7 @@ var aaAPIServices = []string{
 
 // AddonMetricsAdapter describe the metrics-adapter addon command process
 var AddonMetricsAdapter = &addoninit.Addon{
-	Name:    addoninit.MetricsAdapterResourceName,
+	Name:    names.KarmadaMetricsAdapterComponentName,
 	Status:  status,
 	Enable:  enableMetricsAdapter,
 	Disable: disableMetricsAdapter,
@@ -58,7 +59,7 @@ var AddonMetricsAdapter = &addoninit.Addon{
 var status = func(opts *addoninit.CommandAddonsListOption) (string, error) {
 	// check karmada-metrics-adapter deployment status on host cluster
 	deployClient := opts.KubeClientSet.AppsV1().Deployments(opts.Namespace)
-	deployment, err := deployClient.Get(context.TODO(), addoninit.MetricsAdapterResourceName, metav1.GetOptions{})
+	deployment, err := deployClient.Get(context.TODO(), names.KarmadaMetricsAdapterComponentName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return addoninit.AddonDisabledStatus, nil
@@ -102,21 +103,21 @@ var enableMetricsAdapter = func(opts *addoninit.CommandAddonsEnableOption) error
 var disableMetricsAdapter = func(opts *addoninit.CommandAddonsDisableOption) error {
 	// delete karmada metrics adapter service on host cluster
 	serviceClient := opts.KubeClientSet.CoreV1().Services(opts.Namespace)
-	if err := serviceClient.Delete(context.TODO(), addoninit.MetricsAdapterResourceName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+	if err := serviceClient.Delete(context.TODO(), names.KarmadaMetricsAdapterComponentName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 	klog.Infof("Uninstall karmada metrics adapter service on host cluster successfully")
 
 	// delete karmada metrics adapter deployment on host cluster
 	deployClient := opts.KubeClientSet.AppsV1().Deployments(opts.Namespace)
-	if err := deployClient.Delete(context.TODO(), addoninit.MetricsAdapterResourceName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+	if err := deployClient.Delete(context.TODO(), names.KarmadaMetricsAdapterComponentName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 	klog.Infof("Uninstall karmada metrics adapter deployment on host cluster successfully")
 
 	// delete karmada metrics adapter aa service on karmada control plane
 	karmadaServiceClient := opts.KarmadaKubeClientSet.CoreV1().Services(opts.Namespace)
-	if err := karmadaServiceClient.Delete(context.TODO(), addoninit.MetricsAdapterResourceName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+	if err := karmadaServiceClient.Delete(context.TODO(), names.KarmadaMetricsAdapterComponentName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 	klog.Infof("Uninstall karmada metrics adapter AA service on karmada control plane successfully")

--- a/pkg/karmadactl/addons/metricsadapter/metricsadapter_test.go
+++ b/pkg/karmadactl/addons/metricsadapter/metricsadapter_test.go
@@ -36,10 +36,11 @@ import (
 	addoninit "github.com/karmada-io/karmada/pkg/karmadactl/addons/init"
 	addonutils "github.com/karmada-io/karmada/pkg/karmadactl/addons/utils"
 	cmdutil "github.com/karmada-io/karmada/pkg/karmadactl/util"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 func TestStatus(t *testing.T) {
-	name, namespace := addoninit.MetricsAdapterResourceName, "test"
+	name, namespace := names.KarmadaMetricsAdapterComponentName, "test"
 	var replicas int32 = 2
 	tests := []struct {
 		name       string

--- a/pkg/karmadactl/addons/search/search.go
+++ b/pkg/karmadactl/addons/search/search.go
@@ -39,6 +39,7 @@ import (
 	initkarmada "github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/karmada"
 	"github.com/karmada-io/karmada/pkg/karmadactl/options"
 	cmdutil "github.com/karmada-io/karmada/pkg/karmadactl/util"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 const (
@@ -56,7 +57,7 @@ const (
 
 // AddonSearch describe the search addon command process
 var AddonSearch = &addoninit.Addon{
-	Name:    addoninit.SearchResourceName,
+	Name:    names.KarmadaSearchComponentName,
 	Status:  status,
 	Enable:  enableSearch,
 	Disable: disableSearch,
@@ -65,7 +66,7 @@ var AddonSearch = &addoninit.Addon{
 var status = func(opts *addoninit.CommandAddonsListOption) (string, error) {
 	// check karmada-search deployment status on host cluster
 	deployClient := opts.KubeClientSet.AppsV1().Deployments(opts.Namespace)
-	deployment, err := deployClient.Get(context.TODO(), addoninit.SearchResourceName, metav1.GetOptions{})
+	deployment, err := deployClient.Get(context.TODO(), names.KarmadaSearchComponentName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return addoninit.AddonDisabledStatus, nil
@@ -109,21 +110,21 @@ var enableSearch = func(opts *addoninit.CommandAddonsEnableOption) error {
 var disableSearch = func(opts *addoninit.CommandAddonsDisableOption) error {
 	// delete karmada search service on host cluster
 	serviceClient := opts.KubeClientSet.CoreV1().Services(opts.Namespace)
-	if err := serviceClient.Delete(context.TODO(), addoninit.SearchResourceName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+	if err := serviceClient.Delete(context.TODO(), names.KarmadaSearchComponentName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 	klog.Infof("Uninstall karmada search service on host cluster successfully")
 
 	// delete karmada search deployment on host cluster
 	deployClient := opts.KubeClientSet.AppsV1().Deployments(opts.Namespace)
-	if err := deployClient.Delete(context.TODO(), addoninit.SearchResourceName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+	if err := deployClient.Delete(context.TODO(), names.KarmadaSearchComponentName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 	klog.Infof("Uninstall karmada search deployment on host cluster successfully")
 
 	// delete karmada search aa service on karmada control plane
 	karmadaServiceClient := opts.KarmadaKubeClientSet.CoreV1().Services(opts.Namespace)
-	if err := karmadaServiceClient.Delete(context.TODO(), addoninit.SearchResourceName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+	if err := karmadaServiceClient.Delete(context.TODO(), names.KarmadaSearchComponentName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 	klog.Infof("Uninstall karmada search AA service on karmada control plane successfully")

--- a/pkg/karmadactl/addons/search/search_test.go
+++ b/pkg/karmadactl/addons/search/search_test.go
@@ -35,10 +35,11 @@ import (
 	addoninit "github.com/karmada-io/karmada/pkg/karmadactl/addons/init"
 	addonutils "github.com/karmada-io/karmada/pkg/karmadactl/addons/utils"
 	cmdutil "github.com/karmada-io/karmada/pkg/karmadactl/util"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 func TestKarmadaSearchAddonStatus(t *testing.T) {
-	name, namespace := addoninit.SearchResourceName, "test"
+	name, namespace := names.KarmadaSearchComponentName, "test"
 	var replicas int32 = 2
 	tests := []struct {
 		name       string

--- a/pkg/karmadactl/cmdinit/cert/cert_test.go
+++ b/pkg/karmadactl/cmdinit/cert/cert_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/utils"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 const (
@@ -81,9 +82,9 @@ func TestGenCerts(t *testing.T) {
 		"kubernetes.default",
 		"kubernetes.default.svc",
 		"karmada-apiserver",
-		"karmada-webhook",
+		names.KarmadaWebhookComponentName,
 		fmt.Sprintf("%s.%s.svc.cluster.local", "karmada-apiserver", namespace),
-		fmt.Sprintf("%s.%s.svc.cluster.local", "karmada-webhook", namespace),
+		fmt.Sprintf("%s.%s.svc.cluster.local", names.KarmadaWebhookComponentName, namespace),
 		fmt.Sprintf("*.%s.svc.cluster.local", namespace),
 		fmt.Sprintf("*.%s.svc", namespace),
 	}

--- a/pkg/karmadactl/cmdinit/karmada/deploy.go
+++ b/pkg/karmadactl/cmdinit/karmada/deploy.go
@@ -45,15 +45,16 @@ import (
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/bootstraptoken/clusterinfo"
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/utils"
-	"github.com/karmada-io/karmada/pkg/karmadactl/util"
+	cmdutil "github.com/karmada-io/karmada/pkg/karmadactl/util"
 	"github.com/karmada-io/karmada/pkg/karmadactl/util/apiclient"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 const (
 	clusterProxyAdminRole = "cluster-proxy-admin"
 	clusterProxyAdminUser = "system:admin"
 
-	aggregatedApiserverServiceName = "karmada-aggregated-apiserver"
+	aggregatedApiserverServiceName = names.KarmadaAggregatedAPIServerComponentName
 )
 
 // InitKarmadaResources Initialize karmada resource
@@ -69,7 +70,7 @@ func InitKarmadaResources(dir, caBase64, systemNamespace string) error {
 	}
 
 	// create namespace
-	if err := util.CreateOrUpdateNamespace(clientSet, util.NewNamespace(systemNamespace)); err != nil {
+	if err := cmdutil.CreateOrUpdateNamespace(clientSet, cmdutil.NewNamespace(systemNamespace)); err != nil {
 		klog.Exitln(err)
 	}
 
@@ -264,7 +265,7 @@ func initAggregatedAPIService(clientSet *kubernetes.Clientset, restConfig *rest.
 			ExternalName: fmt.Sprintf("%s.%s.svc", aggregatedApiserverServiceName, systemNamespace),
 		},
 	}
-	if err := util.CreateOrUpdateService(clientSet, aaService); err != nil {
+	if err := cmdutil.CreateOrUpdateService(clientSet, aaService); err != nil {
 		return err
 	}
 
@@ -282,7 +283,7 @@ func initAggregatedAPIService(clientSet *kubernetes.Clientset, restConfig *rest.
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   aaAPIServiceObjName,
-			Labels: map[string]string{"app": "karmada-aggregated-apiserver", "apiserver": "true"},
+			Labels: map[string]string{"app": names.KarmadaAggregatedAPIServerComponentName, "apiserver": "true"},
 		},
 		Spec: apiregistrationv1.APIServiceSpec{
 			CABundle:             caBytes,
@@ -297,7 +298,7 @@ func initAggregatedAPIService(clientSet *kubernetes.Clientset, restConfig *rest.
 		},
 	}
 
-	if err = util.CreateOrUpdateAPIService(apiRegistrationClient, aaAPIService); err != nil {
+	if err = cmdutil.CreateOrUpdateAPIService(apiRegistrationClient, aaAPIService); err != nil {
 		return err
 	}
 

--- a/pkg/karmadactl/cmdinit/kubernetes/deployments.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deployments.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
 	globaloptions "github.com/karmada-io/karmada/pkg/karmadactl/options"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 const (
@@ -47,16 +48,16 @@ const (
 	serviceClusterIP                                            = "10.96.0.0/12"
 	kubeControllerManagerClusterRoleAndDeploymentAndServiceName = "kube-controller-manager"
 	kubeControllerManagerPort                                   = 10257
-	schedulerDeploymentNameAndServiceAccountName                = "karmada-scheduler"
-	controllerManagerDeploymentAndServiceName                   = "karmada-controller-manager"
+	schedulerDeploymentNameAndServiceAccountName                = names.KarmadaSchedulerComponentName
+	controllerManagerDeploymentAndServiceName                   = names.KarmadaControllerManagerComponentName
 	controllerManagerSecurePort                                 = 10357
-	webhookDeploymentAndServiceAccountAndServiceName            = "karmada-webhook"
+	webhookDeploymentAndServiceAccountAndServiceName            = names.KarmadaWebhookComponentName
 	webhookCertsName                                            = "karmada-webhook-cert"
 	webhookCertVolumeMountPath                                  = "/var/serving-cert"
 	webhookPortName                                             = "webhook"
 	webhookTargetPort                                           = 8443
 	webhookPort                                                 = 443
-	karmadaAggregatedAPIServerDeploymentAndServiceName          = "karmada-aggregated-apiserver"
+	karmadaAggregatedAPIServerDeploymentAndServiceName          = names.KarmadaAggregatedAPIServerComponentName
 )
 
 var (

--- a/pkg/karmadactl/join/join.go
+++ b/pkg/karmadactl/join/join.go
@@ -36,6 +36,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/karmadactl/util/apiclient"
 	utilcomp "github.com/karmada-io/karmada/pkg/karmadactl/util/completion"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 var (
@@ -145,7 +146,7 @@ func (j *CommandJoinOption) Validate(args []string) error {
 		return fmt.Errorf("invalid cluster name(%s): %s", j.ClusterName, strings.Join(errMsgs, ";"))
 	}
 
-	if j.ClusterNamespace == util.NamespaceKarmadaSystem {
+	if j.ClusterNamespace == names.NamespaceKarmadaSystem {
 		klog.Warningf("karmada-system is always reserved for Karmada control plane. We do not recommend using karmada-system to store secrets of member clusters. It may cause mistaken cleanup of resources.")
 	}
 

--- a/pkg/karmadactl/join/join_test.go
+++ b/pkg/karmadactl/join/join_test.go
@@ -35,7 +35,6 @@ import (
 	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
 	fakekarmadaclient "github.com/karmada-io/karmada/pkg/generated/clientset/versioned/fake"
 	"github.com/karmada-io/karmada/pkg/karmadactl/options"
-	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
@@ -72,7 +71,7 @@ func TestValidate(t *testing.T) {
 			name: "Validate_WithNameSpaceKarmadaSystem_WarningIssuedAndValidated",
 			joinOpts: &CommandJoinOption{
 				ClusterName:      "cluster1",
-				ClusterNamespace: util.NamespaceKarmadaSystem,
+				ClusterNamespace: names.NamespaceKarmadaSystem,
 			},
 			args:    []string{"cluster2"},
 			wantErr: false,

--- a/pkg/karmadactl/register/register.go
+++ b/pkg/karmadactl/register/register.go
@@ -57,6 +57,7 @@ import (
 	tokenutil "github.com/karmada-io/karmada/pkg/karmadactl/util/bootstraptoken"
 	karmadautil "github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/lifted/pubkeypin"
+	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/pkg/version"
 )
 
@@ -94,8 +95,6 @@ const (
 	KarmadaAgentKubeConfigFileName = "karmada-agent.conf"
 	// KarmadaKubeconfigName is the name of karmada kubeconfig
 	KarmadaKubeconfigName = "karmada-kubeconfig"
-	// KarmadaAgentName is the name of karmada-agent
-	KarmadaAgentName = "karmada-agent"
 	// KarmadaAgentServiceAccountName is the name of karmada-agent serviceaccount
 	KarmadaAgentServiceAccountName = "karmada-agent-sa"
 	// SignerName defines the signer name for csr, 'kubernetes.io/kube-apiserver-client' can sign the csr with `O=system:agents,CN=system:agent:` automatically if agentcsrapproving controller if enabled.
@@ -114,7 +113,7 @@ const (
 	DefaultCertExpirationSeconds int32 = 86400 * 365
 )
 
-var karmadaAgentLabels = map[string]string{"app": KarmadaAgentName}
+var karmadaAgentLabels = map[string]string{"app": names.KarmadaAgentComponentName}
 
 // BootstrapTokenDiscovery is used to set the options for bootstrap token based discovery
 type BootstrapTokenDiscovery struct {
@@ -494,9 +493,9 @@ func (o *CommandRegisterOption) preflight() []error {
 			errlist = append(errlist, err)
 		}
 
-		_, err = o.memberClusterClient.AppsV1().Deployments(o.Namespace).Get(context.TODO(), KarmadaAgentName, metav1.GetOptions{})
+		_, err = o.memberClusterClient.AppsV1().Deployments(o.Namespace).Get(context.TODO(), names.KarmadaAgentComponentName, metav1.GetOptions{})
 		if err == nil {
-			errlist = append(errlist, fmt.Errorf("%s/%s Deployment already exists", o.Namespace, KarmadaAgentName))
+			errlist = append(errlist, fmt.Errorf("%s/%s Deployment already exists", o.Namespace, names.KarmadaAgentComponentName))
 		} else if !apierrors.IsNotFound(err) {
 			errlist = append(errlist, err)
 		}
@@ -999,7 +998,7 @@ func (o *CommandRegisterOption) createSecretAndRBACInMemberCluster(karmadaAgentC
 
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   KarmadaAgentName,
+			Name:   names.KarmadaAgentComponentName,
 			Labels: labels,
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -1036,7 +1035,7 @@ func (o *CommandRegisterOption) createSecretAndRBACInMemberCluster(karmadaAgentC
 
 	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   KarmadaAgentName,
+			Name:   names.KarmadaAgentComponentName,
 			Labels: labels,
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -1069,7 +1068,7 @@ func (o *CommandRegisterOption) makeKarmadaAgentDeployment() *appsv1.Deployment 
 			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      KarmadaAgentName,
+			Name:      names.KarmadaAgentComponentName,
 			Namespace: o.Namespace,
 			Labels:    karmadaAgentLabels,
 		},
@@ -1086,7 +1085,7 @@ func (o *CommandRegisterOption) makeKarmadaAgentDeployment() *appsv1.Deployment 
 		ServiceAccountName: KarmadaAgentServiceAccountName,
 		Containers: []corev1.Container{
 			{
-				Name:  KarmadaAgentName,
+				Name:  names.KarmadaAgentComponentName,
 				Image: o.KarmadaAgentImage,
 				Command: []string{
 					"/bin/karmada-agent",
@@ -1140,7 +1139,7 @@ func (o *CommandRegisterOption) makeKarmadaAgentDeployment() *appsv1.Deployment 
 	// PodTemplateSpec
 	podTemplateSpec := corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      KarmadaAgentName,
+			Name:      names.KarmadaAgentComponentName,
 			Namespace: o.Namespace,
 			Labels:    karmadaAgentLabels,
 		},

--- a/pkg/karmadactl/unregister/unregister.go
+++ b/pkg/karmadactl/unregister/unregister.go
@@ -148,7 +148,7 @@ func (j *CommandUnregisterOption) AddFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&j.KarmadaContext, "karmada-context", "", "Context in karmada-config to access karmada-apiserver, optional, defaults to current context.")
 
 	flags.StringVarP(&j.Namespace, "namespace", "n", "karmada-system", "Namespace of the karmada-agent component deployed.")
-	flags.StringVarP(&j.AgentName, "agent-name", "", register.KarmadaAgentName, "Deployment name of the karmada-agent component deployed.")
+	flags.StringVarP(&j.AgentName, "agent-name", "", names.KarmadaAgentComponentName, "Deployment name of the karmada-agent component deployed.")
 	flags.StringVar(&j.ClusterNamespace, "cluster-namespace", options.DefaultKarmadaClusterNamespace, "Namespace in the control plane where member cluster secrets are stored.")
 	flags.DurationVar(&j.Wait, "wait", 60*time.Second, "wait for the unjoin command execution process(default 60s), if there is no success after this time, timeout will be returned.")
 	flags.BoolVar(&j.DryRun, "dry-run", false, "Run the command in dry-run mode, without making any server requests.")
@@ -410,11 +410,11 @@ func (j *CommandUnregisterOption) listMemberClusterResources() []register.Obj {
 		{Kind: "Namespace", Name: j.ClusterNamespace},
 
 		// the deployment of karmada-agent
-		{Kind: "Deployment", Namespace: j.Namespace, Name: register.KarmadaAgentName},
+		{Kind: "Deployment", Namespace: j.Namespace, Name: names.KarmadaAgentComponentName},
 		// the rbac resources used by karmada-agent to access the member cluster's kube-apiserver
 		{Kind: "ServiceAccount", Namespace: j.Namespace, Name: register.KarmadaAgentServiceAccountName},
-		{Kind: "ClusterRole", Name: register.KarmadaAgentName},
-		{Kind: "ClusterRoleBinding", Name: register.KarmadaAgentName},
+		{Kind: "ClusterRole", Name: names.KarmadaAgentComponentName},
+		{Kind: "ClusterRoleBinding", Name: names.KarmadaAgentComponentName},
 		// the karmada config used by karmada-agent to access karmada-apiserver
 		{Kind: "Secret", Namespace: j.Namespace, Name: register.KarmadaKubeconfigName},
 	}

--- a/pkg/karmadactl/unregister/unregister_test.go
+++ b/pkg/karmadactl/unregister/unregister_test.go
@@ -30,6 +30,7 @@ import (
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	fakekarmadaclient "github.com/karmada-io/karmada/pkg/generated/clientset/versioned/fake"
 	"github.com/karmada-io/karmada/pkg/karmadactl/register"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 const (
@@ -153,7 +154,7 @@ func TestCommandUnregisterOption_getKarmadaAgentConfig(t *testing.T) {
 				MemberClusterClient: fake.NewSimpleClientset(tt.clusterResources...),
 			}
 			agent := &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{Name: register.KarmadaAgentName, Namespace: namespace},
+				ObjectMeta: metav1.ObjectMeta{Name: names.KarmadaAgentComponentName, Namespace: namespace},
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{

--- a/pkg/search/apiserver.go
+++ b/pkg/search/apiserver.go
@@ -29,6 +29,7 @@ import (
 	informerfactory "github.com/karmada-io/karmada/pkg/generated/informers/externalversions"
 	searchstorage "github.com/karmada-io/karmada/pkg/registry/search/storage"
 	"github.com/karmada-io/karmada/pkg/search/proxy"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 // ExtraConfig holds custom apiserver config
@@ -79,7 +80,7 @@ var apiGroupInstaller = func(server *APIServer, apiGroupInfo *genericapiserver.A
 }
 
 func (c completedConfig) New() (*APIServer, error) {
-	genericServer, err := c.GenericConfig.New("karmada-search", genericapiserver.NewEmptyDelegate())
+	genericServer, err := c.GenericConfig.New(names.KarmadaSearchComponentName, genericapiserver.NewEmptyDelegate())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/search/proxy/controller.go
+++ b/pkg/search/proxy/controller.go
@@ -52,6 +52,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/helper"
 	"github.com/karmada-io/karmada/pkg/util/lifted"
+	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/pkg/util/restmapper"
 )
 
@@ -299,7 +300,7 @@ func (ctl *Controller) Connect(ctx context.Context, proxyPath string, responder 
 		}
 
 		h = metrics.InstrumentHandlerFunc(requestInfo.Verb, requestInfo.APIGroup, requestInfo.APIVersion, requestInfo.Resource, requestInfo.Subresource,
-			"", "karmada-search", false, "", h.ServeHTTP)
+			"", names.KarmadaSearchComponentName, false, "", h.ServeHTTP)
 		h.ServeHTTP(rw, newReq)
 	}), nil
 }

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -227,11 +227,6 @@ const (
 	CompletionsField = "completions"
 )
 
-const (
-	// NamespaceKarmadaSystem is the karmada system namespace.
-	NamespaceKarmadaSystem = "karmada-system"
-)
-
 // ContextKey is the key of context.
 type ContextKey string
 

--- a/pkg/util/imageparser/parser_test.go
+++ b/pkg/util/imageparser/parser_test.go
@@ -19,6 +19,8 @@ package imageparser
 import (
 	"fmt"
 	"testing"
+
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 func TestParse(t *testing.T) {
@@ -209,7 +211,7 @@ func ExampleComponents_SetTagOrDigest() {
 func ExampleComponents_String() {
 	key := Components{
 		hostname:   "fictional.registry.example",
-		repository: "karmada-scheduler",
+		repository: names.KarmadaSchedulerComponentName,
 		tag:        "v1.0.0",
 	}
 	pKey := &key

--- a/pkg/util/names/names.go
+++ b/pkg/util/names/names.go
@@ -35,6 +35,38 @@ const (
 	NamespaceDefault = "default"
 )
 
+// The following constants define standard names for various Karmada components.
+// These names are used consistently across the project to ensure uniformity and clarity.
+// Using these constants helps avoid typos and ensures that all components are referenced with the correct names.
+const (
+	// KarmadaDeschedulerComponentName is the name of the Karmada Descheduler component.
+	KarmadaDeschedulerComponentName = "karmada-descheduler"
+
+	// KarmadaSchedulerEstimatorComponentName is the name of the Karmada Scheduler Estimator component.
+	KarmadaSchedulerEstimatorComponentName = "karmada-scheduler-estimator"
+
+	// KarmadaSearchComponentName is the name of the Karmada Search addon.
+	KarmadaSearchComponentName = "karmada-search"
+
+	// KarmadaMetricsAdapterComponentName is the name of the Karmada Metrics Adapter component.
+	KarmadaMetricsAdapterComponentName = "karmada-metrics-adapter"
+
+	// KarmadaAggregatedAPIServerComponentName is the name of the Karmada Aggregated API Server component.
+	KarmadaAggregatedAPIServerComponentName = "karmada-aggregated-apiserver"
+
+	// KarmadaAgentComponentName is the name of the Karmada Agent component.
+	KarmadaAgentComponentName = "karmada-agent"
+
+	// KarmadaSchedulerComponentName is the name of the Karmada Scheduler component.
+	KarmadaSchedulerComponentName = "karmada-scheduler"
+
+	// KarmadaWebhookComponentName is the name of the Karmada Webhook component.
+	KarmadaWebhookComponentName = "karmada-webhook"
+
+	// KarmadaControllerManagerComponentName is the name of the Karmada Controller Manager component.
+	KarmadaControllerManagerComponentName = "karmada-controller-manager"
+)
+
 // ExecutionSpacePrefix is the prefix of execution space
 const ExecutionSpacePrefix = "karmada-es-"
 


### PR DESCRIPTION
**Description**

In this commit we unify the usage of addon names i.e `karmada-descheduler`, `karmada-scheduler-estimator`, `karmada-search`, and `karmada-metrics-adapter` across the codebase.

**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Motivated by @XiShanYongYe-Chang's comment https://github.com/karmada-io/karmada/pull/5754#discussion_r1869034764.

**Which issue(s) this PR fixes**:
Follow-up on #5754.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```