### PR TITLE
support namespaceselectors for cluster propagation policies

### DIFF
--- a/pkg/apis/policy/v1alpha1/propagation_types.go
+++ b/pkg/apis/policy/v1alpha1/propagation_types.go
@@ -68,6 +68,10 @@ type PropagationSpec struct {
 	// +kubebuilder:validation:MinItems=1
 	ResourceSelectors []ResourceSelector `json:"resourceSelectors"`
 
+	// NamespaceSelectors used to select resources.
+	// +optional
+	NamespaceSelectors []NamespaceSelector `json:"namespaceSelectors"`
+
 	// Association tells if relevant resources should be selected automatically.
 	// e.g. a ConfigMap referred by a Deployment.
 	// default false.
@@ -225,6 +229,13 @@ type ResourceSelector struct {
 	// A label query over a set of resources.
 	// If name is not empty, labelSelector will be ignored.
 	// +optional
+	LabelSelector *metav1.LabelSelector `json:"labelSelector,omitempty"`
+}
+
+// NamespaceSelector the resource namespace will be selected.
+type NamespaceSelector struct {
+	// A label query over a set of namespaces.
+	// +required
 	LabelSelector *metav1.LabelSelector `json:"labelSelector,omitempty"`
 }
 

--- a/pkg/util/selector.go
+++ b/pkg/util/selector.go
@@ -79,17 +79,22 @@ func ResourceSelectorPriority(resource *unstructured.Unstructured, rs policyv1al
 	}
 
 	// case 3: matches with selector
-	var s labels.Selector
-	var err error
-	if s, err = metav1.LabelSelectorAsSelector(rs.LabelSelector); err != nil {
-		// should not happen because all resource selector should be fully validated by webhook.
-		return PriorityMisMatch
-	}
-
-	if s.Matches(labels.Set(resource.GetLabels())) {
+	if MatchesSelector(resource, rs.LabelSelector) {
 		return PriorityMatchLabelSelector
 	}
 	return PriorityMisMatch
+}
+
+func MatchesSelector(resource *unstructured.Unstructured, ls *metav1.LabelSelector) bool {
+	s, err := metav1.LabelSelectorAsSelector(ls)
+	if err != nil {
+		// should not happen because all resource selector should be fully validated by webhook.
+		return false
+	}
+	if s.Matches(labels.Set(resource.GetLabels())) {
+		return true
+	}
+	return false
 }
 
 // ClusterMatches tells if specific cluster matches the affinity.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

we want to match a clusterpropagationpolicy to resources in only some namespaces

**Special notes for your reviewer**:
POC, need comments on if this makes sense and ideas on how to get the namespace object

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

