### PR TITLE
Fix missing ClusterRole, ClusterRoleBinding, and ServiceAccount for Custom Cert Mode in Helm Chart

### DIFF
--- a/charts/karmada/templates/pre-install-job.yaml
+++ b/charts/karmada/templates/pre-install-job.yaml
@@ -182,6 +182,58 @@ data:
     {{- $.Files.Get $path | nindent 8 }}
   {{ end }}
 
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}-hook-job
+  namespace: {{ $namespace }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "1"
+  {{- if "karmada.preInstallJob.labels" }}
+  labels:
+    {{- include "karmada.preInstallJob.labels" . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $name }}-hook-job
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "1"
+  {{- if "karmada.preInstallJob.labels" }}
+  labels:
+    {{- include "karmada.preInstallJob.labels" . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups: ['*']
+    resources: ['*']
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+  - nonResourceURLs: ['*']
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $name }}-hook-job
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "1"
+  {{- if "karmada.preInstallJob.labels" }}
+  labels:
+    {{- include "karmada.preInstallJob.labels" . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $name }}-hook-job
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}-hook-job
+    namespace: {{ $namespace }}
+
 {{- if eq .Values.certs.mode "custom" }}
 ---
 apiVersion: v1
@@ -445,57 +497,6 @@ spec:
           name: {{ $name }}-config
       - name: configs
         emptyDir: {}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ $name }}-hook-job
-  namespace: {{ $namespace }}
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "1"
-  {{- if "karmada.preInstallJob.labels" }}
-  labels:
-    {{- include "karmada.preInstallJob.labels" . | nindent 4 }}
-  {{- end }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ $name }}-hook-job
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "1"
-  {{- if "karmada.preInstallJob.labels" }}
-  labels:
-    {{- include "karmada.preInstallJob.labels" . | nindent 4 }}
-  {{- end }}
-rules:
-  - apiGroups: ['*']
-    resources: ['*']
-    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
-  - nonResourceURLs: ['*']
-    verbs: ["get"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ $name }}-hook-job
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "1"
-  {{- if "karmada.preInstallJob.labels" }}
-  labels:
-    {{- include "karmada.preInstallJob.labels" . | nindent 4 }}
-  {{- end }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ $name }}-hook-job
-subjects:
-  - kind: ServiceAccount
-    name: {{ $name }}-hook-job
-    namespace: {{ $namespace }}
 ---
 {{- end }}
 {{- end }}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
When installing Karmada using the Helm chart with `certs.mode` set to `custom`, the required `ClusterRole`, `ClusterRoleBinding`, and `ServiceAccount` are not created: https://github.com/karmada-io/karmada/blob/master/charts/karmada/templates/pre-install-job.yaml#L449-L498. 
These resources are essential for the [static-resource-job](https://github.com/karmada-io/karmada/blob/master/charts/karmada/templates/karmada-static-resource-job.yaml#L32), [post-delete-job](https://github.com/karmada-io/karmada/blob/master/charts/karmada/templates/post-delete-job.yaml#L36), and [post-install-job](https://github.com/karmada-io/karmada/blob/master/charts/karmada/templates/post-install-job.yaml#L42) to function correctly.

To resolve this issue, the installation of these resources has been moved outside the certificate mode conditional check, ensuring they are created regardless of the selected certificate mode.

**Which issue(s) this PR fixes**:
Fixes #6185

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
None
```

