### PR TITLE
Update Works index with a unique name

### DIFF
--- a/pkg/controllers/binding/binding_controller_test.go
+++ b/pkg/controllers/binding/binding_controller_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	utilhelper "github.com/karmada-io/karmada/pkg/util/helper"
+	"github.com/karmada-io/karmada/pkg/util/indexregistry"
 	testingutil "github.com/karmada-io/karmada/pkg/util/testing"
 	"github.com/karmada-io/karmada/test/helper"
 )
@@ -54,7 +55,7 @@ import (
 func makeFakeRBCByResource(rs *workv1alpha2.ObjectReference) (*ResourceBindingController, error) {
 	c := fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithIndex(
 		&workv1alpha1.Work{},
-		workv1alpha2.ResourceBindingPermanentIDLabel,
+		indexregistry.WorkIndexByResourceBindingID,
 		utilhelper.IndexerFuncBasedOnLabel(workv1alpha2.ResourceBindingPermanentIDLabel),
 	).Build()
 

--- a/pkg/controllers/binding/cluster_resource_binding_controller_test.go
+++ b/pkg/controllers/binding/cluster_resource_binding_controller_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	utilhelper "github.com/karmada-io/karmada/pkg/util/helper"
+	"github.com/karmada-io/karmada/pkg/util/indexregistry"
 	testingutil "github.com/karmada-io/karmada/pkg/util/testing"
 	"github.com/karmada-io/karmada/test/helper"
 )
@@ -51,7 +52,7 @@ import (
 func makeFakeCRBCByResource(rs *workv1alpha2.ObjectReference) (*ClusterResourceBindingController, error) {
 	c := fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithIndex(
 		&workv1alpha1.Work{},
-		workv1alpha2.ClusterResourceBindingPermanentIDLabel,
+		indexregistry.WorkIndexByClusterResourceBindingID,
 		utilhelper.IndexerFuncBasedOnLabel(workv1alpha2.ClusterResourceBindingPermanentIDLabel),
 	).Build()
 	tempDyClient := fakedynamic.NewSimpleDynamicClient(scheme.Scheme)

--- a/pkg/controllers/status/crb_status_controller_test.go
+++ b/pkg/controllers/status/crb_status_controller_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	utilhelper "github.com/karmada-io/karmada/pkg/util/helper"
+	"github.com/karmada-io/karmada/pkg/util/indexregistry"
 )
 
 func generateCRBStatusController() *CRBStatusController {
@@ -54,7 +55,7 @@ func generateCRBStatusController() *CRBStatusController {
 	c := &CRBStatusController{
 		Client: fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithIndex(
 			&workv1alpha1.Work{},
-			workv1alpha2.ClusterResourceBindingPermanentIDLabel,
+			indexregistry.WorkIndexByClusterResourceBindingID,
 			utilhelper.IndexerFuncBasedOnLabel(workv1alpha2.ClusterResourceBindingPermanentIDLabel),
 		).Build(),
 		DynamicClient:   dynamicClient,
@@ -137,7 +138,7 @@ func TestCRBStatusController_Reconcile(t *testing.T) {
 			// Prepare binding and create it in client
 			if tt.binding != nil {
 				c.Client = fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(tt.binding).WithStatusSubresource(tt.binding).
-					WithIndex(&workv1alpha1.Work{}, workv1alpha2.ClusterResourceBindingPermanentIDLabel, utilhelper.IndexerFuncBasedOnLabel(workv1alpha2.ClusterResourceBindingPermanentIDLabel)).
+					WithIndex(&workv1alpha1.Work{}, indexregistry.WorkIndexByClusterResourceBindingID, utilhelper.IndexerFuncBasedOnLabel(workv1alpha2.ClusterResourceBindingPermanentIDLabel)).
 					Build()
 			}
 
@@ -209,7 +210,7 @@ func TestCRBStatusController_syncBindingStatus(t *testing.T) {
 
 			if tt.resourceExistInClient {
 				c.Client = fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(binding).WithStatusSubresource(binding).
-					WithIndex(&workv1alpha1.Work{}, workv1alpha2.ClusterResourceBindingPermanentIDLabel, utilhelper.IndexerFuncBasedOnLabel(workv1alpha2.ClusterResourceBindingPermanentIDLabel)).
+					WithIndex(&workv1alpha1.Work{}, indexregistry.WorkIndexByClusterResourceBindingID, utilhelper.IndexerFuncBasedOnLabel(workv1alpha2.ClusterResourceBindingPermanentIDLabel)).
 					Build()
 			}
 

--- a/pkg/controllers/status/rb_status_controller_test.go
+++ b/pkg/controllers/status/rb_status_controller_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	utilhelper "github.com/karmada-io/karmada/pkg/util/helper"
+	"github.com/karmada-io/karmada/pkg/util/indexregistry"
 )
 
 func generateRBStatusController() *RBStatusController {
@@ -55,7 +56,7 @@ func generateRBStatusController() *RBStatusController {
 	c := &RBStatusController{
 		Client: fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithIndex(
 			&workv1alpha1.Work{},
-			workv1alpha2.ClusterResourceBindingPermanentIDLabel,
+			indexregistry.WorkIndexByResourceBindingID,
 			utilhelper.IndexerFuncBasedOnLabel(workv1alpha2.ClusterResourceBindingPermanentIDLabel),
 		).Build(),
 		DynamicClient:   dynamicClient,
@@ -143,7 +144,7 @@ func TestRBStatusController_Reconcile(t *testing.T) {
 			// Prepare binding and create it in client
 			if tt.binding != nil {
 				c.Client = fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(tt.binding).WithStatusSubresource(tt.binding).
-					WithIndex(&workv1alpha1.Work{}, workv1alpha2.ResourceBindingPermanentIDLabel, utilhelper.IndexerFuncBasedOnLabel(workv1alpha2.ResourceBindingPermanentIDLabel)).
+					WithIndex(&workv1alpha1.Work{}, indexregistry.WorkIndexByResourceBindingID, utilhelper.IndexerFuncBasedOnLabel(workv1alpha2.ResourceBindingPermanentIDLabel)).
 					Build()
 			}
 
@@ -218,7 +219,7 @@ func TestRBStatusController_syncBindingStatus(t *testing.T) {
 
 			if tt.resourceExistInClient {
 				c.Client = fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(binding).WithStatusSubresource(binding).
-					WithIndex(&workv1alpha1.Work{}, workv1alpha2.ResourceBindingPermanentIDLabel, utilhelper.IndexerFuncBasedOnLabel(workv1alpha2.ResourceBindingPermanentIDLabel)).
+					WithIndex(&workv1alpha1.Work{}, indexregistry.WorkIndexByResourceBindingID, utilhelper.IndexerFuncBasedOnLabel(workv1alpha2.ResourceBindingPermanentIDLabel)).
 					Build()
 			}
 

--- a/pkg/util/helper/binding_test.go
+++ b/pkg/util/helper/binding_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/keys"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
+	"github.com/karmada-io/karmada/pkg/util/indexregistry"
 	"github.com/karmada-io/karmada/pkg/util/names"
 	testhelper "github.com/karmada-io/karmada/test/helper"
 )
@@ -466,7 +467,7 @@ func TestFindOrphanWorks(t *testing.T) {
 					},
 				).WithIndex(
 					&workv1alpha1.Work{},
-					workv1alpha2.ResourceBindingPermanentIDLabel,
+					indexregistry.WorkIndexByResourceBindingID,
 					IndexerFuncBasedOnLabel(workv1alpha2.ResourceBindingPermanentIDLabel),
 				).Build(),
 				bindingNamespace: "default",
@@ -515,7 +516,7 @@ func TestFindOrphanWorks(t *testing.T) {
 					},
 				).WithIndex(
 					&workv1alpha1.Work{},
-					workv1alpha2.ResourceBindingPermanentIDLabel,
+					indexregistry.WorkIndexByResourceBindingID,
 					IndexerFuncBasedOnLabel(workv1alpha2.ResourceBindingPermanentIDLabel),
 				).Build(),
 				bindingNamespace: "default",
@@ -571,7 +572,7 @@ func TestFindOrphanWorks(t *testing.T) {
 					},
 				).WithIndex(
 					&workv1alpha1.Work{},
-					workv1alpha2.ClusterResourceBindingPermanentIDLabel,
+					indexregistry.WorkIndexByClusterResourceBindingID,
 					IndexerFuncBasedOnLabel(workv1alpha2.ClusterResourceBindingPermanentIDLabel),
 				).Build(),
 				bindingNamespace: "",
@@ -1032,7 +1033,7 @@ func TestDeleteWorkByRBNamespaceAndName(t *testing.T) {
 			args: args{
 				c: fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithIndex(
 					&workv1alpha1.Work{},
-					workv1alpha2.ResourceBindingPermanentIDLabel,
+					indexregistry.WorkIndexByResourceBindingID,
 					IndexerFuncBasedOnLabel(workv1alpha2.ResourceBindingPermanentIDLabel),
 				).Build(),
 				namespace: "default",
@@ -1060,7 +1061,7 @@ func TestDeleteWorkByRBNamespaceAndName(t *testing.T) {
 					},
 				).WithIndex(
 					&workv1alpha1.Work{},
-					workv1alpha2.ResourceBindingPermanentIDLabel,
+					indexregistry.WorkIndexByResourceBindingID,
 					IndexerFuncBasedOnLabel(workv1alpha2.ResourceBindingPermanentIDLabel),
 				).Build(),
 				namespace: "default",
@@ -1087,7 +1088,7 @@ func TestDeleteWorkByRBNamespaceAndName(t *testing.T) {
 					},
 				).WithIndex(
 					&workv1alpha1.Work{},
-					workv1alpha2.ClusterResourceBindingPermanentIDLabel,
+					indexregistry.WorkIndexByClusterResourceBindingID,
 					IndexerFuncBasedOnLabel(workv1alpha2.ClusterResourceBindingPermanentIDLabel),
 				).Build(),
 				name:      "foo",

--- a/pkg/util/helper/index.go
+++ b/pkg/util/helper/index.go
@@ -25,17 +25,18 @@ import (
 
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/util/indexregistry"
 )
 
 // IndexWork creates index for Work.
 func IndexWork(ctx context.Context, mgr ctrl.Manager) error {
-	err := mgr.GetFieldIndexer().IndexField(ctx, &workv1alpha1.Work{}, workv1alpha2.ResourceBindingPermanentIDLabel,
+	err := mgr.GetFieldIndexer().IndexField(ctx, &workv1alpha1.Work{}, indexregistry.WorkIndexByResourceBindingID,
 		IndexerFuncBasedOnLabel(workv1alpha2.ResourceBindingPermanentIDLabel))
 	if err != nil {
 		klog.Errorf("failed to create index for work, err: %v", err)
 		return err
 	}
-	err = mgr.GetFieldIndexer().IndexField(ctx, &workv1alpha1.Work{}, workv1alpha2.ClusterResourceBindingPermanentIDLabel,
+	err = mgr.GetFieldIndexer().IndexField(ctx, &workv1alpha1.Work{}, indexregistry.WorkIndexByClusterResourceBindingID,
 		IndexerFuncBasedOnLabel(workv1alpha2.ClusterResourceBindingPermanentIDLabel))
 	if err != nil {
 		klog.Errorf("failed to create index for work, err: %v", err)

--- a/pkg/util/helper/work.go
+++ b/pkg/util/helper/work.go
@@ -33,6 +33,7 @@ import (
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/indexregistry"
 )
 
 // GetWorksByLabelsSet gets WorkList by matching labels.Set.
@@ -48,9 +49,9 @@ func GetWorksByLabelsSet(ctx context.Context, c client.Client, ls labels.Set) (*
 func GetWorksByBindingID(ctx context.Context, c client.Client, bindingID string, namespaced bool) (*workv1alpha1.WorkList, error) {
 	var key string
 	if namespaced {
-		key = workv1alpha2.ResourceBindingPermanentIDLabel
+		key = indexregistry.WorkIndexByResourceBindingID
 	} else {
-		key = workv1alpha2.ClusterResourceBindingPermanentIDLabel
+		key = indexregistry.WorkIndexByClusterResourceBindingID
 	}
 	workList := &workv1alpha1.WorkList{}
 	listOpt := &client.ListOptions{

--- a/pkg/util/helper/work_test.go
+++ b/pkg/util/helper/work_test.go
@@ -33,6 +33,7 @@ import (
 
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/util/indexregistry"
 )
 
 func TestGetWorksByLabelsSet(t *testing.T) {
@@ -119,28 +120,31 @@ func TestGetWorksByBindingID(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		works          []client.Object
-		bindingID      string
-		permanentIDKey string
-		namespaced     bool
-		wantWorks      []string
+		name                string
+		works               []client.Object
+		bindingID           string
+		indexName           string
+		permanentIDLabelKey string
+		namespaced          bool
+		wantWorks           []string
 	}{
 		{
-			name:           "find namespaced binding works",
-			works:          []client.Object{workWithRBID, workWithCRBID},
-			bindingID:      bindingID,
-			permanentIDKey: workv1alpha2.ResourceBindingPermanentIDLabel,
-			namespaced:     true,
-			wantWorks:      []string{"workWithRBID"},
+			name:                "find namespaced binding works",
+			works:               []client.Object{workWithRBID, workWithCRBID},
+			bindingID:           bindingID,
+			indexName:           indexregistry.WorkIndexByResourceBindingID,
+			permanentIDLabelKey: workv1alpha2.ResourceBindingPermanentIDLabel,
+			namespaced:          true,
+			wantWorks:           []string{"workWithRBID"},
 		},
 		{
-			name:           "find cluster binding works",
-			works:          []client.Object{workWithRBID, workWithCRBID},
-			bindingID:      bindingID,
-			permanentIDKey: workv1alpha2.ClusterResourceBindingPermanentIDLabel,
-			namespaced:     false,
-			wantWorks:      []string{"workWithCRBID"},
+			name:                "find cluster binding works",
+			works:               []client.Object{workWithRBID, workWithCRBID},
+			bindingID:           bindingID,
+			indexName:           indexregistry.WorkIndexByClusterResourceBindingID,
+			permanentIDLabelKey: workv1alpha2.ClusterResourceBindingPermanentIDLabel,
+			namespaced:          false,
+			wantWorks:           []string{"workWithCRBID"},
 		},
 	}
 
@@ -150,8 +154,8 @@ func TestGetWorksByBindingID(t *testing.T) {
 				WithScheme(scheme).
 				WithIndex(
 					&workv1alpha1.Work{},
-					tt.permanentIDKey,
-					IndexerFuncBasedOnLabel(tt.permanentIDKey),
+					tt.indexName,
+					IndexerFuncBasedOnLabel(tt.permanentIDLabelKey),
 				).
 				WithObjects(tt.works...).
 				Build()

--- a/pkg/util/helper/workstatus_test.go
+++ b/pkg/util/helper/workstatus_test.go
@@ -36,6 +36,7 @@ import (
 
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/util/indexregistry"
 )
 
 func TestAggregateResourceBindingWorkStatus(t *testing.T) {
@@ -201,7 +202,7 @@ func TestAggregateResourceBindingWorkStatus(t *testing.T) {
 				WithScheme(scheme).
 				WithIndex(
 					&workv1alpha1.Work{},
-					workv1alpha2.ResourceBindingPermanentIDLabel,
+					indexregistry.WorkIndexByResourceBindingID,
 					IndexerFuncBasedOnLabel(workv1alpha2.ResourceBindingPermanentIDLabel),
 				).
 				WithObjects(objects...).
@@ -398,7 +399,7 @@ func TestAggregateClusterResourceBindingWorkStatus(t *testing.T) {
 				WithScheme(scheme).
 				WithIndex(
 					&workv1alpha1.Work{},
-					workv1alpha2.ClusterResourceBindingPermanentIDLabel,
+					indexregistry.WorkIndexByClusterResourceBindingID,
 					IndexerFuncBasedOnLabel(workv1alpha2.ClusterResourceBindingPermanentIDLabel),
 				).
 				WithObjects(objects...).

--- a/pkg/util/indexregistry/fieldindex.go
+++ b/pkg/util/indexregistry/fieldindex.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package indexregistry
+
+const (
+	// WorkIndexByResourceBindingID is the index name for Works that are associated with a ResourceBinding ID.
+	// This index allows efficient lookup of Works by their `metadata.labels.<ResourceBindingPermanentIDLabel>`,
+	// which references the ID of the bound ResourceBinding object.
+	WorkIndexByResourceBindingID = "WorkIndexByResourceBindingID"
+
+	// WorkIndexByClusterResourceBindingID is the index name for Works associated with a ClusterResourceBinding ID.
+	// The index is built using `metadata.labels.<ClusterResourceBindingPermanentIDLabel>` to enable fast queries
+	// of Works linked to specific ClusterResourceBinding objects across all namespaces.
+	WorkIndexByClusterResourceBindingID = "WorkIndexByClusterResourceBindingID"
+)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR introduced two index names for Works, to replace the original label name.
Each index should have a unique name, better not to share it with the label name.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR focuses on renaming the index name and introduces a dedicated package(`pkg/util/indexregistry`) that could be used to store all indexes.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

