### PR TITLE
karmada-webhook: fix the no such host error

### DIFF
--- a/charts/karmada/_crds/patches/webhook_in_clusterresourcebindings.yaml
+++ b/charts/karmada/_crds/patches/webhook_in_clusterresourcebindings.yaml
@@ -9,6 +9,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        url: https://karmada-webhook.karmada-system.svc:443/convert
+        url: "https://{{name}}.{{namespace}}.svc:443/convert"
         caBundle: "{{caBundle}}"
       conversionReviewVersions: ["v1"]

--- a/charts/karmada/_crds/patches/webhook_in_resourcebindings.yaml
+++ b/charts/karmada/_crds/patches/webhook_in_resourcebindings.yaml
@@ -9,6 +9,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        url: https://karmada-webhook.karmada-system.svc:443/convert
+        url: "https://{{name}}.{{namespace}}.svc:443/convert"
         caBundle: "{{caBundle}}"
       conversionReviewVersions: ["v1"]

--- a/hack/deploy-karmada.sh
+++ b/hack/deploy-karmada.sh
@@ -302,7 +302,11 @@ TEMP_PATH_CRDS=$(mktemp -d)
 trap '{ rm -rf ${TEMP_PATH_CRDS}; }' EXIT
 cp -rf "${REPO_ROOT}"/charts/karmada/_crds "${TEMP_PATH_CRDS}"
 util::fill_cabundle "${ROOT_CA_FILE}" "${TEMP_PATH_CRDS}/_crds/patches/webhook_in_resourcebindings.yaml"
+sed -i'' -e "s/{{name}}/karmada-webhook/g" "${TEMP_PATH_CRDS}/_crds/patches/webhook_in_resourcebindings.yaml"
+sed -i'' -e "s/{{namespace}}/karmada-system/g" "${TEMP_PATH_CRDS}/_crds/patches/webhook_in_resourcebindings.yaml"
 util::fill_cabundle "${ROOT_CA_FILE}" "${TEMP_PATH_CRDS}/_crds/patches/webhook_in_clusterresourcebindings.yaml"
+sed -i'' -e "s/{{name}}/karmada-webhook/g" "${TEMP_PATH_CRDS}/_crds/patches/webhook_in_clusterresourcebindings.yaml"
+sed -i'' -e "s/{{namespace}}/karmada-system/g" "${TEMP_PATH_CRDS}/_crds/patches/webhook_in_clusterresourcebindings.yaml"
 installCRDs "karmada-apiserver" "${TEMP_PATH_CRDS}"
 
 # render the caBundle in these apiservice with root ca, then karmada-apiserver can use caBundle to verify corresponding AA's server-cert

--- a/operator/pkg/util/util.go
+++ b/operator/pkg/util/util.go
@@ -230,15 +230,19 @@ func ReadYamlFile(path string) ([]byte, error) {
 	return yaml.YAMLToJSON(data)
 }
 
