### PR TITLE
Fix ETCD PKI Provisioning Issue in Karmada Operator

### DIFF
--- a/operator/pkg/certs/certs.go
+++ b/operator/pkg/certs/certs.go
@@ -85,8 +85,8 @@ func (config *CertConfig) defaultNotAfter() {
 }
 
 // GetDefaultCertList returns all of karmada certConfigs, it include karmada, front and etcd.
-func GetDefaultCertList() []*CertConfig {
-	return []*CertConfig{
+func GetDefaultCertList(karmada *operatorv1alpha1.Karmada) []*CertConfig {
+	certConfigs := []*CertConfig{
 		// karmada cert config.
 		KarmadaCertRootCA(),
 		KarmadaCertAdmin(),
@@ -94,11 +94,11 @@ func GetDefaultCertList() []*CertConfig {
 		// front proxy cert config.
 		KarmadaCertFrontProxyCA(),
 		KarmadaCertFrontProxyClient(),
-		// ETCD cert config.
-		KarmadaCertEtcdCA(),
-		KarmadaCertEtcdServer(),
-		KarmadaCertEtcdClient(),
 	}
+	if karmada.Spec.Components.Etcd.Local != nil {
+		certConfigs = append(certConfigs, KarmadaCertEtcdCA(), KarmadaCertEtcdServer(), KarmadaCertEtcdClient())
+	}
+	return certConfigs
 }
 
 // KarmadaCertRootCA returns karmada ca cert config.

--- a/operator/pkg/init.go
+++ b/operator/pkg/init.go
@@ -99,9 +99,9 @@ func NewInitJob(opt *InitOptions) *workflow.Job {
 
 	// add the all tasks to the init job workflow.
 	initJob.AppendTask(tasks.NewPrepareCrdsTask())
-	initJob.AppendTask(tasks.NewCertTask())
+	initJob.AppendTask(tasks.NewCertTask(opt.Karmada))
 	initJob.AppendTask(tasks.NewNamespaceTask())
-	initJob.AppendTask(tasks.NewUploadCertsTask())
+	initJob.AppendTask(tasks.NewUploadCertsTask(opt.Karmada))
 
 	etcdConfig := opt.Karmada.Spec.Components.Etcd
 	// Only required if local etcd is configured

--- a/operator/pkg/tasks/init/cert.go
+++ b/operator/pkg/tasks/init/cert.go
@@ -33,13 +33,13 @@ import (
 )
 
 // NewCertTask init a Certs task to generate all of karmada certs
-func NewCertTask() workflow.Task {
+func NewCertTask(karmada *operatorv1alpha1.Karmada) workflow.Task {
 	return workflow.Task{
 		Name:        "Certs",
 		Run:         runCerts,
 		Skip:        skipCerts,
 		RunSubTasks: true,
-		Tasks:       newCertSubTasks(),
+		Tasks:       newCertSubTasks(karmada),
 	}
 }
 
@@ -74,11 +74,11 @@ func skipCerts(d workflow.RunData) (bool, error) {
 	return true, nil
 }
 
-func newCertSubTasks() []workflow.Task {
+func newCertSubTasks(karmada *operatorv1alpha1.Karmada) []workflow.Task {
 	var subTasks []workflow.Task
 	caCert := map[string]*certs.CertConfig{}
 
-	for _, cert := range certs.GetDefaultCertList() {
+	for _, cert := range certs.GetDefaultCertList(karmada) {
 		var task workflow.Task
 
 		if cert.CAName == "" {

--- a/operator/pkg/tasks/init/cert_test.go
+++ b/operator/pkg/tasks/init/cert_test.go
@@ -28,6 +28,7 @@ import (
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/karmada-io/karmada/operator/pkg/apis/operator/v1alpha1"
+	operatorv1alpha1 "github.com/karmada-io/karmada/operator/pkg/apis/operator/v1alpha1"
 	"github.com/karmada-io/karmada/operator/pkg/certs"
 	"github.com/karmada-io/karmada/operator/pkg/constants"
 	"github.com/karmada-io/karmada/operator/pkg/util"
@@ -35,6 +36,18 @@ import (
 )
 
 func TestNewCertTask(t *testing.T) {
+	karmada := &operatorv1alpha1.Karmada{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "karmada",
+		},
+		Spec: operatorv1alpha1.KarmadaSpec{
+			Components: &operatorv1alpha1.KarmadaComponents{
+				Etcd: &operatorv1alpha1.Etcd{
+					Local: &operatorv1alpha1.LocalEtcd{},
+				},
+			},
+		},
+	}
 	tests := []struct {
 		name     string
 		wantTask workflow.Task
@@ -46,14 +59,14 @@ func TestNewCertTask(t *testing.T) {
 				Run:         runCerts,
 				Skip:        skipCerts,
 				RunSubTasks: true,
-				Tasks:       newCertSubTasks(),
+				Tasks:       newCertSubTasks(karmada),
 			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			certTask := NewCertTask()
+			certTask := NewCertTask(karmada)
 			err := util.DeepEqualTasks(certTask, test.wantTask)
 			if err != nil {
 				t.Errorf("unexpected error, got %v", err)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When provisioning a Karmada instance to be managed by the Karmada operator, there's support for both in-cluster and external ETCD modes. When external ETCD mode is used, the operator should skip setting up an in-cluster ETCD instance, which entails setting up PKI for the instance and deploying it as a stateful set. However, currently, in external ETCD mode, the operator will skip deploying the stateful set, but will still generate PKI, which is an issue. In external ETCD mode, all tasks relevant to setting up an in-cluster instance should be skipped.

**Which issue(s) this PR fixes**:
Fixes #5975

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-operator`: Fixed the issue that external ETCD certificate be overwritten by generated in-cluster ETCD certificate.
```

