### PR TITLE
Add Support for Component Priority Class Configuration in karmadactl init

### DIFF
--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -150,6 +150,7 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 	flags.StringVar(&opts.ExternalEtcdClientKeyPath, "external-etcd-client-key-path", "", "The path of client side private key to the external etcd cluster in pem format.")
 	flags.StringVar(&opts.ExternalEtcdServers, "external-etcd-servers", "", "The server urls of external etcd cluster, to be used by kube-apiserver through --etcd-servers.")
 	flags.StringVar(&opts.ExternalEtcdKeyPrefix, "external-etcd-key-prefix", "", "The key prefix to be configured to kube-apiserver through --etcd-prefix.")
+	flags.StringVar(&opts.EtcdPriorityClass, "etcd-priority-class", "system-node-critical", "The priority class name for the component etcd.")
 	// karmada
 	flags.StringVar(&opts.CRDs, "crds", kubernetes.DefaultCrdURL, "Karmada crds resource.(local file e.g. --crds /root/crds.tar.gz)")
 	flags.StringVar(&opts.KarmadaInitFilePath, "config", "", "Karmada init file path")
@@ -157,19 +158,31 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 	flags.Int32VarP(&opts.KarmadaAPIServerNodePort, "port", "p", 32443, "Karmada apiserver service node port")
 	flags.StringVarP(&opts.KarmadaDataPath, "karmada-data", "d", "/etc/karmada", "Karmada data path. kubeconfig cert and crds files")
 	flags.StringVarP(&opts.KarmadaPkiPath, "karmada-pki", "", "/etc/karmada/pki", "Karmada pki path. Karmada cert files")
+	flags.IntVarP(&opts.WaitComponentReadyTimeout, "wait-component-ready-timeout", "", cmdinitoptions.WaitComponentReadyTimeout, "Wait for karmada component ready timeout. 0 means wait forever")
+	// karmada-apiserver
 	flags.StringVarP(&opts.KarmadaAPIServerImage, "karmada-apiserver-image", "", "", "Kubernetes apiserver image")
 	flags.Int32VarP(&opts.KarmadaAPIServerReplicas, "karmada-apiserver-replicas", "", 1, "Karmada apiserver replica set")
+	flags.StringVar(&opts.KarmadaAPIServerPriorityClass, "karmada-apiserver-priority-class", "system-node-critical", "The priority class name for the component karmada-apiserver.")
+	// karmada-scheduler
 	flags.StringVarP(&opts.KarmadaSchedulerImage, "karmada-scheduler-image", "", kubernetes.DefaultKarmadaSchedulerImage, "Karmada scheduler image")
 	flags.Int32VarP(&opts.KarmadaSchedulerReplicas, "karmada-scheduler-replicas", "", 1, "Karmada scheduler replica set")
+	flags.StringVar(&opts.KarmadaSchedulerPriorityClass, "karmada-scheduler-priority-class", "system-node-critical", "The priority class name for the component karmada-scheduler.")
+	// karmada-kube-controller-manager
 	flags.StringVarP(&opts.KubeControllerManagerImage, "karmada-kube-controller-manager-image", "", "", "Kubernetes controller manager image")
 	flags.Int32VarP(&opts.KubeControllerManagerReplicas, "karmada-kube-controller-manager-replicas", "", 1, "Karmada kube controller manager replica set")
+	flags.StringVar(&opts.KubeControllerManagerPriorityClass, "karmada-kube-controller-manager-priority-class", "system-node-critical", "The priority class name for the component karmada-kube-controller-manager.")
+	// karamda-controller-manager
 	flags.StringVarP(&opts.KarmadaControllerManagerImage, "karmada-controller-manager-image", "", kubernetes.DefaultKarmadaControllerManagerImage, "Karmada controller manager image")
 	flags.Int32VarP(&opts.KarmadaControllerManagerReplicas, "karmada-controller-manager-replicas", "", 1, "Karmada controller manager replica set")
+	flags.StringVar(&opts.KarmadaControllerManagerPriorityClass, "karmada-controller-manager-priority-class", "system-node-critical", "The priority class name for the component karmada-controller-manager.")
+	// karmada-webhook
 	flags.StringVarP(&opts.KarmadaWebhookImage, "karmada-webhook-image", "", kubernetes.DefaultKarmadaWebhookImage, "Karmada webhook image")
 	flags.Int32VarP(&opts.KarmadaWebhookReplicas, "karmada-webhook-replicas", "", 1, "Karmada webhook replica set")
