### PR TITLE
add work mutating in ctrlutil.CreateOrUpdateWork()

### DIFF
--- a/pkg/controllers/multiclusterservice/endpointslice_dispatch_controller_test.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_dispatch_controller_test.go
@@ -604,7 +604,9 @@ func TestEnsureEndpointSliceWork(t *testing.T) {
                                                 "endpointslice.karmada.io/provision-cluster": "provider",
                                                 "work.karmada.io/name": "test-work",
                                                 "work.karmada.io/namespace": "karmada-es-consumer",
-                                                "resourcetemplate.karmada.io/uid": ""
+                                                "resourcetemplate.karmada.io/uid": "",
+                                                "resourcetemplate.karmada.io/managed-annotations": "endpointslice.karmada.io/provision-cluster,resourcetemplate.karmada.io/managed-annotations,resourcetemplate.karmada.io/managed-labels,resourcetemplate.karmada.io/uid,work.karmada.io/name,work.karmada.io/namespace",
+                                                "resourcetemplate.karmada.io/managed-labels":"endpointslice.kubernetes.io/managed-by,karmada.io/managed,kubernetes.io/service-name"
                                             }
                                         },
                                         "endpoints": [

--- a/pkg/util/helper/work.go
+++ b/pkg/util/helper/work.go
@@ -111,3 +111,14 @@ func IsWorkContains(manifests []workv1alpha1.Manifest, targetResource schema.Gro
 func IsWorkSuspendDispatching(work *workv1alpha1.Work) bool {
 	return ptr.Deref(work.Spec.SuspendDispatching, false)
 }
+
+// SetLabelsAndAnnotationsForWorkload sets the associated work object labels and annotations for workload.
+func SetLabelsAndAnnotationsForWorkload(workload *unstructured.Unstructured, work *workv1alpha1.Work) {
+	util.RecordManagedAnnotations(workload)
+	if work.Labels[workv1alpha2.WorkPermanentIDLabel] != "" {
+		workload.SetLabels(util.DedupeAndMergeLabels(workload.GetLabels(), map[string]string{
+			workv1alpha2.WorkPermanentIDLabel: work.Labels[workv1alpha2.WorkPermanentIDLabel],
+		}))
+	}
+	util.RecordManagedLabels(workload)
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

It could remove unnecessary update operations in `ctrlutil.CreateOrUpdateWork()`, by mutating the `Work` in advance, and let `DeepEqual()` return true. when karmada-controller-manager restart, this may help reduce the time it takes to clear the work queue.

Should be part of #6031, if it's not true please correct me.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Tests will remain failing until #6028 is merged and this PR is rebased on it.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

