### PR TITLE
Automated cherry pick of #6065: fix: resourceregistry merge the same cluster gvk's namespace

### DIFF
--- a/pkg/search/proxy/controller.go
+++ b/pkg/search/proxy/controller.go
@@ -218,27 +218,34 @@ func (ctl *Controller) reconcile(util.QueueKey) error {
 				klog.Warningf("cluster %s is notReady", cluster.Name)
 				continue
 			}
-
-			if _, exist := resourcesByClusters[cluster.Name]; !exist {
-				resourcesByClusters[cluster.Name] = make(map[schema.GroupVersionResource]*store.MultiNamespace)
-			}
-
-			for resource, multiNS := range matchedResources {
-				gvk, err := ctl.restMapper.KindFor(resource)
-				if err != nil {
-					klog.Errorf("Failed to get gvk: %v", err)
-					continue
-				}
-				if !helper.IsAPIEnabled(cluster.Status.APIEnablements, gvk.GroupVersion().String(), gvk.Kind) {
-					klog.Warningf("Resource %s is not enabled for cluster %s", resource.String(), cluster)
-					continue
-				}
-				resourcesByClusters[cluster.Name][resource] = multiNS
-			}
+			ctl.mergeResourcesByClusters(resourcesByClusters, cluster, matchedResources)
 		}
 	}
 
 	return ctl.store.UpdateCache(resourcesByClusters, registeredResources)
+}
+
+func (ctl *Controller) mergeResourcesByClusters(resourcesByClusters map[string]map[schema.GroupVersionResource]*store.MultiNamespace, cluster *clusterv1alpha1.Cluster, matchedResources map[schema.GroupVersionResource]*store.MultiNamespace) {
+	if _, exist := resourcesByClusters[cluster.Name]; !exist {
+		resourcesByClusters[cluster.Name] = make(map[schema.GroupVersionResource]*store.MultiNamespace)
+	}
+
+	for resource, multiNS := range matchedResources {
+		gvk, err := ctl.restMapper.KindFor(resource)
+		if err != nil {
+			klog.Errorf("Failed to get gvk: %v", err)
+			continue
+		}
+		if !helper.IsAPIEnabled(cluster.Status.APIEnablements, gvk.GroupVersion().String(), gvk.Kind) {
+			klog.Warningf("Resource %s is not enabled for cluster %s", resource.String(), cluster)
+			continue
+		}
+		if ns, exist := resourcesByClusters[cluster.Name][resource]; !exist {
+			resourcesByClusters[cluster.Name][resource] = multiNS
+		} else {
+			resourcesByClusters[cluster.Name][resource] = ns.Merge(multiNS)
+		}
+	}
 }
 
 type errorHTTPHandler struct {

--- a/pkg/search/proxy/store/util.go
+++ b/pkg/search/proxy/store/util.go
@@ -284,6 +284,20 @@ type MultiNamespace struct {
 	namespaces    sets.Set[string]
 }
 
+// Merge merges multiNS into n.
+func (n *MultiNamespace) Merge(multiNS *MultiNamespace) *MultiNamespace {
+	if n.allNamespaces || multiNS.allNamespaces {
+		n.allNamespaces = true
+		n.namespaces = nil
+		return n
+	}
+	if n.Equal(multiNS) {
+		return n
+	}
+	n.namespaces.Insert(multiNS.namespaces.Clone().UnsortedList()...)
+	return n
+}
+
 // NewMultiNamespace return a new empty MultiNamespace.
 func NewMultiNamespace() *MultiNamespace {
 	return &MultiNamespace{

--- a/pkg/search/proxy/store/util_test.go
+++ b/pkg/search/proxy/store/util_test.go
@@ -1082,3 +1082,93 @@ func TestMultiNamespace_Equal(t *testing.T) {
 		})
 	}
 }
+
+func TestMultiNamespace_Merge(t *testing.T) {
+	type fields struct {
+		allNamespaces bool
+		namespaces    sets.Set[string]
+	}
+	type args struct {
+		multiNS *MultiNamespace
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *MultiNamespace
+	}{
+		{
+			name: "all ns merge all ns",
+			fields: fields{
+				allNamespaces: true,
+			},
+			args: args{
+				multiNS: &MultiNamespace{
+					allNamespaces: true,
+				},
+			},
+			want: &MultiNamespace{
+				allNamespaces: true,
+			},
+		},
+		{
+			name: "all ns merge not all",
+			fields: fields{
+				allNamespaces: true,
+			},
+			args: args{
+				multiNS: &MultiNamespace{
+					allNamespaces: false,
+					namespaces:    sets.New[string]("foo"),
+				},
+			},
+			want: &MultiNamespace{
+				allNamespaces: true,
+			},
+		},
+		{
+			name: "not all ns merge all",
+			fields: fields{
+				allNamespaces: false,
+				namespaces:    sets.New[string]("foo"),
+			},
+			args: args{
+				multiNS: &MultiNamespace{
+					allNamespaces: true,
+				},
+			},
+			want: &MultiNamespace{
+				allNamespaces: true,
+			},
+		},
+		{
+			name: "not all ns merge not all ns",
+			fields: fields{
+				allNamespaces: false,
+				namespaces:    sets.New[string]("foo", "zoo"),
+			},
+			args: args{
+				multiNS: &MultiNamespace{
+					allNamespaces: false,
+					namespaces:    sets.New[string]("bar"),
+				},
+			},
+			want: &MultiNamespace{
+				allNamespaces: false,
+				namespaces:    sets.New[string]("foo", "bar", "zoo"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := &MultiNamespace{
+				allNamespaces: tt.fields.allNamespaces,
+				namespaces:    tt.fields.namespaces,
+			}
+			got := n.Merge(tt.args.multiNS)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MultiNamespace.Merge() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/search/proxy/testing/constant.go
+++ b/pkg/search/proxy/testing/constant.go
@@ -35,7 +35,12 @@ var (
 	SecretGVR  = corev1.SchemeGroupVersion.WithResource("secret")
 	ClusterGVR = clusterv1alpha1.SchemeGroupVersion.WithResource("cluster")
 
-	PodSelector  = searchv1alpha1.ResourceSelector{APIVersion: PodGVK.GroupVersion().String(), Kind: PodGVK.Kind}
+	PodSelector = searchv1alpha1.ResourceSelector{APIVersion: PodGVK.GroupVersion().String(), Kind: PodGVK.Kind}
+
+	PodSelectorWithNS1 = searchv1alpha1.ResourceSelector{APIVersion: PodGVK.GroupVersion().String(), Kind: PodGVK.Kind, Namespace: "ns1"}
+
+	PodSelectorWithNS2 = searchv1alpha1.ResourceSelector{APIVersion: PodGVK.GroupVersion().String(), Kind: PodGVK.Kind, Namespace: "ns2"}
+
 	NodeSelector = searchv1alpha1.ResourceSelector{APIVersion: NodeGVK.GroupVersion().String(), Kind: NodeGVK.Kind}
 
 	RestMapper *meta.DefaultRESTMapper


### PR DESCRIPTION
Cherry pick of #6065 on release-1.11.
#6065: fix: resourceregistry merge the same cluster gvk's namespace
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-search`: Fixed the issue that namespaces in different ResourceRegistry might be overwritten.
```