### PR TITLE
Standardize the naming of karmada config in Karmada Operator

### DIFF
--- a/hack/deploy-karmada-by-operator.sh
+++ b/hack/deploy-karmada-by-operator.sh
@@ -111,7 +111,7 @@ kubectl --kubeconfig="${HOST_CLUSTER_KUBECONFIG}" --context="${CONTEXT_NAME}" ap
 kubectl --kubeconfig="${HOST_CLUSTER_KUBECONFIG}" --context="${CONTEXT_NAME}" wait --for=condition=Ready --timeout=1000s karmada ${KARMADA_INSTANCE_NAME} -n ${KARMADA_INSTANCE_NAMESPACE}
 
 # generate kubeconfig for karmada instance
-kubectl --kubeconfig="${HOST_CLUSTER_KUBECONFIG}" --context="${CONTEXT_NAME}" get secret -n ${KARMADA_INSTANCE_NAMESPACE} ${KARMADA_INSTANCE_NAME}-admin-config -o jsonpath={.data.kubeconfig} | base64 -d > ~/.kube/${KARMADA_INSTANCE_NAME}-${KARMADA_INSTANCE_NAMESPACE}-tmp-apiserver.config
+kubectl --kubeconfig="${HOST_CLUSTER_KUBECONFIG}" --context="${CONTEXT_NAME}" get secret -n ${KARMADA_INSTANCE_NAMESPACE} ${KARMADA_INSTANCE_NAME}-admin-config -o jsonpath='{.data.karmada\.config}' | base64 -d > ~/.kube/${KARMADA_INSTANCE_NAME}-${KARMADA_INSTANCE_NAMESPACE}-tmp-apiserver.config
 cat ~/.kube/${KARMADA_INSTANCE_NAME}-${KARMADA_INSTANCE_NAMESPACE}-tmp-apiserver.config| grep "certificate-authority-data"| awk '{print $2}'| base64 -d  > ${CERT_DIR}/ca.crt
 cat ~/.kube/${KARMADA_INSTANCE_NAME}-${KARMADA_INSTANCE_NAMESPACE}-tmp-apiserver.config| grep "client-certificate-data"| awk '{print $2}'| base64 -d  > ${CERT_DIR}/karmada.crt
 cat ~/.kube/${KARMADA_INSTANCE_NAME}-${KARMADA_INSTANCE_NAMESPACE}-tmp-apiserver.config| grep "client-key-data"| awk '{print $2}'| base64 -d  > ${CERT_DIR}/karmada.key

--- a/operator/pkg/controller/karmada/planner.go
+++ b/operator/pkg/controller/karmada/planner.go
@@ -159,7 +159,7 @@ func (p *Planner) afterRunJob() error {
 				return fmt.Errorf("error when creating cluster client to install karmada, err: %w", err)
 			}
 
-			secret, err := remoteClient.CoreV1().Secrets(p.karmada.GetNamespace()).Get(context.TODO(), util.AdminKubeconfigSecretName(p.karmada.GetName()), metav1.GetOptions{})
+			secret, err := remoteClient.CoreV1().Secrets(p.karmada.GetNamespace()).Get(context.TODO(), util.AdminKarmadaConfigSecretName(p.karmada.GetName()), metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
@@ -167,7 +167,7 @@ func (p *Planner) afterRunJob() error {
 			_, err = localClusterClient.CoreV1().Secrets(p.karmada.GetNamespace()).Create(context.TODO(), &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: p.karmada.GetNamespace(),
-					Name:      util.AdminKubeconfigSecretName(p.karmada.GetName()),
+					Name:      util.AdminKarmadaConfigSecretName(p.karmada.GetName()),
 				},
 				Data: secret.Data,
 			}, metav1.CreateOptions{})
