### PR TITLE
auto create pr to update helm index when release chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,7 @@ jobs:
   release-charts:
     permissions:
       contents: write  # for softprops/action-gh-release to create GitHub release
+      pull-requests: write
     name: Release charts
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
@@ -145,6 +146,14 @@ jobs:
       run: |
         cd _output/charts
         echo "hashes=$(sha256sum *.tgz|base64 -w0)" >> "$GITHUB_OUTPUT"
+    - name: update chart index
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+        export tag=${{ github.ref_name }}
+        hack/update-chart-index.sh
   charts-provenance:
     needs: [release-charts]
     permissions:

--- a/hack/update-chart-index.sh
+++ b/hack/update-chart-index.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Copyright 2024 The Karmada Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script used to update helm index to specific release version and automatically submit a pr to remote repo.
+# Usage:
+#   export CURRENT_REPO_ORG=karmada-io CURRENT_REPO_NAME=karmada tag=v1.12.0
+#   hack/update-helm-index.sh
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd ${REPO_ROOT}
+
+CURRENT_REMOTE=${CURRENT_REMOTE:-origin}
+CURRENT_REPO_ORG=${CURRENT_REPO_ORG:-$(git remote get-url "$CURRENT_REMOTE" | awk '{gsub(/http[s]:\/\/|git@/,"")}1' | awk -F'[@:./]' 'NR==1{print $3}')}
+CURRENT_REPO_NAME=${CURRENT_REPO_NAME:-$(git remote get-url "$CURRENT_REMOTE" | awk '{gsub(/http[s]:\/\/|git@/,"")}1' | awk -F'[@:./]' 'NR==1{print $4}')}
+
+get_latest_release_tag() {
+  curl --silent "https://api.github.com/repos/$1/releases/latest" |
+    grep '"tag_name":' |
+    sed -E 's/.*"([^"]+)".*/\1/'
+}
+
+# step1: get tag, defaults to latest release tag
+tag=${tag:-"$(get_latest_release_tag "${CURRENT_REPO_ORG}/${CURRENT_REPO_NAME}")"}
+if [ $(grep -c "version: ${tag}" charts/index.yaml) -ge '2' ]; then
+  echo "the tag already in helm index!"
+  exit 0
+fi
+
+# step2: checkout a new branch
+# Normally return if remote branch already exist, which means you can re-execute the script without throwing errors.
+NEWBRANCH="auto-helm-index-${tag}"
+git fetch -q
+if [ $(git branch -r | grep -c "origin/${NEWBRANCH}") -gt '0' ]; then
+  echo 'remote branch '${NEWBRANCH}' already exist!'
+  exit 0
+fi
+git checkout -b ${NEWBRANCH}
+
+# step3: update index for karmada-chart
+wget https://github.com/${CURRENT_REPO_ORG}/${CURRENT_REPO_NAME}/releases/download/${tag}/karmada-chart-${tag}.tgz -P charts/karmada/
+helm repo index charts/karmada --url https://github.com/${CURRENT_REPO_ORG}/${CURRENT_REPO_NAME}/releases/download/${tag} --merge charts/index.yaml
+mv charts/karmada/index.yaml charts/index.yaml
+
+# step4: update index for karmada-operator-chart
+wget https://github.com/${CURRENT_REPO_ORG}/${CURRENT_REPO_NAME}/releases/download/${tag}/karmada-operator-chart-${tag}.tgz -P charts/karmada-operator/
+helm repo index charts/karmada-operator --url https://github.com/${CURRENT_REPO_ORG}/${CURRENT_REPO_NAME}/releases/download/${tag} --merge charts/index.yaml
+mv charts/karmada-operator/index.yaml charts/index.yaml
+
+# step5: the `helm repo index` command also generates index for dependencies(common-2.x.x) by default,
+# which is undesirable; therefore, the contents of the `common` field should be manaually removed.
+# this `sed` command deletes lines between the line `entries:` and the line `karmada:`.
+sed -i'' '/entries:/,/karmada:/{//!d}' charts/index.yaml
+echo "Successfully generated helm index."
+
+# step6: commit the modification
+git add charts/index.yaml
+git commit -s -m "Bump upgrade helm chart index to ${tag}"
+git push origin ${NEWBRANCH}
+echo "Successfully pushed the commit."
+
+# step6: create pull request
+prtext=$(
+  cat <<EOF
+**What type of PR is this?**
+
+/kind cleanup
+
+**What this PR does / why we need it**:
+
+Bump upgrade helm chart index to ${tag}
+
+**Which issue(s) this PR fixes**:
+
+Fixes
+
+**Does this PR introduce a user-facing change?**:
+\`\`\`release-note
+upgrade helm chart index to ${tag}.
+\`\`\`
+EOF
+)
+gh pr create --title "Bump upgrade helm chart index to ${tag}" --body "${prtext}" --base master --head "${NEWBRANCH}" --repo="${CURRENT_REPO_ORG}/${CURRENT_REPO_NAME}"
+echo "Successfully created the pr."


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Auto create pr to update helm index when release chart.

You can see the effective demonstration in my personal repo:
* BuildRelease action: https://github.com/chaosi-zju/karmada/actions/runs/12228744816
* Auto submited pr: https://github.com/chaosi-zju/karmada/pull/17

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

I investigated the [helm/chart-releaser-action](https://github.com/helm/chart-releaser-action). It generates Helm chart releases and updates the chart index on the `gh-pages` branch, but this is not what we need:

* We already have ci process to generate and upload chart release assets, we don't need another ci to do the same thing.
* That `chart-releaser-action` still need someone to submit a pr to update `charts/karmada/Chart.yaml`, in order to trigger the process of this action. However, I think it would be better if the operation of update index can be just right triggered by publishing release without anyone manually submit any pr.
* That  `chart-releaser-action` requires a additional branch `gh-pages`.

So, we just only need a CI process that automatically updates the chart index when a new release is published.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

