### PR TITLE
feat: replace instruction annotation with work suspendDispatching field

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -381,6 +381,9 @@ func startServiceExportController(ctx controllerscontext.Context) (bool, error) 
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 		ClusterCacheSyncTimeout:     ctx.Opts.ClusterCacheSyncTimeout,
 	}
+	if err := mcs.IndexField(ctx.Mgr); err != nil {
+		return false, err
+	}
 	serviceExportController.RunWorkQueue()
 	if err := serviceExportController.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -467,6 +467,9 @@ func startServiceExportController(ctx controllerscontext.Context) (enabled bool,
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSet,
 		ClusterCacheSyncTimeout:     opts.ClusterCacheSyncTimeout,
 	}
+	if err = mcs.IndexField(ctx.Mgr); err != nil {
+		return false, err
+	}
 	serviceExportController.RunWorkQueue()
 	if err := serviceExportController.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err

--- a/pkg/controllers/ctrlutil/work.go
+++ b/pkg/controllers/ctrlutil/work.go
@@ -39,16 +39,14 @@ import (
 // CreateOrUpdateWork creates a Work object if not exist, or updates if it already exists.
 func CreateOrUpdateWork(ctx context.Context, c client.Client, workMeta metav1.ObjectMeta, resource *unstructured.Unstructured, options ...WorkOption) error {
 	resource = resource.DeepCopy()
-	if workMeta.Labels[util.PropagationInstruction] != util.PropagationInstructionSuppressed {
-		// set labels
-		util.MergeLabel(resource, util.ManagedByKarmadaLabel, util.ManagedByKarmadaLabelValue)
-		// set annotations
-		util.MergeAnnotation(resource, workv1alpha2.ResourceTemplateUIDAnnotation, string(resource.GetUID()))
-		util.MergeAnnotation(resource, workv1alpha2.WorkNameAnnotation, workMeta.Name)
-		util.MergeAnnotation(resource, workv1alpha2.WorkNamespaceAnnotation, workMeta.Namespace)
-		if conflictResolution, ok := workMeta.GetAnnotations()[workv1alpha2.ResourceConflictResolutionAnnotation]; ok {
-			util.MergeAnnotation(resource, workv1alpha2.ResourceConflictResolutionAnnotation, conflictResolution)
-		}
+	// set labels
+	util.MergeLabel(resource, util.ManagedByKarmadaLabel, util.ManagedByKarmadaLabelValue)
+	// set annotations
+	util.MergeAnnotation(resource, workv1alpha2.ResourceTemplateUIDAnnotation, string(resource.GetUID()))
+	util.MergeAnnotation(resource, workv1alpha2.WorkNameAnnotation, workMeta.Name)
+	util.MergeAnnotation(resource, workv1alpha2.WorkNamespaceAnnotation, workMeta.Namespace)
+	if conflictResolution, ok := workMeta.GetAnnotations()[workv1alpha2.ResourceConflictResolutionAnnotation]; ok {
+		util.MergeAnnotation(resource, workv1alpha2.ResourceConflictResolutionAnnotation, conflictResolution)
 	}
 	// Do the same thing as the mutating webhook does, remove the irrelevant fields for the resource.
 	// This is to avoid unnecessary updates to the Work object, especially when controller starts.
@@ -79,6 +77,7 @@ func CreateOrUpdateWork(ctx context.Context, c client.Client, workMeta metav1.Ob
 
 			// Do the same thing as the mutating webhook does, add the permanent ID to workload if not exist,
 			// This is to avoid unnecessary updates to the Work object, especially when controller starts.
+			//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
 			if runtimeObject.Labels[util.PropagationInstruction] != util.PropagationInstructionSuppressed {
 				helper.SetLabelsAndAnnotationsForWorkload(resource, runtimeObject)
 			}

--- a/pkg/controllers/mcs/common.go
+++ b/pkg/controllers/mcs/common.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcs
+
+import (
+	"context"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/util/helper"
+)
+
+const (
+	workSuspendDispatchingIndex = "workSpec.suspendDispatching"
+)
+
+// IndexField registers Indexer functions to controller manager.
+func IndexField(mgr controllerruntime.Manager) error {
+	workIndexerFunc := func(obj client.Object) []string {
+		work, ok := obj.(*workv1alpha1.Work)
+		if !ok {
+			return nil
+		}
+		return helper.GetWorkSuspendDispatching(&work.Spec)
+	}
+
+	return utilerrors.NewAggregate([]error{
+		mgr.GetFieldIndexer().IndexField(context.TODO(), &workv1alpha1.Work{}, workSuspendDispatchingIndex, workIndexerFunc),
+	})
+}

--- a/pkg/controllers/mcs/service_export_controller.go
+++ b/pkg/controllers/mcs/service_export_controller.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -151,7 +152,9 @@ func (c *ServiceExportController) RunWorkQueue() {
 func (c *ServiceExportController) enqueueReportedEpsServiceExport() {
 	workList := &workv1alpha1.WorkList{}
 	err := wait.PollUntilContextCancel(context.TODO(), 1*time.Second, true, func(ctx context.Context) (done bool, err error) {
-		err = c.List(ctx, workList, client.MatchingLabels{util.PropagationInstruction: util.PropagationInstructionSuppressed})
+		err = c.List(ctx, workList, client.MatchingFields{
+			workSuspendDispatchingIndex: "true",
+		})
 		if err != nil {
 			klog.Errorf("Failed to list collected EndpointSlices Work from member clusters: %v", err)
 			return false, nil
@@ -428,10 +431,10 @@ func (c *ServiceExportController) removeOrphanWork(ctx context.Context, endpoint
 	if err := c.List(ctx, collectedEpsWorkList, &client.ListOptions{
 		Namespace: names.GenerateExecutionSpaceName(serviceExportKey.Cluster),
 		LabelSelector: labels.SelectorFromSet(labels.Set{
-			util.PropagationInstruction: util.PropagationInstructionSuppressed,
-			util.ServiceNamespaceLabel:  serviceExportKey.Namespace,
-			util.ServiceNameLabel:       serviceExportKey.Name,
+			util.ServiceNamespaceLabel: serviceExportKey.Namespace,
+			util.ServiceNameLabel:      serviceExportKey.Name,
 		}),
+		FieldSelector: fields.OneTermEqualSelector(workSuspendDispatchingIndex, "true"),
 	}); err != nil {
 		klog.Errorf("Failed to list endpointslice work with serviceExport(%s/%s) under namespace %s: %v",
 			serviceExportKey.Namespace, serviceExportKey.Name, names.GenerateExecutionSpaceName(serviceExportKey.Cluster), err)
@@ -495,7 +498,8 @@ func reportEndpointSlice(ctx context.Context, c client.Client, endpointSlice *un
 		return err
 	}
 
-	if err := ctrlutil.CreateOrUpdateWork(ctx, c, workMeta, endpointSlice); err != nil {
+	// indicate the Work should be not propagated since it's collected resource.
+	if err := ctrlutil.CreateOrUpdateWork(ctx, c, workMeta, endpointSlice, ctrlutil.WithSuspendDispatching(true)); err != nil {
 		return err
 	}
 
@@ -518,10 +522,8 @@ func getEndpointSliceWorkMeta(ctx context.Context, c client.Client, ns string, w
 		Namespace:  ns,
 		Finalizers: []string{util.EndpointSliceControllerFinalizer},
 		Labels: map[string]string{
-			util.ServiceNamespaceLabel: endpointSlice.GetNamespace(),
-			util.ServiceNameLabel:      endpointSlice.GetLabels()[discoveryv1.LabelServiceName],
-			// indicate the Work should be not propagated since it's collected resource.
-			util.PropagationInstruction:          util.PropagationInstructionSuppressed,
+			util.ServiceNamespaceLabel:           endpointSlice.GetNamespace(),
+			util.ServiceNameLabel:                endpointSlice.GetLabels()[discoveryv1.LabelServiceName],
 			util.EndpointSliceWorkManagedByLabel: util.ServiceExportKind,
 		},
 	}

--- a/pkg/controllers/multiclusterservice/endpointslice_collect_controller.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_collect_controller.go
@@ -386,7 +386,8 @@ func reportEndpointSlice(ctx context.Context, c client.Client, endpointSlice *un
 		return err
 	}
 
-	if err := ctrlutil.CreateOrUpdateWork(ctx, c, workMeta, endpointSlice); err != nil {
+	// indicate the Work should be not propagated since it's collected resource.
+	if err := ctrlutil.CreateOrUpdateWork(ctx, c, workMeta, endpointSlice, ctrlutil.WithSuspendDispatching(true)); err != nil {
 		klog.Errorf("Failed to create or update work(%s/%s), Error: %v", workMeta.Namespace, workMeta.Name, err)
 		return err
 	}
@@ -408,9 +409,7 @@ func getEndpointSliceWorkMeta(ctx context.Context, c client.Client, ns string, w
 	ls := map[string]string{
 		util.MultiClusterServiceNamespaceLabel: endpointSlice.GetNamespace(),
 		util.MultiClusterServiceNameLabel:      endpointSlice.GetLabels()[discoveryv1.LabelServiceName],
-		// indicate the Work should be not propagated since it's collected resource.
-		util.PropagationInstruction:          util.PropagationInstructionSuppressed,
-		util.EndpointSliceWorkManagedByLabel: util.MultiClusterServiceKind,
+		util.EndpointSliceWorkManagedByLabel:   util.MultiClusterServiceKind,
 	}
 	if existWork.Labels == nil || (err != nil && apierrors.IsNotFound(err)) {
 		workMeta := metav1.ObjectMeta{Name: workName, Namespace: ns, Labels: ls}

--- a/pkg/controllers/multiclusterservice/endpointslice_collect_controller_test.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_collect_controller_test.go
@@ -144,7 +144,6 @@ func TestGetEndpointSliceWorkMeta(t *testing.T) {
 				Labels: map[string]string{
 					util.MultiClusterServiceNamespaceLabel: "default",
 					util.MultiClusterServiceNameLabel:      "test-service",
-					util.PropagationInstruction:            util.PropagationInstructionSuppressed,
 					util.EndpointSliceWorkManagedByLabel:   util.MultiClusterServiceKind,
 				},
 			},
@@ -159,7 +158,6 @@ func TestGetEndpointSliceWorkMeta(t *testing.T) {
 				Labels: map[string]string{
 					util.MultiClusterServiceNamespaceLabel: "default",
 					util.MultiClusterServiceNameLabel:      "test-service",
-					util.PropagationInstruction:            util.PropagationInstructionSuppressed,
 					util.EndpointSliceWorkManagedByLabel:   "ExistingController.MultiClusterService",
 				},
 				Finalizers: []string{util.MCSEndpointSliceDispatchControllerFinalizer},

--- a/pkg/controllers/multiclusterservice/mcs_controller.go
+++ b/pkg/controllers/multiclusterservice/mcs_controller.go
@@ -299,7 +299,6 @@ func (c *MCSController) propagateMultiClusterService(ctx context.Context, mcs *n
 			Labels: map[string]string{
 				// We add this id in mutating webhook, let's just use it
 				networkingv1alpha1.MultiClusterServicePermanentIDLabel: util.GetLabelValue(mcs.Labels, networkingv1alpha1.MultiClusterServicePermanentIDLabel),
-				util.PropagationInstruction:                            util.PropagationInstructionSuppressed,
 				util.MultiClusterServiceNamespaceLabel:                 mcs.Namespace,
 				util.MultiClusterServiceNameLabel:                      mcs.Name,
 			},
@@ -310,7 +309,7 @@ func (c *MCSController) propagateMultiClusterService(ctx context.Context, mcs *n
 			klog.Errorf("Failed to convert MultiClusterService(%s/%s) to unstructured object, err is %v", mcs.Namespace, mcs.Name, err)
 			return err
 		}
-		if err = ctrlutil.CreateOrUpdateWork(ctx, c, workMeta, mcsObj); err != nil {
+		if err = ctrlutil.CreateOrUpdateWork(ctx, c, workMeta, mcsObj, ctrlutil.WithSuspendDispatching(true)); err != nil {
 			klog.Errorf("Failed to create or update MultiClusterService(%s/%s) work in the given member cluster %s, err is %v",
 				mcs.Namespace, mcs.Name, clusterName, err)
 			return err

--- a/pkg/controllers/status/work_status_controller.go
+++ b/pkg/controllers/status/work_status_controller.go
@@ -294,6 +294,7 @@ func (c *WorkStatusController) handleDeleteEvent(ctx context.Context, key keys.F
 		return nil
 	}
 
+	//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
 	if util.GetLabelValue(work.Labels, util.PropagationInstruction) == util.PropagationInstructionSuppressed {
 		return nil
 	}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -46,6 +46,10 @@ const (
 	//
 	// Note: This instruction is intended to set on Work objects to indicate the Work should be ignored by
 	// execution controller. The instruction maybe deprecated once we extend the Work API and no other scenario want this.
+	//
+	// Deprecated: This label has been deprecated since v1.14, and will be replaced by the filed .spec.suspendDispatching of
+	// Work API. This label should only be used internally by Karmada, but for compatibility, the deletion will be postponed
+	// to release 1.15.
 	PropagationInstruction = "propagation.karmada.io/instruction"
 
 	// FederatedResourceQuotaNamespaceLabel is added to Work to specify associated FederatedResourceQuota's namespace.

--- a/pkg/util/helper/predicate.go
+++ b/pkg/util/helper/predicate.go
@@ -38,6 +38,7 @@ func NewExecutionPredicate(mgr controllerruntime.Manager) predicate.Funcs {
 		obj := object.(*workv1alpha1.Work)
 
 		// Ignore the object that has been suppressed.
+		//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
 		if util.GetLabelValue(obj.Labels, util.PropagationInstruction) == util.PropagationInstructionSuppressed {
 			klog.V(5).Infof("Ignored Work(%s/%s) %s event as propagation instruction is suppressed.", obj.Namespace, obj.Name, eventType)
 			return false
@@ -79,8 +80,14 @@ func NewPredicateForServiceExportController(mgr controllerruntime.Manager) predi
 	predFunc := func(eventType string, object client.Object) bool {
 		obj := object.(*workv1alpha1.Work)
 
+		//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
 		if util.GetLabelValue(obj.Labels, util.PropagationInstruction) == util.PropagationInstructionSuppressed {
 			klog.V(5).Infof("Ignored Work(%s/%s) %s event as propagation instruction is suppressed.", obj.Namespace, obj.Name, eventType)
+			return false
+		}
+
+		if IsWorkSuspendDispatching(obj) {
+			klog.V(5).Infof("Ignored Work(%s/%s) %s event as dispatching is suspended.", obj.Namespace, obj.Name, eventType)
 			return false
 		}
 
@@ -171,8 +178,14 @@ func NewPredicateForServiceExportControllerOnAgent(curClusterName string) predic
 	predFunc := func(eventType string, object client.Object) bool {
 		obj := object.(*workv1alpha1.Work)
 
+		//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
 		if util.GetLabelValue(obj.Labels, util.PropagationInstruction) == util.PropagationInstructionSuppressed {
 			klog.V(5).Infof("Ignored Work(%s/%s) %s event as propagation instruction is suppressed.", obj.Namespace, obj.Name, eventType)
+			return false
+		}
+
+		if IsWorkSuspendDispatching(obj) {
+			klog.V(5).Infof("Ignored Work(%s/%s) %s event as dispatching is suspended.", obj.Namespace, obj.Name, eventType)
 			return false
 		}
 
@@ -237,6 +250,7 @@ func NewExecutionPredicateOnAgent() predicate.Funcs {
 		obj := object.(*workv1alpha1.Work)
 
 		// Ignore the object that has been suppressed.
+		//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
 		if util.GetLabelValue(obj.Labels, util.PropagationInstruction) == util.PropagationInstructionSuppressed {
 			klog.V(5).Infof("Ignored Work(%s/%s) %s event as propagation instruction is suppressed.", obj.Namespace, obj.Name, eventType)
 			return false

--- a/pkg/util/helper/predicate_test.go
+++ b/pkg/util/helper/predicate_test.go
@@ -110,6 +110,7 @@ func TestNewExecutionPredicate(t *testing.T) {
 				obj: &workv1alpha1.Work{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "work", Namespace: names.ExecutionSpacePrefix + "cluster",
+						//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
 						Labels: map[string]string{util.PropagationInstruction: util.PropagationInstructionSuppressed},
 					},
 				},
@@ -230,6 +231,7 @@ func TestNewExecutionPredicate_Update(t *testing.T) {
 	unmatched := &workv1alpha1.Work{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "work", Namespace: names.ExecutionSpacePrefix + "cluster",
+			//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
 			Labels: map[string]string{util.PropagationInstruction: util.PropagationInstructionSuppressed},
 		},
 	}
@@ -301,6 +303,7 @@ func TestNewExecutionPredicateOnAgent(t *testing.T) {
 		{
 			name: "object is suppressed",
 			obj: &workv1alpha1.Work{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+				//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
 				util.PropagationInstruction: util.PropagationInstructionSuppressed,
 			}}},
 			want: want{
@@ -348,6 +351,7 @@ func TestNewExecutionPredicateOnAgent_Update(t *testing.T) {
 	unmatched := &workv1alpha1.Work{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "work", Namespace: names.ExecutionSpacePrefix + "cluster",
+			//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
 			Labels: map[string]string{util.PropagationInstruction: util.PropagationInstructionSuppressed},
 		},
 	}
@@ -431,6 +435,7 @@ func TestNewPredicateForServiceExportController(t *testing.T) {
 				obj: &workv1alpha1.Work{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "work", Namespace: names.ExecutionSpacePrefix + "cluster",
+						//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
 						Labels: map[string]string{util.PropagationInstruction: util.PropagationInstructionSuppressed},
 					},
 				},
@@ -551,6 +556,7 @@ func TestNewPredicateForServiceExportController_Update(t *testing.T) {
 	unmatched := &workv1alpha1.Work{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "work", Namespace: names.ExecutionSpacePrefix + "cluster",
+			//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
 			Labels: map[string]string{util.PropagationInstruction: util.PropagationInstructionSuppressed},
 		},
 	}
@@ -623,6 +629,7 @@ func TestNewPredicateForServiceExportControllerOnAgent(t *testing.T) {
 			name: "object is suppressed",
 			obj: &workv1alpha1.Work{ObjectMeta: metav1.ObjectMeta{
 				Name: "work", Namespace: names.ExecutionSpacePrefix + "cluster",
+				//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
 				Labels: map[string]string{util.PropagationInstruction: util.PropagationInstructionSuppressed},
 			}},
 			want: want{
@@ -695,6 +702,7 @@ func TestNewPredicateForServiceExportControllerOnAgent_Update(t *testing.T) {
 	unmatched := &workv1alpha1.Work{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "work", Namespace: names.ExecutionSpacePrefix + "cluster",
+			//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
 			Labels: map[string]string{util.PropagationInstruction: util.PropagationInstructionSuppressed},
 		},
 	}

--- a/pkg/util/helper/work.go
+++ b/pkg/util/helper/work.go
@@ -19,6 +19,7 @@ package helper
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -121,4 +122,9 @@ func SetLabelsAndAnnotationsForWorkload(workload *unstructured.Unstructured, wor
 		}))
 	}
 	util.RecordManagedLabels(workload)
+}
+
+// GetWorkSuspendDispatching will get suspendDispatching field from work spec
+func GetWorkSuspendDispatching(spec *workv1alpha1.WorkSpec) []string {
+	return []string{strconv.FormatBool(ptr.Deref(spec.SuspendDispatching, false))}
 }

--- a/pkg/webhook/work/mutating.go
+++ b/pkg/webhook/work/mutating.go
@@ -75,10 +75,7 @@ func (a *MutatingAdmission) Handle(_ context.Context, req admission.Request) adm
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
 
-		// Skip label/annotate the workload of Work that is not intended to be propagated.
-		if work.Labels[util.PropagationInstruction] != util.PropagationInstructionSuppressed {
-			helper.SetLabelsAndAnnotationsForWorkload(workloadObj, work)
-		}
+		helper.SetLabelsAndAnnotationsForWorkload(workloadObj, work)
 
 		workloadJSON, err := workloadObj.MarshalJSON()
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind deprecation
**What this PR does / why we need it**:
Replace `propagation.karmada.io/instruction` with `suspendDispatching` field. Annotation was just a temporary solution. With the native support of the work API, we should deprecate the use of annotations and utilize the work field instead.
**Which issue(s) this PR fixes**:
Fixes #5386 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`Deprecation`: The label `propagation.karmada.io/instruction` now has been deprecated in favor of the field(`.spec.suspendDispatching`) in Work API, the label will be removed in future releases.
```