@@ -178,7 +178,7 @@ func (p *Planner) afterRunJob() error {
 
 		p.karmada.Status.SecretRef = &operatorv1alpha1.LocalSecretReference{
 			Namespace: p.karmada.GetNamespace(),
-			Name:      util.AdminKubeconfigSecretName(p.karmada.GetName()),
+			Name:      util.AdminKarmadaConfigSecretName(p.karmada.GetName()),
 		}
 		p.karmada.Status.APIServerService = &operatorv1alpha1.APIServerService{
 			Name: util.KarmadaAPIServerName(p.karmada.GetName()),

--- a/operator/pkg/controller/karmada/planner_test.go
+++ b/operator/pkg/controller/karmada/planner_test.go
@@ -244,7 +244,7 @@ func TestAfterRunJob(t *testing.T) {
 			config: &rest.Config{},
 			action: InitAction,
 			verify: func(karmada *operatorv1alpha1.Karmada, planner *Planner, action Action) error {
-				secretRefNameExpected := util.AdminKubeconfigSecretName(karmada.GetName())
+				secretRefNameExpected := util.AdminKarmadaConfigSecretName(karmada.GetName())
 				if planner.karmada.Status.SecretRef == nil {
 					return fmt.Errorf("expected SecretRef to be set, but got nil")
 				}

--- a/operator/pkg/controlplane/apiserver/apiserver.go
+++ b/operator/pkg/controlplane/apiserver/apiserver.go
@@ -125,7 +125,7 @@ func installKarmadaAggregatedAPIServer(client clientset.Interface, cfg *operator
 		Namespace:          namespace,
 		Image:              cfg.Image.Name(),
 		ImagePullPolicy:    string(cfg.ImagePullPolicy),
-		KubeconfigSecret:   util.AdminKubeconfigSecretName(name),
+		KubeconfigSecret:   util.ComponentKarmadaConfigSecretName(util.KarmadaAggregatedAPIServerName(name)),
 		KarmadaCertsSecret: util.KarmadaCertSecretName(name),
 		Replicas:           cfg.Replicas,
 	})

--- a/operator/pkg/controlplane/apiserver/apiserver_test.go
+++ b/operator/pkg/controlplane/apiserver/apiserver_test.go
@@ -423,7 +423,7 @@ func verifyAggregatedAPIServerDeploymentAdditionalDetails(featureGates map[strin
 	for _, volume := range deployment.Spec.Template.Spec.Volumes {
 		extractedSecrets = append(extractedSecrets, volume.Secret.SecretName)
 	}
-	expectedSecrets := []string{util.AdminKubeconfigSecretName(expectedDeploymentName), util.KarmadaCertSecretName(expectedDeploymentName), util.EtcdCertSecretName(expectedDeploymentName)}
+	expectedSecrets := []string{util.ComponentKarmadaConfigSecretName(util.KarmadaAggregatedAPIServerName(expectedDeploymentName)), util.KarmadaCertSecretName(expectedDeploymentName), util.EtcdCertSecretName(expectedDeploymentName)}
 	for _, expectedSecret := range expectedSecrets {
 		if !contains(extractedSecrets, expectedSecret) {
 			return fmt.Errorf("expected secret '%s' not found in extracted secrets", expectedSecret)

--- a/operator/pkg/controlplane/apiserver/manifests.go
+++ b/operator/pkg/controlplane/apiserver/manifests.go
@@ -162,9 +162,9 @@ spec:
         imagePullPolicy: {{ .ImagePullPolicy }}
         command:
         - /bin/karmada-aggregated-apiserver
-        - --kubeconfig=/etc/karmada/kubeconfig
-        - --authentication-kubeconfig=/etc/karmada/kubeconfig
-        - --authorization-kubeconfig=/etc/karmada/kubeconfig
+        - --kubeconfig=/etc/karmada/config/karmada.config
+        - --authentication-kubeconfig=/etc/karmada/config/karmada.config
+        - --authorization-kubeconfig=/etc/karmada/config/karmada.config
         - --tls-cert-file=/etc/karmada/pki/karmada.crt
         - --tls-private-key-file=/etc/karmada/pki/karmada.key
         - --tls-min-version=VersionTLS13
@@ -172,14 +172,13 @@ spec:
         - --audit-log-maxage=0
         - --audit-log-maxbackup=0
         volumeMounts:
-        - mountPath: /etc/karmada/kubeconfig
-          name: kubeconfig
-          subPath: kubeconfig
+        - name: karmada-config
+          mountPath: /etc/karmada/config
         - mountPath: /etc/karmada/pki
           name: apiserver-cert
           readOnly: true
       volumes:
-      - name: kubeconfig
+      - name: karmada-config
         secret:
           secretName: {{ .KubeconfigSecret }}
       - name: apiserver-cert

--- a/operator/pkg/controlplane/controlplane.go
+++ b/operator/pkg/controlplane/controlplane.go
@@ -93,7 +93,7 @@ func getKubeControllerManagerManifest(name, namespace string, cfg *operatorv1alp
 		Image:              cfg.Image.Name(),
 		ImagePullPolicy:    string(cfg.ImagePullPolicy),
 		KarmadaCertsSecret: util.KarmadaCertSecretName(name),
-		KubeconfigSecret:   util.AdminKubeconfigSecretName(name),
+		KubeconfigSecret:   util.ComponentKarmadaConfigSecretName(util.KubeControllerManagerName(name)),
 		Replicas:           cfg.Replicas,
 	})
 	if err != nil {
@@ -122,7 +122,7 @@ func getKarmadaControllerManagerManifest(name, namespace string, featureGates ma
 		SystemNamespace:  constants.KarmadaSystemNamespace,
 		Image:            cfg.Image.Name(),
 		ImagePullPolicy:  string(cfg.ImagePullPolicy),
-		KubeconfigSecret: util.AdminKubeconfigSecretName(name),
+		KubeconfigSecret: util.ComponentKarmadaConfigSecretName(util.KarmadaControllerManagerName(name)),
 		Replicas:         cfg.Replicas,
 	})
 	if err != nil {
@@ -151,7 +151,7 @@ func getKarmadaSchedulerManifest(name, namespace string, featureGates map[string
 		SystemNamespace:    constants.KarmadaSystemNamespace,
 		Image:              cfg.Image.Name(),
 		ImagePullPolicy:    string(cfg.ImagePullPolicy),
-		KubeconfigSecret:   util.AdminKubeconfigSecretName(name),
+		KubeconfigSecret:   util.ComponentKarmadaConfigSecretName(util.KarmadaSchedulerName(name)),
 		KarmadaCertsSecret: util.KarmadaCertSecretName(name),
 		Replicas:           cfg.Replicas,
 	})
@@ -181,7 +181,7 @@ func getKarmadaDeschedulerManifest(name, namespace string, featureGates map[stri
 		SystemNamespace:    constants.KarmadaSystemNamespace,
 		Image:              cfg.Image.Name(),
 		ImagePullPolicy:    string(cfg.ImagePullPolicy),
-		KubeconfigSecret:   util.AdminKubeconfigSecretName(name),
+		KubeconfigSecret:   util.ComponentKarmadaConfigSecretName(util.KarmadaDeschedulerName(name)),
 		KarmadaCertsSecret: util.KarmadaCertSecretName(name),
 		Replicas:           cfg.Replicas,
 	})

--- a/operator/pkg/controlplane/controlplane_test.go
+++ b/operator/pkg/controlplane/controlplane_test.go
@@ -167,7 +167,7 @@ func TestGetKubeControllerManagerManifest(t *testing.T) {
 	}
 
 	expectedSecrets := []string{
-		util.AdminKubeconfigSecretName(name),
+		util.ComponentKarmadaConfigSecretName(util.KubeControllerManagerName(name)),
 		util.KarmadaCertSecretName(name),
 	}
 	err = verifySecrets(deployment, expectedSecrets)
@@ -226,7 +226,7 @@ func TestGetKarmadaControllerManagerManifest(t *testing.T) {
 		t.Errorf("failed to verify karmada controller manager system namespace: %v", err)
 	}
 
-	expectedSecrets := []string{util.AdminKubeconfigSecretName(name)}
+	expectedSecrets := []string{util.ComponentKarmadaConfigSecretName(util.KarmadaControllerManagerName(name))}
 	err = verifySecrets(deployment, expectedSecrets)
 	if err != nil {
 		t.Errorf("failed to verify karmada controller manager secrets: %v", err)
@@ -285,7 +285,7 @@ func TestGetKarmadaSchedulerManifest(t *testing.T) {
 	}
 
 	expectedSecrets := []string{
-		util.AdminKubeconfigSecretName(name),
+		util.ComponentKarmadaConfigSecretName(util.KarmadaSchedulerName(name)),
 		util.KarmadaCertSecretName(name),
 	}
 	err = verifySecrets(deployment, expectedSecrets)
@@ -346,7 +346,7 @@ func TestGetKarmadaDeschedulerManifest(t *testing.T) {
 	}
 
 	expectedSecrets := []string{
-		util.AdminKubeconfigSecretName(name),
+		util.ComponentKarmadaConfigSecretName(util.KarmadaDeschedulerName(name)),
 		util.KarmadaCertSecretName(name),
 	}
 	err = verifySecrets(deployment, expectedSecrets)

--- a/operator/pkg/controlplane/manifests.go
+++ b/operator/pkg/controlplane/manifests.go
@@ -54,9 +54,9 @@ spec:
         command:
         - kube-controller-manager
         - --allocate-node-cidrs=true
-        - --kubeconfig=/etc/karmada/kubeconfig
-        - --authentication-kubeconfig=/etc/karmada/kubeconfig
-        - --authorization-kubeconfig=/etc/karmada/kubeconfig
+        - --kubeconfig=/etc/karmada/config/karmada.config
+        - --authentication-kubeconfig=/etc/karmada/config/karmada.config
+        - --authorization-kubeconfig=/etc/karmada/config/karmada.config
         - --bind-address=0.0.0.0
         - --client-ca-file=/etc/karmada/pki/ca.crt
         - --cluster-cidr=10.244.0.0/16
@@ -85,14 +85,13 @@ spec:
         - name: karmada-certs
           mountPath: /etc/karmada/pki
           readOnly: true
-        - name: kubeconfig
-          mountPath: /etc/karmada/kubeconfig
-          subPath: kubeconfig
+        - name: karmada-config
+          mountPath: /etc/karmada/config
       volumes:
         - name: karmada-certs
           secret:
             secretName: {{ .KarmadaCertsSecret }}
-        - name: kubeconfig
+        - name: karmada-config
           secret:
             secretName: {{ .KubeconfigSecret }}
 `
@@ -126,7 +125,7 @@ spec:
         imagePullPolicy: {{ .ImagePullPolicy }}
         command:
         - /bin/karmada-controller-manager
-        - --kubeconfig=/etc/karmada/kubeconfig
+        - --kubeconfig=/etc/karmada/config/karmada.config
         - --metrics-bind-address=:8080
         - --cluster-status-update-frequency=10s
         - --failover-eviction-timeout=30s
@@ -147,11 +146,10 @@ spec:
           name: metrics
           protocol: TCP
         volumeMounts:
-        - name: kubeconfig
-          subPath: kubeconfig
-          mountPath: /etc/karmada/kubeconfig
+        - name: karmada-config
+          mountPath: /etc/karmada/config
       volumes:
-      - name: kubeconfig
+      - name: karmada-config
         secret:
           secretName: {{ .KubeconfigSecret }}
 `
@@ -186,7 +184,7 @@ spec:
         imagePullPolicy: {{ .ImagePullPolicy }}
         command:
         - /bin/karmada-scheduler
-        - --kubeconfig=/etc/karmada/kubeconfig
+        - --kubeconfig=/etc/karmada/config/karmada.config
         - --metrics-bind-address=0.0.0.0:8080
         - --health-probe-bind-address=0.0.0.0:10351
         - --enable-scheduler-estimator=true
@@ -212,14 +210,13 @@ spec:
         - name: karmada-certs
           mountPath: /etc/karmada/pki
           readOnly: true
-        - name: kubeconfig
-          subPath: kubeconfig
-          mountPath: /etc/karmada/kubeconfig
+        - name: karmada-config
+          mountPath: /etc/karmada/config
       volumes:
         - name: karmada-certs
           secret:
             secretName: {{ .KarmadaCertsSecret }}
-        - name: kubeconfig
+        - name: karmada-config
           secret:
             secretName: {{ .KubeconfigSecret }}
 `
@@ -254,7 +251,7 @@ spec:
         imagePullPolicy: {{ .ImagePullPolicy }}
         command:
         - /bin/karmada-descheduler
-        - --kubeconfig=/etc/karmada/kubeconfig
+        - --kubeconfig=/etc/karmada/config/karmada.config
         - --metrics-bind-address=0.0.0.0:8080
         - --health-probe-bind-address=0.0.0.0:10358
         - --leader-elect-resource-namespace={{ .SystemNamespace }}
@@ -279,14 +276,13 @@ spec:
         - name: karmada-certs
           mountPath: /etc/karmada/pki
           readOnly: true
-        - name: kubeconfig
-          subPath: kubeconfig
-          mountPath: /etc/karmada/kubeconfig
+        - name: karmada-config
+          mountPath: /etc/karmada/config
       volumes:
         - name: karmada-certs
           secret:
             secretName: {{ .KarmadaCertsSecret }}
-        - name: kubeconfig
+        - name: karmada-config
           secret:
             secretName: {{ .KubeconfigSecret }}
 `

--- a/operator/pkg/controlplane/metricsadapter/manifests.go
+++ b/operator/pkg/controlplane/metricsadapter/manifests.go
@@ -47,10 +47,10 @@ spec:
         imagePullPolicy: {{ .ImagePullPolicy }}
         command:
         - /bin/karmada-metrics-adapter
-        - --kubeconfig=/etc/karmada/kubeconfig
+        - --kubeconfig=/etc/karmada/config/karmada.config
         - --metrics-bind-address=:8080
-        - --authentication-kubeconfig=/etc/karmada/kubeconfig
-        - --authorization-kubeconfig=/etc/karmada/kubeconfig
+        - --authentication-kubeconfig=/etc/karmada/config/karmada.config
+        - --authorization-kubeconfig=/etc/karmada/config/karmada.config
         - --client-ca-file=/etc/karmada/pki/ca.crt
         - --tls-cert-file=/etc/karmada/pki/karmada.crt
         - --tls-private-key-file=/etc/karmada/pki/karmada.key
@@ -59,9 +59,8 @@ spec:
         - --audit-log-maxage=0
         - --audit-log-maxbackup=0
         volumeMounts:
-        - name: kubeconfig
-          subPath: kubeconfig
-          mountPath: /etc/karmada/kubeconfig
+        - name: karmada-config
+          mountPath: /etc/karmada/config
         - name: karmada-cert
           mountPath: /etc/karmada/pki
           readOnly: true
@@ -87,7 +86,7 @@ spec:
           requests:
             cpu: 100m
       volumes:
-      - name: kubeconfig
+      - name: karmada-config
         secret:
           secretName: {{ .KubeconfigSecret }}
       - name: karmada-cert

--- a/operator/pkg/controlplane/metricsadapter/metricsadapter.go
+++ b/operator/pkg/controlplane/metricsadapter/metricsadapter.go
@@ -51,7 +51,7 @@ func installKarmadaMetricAdapter(client clientset.Interface, cfg *operatorv1alph
 		Image:              cfg.Image.Name(),
 		ImagePullPolicy:    string(cfg.ImagePullPolicy),
 		Replicas:           cfg.Replicas,
-		KubeconfigSecret:   util.AdminKubeconfigSecretName(name),
+		KubeconfigSecret:   util.ComponentKarmadaConfigSecretName(util.KarmadaMetricsAdapterName(name)),
 		KarmadaCertsSecret: util.KarmadaCertSecretName(name),
 	})
 	if err != nil {

--- a/operator/pkg/controlplane/metricsadapter/metricsadapter_test.go
+++ b/operator/pkg/controlplane/metricsadapter/metricsadapter_test.go
@@ -221,7 +221,7 @@ func verifyDeploymentDetails(deployment *appsv1.Deployment, replicas int32, imag
 		extractedSecrets = append(extractedSecrets, volume.Secret.SecretName)
 	}
 	expectedSecrets := []string{
-		util.AdminKubeconfigSecretName(name),
+		util.ComponentKarmadaConfigSecretName(util.KarmadaMetricsAdapterName(name)),
 		util.KarmadaCertSecretName(name),
 	}
 	for _, expectedSecret := range expectedSecrets {

--- a/operator/pkg/controlplane/search/manifests.go
+++ b/operator/pkg/controlplane/search/manifests.go
@@ -49,14 +49,13 @@ spec:
             - name: k8s-certs
               mountPath: /etc/karmada/pki
               readOnly: true
-            - name: kubeconfig
-              subPath: kubeconfig
-              mountPath: /etc/kubeconfig
+            - name: karmada-config
+              mountPath: /etc/karmada/config
           command:
             - /bin/karmada-search
-            - --kubeconfig=/etc/kubeconfig
-            - --authentication-kubeconfig=/etc/kubeconfig
-            - --authorization-kubeconfig=/etc/kubeconfig
+            - --kubeconfig=/etc/karmada/config/karmada.config
+            - --authentication-kubeconfig=/etc/karmada/config/karmada.config
+            - --authorization-kubeconfig=/etc/karmada/config/karmada.config
             - --tls-cert-file=/etc/karmada/pki/karmada.crt
             - --tls-private-key-file=/etc/karmada/pki/karmada.key
             - --tls-min-version=VersionTLS13
@@ -79,7 +78,7 @@ spec:
         - name: k8s-certs
           secret:
             secretName: {{ .KarmadaCertsSecret }}
-        - name: kubeconfig
+        - name: karmada-config
           secret:
             secretName: {{ .KubeconfigSecret }}
 `

--- a/operator/pkg/controlplane/search/search.go
+++ b/operator/pkg/controlplane/search/search.go
@@ -53,7 +53,7 @@ func installKarmadaSearch(client clientset.Interface, cfg *operatorv1alpha1.Karm
 		ImagePullPolicy:    string(cfg.ImagePullPolicy),
 		KarmadaCertsSecret: util.KarmadaCertSecretName(name),
 		Replicas:           cfg.Replicas,
-		KubeconfigSecret:   util.AdminKubeconfigSecretName(name),
+		KubeconfigSecret:   util.ComponentKarmadaConfigSecretName(util.KarmadaSearchName(name)),
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing KarmadaSearch Deployment template: %w", err)

--- a/operator/pkg/controlplane/search/search_test.go
+++ b/operator/pkg/controlplane/search/search_test.go
@@ -242,7 +242,7 @@ func verifySecrets(deployment *appsv1.Deployment, name string) error {
 		extractedSecrets = append(extractedSecrets, volume.Secret.SecretName)
 	}
 	expectedSecrets := []string{
-		util.AdminKubeconfigSecretName(name),
+		util.ComponentKarmadaConfigSecretName(util.KarmadaSearchName(name)),
 		util.KarmadaCertSecretName(name),
 	}
 	for _, expectedSecret := range expectedSecrets {

--- a/operator/pkg/controlplane/webhook/manifests.go
+++ b/operator/pkg/controlplane/webhook/manifests.go
@@ -47,7 +47,7 @@ spec:
         imagePullPolicy: {{ .ImagePullPolicy }}
         command:
         - /bin/karmada-webhook
-        - --kubeconfig=/etc/karmada/kubeconfig
+        - --kubeconfig=/etc/karmada/config/karmada.config
         - --bind-address=0.0.0.0
         - --metrics-bind-address=:8080
         - --default-not-ready-toleration-seconds=30
@@ -61,9 +61,8 @@ spec:
           name: metrics
           protocol: TCP
         volumeMounts:
-        - name: kubeconfig
-          subPath: kubeconfig
-          mountPath: /etc/karmada/kubeconfig
+        - name: karmada-config
+          mountPath: /etc/karmada/config
         - name: cert
           mountPath: /var/serving-cert
           readOnly: true
@@ -73,7 +72,7 @@ spec:
             port: 8443
             scheme: HTTPS
       volumes:
-      - name: kubeconfig
+      - name: karmada-config
         secret:
           secretName: {{ .KubeconfigSecret }}
       - name: cert

--- a/operator/pkg/controlplane/webhook/webhook.go
+++ b/operator/pkg/controlplane/webhook/webhook.go
@@ -51,7 +51,7 @@ func installKarmadaWebhook(client clientset.Interface, cfg *operatorv1alpha1.Kar
 		Image:              cfg.Image.Name(),
 		ImagePullPolicy:    string(cfg.ImagePullPolicy),
 		Replicas:           cfg.Replicas,
-		KubeconfigSecret:   util.AdminKubeconfigSecretName(name),
+		KubeconfigSecret:   util.ComponentKarmadaConfigSecretName(util.KarmadaWebhookName(name)),
 		WebhookCertsSecret: util.WebhookCertSecretName(name),
 	})
 	if err != nil {

--- a/operator/pkg/controlplane/webhook/webhook_test.go
+++ b/operator/pkg/controlplane/webhook/webhook_test.go
@@ -232,7 +232,7 @@ func verifySecrets(deployment *appsv1.Deployment, name string) error {
 		extractedSecrets = append(extractedSecrets, volume.Secret.SecretName)
 	}
 	expectedSecrets := []string{
-		util.AdminKubeconfigSecretName(name),
+		util.ComponentKarmadaConfigSecretName(util.KarmadaWebhookName(name)),
 		util.WebhookCertSecretName(name),
 	}
 	for _, expectedSecret := range expectedSecrets {

--- a/operator/pkg/tasks/deinit/kubeconfig_test.go
+++ b/operator/pkg/tasks/deinit/kubeconfig_test.go
@@ -73,7 +73,7 @@ func TestRunCleanupKubeconfig(t *testing.T) {
 			prep:    func(workflow.RunData, *corev1.Secret) error { return nil },
 			verify:  func(workflow.RunData, *corev1.Secret) error { return nil },
 			wantErr: true,
-			errMsg:  "cleanup-kubeconfig task invoked with an invalid data struct",
+			errMsg:  "cleanup-karmada-config task invoked with an invalid data struct",
 		},
 		{
 			name: "RunCleanupKubeconfig_DeleteSecretWithKarmadaOperatorLabel_SecretDeleted",
@@ -82,7 +82,7 @@ func TestRunCleanupKubeconfig(t *testing.T) {
 				namespace:    namespace,
 				remoteClient: fakeclientset.NewSimpleClientset(),
 			},
-			secret: helper.NewSecret(namespace, util.AdminKubeconfigSecretName(name), map[string][]byte{}),
+			secret: helper.NewSecret(namespace, util.AdminKarmadaConfigSecretName(name), map[string][]byte{}),
 			prep: func(rd workflow.RunData, s *corev1.Secret) error {
 				data := rd.(*TestDeInitData)
 				s.Labels = constants.KarmadaOperatorLabel

--- a/operator/pkg/util/naming.go
+++ b/operator/pkg/util/naming.go
@@ -24,9 +24,14 @@ import (
 // Namefunc defines a function to generate resource name according to karmada resource name.
 type Namefunc func(karmada string) string
 
-// AdminKubeconfigSecretName returns secret name of karmada-admin kubeconfig
-func AdminKubeconfigSecretName(karmada string) string {
+// AdminKarmadaConfigSecretName returns secret name of karmada-admin karmada-config
+func AdminKarmadaConfigSecretName(karmada string) string {
 	return generateResourceName(karmada, "admin-config")
+}
+
+// ComponentKarmadaConfigSecretName returns secret name of karmada component karmada-config
+func ComponentKarmadaConfigSecretName(karmadaComponent string) string {
+	return fmt.Sprintf("%s-config", karmadaComponent)
 }
 
 // KarmadaCertSecretName returns secret name of karmada certs


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
In karmada, here are two important secrets, which is mount by most karmada components. One is karmada-cert, which contains a series of cert files like ca.crt, apiserver.crt and so on; another is karmada-kubeconfig, which contains a kubeconfig of karmada-apiserver.

However, in different installation methods, we used inconsistent secret naming or file path naming, which can potentially cause some unnecessary problems, detail refer to https://github.com/karmada-io/karmada/issues/5363.

This PR aims to standardize the naming of karmada config in Karmada Operator installation method.

**Which issue(s) this PR fixes**:
Part of #6051 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-operator`: standardize the naming of karmada config in karmada-operator installation method
```

