### PR TITLE
Unify Component Priority Class in local-up

### DIFF
--- a/artifacts/agent/karmada-agent.yaml
+++ b/artifacts/agent/karmada-agent.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app: karmada-agent
     spec:
+      priorityClassName: system-node-critical
       serviceAccountName: karmada-agent-sa
       tolerations:
         - key: node-role.kubernetes.io/master

--- a/artifacts/deploy/karmada-aggregated-apiserver.yaml
+++ b/artifacts/deploy/karmada-aggregated-apiserver.yaml
@@ -83,6 +83,7 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      priorityClassName: system-node-critical
 ---
 apiVersion: v1
 kind: Service

--- a/artifacts/deploy/karmada-controller-manager.yaml
+++ b/artifacts/deploy/karmada-controller-manager.yaml
@@ -59,3 +59,4 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      priorityClassName: system-node-critical

--- a/artifacts/deploy/karmada-descheduler.yaml
+++ b/artifacts/deploy/karmada-descheduler.yaml
@@ -64,3 +64,4 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      priorityClassName: system-node-critical

--- a/artifacts/deploy/karmada-etcd.yaml
+++ b/artifacts/deploy/karmada-etcd.yaml
@@ -105,6 +105,7 @@ spec:
         - name: etcd-client-cert
           secret:
             secretName: etcd-etcd-client-cert
+      priorityClassName: system-node-critical
 ---
 
 apiVersion: v1

--- a/artifacts/deploy/karmada-metrics-adapter.yaml
+++ b/artifacts/deploy/karmada-metrics-adapter.yaml
@@ -77,6 +77,7 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      priorityClassName: system-node-critical
 ---
 apiVersion: v1
 kind: Service

--- a/artifacts/deploy/karmada-scheduler-estimator.yaml
+++ b/artifacts/deploy/karmada-scheduler-estimator.yaml
@@ -65,6 +65,7 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      priorityClassName: system-node-critical
 ---
 apiVersion: v1
 kind: Service

--- a/artifacts/deploy/karmada-scheduler.yaml
+++ b/artifacts/deploy/karmada-scheduler.yaml
@@ -65,3 +65,4 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      priorityClassName: system-node-critical

--- a/artifacts/deploy/karmada-search.yaml
+++ b/artifacts/deploy/karmada-search.yaml
@@ -76,6 +76,7 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      priorityClassName: system-node-critical
 ---
 apiVersion: v1
 kind: Service

--- a/artifacts/deploy/karmada-webhook.yaml
+++ b/artifacts/deploy/karmada-webhook.yaml
@@ -62,6 +62,7 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      priorityClassName: system-node-critical
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Refer to #6042. installation tools of Karmada now support setting the Priority Class of components, with the default value being `system-node-critical`. This PR is used to unify the configuration of Component Priority Class in `local-up`. 


**Which issue(s) this PR fixes**:
Parts of #6042

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

