### PR TITLE
config security context

### DIFF
--- a/artifacts/deploy/karmada-aggregated-apiserver.yaml
+++ b/artifacts/deploy/karmada-aggregated-apiserver.yaml
@@ -24,6 +24,9 @@ spec:
         - name: karmada-aggregated-apiserver
           image: docker.io/karmada/karmada-aggregated-apiserver:latest
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
           command:
             - /bin/karmada-aggregated-apiserver
             - --kubeconfig=/etc/karmada/config/karmada.config
@@ -77,6 +80,9 @@ spec:
         - name: etcd-client-cert
           secret:
             secretName: karmada-aggregated-apiserver-etcd-client-cert
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
 ---
 apiVersion: v1
 kind: Service

--- a/artifacts/deploy/karmada-apiserver.yaml
+++ b/artifacts/deploy/karmada-apiserver.yaml
@@ -100,6 +100,9 @@ spec:
             - name: service-account-key-pair
               mountPath: /etc/karmada/pki/service-account-key-pair
               readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
       volumes:
         - name: server-cert
           secret:
@@ -121,7 +124,9 @@ spec:
       priorityClassName: system-node-critical
       restartPolicy: Always
       schedulerName: default-scheduler
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 30
       tolerations:
         - effect: NoExecute

--- a/artifacts/deploy/karmada-controller-manager.yaml
+++ b/artifacts/deploy/karmada-controller-manager.yaml
@@ -21,6 +21,9 @@ spec:
         operator: Exists
       containers:
         - name: karmada-controller-manager
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
           image: docker.io/karmada/karmada-controller-manager:latest
           imagePullPolicy: IfNotPresent
           command:
@@ -53,3 +56,6 @@ spec:
         - name: karmada-config
           secret:
             secretName: karmada-controller-manager-config
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault

--- a/artifacts/deploy/karmada-descheduler.yaml
+++ b/artifacts/deploy/karmada-descheduler.yaml
@@ -21,6 +21,9 @@ spec:
           operator: Exists
       containers:
         - name: karmada-descheduler
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
           image: docker.io/karmada/karmada-descheduler:latest
           imagePullPolicy: IfNotPresent
           command:
@@ -58,3 +61,6 @@ spec:
         - name: scheduler-estimator-client-cert
           secret:
             secretName: karmada-descheduler-scheduler-estimator-client-cert
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault

--- a/artifacts/deploy/karmada-etcd.yaml
+++ b/artifacts/deploy/karmada-etcd.yaml
@@ -33,6 +33,9 @@ spec:
         - operator: Exists
       containers:
         - name: etcd
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
           image: registry.k8s.io/etcd:3.5.16-0
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -88,6 +91,9 @@ spec:
               mountPath: /etc/karmada/pki/server
             - name: etcd-client-cert
               mountPath: /etc/karmada/pki/etcd-client
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
         - name: etcd-data
           hostPath:

--- a/artifacts/deploy/karmada-metrics-adapter.yaml
+++ b/artifacts/deploy/karmada-metrics-adapter.yaml
@@ -22,6 +22,9 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: karmada-metrics-adapter
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
           image: docker.io/karmada/karmada-metrics-adapter:latest
           imagePullPolicy: IfNotPresent
           command:
@@ -71,6 +74,9 @@ spec:
         - name: server-cert
           secret:
             secretName: karmada-metrics-adapter-cert
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
 ---
 apiVersion: v1
 kind: Service

--- a/artifacts/deploy/karmada-scheduler-estimator.yaml
+++ b/artifacts/deploy/karmada-scheduler-estimator.yaml
@@ -21,6 +21,9 @@ spec:
           operator: Exists
       containers:
         - name: karmada-scheduler-estimator
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
           image: docker.io/karmada/karmada-scheduler-estimator:latest
           imagePullPolicy: IfNotPresent
           command:
@@ -59,6 +62,9 @@ spec:
         - name: member-kubeconfig
           secret:
             secretName: {{member_cluster_name}}-kubeconfig
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
 ---
 apiVersion: v1
 kind: Service

--- a/artifacts/deploy/karmada-scheduler.yaml
+++ b/artifacts/deploy/karmada-scheduler.yaml
@@ -21,6 +21,9 @@ spec:
           operator: Exists
       containers:
         - name: karmada-scheduler
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
           image: docker.io/karmada/karmada-scheduler:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -59,3 +62,6 @@ spec:
         - name: scheduler-estimator-client-cert
           secret:
             secretName: karmada-scheduler-scheduler-estimator-client-cert
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault

--- a/artifacts/deploy/karmada-search.yaml
+++ b/artifacts/deploy/karmada-search.yaml
@@ -22,6 +22,9 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: karmada-search
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
           image: docker.io/karmada/karmada-search:latest
           imagePullPolicy: IfNotPresent
           command:
@@ -70,6 +73,9 @@ spec:
         - name: etcd-client-cert
           secret:
             secretName: karmada-search-etcd-client-cert
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
 ---
 apiVersion: v1
 kind: Service

--- a/artifacts/deploy/karmada-webhook.yaml
+++ b/artifacts/deploy/karmada-webhook.yaml
@@ -21,6 +21,9 @@ spec:
           operator: Exists
       containers:
         - name: karmada-webhook
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
           image: docker.io/karmada/karmada-webhook:latest
           imagePullPolicy: IfNotPresent
           command:
@@ -56,6 +59,9 @@ spec:
         - name: server-cert
           secret:
             secretName: karmada-webhook-cert
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
 ---
 apiVersion: v1
 kind: Service

--- a/artifacts/deploy/kube-controller-manager.yaml
+++ b/artifacts/deploy/kube-controller-manager.yaml
@@ -58,6 +58,9 @@ spec:
             - --v=4
           image: registry.k8s.io/kube-controller-manager:{{karmada_apiserver_version}}
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
           livenessProbe:
             failureThreshold: 8
             httpGet:
@@ -91,3 +94,6 @@ spec:
         - name: service-account-key-pair
           secret:
             secretName: kube-controller-manager-service-account-key-pair
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
A [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) defines privilege and access control settings for a Pod or Container. More details can refer to https://www.dynatrace.com/engineering/blog/kubernetes-security-part-3-security-context/

This PR restricted the component's security context, including,
- set `allowPrivilegeEscalation` to false
- set `privileged` to false,
- configured the `seccompProfile` to `RuntimeDefault`

Regarding `runAsUser` and `runAsNonRoot`, unfortunately, imposing these restrictions resulted in abnormal functionality of the component, so they could not be applied. As for `readOnlyRootFilesystem`, implementing this would reduce convenience during troubleshooting. Given that the manifests files maintained under the `artifacts` directory are primarily used by developers, this PR decides not to set this option for now.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
For other installation methods, this configuration can be adapted later, and it should provide users with the ability to customize security context.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

