### PR TITLE
fix the issue where the binding gracefulEvictionTask can never be clear

### DIFF
--- a/pkg/controllers/gracefuleviction/crb_graceful_eviction_controller_test.go
+++ b/pkg/controllers/gracefuleviction/crb_graceful_eviction_controller_test.go
@@ -67,7 +67,8 @@ func TestCRBGracefulEvictionController_Reconcile(t *testing.T) {
 			name: "binding with active graceful eviction tasks",
 			binding: &workv1alpha2.ClusterResourceBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-binding",
+					Name:       "test-binding",
+					Generation: 1,
 				},
 				Spec: workv1alpha2.ResourceBindingSpec{
 					GracefulEvictionTasks: []workv1alpha2.GracefulEvictionTask{

--- a/pkg/controllers/gracefuleviction/rb_graceful_eviction_controller_test.go
+++ b/pkg/controllers/gracefuleviction/rb_graceful_eviction_controller_test.go
@@ -69,8 +69,9 @@ func TestRBGracefulEvictionController_Reconcile(t *testing.T) {
 			name: "binding with active graceful eviction tasks",
 			binding: &workv1alpha2.ResourceBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-binding",
-					Namespace: "default",
+					Name:       "test-binding",
+					Namespace:  "default",
+					Generation: 1,
 				},
 				Spec: workv1alpha2.ResourceBindingSpec{
 					GracefulEvictionTasks: []workv1alpha2.GracefulEvictionTask{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

When the binding object is scheduled but there is no result, the SchedulerObservedGeneration in the binding object status will not be set to the generation value, which results in graceful-eviction-controller will not be able to handle gracefulEvictionTask and will always remain.

**Which issue(s) this PR fixes**:
Fixes #3747

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: fix the issue where the binding gracefulEvictionTask can never be clear.
```

