### PR TITLE
Automated cherry pick of #6180: Fix issues with running multiple Karmada instances in the

### DIFF
--- a/hack/deploy-karmada-operator.sh
+++ b/hack/deploy-karmada-operator.sh
@@ -70,4 +70,4 @@ kubectl --kubeconfig="${KUBECONFIG}" --context="${CONTEXT_NAME}" apply -f "${REP
 kubectl --kubeconfig="${KUBECONFIG}" --context="${CONTEXT_NAME}" apply -f "${REPO_ROOT}/operator/config/deploy/karmada-operator-deployment.yaml"
 
 # wait karmada-operator ready
-kubectl --kubeconfig="${KUBECONFIG}" --context="${CONTEXT_NAME}" wait --for=condition=Ready --timeout=30s pods -l karmada-app=karmada-operator -n ${KARMADA_SYSTEM_NAMESPACE}
+kubectl --kubeconfig="${KUBECONFIG}" --context="${CONTEXT_NAME}" wait --for=condition=Ready --timeout=30s pods -l app.kubernetes.io/name=karmada-operator -n ${KARMADA_SYSTEM_NAMESPACE}

--- a/hack/local-up-karmada-by-operator.sh
+++ b/hack/local-up-karmada-by-operator.sh
@@ -84,7 +84,7 @@ cd -
 CRDTARBALL_URL="http://local"
 DATA_DIR="/var/lib/karmada"
 CRD_CACHE_DIR=$(getCrdsDir "${DATA_DIR}" "${CRDTARBALL_URL}")
-OPERATOR_POD_NAME=$(kubectl --kubeconfig="${MAIN_KUBECONFIG}" --context="${HOST_CLUSTER_NAME}" get pods -n ${KARMADA_SYSTEM_NAMESPACE} -l karmada-app=karmada-operator -o custom-columns=NAME:.metadata.name --no-headers)
+OPERATOR_POD_NAME=$(kubectl --kubeconfig="${MAIN_KUBECONFIG}" --context="${HOST_CLUSTER_NAME}" get pods -n ${KARMADA_SYSTEM_NAMESPACE} -l app.kubernetes.io/name=karmada-operator -o custom-columns=NAME:.metadata.name --no-headers)
 kubectl --kubeconfig="${MAIN_KUBECONFIG}" --context="${HOST_CLUSTER_NAME}" exec -i ${OPERATOR_POD_NAME} -n ${KARMADA_SYSTEM_NAMESPACE} -- mkdir -p ${CRD_CACHE_DIR}
 kubectl --kubeconfig="${MAIN_KUBECONFIG}" --context="${HOST_CLUSTER_NAME}" cp ${REPO_ROOT}/crds.tar.gz ${KARMADA_SYSTEM_NAMESPACE}/${OPERATOR_POD_NAME}:${CRD_CACHE_DIR}
 

--- a/hack/operator-e2e-environment.sh
+++ b/hack/operator-e2e-environment.sh
@@ -77,6 +77,6 @@ cd -
 CRDTARBALL_URL="http://local"
 DATA_DIR="/var/lib/karmada"
 CRD_CACHE_DIR=$(getCrdsDir "${DATA_DIR}" "${CRDTARBALL_URL}")
-OPERATOR_POD_NAME=$(kubectl --kubeconfig="${MAIN_KUBECONFIG}" --context="${HOST_CLUSTER_NAME}" get pods -n ${KARMADA_SYSTEM_NAMESPACE} -l karmada-app=karmada-operator -o custom-columns=NAME:.metadata.name --no-headers)
+OPERATOR_POD_NAME=$(kubectl --kubeconfig="${MAIN_KUBECONFIG}" --context="${HOST_CLUSTER_NAME}" get pods -n ${KARMADA_SYSTEM_NAMESPACE} -l app.kubernetes.io/name=karmada-operator -o custom-columns=NAME:.metadata.name --no-headers)
 kubectl --kubeconfig="${MAIN_KUBECONFIG}" --context="${HOST_CLUSTER_NAME}" exec -i ${OPERATOR_POD_NAME} -n ${KARMADA_SYSTEM_NAMESPACE} -- mkdir -p ${CRD_CACHE_DIR}
 kubectl --kubeconfig="${MAIN_KUBECONFIG}" --context="${HOST_CLUSTER_NAME}" cp ${REPO_ROOT}/crds.tar.gz ${KARMADA_SYSTEM_NAMESPACE}/${OPERATOR_POD_NAME}:${CRD_CACHE_DIR}

--- a/operator/config/deploy/karmada-operator-clusterrole.yaml
+++ b/operator/config/deploy/karmada-operator-clusterrole.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   name: karmada-operator
   labels:
-    karmada-app: karmada-operator
+    app.kubernetes.io/name: karmada-operator
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"] # karmada-operator requires access to the Lease resource for leader election

--- a/operator/config/deploy/karmada-operator-clusterrolebinding.yaml
+++ b/operator/config/deploy/karmada-operator-clusterrolebinding.yaml
@@ -3,7 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   name: karmada-operator
   labels:
-    karmada-app: karmada-operator
+    app.kubernetes.io/name: karmada-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/operator/config/deploy/karmada-operator-deployment.yaml
+++ b/operator/config/deploy/karmada-operator-deployment.yaml
@@ -4,16 +4,16 @@ metadata:
   name: karmada-operator
   namespace: karmada-system
   labels:
-    karmada-app: karmada-operator
+    app.kubernetes.io/name: karmada-operator
 spec:
   replicas: 1
   selector:
     matchLabels:
-      karmada-app: karmada-operator
+      app.kubernetes.io/name: karmada-operator
   template:
     metadata:
       labels:
-        karmada-app: karmada-operator
+        app.kubernetes.io/name: karmada-operator
     spec:
       containers:
       - name: karmada-operator

--- a/operator/config/deploy/karmada-operator-serviceaccount.yaml
+++ b/operator/config/deploy/karmada-operator-serviceaccount.yaml
@@ -4,4 +4,4 @@ metadata:
   name: karmada-operator
   namespace: karmada-system
   labels:
-    karmada-app: karmada-operator
+    app.kubernetes.io/name: karmada-operator

