### PR TITLE
Make priorityClassSource in the SchedulePriority of PropagationPolicy a required field

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -19297,6 +19297,7 @@
       "description": "SchedulePriority defines how Karmada should resolve the priority and preemption policy for workload scheduling.",
       "type": "object",
       "required": [
+        "priorityClassSource",
         "priorityClassName"
       ],
       "properties": {
@@ -19305,7 +19306,7 @@
           "type": "string"
         },
         "priorityClassSource": {
-          "description": "PriorityClassSource specifies where Karmada should look for the PriorityClass definition. Available options: - KubePriorityClass (default): Uses Kubernetes PriorityClass (scheduling.k8s.io/v1) - PodPriorityClass: Uses PriorityClassName from PodTemplate: PodSpec.PriorityClassName (not yet implemented) - FederatedPriorityClass: Uses Karmada FederatedPriorityClass (not yet implemented)",
+          "description": "PriorityClassSource specifies where Karmada should look for the PriorityClass definition. Available options: - KubePriorityClass: Uses Kubernetes PriorityClass (scheduling.k8s.io/v1) - PodPriorityClass: Uses PriorityClassName from PodTemplate: PodSpec.PriorityClassName (not yet implemented) - FederatedPriorityClass: Uses Karmada FederatedPriorityClass (not yet implemented)",
           "type": "string"
         }
       }

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_clusterpropagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_clusterpropagationpolicies.yaml
@@ -902,11 +902,10 @@ spec:
                       - Not yet implemented.
                     type: string
                   priorityClassSource:
-                    default: KubePriorityClass
                     description: |-
                       PriorityClassSource specifies where Karmada should look for the PriorityClass definition.
                       Available options:
-                      - KubePriorityClass (default): Uses Kubernetes PriorityClass (scheduling.k8s.io/v1)
+                      - KubePriorityClass: Uses Kubernetes PriorityClass (scheduling.k8s.io/v1)
                       - PodPriorityClass: Uses PriorityClassName from PodTemplate: PodSpec.PriorityClassName (not yet implemented)
                       - FederatedPriorityClass: Uses Karmada FederatedPriorityClass (not yet implemented)
                     enum:
@@ -914,6 +913,7 @@ spec:
                     type: string
                 required:
                 - priorityClassName
+                - priorityClassSource
                 type: object
               schedulerName:
                 default: default-scheduler

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_propagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_propagationpolicies.yaml
@@ -899,11 +899,10 @@ spec:
                       - Not yet implemented.
                     type: string
                   priorityClassSource:
-                    default: KubePriorityClass
                     description: |-
                       PriorityClassSource specifies where Karmada should look for the PriorityClass definition.
                       Available options:
-                      - KubePriorityClass (default): Uses Kubernetes PriorityClass (scheduling.k8s.io/v1)
+                      - KubePriorityClass: Uses Kubernetes PriorityClass (scheduling.k8s.io/v1)
                       - PodPriorityClass: Uses PriorityClassName from PodTemplate: PodSpec.PriorityClassName (not yet implemented)
                       - FederatedPriorityClass: Uses Karmada FederatedPriorityClass (not yet implemented)
                     enum:
@@ -911,6 +910,7 @@ spec:
                     type: string
                 required:
                 - priorityClassName
+                - priorityClassSource
                 type: object
               schedulerName:
                 default: default-scheduler

--- a/pkg/apis/policy/v1alpha1/propagation_types.go
+++ b/pkg/apis/policy/v1alpha1/propagation_types.go
@@ -682,13 +682,12 @@ const (
 type SchedulePriority struct {
 	// PriorityClassSource specifies where Karmada should look for the PriorityClass definition.
 	// Available options:
-	// - KubePriorityClass (default): Uses Kubernetes PriorityClass (scheduling.k8s.io/v1)
+	// - KubePriorityClass: Uses Kubernetes PriorityClass (scheduling.k8s.io/v1)
 	// - PodPriorityClass: Uses PriorityClassName from PodTemplate: PodSpec.PriorityClassName (not yet implemented)
 	// - FederatedPriorityClass: Uses Karmada FederatedPriorityClass (not yet implemented)
 	//
-	// +kubebuilder:default="KubePriorityClass"
 	// +kubebuilder:validation:Enum=KubePriorityClass
-	// +optional
+	// +required
 	PriorityClassSource PriorityClassSource `json:"priorityClassSource,omitempty"`
 
 	// PriorityClassName specifies which PriorityClass to use. Its behavior depends on PriorityClassSource:

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -5150,7 +5150,7 @@ func schema_pkg_apis_policy_v1alpha1_SchedulePriority(ref common.ReferenceCallba
 				Properties: map[string]spec.Schema{
 					"priorityClassSource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PriorityClassSource specifies where Karmada should look for the PriorityClass definition. Available options: - KubePriorityClass (default): Uses Kubernetes PriorityClass (scheduling.k8s.io/v1) - PodPriorityClass: Uses PriorityClassName from PodTemplate: PodSpec.PriorityClassName (not yet implemented) - FederatedPriorityClass: Uses Karmada FederatedPriorityClass (not yet implemented)",
+							Description: "PriorityClassSource specifies where Karmada should look for the PriorityClass definition. Available options: - KubePriorityClass: Uses Kubernetes PriorityClass (scheduling.k8s.io/v1) - PodPriorityClass: Uses PriorityClassName from PodTemplate: PodSpec.PriorityClassName (not yet implemented) - FederatedPriorityClass: Uses Karmada FederatedPriorityClass (not yet implemented)",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5163,7 +5163,7 @@ func schema_pkg_apis_policy_v1alpha1_SchedulePriority(ref common.ReferenceCallba
 						},
 					},
 				},
-				Required: []string{"priorityClassName"},
+				Required: []string{"priorityClassSource", "priorityClassName"},
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Making it a required field allows for more flexibility in future changes. For example, if we need to modify the default value later, we can make it optional and explicitly define a default value.

**Which issue(s) this PR fixes**:
Part of #5961

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Make priorityClassSource in the SchedulePriority of PropagationPolicy a required field.
```

