### PR TITLE
`karmada-webhook`: Fix panic when validating ResourceInterpreterWebhookConfiguration with unspecified service port

### DIFF
--- a/pkg/webhook/configuration/validating_test.go
+++ b/pkg/webhook/configuration/validating_test.go
@@ -271,6 +271,20 @@ func TestValidateWebhook(t *testing.T) {
 			},
 			expectedError: fmt.Sprintf("must include at least one of %v", strings.Join(acceptedInterpreterContextVersions, ", ")),
 		},
+		{
+			name: "valid webhook configuration: use Service in ClientConfig but with port unspecified",
+			hook: &configv1alpha1.ResourceInterpreterWebhook{
+				Name: "workloads.karmada.io",
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					Service: &admissionregistrationv1.ServiceReference{
+						Namespace: "default",
+						Name:      "svc",
+						Path:      strPtr("/interpreter"),
+					},
+				},
+				InterpreterContextVersions: []string{"v1alpha1"},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

When I apply a ResourceInterpreterWebhookConfiguration's `.webhooks[*].clientConfig.service.port` is nil, it report panic in the `karmada-webhook` component.

```yaml
apiVersion: config.karmada.io/v1alpha1
kind: ResourceInterpreterWebhookConfiguration
metadata:
  name: examples
webhooks:
- clientConfig:
    caBundle: {{caBundle}}
    service:
      namespace: karmada-system
      name: karmada-interpreter-webhook-example
      path: /interpreter-workload
  interpreterContextVersions:
  - v1alpha1
  name: workloads.example.com
  rules:
  - apiGroups:
    - workload.example.io
    apiVersions:
    - v1alpha1
    kinds:
    - Workload
    operations:
    - InterpretReplica
    - ReviseReplica
    - Retain
    - AggregateStatus
    - InterpretHealth
    - InterpretStatus
    - InterpretDependency
  timeoutSeconds: 3

```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-webhook`: Fixed panic when validating ResourceInterpreterWebhookConfiguration with unspecified service port.
```