+	flags.StringVar(&opts.KarmadaWebhookPriorityClass, "karmada-webhook-priority-class", "system-node-critical", "The priority class name for the component karmada-webhook.")
+	// karmada-aggregated-apiserver
 	flags.StringVarP(&opts.KarmadaAggregatedAPIServerImage, "karmada-aggregated-apiserver-image", "", kubernetes.DefaultKarmadaAggregatedAPIServerImage, "Karmada aggregated apiserver image")
 	flags.Int32VarP(&opts.KarmadaAggregatedAPIServerReplicas, "karmada-aggregated-apiserver-replicas", "", 1, "Karmada aggregated apiserver replica set")
-	flags.IntVarP(&opts.WaitComponentReadyTimeout, "wait-component-ready-timeout", "", cmdinitoptions.WaitComponentReadyTimeout, "Wait for karmada component ready timeout. 0 means wait forever")
+	flags.StringVar(&opts.KarmadaAggregatedAPIServerPriorityClass, "karmada-aggregated-apiserver-priority-class", "system-node-critical", "The priority class name for the component karmada-aggregated-apiserver.")
 
 	return cmd
 }

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -138,58 +138,82 @@ func init() {
 
 // CommandInitOption holds all flags options for init.
 type CommandInitOption struct {
-	ImageRegistry                      string
-	ImagePullPolicy                    string
-	KubeImageRegistry                  string
-	KubeImageMirrorCountry             string
-	KubeImageTag                       string
-	EtcdImage                          string
-	EtcdReplicas                       int32
-	EtcdInitImage                      string
-	EtcdStorageMode                    string
-	EtcdHostDataPath                   string
-	EtcdNodeSelectorLabels             string
-	EtcdNodeSelectorLabelsMap          map[string]string
-	EtcdPersistentVolumeSize           string
-	ExternalEtcdCACertPath             string
-	ExternalEtcdClientCertPath         string
-	ExternalEtcdClientKeyPath          string
-	ExternalEtcdServers                string
-	ExternalEtcdKeyPrefix              string
-	KarmadaAPIServerImage              string
-	KarmadaAPIServerReplicas           int32
-	KarmadaAPIServerAdvertiseAddress   string
-	KarmadaAPIServerNodePort           int32
-	KarmadaSchedulerImage              string
-	KarmadaSchedulerReplicas           int32
+	ImageRegistry          string
+	ImagePullPolicy        string
+	KubeImageRegistry      string
+	KubeImageMirrorCountry string
+	KubeImageTag           string
+
+	// internal etcd
+	EtcdImage                 string
+	EtcdReplicas              int32
+	EtcdInitImage             string
+	EtcdStorageMode           string
+	EtcdHostDataPath          string
+	EtcdNodeSelectorLabels    string
+	EtcdNodeSelectorLabelsMap map[string]string
+	EtcdPersistentVolumeSize  string
+	EtcdPriorityClass         string
+
+	// external etcd
+	ExternalEtcdCACertPath     string
+	ExternalEtcdClientCertPath string
+	ExternalEtcdClientKeyPath  string
+	ExternalEtcdServers        string
+	ExternalEtcdKeyPrefix      string
+
+	// karmada-apiserver
+	KarmadaAPIServerImage            string
+	KarmadaAPIServerReplicas         int32
+	KarmadaAPIServerAdvertiseAddress string
+	KarmadaAPIServerNodePort         int32
+	KarmadaAPIServerIP               []net.IP
+	KarmadaAPIServerPriorityClass    string
+
+	// karmada-scheduler
+	KarmadaSchedulerImage         string
+	KarmadaSchedulerReplicas      int32
+	KarmadaSchedulerPriorityClass string
+
+	// kube-controller-manager
 	KubeControllerManagerImage         string
 	KubeControllerManagerReplicas      int32
-	KarmadaControllerManagerImage      string
-	KarmadaControllerManagerReplicas   int32
-	KarmadaWebhookImage                string
-	KarmadaWebhookReplicas             int32
-	KarmadaAggregatedAPIServerImage    string
-	KarmadaAggregatedAPIServerReplicas int32
-	Namespace                          string
-	KubeConfig                         string
-	Context                            string
-	StorageClassesName                 string
-	KarmadaDataPath                    string
-	KarmadaPkiPath                     string
-	CRDs                               string
-	ExternalIP                         string
-	ExternalDNS                        string
-	PullSecrets                        []string
-	CertValidity                       time.Duration
-	KubeClientSet                      kubernetes.Interface
-	CertAndKeyFileData                 map[string][]byte
-	RestConfig                         *rest.Config
-	KarmadaAPIServerIP                 []net.IP
-	HostClusterDomain                  string
-	WaitComponentReadyTimeout          int
-	CaCertFile                         string
-	CaKeyFile                          string
-	KarmadaInitFilePath                string
+	KubeControllerManagerPriorityClass string
+
+	// karmada-controller-manager
+	KarmadaControllerManagerImage         string
+	KarmadaControllerManagerReplicas      int32
+	KarmadaControllerManagerPriorityClass string
+
+	KarmadaWebhookImage         string
+	KarmadaWebhookReplicas      int32
+	KarmadaWebhookPriorityClass string
+
+	// karamda-aggregated-apiserver
+	KarmadaAggregatedAPIServerImage         string
+	KarmadaAggregatedAPIServerReplicas      int32
+	KarmadaAggregatedAPIServerPriorityClass string
+
+	Namespace          string
+	KubeConfig         string
+	Context            string
+	StorageClassesName string
+	KarmadaDataPath    string
+	KarmadaPkiPath     string
+	CRDs               string
+	ExternalIP         string
+	ExternalDNS        string
+	PullSecrets        []string
+	CertValidity       time.Duration
+	KubeClientSet      kubernetes.Interface
+	CertAndKeyFileData map[string][]byte
+	RestConfig         *rest.Config
+
+	HostClusterDomain         string
+	WaitComponentReadyTimeout int
+	CaCertFile                string
+	CaKeyFile                 string
+	KarmadaInitFilePath       string
 }
 
 func (i *CommandInitOption) validateLocalEtcd(parentCommand string) error {

--- a/pkg/karmadactl/cmdinit/kubernetes/deployments.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deployments.go
@@ -164,7 +164,8 @@ func (i *CommandInitOption) makeKarmadaAPIServerDeployment() *appsv1.Deployment 
 	}
 
 	podSpec := corev1.PodSpec{
-		ImagePullSecrets: i.getImagePullSecrets(),
+		ImagePullSecrets:  i.getImagePullSecrets(),
+		PriorityClassName: i.KarmadaAPIServerPriorityClass,
 		Affinity: &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
@@ -278,7 +279,8 @@ func (i *CommandInitOption) makeKarmadaKubeControllerManagerDeployment() *appsv1
 	}
 
 	podSpec := corev1.PodSpec{
-		ImagePullSecrets: i.getImagePullSecrets(),
+		ImagePullSecrets:  i.getImagePullSecrets(),
+		PriorityClassName: i.KubeControllerManagerPriorityClass,
 		Affinity: &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
@@ -423,7 +425,8 @@ func (i *CommandInitOption) makeKarmadaSchedulerDeployment() *appsv1.Deployment 
 	}
 
 	podSpec := corev1.PodSpec{
-		ImagePullSecrets: i.getImagePullSecrets(),
+		ImagePullSecrets:  i.getImagePullSecrets(),
+		PriorityClassName: i.KarmadaSchedulerPriorityClass,
 		Affinity: &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
@@ -561,7 +564,8 @@ func (i *CommandInitOption) makeKarmadaControllerManagerDeployment() *appsv1.Dep
 	}
 
 	podSpec := corev1.PodSpec{
-		ImagePullSecrets: i.getImagePullSecrets(),
+		ImagePullSecrets:  i.getImagePullSecrets(),
+		PriorityClassName: i.KarmadaControllerManagerPriorityClass,
 		Affinity: &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
@@ -683,7 +687,8 @@ func (i *CommandInitOption) makeKarmadaWebhookDeployment() *appsv1.Deployment {
 	}
 
 	podSpec := corev1.PodSpec{
-		ImagePullSecrets: i.getImagePullSecrets(),
+		ImagePullSecrets:  i.getImagePullSecrets(),
+		PriorityClassName: i.KarmadaWebhookPriorityClass,
 		Affinity: &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
@@ -858,7 +863,8 @@ func (i *CommandInitOption) makeKarmadaAggregatedAPIServerDeployment() *appsv1.D
 		command = append(command, fmt.Sprintf("--etcd-prefix=%s", i.ExternalEtcdKeyPrefix))
 	}
 	podSpec := corev1.PodSpec{
-		ImagePullSecrets: i.getImagePullSecrets(),
+		ImagePullSecrets:  i.getImagePullSecrets(),
+		PriorityClassName: i.KarmadaAggregatedAPIServerPriorityClass,
 		Affinity: &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{

--- a/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
@@ -232,7 +232,8 @@ func (i *CommandInitOption) makeETCDStatefulSet() *appsv1.StatefulSet {
 
 	// etcd Container
 	podSpec := corev1.PodSpec{
-		ImagePullSecrets: i.getImagePullSecrets(),
+		ImagePullSecrets:  i.getImagePullSecrets(),
+		PriorityClassName: i.EtcdPriorityClass,
 		Affinity: &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Currently, the priority class name for Karmada components is hardcoded to system-node-critical for some components, while others do not specify a priority class at all. This limitation can compromise the reliability and stability of the system in environments where scheduling of critical components is essential.
This pr is going to add support for Component Priority Class Configuration in `karmadactl init`.

**Which issue(s) this PR fixes**:
Parts of #6042

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmadactl`: command `init` now can specify the priority class name of the karmada components, default to `system-node-critical`.
```

