### PR TITLE
Add deepequal check for objectWatcher.Update()

### DIFF
--- a/pkg/controllers/status/work_status_controller.go
+++ b/pkg/controllers/status/work_status_controller.go
@@ -249,11 +249,7 @@ func (c *WorkStatusController) updateResource(ctx context.Context, observedObj *
 
 	// we should check if the observed status is consistent with the declaration to prevent accidental changes made
 	// in member clusters.
-	needUpdate, err := c.ObjectWatcher.NeedsUpdate(clusterName, desiredObj, observedObj)
-	if err != nil {
-		return err
-	}
-
+	needUpdate := c.ObjectWatcher.NeedsUpdate(clusterName, desiredObj, observedObj)
 	if needUpdate {
 		operationResult, updateErr := c.ObjectWatcher.Update(ctx, clusterName, desiredObj, observedObj)
 		metrics.CountUpdateResourceToCluster(updateErr, desiredObj.GetAPIVersion(), desiredObj.GetKind(), clusterName, string(operationResult))


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Add deepequal check for objectWatcher.Update() in karmada-controller-manager to reduce redundant HTTP update operations on member clusters, which helps reduce the time consumption of karmada-controller-manager startup.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

If #6148 can be merged and this PR can be rebased on it, the changes brought by this PR can be more clearly shown through these metrics.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`Performance`/`karmada-controller-manager`: Now when karmada-controller-manager tries to update a resource to a member cluster, it will attempt to compare the contents to skip redundant update operations. The optimization significantly reduces the execution-controller by 80% during the controller start-up.
```

