### PR TITLE
expose metrics of karmada-metrics-adapter

### DIFF
--- a/artifacts/deploy/karmada-metrics-adapter.yaml
+++ b/artifacts/deploy/karmada-metrics-adapter.yaml
@@ -27,6 +27,7 @@ spec:
           command:
             - /bin/karmada-metrics-adapter
             - --kubeconfig=/etc/karmada/config/karmada.config
+            - --metrics-bind-address=:8080
             - --authentication-kubeconfig=/etc/karmada/config/karmada.config
             - --authorization-kubeconfig=/etc/karmada/config/karmada.config
             - --client-ca-file=/etc/karmada/pki/server/ca.crt

--- a/charts/karmada/templates/karmada-metrics-adapter.yaml
+++ b/charts/karmada/templates/karmada-metrics-adapter.yaml
@@ -44,6 +44,7 @@ spec:
           command:
             - /bin/karmada-metrics-adapter
             - --kubeconfig=/etc/kubeconfig
+            - --metrics-bind-address=:8080
             - --authentication-kubeconfig=/etc/kubeconfig
             - --authorization-kubeconfig=/etc/kubeconfig
             - --tls-cert-file=/etc/kubernetes/pki/karmada.crt

--- a/operator/pkg/controlplane/metricsadapter/manifests.go
+++ b/operator/pkg/controlplane/metricsadapter/manifests.go
@@ -48,6 +48,7 @@ spec:
         command:
         - /bin/karmada-metrics-adapter
         - --kubeconfig=/etc/karmada/kubeconfig
+        - --metrics-bind-address=:8080
         - --authentication-kubeconfig=/etc/karmada/kubeconfig
         - --authorization-kubeconfig=/etc/karmada/kubeconfig
         - --client-ca-file=/etc/karmada/pki/ca.crt

--- a/pkg/karmadactl/addons/metricsadapter/manifests.go
+++ b/pkg/karmadactl/addons/metricsadapter/manifests.go
@@ -53,6 +53,7 @@ spec:
           command:
             - /bin/karmada-metrics-adapter
             - --kubeconfig=/etc/kubeconfig
+            - --metrics-bind-address=:8080
             - --authentication-kubeconfig=/etc/kubeconfig
             - --authorization-kubeconfig=/etc/kubeconfig
             - --client-ca-file=/etc/karmada/pki/ca.crt


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

expose metrics of karmada-metrics-adapter

**Which issue(s) this PR fixes**:

Fixes part of #5954

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-metrics-adapter`: Introduced `--metrics-bind-address` flag which will be used to expose Prometheus metrics.
```

