### PR TITLE
[WIP] allow agent to register cluster with labels and annotations

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -165,7 +165,7 @@ func run(ctx context.Context, opts *options.Options) error {
 	registerOption := util.ClusterRegisterOption{
 		ClusterNamespace:   opts.ClusterNamespace,
 		ClusterName:        opts.ClusterName,
-		ClusterLabels:      parseLabelsAnnotations(opts.ClusterLables),
+		ClusterLabels:      parseLabelsAnnotations(opts.ClusterLabels),
 		ClusterAnnotations: parseLabelsAnnotations(opts.ClusterAnnotations),
 		ReportSecrets:      opts.ReportSecrets,
 		ClusterAPIEndpoint: opts.ClusterAPIEndpoint,

--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -54,7 +54,7 @@ type Options struct {
 	// Default value is the current-context.
 	KarmadaContext     string
 	ClusterName        string
-	ClusterLables      []string
+	ClusterLabels      []string
 	ClusterAnnotations []string
 	// ClusterNamespace holds the namespace name where the member cluster secrets are stored.
 	ClusterNamespace string
@@ -183,7 +183,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, allControllers []string) {
 	fs.StringVar(&o.KarmadaKubeConfig, "karmada-kubeconfig", o.KarmadaKubeConfig, "Path to karmada control plane kubeconfig file.")
 	fs.StringVar(&o.KarmadaContext, "karmada-context", "", "Name of the cluster context in karmada control plane kubeconfig file.")
 	fs.StringVar(&o.ClusterName, "cluster-name", o.ClusterName, "Name of member cluster that the agent serves for.")
-	fs.StringArrayVar(&o.ClusterLables, "cluster-labels", []string{}, "Specify labels for the member cluster in the format <key>=<value> e.g., --cluster-labels=foo=bar. You can use this flag multiple times. Note that it reconciles the labels of the cluster object when the agent restarts.")
+	fs.StringArrayVar(&o.ClusterLabels, "cluster-labels", []string{}, "Specify labels for the member cluster in the format <key>=<value> e.g., --cluster-labels=foo=bar. You can use this flag multiple times. Note that it reconciles the labels of the cluster object when the agent restarts.")
 	fs.StringArrayVar(&o.ClusterAnnotations, "cluster-annotations", []string{}, "Specify annotations for the member cluster in the format <key>=<value> e.g., --cluster-annotations=foo=bar. You can use this flag multiple times. Note that it reconciles the annotations of the cluster object when the agent restarts.")
 	fs.StringVar(&o.ClusterNamespace, "cluster-namespace", DefaultKarmadaClusterNamespace, "Namespace in the control plane where member cluster secrets are stored.")
 	fs.DurationVar(&o.ClusterStatusUpdateFrequency.Duration, "cluster-status-update-frequency", 10*time.Second, "Specifies how often karmada-agent posts cluster status to karmada-apiserver. Note: be cautious when changing the constant, it must work with ClusterMonitorGracePeriod in karmada-controller-manager.")

--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -52,8 +52,10 @@ type Options struct {
 	KarmadaKubeConfig string
 	// ClusterContext is the name of the cluster context in control plane KUBECONFIG file.
 	// Default value is the current-context.
-	KarmadaContext string
-	ClusterName    string
+	KarmadaContext     string
+	ClusterName        string
+	ClusterLables      []string
+	ClusterAnnotations []string
 	// ClusterNamespace holds the namespace name where the member cluster secrets are stored.
 	ClusterNamespace string
 	// ClusterStatusUpdateFrequency is the frequency that controller computes and report cluster status.
@@ -181,6 +183,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, allControllers []string) {
 	fs.StringVar(&o.KarmadaKubeConfig, "karmada-kubeconfig", o.KarmadaKubeConfig, "Path to karmada control plane kubeconfig file.")
 	fs.StringVar(&o.KarmadaContext, "karmada-context", "", "Name of the cluster context in karmada control plane kubeconfig file.")
 	fs.StringVar(&o.ClusterName, "cluster-name", o.ClusterName, "Name of member cluster that the agent serves for.")
+	fs.StringArrayVar(&o.ClusterLables, "cluster-labels", []string{}, "Lables of the member cluster")
+	fs.StringArrayVar(&o.ClusterAnnotations, "cluster-annotations", []string{}, "Annotations of the member cluster")
 	fs.StringVar(&o.ClusterNamespace, "cluster-namespace", DefaultKarmadaClusterNamespace, "Namespace in the control plane where member cluster secrets are stored.")
 	fs.DurationVar(&o.ClusterStatusUpdateFrequency.Duration, "cluster-status-update-frequency", 10*time.Second, "Specifies how often karmada-agent posts cluster status to karmada-apiserver. Note: be cautious when changing the constant, it must work with ClusterMonitorGracePeriod in karmada-controller-manager.")
 	fs.DurationVar(&o.ClusterLeaseDuration.Duration, "cluster-lease-duration", 40*time.Second,

--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -183,8 +183,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, allControllers []string) {
 	fs.StringVar(&o.KarmadaKubeConfig, "karmada-kubeconfig", o.KarmadaKubeConfig, "Path to karmada control plane kubeconfig file.")
 	fs.StringVar(&o.KarmadaContext, "karmada-context", "", "Name of the cluster context in karmada control plane kubeconfig file.")
 	fs.StringVar(&o.ClusterName, "cluster-name", o.ClusterName, "Name of member cluster that the agent serves for.")
-	fs.StringArrayVar(&o.ClusterLables, "cluster-labels", []string{}, "Lables of the member cluster")
-	fs.StringArrayVar(&o.ClusterAnnotations, "cluster-annotations", []string{}, "Annotations of the member cluster")
+	fs.StringArrayVar(&o.ClusterLables, "cluster-labels", []string{}, "Specify labels for the member cluster in the format <key>=<value> e.g., --cluster-labels=foo=bar. You can use this flag multiple times. Note that it reconciles the labels of the cluster object when the agent restarts.")
+	fs.StringArrayVar(&o.ClusterAnnotations, "cluster-annotations", []string{}, "Specify annotations for the member cluster in the format <key>=<value> e.g., --cluster-annotations=foo=bar. You can use this flag multiple times. Note that it reconciles the annotations of the cluster object when the agent restarts.")
 	fs.StringVar(&o.ClusterNamespace, "cluster-namespace", DefaultKarmadaClusterNamespace, "Namespace in the control plane where member cluster secrets are stored.")
 	fs.DurationVar(&o.ClusterStatusUpdateFrequency.Duration, "cluster-status-update-frequency", 10*time.Second, "Specifies how often karmada-agent posts cluster status to karmada-apiserver. Note: be cautious when changing the constant, it must work with ClusterMonitorGracePeriod in karmada-controller-manager.")
 	fs.DurationVar(&o.ClusterLeaseDuration.Duration, "cluster-lease-duration", 40*time.Second,

--- a/cmd/agent/app/options/validation.go
+++ b/cmd/agent/app/options/validation.go
@@ -33,6 +33,25 @@ func (o *Options) Validate() field.ErrorList {
 		errs = append(errs, field.Invalid(newPath.Child("ClusterName"), o.ClusterName, strings.Join(errMsgs, ",")))
 	}
 
+	parseLabelsAnnotations := func(inputs []string) map[string]string {
+		outputs := make(map[string]string)
+		for _, v := range inputs {
+			key, value, found := strings.Cut(v, "=")
+			if found {
+				outputs[key] = value
+			}
+		}
+		return outputs
+	}
+
+	if o.ClusterLables != nil {
+		errs = append(errs, validation.ValidateClusterLabels(parseLabelsAnnotations(o.ClusterLables))...)
+	}
+
+	if o.ClusterAnnotations != nil {
+		errs = append(errs, validation.ValidateClusterAnnotationss(parseLabelsAnnotations(o.ClusterAnnotations))...)
+	}
+
 	if o.ClusterStatusUpdateFrequency.Duration < 0 {
 		errs = append(errs, field.Invalid(newPath.Child("ClusterStatusUpdateFrequency"), o.ClusterStatusUpdateFrequency, "must be greater than or equal to 0"))
 	}

--- a/cmd/agent/app/options/validation.go
+++ b/cmd/agent/app/options/validation.go
@@ -44,12 +44,12 @@ func (o *Options) Validate() field.ErrorList {
 		return outputs
 	}
 
-	if o.ClusterLables != nil {
-		errs = append(errs, validation.ValidateClusterLabels(parseLabelsAnnotations(o.ClusterLables))...)
+	if o.ClusterLabels != nil {
+		errs = append(errs, validation.ValidateClusterLabels(parseLabelsAnnotations(o.ClusterLabels))...)
 	}
 
 	if o.ClusterAnnotations != nil {
-		errs = append(errs, validation.ValidateClusterAnnotationss(parseLabelsAnnotations(o.ClusterAnnotations))...)
+		errs = append(errs, validation.ValidateClusterAnnotations(parseLabelsAnnotations(o.ClusterAnnotations))...)
 	}
 
 	if o.ClusterStatusUpdateFrequency.Duration < 0 {

--- a/cmd/agent/app/options/validation_test.go
+++ b/cmd/agent/app/options/validation_test.go
@@ -73,7 +73,7 @@ func TestValidateKarmadaAgentConfiguration(t *testing.T) {
 		},
 		"invalid ClusterLabels": {
 			opt: New(func(options *Options) {
-				options.ClusterLables = []string{"key=invalid=value"}
+				options.ClusterLabels = []string{"key=invalid=value"}
 			}),
 			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("ClusterLabels"), "invalid=value", "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')")},
 		},

--- a/cmd/agent/app/options/validation_test.go
+++ b/cmd/agent/app/options/validation_test.go
@@ -71,6 +71,18 @@ func TestValidateKarmadaAgentConfiguration(t *testing.T) {
 			}),
 			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("ClusterName"), "", "must be not empty")},
 		},
+		"invalid ClusterLabels": {
+			opt: New(func(options *Options) {
+				options.ClusterLables = []string{"key=invalid=value"}
+			}),
+			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("ClusterLabels"), "invalid=value", "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')")},
+		},
+		"invalid ClusterAnnotations": {
+			opt: New(func(options *Options) {
+				options.ClusterAnnotations = []string{"_key=value"}
+			}),
+			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("ClusterAnnotations"), "_key", "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')")},
+		},
 		"invalid ClusterStatusUpdateFrequency": {
 			opt: New(func(options *Options) {
 				options.ClusterStatusUpdateFrequency = metav1.Duration{Duration: -10 * time.Second}

--- a/pkg/apis/cluster/validation/validation.go
+++ b/pkg/apis/cluster/validation/validation.go
@@ -60,8 +60,8 @@ func ValidateClusterLabels(labels map[string]string) field.ErrorList {
 	return metav1validation.ValidateLabels(labels, field.NewPath("Options.ClusterLabels"))
 }
 
-// ValidateClusterAnnotationss tests whether the annotations passed are valid
-func ValidateClusterAnnotationss(annotations map[string]string) field.ErrorList {
+// ValidateClusterAnnotations tests whether the annotations passed are valid
+func ValidateClusterAnnotations(annotations map[string]string) field.ErrorList {
 	return validation.ValidateAnnotations(annotations, field.NewPath("Options.ClusterAnnotations"))
 }
 

--- a/pkg/apis/cluster/validation/validation.go
+++ b/pkg/apis/cluster/validation/validation.go
@@ -22,7 +22,9 @@ import (
 	"net/url"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/validation"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/util/sets"
 	kubevalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -51,6 +53,16 @@ func ValidateClusterName(name string) []string {
 	}
 
 	return kubevalidation.IsDNS1123Label(name)
+}
+
+// ValidateClusterLabels tests whether the labels passed are valid
+func ValidateClusterLabels(labels map[string]string) field.ErrorList {
+	return metav1validation.ValidateLabels(labels, field.NewPath("Options.ClusterLabels"))
+}
+
+// ValidateClusterAnnotationss tests whether the annotations passed are valid
+func ValidateClusterAnnotationss(annotations map[string]string) field.ErrorList {
+	return validation.ValidateAnnotations(annotations, field.NewPath("Options.ClusterAnnotations"))
 }
 
 var (

--- a/pkg/util/cluster.go
+++ b/pkg/util/cluster.go
@@ -146,7 +146,7 @@ func CreateOrUpdateClusterObject(controlPlaneClient karmadaclientset.Interface, 
 		clusterCopy := cluster.DeepCopy()
 		mutate(cluster)
 		if reflect.DeepEqual(clusterCopy.ObjectMeta.Annotations, cluster.ObjectMeta.Annotations) && reflect.DeepEqual(clusterCopy.ObjectMeta.Labels, cluster.ObjectMeta.Labels) && reflect.DeepEqual(clusterCopy.Spec, cluster.Spec) {
-			klog.Warningf("Cluster(%s) already exist and newest", clusterObj.Name)
+			klog.Infof("Skip updating Cluster(%s) as it is already up-to-date.", clusterObj.Name)
 			return cluster, nil
 		}
 

--- a/pkg/util/cluster.go
+++ b/pkg/util/cluster.go
@@ -145,7 +145,7 @@ func CreateOrUpdateClusterObject(controlPlaneClient karmadaclientset.Interface, 
 	if exist {
 		clusterCopy := cluster.DeepCopy()
 		mutate(cluster)
-		if reflect.DeepEqual(clusterCopy, cluster) {
+		if reflect.DeepEqual(clusterCopy.ObjectMeta.Annotations, cluster.ObjectMeta.Annotations) && reflect.DeepEqual(clusterCopy.ObjectMeta.Labels, cluster.ObjectMeta.Labels) && reflect.DeepEqual(clusterCopy.Spec, cluster.Spec) {
 			klog.Warningf("Cluster(%s) already exist and newest", clusterObj.Name)
 			return cluster, nil
 		}

--- a/pkg/util/cluster.go
+++ b/pkg/util/cluster.go
@@ -52,6 +52,8 @@ const (
 type ClusterRegisterOption struct {
 	ClusterNamespace   string
 	ClusterName        string
+	ClusterLabels      map[string]string
+	ClusterAnnotations map[string]string
 	ReportSecrets      []string
 	ClusterAPIEndpoint string
 	ProxyServerAddress string
@@ -143,7 +145,7 @@ func CreateOrUpdateClusterObject(controlPlaneClient karmadaclientset.Interface, 
 	if exist {
 		clusterCopy := cluster.DeepCopy()
 		mutate(cluster)
-		if reflect.DeepEqual(clusterCopy.Spec, cluster.Spec) {
+		if reflect.DeepEqual(clusterCopy, cluster) {
 			klog.Warningf("Cluster(%s) already exist and newest", clusterObj.Name)
 			return cluster, nil
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
To allow agent to directly register/update the cluster with the label/annotation
If the labels/annotations are passed via the agent cli flags, it will be reconciled if the agent pod restarts. 
**Which issue(s) this PR fixes**:
Fixes #6175 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

