### PR TITLE
Automated cherry pick of #5943: Fix the problem of ResourceBinding remaining when the

### DIFF
--- a/pkg/dependenciesdistributor/dependencies_distributor.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor.go
@@ -640,11 +640,6 @@ func (d *DependenciesDistributor) SetupWithManager(mgr controllerruntime.Manager
 						return false
 					}
 
-					// prevent newBindingObject from the queue if it's not scheduled yet.
-					if len(oldBindingObject.Spec.Clusters) == 0 && len(newBindingObject.Spec.Clusters) == 0 {
-						klog.V(4).Infof("Dropping resource binding(%s/%s) as it is not scheduled yet.", newBindingObject.Namespace, newBindingObject.Name)
-						return false
-					}
 					return oldBindingObject.Spec.PropagateDeps || newBindingObject.Spec.PropagateDeps
 				},
 			}).


### PR DESCRIPTION
Cherry pick of #5943 on release-1.11.
#5943: Fix the problem of ResourceBinding remaining when the
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager: Fixed the problem of ResourceBinding remaining after the resource template is deleted in the dependencies distribution scenario.
```