### PR TITLE
Fix segmentation violation error in `agent` component

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -184,8 +184,12 @@ func run(ctx context.Context, opts *options.Options) error {
 	if err != nil {
 		return err
 	}
-	registerOption.Secret = *clusterSecret
-	registerOption.ImpersonatorSecret = *impersonatorSecret
+	if clusterSecret != nil {
+		registerOption.Secret = *clusterSecret
+	}
+	if impersonatorSecret != nil {
+		registerOption.ImpersonatorSecret = *impersonatorSecret
+	}
 	err = util.RegisterClusterInControllerPlane(registerOption, controlPlaneKubeClient, generateClusterInControllerPlane)
 	if err != nil {
 		return fmt.Errorf("failed to register with karmada control plane: %w", err)


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind bug

**What this PR does / why we need it**:
When the [report-secrets](https://github.com/karmada-io/karmada/blob/release-1.13/cmd/agent/app/options/options.go#L202) flag is set to `None` in the `agent` component, cluster and cluster impersonator secrets will not be generated.  However, those secret pointers will still be dereferenced in the code, resulting in a segmentation violation.

**Which issue(s) this PR fixes**:
Fixes #6213

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-agent`: Fixed a panic issue where the agent does not need to report secure when registering cluster.
```

