### PR TITLE
Automated cherry pick of #6214: Fix segmentation violation error in karmada-agent component

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -184,8 +184,12 @@ func run(ctx context.Context, opts *options.Options) error {
 	if err != nil {
 		return err
 	}
-	registerOption.Secret = *clusterSecret
-	registerOption.ImpersonatorSecret = *impersonatorSecret
+	if clusterSecret != nil {
+		registerOption.Secret = *clusterSecret
+	}
+	if impersonatorSecret != nil {
+		registerOption.ImpersonatorSecret = *impersonatorSecret
+	}
 	err = util.RegisterClusterInControllerPlane(registerOption, controlPlaneKubeClient, generateClusterInControllerPlane)
 	if err != nil {
 		return fmt.Errorf("failed to register with karmada control plane: %w", err)


### PR DESCRIPTION
Cherry pick of #6214 on release-1.13.
#6214: Fix segmentation violation error in karmada-agent component
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-agent`: Fixed a panic issue where the agent does not need to report secret when registering cluster.
```