### PR TITLE
Allow configuring karmada-apiserver OIDC via Helm

### DIFF
--- a/charts/karmada/templates/karmada-apiserver.yaml
+++ b/charts/karmada/templates/karmada-apiserver.yaml
@@ -73,6 +73,35 @@ spec:
             - --max-requests-inflight={{ .Values.apiServer.maxRequestsInflight }}
             - --max-mutating-requests-inflight={{ .Values.apiServer.maxMutatingRequestsInflight }}
             - --tls-min-version=VersionTLS13
+            {{- with .Values.apiServer.oidc }}
+            {{- if .caFile }}
+            - --oidc-ca-file={{ .caFile }}
+            {{- end }}
+            {{- if .clientId }}
+            - --oidc-client-id={{ .clientId }}
+            {{- end }}
+            {{- if .groupsClaim }}
+            - --oidc-groups-claim={{ .groupsClaim }}
+            {{- end }}
+            {{- if .groupsPrefix }}
+            - --oidc-groups-prefix={{ .groupsPrefix }}
+            {{- end }}
+            {{- if .issuerUrl }}
+            - --oidc-issuer-url={{ .issuerUrl }}
+            {{- end }}
+            {{- if .requiredClaim }}
+            - --oidc-required-claim={{ .requiredClaim }}
+            {{- end }}
+            {{- if .signingAlgs }}
+            - --oidc-signing-algs={{ .signingAlgs }}
+            {{- end }}
+            {{- if .usernameClaim }}
+            - --oidc-username-claim={{ .usernameClaim }}
+            {{- end }}
+            {{- if .usernamePrefix }}
+            - --oidc-username-prefix={{ .usernamePrefix }}
+            {{- end }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 5443

--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -443,6 +443,17 @@ apiServer:
   podDisruptionBudget: *podDisruptionBudget
   ## @param apiServer.priorityClassName the priority class name for the karmada-apiserver
   priorityClassName: "system-node-critical"
+  oidc:
+    caFile: ""
+    clientId: ""
+    groupsClaim: ""
+    groupsPrefix: ""
+    issuerUrl: ""
+    # @param apiServer.oidc.requiredClaim comma separated 'key=value' pairs that describe required claims in the ID token
+    requiredClaim: ""
+    signingAlgs: ""
+    usernameClaim: ""
+    usernamePrefix: ""
 
 ## karmada aggregated apiserver config
 aggregatedApiServer:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Initial implementation of karmada-io/karmada#6144, for Helm only.

**Special notes for your reviewer**:

Other installation methods can be handled in separate PRs, if that's OK.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`HELM Chart`: OpenID Connect based auth can be configured for the Karmada API server when installing via Helm
```

