### PR TITLE
use meta.Accessor() in onResourceBindingUpdate()

### DIFF
--- a/pkg/scheduler/event_handler.go
+++ b/pkg/scheduler/event_handler.go
@@ -37,7 +37,6 @@ import (
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
-	"github.com/karmada-io/karmada/pkg/util/helper"
 )
 
 // addAllEventHandlers is a helper function used in Scheduler
@@ -130,20 +129,26 @@ func (s *Scheduler) onResourceBindingAdd(obj interface{}) {
 }
 
 func (s *Scheduler) onResourceBindingUpdate(old, cur interface{}) {
-	unstructuredOldObj, err := helper.ToUnstructured(old)
+	t, err := meta.TypeAccessor(old)
 	if err != nil {
-		klog.Errorf("Failed to transform oldObj, error: %v", err)
+		klog.Errorf("Failed to transform oldObj as meta.Type, error: %v", err)
 		return
 	}
 
-	unstructuredNewObj, err := helper.ToUnstructured(cur)
+	oldMeta, err := meta.Accessor(old)
 	if err != nil {
-		klog.Errorf("Failed to transform newObj, error: %v", err)
+		klog.Errorf("Failed to transform oldObj as metav1.Object, error: %v", err)
 		return
 	}
 
-	if unstructuredOldObj.GetGeneration() == unstructuredNewObj.GetGeneration() {
-		klog.V(4).Infof("Ignore update event of object (kind=%s, %s/%s) as specification no change", unstructuredOldObj.GetKind(), unstructuredOldObj.GetNamespace(), unstructuredOldObj.GetName())
+	newMeta, err := meta.Accessor(cur)
+	if err != nil {
+		klog.Errorf("Failed to transform newObj as metav1.Object, error: %v", err)
+		return
+	}
+
+	if oldMeta.GetGeneration() == newMeta.GetGeneration() {
+		klog.V(4).Infof("Ignore update event of object (kind=%s, %s/%s) as specification no change", t.GetKind(), oldMeta.GetNamespace(), oldMeta.GetName())
 		return
 	}
 

--- a/pkg/scheduler/event_handler.go
+++ b/pkg/scheduler/event_handler.go
@@ -129,12 +129,6 @@ func (s *Scheduler) onResourceBindingAdd(obj interface{}) {
 }
 
 func (s *Scheduler) onResourceBindingUpdate(old, cur interface{}) {
-	t, err := meta.TypeAccessor(old)
-	if err != nil {
-		klog.Errorf("Failed to transform oldObj as meta.Type, error: %v", err)
-		return
-	}
-
 	oldMeta, err := meta.Accessor(old)
 	if err != nil {
 		klog.Errorf("Failed to transform oldObj as metav1.Object, error: %v", err)
@@ -148,7 +142,11 @@ func (s *Scheduler) onResourceBindingUpdate(old, cur interface{}) {
 	}
 
 	if oldMeta.GetGeneration() == newMeta.GetGeneration() {
-		klog.V(4).Infof("Ignore update event of object (kind=%s, %s/%s) as specification no change", t.GetKind(), oldMeta.GetNamespace(), oldMeta.GetName())
+		if oldMeta.GetNamespace() != "" {
+			klog.V(4).Infof("Ignore update event of resourceBinding %s/%s as specification no change", oldMeta.GetNamespace(), oldMeta.GetName())
+		} else {
+			klog.V(4).Infof("Ignore update event of clusterResourceBinding %s as specification no change", oldMeta.GetName())
+		}
 		return
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Part of the content of https://github.com/karmada-io/karmada/pull/6028

in `onResourceBindingUpdate()` in karmada-scheduler, it calls `helper.ToUnstructured()` on crb and rb to simplify the get Generation operation. But this type conversion is unnecessary, we can use `meta.Accessor()` to achieve the same effect, which should slightly improve the performance of karmada-scheduler.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

