### PR TITLE
[helm] add the ability to specify hostIP of karmada apiserver

### DIFF
--- a/charts/karmada/templates/_karmada_bootstrap_token_configuration.tpl
+++ b/charts/karmada/templates/_karmada_bootstrap_token_configuration.tpl
@@ -17,7 +17,13 @@ data:
     clusters:
     - cluster:
         {{- include "karmada.kubeconfig.caData" . | nindent 8 }}
+        {{- if and (.Values.apiServer.hostIP) (eq .Values.apiServer.serviceType "NodePort") (.Values.apiServer.nodePort) }}
+        server: https://{{ .Values.apiServer.hostIP }}:{{ .Values.apiServer.nodePort }}
+        {{- else if .Values.apiServer.hostIP }}
+        server: https://{{ .Values.apiServer.hostIP }}:5443
+        {{- else }}
         server: https://{{ $name }}-apiserver.{{ $namespace }}.svc.{{ .Values.clusterDomain }}:5443
+        {{- end }}
     kind: Config
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/karmada/templates/pre-install-job.yaml
+++ b/charts/karmada/templates/pre-install-job.yaml
@@ -292,7 +292,13 @@ data:
         clusters:
           - cluster:
               certificate-authority-data: {{ print "{{ ca_crt }}" }}
+              {{- if and (.Values.apiServer.hostIP) (eq .Values.apiServer.serviceType "NodePort") (.Values.apiServer.nodePort) }}
+              server: https://{{ .Values.apiServer.hostIP }}:{{ .Values.apiServer.nodePort }}
+              {{- else if .Values.apiServer.hostIP }}
+              server: https://{{ .Values.apiServer.hostIP }}:5443
+              {{- else }}
               server: https://{{ $name }}-apiserver.{{ $namespace }}.svc.{{ .Values.clusterDomain }}:5443
+              {{- end }}
             name: {{ $name }}-apiserver
         users:
           - user:
@@ -391,9 +397,13 @@ spec:
           openssl req -x509 -sha256 -new -nodes -days 365 -newkey rsa:{{ .Values.certs.auto.rsaSize }} -keyout "/opt/certs/server-ca.key" -out "/opt/certs/server-ca.crt" -subj "/C=xx/ST=x/L=x/O=x/OU=x/CN=ca/emailAddress=x/"
           openssl req -x509 -sha256 -new -nodes -days 365 -newkey rsa:{{ .Values.certs.auto.rsaSize }} -keyout "/opt/certs/front-proxy-ca.key" -out "/opt/certs/front-proxy-ca.crt" -subj "/C=xx/ST=x/L=x/O=x/OU=x/CN=ca/emailAddress=x/"
           echo '{"signing":{"default":{"expiry":{{ printf `"%s"` .Values.certs.auto.expiry }},"usages":["signing","key encipherment","client auth","server auth"]}}}' > "/opt/certs/server-ca-config.json"
-          echo '{"CN":"system:admin","hosts":{{ tpl (toJson .Values.certs.auto.hosts) . }},"names":[{"O":"system:masters"}],"key":{"algo":"rsa","size":{{ .Values.certs.auto.rsaSize }}}}' | cfssl gencert -ca=/opt/certs/server-ca.crt -ca-key=/opt/certs/server-ca.key -config=/opt/certs/server-ca-config.json - | cfssljson -bare /opt/certs/karmada
+          {{- $hosts := .Values.certs.auto.hosts }}
+          {{- if .Values.apiServer.hostIP }}
+          {{- $hosts = append $hosts .Values.apiServer.hostIP }}
+          {{- end }}
+          echo '{"CN":"system:admin","hosts":{{ tpl (toJson $hosts) . }},"names":[{"O":"system:masters"}],"key":{"algo":"rsa","size":{{ .Values.certs.auto.rsaSize }}}}' | cfssl gencert -ca=/opt/certs/server-ca.crt -ca-key=/opt/certs/server-ca.key -config=/opt/certs/server-ca-config.json - | cfssljson -bare /opt/certs/karmada
           echo '{"signing":{"default":{"expiry":{{ printf `"%s"` .Values.certs.auto.expiry }},"usages":["signing","key encipherment","client auth","server auth"]}}}' > "/opt/certs/front-proxy-ca-config.json"
-          echo '{"CN":"front-proxy-client","hosts":{{ tpl (toJson .Values.certs.auto.hosts) . }},"names":[{"O":"system:masters"}],"key":{"algo":"rsa","size":{{ .Values.certs.auto.rsaSize }}}}' | cfssl gencert -ca=/opt/certs/front-proxy-ca.crt -ca-key=/opt/certs/front-proxy-ca.key -config=/opt/certs/front-proxy-ca-config.json - | cfssljson -bare /opt/certs/front-proxy-client
+          echo '{"CN":"front-proxy-client","hosts":{{ tpl (toJson $hosts) . }},"names":[{"O":"system:masters"}],"key":{"algo":"rsa","size":{{ .Values.certs.auto.rsaSize }}}}' | cfssl gencert -ca=/opt/certs/front-proxy-ca.crt -ca-key=/opt/certs/front-proxy-ca.key -config=/opt/certs/front-proxy-ca-config.json - | cfssljson -bare /opt/certs/front-proxy-client
           karmada_ca=$(base64 /opt/certs/server-ca.crt | tr -d '\r\n')
           karmada_ca_key=$(base64 /opt/certs/server-ca.key | tr -d '\r\n')
           karmada_crt=$(base64 /opt/certs/karmada.pem | tr -d '\r\n')

--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -424,6 +424,9 @@ apiServer:
   ## will take effect when 'apiServer.serviceType' is 'NodePort'.
   ## If no port is specified, the nodePort will be automatically assigned.
   nodePort: 0
+  ## @param apiServer.hostIP, the IP address of the node where the karmada apiserver is running,
+  ## used for external components or clients to connect.
+  hostIP: ""
   serviceClusterIPRange: "10.96.0.0/12"
   maxRequestsInflight: 1500
   maxMutatingRequestsInflight: 500


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When installing Karmada using Helm, if we want to access the karmada-apiserver  externally, the following issues will arise:
 - The format of the `clusters server` in the generated `kubeconfig` is: `https://{{ $name }}-apiserver.{{ $namespace }}.svc.{{.Values.clusterDomain }}:5443`, which cannot be directly accessed externally.
 - The format of the `server` provided by the generated `cluster-info` ConfigMap is `https://{{ $name }}-apiserver.{{ $namespace }}.svc.{{.Values.clusterDomain }}:5443`, which cannot be directly accessed externally.
 - If we manually replace the above `server IP` with the host IP of the karmada-apiserver, when accessing the karmada-apiserver, the certificate verification will fail because the host IP is not in the Subject Alternative Name list of the certificate.

In summary, these issues will be addressed by adding the ability to specify the host IP of the karmada-apiserver. 

**Which issue(s) this PR fixes**:
Fixes #3594

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`helm`: add the ability to specify hostIP of karmada-apiserver
```

