### PR TITLE
Add Support for Component Priority Class Configuration in Karmada Operator

### DIFF
--- a/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
+++ b/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
@@ -153,6 +153,12 @@ spec:
                             items:
                               type: string
                             type: array
+                          priorityClassName:
+                            default: system-node-critical
+                            description: |-
+                              PriorityClassName specifies the priority class name for the component.
+                              If not specified, it defaults to "system-node-critical".
+                            type: string
                           replicas:
                             description: |-
                               Number of desired pods. This is a pointer to distinguish between explicit
@@ -2465,6 +2471,12 @@ spec:
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
+                      priorityClassName:
+                        default: system-node-critical
+                        description: |-
+                          PriorityClassName specifies the priority class name for the component.
+                          If not specified, it defaults to "system-node-critical".
+                        type: string
                       replicas:
                         description: |-
                           Number of desired pods. This is a pointer to distinguish between explicit
@@ -2625,6 +2637,12 @@ spec:
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
+                      priorityClassName:
+                        default: system-node-critical
+                        description: |-
+                          PriorityClassName specifies the priority class name for the component.
+                          If not specified, it defaults to "system-node-critical".
+                        type: string
                       replicas:
                         description: |-
                           Number of desired pods. This is a pointer to distinguish between explicit
@@ -2776,6 +2794,12 @@ spec:
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
+                      priorityClassName:
+                        default: system-node-critical
+                        description: |-
+                          PriorityClassName specifies the priority class name for the component.
+                          If not specified, it defaults to "system-node-critical".
+                        type: string
                       replicas:
                         description: |-
                           Number of desired pods. This is a pointer to distinguish between explicit
@@ -2900,6 +2924,12 @@ spec:
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
+                      priorityClassName:
+                        default: system-node-critical
+                        description: |-
+                          PriorityClassName specifies the priority class name for the component.
+                          If not specified, it defaults to "system-node-critical".
+                        type: string
                       replicas:
                         description: |-
                           Number of desired pods. This is a pointer to distinguish between explicit
@@ -3024,6 +3054,12 @@ spec:
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
+                      priorityClassName:
+                        default: system-node-critical
+                        description: |-
+                          PriorityClassName specifies the priority class name for the component.
+                          If not specified, it defaults to "system-node-critical".
+                        type: string
                       replicas:
                         description: |-
                           Number of desired pods. This is a pointer to distinguish between explicit
@@ -3156,6 +3192,12 @@ spec:
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
+                      priorityClassName:
+                        default: system-node-critical
+                        description: |-
+                          PriorityClassName specifies the priority class name for the component.
+                          If not specified, it defaults to "system-node-critical".
+                        type: string
                       replicas:
                         description: |-
                           Number of desired pods. This is a pointer to distinguish between explicit
@@ -3280,6 +3322,12 @@ spec:
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
+                      priorityClassName:
+                        default: system-node-critical
+                        description: |-
+                          PriorityClassName specifies the priority class name for the component.
+                          If not specified, it defaults to "system-node-critical".
+                        type: string
                       replicas:
                         description: |-
                           Number of desired pods. This is a pointer to distinguish between explicit
@@ -3404,6 +3452,12 @@ spec:
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
+                      priorityClassName:
+                        default: system-node-critical
+                        description: |-
+                          PriorityClassName specifies the priority class name for the component.
+                          If not specified, it defaults to "system-node-critical".
+                        type: string
                       replicas:
                         description: |-
                           Number of desired pods. This is a pointer to distinguish between explicit
@@ -3574,6 +3628,12 @@ spec:
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
+                      priorityClassName:
+                        default: system-node-critical
+                        description: |-
+                          PriorityClassName specifies the priority class name for the component.
+                          If not specified, it defaults to "system-node-critical".
+                        type: string
                       replicas:
                         description: |-
                           Number of desired pods. This is a pointer to distinguish between explicit

--- a/operator/config/crds/operator.karmada.io_karmadas.yaml
+++ b/operator/config/crds/operator.karmada.io_karmadas.yaml
@@ -153,6 +153,12 @@ spec:
                             items:
                               type: string
                             type: array
