### PR TITLE
Read MIN_GO_VERSION directly with Go CLI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/karmada-io/karmada
 
-go 1.22.11 // keep in sync with .go-version and hack/util.sh
+go 1.22.11 // keep in sync with .go-version
 
 require (
 	github.com/adhocore/gronx v1.6.3

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -37,7 +37,7 @@ KARMADA_METRICS_ADAPTER_LABEL="karmada-metrics-adapter"
 
 KARMADA_GO_PACKAGE="github.com/karmada-io/karmada"
 
-MIN_Go_VERSION=go1.22.11
+MIN_GO_VERSION="go$(go list -m -f {{.GoVersion}})"
 
 DEFAULT_CLUSTER_VERSION="kindest/node:v1.31.2"
 
@@ -122,10 +122,10 @@ function util::verify_docker {
 function util::verify_go_version {
     local go_version
     IFS=" " read -ra go_version <<< "$(GOFLAGS='' go version)"
-    if [[ "${MIN_Go_VERSION}" != $(echo -e "${MIN_Go_VERSION}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
+    if [[ "${MIN_GO_VERSION}" != $(echo -e "${MIN_GO_VERSION}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
       echo "Detected go version: ${go_version[*]}."
-      echo "Karmada requires ${MIN_Go_VERSION} or greater."
-      echo "Please install ${MIN_Go_VERSION} or later."
+      echo "Karmada requires ${MIN_GO_VERSION} or greater."
+      echo "Please install ${MIN_GO_VERSION} or later."
       exit 1
     fi
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

In `hack/util.sh`, we can directly read `MIN_GO_VERSION` from `go.mod` via Go CLI. No need to remember to modify it manually when updating Go version.

Discussed here: https://github.com/karmada-io/karmada/pull/6066#discussion_r1921418431

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

