### PR TITLE
fix(dependenciesdistributor): reduce update trigger

### DIFF
--- a/pkg/dependenciesdistributor/dependencies_distributor_test.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor_test.go
@@ -114,7 +114,7 @@ func Test_OnUpdate(t *testing.T) {
 					},
 				},
 			},
-			wantQueueSize: 2,
+			wantQueueSize: 1,
 		},
 		{
 			name: "do not update the object, no specification changed",
@@ -139,6 +139,130 @@ func Test_OnUpdate(t *testing.T) {
 				},
 			},
 			wantQueueSize: 0,
+		},
+		{
+			name: "no specification changed, labels changed",
+			args: args{
+				oldObj: &corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Node",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Labels: map[string]string{
+							"app": "test",
+						},
+					},
+				},
+				newObj: &corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Node",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Labels: map[string]string{
+							"app": "new-test",
+						},
+					},
+				},
+			},
+			wantQueueSize: 2,
+		},
+		{
+			name: "specification changed, labels not changed",
+			args: args{
+				oldObj: &corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Node",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Labels: map[string]string{
+							"app": "test",
+						},
+					},
+				},
+				newObj: &corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Node",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Labels: map[string]string{
+							"app": "test",
+						},
+					},
+				},
+			},
+			wantQueueSize: 1,
+		},
+		{
+			name: "specification changed,  more than two elements in labels and not changed",
+			args: args{
+				oldObj: &corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Node",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Labels: map[string]string{
+							"app":    "test",
+							"online": "svc",
+						},
+					},
+				},
+				newObj: &corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Node",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Labels: map[string]string{
+							"online": "svc",
+							"app":    "test",
+						},
+					},
+				},
+			},
+			wantQueueSize: 1,
+		},
+		{
+			name: "specification changed,  more than two elements in labels and changed",
+			args: args{
+				oldObj: &corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Node",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Labels: map[string]string{
+							"app":    "test",
+							"online": "svc",
+						},
+					},
+				},
+				newObj: &corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Node",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Labels: map[string]string{
+							"online": "svc1",
+							"app":    "test",
+						},
+					},
+				},
+			},
+			wantQueueSize: 2,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Each time a dependency resource is updated, dependenciesdistributor reconcile will be triggered and executed twice, if  `labels` field not updated, the second time is unnecessary.

**Which issue(s) this PR fixes**:

When dependent resources are updated, reconcile is triggered twice. If labels are not updated, the second reconcile is meaningless.

The queue provided by go-client will automatically deduplicate if the same resource object key exists, provided that the resource object key is comparable, that is, implements the Comparable interface. The following types can be compared:

![image](https://github.com/user-attachments/assets/de349727-15a1-4c6e-b3bb-9292f43d56ae)

For the type `LabelsKey`, because there is an element labels, which is a map type, and  `LabelsKey` is pointer type, it becomes an incomparable type.

https://github.com/karmada-io/karmada/blob/65e7f74c991631a5888f5176342af118f4d5712e/pkg/dependenciesdistributor/dependencies_distributor.go#L603-L624

https://github.com/karmada-io/karmada/blob/56b72f1a80634d18b12bbfa87131a7a367b7e2ff/pkg/dependenciesdistributor/dependencies_distributor.go#L87-L90

https://github.com/karmada-io/karmada/blob/56b72f1a80634d18b12bbfa87131a7a367b7e2ff/vendor/k8s.io/client-go/util/workqueue/rate_limiting_queue.go#L93-L110

https://github.com/karmada-io/karmada/blob/56b72f1a80634d18b12bbfa87131a7a367b7e2ff/vendor/k8s.io/client-go/util/workqueue/queue.go#L240-L263

https://github.com/karmada-io/karmada/blob/56b72f1a80634d18b12bbfa87131a7a367b7e2ff/vendor/k8s.io/client-go/util/workqueue/queue.go#L222-L224



**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

