### PR TITLE
remove workaround code for resolving workqueue metrics loss by modifying import order

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -23,7 +23,6 @@ import (
 	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
 	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
-	_ "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/karmada-io/karmada/cmd/agent/app"
 )

--- a/cmd/controller-manager/controller-manager.go
+++ b/cmd/controller-manager/controller-manager.go
@@ -23,7 +23,6 @@ import (
 	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
 	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
-	_ "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/karmada-io/karmada/cmd/controller-manager/app"
 )

--- a/cmd/descheduler/main.go
+++ b/cmd/descheduler/main.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/component-base/cli"
 	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
 	controllerruntime "sigs.k8s.io/controller-runtime"
-	_ "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/karmada-io/karmada/cmd/descheduler/app"
 )

--- a/cmd/scheduler-estimator/main.go
+++ b/cmd/scheduler-estimator/main.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/component-base/cli"
 	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
 	controllerruntime "sigs.k8s.io/controller-runtime"
-	_ "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/karmada-io/karmada/cmd/scheduler-estimator/app"
 )

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/component-base/cli"
 	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
 	controllerruntime "sigs.k8s.io/controller-runtime"
-	_ "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/karmada-io/karmada/cmd/scheduler/app"
 )

--- a/operator/cmd/operator/operator.go
+++ b/operator/cmd/operator/operator.go
@@ -23,7 +23,6 @@ import (
 	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
 	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
-	_ "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/karmada-io/karmada/operator/cmd/operator/app"
 )


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

remove workaround code for resolving workqueue metrics loss by modifying import order

**Which issue(s) this PR fixes**:

Fixes part of #5954

**Special notes for your reviewer**:

Lastst test report:

<details>
<summary>click here to see test report</summary>


* karmada-controller-manager:
```shell
/ # curl http://127.0.0.1:8080/metrics | grep workqueue_queue_duration_seconds_sum
...
workqueue_queue_duration_seconds_sum{controller="taint-manager",name="taint-manager"} 0.302839183
workqueue_queue_duration_seconds_sum{controller="unified-auth-controller",name="unified-auth-controller"} 0.080192647
workqueue_queue_duration_seconds_sum{controller="work-status",name="work-status"} 0.003801357
workqueue_queue_duration_seconds_sum{controller="work-status-controller",name="work-status-controller"} 0.104381849
...
```

* karmada-agent
```shell
/ # curl http://127.0.0.1:8080/metrics | grep workqueue_queue_duration_seconds_sum
...
workqueue_queue_duration_seconds_sum{controller="service-export-controller",name="service-export-controller"} 3.1737e-05
workqueue_queue_duration_seconds_sum{controller="work-status",name="work-status"} 2.4132999999999997e-05
workqueue_queue_duration_seconds_sum{controller="work-status-controller",name="work-status-controller"} 0.21671174700000004
...
```

* karmada-scheduler
```shell
/ # curl http://127.0.0.1:8080/metrics | grep workqueue_queue_duration_seconds_sum
...
workqueue_queue_duration_seconds_sum{controller="scheduler-estimator",name="scheduler-estimator"} 0.00017573
workqueue_queue_duration_seconds_sum{controller="scheduler-queue",name="scheduler-queue"} 0
...
```

* karmada-descheduler
```shell
/ # curl http://127.0.0.1:8080/metrics | grep workqueue_queue_duration_seconds_sum
...
workqueue_queue_duration_seconds_sum{controller="descheduler",name="descheduler"} 0
workqueue_queue_duration_seconds_sum{controller="scheduler-estimator",name="scheduler-estimator"} 34.711164511
...
```

* karmada-operator
```shell
/ # curl http://127.0.0.1:8080/metrics | grep workqueue_queue_duration_seconds_sum
...
workqueue_queue_duration_seconds_sum{controller="karmada-operator-controller",name="karmada-operator-controller"} 0.605636931
...
```

* karmada-schedule-estimator
  not controller-runtime component, no related metrics.

</details>

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

