### PR TITLE
Fix verify license lint error

### DIFF
--- a/hack/verify-license.sh
+++ b/hack/verify-license.sh
@@ -40,7 +40,6 @@ missing_license_header_files="$($ADDLICENSE_BIN \
   -ignore "**/*.yml" \
   -ignore "**/*.json" \
   -ignore ".idea/**" \
-  -ignore ".git/**"
   .)" || true
 
 if [[ "$missing_license_header_files" ]]; then

--- a/operator/pkg/controller/karmada/validating_test.go
+++ b/operator/pkg/controller/karmada/validating_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package karmada
 
 import (

--- a/pkg/resourceinterpreter/customized/webhook/serviceresolvers.go
+++ b/pkg/resourceinterpreter/customized/webhook/serviceresolvers.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package webhook
 
 import (

--- a/pkg/resourceinterpreter/customized/webhook/serviceresolvers_test.go
+++ b/pkg/resourceinterpreter/customized/webhook/serviceresolvers_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package webhook
 
 import (

--- a/pkg/util/helper/index.go
+++ b/pkg/util/helper/index.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package helper
 
 import (

--- a/pkg/util/helper/index_test.go
+++ b/pkg/util/helper/index_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package helper
 
 import (


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

I found that some files I did not add licenses, but lint CI did not report errors, so I checked the `hack/verify-license.sh` script.

When I run it, it report:

```log
# hack/verify-license.sh
Usage: addlicense [flags] pattern [pattern ...]

The program ensures source code files have copyright license headers
by scanning directory patterns recursively.

It modifies all source files in place and avoids adding a license header
to any file that already has one.

The pattern argument can be provided multiple times, and may also refer
to single files.

Flags:

  -c string
        copyright holder (default "Google LLC")
  -check
        check only mode: verify presence of license headers and exit with non-zero code if missing
  -f string
        license file
  -ignore value
        file patterns to ignore, for example: -ignore **/*.go -ignore vendor/**
  -l string
        license type: apache, bsd, mit, mpl (default "apache")
  -s    Include SPDX identifier in license header. Set -s=only to only include SPDX identifier.
  -skip value
        [deprecated: see -ignore] file extensions to skip, for example: -skip rb -skip go
  -v    verbose mode: print the name of the files that are modified or were skipped
  -y string
        copyright year(s) (default "2024")
hack/verify-license.sh: line 45: .: filename argument required
.: usage: . filename [arguments]
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

