### PR TITLE
fix pp suspension mistakenly override scheduling suspension

### DIFF
--- a/pkg/controllers/multiclusterservice/mcs_controller.go
+++ b/pkg/controllers/multiclusterservice/mcs_controller.go
@@ -404,7 +404,12 @@ func (c *MCSController) propagateService(ctx context.Context, mcs *networkingv1a
 			bindingCopy.Spec.Placement = binding.Spec.Placement
 			bindingCopy.Spec.Resource = binding.Spec.Resource
 			bindingCopy.Spec.ConflictResolution = binding.Spec.ConflictResolution
-			bindingCopy.Spec.Suspension = binding.Spec.Suspension
+			if binding.Spec.Suspension != nil {
+				if bindingCopy.Spec.Suspension == nil {
+					bindingCopy.Spec.Suspension = &workv1alpha2.Suspension{}
+				}
+				bindingCopy.Spec.Suspension.Suspension = binding.Spec.Suspension.Suspension
+			}
 			return nil
 		})
 		if err != nil {

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -476,8 +476,13 @@ func (d *ResourceDetector) ApplyPolicy(object *unstructured.Unstructured, object
 			bindingCopy.Spec.Placement = binding.Spec.Placement
 			bindingCopy.Spec.Failover = binding.Spec.Failover
 			bindingCopy.Spec.ConflictResolution = binding.Spec.ConflictResolution
-			bindingCopy.Spec.Suspension = binding.Spec.Suspension
 			bindingCopy.Spec.PreserveResourcesOnDeletion = binding.Spec.PreserveResourcesOnDeletion
+			if binding.Spec.Suspension != nil {
+				if bindingCopy.Spec.Suspension == nil {
+					bindingCopy.Spec.Suspension = &workv1alpha2.Suspension{}
+				}
+				bindingCopy.Spec.Suspension.Suspension = binding.Spec.Suspension.Suspension
+			}
 			excludeClusterPolicy(bindingCopy)
 			return nil
 		})
@@ -565,8 +570,13 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 				bindingCopy.Spec.Placement = binding.Spec.Placement
 				bindingCopy.Spec.Failover = binding.Spec.Failover
 				bindingCopy.Spec.ConflictResolution = binding.Spec.ConflictResolution
-				bindingCopy.Spec.Suspension = binding.Spec.Suspension
 				bindingCopy.Spec.PreserveResourcesOnDeletion = binding.Spec.PreserveResourcesOnDeletion
+				if binding.Spec.Suspension != nil {
+					if bindingCopy.Spec.Suspension == nil {
+						bindingCopy.Spec.Suspension = &workv1alpha2.Suspension{}
+					}
+					bindingCopy.Spec.Suspension.Suspension = binding.Spec.Suspension.Suspension
+				}
 				return nil
 			})
 			return err
@@ -612,8 +622,13 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 				bindingCopy.Spec.Placement = binding.Spec.Placement
 				bindingCopy.Spec.Failover = binding.Spec.Failover
 				bindingCopy.Spec.ConflictResolution = binding.Spec.ConflictResolution
-				bindingCopy.Spec.Suspension = binding.Spec.Suspension
 				bindingCopy.Spec.PreserveResourcesOnDeletion = binding.Spec.PreserveResourcesOnDeletion
+				if binding.Spec.Suspension != nil {
+					if bindingCopy.Spec.Suspension == nil {
+						bindingCopy.Spec.Suspension = &workv1alpha2.Suspension{}
+					}
+					bindingCopy.Spec.Suspension.Suspension = binding.Spec.Suspension.Suspension
+				}
 				return nil
 			})
 			return err


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change

/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
The https://github.com/karmada-io/karmada/pull/5974 has decoupled `work` suspension inherited from pp and `resourcebinding` suspension, but there is something missed, when update rb conflicted, the whole suspension filed will be override by suspension from pp, which will casue rb scheduling suspension to nil, this pr fix it, and also print the suspension state using kubectl.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Fixed an issue that the scheduling suspension on ResourceBinding might be mistakenly overwritten.
```

