### PR TITLE
Automated cherry pick of #5400, #5216

### DIFF
--- a/pkg/apis/cluster/types.go
+++ b/pkg/apis/cluster/types.go
@@ -266,6 +266,9 @@ type LocalSecretReference struct {
 const (
 	// ClusterConditionReady means the cluster is healthy and ready to accept workloads.
 	ClusterConditionReady = "Ready"
+
+	// ClusterConditionCompleteAPIEnablements indicates whether the cluster's API enablements(.status.apiEnablements) is complete.
+	ClusterConditionCompleteAPIEnablements = "CompleteAPIEnablements"
 )
 
 // ClusterStatus contains information about the current status of a

--- a/pkg/apis/cluster/v1alpha1/types.go
+++ b/pkg/apis/cluster/v1alpha1/types.go
@@ -278,6 +278,9 @@ type LocalSecretReference struct {
 const (
 	// ClusterConditionReady means the cluster is healthy and ready to accept workloads.
 	ClusterConditionReady = "Ready"
+
+	// ClusterConditionCompleteAPIEnablements indicates whether the cluster's API enablements(.status.apiEnablements) is complete.
+	ClusterConditionCompleteAPIEnablements = "CompleteAPIEnablements"
 )
 
 // ClusterStatus contains information about the current status of a

--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -67,6 +67,10 @@ const (
 	clusterNotReachableReason = "ClusterNotReachable"
 	clusterNotReachableMsg    = "cluster is not reachable"
 	statusCollectionFailed    = "StatusCollectionFailed"
+
+	apiEnablementsComplete             = "Complete"
+	apiEnablementPartialAPIEnablements = "Partial"
+	apiEnablementEmptyAPIEnablements   = "Empty"
 )
 
 var (
@@ -214,29 +218,42 @@ func (c *ClusterStatusController) syncClusterStatus(cluster *clusterv1alpha1.Clu
 		//  can be safely removed from current controller.
 		c.initializeGenericInformerManagerForCluster(clusterClient)
 
-		err = c.setCurrentClusterStatus(clusterClient, cluster, &currentClusterStatus)
+		var conditions []metav1.Condition
+		conditions, err = c.setCurrentClusterStatus(clusterClient, cluster, &currentClusterStatus)
 		if err != nil {
 			return err
 		}
+		conditions = append(conditions, *readyCondition)
+		return c.updateStatusIfNeeded(cluster, currentClusterStatus, conditions...)
 	}
 
 	return c.updateStatusIfNeeded(cluster, currentClusterStatus, *readyCondition)
 }
 
-func (c *ClusterStatusController) setCurrentClusterStatus(clusterClient *util.ClusterClient, cluster *clusterv1alpha1.Cluster, currentClusterStatus *clusterv1alpha1.ClusterStatus) error {
+func (c *ClusterStatusController) setCurrentClusterStatus(clusterClient *util.ClusterClient, cluster *clusterv1alpha1.Cluster, currentClusterStatus *clusterv1alpha1.ClusterStatus) ([]metav1.Condition, error) {
+	var conditions []metav1.Condition
 	clusterVersion, err := getKubernetesVersion(clusterClient)
 	if err != nil {
 		klog.Errorf("Failed to get Kubernetes version for Cluster %s. Error: %v.", cluster.GetName(), err)
 	}
 	currentClusterStatus.KubernetesVersion = clusterVersion
 
+	var apiEnablementCondition metav1.Condition
 	// get the list of APIs installed in the member cluster
 	apiEnables, err := getAPIEnablements(clusterClient)
 	if len(apiEnables) == 0 {
+		apiEnablementCondition = util.NewCondition(clusterv1alpha1.ClusterConditionCompleteAPIEnablements,
+			apiEnablementEmptyAPIEnablements, "collected empty APIEnablements from the cluster", metav1.ConditionFalse)
 		klog.Errorf("Failed to get any APIs installed in Cluster %s. Error: %v.", cluster.GetName(), err)
 	} else if err != nil {
+		apiEnablementCondition = util.NewCondition(clusterv1alpha1.ClusterConditionCompleteAPIEnablements,
+			apiEnablementPartialAPIEnablements, fmt.Sprintf("might collect partial APIEnablements(%d) from the cluster", len(apiEnables)), metav1.ConditionFalse)
 		klog.Warningf("Maybe get partial(%d) APIs installed in Cluster %s. Error: %v.", len(apiEnables), cluster.GetName(), err)
+	} else {
+		apiEnablementCondition = util.NewCondition(clusterv1alpha1.ClusterConditionCompleteAPIEnablements,
+			apiEnablementsComplete, "collected complete APIEnablements from the cluster", metav1.ConditionTrue)
 	}
+	conditions = append(conditions, apiEnablementCondition)
 	currentClusterStatus.APIEnablements = apiEnables
 
 	if c.EnableClusterResourceModeling {
@@ -246,7 +263,7 @@ func (c *ClusterStatusController) setCurrentClusterStatus(clusterClient *util.Cl
 			klog.Errorf("Failed to get or create informer for Cluster %s. Error: %v.", cluster.GetName(), err)
 			// in large-scale clusters, the timeout may occur.
 			// if clusterInformerManager fails to be built, should be returned, otherwise, it may cause a nil pointer
-			return err
+			return nil, err
 		}
 		nodes, err := listNodes(clusterInformerManager)
 		if err != nil {
@@ -264,7 +281,7 @@ func (c *ClusterStatusController) setCurrentClusterStatus(clusterClient *util.Cl
 			currentClusterStatus.ResourceSummary.AllocatableModelings = getAllocatableModelings(cluster, nodes, pods)
 		}
 	}
-	return nil
+	return conditions, nil
 }
 
 func setStatusCollectionFailedCondition(c client.Client, cluster *clusterv1alpha1.Cluster, message string) error {


### PR DESCRIPTION
Cherry pick of #5400, #5216 on release-1.10.
#5400: add new cluster condition: IncompleteAPIEnablements
#5216: skip the filter if the cluster is already in the list of scheduling result even if the API is missed
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
karmada-scheduler: cluster in the scheduling list won't be filtered out even if it's APIEnablements don't include the resource's API
```