### PR TITLE
Standardize the naming of karmada config in Helm chart

### DIFF
--- a/charts/karmada/templates/karmada-aggregated-apiserver.yaml
+++ b/charts/karmada/templates/karmada-aggregated-apiserver.yaml
@@ -45,9 +45,9 @@ spec:
               readOnly: true
           command:
             - /bin/karmada-aggregated-apiserver
-            - --kubeconfig=/etc/kubeconfig
-            - --authentication-kubeconfig=/etc/kubeconfig
-            - --authorization-kubeconfig=/etc/kubeconfig
+            - --kubeconfig=/etc/karmada/config/karmada.config
+            - --authentication-kubeconfig=/etc/karmada/config/karmada.config
+            - --authorization-kubeconfig=/etc/karmada/config/karmada.config
             {{- if eq .Values.etcd.mode "external" }}
             - --etcd-cafile=/etc/etcd/pki/ca.crt
             - --etcd-certfile=/etc/etcd/pki/tls.crt
@@ -99,7 +99,9 @@ spec:
       {{- end }}
       priorityClassName: {{ .Values.aggregatedApiServer.priorityClassName }}
       volumes:
-        {{- include "karmada.kubeconfig.volume" . | nindent 8 }}
+        - name: karmada-config
+          secret:
+            secretName: {{ $name }}-aggregated-apiserver-config
         - name: apiserver-cert
           secret:
             secretName: {{ $name }}-cert

--- a/charts/karmada/templates/karmada-controller-manager.yaml
+++ b/charts/karmada/templates/karmada-controller-manager.yaml
@@ -43,7 +43,9 @@ spec:
       {{- end }}
       priorityClassName: {{ .Values.controllerManager.priorityClassName }}
       volumes:
-      {{- include "karmada.kubeconfig.volume" . | nindent 8 }}
+        - name: karmada-config
+          secret:
+            secretName: {{ $name }}-controller-manager-config
       initContainers:
         {{- include "karmada.initContainer.waitStaticResource" . | nindent 8 }}
       containers:
@@ -52,7 +54,7 @@ spec:
           imagePullPolicy: {{ .Values.controllerManager.image.pullPolicy }}
           command:
             - /bin/karmada-controller-manager
-            - --kubeconfig=/etc/kubeconfig
+            - --kubeconfig=/etc/karmada/config/karmada.config
             - --cluster-status-update-frequency=10s
             - --leader-elect-resource-namespace={{ $systemNamespace }}
             - --health-probe-bind-address=0.0.0.0:10357

--- a/charts/karmada/templates/karmada-descheduler.yaml
+++ b/charts/karmada/templates/karmada-descheduler.yaml
@@ -49,7 +49,7 @@ spec:
           imagePullPolicy: {{ .Values.descheduler.image.pullPolicy }}
           command:
             - /bin/karmada-descheduler
-            - --kubeconfig=/etc/kubeconfig
+            - --kubeconfig=/etc/karmada/config/karmada.config
             - --metrics-bind-address=0.0.0.0:8080
             - --health-probe-bind-address=0.0.0.0:10358
             - --leader-elect-resource-namespace={{ $systemNamespace }}

--- a/charts/karmada/templates/karmada-kubeconfig.yaml
+++ b/charts/karmada/templates/karmada-kubeconfig.yaml
@@ -3,10 +3,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $name }}-kubeconfig
+  name: {{ $name }}-config
   namespace: {{ include "karmada.namespace" . }}
 stringData:
-  kubeconfig: |-
+  karmada.config: |-
     apiVersion: v1
     kind: Config
     clusters:
@@ -26,4 +26,36 @@ stringData:
           user: {{ $name }}-apiserver
         name: {{ $name }}-apiserver
     current-context: {{ $name }}-apiserver
