### PR TITLE
Add Support to Configure Leaf Certificate Validity Period in Karmada Operator

### DIFF
--- a/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
+++ b/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
@@ -5197,6 +5197,13 @@ spec:
                           referenced.
                         type: string
                     type: object
+                  leafCertValidityDays:
+                    description: |-
+                      LeafCertValidityDays specifies the validity period of leaf certificates (e.g., API Server certificate) in days.
+                      If not specified, the default validity period of 1 year will be used.
+                    format: int32
+                    minimum: 1
+                    type: integer
                 type: object
               featureGates:
                 additionalProperties:

--- a/operator/config/crds/operator.karmada.io_karmadas.yaml
+++ b/operator/config/crds/operator.karmada.io_karmadas.yaml
@@ -5197,6 +5197,13 @@ spec:
                           referenced.
                         type: string
                     type: object
+                  leafCertValidityDays:
+                    description: |-
+                      LeafCertValidityDays specifies the validity period of leaf certificates (e.g., API Server certificate) in days.
+                      If not specified, the default validity period of 1 year will be used.
+                    format: int32
+                    minimum: 1
+                    type: integer
                 type: object
               featureGates:
                 additionalProperties:

--- a/operator/pkg/apis/operator/v1alpha1/type.go
+++ b/operator/pkg/apis/operator/v1alpha1/type.go
@@ -133,6 +133,12 @@ type CustomCertificate struct {
 	// all components that access the APIServer as clients.
 	// +optional
 	APIServerCACert *LocalSecretReference `json:"apiServerCACert,omitempty"`
+
+	// LeafCertValidityDays specifies the validity period of leaf certificates (e.g., API Server certificate) in days.
+	// If not specified, the default validity period of 1 year will be used.
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	LeafCertValidityDays *int32 `json:"leafCertValidityDays,omitempty"`
 }
 
 // ImageRegistry represents an image registry as well as the

--- a/operator/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -114,6 +114,11 @@ func (in *CustomCertificate) DeepCopyInto(out *CustomCertificate) {
 		*out = new(LocalSecretReference)
 		**out = **in
 	}
+	if in.LeafCertValidityDays != nil {
+		in, out := &in.LeafCertValidityDays, &out.LeafCertValidityDays
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/operator/pkg/tasks/init/cert.go
+++ b/operator/pkg/tasks/init/cert.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -198,6 +199,12 @@ func mutateCertConfig(data InitData, cc *certs.CertConfig) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if data.CustomCertificate().LeafCertValidityDays != nil {
+		certValidityDuration := time.Hour * 24 * time.Duration(*data.CustomCertificate().LeafCertValidityDays)
+		notAfter := time.Now().Add(certValidityDuration).UTC()
+		cc.NotAfter = &notAfter
 	}
 
 	return nil


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
This is an implementation of this [proposal](https://github.com/karmada-io/karmada/pull/6176) to add support to the Karmada operator for configuring the validity period of control plane leaf certificates.

### With Default Validity
```shell
mc -n karmada-system get karmadas.operator.karmada.io t1 -oyaml | yq '.spec.customCertificate'
```

```yaml
null
```

```shell
mc -n karmada-system get secrets t1-karmada-cert -o jsonpath='{.data.apiserver\.crt}' | base64 --decode | openssl x509 -text -noout | grep -i "not after"
```

```text
Not After : Mar  9 16:10:09 2026 GMT
```

### With Custom Validity

```shell
mc -n karmada-system get karmadas.operator.karmada.io t2 -oyaml | yq '.spec.customCertificate'
```

```yaml
leafCertValidityDays: 90
```

```shell
mc -n karmada-system get secrets t2-karmada-cert -o jsonpath='{.data.apiserver\.crt}' | base64 --decode | openssl x509 -text -noout | grep -i "not after"
```

```text
Not After : Jun  7 16:12:19 2025 GMT
```


**Which issue(s) this PR fixes**:
Part of #6174
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-operator`: The new `spec.customCertificate.leafCertValidityDays` field can optionally be used to specify a custom validity period in days for control plane leaf certificates (e.g., API server certificate). When not explicitly set, the default validity period of 1 year is used.
```