### PR TITLE
add the ratelimiter options parameter for controllers that are missing it

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -339,7 +339,7 @@ func startExecutionController(ctx controllerscontext.Context) (bool, error) {
 		ObjectWatcher:      ctx.ObjectWatcher,
 		PredicateFunc:      helper.NewExecutionPredicateOnAgent(),
 		InformerManager:    genericmanager.GetInstance(),
-		RatelimiterOptions: ctx.Opts.RateLimiterOptions,
+		RateLimiterOptions: ctx.Opts.RateLimiterOptions,
 	}
 	if err := executionController.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err
@@ -380,6 +380,7 @@ func startServiceExportController(ctx controllerscontext.Context) (bool, error) 
 		PredicateFunc:               helper.NewPredicateForServiceExportControllerOnAgent(ctx.Opts.ClusterName),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 		ClusterCacheSyncTimeout:     ctx.Opts.ClusterCacheSyncTimeout,
+		RateLimiterOptions:          ctx.Opts.RateLimiterOptions,
 	}
 	serviceExportController.RunWorkQueue()
 	if err := serviceExportController.SetupWithManager(ctx.Mgr); err != nil {
@@ -402,6 +403,7 @@ func startEndpointSliceCollectController(ctx controllerscontext.Context) (enable
 		PredicateFunc:               helper.NewPredicateForEndpointSliceCollectControllerOnAgent(opts.ClusterName),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSet,
 		ClusterCacheSyncTimeout:     opts.ClusterCacheSyncTimeout,
+		RateLimiterOptions:          ctx.Opts.RateLimiterOptions,
 	}
 	endpointSliceCollectController.RunWorkQueue()
 	if err := endpointSliceCollectController.SetupWithManager(ctx.Mgr); err != nil {

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -255,6 +255,7 @@ func startClusterController(ctx controllerscontext.Context) (enabled bool, err e
 		EnableTaintManager:                 ctx.Opts.EnableTaintManager,
 		ClusterTaintEvictionRetryFrequency: 10 * time.Second,
 		ExecutionSpaceRetryFrequency:       10 * time.Second,
+		RateLimiterOptions:                 ctx.Opts.RateLimiterOptions,
 	}
 	if err := clusterController.SetupWithManager(mgr); err != nil {
 		return false, err
@@ -269,6 +270,7 @@ func startClusterController(ctx controllerscontext.Context) (enabled bool, err e
 			EventRecorder:                      mgr.GetEventRecorderFor(cluster.TaintManagerName),
 			ClusterTaintEvictionRetryFrequency: 10 * time.Second,
 			ConcurrentReconciles:               3,
+			RateLimiterOptions:                 ctx.Opts.RateLimiterOptions,
 		}
 		if err := taintManager.SetupWithManager(mgr); err != nil {
 			return false, err
@@ -409,7 +411,7 @@ func startExecutionController(ctx controllerscontext.Context) (enabled bool, err
 		ObjectWatcher:      ctx.ObjectWatcher,
 		PredicateFunc:      helper.NewExecutionPredicate(ctx.Mgr),
 		InformerManager:    genericmanager.GetInstance(),
-		RatelimiterOptions: ctx.Opts.RateLimiterOptions,
+		RateLimiterOptions: ctx.Opts.RateLimiterOptions,
 	}
 	if err := executionController.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err
@@ -447,6 +449,7 @@ func startNamespaceController(ctx controllerscontext.Context) (enabled bool, err
 		EventRecorder:                ctx.Mgr.GetEventRecorderFor(namespace.ControllerName),
 		SkippedPropagatingNamespaces: ctx.Opts.SkippedPropagatingNamespaces,
 		OverrideManager:              ctx.OverrideManager,
+		RateLimiterOptions:           ctx.Opts.RateLimiterOptions,
 	}
 	if err := namespaceSyncController.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err
@@ -466,6 +469,7 @@ func startServiceExportController(ctx controllerscontext.Context) (enabled bool,
 		PredicateFunc:               helper.NewPredicateForServiceExportController(ctx.Mgr),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSet,
 		ClusterCacheSyncTimeout:     opts.ClusterCacheSyncTimeout,
+		RateLimiterOptions:          ctx.Opts.RateLimiterOptions,
 	}
 	serviceExportController.RunWorkQueue()
 	if err := serviceExportController.SetupWithManager(ctx.Mgr); err != nil {
@@ -488,6 +492,7 @@ func startEndpointSliceCollectController(ctx controllerscontext.Context) (enable
 		PredicateFunc:               helper.NewPredicateForEndpointSliceCollectController(ctx.Mgr),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSet,
 		ClusterCacheSyncTimeout:     opts.ClusterCacheSyncTimeout,
+		RateLimiterOptions:          ctx.Opts.RateLimiterOptions,
 	}
 	endpointSliceCollectController.RunWorkQueue()
 	if err := endpointSliceCollectController.SetupWithManager(ctx.Mgr); err != nil {
@@ -501,10 +506,11 @@ func startEndpointSliceDispatchController(ctx controllerscontext.Context) (enabl
 		return false, nil
 	}
 	endpointSliceSyncController := &multiclusterservice.EndpointsliceDispatchController{
-		Client:          ctx.Mgr.GetClient(),
-		EventRecorder:   ctx.Mgr.GetEventRecorderFor(multiclusterservice.EndpointsliceDispatchControllerName),
-		RESTMapper:      ctx.Mgr.GetRESTMapper(),
-		InformerManager: genericmanager.GetInstance(),
+		Client:             ctx.Mgr.GetClient(),
+		EventRecorder:      ctx.Mgr.GetEventRecorderFor(multiclusterservice.EndpointsliceDispatchControllerName),
+		RESTMapper:         ctx.Mgr.GetRESTMapper(),
+		InformerManager:    genericmanager.GetInstance(),
+		RateLimiterOptions: ctx.Opts.RateLimiterOptions,
 	}
 	if err := endpointSliceSyncController.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err
@@ -514,8 +520,9 @@ func startEndpointSliceDispatchController(ctx controllerscontext.Context) (enabl
 
 func startEndpointSliceController(ctx controllerscontext.Context) (enabled bool, err error) {
 	endpointSliceController := &mcs.EndpointSliceController{
-		Client:        ctx.Mgr.GetClient(),
-		EventRecorder: ctx.Mgr.GetEventRecorderFor(mcs.EndpointSliceControllerName),
+		Client:             ctx.Mgr.GetClient(),
+		EventRecorder:      ctx.Mgr.GetEventRecorderFor(mcs.EndpointSliceControllerName),
+		RateLimiterOptions: ctx.Opts.RateLimiterOptions,
 	}
 	if err := endpointSliceController.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err
@@ -525,8 +532,9 @@ func startEndpointSliceController(ctx controllerscontext.Context) (enabled bool,
 
 func startServiceImportController(ctx controllerscontext.Context) (enabled bool, err error) {
 	serviceImportController := &mcs.ServiceImportController{
-		Client:        ctx.Mgr.GetClient(),
-		EventRecorder: ctx.Mgr.GetEventRecorderFor(mcs.ServiceImportControllerName),
+		Client:             ctx.Mgr.GetClient(),
+		EventRecorder:      ctx.Mgr.GetEventRecorderFor(mcs.ServiceImportControllerName),
+		RateLimiterOptions: ctx.Opts.RateLimiterOptions,
 	}
 	if err := serviceImportController.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err
@@ -536,8 +544,9 @@ func startServiceImportController(ctx controllerscontext.Context) (enabled bool,
 
 func startUnifiedAuthController(ctx controllerscontext.Context) (enabled bool, err error) {
 	unifiedAuthController := &unifiedauth.Controller{
-		Client:        ctx.Mgr.GetClient(),
-		EventRecorder: ctx.Mgr.GetEventRecorderFor(unifiedauth.ControllerName),
+		Client:             ctx.Mgr.GetClient(),
+		EventRecorder:      ctx.Mgr.GetEventRecorderFor(unifiedauth.ControllerName),
+		RateLimiterOptions: ctx.Opts.RateLimiterOptions,
 	}
 	if err := unifiedAuthController.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err
@@ -547,8 +556,9 @@ func startUnifiedAuthController(ctx controllerscontext.Context) (enabled bool, e
 
 func startFederatedResourceQuotaSyncController(ctx controllerscontext.Context) (enabled bool, err error) {
 	controller := federatedresourcequota.SyncController{
-		Client:        ctx.Mgr.GetClient(),
-		EventRecorder: ctx.Mgr.GetEventRecorderFor(federatedresourcequota.SyncControllerName),
+		Client:             ctx.Mgr.GetClient(),
+		EventRecorder:      ctx.Mgr.GetEventRecorderFor(federatedresourcequota.SyncControllerName),
+		RateLimiterOptions: ctx.Opts.RateLimiterOptions,
 	}
 	if err = controller.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err
@@ -558,8 +568,9 @@ func startFederatedResourceQuotaSyncController(ctx controllerscontext.Context) (
 
 func startFederatedResourceQuotaStatusController(ctx controllerscontext.Context) (enabled bool, err error) {
 	controller := federatedresourcequota.StatusController{
-		Client:        ctx.Mgr.GetClient(),
-		EventRecorder: ctx.Mgr.GetEventRecorderFor(federatedresourcequota.StatusControllerName),
+		Client:             ctx.Mgr.GetClient(),
+		EventRecorder:      ctx.Mgr.GetEventRecorderFor(federatedresourcequota.StatusControllerName),
+		RateLimiterOptions: ctx.Opts.RateLimiterOptions,
 	}
 	if err = controller.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err
@@ -596,6 +607,7 @@ func startApplicationFailoverController(ctx controllerscontext.Context) (enabled
 		Client:              ctx.Mgr.GetClient(),
 		EventRecorder:       ctx.Mgr.GetEventRecorderFor(applicationfailover.RBApplicationFailoverControllerName),
 		ResourceInterpreter: ctx.ResourceInterpreter,
+		RateLimiterOptions:  ctx.Opts.RateLimiterOptions,
 	}
 	if err = rbApplicationFailoverController.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err
@@ -605,6 +617,7 @@ func startApplicationFailoverController(ctx controllerscontext.Context) (enabled
 		Client:              ctx.Mgr.GetClient(),
 		EventRecorder:       ctx.Mgr.GetEventRecorderFor(applicationfailover.CRBApplicationFailoverControllerName),
 		ResourceInterpreter: ctx.ResourceInterpreter,
+		RateLimiterOptions:  ctx.Opts.RateLimiterOptions,
 	}
 	if err = crbApplicationFailoverController.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err
@@ -659,8 +672,9 @@ func startCronFederatedHorizontalPodAutoscalerController(ctx controllerscontext.
 
 func startHPAScaleTargetMarkerController(ctx controllerscontext.Context) (enabled bool, err error) {
 	hpaScaleTargetMarker := hpascaletargetmarker.HpaScaleTargetMarker{
-		DynamicClient: ctx.DynamicClientSet,
-		RESTMapper:    ctx.Mgr.GetRESTMapper(),
+		DynamicClient:      ctx.DynamicClientSet,
+		RESTMapper:         ctx.Mgr.GetRESTMapper(),
+		RateLimiterOptions: ctx.Opts.RateLimiterOptions,
 	}
 	err = hpaScaleTargetMarker.SetupWithManager(ctx.Mgr)
 	if err != nil {
@@ -672,7 +686,8 @@ func startHPAScaleTargetMarkerController(ctx controllerscontext.Context) (enable
 
 func startDeploymentReplicasSyncerController(ctx controllerscontext.Context) (enabled bool, err error) {
 	deploymentReplicasSyncer := deploymentreplicassyncer.DeploymentReplicasSyncer{
-		Client: ctx.Mgr.GetClient(),
+		Client:             ctx.Mgr.GetClient(),
+		RateLimiterOptions: ctx.Opts.RateLimiterOptions,
 	}
 	err = deploymentReplicasSyncer.SetupWithManager(ctx.Mgr)
 	if err != nil {
@@ -710,7 +725,8 @@ func startRemedyController(ctx controllerscontext.Context) (enabled bool, err er
 
 func startWorkloadRebalancerController(ctx controllerscontext.Context) (enabled bool, err error) {
 	workloadRebalancer := workloadrebalancer.RebalancerController{
-		Client: ctx.Mgr.GetClient(),
+		Client:             ctx.Mgr.GetClient(),
+		RateLimiterOptions: ctx.Opts.RateLimiterOptions,
 	}
 	err = workloadRebalancer.SetupWithManager(ctx.Mgr)
 	if err != nil {
@@ -721,7 +737,10 @@ func startWorkloadRebalancerController(ctx controllerscontext.Context) (enabled 
 }
 
 func startAgentCSRApprovingController(ctx controllerscontext.Context) (enabled bool, err error) {
-	agentCSRApprover := approver.AgentCSRApprovingController{Client: ctx.KubeClientSet}
+	agentCSRApprover := approver.AgentCSRApprovingController{
+		Client:             ctx.KubeClientSet,
+		RateLimiterOptions: ctx.Opts.RateLimiterOptions,
+	}
 	err = agentCSRApprover.SetupWithManager(ctx.Mgr)
 	if err != nil {
 		return false, err

--- a/pkg/controllers/execution/execution_controller.go
+++ b/pkg/controllers/execution/execution_controller.go
@@ -73,7 +73,7 @@ type Controller struct {
 	ObjectWatcher      objectwatcher.ObjectWatcher
 	PredicateFunc      predicate.Predicate
 	InformerManager    genericmanager.MultiClusterInformerManager
-	RatelimiterOptions ratelimiterflag.Options
+	RateLimiterOptions ratelimiterflag.Options
 }
 
 // Reconcile performs a full reconciliation for the object referred to by the Request.
@@ -137,7 +137,7 @@ func (c *Controller) SetupWithManager(mgr controllerruntime.Manager) error {
 		For(&workv1alpha1.Work{}, builder.WithPredicates(c.PredicateFunc)).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		WithOptions(controller.Options{
-			RateLimiter: ratelimiterflag.DefaultControllerRateLimiter[controllerruntime.Request](c.RatelimiterOptions),
+			RateLimiter: ratelimiterflag.DefaultControllerRateLimiter[controllerruntime.Request](c.RateLimiterOptions),
 		}).
 		Complete(c)
 }

--- a/pkg/controllers/federatedresourcequota/federated_resource_quota_sync_controller.go
+++ b/pkg/controllers/federatedresourcequota/federated_resource_quota_sync_controller.go
@@ -29,6 +29,7 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -39,6 +40,7 @@ import (
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/controllers/ctrlutil"
 	"github.com/karmada-io/karmada/pkg/events"
+	"github.com/karmada-io/karmada/pkg/sharedcli/ratelimiterflag"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/helper"
 	"github.com/karmada-io/karmada/pkg/util/names"
@@ -51,8 +53,9 @@ const (
 
 // SyncController is to sync FederatedResourceQuota.
 type SyncController struct {
-	client.Client // used to operate Work resources.
-	EventRecorder record.EventRecorder
+	client.Client      // used to operate Work resources.
+	EventRecorder      record.EventRecorder
+	RateLimiterOptions ratelimiterflag.Options
 }
 
 // Reconcile performs a full reconciliation for the object referred to by the Request.
@@ -133,6 +136,9 @@ func (c *SyncController) SetupWithManager(mgr controllerruntime.Manager) error {
 		Named(SyncControllerName).
 		For(&policyv1alpha1.FederatedResourceQuota{}).
 		Watches(&clusterv1alpha1.Cluster{}, handler.EnqueueRequestsFromMapFunc(fn), clusterPredicate).
+		WithOptions(controller.Options{
+			RateLimiter: ratelimiterflag.DefaultControllerRateLimiter[controllerruntime.Request](c.RateLimiterOptions),
+		}).
 		Complete(c)
 }
 

--- a/pkg/controllers/mcs/service_import_controller.go
+++ b/pkg/controllers/mcs/service_import_controller.go
@@ -28,9 +28,11 @@ import (
 	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	mcsv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
 	"github.com/karmada-io/karmada/pkg/events"
+	"github.com/karmada-io/karmada/pkg/sharedcli/ratelimiterflag"
 	"github.com/karmada-io/karmada/pkg/util/helper"
 	"github.com/karmada-io/karmada/pkg/util/names"
 )
@@ -41,7 +43,8 @@ const ServiceImportControllerName = "service-import-controller"
 // ServiceImportController is to sync derived service from ServiceImport.
 type ServiceImportController struct {
 	client.Client
-	EventRecorder record.EventRecorder
+	EventRecorder      record.EventRecorder
+	RateLimiterOptions ratelimiterflag.Options
 }
 
 // Reconcile performs a full reconciliation for the object referred to by the Request.
@@ -74,6 +77,7 @@ func (c *ServiceImportController) SetupWithManager(mgr controllerruntime.Manager
 	return controllerruntime.NewControllerManagedBy(mgr).
 		Named(ServiceImportControllerName).
 		For(&mcsv1alpha1.ServiceImport{}).
+		WithOptions(controller.Options{RateLimiter: ratelimiterflag.DefaultControllerRateLimiter[controllerruntime.Request](c.RateLimiterOptions)}).
 		Complete(c)
 }
 

--- a/pkg/controllers/workloadrebalancer/workloadrebalancer_controller.go
+++ b/pkg/controllers/workloadrebalancer/workloadrebalancer_controller.go
@@ -31,11 +31,13 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	appsv1alpha1 "github.com/karmada-io/karmada/pkg/apis/apps/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/sharedcli/ratelimiterflag"
 	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
@@ -46,7 +48,8 @@ const (
 
 // RebalancerController is to handle a rebalance to workloads selected by WorkloadRebalancer object.
 type RebalancerController struct {
-	Client client.Client
+	Client             client.Client
+	RateLimiterOptions ratelimiterflag.Options
 }
 
 // SetupWithManager creates a controller and register to controller manager.
@@ -65,6 +68,7 @@ func (c *RebalancerController) SetupWithManager(mgr controllerruntime.Manager) e
 	return controllerruntime.NewControllerManagedBy(mgr).
 		Named(ControllerName).
 		For(&appsv1alpha1.WorkloadRebalancer{}, builder.WithPredicates(predicateFunc)).
+		WithOptions(controller.Options{RateLimiter: ratelimiterflag.DefaultControllerRateLimiter[controllerruntime.Request](c.RateLimiterOptions)}).
 		Complete(c)
 }
 

--- a/pkg/dependenciesdistributor/dependencies_distributor.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor.go
@@ -619,7 +619,8 @@ func (d *DependenciesDistributor) Start(ctx context.Context) error {
 				Labels:         metaInfo.GetLabels(),
 			}, nil
 		},
-		ReconcileFunc: d.reconcileResourceTemplate,
+		ReconcileFunc:      d.reconcileResourceTemplate,
+		RateLimiterOptions: d.RateLimiterOptions,
 	}
 	d.eventHandler = fedinformer.NewHandlerOnEvents(d.OnAdd, d.OnUpdate, d.OnDelete)
 	d.resourceProcessor = util.NewAsyncWorker(resourceWorkerOptions)

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -117,16 +117,18 @@ func (d *ResourceDetector) Start(ctx context.Context) error {
 
 	// setup policy reconcile worker
 	policyWorkerOptions := util.Options{
-		Name:          "propagationPolicy reconciler",
-		KeyFunc:       ClusterWideKeyFunc,
-		ReconcileFunc: d.ReconcilePropagationPolicy,
+		Name:               "propagationPolicy reconciler",
+		KeyFunc:            ClusterWideKeyFunc,
+		ReconcileFunc:      d.ReconcilePropagationPolicy,
+		RateLimiterOptions: d.RateLimiterOptions,
 	}
 	d.policyReconcileWorker = util.NewAsyncWorker(policyWorkerOptions)
 	d.policyReconcileWorker.Run(d.ConcurrentPropagationPolicySyncs, d.stopCh)
 	clusterPolicyWorkerOptions := util.Options{
-		Name:          "clusterPropagationPolicy reconciler",
-		KeyFunc:       ClusterWideKeyFunc,
-		ReconcileFunc: d.ReconcileClusterPropagationPolicy,
+		Name:               "clusterPropagationPolicy reconciler",
+		KeyFunc:            ClusterWideKeyFunc,
+		ReconcileFunc:      d.ReconcileClusterPropagationPolicy,
+		RateLimiterOptions: d.RateLimiterOptions,
 	}
 	d.clusterPolicyReconcileWorker = util.NewAsyncWorker(clusterPolicyWorkerOptions)
 	d.clusterPolicyReconcileWorker.Run(d.ConcurrentClusterPropagationPolicySyncs, d.stopCh)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
part of  https://github.com/karmada-io/karmada/issues/5790

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: All controller reconcile frequency will honor a unified rate limiter configuration(--rate-limiter-*).
`karmada-agent`: All controller reconcile frequency will honor a unified rate limiter configuration(--rate-limiter-*).
```

