### PR TITLE
feat: cluster-level resource scheduling suspend and resume capabilities

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -20435,7 +20435,7 @@
       }
     },
     "com.github.karmada-io.karmada.pkg.apis.work.v1alpha2.Suspension": {
-      "description": "Suspension defines the policy for suspending of propagation.",
+      "description": "Suspension defines the policy for suspending dispatching and scheduling.",
       "type": "object",
       "properties": {
         "dispatching": {
@@ -20445,6 +20445,10 @@
         "dispatchingOnClusters": {
           "description": "DispatchingOnClusters declares a list of clusters to which the dispatching should be suspended. Note: Can not co-exist with Dispatching which is used to suspend all.",
           "$ref": "#/definitions/com.github.karmada-io.karmada.pkg.apis.policy.v1alpha1.SuspendClusters"
+        },
+        "scheduling": {
+          "description": "Scheduling controls whether scheduling should be suspended, the scheduler will pause scheduling and not process resource binding when the value is true and resume scheduling when it's false or nil. This is designed for third-party systems to temporarily pause the scheduling of applications, which enabling manage resource allocation, prioritize critical workloads, etc. It is expected that third-party systems use an admission webhook to suspend scheduling at the time of ResourceBinding creation. Once a ResourceBinding has been scheduled, it cannot be paused afterward, as it may lead to ineffective suspension.",
+          "type": "boolean"
         }
       }
     },

--- a/charts/karmada/_crds/bases/work/work.karmada.io_clusterresourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work/work.karmada.io_clusterresourcebindings.yaml
@@ -1281,6 +1281,16 @@ spec:
                           type: string
                         type: array
                     type: object
+                  scheduling:
+                    description: |-
+                      Scheduling controls whether scheduling should be suspended, the scheduler will pause scheduling and not
+                      process resource binding when the value is true and resume scheduling when it's false or nil.
+                      This is designed for third-party systems to temporarily pause the scheduling of applications, which enabling
+                      manage resource allocation, prioritize critical workloads, etc.
+                      It is expected that third-party systems use an admission webhook to suspend scheduling at the time of
+                      ResourceBinding creation. Once a ResourceBinding has been scheduled, it cannot be paused afterward, as it may
+                      lead to ineffective suspension.
+                    type: boolean
                 type: object
             required:
             - resource

--- a/charts/karmada/_crds/bases/work/work.karmada.io_resourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work/work.karmada.io_resourcebindings.yaml
@@ -1281,6 +1281,16 @@ spec:
                           type: string
                         type: array
                     type: object
+                  scheduling:
+                    description: |-
+                      Scheduling controls whether scheduling should be suspended, the scheduler will pause scheduling and not
+                      process resource binding when the value is true and resume scheduling when it's false or nil.
+                      This is designed for third-party systems to temporarily pause the scheduling of applications, which enabling
+                      manage resource allocation, prioritize critical workloads, etc.
+                      It is expected that third-party systems use an admission webhook to suspend scheduling at the time of
+                      ResourceBinding creation. Once a ResourceBinding has been scheduled, it cannot be paused afterward, as it may
+                      lead to ineffective suspension.
+                    type: boolean
                 type: object
             required:
             - resource

--- a/pkg/apis/work/v1alpha2/binding_types.go
+++ b/pkg/apis/work/v1alpha2/binding_types.go
@@ -322,9 +322,19 @@ type BindingSnapshot struct {
 	Clusters []TargetCluster `json:"clusters,omitempty"`
 }
 
-// Suspension defines the policy for suspending of propagation.
+// Suspension defines the policy for suspending dispatching and scheduling.
 type Suspension struct {
 	policyv1alpha1.Suspension `json:",inline"`
+
+	// Scheduling controls whether scheduling should be suspended, the scheduler will pause scheduling and not
+	// process resource binding when the value is true and resume scheduling when it's false or nil.
+	// This is designed for third-party systems to temporarily pause the scheduling of applications, which enabling
+	// manage resource allocation, prioritize critical workloads, etc.
+	// It is expected that third-party systems use an admission webhook to suspend scheduling at the time of
+	// ResourceBinding creation. Once a ResourceBinding has been scheduled, it cannot be paused afterward, as it may
+	// lead to ineffective suspension.
+	// +optional
+	Scheduling *bool `json:"scheduling,omitempty"`
 }
 
 // ResourceBindingStatus represents the overall status of the strategy as well as the referenced resources.

--- a/pkg/apis/work/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/work/v1alpha2/zz_generated.deepcopy.go
@@ -421,6 +421,11 @@ func (in *ResourceBindingStatus) DeepCopy() *ResourceBindingStatus {
 func (in *Suspension) DeepCopyInto(out *Suspension) {
 	*out = *in
 	in.Suspension.DeepCopyInto(&out.Suspension)
+	if in.Scheduling != nil {
+		in, out := &in.Scheduling, &out.Scheduling
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -7461,7 +7461,7 @@ func schema_pkg_apis_work_v1alpha2_Suspension(ref common.ReferenceCallback) comm
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "Suspension defines the policy for suspending of propagation.",
+				Description: "Suspension defines the policy for suspending dispatching and scheduling.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"dispatching": {
@@ -7475,6 +7475,13 @@ func schema_pkg_apis_work_v1alpha2_Suspension(ref common.ReferenceCallback) comm
 						SchemaProps: spec.SchemaProps{
 							Description: "DispatchingOnClusters declares a list of clusters to which the dispatching should be suspended. Note: Can not co-exist with Dispatching which is used to suspend all.",
 							Ref:         ref("github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1.SuspendClusters"),
+						},
+					},
+					"scheduling": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Scheduling controls whether scheduling should be suspended, the scheduler will pause scheduling and not process resource binding when the value is true and resume scheduling when it's false or nil. This is designed for third-party systems to temporarily pause the scheduling of applications, which enabling manage resource allocation, prioritize critical workloads, etc. It is expected that third-party systems use an admission webhook to suspend scheduling at the time of ResourceBinding creation. Once a ResourceBinding has been scheduled, it cannot be paused afterward, as it may lead to ineffective suspension.",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 				},

--- a/pkg/scheduler/event_handler.go
+++ b/pkg/scheduler/event_handler.go
@@ -101,8 +101,14 @@ func (s *Scheduler) resourceBindingEventFilter(obj interface{}) bool {
 		if !schedulerNameFilter(s.schedulerName, t.Spec.SchedulerName) {
 			return false
 		}
+		if util.IsBindingSuspendScheduling(t) {
+			return false
+		}
 	case *workv1alpha2.ClusterResourceBinding:
 		if !schedulerNameFilter(s.schedulerName, t.Spec.SchedulerName) {
+			return false
+		}
+		if util.IsClusterBindingSuspendScheduling(t) {
 			return false
 		}
 	}

--- a/pkg/util/binding.go
+++ b/pkg/util/binding.go
@@ -110,3 +110,19 @@ func RescheduleRequired(rescheduleTriggeredAt, lastScheduledTime *metav1.Time) b
 	}
 	return rescheduleTriggeredAt.After(lastScheduledTime.Time)
 }
+
+// IsBindingSuspendScheduling tells whether resource binding is scheduling suspended.
+func IsBindingSuspendScheduling(rb *workv1alpha2.ResourceBinding) bool {
+	if rb == nil || rb.Spec.Suspension == nil || rb.Spec.Suspension.Scheduling == nil {
+		return false
+	}
+	return *rb.Spec.Suspension.Scheduling
+}
+
+// IsClusterBindingSuspendScheduling tells whether cluster resource binding is scheduling suspended.
+func IsClusterBindingSuspendScheduling(crb *workv1alpha2.ClusterResourceBinding) bool {
+	if crb == nil || crb.Spec.Suspension == nil || crb.Spec.Suspension.Scheduling == nil {
+		return false
+	}
+	return *crb.Spec.Suspension.Scheduling
+}

--- a/pkg/util/binding_test.go
+++ b/pkg/util/binding_test.go
@@ -21,8 +21,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
@@ -416,6 +418,118 @@ func TestRescheduleRequired(t *testing.T) {
 			if got := RescheduleRequired(tt.rescheduleTriggeredAt, tt.lastScheduledTime); got != tt.want {
 				t.Errorf("RescheduleRequired() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestIsBindingSuspendScheduling(t *testing.T) {
+	tests := []struct {
+		name     string
+		rb       *workv1alpha2.ResourceBinding
+		expected bool
+	}{
+		{
+			name:     "rb is nil",
+			rb:       nil,
+			expected: false,
+		},
+		{
+			name:     "rb.Spec.Suspension is nil",
+			rb:       &workv1alpha2.ResourceBinding{},
+			expected: false,
+		},
+		{
+			name: "rb.Spec.Suspension.Scheduling is nil",
+			rb: &workv1alpha2.ResourceBinding{
+				Spec: workv1alpha2.ResourceBindingSpec{
+					Suspension: &workv1alpha2.Suspension{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "rb.Spec.Suspension.Scheduling is false",
+			rb: &workv1alpha2.ResourceBinding{
+				Spec: workv1alpha2.ResourceBindingSpec{
+					Suspension: &workv1alpha2.Suspension{
+						Scheduling: ptr.To(false),
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "rb.Spec.Suspension.Scheduling is true",
+			rb: &workv1alpha2.ResourceBinding{
+				Spec: workv1alpha2.ResourceBindingSpec{
+					Suspension: &workv1alpha2.Suspension{
+						Scheduling: ptr.To(true),
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsBindingSuspendScheduling(tt.rb))
+		})
+	}
+}
+
+func TestIsClusterBindingSuspendScheduling(t *testing.T) {
+	tests := []struct {
+		name     string
+		crb      *workv1alpha2.ClusterResourceBinding
+		expected bool
+	}{
+		{
+			name:     "crb is nil",
+			crb:      nil,
+			expected: false,
+		},
+		{
+			name:     "crb.Spec.Suspension is nil",
+			crb:      &workv1alpha2.ClusterResourceBinding{},
+			expected: false,
+		},
+		{
+			name: "crb.Spec.Suspension.Scheduling is nil",
+			crb: &workv1alpha2.ClusterResourceBinding{
+				Spec: workv1alpha2.ResourceBindingSpec{
+					Suspension: &workv1alpha2.Suspension{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "crb.Spec.Suspension.Scheduling is false",
+			crb: &workv1alpha2.ClusterResourceBinding{
+				Spec: workv1alpha2.ResourceBindingSpec{
+					Suspension: &workv1alpha2.Suspension{
+						Scheduling: ptr.To(false),
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "crb.Spec.Suspension.Scheduling is true",
+			crb: &workv1alpha2.ClusterResourceBinding{
+				Spec: workv1alpha2.ResourceBindingSpec{
+					Suspension: &workv1alpha2.Suspension{
+						Scheduling: ptr.To(true),
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsClusterBindingSuspendScheduling(tt.crb))
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change
/kind feature

**What this PR does / why we need it**:
Add rb suspension capability, background: https://github.com/karmada-io/karmada/pull/5690

**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/karmada/pull/5690


**Special notes for your reviewer**:
It extends the Suspension fileds and support rb susupend and resume, mostly like the previous issue https://github.com/karmada-io/karmada/issues/5217 and PRs implemented in it. 
 This pr just implemented  binding suspension in `scheduler `, setting status condition in `controller` will be implemented in another pr after https://github.com/karmada-io/karmada/pull/6002 merged because it may lead to status update conflict between scheduler and controller.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`API Change`: Introduced `Scheduling` suspension in both `ResourceBinding` and `ClusterResourceBinding` which will be used for third-party systems to suspend application scheduling.
```