+                          priorityClassName:
+                            default: system-node-critical
+                            description: |-
+                              PriorityClassName specifies the priority class name for the component.
+                              If not specified, it defaults to "system-node-critical".
+                            type: string
                           replicas:
                             description: |-
                               Number of desired pods. This is a pointer to distinguish between explicit
@@ -2465,6 +2471,12 @@ spec:
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
+                      priorityClassName:
+                        default: system-node-critical
+                        description: |-
+                          PriorityClassName specifies the priority class name for the component.
+                          If not specified, it defaults to "system-node-critical".
+                        type: string
                       replicas:
                         description: |-
                           Number of desired pods. This is a pointer to distinguish between explicit
@@ -2625,6 +2637,12 @@ spec:
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
+                      priorityClassName:
+                        default: system-node-critical
+                        description: |-
+                          PriorityClassName specifies the priority class name for the component.
+                          If not specified, it defaults to "system-node-critical".
+                        type: string
                       replicas:
                         description: |-
                           Number of desired pods. This is a pointer to distinguish between explicit
@@ -2776,6 +2794,12 @@ spec:
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
+                      priorityClassName:
+                        default: system-node-critical
+                        description: |-
+                          PriorityClassName specifies the priority class name for the component.
+                          If not specified, it defaults to "system-node-critical".
+                        type: string
                       replicas:
                         description: |-
                           Number of desired pods. This is a pointer to distinguish between explicit
@@ -2900,6 +2924,12 @@ spec:
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
+                      priorityClassName:
+                        default: system-node-critical
+                        description: |-
+                          PriorityClassName specifies the priority class name for the component.
+                          If not specified, it defaults to "system-node-critical".
+                        type: string
                       replicas:
                         description: |-
                           Number of desired pods. This is a pointer to distinguish between explicit
@@ -3024,6 +3054,12 @@ spec:
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
+                      priorityClassName:
+                        default: system-node-critical
+                        description: |-
+                          PriorityClassName specifies the priority class name for the component.
+                          If not specified, it defaults to "system-node-critical".
+                        type: string
                       replicas:
                         description: |-
                           Number of desired pods. This is a pointer to distinguish between explicit
@@ -3156,6 +3192,12 @@ spec:
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
+                      priorityClassName:
+                        default: system-node-critical
+                        description: |-
+                          PriorityClassName specifies the priority class name for the component.
+                          If not specified, it defaults to "system-node-critical".
+                        type: string
                       replicas:
                         description: |-
                           Number of desired pods. This is a pointer to distinguish between explicit
@@ -3280,6 +3322,12 @@ spec:
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
+                      priorityClassName:
+                        default: system-node-critical
+                        description: |-
+                          PriorityClassName specifies the priority class name for the component.
+                          If not specified, it defaults to "system-node-critical".
+                        type: string
                       replicas:
                         description: |-
                           Number of desired pods. This is a pointer to distinguish between explicit
@@ -3404,6 +3452,12 @@ spec:
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
+                      priorityClassName:
+                        default: system-node-critical
+                        description: |-
+                          PriorityClassName specifies the priority class name for the component.
+                          If not specified, it defaults to "system-node-critical".
+                        type: string
                       replicas:
                         description: |-
                           Number of desired pods. This is a pointer to distinguish between explicit
@@ -3574,6 +3628,12 @@ spec:
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
+                      priorityClassName:
+                        default: system-node-critical
+                        description: |-
+                          PriorityClassName specifies the priority class name for the component.
+                          If not specified, it defaults to "system-node-critical".
+                        type: string
                       replicas:
                         description: |-
                           Number of desired pods. This is a pointer to distinguish between explicit

