### PR TITLE
Bump helm/chart-testing-action from 2.6.1 to 2.7.0

### DIFF
--- a/.github/workflows/installation-chart.yaml
+++ b/.github/workflows/installation-chart.yaml
@@ -84,7 +84,7 @@ jobs:
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@v2.7.0
 
       - name: Add dependency chart repos
         run: |
@@ -93,14 +93,14 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$( ct list-changed )
+          changed=$( ct list-changed --target-branch ${{ github.event.repository.default_branch }})
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct lint --debug --check-version-increment=false
+        run: ct lint --debug --check-version-increment=false --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Run chart-testing (install)
         run: |
@@ -108,5 +108,5 @@ jobs:
           hack/setup-dev-base.sh
           export KUBECONFIG=~/.kube/karmada.config
           
-          ct install --charts charts/karmada --debug --helm-extra-set-args '--set components={search,metricsAdapter,descheduler},apiServer.hostNetwork=true' --helm-extra-args "--timeout 800s" --skip-clean-up
+          ct install --target-branch ${{ github.event.repository.default_branch }} --charts charts/karmada --debug --helm-extra-set-args '--set components={search,metricsAdapter,descheduler},apiServer.hostNetwork=true' --helm-extra-args "--timeout 800s" --skip-clean-up
           kubectl get pods -A


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Bumps [helm/chart-testing-action](https://github.com/helm/chart-testing-action) from 2.6.1 to 2.7.0.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The dependabot bot sent another PR(#6089) but was blocked due to the default behavior of `CT` changing, which needs manual adoption.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

