### PR TITLE
Automated cherry pick of #6157 #6161 upstream release 1.11

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -492,7 +492,6 @@ func (d *ResourceDetector) ApplyPolicy(object *unstructured.Unstructured, object
 			bindingCopy.Labels = util.DedupeAndMergeLabels(bindingCopy.Labels, binding.Labels)
 			bindingCopy.Finalizers = util.DedupeAndMergeFinalizers(bindingCopy.Finalizers, binding.Finalizers)
 			bindingCopy.OwnerReferences = binding.OwnerReferences
-			bindingCopy.Finalizers = binding.Finalizers
 			bindingCopy.Spec.Resource = binding.Spec.Resource
 			bindingCopy.Spec.ReplicaRequirements = binding.Spec.ReplicaRequirements
 			bindingCopy.Spec.Replicas = binding.Spec.Replicas
@@ -588,7 +587,6 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 				bindingCopy.Labels = util.DedupeAndMergeLabels(bindingCopy.Labels, binding.Labels)
 				bindingCopy.Finalizers = util.DedupeAndMergeFinalizers(bindingCopy.Finalizers, binding.Finalizers)
 				bindingCopy.OwnerReferences = binding.OwnerReferences
-				bindingCopy.Finalizers = binding.Finalizers
 				bindingCopy.Spec.Resource = binding.Spec.Resource
 				bindingCopy.Spec.ReplicaRequirements = binding.Spec.ReplicaRequirements
 				bindingCopy.Spec.Replicas = binding.Spec.Replicas
@@ -636,7 +634,6 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 				bindingCopy.Labels = util.DedupeAndMergeLabels(bindingCopy.Labels, binding.Labels)
 				bindingCopy.Finalizers = util.DedupeAndMergeFinalizers(bindingCopy.Finalizers, binding.Finalizers)
 				bindingCopy.OwnerReferences = binding.OwnerReferences
-				bindingCopy.Finalizers = binding.Finalizers
 				bindingCopy.Spec.Resource = binding.Spec.Resource
 				bindingCopy.Spec.ReplicaRequirements = binding.Spec.ReplicaRequirements
 				bindingCopy.Spec.Replicas = binding.Spec.Replicas

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -490,6 +490,7 @@ func (d *ResourceDetector) ApplyPolicy(object *unstructured.Unstructured, object
 			// Just update necessary fields, especially avoid modifying Spec.Clusters which is scheduling result, if already exists.
 			bindingCopy.Annotations = util.DedupeAndMergeAnnotations(bindingCopy.Annotations, binding.Annotations)
 			bindingCopy.Labels = util.DedupeAndMergeLabels(bindingCopy.Labels, binding.Labels)
+			bindingCopy.Finalizers = util.DedupeAndMergeFinalizers(bindingCopy.Finalizers, binding.Finalizers)
 			bindingCopy.OwnerReferences = binding.OwnerReferences
 			bindingCopy.Finalizers = binding.Finalizers
 			bindingCopy.Spec.Resource = binding.Spec.Resource
@@ -585,6 +586,7 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 				// Just update necessary fields, especially avoid modifying Spec.Clusters which is scheduling result, if already exists.
 				bindingCopy.Annotations = util.DedupeAndMergeAnnotations(bindingCopy.Annotations, binding.Annotations)
 				bindingCopy.Labels = util.DedupeAndMergeLabels(bindingCopy.Labels, binding.Labels)
+				bindingCopy.Finalizers = util.DedupeAndMergeFinalizers(bindingCopy.Finalizers, binding.Finalizers)
 				bindingCopy.OwnerReferences = binding.OwnerReferences
 				bindingCopy.Finalizers = binding.Finalizers
 				bindingCopy.Spec.Resource = binding.Spec.Resource
@@ -632,6 +634,7 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 				// Just update necessary fields, especially avoid modifying Spec.Clusters which is scheduling result, if already exists.
 				bindingCopy.Annotations = util.DedupeAndMergeAnnotations(bindingCopy.Annotations, binding.Annotations)
 				bindingCopy.Labels = util.DedupeAndMergeLabels(bindingCopy.Labels, binding.Labels)
+				bindingCopy.Finalizers = util.DedupeAndMergeFinalizers(bindingCopy.Finalizers, binding.Finalizers)
 				bindingCopy.OwnerReferences = binding.OwnerReferences
 				bindingCopy.Finalizers = binding.Finalizers
 				bindingCopy.Spec.Resource = binding.Spec.Resource

--- a/pkg/util/label.go
+++ b/pkg/util/label.go
@@ -124,3 +124,21 @@ func RecordManagedLabels(object *unstructured.Unstructured) {
 	annotations[workv1alpha2.ManagedLabels] = strings.Join(managedKeys, ",")
 	object.SetAnnotations(annotations)
 }
+
+// DedupeAndMergeFinalizers merges the new finalizers into exist finalizers.
+func DedupeAndMergeFinalizers(existFinalizers, newFinalizers []string) []string {
+	if len(existFinalizers) == 0 {
+		return newFinalizers
+	}
+	existFinalizerSets := sets.Set[string]{}
+	existFinalizerSets.Insert(existFinalizers...)
+
+	var mergedFinalizers []string
+	mergedFinalizers = append(mergedFinalizers, existFinalizers...)
+	for _, item := range newFinalizers {
+		if !existFinalizerSets.Has(item) {
+			mergedFinalizers = append(mergedFinalizers, item)
+		}
+	}
+	return mergedFinalizers
+}


### PR DESCRIPTION
Cherry pick of https://github.com/karmada-io/karmada/pull/6157 https://github.com/karmada-io/karmada/pull/6161 on release-1.11.
https://github.com/karmada-io/karmada/pull/6157: fix(detector): fix new binding object
https://github.com/karmada-io/karmada/pull/6161: fix(detector): fix new binding object
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.

```release-note

`karmada-controller-manager`: Fixed the issue where the `detector` unnecessary updates for RB issue.

```