--- a/operator/pkg/apis/operator/v1alpha1/type.go
+++ b/operator/pkg/apis/operator/v1alpha1/type.go
@@ -648,6 +648,12 @@ type CommonSettings struct {
 	// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 	// +optional
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+
+	// PriorityClassName specifies the priority class name for the component.
+	// If not specified, it defaults to "system-node-critical".
+	// +kubebuilder:default="system-node-critical"
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 
 // Image allows to customize the image used for components.

--- a/operator/pkg/controlplane/apiserver/apiserver.go
+++ b/operator/pkg/controlplane/apiserver/apiserver.go
@@ -79,6 +79,7 @@ func installKarmadaAPIServer(client clientset.Interface, cfg *operatorv1alpha1.K
 	}
 
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
+		WithPriorityClassName(cfg.CommonSettings.PriorityClassName).
 		WithExtraArgs(cfg.ExtraArgs).WithExtraVolumeMounts(cfg.ExtraVolumeMounts).
 		WithExtraVolumes(cfg.ExtraVolumes).WithResources(cfg.Resources).ForDeployment(apiserverDeployment)
 
@@ -143,6 +144,7 @@ func installKarmadaAggregatedAPIServer(client clientset.Interface, cfg *operator
 	}
 
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
+		WithPriorityClassName(cfg.CommonSettings.PriorityClassName).
 		WithExtraArgs(cfg.ExtraArgs).WithFeatureGates(featureGates).WithResources(cfg.Resources).ForDeployment(aggregatedAPIServerDeployment)
 
 	if err := apiclient.CreateOrUpdateDeployment(client, aggregatedAPIServerDeployment); err != nil {

--- a/operator/pkg/controlplane/apiserver/manifests.go
+++ b/operator/pkg/controlplane/apiserver/manifests.go
@@ -108,7 +108,6 @@ spec:
         - mountPath: /etc/karmada/pki
           name: apiserver-cert
           readOnly: true
-      priorityClassName: system-node-critical
       volumes:
       - name: apiserver-cert
         secret:

--- a/operator/pkg/controlplane/controlplane.go
+++ b/operator/pkg/controlplane/controlplane.go
@@ -106,6 +106,7 @@ func getKubeControllerManagerManifest(name, namespace string, cfg *operatorv1alp
 	}
 
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).
+		WithPriorityClassName(cfg.CommonSettings.PriorityClassName).
 		WithLabels(cfg.Labels).WithExtraArgs(cfg.ExtraArgs).WithResources(cfg.Resources).ForDeployment(kcm)
 	return kcm, nil
 }
@@ -134,6 +135,7 @@ func getKarmadaControllerManagerManifest(name, namespace string, featureGates ma
 	}
 
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
+		WithPriorityClassName(cfg.CommonSettings.PriorityClassName).
 		WithExtraArgs(cfg.ExtraArgs).WithFeatureGates(featureGates).WithResources(cfg.Resources).ForDeployment(kcm)
 	return kcm, nil
 }
@@ -163,6 +165,7 @@ func getKarmadaSchedulerManifest(name, namespace string, featureGates map[string
 	}
 
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
+		WithPriorityClassName(cfg.CommonSettings.PriorityClassName).
 		WithExtraArgs(cfg.ExtraArgs).WithFeatureGates(featureGates).WithResources(cfg.Resources).ForDeployment(scheduler)
 	return scheduler, nil
 }
