### PR TITLE
fix(search/proxy/controller): resourceregistry merge ns

### DIFF
--- a/pkg/search/proxy/store/util.go
+++ b/pkg/search/proxy/store/util.go
@@ -284,6 +284,20 @@ type MultiNamespace struct {
 	namespaces    sets.Set[string]
 }
 
+// Merge merges multiNS into n.
+func (n *MultiNamespace) Merge(multiNS *MultiNamespace) *MultiNamespace {
+	if n.allNamespaces || multiNS.allNamespaces {
+		n.allNamespaces = true
+		n.namespaces = nil
+		return n
+	}
+	if n.Equal(multiNS) {
+		return n
+	}
+	n.namespaces.Insert(multiNS.namespaces.Clone().UnsortedList()...)
+	return n
+}
+
 // NewMultiNamespace return a new empty MultiNamespace.
 func NewMultiNamespace() *MultiNamespace {
 	return &MultiNamespace{

--- a/pkg/search/proxy/store/util_test.go
+++ b/pkg/search/proxy/store/util_test.go
@@ -1082,3 +1082,93 @@ func TestMultiNamespace_Equal(t *testing.T) {
 		})
 	}
 }
+
+func TestMultiNamespace_Merge(t *testing.T) {
+	type fields struct {
+		allNamespaces bool
+		namespaces    sets.Set[string]
+	}
+	type args struct {
+		multiNS *MultiNamespace
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *MultiNamespace
+	}{
+		{
+			name: "all ns merge all ns",
+			fields: fields{
+				allNamespaces: true,
+			},
+			args: args{
+				multiNS: &MultiNamespace{
+					allNamespaces: true,
+				},
+			},
+			want: &MultiNamespace{
+				allNamespaces: true,
+			},
+		},
+		{
+			name: "all ns merge not all",
+			fields: fields{
+				allNamespaces: true,
+			},
+			args: args{
+				multiNS: &MultiNamespace{
+					allNamespaces: false,
+					namespaces:    sets.New[string]("foo"),
+				},
+			},
+			want: &MultiNamespace{
+				allNamespaces: true,
+			},
+		},
+		{
+			name: "not all ns merge all",
+			fields: fields{
+				allNamespaces: false,
+				namespaces:    sets.New[string]("foo"),
+			},
+			args: args{
+				multiNS: &MultiNamespace{
+					allNamespaces: true,
+				},
+			},
+			want: &MultiNamespace{
+				allNamespaces: true,
+			},
+		},
+		{
+			name: "not all ns merge not all ns",
+			fields: fields{
+				allNamespaces: false,
+				namespaces:    sets.New[string]("foo", "zoo"),
+			},
+			args: args{
+				multiNS: &MultiNamespace{
+					allNamespaces: false,
+					namespaces:    sets.New[string]("bar"),
+				},
+			},
+			want: &MultiNamespace{
+				allNamespaces: false,
+				namespaces:    sets.New[string]("foo", "bar", "zoo"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := &MultiNamespace{
+				allNamespaces: tt.fields.allNamespaces,
+				namespaces:    tt.fields.namespaces,
+			}
+			got := n.Merge(tt.args.multiNS)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MultiNamespace.Merge() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/search/proxy/testing/constant.go
+++ b/pkg/search/proxy/testing/constant.go
@@ -35,7 +35,12 @@ var (
 	SecretGVR  = corev1.SchemeGroupVersion.WithResource("secret")
 	ClusterGVR = clusterv1alpha1.SchemeGroupVersion.WithResource("cluster")
 
-	PodSelector  = searchv1alpha1.ResourceSelector{APIVersion: PodGVK.GroupVersion().String(), Kind: PodGVK.Kind}
+	PodSelector = searchv1alpha1.ResourceSelector{APIVersion: PodGVK.GroupVersion().String(), Kind: PodGVK.Kind}
+
+	PodSelectorWithNS1 = searchv1alpha1.ResourceSelector{APIVersion: PodGVK.GroupVersion().String(), Kind: PodGVK.Kind, Namespace: "ns1"}
+
+	PodSelectorWithNS2 = searchv1alpha1.ResourceSelector{APIVersion: PodGVK.GroupVersion().String(), Kind: PodGVK.Kind, Namespace: "ns2"}
+
 	NodeSelector = searchv1alpha1.ResourceSelector{APIVersion: NodeGVK.GroupVersion().String(), Kind: NodeGVK.Kind}
 
 	RestMapper *meta.DefaultRESTMapper


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
karmada-search resourceregistry can merge the same cluster gvk's namespaces
get ResourceRegistry:
![image](https://github.com/user-attachments/assets/ce884733-05af-497d-ba2d-c8f077035e40)
get secret:
![image](https://github.com/user-attachments/assets/425e1705-e94b-429d-ac7e-5c744a68ee49)

**Which issue(s) this PR fixes**:
Fixes #6064

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-search`: Fixed the issue that namespaces in different ResourceRegistry might be overwritten.
```

