### PR TITLE
Standardize the naming of karmada secrets in karmadactl method

### DIFF
--- a/pkg/karmadactl/addons/descheduler/manifests.go
+++ b/pkg/karmadactl/addons/descheduler/manifests.go
@@ -49,9 +49,9 @@ spec:
             - --metrics-bind-address=0.0.0.0:8080
             - --health-probe-bind-address=0.0.0.0:10358
             - --leader-elect-resource-namespace={{ .Namespace }}
-            - --scheduler-estimator-ca-file=/etc/karmada/pki/ca.crt
-            - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada.crt
-            - --scheduler-estimator-key-file=/etc/karmada/pki/karmada.key
+            - --scheduler-estimator-ca-file=/etc/karmada/pki//etc/karmada/pki/scheduler-estimator-client/ca.crt
+            - --scheduler-estimator-cert-file=/etc/karmada/pki/scheduler-estimator-client/tls.crt
+            - --scheduler-estimator-key-file=/etc/karmada/pki/scheduler-estimator-client/tls.key
             - --v=4
           livenessProbe:
             httpGet:
@@ -69,16 +69,16 @@ spec:
           volumeMounts:
             - name: karmada-config
               mountPath: /etc/karmada/config
-            - name: k8s-certs
-              mountPath: /etc/karmada/pki
+            - name: scheduler-estimator-client-cert
+              mountPath: /etc/karmada/pki/scheduler-estimator-client
               readOnly: true
       volumes:
         - name: karmada-config
           secret:
             secretName: karmada-descheduler-config
-        - name: k8s-certs
+        - name: scheduler-estimator-client-cert
           secret:
-            secretName: karmada-cert
+            secretName: karmada-descheduler-scheduler-estimator-client-cert
 `
 
 // DeploymentReplace is a struct to help to concrete

--- a/pkg/karmadactl/addons/estimator/manifests.go
+++ b/pkg/karmadactl/addons/estimator/manifests.go
@@ -49,9 +49,9 @@ spec:
             - /bin/karmada-scheduler-estimator
             - --kubeconfig=/etc/{{ .MemberClusterName}}-kubeconfig
             - --cluster-name={{ .MemberClusterName}}
-            - --grpc-auth-cert-file=/etc/karmada/pki/karmada.crt
-            - --grpc-auth-key-file=/etc/karmada/pki/karmada.key
-            - --grpc-client-ca-file=/etc/karmada/pki/ca.crt
+            - --grpc-auth-cert-file=/etc/karmada/pki/server/tls.crt
+            - --grpc-auth-key-file=/etc/karmada/pki/server/tls.key
+            - --grpc-client-ca-file=/etc/karmada/pki/server/ca.crt
             - --metrics-bind-address=0.0.0.0:8080
             - --health-probe-bind-address=0.0.0.0:10351
           livenessProbe:
@@ -75,7 +75,7 @@ spec:
               subPath: {{ .MemberClusterName}}-kubeconfig
               mountPath: /etc/{{ .MemberClusterName}}-kubeconfig
       volumes:
-        - name: k8s-certs
+        - name: server-cert
           secret:
             secretName: karmada-cert
         - name: member-kubeconfig


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
In karmada, here are two important secrets, which are mounted by most karmada components. One is karmada-cert, which contains a series of cert files like ca.crt, apiserver.crt and so on; another is karmada-kubeconfig, which contains a kubeconfig of karmada-apiserver.

However, in different installation methods, we used inconsistent secret naming or file path naming, which can potentially cause some unnecessary problems, details refer to https://github.com/karmada-io/karmada/issues/5363.

This PR aims to standardize the naming of karmada secrets in karmadactl installation method.

**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/karmada/issues/5363

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

