### PR TITLE
Restrict the cluster sync mode for the unjoin and unregister command

### DIFF
--- a/pkg/karmadactl/unregister/unregister_test.go
+++ b/pkg/karmadactl/unregister/unregister_test.go
@@ -200,10 +200,22 @@ func TestCommandUnregisterOption_RunUnregisterCluster(t *testing.T) {
 			wantErr:          true,
 		},
 		{
-			name:             "cluster exist, but cluster resources not found",
-			clusterObject:    []runtime.Object{&clusterv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: clusterName}}},
+			name: "cluster exist, but cluster resources not found",
+			clusterObject: []runtime.Object{&clusterv1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName},
+				Spec:       clusterv1alpha1.ClusterSpec{SyncMode: clusterv1alpha1.Pull}},
+			},
 			clusterResources: []runtime.Object{},
 			wantErr:          false,
+		},
+		{
+			name: "push mode member cluster",
+			clusterObject: []runtime.Object{&clusterv1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName},
+				Spec:       clusterv1alpha1.ClusterSpec{SyncMode: clusterv1alpha1.Push}},
+			},
+			clusterResources: []runtime.Object{},
+			wantErr:          true,
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Restrict the cluster sync mode for the unjoin and unregister command.
```bash
$ karmadactl get cluster
NAME      CLUSTER   VERSION   MODE   READY   AGE     ADOPTION
member1   Karmada   v1.31.2   Push   True    17h     -
member3   Karmada   v1.31.2   Pull   True    3d23h   -
$ karmadactl unregister member1  --cluster-kubeconfig ~/.kube/members.config --karmada-config ~/.kube/karmada.config --cluster-context member1 -v=4 
I0124 11:10:55.943833 2452252 unregister.go:188] Unregistering cluster. cluster name: member1
I0124 11:10:55.943887 2452252 unregister.go:189] Unregistering cluster. karmada-agent deployed in namespace: karmada-system
I0124 11:10:55.943901 2452252 unregister.go:190] Unregistering cluster. member cluster secrets stored in namespace: karmada-cluster
error: cluster member1 is a Push mode member cluster, please use command `unjoin` if you want to unregister cluster
$ karmadactl unjoin member3 --cluster-kubeconfig=/root/.kube/members.config --cluster-context=member3                                               
error: cluster member3 is a Pull mode member cluster, please use command `unregister` if you want to unregister cluster
```

**Which issue(s) this PR fixes**:
Fixes #801

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: The `unjoin` command is restricted to only unjoin push mode member clusters. The `unregister` command is restricted to only unregister pull mode member clusters.
```

