### PR TITLE
Automated cherry pick of #5989: fix rebalancer auto deleted failed

### DIFF
--- a/pkg/controllers/workloadrebalancer/workloadrebalancer_controller.go
+++ b/pkg/controllers/workloadrebalancer/workloadrebalancer_controller.go
@@ -90,15 +90,12 @@ func (c *RebalancerController) Reconcile(ctx context.Context, req controllerrunt
 		return controllerruntime.Result{}, err
 	}
 
-	if rebalancer.Status.FinishTime == nil {
-		// should never reach here.
-		klog.Errorf("finishTime shouldn't be nil, current status: %+v", rebalancer.Status)
-		return controllerruntime.Result{}, nil
-	}
-
 	// 3. when all workloads finished, judge whether the rebalancer needs cleanup.
 	rebalancer.Status = *newStatus
 	if rebalancer.Spec.TTLSecondsAfterFinished != nil {
+		if rebalancer.Status.FinishTime == nil {
+			return controllerruntime.Result{}, fmt.Errorf("finish time should not be nil")
+		}
 		remainingTTL := timeLeft(rebalancer)
 		if remainingTTL > 0 {
 			return controllerruntime.Result{RequeueAfter: remainingTTL}, nil

--- a/test/e2e/workloadrebalancer_test.go
+++ b/test/e2e/workloadrebalancer_test.go
@@ -193,6 +193,12 @@ var _ = framework.SerialDescribe("workload rebalancer testing", func() {
 				framework.WaitRebalancerDisappear(karmadaClient, rebalancerName)
 			})
 		})
+
+		ginkgo.It("create rebalancer with ttl and verify it can auto clean", func() {
+			rebalancer.Spec.TTLSecondsAfterFinished = ptr.To[int32](5)
+			framework.CreateWorkloadRebalancer(karmadaClient, rebalancer)
+			framework.WaitRebalancerDisappear(karmadaClient, rebalancerName)
+		})
 	})
 
 	// 2. static weight scheduling


### PR DESCRIPTION
Cherry pick of #5989 on release-1.11.
#5989: fix rebalancer auto deleted failed
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`: Fixed the bug of WorkloadRebalancer doesn't get deleted after TTL.
```