### PR TITLE
Automated cherry pick of #5960: Fix panic when validating ResourceInterpreterWebhookConfiguration with unspecified service port

### DIFF
--- a/pkg/webhook/configuration/validating_test.go
+++ b/pkg/webhook/configuration/validating_test.go
@@ -271,6 +271,20 @@ func TestValidateWebhook(t *testing.T) {
 			},
 			expectedError: fmt.Sprintf("must include at least one of %v", strings.Join(acceptedInterpreterContextVersions, ", ")),
 		},
+		{
+			name: "valid webhook configuration: use Service in ClientConfig but with port unspecified",
+			hook: &configv1alpha1.ResourceInterpreterWebhook{
+				Name: "workloads.karmada.io",
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					Service: &admissionregistrationv1.ServiceReference{
+						Namespace: "default",
+						Name:      "svc",
+						Path:      strPtr("/interpreter"),
+					},
+				},
+				InterpreterContextVersions: []string{"v1alpha1"},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Cherry pick of #5960 on release-1.12.
#5960: fix validate panic when
Part of #5964 
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-webhook`: Fixed panic when validating ResourceInterpreterWebhookConfiguration with unspecified service port.
```