--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -121,6 +121,9 @@ const (
 
 	// APIServiceName defines the karmada aggregated apiserver APIService resource name.
 	APIServiceName = "v1alpha1.cluster.karmada.io"
+
+	AppNameLabel     = "app.kubernetes.io/name"
+	AppInstanceLabel = "app.kubernetes.io/instance"
 )
 
 var (

--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -122,7 +122,9 @@ const (
 	// APIServiceName defines the karmada aggregated apiserver APIService resource name.
 	APIServiceName = "v1alpha1.cluster.karmada.io"
 
-	AppNameLabel     = "app.kubernetes.io/name"
+	// AppNameLabel defines the recommended label for identifying an application.
+	AppNameLabel = "app.kubernetes.io/name"
+	// AppInstanceLabel defines the recommended label for identifying an application instance.
 	AppInstanceLabel = "app.kubernetes.io/instance"
 )
 

--- a/operator/pkg/controlplane/apiserver/apiserver.go
+++ b/operator/pkg/controlplane/apiserver/apiserver.go
@@ -52,17 +52,18 @@ func EnsureKarmadaAggregatedAPIServer(client clientset.Interface, cfg *operatorv
 
 func installKarmadaAPIServer(client clientset.Interface, cfg *operatorv1alpha1.KarmadaAPIServer, etcdCfg *operatorv1alpha1.Etcd, name, namespace string, _ map[string]bool) error {
 	apiserverDeploymentBytes, err := util.ParseTemplate(KarmadaApiserverDeployment, struct {
-		DeploymentName, Namespace, Image, ImagePullPolicy string
-		ServiceSubnet, KarmadaCertsSecret                 string
-		Replicas                                          *int32
+		KarmadaInstanceName, DeploymentName, Namespace, Image, ImagePullPolicy string
+		ServiceSubnet, KarmadaCertsSecret                                      string
+		Replicas                                                               *int32
 	}{
-		DeploymentName:     util.KarmadaAPIServerName(name),
-		Namespace:          namespace,
-		Image:              cfg.Image.Name(),
-		ImagePullPolicy:    string(cfg.ImagePullPolicy),
-		ServiceSubnet:      *cfg.ServiceSubnet,
-		KarmadaCertsSecret: util.KarmadaCertSecretName(name),
-		Replicas:           cfg.Replicas,
+		KarmadaInstanceName: name,
+		DeploymentName:      util.KarmadaAPIServerName(name),
+		Namespace:           namespace,
+		Image:               cfg.Image.Name(),
+		ImagePullPolicy:     string(cfg.ImagePullPolicy),
+		ServiceSubnet:       *cfg.ServiceSubnet,
+		KarmadaCertsSecret:  util.KarmadaCertSecretName(name),
+		Replicas:            cfg.Replicas,
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing karmadaApiserver deployment template: %w", err)
@@ -91,11 +92,12 @@ func installKarmadaAPIServer(client clientset.Interface, cfg *operatorv1alpha1.K
 
 func createKarmadaAPIServerService(client clientset.Interface, cfg *operatorv1alpha1.KarmadaAPIServer, name, namespace string) error {
 	karmadaApiserverServiceBytes, err := util.ParseTemplate(KarmadaApiserverService, struct {
-		ServiceName, Namespace, ServiceType string
+		KarmadaInstanceName, ServiceName, Namespace, ServiceType string
 	}{
-		ServiceName: util.KarmadaAPIServerName(name),
-		Namespace:   namespace,
-		ServiceType: string(cfg.ServiceType),
+		KarmadaInstanceName: name,
+		ServiceName:         util.KarmadaAPIServerName(name),
+		Namespace:           namespace,
+		ServiceType:         string(cfg.ServiceType),
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing karmadaApiserver serive template: %w", err)
@@ -117,17 +119,18 @@ func createKarmadaAPIServerService(client clientset.Interface, cfg *operatorv1al
 
 func installKarmadaAggregatedAPIServer(client clientset.Interface, cfg *operatorv1alpha1.KarmadaAggregatedAPIServer, etcdCfg *operatorv1alpha1.Etcd, name, namespace string, featureGates map[string]bool) error {
 	aggregatedAPIServerDeploymentBytes, err := util.ParseTemplate(KarmadaAggregatedAPIServerDeployment, struct {
-		DeploymentName, Namespace, Image, ImagePullPolicy string
-		KubeconfigSecret, KarmadaCertsSecret              string
-		Replicas                                          *int32
+		KarmadaInstanceName, DeploymentName, Namespace, Image, ImagePullPolicy string
+		KubeconfigSecret, KarmadaCertsSecret                                   string
+		Replicas                                                               *int32
 	}{
-		DeploymentName:     util.KarmadaAggregatedAPIServerName(name),
-		Namespace:          namespace,
-		Image:              cfg.Image.Name(),
-		ImagePullPolicy:    string(cfg.ImagePullPolicy),
-		KubeconfigSecret:   util.ComponentKarmadaConfigSecretName(util.KarmadaAggregatedAPIServerName(name)),
-		KarmadaCertsSecret: util.KarmadaCertSecretName(name),
-		Replicas:           cfg.Replicas,
+		KarmadaInstanceName: name,
+		DeploymentName:      util.KarmadaAggregatedAPIServerName(name),
+		Namespace:           namespace,
+		Image:               cfg.Image.Name(),
+		ImagePullPolicy:     string(cfg.ImagePullPolicy),
+		KubeconfigSecret:    util.ComponentKarmadaConfigSecretName(util.KarmadaAggregatedAPIServerName(name)),
+		KarmadaCertsSecret:  util.KarmadaCertSecretName(name),
+		Replicas:            cfg.Replicas,
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing karmadaAggregatedAPIServer deployment template: %w", err)
@@ -155,10 +158,11 @@ func installKarmadaAggregatedAPIServer(client clientset.Interface, cfg *operator
 
 func createKarmadaAggregatedAPIServerService(client clientset.Interface, name, namespace string) error {
 	aggregatedAPIServerServiceBytes, err := util.ParseTemplate(KarmadaAggregatedAPIServerService, struct {
-		ServiceName, Namespace string
+		KarmadaInstanceName, ServiceName, Namespace string
 	}{
-		ServiceName: util.KarmadaAggregatedAPIServerName(name),
-		Namespace:   namespace,
+		KarmadaInstanceName: name,
+		ServiceName:         util.KarmadaAggregatedAPIServerName(name),
+		Namespace:           namespace,
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing karmadaAggregatedAPIServer serive template: %w", err)

--- a/operator/pkg/controlplane/apiserver/manifests.go
+++ b/operator/pkg/controlplane/apiserver/manifests.go
@@ -23,19 +23,22 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    karmada-app: karmada-apiserver
     app.kubernetes.io/managed-by: karmada-operator
+    app.kubernetes.io/name: karmada-apiserver
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
   name: {{ .DeploymentName }}
   namespace: {{ .Namespace }}
 spec:
   replicas: {{ .Replicas }}
   selector:
     matchLabels:
-      karmada-app: karmada-apiserver
+      app.kubernetes.io/name: karmada-apiserver
+      app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
   template:
     metadata:
       labels:
-        karmada-app: karmada-apiserver
+        app.kubernetes.io/name: karmada-apiserver
+        app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
     spec:
       automountServiceAccountToken: false
       containers:
@@ -69,7 +72,6 @@ spec:
         - --max-requests-inflight=1500
         - --max-mutating-requests-inflight=500
         - --v=4
-
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -94,11 +96,15 @@ spec:
           podAntiAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
-              matchExpressions:
-              - key: karmada-app
-                operator: In
-                values:
-                - karmada-apiserver
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - karmada-apiserver
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - {{ .KarmadaInstanceName }}
               topologyKey: kubernetes.io/hostname
         ports:
         - containerPort: 5443
@@ -120,8 +126,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    karmada-app: karmada-apiserver
     app.kubernetes.io/managed-by: karmada-operator
+    app.kubernetes.io/name: karmada-apiserver
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
   name: {{ .ServiceName }}
   namespace: {{ .Namespace }}
 spec:
@@ -131,29 +138,33 @@ spec:
     protocol: TCP
     targetPort: 5443
   selector:
-    karmada-app: karmada-apiserver
+    app.kubernetes.io/name: karmada-apiserver
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
   type: {{ .ServiceType }}
 `
 
-	// KarmadaAggregatedAPIServerDeployment is karmada aggreagated apiserver deployment manifest
+	// KarmadaAggregatedAPIServerDeployment is karmada aggregated apiserver deployment manifest
 	KarmadaAggregatedAPIServerDeployment = `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    karmada-app: karmada-aggregated-apiserver
     app.kubernetes.io/managed-by: karmada-operator
+    app.kubernetes.io/name: karmada-aggregated-apiserver
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
   name: {{ .DeploymentName }}
   namespace: {{ .Namespace }}
 spec:
   replicas: {{ .Replicas }}
   selector:
     matchLabels:
-      karmada-app: karmada-aggregated-apiserver
+      app.kubernetes.io/name: karmada-aggregated-apiserver
+      app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
   template:
     metadata:
       labels:
-        karmada-app: karmada-aggregated-apiserver
+        app.kubernetes.io/name: karmada-aggregated-apiserver
+        app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
     spec:
       automountServiceAccountToken: false
       containers:
@@ -185,14 +196,16 @@ spec:
         secret:
           secretName: {{ .KarmadaCertsSecret }}
 `
+
 	// KarmadaAggregatedAPIServerService is karmada aggregated APIServer Service manifest
 	KarmadaAggregatedAPIServerService = `
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    karmada-app: karmada-aggregated-apiserver
     app.kubernetes.io/managed-by: karmada-operator
+    app.kubernetes.io/name: karmada-aggregated-apiserver
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
   name: {{ .ServiceName }}
   namespace: {{ .Namespace }}
 spec:
@@ -201,7 +214,8 @@ spec:
     protocol: TCP
     targetPort: 443
   selector:
-    karmada-app: karmada-aggregated-apiserver
+    app.kubernetes.io/name: karmada-aggregated-apiserver
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
   type: ClusterIP
 `
 )

--- a/operator/pkg/controlplane/controlplane.go
+++ b/operator/pkg/controlplane/controlplane.go
@@ -84,17 +84,18 @@ func getComponentManifests(name, namespace string, featureGates map[string]bool,
 
 func getKubeControllerManagerManifest(name, namespace string, cfg *operatorv1alpha1.KubeControllerManager) (*appsv1.Deployment, error) {
 	kubeControllerManagerBytes, err := util.ParseTemplate(KubeControllerManagerDeployment, struct {
-		DeploymentName, Namespace, Image, ImagePullPolicy string
-		KarmadaCertsSecret, KubeconfigSecret              string
-		Replicas                                          *int32
+		KarmadaInstanceName, DeploymentName, Namespace, Image, ImagePullPolicy string
+		KarmadaCertsSecret, KubeconfigSecret                                   string
+		Replicas                                                               *int32
 	}{
-		DeploymentName:     util.KubeControllerManagerName(name),
-		Namespace:          namespace,
-		Image:              cfg.Image.Name(),
-		ImagePullPolicy:    string(cfg.ImagePullPolicy),
-		KarmadaCertsSecret: util.KarmadaCertSecretName(name),
-		KubeconfigSecret:   util.ComponentKarmadaConfigSecretName(util.KubeControllerManagerName(name)),
-		Replicas:           cfg.Replicas,
+		KarmadaInstanceName: name,
+		DeploymentName:      util.KubeControllerManagerName(name),
+		Namespace:           namespace,
+		Image:               cfg.Image.Name(),
+		ImagePullPolicy:     string(cfg.ImagePullPolicy),
+		KarmadaCertsSecret:  util.KarmadaCertSecretName(name),
+		KubeconfigSecret:    util.ComponentKarmadaConfigSecretName(util.KubeControllerManagerName(name)),
+		Replicas:            cfg.Replicas,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error when parsing kube-controller-manager deployment template: %w", err)
@@ -113,17 +114,18 @@ func getKubeControllerManagerManifest(name, namespace string, cfg *operatorv1alp
 
 func getKarmadaControllerManagerManifest(name, namespace string, featureGates map[string]bool, cfg *operatorv1alpha1.KarmadaControllerManager) (*appsv1.Deployment, error) {
 	karmadaControllerManagerBytes, err := util.ParseTemplate(KamradaControllerManagerDeployment, struct {
-		Replicas                                   *int32
-		DeploymentName, Namespace, SystemNamespace string
-		Image, ImagePullPolicy, KubeconfigSecret   string
+		Replicas                                                        *int32
+		KarmadaInstanceName, DeploymentName, Namespace, SystemNamespace string
+		Image, ImagePullPolicy, KubeconfigSecret                        string
 	}{
-		DeploymentName:   util.KarmadaControllerManagerName(name),
-		Namespace:        namespace,
-		SystemNamespace:  constants.KarmadaSystemNamespace,
-		Image:            cfg.Image.Name(),
-		ImagePullPolicy:  string(cfg.ImagePullPolicy),
-		KubeconfigSecret: util.ComponentKarmadaConfigSecretName(util.KarmadaControllerManagerName(name)),
-		Replicas:         cfg.Replicas,
+		KarmadaInstanceName: name,
+		DeploymentName:      util.KarmadaControllerManagerName(name),
+		Namespace:           namespace,
+		SystemNamespace:     constants.KarmadaSystemNamespace,
+		Image:               cfg.Image.Name(),
+		ImagePullPolicy:     string(cfg.ImagePullPolicy),
+		KubeconfigSecret:    util.ComponentKarmadaConfigSecretName(util.KarmadaControllerManagerName(name)),
+		Replicas:            cfg.Replicas,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error when parsing karmada-controller-manager deployment template: %w", err)
@@ -142,18 +144,19 @@ func getKarmadaControllerManagerManifest(name, namespace string, featureGates ma
 
 func getKarmadaSchedulerManifest(name, namespace string, featureGates map[string]bool, cfg *operatorv1alpha1.KarmadaScheduler) (*appsv1.Deployment, error) {
 	karmadaSchedulerBytes, err := util.ParseTemplate(KarmadaSchedulerDeployment, struct {
-		Replicas                                                     *int32
-		DeploymentName, Namespace, SystemNamespace                   string
-		Image, ImagePullPolicy, KubeconfigSecret, KarmadaCertsSecret string
+		Replicas                                                        *int32
+		KarmadaInstanceName, DeploymentName, Namespace, SystemNamespace string
+		Image, ImagePullPolicy, KubeconfigSecret, KarmadaCertsSecret    string
 	}{
-		DeploymentName:     util.KarmadaSchedulerName(name),
-		Namespace:          namespace,
-		SystemNamespace:    constants.KarmadaSystemNamespace,
-		Image:              cfg.Image.Name(),
-		ImagePullPolicy:    string(cfg.ImagePullPolicy),
-		KubeconfigSecret:   util.ComponentKarmadaConfigSecretName(util.KarmadaSchedulerName(name)),
-		KarmadaCertsSecret: util.KarmadaCertSecretName(name),
-		Replicas:           cfg.Replicas,
+		KarmadaInstanceName: name,
+		DeploymentName:      util.KarmadaSchedulerName(name),
+		Namespace:           namespace,
+		SystemNamespace:     constants.KarmadaSystemNamespace,
+		Image:               cfg.Image.Name(),
+		ImagePullPolicy:     string(cfg.ImagePullPolicy),
+		KubeconfigSecret:    util.ComponentKarmadaConfigSecretName(util.KarmadaSchedulerName(name)),
+		KarmadaCertsSecret:  util.KarmadaCertSecretName(name),
+		Replicas:            cfg.Replicas,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error when parsing karmada-scheduler deployment template: %w", err)
@@ -172,18 +175,19 @@ func getKarmadaSchedulerManifest(name, namespace string, featureGates map[string
 
 func getKarmadaDeschedulerManifest(name, namespace string, featureGates map[string]bool, cfg *operatorv1alpha1.KarmadaDescheduler) (*appsv1.Deployment, error) {
 	karmadaDeschedulerBytes, err := util.ParseTemplate(KarmadaDeschedulerDeployment, struct {
-		Replicas                                                     *int32
-		DeploymentName, Namespace, SystemNamespace                   string
-		Image, ImagePullPolicy, KubeconfigSecret, KarmadaCertsSecret string
+		Replicas                                                        *int32
+		KarmadaInstanceName, DeploymentName, Namespace, SystemNamespace string
+		Image, ImagePullPolicy, KubeconfigSecret, KarmadaCertsSecret    string
 	}{
-		DeploymentName:     util.KarmadaDeschedulerName(name),
-		Namespace:          namespace,
-		SystemNamespace:    constants.KarmadaSystemNamespace,
-		Image:              cfg.Image.Name(),
-		ImagePullPolicy:    string(cfg.ImagePullPolicy),
-		KubeconfigSecret:   util.ComponentKarmadaConfigSecretName(util.KarmadaDeschedulerName(name)),
-		KarmadaCertsSecret: util.KarmadaCertSecretName(name),
-		Replicas:           cfg.Replicas,
+		KarmadaInstanceName: name,
+		DeploymentName:      util.KarmadaDeschedulerName(name),
+		Namespace:           namespace,
+		SystemNamespace:     constants.KarmadaSystemNamespace,
+		Image:               cfg.Image.Name(),
+		ImagePullPolicy:     string(cfg.ImagePullPolicy),
+		KubeconfigSecret:    util.ComponentKarmadaConfigSecretName(util.KarmadaDeschedulerName(name)),
+		KarmadaCertsSecret:  util.KarmadaCertSecretName(name),
+		Replicas:            cfg.Replicas,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error when parsing karmada-descheduler deployment template: %w", err)

--- a/operator/pkg/controlplane/etcd/etcd.go
+++ b/operator/pkg/controlplane/etcd/etcd.go
@@ -62,11 +62,12 @@ func installKarmadaEtcd(client clientset.Interface, name, namespace string, cfg 
 	}
 
 	etcdStatefulSetBytes, err := util.ParseTemplate(KarmadaEtcdStatefulSet, struct {
-		StatefulSetName, Namespace, Image, ImagePullPolicy, EtcdClientService string
-		CertsSecretName, EtcdPeerServiceName                                  string
-		InitialCluster, EtcdDataVolumeName, EtcdCipherSuites                  string
-		Replicas, EtcdListenClientPort, EtcdListenPeerPort                    int32
+		KarmadaInstanceName, StatefulSetName, Namespace, Image, ImagePullPolicy, EtcdClientService string
+		CertsSecretName, EtcdPeerServiceName                                                       string
+		InitialCluster, EtcdDataVolumeName, EtcdCipherSuites                                       string
+		Replicas, EtcdListenClientPort, EtcdListenPeerPort                                         int32
 	}{
+		KarmadaInstanceName:  name,
 		StatefulSetName:      util.KarmadaEtcdName(name),
 		Namespace:            namespace,
 		Image:                cfg.Image.Name(),
@@ -103,9 +104,10 @@ func installKarmadaEtcd(client clientset.Interface, name, namespace string, cfg 
 
 func createEtcdService(client clientset.Interface, name, namespace string) error {
 	etcdServicePeerBytes, err := util.ParseTemplate(KarmadaEtcdPeerService, struct {
-		ServiceName, Namespace                   string
-		EtcdListenClientPort, EtcdListenPeerPort int32
+		KarmadaInstanceName, ServiceName, Namespace string
+		EtcdListenClientPort, EtcdListenPeerPort    int32
 	}{
+		KarmadaInstanceName:  name,
 		ServiceName:          util.KarmadaEtcdName(name),
 		Namespace:            namespace,
 		EtcdListenClientPort: constants.EtcdListenClientPort,
@@ -125,9 +127,10 @@ func createEtcdService(client clientset.Interface, name, namespace string) error
 	}
 
 	etcdClientServiceBytes, err := util.ParseTemplate(KarmadaEtcdClientService, struct {
-		ServiceName, Namespace string
-		EtcdListenClientPort   int32
+		KarmadaInstanceName, ServiceName, Namespace string
+		EtcdListenClientPort                        int32
 	}{
+		KarmadaInstanceName:  name,
 		ServiceName:          util.KarmadaEtcdClientName(name),
 		Namespace:            namespace,
 		EtcdListenClientPort: constants.EtcdListenClientPort,

--- a/operator/pkg/controlplane/etcd/manifests.go
+++ b/operator/pkg/controlplane/etcd/manifests.go
@@ -23,7 +23,8 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
-    karmada-app: etcd
+    app.kubernetes.io/name: etcd
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
     app.kubernetes.io/managed-by: karmada-operator
   namespace: {{ .Namespace }}
   name: {{ .StatefulSetName }}
@@ -33,13 +34,13 @@ spec:
   podManagementPolicy: Parallel
   selector:
     matchLabels:
-      karmada-app: etcd
+      app.kubernetes.io/name: etcd
+      app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
   template:
     metadata:
       labels:
-        karmada-app: etcd
-    tolerations:
-    - operator: Exists
+        app.kubernetes.io/name: etcd
+        app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
     spec:
       automountServiceAccountToken: false
       containers:
@@ -49,7 +50,7 @@ spec:
         command:
         - /usr/local/bin/etcd
         - --name=$(KARMADA_ETCD_NAME)
-        - --listen-client-urls= https://0.0.0.0:{{ .EtcdListenClientPort }}
+        - --listen-client-urls=https://0.0.0.0:{{ .EtcdListenClientPort }}
         - --listen-peer-urls=http://0.0.0.0:{{ .EtcdListenPeerPort }}
         - --advertise-client-urls=https://{{ .EtcdClientService }}.{{ .Namespace }}.svc.cluster.local:{{ .EtcdListenClientPort }}
         - --initial-cluster={{ .InitialCluster }}
@@ -103,7 +104,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    karmada-app: etcd
+    app.kubernetes.io/name: etcd
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
     app.kubernetes.io/managed-by: karmada-operator
   name: {{ .ServiceName }}
   namespace: {{ .Namespace }}
@@ -114,33 +116,36 @@ spec:
     protocol: TCP
     targetPort: {{ .EtcdListenClientPort }}
   selector:
-    karmada-app: etcd
+    app.kubernetes.io/name: etcd
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
   type: ClusterIP
- `
+`
 
 	// KarmadaEtcdPeerService is karmada etcd peer Service manifest
 	KarmadaEtcdPeerService = `
- apiVersion: v1
- kind: Service
- metadata:
-   labels:
-     karmada-app: etcd
-     app.kubernetes.io/managed-by: karmada-operator
-   name: {{ .ServiceName }}
-   namespace: {{ .Namespace }}
- spec:
-   clusterIP: None
-   ports:
-   - name: client
-     port: {{ .EtcdListenClientPort }}
-     protocol: TCP
-     targetPort: {{ .EtcdListenClientPort }}
-   - name: server
-     port: {{ .EtcdListenPeerPort }}
-     protocol: TCP
-     targetPort: {{ .EtcdListenPeerPort }}
-   selector:
-     karmada-app: etcd
-   type: ClusterIP
-  `
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: etcd
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
+    app.kubernetes.io/managed-by: karmada-operator
+  name: {{ .ServiceName }}
+  namespace: {{ .Namespace }}
+spec:
+  clusterIP: None
+  ports:
+  - name: client
+    port: {{ .EtcdListenClientPort }}
+    protocol: TCP
+    targetPort: {{ .EtcdListenClientPort }}
+  - name: server
+    port: {{ .EtcdListenPeerPort }}
+    protocol: TCP
+    targetPort: {{ .EtcdListenPeerPort }}
+  selector:
+    app.kubernetes.io/name: etcd
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
+  type: ClusterIP
+`
 )

--- a/operator/pkg/controlplane/manifests.go
+++ b/operator/pkg/controlplane/manifests.go
@@ -17,7 +17,7 @@ limitations under the License.
 package controlplane
 
 const (
-	// KubeControllerManagerDeployment is KubeControllerManage deployment manifest
+	// KubeControllerManagerDeployment is KubeControllerManager deployment manifest
 	KubeControllerManagerDeployment = `
 apiVersion: apps/v1
 kind: Deployment
@@ -25,68 +25,76 @@ metadata:
   name: {{ .DeploymentName }}
   namespace: {{ .Namespace }}
   labels:
-    karmada-app: kube-controller-manager
+    app.kubernetes.io/name: kube-controller-manager
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
     app.kubernetes.io/managed-by: karmada-operator
 spec:
   replicas: {{ .Replicas }}
   selector:
     matchLabels:
-      karmada-app: kube-controller-manager
+      app.kubernetes.io/name: kube-controller-manager
+      app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
   template:
     metadata:
       labels:
-        karmada-app: kube-controller-manager
+        app.kubernetes.io/name: kube-controller-manager
+        app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
     spec:
       automountServiceAccountToken: false
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
-              matchExpressions:
-              - key: karmada-app
-                operator: In
-                values: ["kube-controller-manager"]
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - kube-controller-manager
+                  - key: app.kubernetes.io/instance
+                    operator: In
+                    values:
+                      - {{ .KarmadaInstanceName }}
               topologyKey: kubernetes.io/hostname
       containers:
-      - name: kube-controller-manager
-        image: {{ .Image }}
-        imagePullPolicy: {{ .ImagePullPolicy }}
-        command:
-        - kube-controller-manager
-        - --allocate-node-cidrs=true
-        - --kubeconfig=/etc/karmada/config/karmada.config
-        - --authentication-kubeconfig=/etc/karmada/config/karmada.config
-        - --authorization-kubeconfig=/etc/karmada/config/karmada.config
-        - --bind-address=0.0.0.0
-        - --client-ca-file=/etc/karmada/pki/ca.crt
-        - --cluster-cidr=10.244.0.0/16
-        - --cluster-name=karmada
-        - --cluster-signing-cert-file=/etc/karmada/pki/ca.crt
-        - --cluster-signing-key-file=/etc/karmada/pki/ca.key
-        - --controllers=namespace,garbagecollector,serviceaccount-token,ttl-after-finished,bootstrapsigner,csrcleaner,csrsigning,clusterrole-aggregation
-        - --leader-elect=true
-        - --node-cidr-mask-size=24
-        - --root-ca-file=/etc/karmada/pki/ca.crt
-        - --service-account-private-key-file=/etc/karmada/pki/karmada.key
-        - --service-cluster-ip-range=10.96.0.0/12
-        - --use-service-account-credentials=true
-        - --v=4
-        livenessProbe:
-          failureThreshold: 8
-          httpGet:
-            path: /healthz
-            port: 10257
-            scheme: HTTPS
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
-        volumeMounts:
-        - name: karmada-certs
-          mountPath: /etc/karmada/pki
-          readOnly: true
-        - name: karmada-config
-          mountPath: /etc/karmada/config
+        - name: kube-controller-manager
+          image: {{ .Image }}
+          imagePullPolicy: {{ .ImagePullPolicy }}
+          command:
+            - kube-controller-manager
+            - --allocate-node-cidrs=true
+            - --kubeconfig=/etc/karmada/config/karmada.config
+            - --authentication-kubeconfig=/etc/karmada/config/karmada.config
+            - --authorization-kubeconfig=/etc/karmada/config/karmada.config
+            - --bind-address=0.0.0.0
+            - --client-ca-file=/etc/karmada/pki/ca.crt
+            - --cluster-cidr=10.244.0.0/16
+            - --cluster-name=karmada
+            - --cluster-signing-cert-file=/etc/karmada/pki/ca.crt
+            - --cluster-signing-key-file=/etc/karmada/pki/ca.key
+            - --controllers=namespace,garbagecollector,serviceaccount-token,ttl-after-finished,bootstrapsigner,csrcleaner,csrsigning,clusterrole-aggregation
+            - --leader-elect=true
+            - --node-cidr-mask-size=24
+            - --root-ca-file=/etc/karmada/pki/ca.crt
+            - --service-account-private-key-file=/etc/karmada/pki/karmada.key
+            - --service-cluster-ip-range=10.96.0.0/12
+            - --use-service-account-credentials=true
+            - --v=4
+          livenessProbe:
+            failureThreshold: 8
+            httpGet:
+              path: /healthz
+              port: 10257
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 15
+          volumeMounts:
+            - name: karmada-certs
+              mountPath: /etc/karmada/pki
+              readOnly: true
+            - name: karmada-config
+              mountPath: /etc/karmada/config
       volumes:
         - name: karmada-certs
           secret:
@@ -95,6 +103,7 @@ spec:
           secret:
             secretName: {{ .KubeconfigSecret }}
 `
+
 	// KamradaControllerManagerDeployment is karmada controllerManager Deployment manifest
 	KamradaControllerManagerDeployment = `
 apiVersion: apps/v1
@@ -103,55 +112,58 @@ metadata:
   name: {{ .DeploymentName }}
   namespace: {{ .Namespace }}
   labels:
-    karmada-app: karmada-controller-manager
+    app.kubernetes.io/name: karmada-controller-manager
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
     app.kubernetes.io/managed-by: karmada-operator
 spec:
   replicas: {{ .Replicas }}
   selector:
     matchLabels:
-      karmada-app: karmada-controller-manager
+      app.kubernetes.io/name: karmada-controller-manager
+      app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
   template:
     metadata:
       labels:
-        karmada-app: karmada-controller-manager
+        app.kubernetes.io/name: karmada-controller-manager
+        app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
     spec:
       automountServiceAccountToken: false
       tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+        - key: node-role.kubernetes.io/master
+          operator: Exists
       containers:
-      - name: karmada-controller-manager
-        image: {{ .Image }}
-        imagePullPolicy: {{ .ImagePullPolicy }}
-        command:
-        - /bin/karmada-controller-manager
-        - --kubeconfig=/etc/karmada/config/karmada.config
-        - --metrics-bind-address=:8080
-        - --cluster-status-update-frequency=10s
-        - --failover-eviction-timeout=30s
-        - --leader-elect-resource-namespace={{ .SystemNamespace }}
-        - --health-probe-bind-address=0.0.0.0:10357
-        - --v=4
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 10357
-            scheme: HTTP
-          failureThreshold: 3
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          timeoutSeconds: 5
-        ports:
-        - containerPort: 8080
-          name: metrics
-          protocol: TCP
-        volumeMounts:
-        - name: karmada-config
-          mountPath: /etc/karmada/config
+        - name: karmada-controller-manager
+          image: {{ .Image }}
+          imagePullPolicy: {{ .ImagePullPolicy }}
+          command:
+            - /bin/karmada-controller-manager
+            - --kubeconfig=/etc/karmada/config/karmada.config
+            - --metrics-bind-address=:8080
+            - --cluster-status-update-frequency=10s
+            - --failover-eviction-timeout=30s
+            - --leader-elect-resource-namespace={{ .SystemNamespace }}
+            - --health-probe-bind-address=0.0.0.0:10357
+            - --v=4
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 10357
+              scheme: HTTP
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 5
+          ports:
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
+          volumeMounts:
+            - name: karmada-config
+              mountPath: /etc/karmada/config
       volumes:
-      - name: karmada-config
-        secret:
-          secretName: {{ .KubeconfigSecret }}
+        - name: karmada-config
+          secret:
+            secretName: {{ .KubeconfigSecret }}
 `
 
 	// KarmadaSchedulerDeployment is KarmadaScheduler Deployment manifest
@@ -162,56 +174,59 @@ metadata:
   name: {{ .DeploymentName }}
   namespace: {{ .Namespace }}
   labels:
-    karmada-app: karmada-scheduler
+    app.kubernetes.io/name: karmada-scheduler
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
     app.kubernetes.io/managed-by: karmada-operator
 spec:
   replicas: {{ .Replicas }}
   selector:
     matchLabels:
-      karmada-app: karmada-scheduler
+      app.kubernetes.io/name: karmada-scheduler
+      app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
   template:
     metadata:
       labels:
-        karmada-app: karmada-scheduler
+        app.kubernetes.io/name: karmada-scheduler
+        app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
     spec:
       automountServiceAccountToken: false
       tolerations:
         - key: node-role.kubernetes.io/master
           operator: Exists
       containers:
-      - name: karmada-scheduler
-        image: {{ .Image }}
-        imagePullPolicy: {{ .ImagePullPolicy }}
-        command:
-        - /bin/karmada-scheduler
-        - --kubeconfig=/etc/karmada/config/karmada.config
-        - --metrics-bind-address=0.0.0.0:8080
-        - --health-probe-bind-address=0.0.0.0:10351
-        - --enable-scheduler-estimator=true
-        - --leader-elect-resource-namespace={{ .SystemNamespace }}
-        - --scheduler-estimator-ca-file=/etc/karmada/pki/ca.crt
-        - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada.crt
-        - --scheduler-estimator-key-file=/etc/karmada/pki/karmada.key
-        - --v=4
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 10351
-            scheme: HTTP
-          failureThreshold: 3
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          timeoutSeconds: 5
-        ports:
-        - containerPort: 8080
-          name: metrics
-          protocol: TCP
-        volumeMounts:
-        - name: karmada-certs
-          mountPath: /etc/karmada/pki
-          readOnly: true
-        - name: karmada-config
-          mountPath: /etc/karmada/config
+        - name: karmada-scheduler
+          image: {{ .Image }}
+          imagePullPolicy: {{ .ImagePullPolicy }}
+          command:
+            - /bin/karmada-scheduler
+            - --kubeconfig=/etc/karmada/config/karmada.config
+            - --metrics-bind-address=0.0.0.0:8080
+            - --health-probe-bind-address=0.0.0.0:10351
+            - --enable-scheduler-estimator=true
+            - --leader-elect-resource-namespace={{ .SystemNamespace }}
+            - --scheduler-estimator-ca-file=/etc/karmada/pki/ca.crt
+            - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada.crt
+            - --scheduler-estimator-key-file=/etc/karmada/pki/karmada.key
+            - --v=4
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 10351
+              scheme: HTTP
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 5
+          ports:
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
+          volumeMounts:
+            - name: karmada-certs
+              mountPath: /etc/karmada/pki
+              readOnly: true
+            - name: karmada-config
+              mountPath: /etc/karmada/config
       volumes:
         - name: karmada-certs
           secret:
@@ -229,55 +244,58 @@ metadata:
   name: {{ .DeploymentName }}
   namespace: {{ .Namespace }}
   labels:
-    karmada-app: karmada-descheduler
+    app.kubernetes.io/name: karmada-descheduler
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
     app.kubernetes.io/managed-by: karmada-operator
 spec:
   replicas: {{ .Replicas }}
   selector:
     matchLabels:
-      karmada-app: karmada-descheduler
+      app.kubernetes.io/name: karmada-descheduler
+      app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
   template:
     metadata:
       labels:
-        karmada-app: karmada-descheduler
+        app.kubernetes.io/name: karmada-descheduler
+        app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
     spec:
       automountServiceAccountToken: false
       tolerations:
         - key: node-role.kubernetes.io/master
           operator: Exists
       containers:
-      - name: karmada-descheduler
-        image: {{ .Image }}
-        imagePullPolicy: {{ .ImagePullPolicy }}
-        command:
-        - /bin/karmada-descheduler
-        - --kubeconfig=/etc/karmada/config/karmada.config
-        - --metrics-bind-address=0.0.0.0:8080
-        - --health-probe-bind-address=0.0.0.0:10358
-        - --leader-elect-resource-namespace={{ .SystemNamespace }}
-        - --scheduler-estimator-ca-file=/etc/karmada/pki/ca.crt
-        - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada.crt
-        - --scheduler-estimator-key-file=/etc/karmada/pki/karmada.key
-        - --v=4
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 10358
-            scheme: HTTP
-          failureThreshold: 3
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          timeoutSeconds: 5
-        ports:
-        - containerPort: 8080
-          name: metrics
-          protocol: TCP
-        volumeMounts:
-        - name: karmada-certs
-          mountPath: /etc/karmada/pki
-          readOnly: true
-        - name: karmada-config
-          mountPath: /etc/karmada/config
+        - name: karmada-descheduler
+          image: {{ .Image }}
+          imagePullPolicy: {{ .ImagePullPolicy }}
+          command:
+            - /bin/karmada-descheduler
+            - --kubeconfig=/etc/karmada/config/karmada.config
+            - --metrics-bind-address=0.0.0.0:8080
+            - --health-probe-bind-address=0.0.0.0:10358
+            - --leader-elect-resource-namespace={{ .SystemNamespace }}
+            - --scheduler-estimator-ca-file=/etc/karmada/pki/ca.crt
+            - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada.crt
+            - --scheduler-estimator-key-file=/etc/karmada/pki/karmada.key
+            - --v=4
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 10358
+              scheme: HTTP
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 5
+          ports:
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
+          volumeMounts:
+            - name: karmada-certs
+              mountPath: /etc/karmada/pki
+              readOnly: true
+            - name: karmada-config
+              mountPath: /etc/karmada/config
       volumes:
         - name: karmada-certs
           secret:

--- a/operator/pkg/controlplane/metricsadapter/manifests.go
+++ b/operator/pkg/controlplane/metricsadapter/manifests.go
@@ -25,73 +25,76 @@ metadata:
   name: {{ .DeploymentName }}
   namespace: {{ .Namespace }}
   labels:
-    karmada-app: karmada-metrics-adapter
+    app.kubernetes.io/name: karmada-metrics-adapter
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
     app.kubernetes.io/managed-by: karmada-operator
 spec:
   replicas: {{ .Replicas }}
   selector:
     matchLabels:
-      karmada-app: karmada-metrics-adapter
+      app.kubernetes.io/name: karmada-metrics-adapter
+      app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
   template:
     metadata:
       labels:
-        karmada-app: karmada-metrics-adapter
+        app.kubernetes.io/name: karmada-metrics-adapter
+        app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
     spec:
       automountServiceAccountToken: false
       tolerations:
         - key: node-role.kubernetes.io/master
           operator: Exists
       containers:
-      - name: karmada-metrics-adapter
-        image: {{ .Image }}
-        imagePullPolicy: {{ .ImagePullPolicy }}
-        command:
-        - /bin/karmada-metrics-adapter
-        - --kubeconfig=/etc/karmada/config/karmada.config
-        - --metrics-bind-address=:8080
-        - --authentication-kubeconfig=/etc/karmada/config/karmada.config
-        - --authorization-kubeconfig=/etc/karmada/config/karmada.config
-        - --client-ca-file=/etc/karmada/pki/ca.crt
-        - --tls-cert-file=/etc/karmada/pki/karmada.crt
-        - --tls-private-key-file=/etc/karmada/pki/karmada.key
-        - --tls-min-version=VersionTLS13
-        - --audit-log-path=-
-        - --audit-log-maxage=0
-        - --audit-log-maxbackup=0
-        volumeMounts:
-        - name: karmada-config
-          mountPath: /etc/karmada/config
-        - name: karmada-cert
-          mountPath: /etc/karmada/pki
-          readOnly: true
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 443
-            scheme: HTTPS
-          initialDelaySeconds: 1
-          failureThreshold: 3
-          periodSeconds: 3
-          timeoutSeconds: 15
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 443
-            scheme: HTTPS
-          initialDelaySeconds: 10
-          failureThreshold: 3
-          periodSeconds: 10
-          timeoutSeconds: 15
-        resources:
-          requests:
-            cpu: 100m
+        - name: karmada-metrics-adapter
+          image: {{ .Image }}
+          imagePullPolicy: {{ .ImagePullPolicy }}
+          command:
+            - /bin/karmada-metrics-adapter
+            - --kubeconfig=/etc/karmada/config/karmada.config
+            - --metrics-bind-address=:8080
+            - --authentication-kubeconfig=/etc/karmada/config/karmada.config
+            - --authorization-kubeconfig=/etc/karmada/config/karmada.config
+            - --client-ca-file=/etc/karmada/pki/ca.crt
+            - --tls-cert-file=/etc/karmada/pki/karmada.crt
+            - --tls-private-key-file=/etc/karmada/pki/karmada.key
+            - --tls-min-version=VersionTLS13
+            - --audit-log-path=-
+            - --audit-log-maxage=0
+            - --audit-log-maxbackup=0
+          volumeMounts:
+            - name: karmada-config
+              mountPath: /etc/karmada/config
+            - name: karmada-cert
+              mountPath: /etc/karmada/pki
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 443
+              scheme: HTTPS
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 3
+            timeoutSeconds: 15
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 443
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 15
+          resources:
+            requests:
+              cpu: 100m
       volumes:
-      - name: karmada-config
-        secret:
-          secretName: {{ .KubeconfigSecret }}
-      - name: karmada-cert
-        secret:
-          secretName: {{ .KarmadaCertsSecret }}
+        - name: karmada-config
+          secret:
+            secretName: {{ .KubeconfigSecret }}
+        - name: karmada-cert
+          secret:
+            secretName: {{ .KarmadaCertsSecret }}
 `
 
 	// KarmadaMetricsAdapterService is karmada-metrics-adapter service manifest
@@ -105,10 +108,11 @@ metadata:
     app.kubernetes.io/managed-by: karmada-operator
 spec:
   selector:
-    karmada-app: karmada-metrics-adapter
+    app.kubernetes.io/name: karmada-metrics-adapter
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
   ports:
-  - port: 443
-    protocol: TCP
-    targetPort: 443
+    - port: 443
+      protocol: TCP
+      targetPort: 443
 `
 )

--- a/operator/pkg/controlplane/metricsadapter/metricsadapter.go
+++ b/operator/pkg/controlplane/metricsadapter/metricsadapter.go
@@ -42,17 +42,18 @@ func EnsureKarmadaMetricAdapter(client clientset.Interface, cfg *operatorv1alpha
 
 func installKarmadaMetricAdapter(client clientset.Interface, cfg *operatorv1alpha1.KarmadaMetricsAdapter, name, namespace string) error {
 	metricAdapterBytes, err := util.ParseTemplate(KarmadaMetricsAdapterDeployment, struct {
-		DeploymentName, Namespace, Image, ImagePullPolicy string
-		KubeconfigSecret, KarmadaCertsSecret              string
-		Replicas                                          *int32
+		KarmadaInstanceName, DeploymentName, Namespace, Image, ImagePullPolicy string
+		KubeconfigSecret, KarmadaCertsSecret                                   string
+		Replicas                                                               *int32
 	}{
-		DeploymentName:     util.KarmadaMetricsAdapterName(name),
-		Namespace:          namespace,
-		Image:              cfg.Image.Name(),
-		ImagePullPolicy:    string(cfg.ImagePullPolicy),
-		Replicas:           cfg.Replicas,
-		KubeconfigSecret:   util.ComponentKarmadaConfigSecretName(util.KarmadaMetricsAdapterName(name)),
-		KarmadaCertsSecret: util.KarmadaCertSecretName(name),
+		KarmadaInstanceName: name,
+		DeploymentName:      util.KarmadaMetricsAdapterName(name),
+		Namespace:           namespace,
+		Image:               cfg.Image.Name(),
+		ImagePullPolicy:     string(cfg.ImagePullPolicy),
+		Replicas:            cfg.Replicas,
+		KubeconfigSecret:    util.ComponentKarmadaConfigSecretName(util.KarmadaMetricsAdapterName(name)),
+		KarmadaCertsSecret:  util.KarmadaCertSecretName(name),
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing KarmadaMetricAdapter Deployment template: %w", err)
@@ -74,10 +75,11 @@ func installKarmadaMetricAdapter(client clientset.Interface, cfg *operatorv1alph
 
 func createKarmadaMetricAdapterService(client clientset.Interface, name, namespace string) error {
 	metricAdapterServiceBytes, err := util.ParseTemplate(KarmadaMetricsAdapterService, struct {
-		ServiceName, Namespace string
+		KarmadaInstanceName, ServiceName, Namespace string
 	}{
-		ServiceName: util.KarmadaMetricsAdapterName(name),
-		Namespace:   namespace,
+		KarmadaInstanceName: name,
+		ServiceName:         util.KarmadaMetricsAdapterName(name),
+		Namespace:           namespace,
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing KarmadaMetricAdapter Service template: %w", err)

--- a/operator/pkg/controlplane/search/manifests.go
+++ b/operator/pkg/controlplane/search/manifests.go
@@ -25,19 +25,22 @@ metadata:
   name: {{ .DeploymentName }}
   namespace: {{ .Namespace }}
   labels:
+    app.kubernetes.io/name: karmada-search
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
     app.kubernetes.io/managed-by: karmada-operator
-    karmada-app: karmada-search
     apiserver: "true"
 spec:
   selector:
     matchLabels:
-      karmada-app: karmada-search
+      app.kubernetes.io/name: karmada-search
+      app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
       apiserver: "true"
   replicas: {{ .Replicas }}
   template:
     metadata:
       labels:
-        karmada-app: karmada-search
+        app.kubernetes.io/name: karmada-search
+        app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
         apiserver: "true"
     spec:
       automountServiceAccountToken: false
@@ -91,8 +94,9 @@ metadata:
   name: {{ .ServiceName }}
   namespace: {{ .Namespace }}
   labels:
+    app.kubernetes.io/name: karmada-search
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
     app.kubernetes.io/managed-by: karmada-operator
-    karmada-app: karmada-search
     apiserver: "true"
 spec:
   ports:
@@ -100,6 +104,8 @@ spec:
       protocol: TCP
       targetPort: 443
   selector:
-    karmada-app: karmada-search
+    app.kubernetes.io/name: karmada-search
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
+    apiserver: "true"
 `
 )

--- a/operator/pkg/controlplane/search/search.go
+++ b/operator/pkg/controlplane/search/search.go
@@ -43,17 +43,18 @@ func EnsureKarmadaSearch(client clientset.Interface, cfg *operatorv1alpha1.Karma
 
 func installKarmadaSearch(client clientset.Interface, cfg *operatorv1alpha1.KarmadaSearch, etcdCfg *operatorv1alpha1.Etcd, name, namespace string, _ map[string]bool) error {
 	searchDeploymentSetBytes, err := util.ParseTemplate(KarmadaSearchDeployment, struct {
-		DeploymentName, Namespace, Image, ImagePullPolicy, KarmadaCertsSecret string
-		KubeconfigSecret                                                      string
-		Replicas                                                              *int32
+		KarmadaInstanceName, DeploymentName, Namespace, Image, ImagePullPolicy, KarmadaCertsSecret string
+		KubeconfigSecret                                                                           string
+		Replicas                                                                                   *int32
 	}{
-		DeploymentName:     util.KarmadaSearchName(name),
-		Namespace:          namespace,
-		Image:              cfg.Image.Name(),
-		ImagePullPolicy:    string(cfg.ImagePullPolicy),
-		KarmadaCertsSecret: util.KarmadaCertSecretName(name),
-		Replicas:           cfg.Replicas,
-		KubeconfigSecret:   util.ComponentKarmadaConfigSecretName(util.KarmadaSearchName(name)),
+		KarmadaInstanceName: name,
+		DeploymentName:      util.KarmadaSearchName(name),
+		Namespace:           namespace,
+		Image:               cfg.Image.Name(),
+		ImagePullPolicy:     string(cfg.ImagePullPolicy),
+		KarmadaCertsSecret:  util.KarmadaCertSecretName(name),
+		Replicas:            cfg.Replicas,
+		KubeconfigSecret:    util.ComponentKarmadaConfigSecretName(util.KarmadaSearchName(name)),
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing KarmadaSearch Deployment template: %w", err)
@@ -81,10 +82,11 @@ func installKarmadaSearch(client clientset.Interface, cfg *operatorv1alpha1.Karm
 
 func createKarmadaSearchService(client clientset.Interface, name, namespace string) error {
 	searchServiceSetBytes, err := util.ParseTemplate(KarmadaSearchService, struct {
-		ServiceName, Namespace string
+		KarmadaInstanceName, ServiceName, Namespace string
 	}{
-		ServiceName: util.KarmadaSearchName(name),
-		Namespace:   namespace,
+		KarmadaInstanceName: name,
+		ServiceName:         util.KarmadaSearchName(name),
+		Namespace:           namespace,
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing KarmadaSearch Service template: %w", err)

--- a/operator/pkg/controlplane/webhook/manifests.go
+++ b/operator/pkg/controlplane/webhook/manifests.go
@@ -25,59 +25,62 @@ metadata:
   name: {{ .DeploymentName }}
   namespace: {{ .Namespace }}
   labels:
-    karmada-app: karmada-webhook
+    app.kubernetes.io/name: karmada-webhook
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
     app.kubernetes.io/managed-by: karmada-operator
 spec:
   replicas: {{ .Replicas }}
   selector:
     matchLabels:
-      karmada-app: karmada-webhook
+      app.kubernetes.io/name: karmada-webhook
+      app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
   template:
     metadata:
       labels:
-        karmada-app: karmada-webhook
+        app.kubernetes.io/name: karmada-webhook
+        app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
     spec:
       automountServiceAccountToken: false
       tolerations:
         - key: node-role.kubernetes.io/master
           operator: Exists
       containers:
-      - name: karmada-webhook
-        image: {{ .Image }}
-        imagePullPolicy: {{ .ImagePullPolicy }}
-        command:
-        - /bin/karmada-webhook
-        - --kubeconfig=/etc/karmada/config/karmada.config
-        - --bind-address=0.0.0.0
-        - --metrics-bind-address=:8080
-        - --default-not-ready-toleration-seconds=30
-        - --default-unreachable-toleration-seconds=30
-        - --secure-port=8443
-        - --cert-dir=/var/serving-cert
-        - --v=4
-        ports:
-        - containerPort: 8443
-        - containerPort: 8080
-          name: metrics
-          protocol: TCP
-        volumeMounts:
-        - name: karmada-config
-          mountPath: /etc/karmada/config
-        - name: cert
-          mountPath: /var/serving-cert
-          readOnly: true
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8443
-            scheme: HTTPS
+        - name: karmada-webhook
+          image: {{ .Image }}
+          imagePullPolicy: {{ .ImagePullPolicy }}
+          command:
+            - /bin/karmada-webhook
+            - --kubeconfig=/etc/karmada/config/karmada.config
+            - --bind-address=0.0.0.0
+            - --metrics-bind-address=:8080
+            - --default-not-ready-toleration-seconds=30
+            - --default-unreachable-toleration-seconds=30
+            - --secure-port=8443
+            - --cert-dir=/var/serving-cert
+            - --v=4
+          ports:
+            - containerPort: 8443
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
+          volumeMounts:
+            - name: karmada-config
+              mountPath: /etc/karmada/config
+            - name: cert
+              mountPath: /var/serving-cert
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8443
+              scheme: HTTPS
       volumes:
-      - name: karmada-config
-        secret:
-          secretName: {{ .KubeconfigSecret }}
-      - name: cert
-        secret:
-          secretName: {{ .WebhookCertsSecret }}
+        - name: karmada-config
+          secret:
+            secretName: {{ .KubeconfigSecret }}
+        - name: cert
+          secret:
+            secretName: {{ .WebhookCertsSecret }}
 `
 
 	// KarmadaWebhookService is karmada webhook service manifest
@@ -88,12 +91,15 @@ metadata:
   name: {{ .ServiceName }}
   namespace: {{ .Namespace }}
   labels:
+    app.kubernetes.io/name: karmada-webhook
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
     app.kubernetes.io/managed-by: karmada-operator
 spec:
   selector:
-    karmada-app: karmada-webhook
+    app.kubernetes.io/name: karmada-webhook
+    app.kubernetes.io/instance: {{ .KarmadaInstanceName }}
   ports:
-  - port: 443
-    targetPort: 8443
+    - port: 443
+      targetPort: 8443
 `
 )

--- a/operator/pkg/controlplane/webhook/webhook.go
+++ b/operator/pkg/controlplane/webhook/webhook.go
@@ -42,17 +42,18 @@ func EnsureKarmadaWebhook(client clientset.Interface, cfg *operatorv1alpha1.Karm
 
 func installKarmadaWebhook(client clientset.Interface, cfg *operatorv1alpha1.KarmadaWebhook, name, namespace string, _ map[string]bool) error {
 	webhookDeploymentSetBytes, err := util.ParseTemplate(KarmadaWebhookDeployment, struct {
-		DeploymentName, Namespace, Image, ImagePullPolicy string
-		KubeconfigSecret, WebhookCertsSecret              string
-		Replicas                                          *int32
+		KarmadaInstanceName, DeploymentName, Namespace, Image, ImagePullPolicy string
+		KubeconfigSecret, WebhookCertsSecret                                   string
+		Replicas                                                               *int32
 	}{
-		DeploymentName:     util.KarmadaWebhookName(name),
-		Namespace:          namespace,
-		Image:              cfg.Image.Name(),
-		ImagePullPolicy:    string(cfg.ImagePullPolicy),
-		Replicas:           cfg.Replicas,
-		KubeconfigSecret:   util.ComponentKarmadaConfigSecretName(util.KarmadaWebhookName(name)),
-		WebhookCertsSecret: util.WebhookCertSecretName(name),
+		KarmadaInstanceName: name,
+		DeploymentName:      util.KarmadaWebhookName(name),
+		Namespace:           namespace,
+		Image:               cfg.Image.Name(),
+		ImagePullPolicy:     string(cfg.ImagePullPolicy),
+		Replicas:            cfg.Replicas,
+		KubeconfigSecret:    util.ComponentKarmadaConfigSecretName(util.KarmadaWebhookName(name)),
+		WebhookCertsSecret:  util.WebhookCertSecretName(name),
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing KarmadaWebhook Deployment template: %w", err)
@@ -75,10 +76,11 @@ func installKarmadaWebhook(client clientset.Interface, cfg *operatorv1alpha1.Kar
 
 func createKarmadaWebhookService(client clientset.Interface, name, namespace string) error {
 	webhookServiceSetBytes, err := util.ParseTemplate(KarmadaWebhookService, struct {
-		ServiceName, Namespace string
+		KarmadaInstanceName, ServiceName, Namespace string
 	}{
-		ServiceName: util.KarmadaWebhookName(name),
-		Namespace:   namespace,
+		KarmadaInstanceName: name,
+		ServiceName:         util.KarmadaWebhookName(name),
+		Namespace:           namespace,
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing KarmadaWebhook Service template: %w", err)

--- a/operator/pkg/tasks/init/wait.go
+++ b/operator/pkg/tasks/init/wait.go
@@ -40,14 +40,14 @@ var (
 	// the process will stop and return an error.
 	failureThreshold = 3
 
-	etcdLabels                       = labels.Set{"karmada-app": constants.Etcd}
-	karmadaApiserverLabels           = labels.Set{"karmada-app": constants.KarmadaAPIServer}
-	karmadaAggregatedAPIServerLabels = labels.Set{"karmada-app": names.KarmadaAggregatedAPIServerComponentName}
-	kubeControllerManagerLabels      = labels.Set{"karmada-app": constants.KubeControllerManager}
-	karmadaControllerManagerLabels   = labels.Set{"karmada-app": names.KarmadaControllerManagerComponentName}
-	karmadaSchedulerLabels           = labels.Set{"karmada-app": names.KarmadaSchedulerComponentName}
-	karmadaWebhookLabels             = labels.Set{"karmada-app": names.KarmadaWebhookComponentName}
-	karmadaMetricAdapterLabels       = labels.Set{"karmada-app": names.KarmadaMetricsAdapterComponentName}
+	etcdLabels                       = labels.Set{constants.AppNameLabel: constants.Etcd}
+	karmadaApiserverLabels           = labels.Set{constants.AppNameLabel: constants.KarmadaAPIServer}
+	karmadaAggregatedAPIServerLabels = labels.Set{constants.AppNameLabel: names.KarmadaAggregatedAPIServerComponentName}
+	kubeControllerManagerLabels      = labels.Set{constants.AppNameLabel: constants.KubeControllerManager}
+	karmadaControllerManagerLabels   = labels.Set{constants.AppNameLabel: names.KarmadaControllerManagerComponentName}
+	karmadaSchedulerLabels           = labels.Set{constants.AppNameLabel: names.KarmadaSchedulerComponentName}
+	karmadaWebhookLabels             = labels.Set{constants.AppNameLabel: names.KarmadaWebhookComponentName}
+	karmadaMetricAdapterLabels       = labels.Set{constants.AppNameLabel: names.KarmadaMetricsAdapterComponentName}
 )
 
 // NewCheckApiserverHealthTask init wait-apiserver task
@@ -114,6 +114,7 @@ func runWaitControlPlaneSubTask(component string, ls labels.Set) func(r workflow
 			return errors.New("wait-controlPlane task invoked with an invalid data struct")
 		}
 
+		ls[constants.AppInstanceLabel] = data.GetName()
 		waiter := apiclient.NewKarmadaWaiter(nil, data.RemoteClient(), componentBeReadyTimeout)
 		if err := waiter.WaitForSomePods(ls.String(), data.GetNamespace(), 1); err != nil {
 			return fmt.Errorf("waiting for %s to ready timeout, err: %w", component, err)

--- a/operator/pkg/util/apiclient/wait_test.go
+++ b/operator/pkg/util/apiclient/wait_test.go
@@ -196,7 +196,7 @@ func TestWaitForAPIService(t *testing.T) {
 
 func TestWaitForPods(t *testing.T) {
 	name, namespace := "karmada-demo-apiserver", "test"
-	karmadaAPIServerLabels := labels.Set{"karmada-app": constants.KarmadaAPIServer}
+	karmadaAPIServerLabels := labels.Set{constants.AppNameLabel: constants.KarmadaAPIServer}
 	var replicas int32 = 2
 	tests := []struct {
 		name          string
@@ -263,7 +263,7 @@ func TestWaitForPods(t *testing.T) {
 
 func TestWaitForSomePods(t *testing.T) {
 	name, namespace := "karmada-demo-apiserver", "test"
-	karmadaAPIServerLabels := labels.Set{"karmada-app": constants.KarmadaAPIServer}
+	karmadaAPIServerLabels := labels.Set{constants.AppNameLabel: constants.KarmadaAPIServer}
 	var replicas int32 = 2
 	tests := []struct {
 		name          string


### PR DESCRIPTION
Cherry pick of #6180 on release-1.13.
#6180: Fix issues with running multiple Karmada instances in the
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-operator`: The `karmada-app` label key previously used for control plane components and for the components of the operator itself has been changed to the more idiomatic `app.kubernetes.io/name` label key.
```