### PR TITLE
operator: fix the issue that the default values of Karmada are not correctly applied

### DIFF
--- a/operator/pkg/controller/karmada/controller.go
+++ b/operator/pkg/controller/karmada/controller.go
@@ -92,13 +92,13 @@ func (ctrl *Controller) Reconcile(ctx context.Context, req controllerruntime.Req
 		return ctrl.removeFinalizer(ctx, karmada)
 	}
 
+	if err := ctrl.updateKarmada(ctx, karmada); err != nil {
+		return controllerruntime.Result{}, err
+	}
+
 	if err := ctrl.validateKarmada(ctx, karmada); err != nil {
 		klog.Errorf("Validation failed for karmada: %+v", err)
 		return controllerruntime.Result{}, nil
-	}
-
-	if err := ctrl.ensureKarmada(ctx, karmada); err != nil {
-		return controllerruntime.Result{}, err
 	}
 
 	return controllerruntime.Result{}, ctrl.syncKarmada(karmada)
@@ -129,7 +129,7 @@ func (ctrl *Controller) removeFinalizer(ctx context.Context, karmada *operatorv1
 	})
 }
 
-func (ctrl *Controller) ensureKarmada(ctx context.Context, karmada *operatorv1alpha1.Karmada) error {
+func (ctrl *Controller) updateKarmada(ctx context.Context, karmada *operatorv1alpha1.Karmada) error {
 	// The object is not being deleted, so if it does not have our finalizer,
 	// then lets add the finalizer and update the object. This is equivalent
 	// registering our finalizer.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When the operator reconciles the Karmada CR, it will first validate the Karmada CR and then set the default values. This causes the validation to fail when users omit the configuration of certain fields.

It is necessary to set the default values first and then perform the validation. 


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
How to reproduce it:
1. deploy karmada-operator
```bash
$ hack/deploy-karmada-operator.sh {path/to/kubeconfig} {context}
```

2. deploy a karmada CR
```bash
$ kubectl apply -v=4 -f - <<EOF
apiVersion: operator.karmada.io/v1alpha1
kind: Karmada
metadata:
  name: karmada-demo
  namespace: test
spec:
  components:
    karmadaDescheduler: {}
    etcd: {}
EOF
```

3. view operator log
```bash
E0224 11:56:27.802480       1 controller.go:96] Validation failed for karmada: validation errors: [spec.components.etcd: Invalid value: v1alpha1.Etcd{Local:(*v1alpha1.LocalEtcd)(nil), External:(*v1alpha1.ExternalEtcd)(nil)}: unexpected empty etcd configuration]
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-operator`: fix the error of validation failure when some fields of the Karmada CR are not configured. 
```