+---
+{{- range $component := (include "karmada.kubeconfigComponents" . | fromYamlArray) }}
+{{- if eq (include "karmada.shouldCreateComponentKubeconfig" (dict "component" $component "components" $.Values.components)) "true" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}-{{ $component }}-config
+  namespace: {{ include "karmada.namespace" $ }}
+stringData:
+  karmada.config: |-
+    apiVersion: v1
+    kind: Config
+    clusters:
+      - cluster:
+          certificate-authority-data: {{ b64enc $.Values.certs.custom.caCrt }}
+          insecure-skip-tls-verify: false
+          server: https://{{ $name }}-apiserver.{{ include "karmada.namespace" $ }}.svc.{{ $.Values.clusterDomain }}:5443
+        name: {{ $name }}-apiserver
+    users:
+      - user:
+          client-certificate-data: {{ b64enc $.Values.certs.custom.crt }}
+          client-key-data: {{ b64enc $.Values.certs.custom.key }}
+        name: {{ $name }}-apiserver
+    contexts:
+      - context:
+          cluster: {{ $name }}-apiserver
+          user: {{ $name }}-apiserver
+        name: {{ $name }}-apiserver
+    current-context: {{ $name }}-apiserver
+---
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/karmada/templates/karmada-metrics-adapter.yaml
+++ b/charts/karmada/templates/karmada-metrics-adapter.yaml
@@ -43,10 +43,10 @@ spec:
               readOnly: true
           command:
             - /bin/karmada-metrics-adapter
-            - --kubeconfig=/etc/kubeconfig
+            - --kubeconfig=/etc/karmada/config/karmada.config
             - --metrics-bind-address=:8080
-            - --authentication-kubeconfig=/etc/kubeconfig
-            - --authorization-kubeconfig=/etc/kubeconfig
+            - --authentication-kubeconfig=/etc/karmada/config/karmada.config
+            - --authorization-kubeconfig=/etc/karmada/config/karmada.config
             - --tls-cert-file=/etc/kubernetes/pki/karmada.crt
             - --tls-private-key-file=/etc/kubernetes/pki/karmada.key
             - --audit-log-path=-
@@ -85,7 +85,9 @@ spec:
       {{- end }}
       priorityClassName: {{ .Values.metricsAdapter.priorityClassName }}
       volumes:
-        {{- include "karmada.kubeconfig.volume" . | nindent 8 }}
+        - name: karmada-config
+          secret:
+            secretName: {{ $name }}-metrics-adapter-config
         - name: apiserver-cert
           secret:
             secretName: {{ $name }}-cert

--- a/charts/karmada/templates/karmada-scheduler.yaml
+++ b/charts/karmada/templates/karmada-scheduler.yaml
@@ -49,7 +49,7 @@ spec:
           imagePullPolicy: {{ .Values.scheduler.image.pullPolicy }}
           command:
             - /bin/karmada-scheduler
-            - --kubeconfig=/etc/kubeconfig
+            - --kubeconfig=/etc/karmada/config/karmada.config
             - --metrics-bind-address=0.0.0.0:8080
             - --health-probe-bind-address=0.0.0.0:10351
             - --leader-elect-resource-namespace={{ $systemNamespace }}
@@ -81,7 +81,9 @@ spec:
           {{- toYaml .Values.scheduler.resources | nindent 12 }}
       priorityClassName: {{ .Values.scheduler.priorityClassName }}
       volumes:
-      {{- include "karmada.kubeconfig.volume" . | nindent 8 }}
+        - name: karmada-config
+          secret:
+            secretName: {{ $name }}-scheduler-config
       {{- include "karmada.scheduler.cert.volume" . | nindent 8 }}
 
 {{ if .Values.scheduler.podDisruptionBudget }}

--- a/charts/karmada/templates/karmada-search.yaml
+++ b/charts/karmada/templates/karmada-search.yaml
@@ -53,14 +53,12 @@ spec:
             - name: etcd-certs
               mountPath: /etc/etcd/pki
               readOnly: true
-            - name: kubeconfig-secret
-              subPath: kubeconfig
-              mountPath: /etc/kubeconfig
+          {{- include "karmada.kubeconfig.volumeMount" . | nindent 12 }}
           command:
             - /bin/karmada-search
-            - --kubeconfig=/etc/kubeconfig
-            - --authentication-kubeconfig=/etc/kubeconfig
-            - --authorization-kubeconfig=/etc/kubeconfig
+            - --kubeconfig=/etc/karmada/config/karmada.config
+            - --authentication-kubeconfig=/etc/karmada/config/karmada.config
+            - --authorization-kubeconfig=/etc/karmada/config/karmada.config
             {{- if eq .Values.etcd.mode "external" }}
             - --etcd-cafile=/etc/etcd/pki/ca.crt
             - --etcd-certfile=/etc/etcd/pki/tls.crt
@@ -160,7 +158,7 @@ spec:
             - |
               bash <<'EOF'
               set -ex
-              kubectl apply -f /search-apiservice --kubeconfig /etc/kubeconfig
+              kubectl apply -f /search-apiservice --kubeconfig /etc/karmada/config/karmada.config
               EOF
           volumeMounts:
             - name: {{ $name }}-search-apiservice

--- a/charts/karmada/templates/karmada-static-resource-job.yaml
+++ b/charts/karmada/templates/karmada-static-resource-job.yaml
@@ -42,11 +42,11 @@ spec:
           bash <<'EOF'
           set -ex
           kubectl rollout status deployment {{ $name }}-apiserver -n {{ $namespace }}
-          kubectl apply -k /crds --kubeconfig /etc/kubeconfig
-          kubectl apply -f /static-resources/system-namespace.yaml --kubeconfig /etc/kubeconfig
-          kubectl apply -f /static-resources/ --kubeconfig /etc/kubeconfig
+          kubectl apply -k /crds --kubeconfig /etc/karmada/config/karmada.config
+          kubectl apply -f /static-resources/system-namespace.yaml --kubeconfig /etc/karmada/config/karmada.config
+          kubectl apply -f /static-resources/ --kubeconfig /etc/karmada/config/karmada.config
 
-          kubectl --kubeconfig /etc/kubeconfig apply -f - <<InnerEOF
+          kubectl --kubeconfig /etc/karmada/config/karmada.config apply -f - <<InnerEOF
           apiVersion: v1
           kind: ConfigMap
           metadata:

--- a/charts/karmada/templates/karmada-webhook.yaml
+++ b/charts/karmada/templates/karmada-webhook.yaml
@@ -49,7 +49,7 @@ spec:
           imagePullPolicy: {{ .Values.webhook.image.pullPolicy }}
           command:
             - /bin/karmada-webhook
-            - --kubeconfig=/etc/kubeconfig
+            - --kubeconfig=/etc/karmada/config/karmada.config
             - --bind-address=0.0.0.0
             - --secure-port=8443
             - --cert-dir=/var/serving-cert
@@ -72,7 +72,9 @@ spec:
           {{- toYaml .Values.webhook.resources | nindent 12 }}
       priorityClassName: {{ .Values.webhook.priorityClassName }}
       volumes:
-      {{- include "karmada.kubeconfig.volume" . | nindent 8 }}
+        - name: karmada-config
+          secret:
+            secretName: {{ $name }}-webhook-config
         - name: {{ $name }}-webhook-cert-secret
           secret:
             secretName: {{ $name }}-webhook-cert

--- a/charts/karmada/templates/kube-controller-manager.yaml
+++ b/charts/karmada/templates/kube-controller-manager.yaml
@@ -47,8 +47,8 @@ spec:
         - command:
             - kube-controller-manager
             - --allocate-node-cidrs=true
-            - --authentication-kubeconfig=/etc/kubeconfig
-            - --authorization-kubeconfig=/etc/kubeconfig
+            - --authentication-kubeconfig=/etc/karmada/config/karmada.config
+            - --authorization-kubeconfig=/etc/karmada/config/karmada.config
             - --bind-address=0.0.0.0
             - --client-ca-file=/etc/karmada/pki/server-ca.crt
             - --cluster-cidr={{ .Values.kubeControllerManager.clusterCIDR }}
@@ -56,7 +56,7 @@ spec:
             - --cluster-signing-cert-file=/etc/karmada/pki/server-ca.crt
             - --cluster-signing-key-file=/etc/karmada/pki/server-ca.key
             - --controllers={{ .Values.kubeControllerManager.controllers }}
-            - --kubeconfig=/etc/kubeconfig
+            - --kubeconfig=/etc/karmada/config/karmada.config
             - --leader-elect=true
             - --node-cidr-mask-size=24
             - --root-ca-file=/etc/karmada/pki/server-ca.crt
@@ -89,7 +89,9 @@ spec:
         - name: apiserver-cert
           secret:
             secretName: {{ $name }}-cert
-        {{- include "karmada.kubeconfig.volume" . | nindent 8 }}
+        - name: karmada-config
+          secret:
+            secretName: {{ $name }}-kube-controller-manager-config
 
 {{ if .Values.kubeControllerManager.podDisruptionBudget }}
 ---

--- a/charts/karmada/templates/pre-install-job.yaml
+++ b/charts/karmada/templates/pre-install-job.yaml
@@ -331,14 +331,44 @@ data:
         {{ print "{{ crt }}" }}
       tls.key: |-
         {{ print "{{ key }}" }}
+  {{- range $component := (include "karmada.kubeconfigComponents" . | fromYamlArray) }}
+  {{- if eq (include "karmada.shouldCreateComponentKubeconfig" (dict "component" $component "components" $.Values.components)) "true" }}
+  {{ $component }}-kubeconfig.yaml: |- 
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: {{ $name }}-{{ $component }}-config
+      namespace: {{ $namespace }}
+    stringData:
+      karmada.config: |-
+        apiVersion: v1
+        kind: Config
+        clusters:
+          - cluster:
+              certificate-authority-data: {{ print "{{ ca_crt }}" }}
+              server: https://{{ $name }}-apiserver.{{ $namespace }}.svc.{{ $.Values.clusterDomain }}:5443
+            name: {{ $name }}-apiserver
+        users:
+          - user:
+              client-certificate-data: {{ print "{{ crt }}" }}
+              client-key-data: {{ print "{{ key }}" }}
+            name: {{ $name }}-apiserver
+        contexts:
+          - context:
+              cluster: {{ $name }}-apiserver
+              user: {{ $name }}-apiserver
+            name: {{ $name }}-apiserver
+        current-context: {{ $name }}-apiserver
+  {{- end }}
+  {{- end }}
   kubeconfig.yaml: |-
     apiVersion: v1
     kind: Secret
     metadata:
-      name: {{ $name }}-kubeconfig
+      name: {{ $name }}-config
       namespace: {{ $namespace }}
     stringData:
-      kubeconfig: |-
+      karmada.config: |-
         apiVersion: v1
         kind: Config
         clusters:
@@ -467,6 +497,13 @@ spec:
           sed -i'' -e "s/{{ print "{{ key }}" }}/${karmada_key}/g" /opt/configs/webhook-cert.yaml
           sed -i'' -e "s/{{ print "{{ ca_crt }}" }}/${karmada_ca}/g" /opt/configs/static-resources-configmaps.yaml
           sed -i'' -e "s/{{ print "{{ ca_crt }}" }}/${karmada_ca}/g" /opt/configs/crds-patches-configmaps.yaml
+          {{- range $component := (include "karmada.kubeconfigComponents" . | fromYamlArray) }}
+          {{- if eq (include "karmada.shouldCreateComponentKubeconfig" (dict "component" $component "components" $.Values.components)) "true" }}
+          sed -i'' -e "s/{{ print "{{ ca_crt }}" }}/${karmada_ca}/g" /opt/configs/{{ $component }}-kubeconfig.yaml
+          sed -i'' -e "s/{{ print "{{ crt }}" }}/${karmada_crt}/g" /opt/configs/{{ $component }}-kubeconfig.yaml
+          sed -i'' -e "s/{{ print "{{ key }}" }}/${karmada_key}/g" /opt/configs/{{ $component }}-kubeconfig.yaml
+          {{- end }}
+          {{- end }}
           EOF
         volumeMounts:
         - name: mount

--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -945,7 +945,7 @@ descheduler:
       maxUnavailable: 0
       maxSurge: 50%
   ## @param descheduler.kubeconfig kubeconfig of the descheduler
-  kubeconfig: karmada-kubeconfig
+  kubeconfig: karmada-config
   ## @param apiServer.podDisruptionBudget
   podDisruptionBudget: *podDisruptionBudget
   ## @param descheduler.priorityClassName the priority class name for the descheduler
@@ -1007,7 +1007,7 @@ search:
   ## @param search.certs certs of the search
   certs: karmada-cert
   ## @param search.kubeconfig kubeconfig of the search
-  kubeconfig: karmada-kubeconfig
+  kubeconfig: karmada-config
   ## @param apiServer.podDisruptionBudget
   podDisruptionBudget: *podDisruptionBudget
   ## @param search.priorityClassName the priority class name for the karmada-search


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
In karmada, here are two important secrets, which is mount by most karmada components. One is karmada-cert, which contains a series of cert files like ca.crt, apiserver.crt and so on; another is karmada-kubeconfig, which contains a kubeconfig of karmada-apiserver.

However, in different installation methods, we used inconsistent secret naming or file path naming, which can potentially cause some unnecessary problems, detail refer to https://github.com/karmada-io/karmada/issues/5363.

This PR aims to standardize the naming of karmada config in Helm installation method.

**Which issue(s) this PR fixes**:
Part of #6051 

**Special notes for your reviewer**:
For the users who use the kubeconfig-secret in their custom webhook, they might need to change the secret name and the kubeconfig path in their command.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`helm`: standardize the naming of karmada config in helm installation method
```
