### PR TITLE
fix flake test of KarmadactlTopPod

### DIFF
--- a/test/e2e/karmadactl_test.go
+++ b/test/e2e/karmadactl_test.go
@@ -544,10 +544,12 @@ var _ = ginkgo.Describe("Karmadactl top testing", func() {
 		ginkgo.It("Karmadactl top pod which does not exist", func() {
 			podName := podNamePrefix + rand.String(RandomStrLength)
 			for _, clusterName := range framework.ClusterNames() {
-				cmd := framework.NewKarmadactlCommand(kubeconfig, karmadaContext, karmadactlPath, "", karmadactlTimeout, "top", "pod", podName, "-n", testNamespace, "-C", clusterName)
-				_, err := cmd.ExecOrDie()
-				gomega.Expect(err).Should(gomega.HaveOccurred())
-				gomega.Expect(strings.Contains(err.Error(), fmt.Sprintf("pods \"%s\" not found", podName))).To(gomega.BeTrue(), "should not found", fmt.Sprintf("errMsg: %s", err.Error()))
+				gomega.Eventually(func() bool {
+					cmd := framework.NewKarmadactlCommand(kubeconfig, karmadaContext, karmadactlPath, "", karmadactlTimeout, "top", "pod", podName, "-n", testNamespace, "-C", clusterName)
+					_, err := cmd.ExecOrDie()
+					fmt.Printf("Should receive a NotFound error, and actually received: %+v\n", err)
+					return err != nil && strings.Contains(err.Error(), fmt.Sprintf("pods \"%s\" not found", podName))
+				}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 			}
 		})
 	})


### PR DESCRIPTION
**What type of PR is this?**
/kind flake
/kind failing-test
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
The e2e test `Karmadactl top testing Karmadactl top pod which does not exist [It] Karmadactl top pod which does not exist` has been intermittently failing. 
See,  https://github.com/karmada-io/karmada/actions/runs/12197101877/job/34026335469?pr=5772#step:6:1770

the e2e fails because the member cluster's server is not available at this time.
> error: cluster(member1): the server is currently unable to handle the request (get pods.metrics.k8s.io pod-z682t)

We are unable to determine why the metrics-server in member1 cannot handle requests due to the absence of logs from the member cluster and uncertainty regarding whether this is a transient service outage. However, we can enhance the end-to-end (e2e) stability by implementing retry logic.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE.
```

