### PR TITLE
Automated cherry pick of #6227: to prevent the generation judgment from always being false

### DIFF
--- a/pkg/controllers/gracefuleviction/crb_graceful_eviction_controller_test.go
+++ b/pkg/controllers/gracefuleviction/crb_graceful_eviction_controller_test.go
@@ -67,7 +67,8 @@ func TestCRBGracefulEvictionController_Reconcile(t *testing.T) {
 			name: "binding with active graceful eviction tasks",
 			binding: &workv1alpha2.ClusterResourceBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-binding",
+					Name:       "test-binding",
+					Generation: 1,
 				},
 				Spec: workv1alpha2.ResourceBindingSpec{
 					GracefulEvictionTasks: []workv1alpha2.GracefulEvictionTask{

--- a/pkg/controllers/gracefuleviction/rb_graceful_eviction_controller_test.go
+++ b/pkg/controllers/gracefuleviction/rb_graceful_eviction_controller_test.go
@@ -69,8 +69,9 @@ func TestRBGracefulEvictionController_Reconcile(t *testing.T) {
 			name: "binding with active graceful eviction tasks",
 			binding: &workv1alpha2.ResourceBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-binding",
-					Namespace: "default",
+					Name:       "test-binding",
+					Namespace:  "default",
+					Generation: 1,
 				},
 				Spec: workv1alpha2.ResourceBindingSpec{
 					GracefulEvictionTasks: []workv1alpha2.GracefulEvictionTask{


### PR DESCRIPTION
Cherry pick of #6227 on release-1.12.
#6227: to prevent the generation judgment from always being false
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`: Fixed the issue that the gracefulEvictionTask of ResourceBinding can not be cleared in case of schedule fails.
```