-// ReplaceYamlForReg replace content of yaml file with a Regexp
-func ReplaceYamlForReg(path, destResource string, reg *regexp.Regexp) ([]byte, error) {
+// ReplaceYamlForRegs replace content of yaml file with Regexps
+func ReplaceYamlForRegs(path string, replacements map[*regexp.Regexp]string) ([]byte, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	repl := reg.ReplaceAllString(string(data), destResource)
-	return yaml.YAMLToJSON([]byte(repl))
+	src := string(data)
+	for reg, dest := range replacements {
+		src = reg.ReplaceAllString(src, dest)
+	}
+
+	return yaml.YAMLToJSON([]byte(src))
 }
 
 // ContainAllTasks checks if all tasks in the subset are present in the tasks slice.

--- a/pkg/karmadactl/cmdinit/karmada/deploy_test.go
+++ b/pkg/karmadactl/cmdinit/karmada/deploy_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package karmada
+
+import (
+	"os"
+	"testing"
+
+	"github.com/karmada-io/karmada/pkg/util/names"
+)
+
+func TestCrdPatchesResources(t *testing.T) {
+	tests := []struct {
+		name            string
+		content         string
+		caBundle        string
+		systemNs        string
+		expectedContent string
+	}{
+		{
+			name:            "simple replacement",
+			content:         "caBundle: {{caBundle}}\nname: {{name}}\nnamespace: {{namespace}}",
+			caBundle:        "testCaBundle",
+			systemNs:        "testNamespace",
+			expectedContent: "caBundle: testCaBundle\nname: " + names.KarmadaWebhookComponentName + "\nnamespace: testNamespace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpFile, err := os.CreateTemp("", "example")
+			if err != nil {
+				t.Fatalf("failed to create temp file: %v", err)
+			}
+			defer os.Remove(tmpFile.Name())
+
+			if _, err := tmpFile.Write([]byte(tt.content)); err != nil {
+				t.Fatalf("failed to write temp file: %v", err)
+			}
+			if err := tmpFile.Close(); err != nil {
+				t.Fatalf("failed to close temp file: %v", err)
+			}
+
+			result, err := crdPatchesResources(tmpFile.Name(), tt.caBundle, tt.systemNs)
+			if err != nil {
+				t.Errorf("crdPatchesResources() error = %v", err)
+			}
+
+			if string(result) != tt.expectedContent {
+				t.Errorf("crdPatchesResources() = %v, want %v", string(result), tt.expectedContent)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
when deploying karmada instance by operator or `karmadactl init`，karmada-apiserver will report `dial tcp: lookup karmada-webhook.karmada-system.svc on x.x.x.x: no such host` error if the namespace of karmada instance is not `karmada-system`.
```bash
E0208 07:01:36.926856       1 watcher.go:567] failed to prepare current and previous objects: conversion webhook for work.karmada.io/v1alpha2, Kind=ResourceBinding failed: Post "https://karmada-webhook.karmada-system.svc:443/convert?timeout=30s": dial tcp: lookup karmada-webhook.karmada-system.svc on 100.136.0.10:53: no such host
I0208 07:01:36.927733       1 reflector.go:481] storage/cacher.go:/work.karmada.io/resourcebindings: retrying watch of work.karmada.io/v1alpha1, Kind=ResourceBinding internal error: Internal error occurred: conversion webhook for work.karmada.io/v1alpha2, Kind=ResourceBinding failed: Post "https://karmada-webhook.karmada-system.svc:443/convert?timeout=30s": dial tcp: lookup karmada-webhook.karmada-system.svc on 100.136.0.10:53: no such host
E0208 07:02:07.875403       1 cacher.go:478] cacher (resourcebindings.work.karmada.io): unexpected ListAndWatch error: failed to list work.karmada.io/v1alpha1, Kind=ResourceBinding: conversion webhook for work.karmada.io/v1alpha2, Kind=ResourceBinding failed: Post "https://karmada-webhook.karmada-system.svc:443/convert?timeout=30s": dial tcp: lookup karmada-webhook.karmada-system.svc on 100.136.0.10:53: no such host; reinitializing...
W0208 07:02:07.875388       1 reflector.go:561] storage/cacher.go:/work.karmada.io/resourcebindings: failed to list work.karmada.io/v1alpha1, Kind=ResourceBinding: conversion webhook for work.karmada.io/v1alpha2, Kind=ResourceBinding failed: Post "https://karmada-webhook.karmada-system.svc:443/convert?timeout=30s": dial tcp: lookup karmada-webhook.karmada-system.svc on 100.136.0.10:53: no such host
```

https://github.com/karmada-io/karmada/blob/211351bb0f9f50b95205c5da698defaebc08499f/charts/karmada/_crds/patches/webhook_in_resourcebindings.yaml#L1-L14
The webhook url is hardcoded and actually needs to be entered via a variable.


**Which issue(s) this PR fixes**:
Fixes #4893

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-operator`: fix the "no such host" error when accessing the /convert webhook.
```