@@ -192,6 +195,7 @@ func getKarmadaDeschedulerManifest(name, namespace string, featureGates map[stri
 	}
 
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
+		WithPriorityClassName(cfg.CommonSettings.PriorityClassName).
 		WithExtraArgs(cfg.ExtraArgs).WithFeatureGates(featureGates).WithResources(cfg.Resources).ForDeployment(descheduler)
 
 	return descheduler, nil

--- a/operator/pkg/controlplane/controlplane_test.go
+++ b/operator/pkg/controlplane/controlplane_test.go
@@ -135,6 +135,7 @@ func TestGetKubeControllerManagerManifest(t *testing.T) {
 	annotations := map[string]string{"annotationKey": "annotationValue"}
 	labels := map[string]string{"labelKey": "labelValue"}
 	extraArgs := map[string]string{"cmd1": "arg1", "cmd2": "arg2"}
+	priorityClassName := "system-cluster-critical"
 
 	cfg := &operatorv1alpha1.KubeControllerManager{
 		CommonSettings: operatorv1alpha1.CommonSettings{
@@ -142,11 +143,12 @@ func TestGetKubeControllerManagerManifest(t *testing.T) {
 				ImageRepository: image,
 				ImageTag:        imageTag,
 			},
-			Replicas:        ptr.To[int32](replicas),
-			Annotations:     annotations,
-			Labels:          labels,
-			Resources:       corev1.ResourceRequirements{},
-			ImagePullPolicy: imagePullPolicy,
+			Replicas:          ptr.To[int32](replicas),
+			Annotations:       annotations,
+			Labels:            labels,
+			Resources:         corev1.ResourceRequirements{},
+			ImagePullPolicy:   imagePullPolicy,
+			PriorityClassName: priorityClassName,
 		},
 		ExtraArgs: extraArgs,
 	}
@@ -158,7 +160,7 @@ func TestGetKubeControllerManagerManifest(t *testing.T) {
 
 	deployment, _, err = verifyDeploymentDetails(
 		deployment, replicas, imagePullPolicy, extraArgs, namespace,
-		image, imageTag, util.KubeControllerManagerName(name),
+		image, imageTag, util.KubeControllerManagerName(name), priorityClassName,
 	)
 	if err != nil {
 		t.Errorf("failed to verify kube controller manager deployment details: %v", err)
@@ -182,6 +184,7 @@ func TestGetKarmadaControllerManagerManifest(t *testing.T) {
 	annotations := map[string]string{"annotationKey": "annotationValue"}
 	labels := map[string]string{"labelKey": "labelValue"}
 	extraArgs := map[string]string{"cmd1": "arg1", "cmd2": "arg2"}
+	priorityClassName := "system-cluster-critical"
 
 	cfg := &operatorv1alpha1.KarmadaControllerManager{
 		CommonSettings: operatorv1alpha1.CommonSettings{
@@ -189,10 +192,11 @@ func TestGetKarmadaControllerManagerManifest(t *testing.T) {
 				ImageRepository: image,
 				ImageTag:        imageTag,
 			},
-			Replicas:        ptr.To[int32](replicas),
-			Annotations:     annotations,
-			Labels:          labels,
-			ImagePullPolicy: imagePullPolicy,
+			Replicas:          ptr.To[int32](replicas),
+			Annotations:       annotations,
+			Labels:            labels,
+			ImagePullPolicy:   imagePullPolicy,
+			PriorityClassName: priorityClassName,
 		},
 		ExtraArgs: extraArgs,
 	}
@@ -206,7 +210,7 @@ func TestGetKarmadaControllerManagerManifest(t *testing.T) {
 
 	deployment, container, err := verifyDeploymentDetails(
 		deployment, replicas, imagePullPolicy, extraArgs, namespace,
-		image, imageTag, util.KarmadaControllerManagerName(name),
+		image, imageTag, util.KarmadaControllerManagerName(name), priorityClassName,
 	)
 	if err != nil {
 		t.Errorf("failed to verify karmada controller manager deployment details: %v", err)
@@ -237,6 +241,7 @@ func TestGetKarmadaSchedulerManifest(t *testing.T) {
 	annotations := map[string]string{"annotationKey": "annotationValue"}
 	labels := map[string]string{"labelKey": "labelValue"}
 	extraArgs := map[string]string{"cmd1": "arg1", "cmd2": "arg2"}
+	priorityClassName := "system-cluster-critical"
 
 	cfg := &operatorv1alpha1.KarmadaScheduler{
 		CommonSettings: operatorv1alpha1.CommonSettings{
@@ -244,11 +249,12 @@ func TestGetKarmadaSchedulerManifest(t *testing.T) {
 				ImageRepository: image,
 				ImageTag:        imageTag,
 			},
-			Replicas:        ptr.To[int32](replicas),
-			Annotations:     annotations,
-			Labels:          labels,
-			Resources:       corev1.ResourceRequirements{},
-			ImagePullPolicy: imagePullPolicy,
+			Replicas:          ptr.To[int32](replicas),
+			Annotations:       annotations,
+			Labels:            labels,
+			Resources:         corev1.ResourceRequirements{},
+			ImagePullPolicy:   imagePullPolicy,
+			PriorityClassName: priorityClassName,
 		},
 		ExtraArgs: extraArgs,
 	}
@@ -262,7 +268,7 @@ func TestGetKarmadaSchedulerManifest(t *testing.T) {
 
 	deployment, container, err := verifyDeploymentDetails(
 		deployment, replicas, imagePullPolicy, extraArgs, namespace,
-		image, imageTag, util.KarmadaSchedulerName(name),
+		image, imageTag, util.KarmadaSchedulerName(name), priorityClassName,
 	)
 	if err != nil {
 		t.Errorf("failed to verify karmada scheduler deployment details: %v", err)
@@ -296,6 +302,7 @@ func TestGetKarmadaDeschedulerManifest(t *testing.T) {
 	annotations := map[string]string{"annotationKey": "annotationValue"}
 	labels := map[string]string{"labelKey": "labelValue"}
 	extraArgs := map[string]string{"cmd1": "arg1", "cmd2": "arg2"}
+	priorityClassName := "system-cluster-critical"
 
 	cfg := &operatorv1alpha1.KarmadaDescheduler{
 		CommonSettings: operatorv1alpha1.CommonSettings{
@@ -303,11 +310,12 @@ func TestGetKarmadaDeschedulerManifest(t *testing.T) {
 				ImageRepository: image,
 				ImageTag:        imageTag,
 			},
-			Replicas:        ptr.To[int32](replicas),
-			Annotations:     annotations,
-			Labels:          labels,
-			Resources:       corev1.ResourceRequirements{},
-			ImagePullPolicy: imagePullPolicy,
+			Replicas:          ptr.To[int32](replicas),
+			Annotations:       annotations,
+			Labels:            labels,
+			Resources:         corev1.ResourceRequirements{},
+			ImagePullPolicy:   imagePullPolicy,
+			PriorityClassName: priorityClassName,
 		},
 		ExtraArgs: extraArgs,
 	}
@@ -321,7 +329,7 @@ func TestGetKarmadaDeschedulerManifest(t *testing.T) {
 
 	deployment, container, err := verifyDeploymentDetails(
 		deployment, replicas, imagePullPolicy, extraArgs, namespace,
-		image, imageTag, util.KarmadaDeschedulerName(name),
+		image, imageTag, util.KarmadaDeschedulerName(name), priorityClassName,
 	)
 	if err != nil {
 		t.Errorf("failed to verify karmada descheduler deployment details: %v", err)
@@ -352,9 +360,13 @@ func TestGetKarmadaDeschedulerManifest(t *testing.T) {
 // It validates that the deployment matches the expected Karmada Controlplane settings.
 // It could be against Kube Controller Manager, Karmada Controller Manager, Karmada Scheduler,
 // and Karmada Descheduler.
-func verifyDeploymentDetails(deployment *appsv1.Deployment, replicas int32, imagePullPolicy corev1.PullPolicy, extraArgs map[string]string, namespace, image, imageTag, expectedDeploymentName string) (*appsv1.Deployment, *corev1.Container, error) {
+func verifyDeploymentDetails(deployment *appsv1.Deployment, replicas int32, imagePullPolicy corev1.PullPolicy, extraArgs map[string]string, namespace, image, imageTag, expectedDeploymentName, priorityClassName string) (*appsv1.Deployment, *corev1.Container, error) {
 	if deployment.Name != expectedDeploymentName {
 		return nil, nil, fmt.Errorf("expected deployment name '%s', but got '%s'", expectedDeploymentName, deployment.Name)
+	}
+
+	if deployment.Spec.Template.Spec.PriorityClassName != priorityClassName {
+		return nil, nil, fmt.Errorf("expected priorityClassName to be set to %s, but got %s", priorityClassName, deployment.Spec.Template.Spec.PriorityClassName)
 	}
 
 	if deployment.Namespace != namespace {

--- a/operator/pkg/controlplane/etcd/etcd.go
+++ b/operator/pkg/controlplane/etcd/etcd.go
@@ -91,6 +91,7 @@ func installKarmadaEtcd(client clientset.Interface, name, namespace string, cfg 
 	}
 
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
+		WithPriorityClassName(cfg.CommonSettings.PriorityClassName).
 		WithVolumeData(cfg.VolumeData).WithResources(cfg.Resources).ForStatefulSet(etcdStatefulSet)
 
 	if err := apiclient.CreateOrUpdateStatefulSet(client, etcdStatefulSet); err != nil {

--- a/operator/pkg/controlplane/manifests.go
+++ b/operator/pkg/controlplane/manifests.go
@@ -38,7 +38,6 @@ spec:
         karmada-app: kube-controller-manager
     spec:
       automountServiceAccountToken: false
-      priorityClassName: system-node-critical
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/operator/pkg/controlplane/metricsadapter/metricsadapter.go
+++ b/operator/pkg/controlplane/metricsadapter/metricsadapter.go
@@ -63,7 +63,8 @@ func installKarmadaMetricAdapter(client clientset.Interface, cfg *operatorv1alph
 		return fmt.Errorf("err when decoding KarmadaMetricAdapter Deployment: %w", err)
 	}
 
-	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).WithResources(cfg.Resources).ForDeployment(metricAdapter)
+	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).WithPriorityClassName(cfg.CommonSettings.PriorityClassName).
+		WithResources(cfg.Resources).ForDeployment(metricAdapter)
 
 	if err := apiclient.CreateOrUpdateDeployment(client, metricAdapter); err != nil {
 		return fmt.Errorf("error when creating deployment for %s, err: %w", metricAdapter.Name, err)

--- a/operator/pkg/controlplane/search/search.go
+++ b/operator/pkg/controlplane/search/search.go
@@ -70,6 +70,7 @@ func installKarmadaSearch(client clientset.Interface, cfg *operatorv1alpha1.Karm
 	}
 
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
+		WithPriorityClassName(cfg.CommonSettings.PriorityClassName).
 		WithExtraArgs(cfg.ExtraArgs).WithResources(cfg.Resources).ForDeployment(searchDeployment)
 
 	if err := apiclient.CreateOrUpdateDeployment(client, searchDeployment); err != nil {

--- a/operator/pkg/controlplane/webhook/webhook.go
+++ b/operator/pkg/controlplane/webhook/webhook.go
@@ -64,6 +64,7 @@ func installKarmadaWebhook(client clientset.Interface, cfg *operatorv1alpha1.Kar
 	}
 
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
+		WithPriorityClassName(cfg.CommonSettings.PriorityClassName).
 		WithExtraArgs(cfg.ExtraArgs).WithResources(cfg.Resources).ForDeployment(webhookDeployment)
 
 	if err := apiclient.CreateOrUpdateDeployment(client, webhookDeployment); err != nil {

--- a/operator/pkg/util/patcher/pather.go
+++ b/operator/pkg/util/patcher/pather.go
@@ -35,6 +35,7 @@ import (
 
 // Patcher defines multiple variables that need to be patched.
 type Patcher struct {
+	priorityClassName string
 	labels            map[string]string
 	annotations       map[string]string
 	extraArgs         map[string]string
@@ -65,6 +66,12 @@ func (p *Patcher) WithAnnotations(annotations labels.Set) *Patcher {
 // WithExtraArgs sets extraArgs to the patcher.
 func (p *Patcher) WithExtraArgs(extraArgs map[string]string) *Patcher {
 	p.extraArgs = extraArgs
+	return p
+}
+
+// WithPriorityClassName sets the priority class name for the patcher.
+func (p *Patcher) WithPriorityClassName(priorityClassName string) *Patcher {
+	p.priorityClassName = priorityClassName
 	return p
 }
 
@@ -105,6 +112,7 @@ func (p *Patcher) ForDeployment(deployment *appsv1.Deployment) {
 
 	deployment.Annotations = labels.Merge(deployment.Annotations, p.annotations)
 	deployment.Spec.Template.Annotations = labels.Merge(deployment.Spec.Template.Annotations, p.annotations)
+	deployment.Spec.Template.Spec.PriorityClassName = p.priorityClassName
 
 	if p.resources.Size() > 0 {
 		// It's considered the first container is the karmada component by default.
@@ -149,6 +157,7 @@ func (p *Patcher) ForStatefulSet(sts *appsv1.StatefulSet) {
 
 	sts.Annotations = labels.Merge(sts.Annotations, p.annotations)
 	sts.Spec.Template.Annotations = labels.Merge(sts.Spec.Template.Annotations, p.annotations)
+	sts.Spec.Template.Spec.PriorityClassName = p.priorityClassName
 
 	if p.volume != nil {
 		patchVolumeForStatefulSet(sts, p.volume)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
This is an implementation of this [proposal](https://github.com/karmada-io/karmada/pull/6010) to add support for configuring the priority class name of Karmada control plane components.

**Which issue(s) this PR fixes**:
Fixes #6009
Partof #6042
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-operator`: The new `PriorityClassName` field added as part of the Karmada control plane component configurations can be used to specify the priority class name of that component.
```