### PR TITLE
Fix the naming of the server certificate of karmada-scheduler-estimator

### DIFF
--- a/artifacts/deploy/karmada-scheduler-estimator.yaml
+++ b/artifacts/deploy/karmada-scheduler-estimator.yaml
@@ -58,7 +58,7 @@ spec:
       volumes:
         - name: server-cert
           secret:
-            secretName: karmada-metrics-adapter-cert
+            secretName: karmada-scheduler-estimator-cert
         - name: member-kubeconfig
           secret:
             secretName: {{member_cluster_name}}-kubeconfig

--- a/hack/deploy-karmada.sh
+++ b/hack/deploy-karmada.sh
@@ -102,6 +102,7 @@ function generate_cert_related_secrets {
     generate_cert_secret karmada-search ${karmada_ca} ${SERVER_CRT} ${SERVER_KEY}
     generate_cert_secret karmada-webhook ${karmada_ca} ${SERVER_CRT} ${SERVER_KEY}
     generate_cert_secret karmada-interpreter-webhook-example ${karmada_ca} ${SERVER_CRT} ${SERVER_KEY}
+    generate_cert_secret karmada-scheduler-estimator ${karmada_ca} ${SERVER_CRT} ${SERVER_KEY}
     generate_cert_secret etcd ${karmada_ca} ${ETCD_SERVER_CRT} ${ETCD_SERVER_KEY}
 
     # 2. generate secret with client cert


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Change the name of the server certificate used by the karmada-scheduler-estimator from `karmada-metrics-adapter-cert` to `karmada-scheduler-estimator-cert` to meet the convention.
**Which issue(s) this PR fixes**:
Part of https://github.com/karmada-io/karmada/issues/6051
**Special notes for your reviewer**:
The secrets generated from local-up-karmada.sh
![Screenshot 2025-03-15 at 3 26 48 PM](https://github.com/user-attachments/assets/9ac609fa-8a86-48f5-978d-8b766eea1780)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
None
```

