### PR TITLE
Upgrade golangci-lint from v1.64.8 to v2.0.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,11 @@
 # This files contains all configuration options for analysis running.
 # More details please refer to: https://golangci-lint.run/usage/configuration/
 
+version: "2"
 run:
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  # timeout for analysis, e.g. 30s, 5m, default timeout is disabled
   timeout: 10m
-
+  
   # One of 'readonly' and 'vendor'.
   #  - readonly: the go command is disallowed from the implicit automatic updating of go.mod described above.
   #              Instead, it fails when any changes to go.mod are needed. This setting is most useful to check
@@ -14,95 +15,97 @@ run:
   modules-download-mode: readonly
 linters:
   enable:
-  # linters maintained by golang.org
-  - gofmt
-  - goimports
-  - govet
-  # linters default enabled by golangci-lint .
-  - errcheck
-  - gosimple
-  - ineffassign
-  - staticcheck
-  - typecheck
-  - unused
-  # other linters supported by golangci-lint.
-  - gci
-  - gocyclo
-  - gosec
-  - misspell
-  - whitespace
-  - revive
-  - depguard
-
-linters-settings:
-  depguard:
-    rules:
-      main:
-        deny:
-        - pkg: "io/ioutil"
-          desc: "replaced by io and os packages since Go 1.16: https://tip.golang.org/doc/go1.16#ioutil"
-  goimports:
-    local-prefixes: github.com/karmada-io/karmada
-  gocyclo:
-    # minimal cyclomatic complexity to report
-    min-complexity: 15
-  gci:
-    sections:
-      - Standard
-      - Default
-      - Prefix(github.com/karmada-io/karmada)
-  revive:
-    rules:
-      # Disable if-return as it is too strict and not always useful.
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#if-return
-      - name: if-return
-        disabled: true
-      - name: package-comments
-      - name: superfluous-else
-        arguments:
-          - preserveScope
-      - name: error-strings
-      - name: error-return
-      - name: receiver-naming
-      - name: increment-decrement
-      - name: range
-      - name: error-naming
-      - name: dot-imports
-      - name: errorf
-      - name: exported
-      - name: var-declaration
-      - name: blank-imports
-      - name: indent-error-flow
-      - name: unreachable-code
-      - name: var-naming
-      - name: redefines-builtin-id
-      - name: unused-parameter
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: unexported-return
-      - name: time-naming
-      - name: empty-block
-
-issues:
-  # The list of ids of default excludes to include or disable. By default it's empty.
-  include:
-  # disable excluding of issues about comments from revive
-  # see https://golangci-lint.run/usage/configuration/#command-line-options for more info
-  - EXC0012
-  - EXC0013
-  - EXC0014
-  # Which dirs to exclude: issues from them won't be reported.
-  # Can use regexp here: `generated.*`, regexp is applied on full path,
-  # including the path prefix if one is set.
-  # Default dirs are skipped independently of this option's value (see exclude-dirs-use-default).
-  # "/" will be replaced by current OS file path separator to properly work on Windows.
-  # Default: []
-  exclude-dirs:
-    - hack/tools/preferredimports # This code is directly lifted from the Kubernetes codebase, skip checking
-    - (^|/)vendor($|/)
-    - (^|/)third_party($|/)
-    - pkg/util/lifted # This code is lifted from other projects(Kubernetes, Kubefed, and so on), skip checking.
-  # Enables exclude of directories:
-  # - vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  # Default: true
-  exclude-dirs-use-default: false
+    - depguard
+    - gocyclo
+    - gosec
+    - misspell
+    - revive
+    - whitespace
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: io/ioutil
+              desc: 'replaced by io and os packages since Go 1.16: https://tip.golang.org/doc/go1.16#ioutil'
+    gocyclo:
+      # minimal cyclomatic complexity to report
+      min-complexity: 15
+    revive:
+      rules:
+        # Disable if-return as it is too strict and not always useful.
+        # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#if-return
+        - name: if-return
+          disabled: true
+        - name: package-comments
+          disabled: true
+        - name: superfluous-else
+          arguments:
+            - preserveScope
+        - name: error-strings
+        - name: error-return
+        - name: receiver-naming
+        - name: increment-decrement
+        - name: range
+        - name: error-naming
+        - name: dot-imports
+        - name: errorf
+        - name: exported
+        - name: var-declaration
+        - name: blank-imports
+        - name: indent-error-flow
+        - name: unreachable-code
+        - name: var-naming
+        - name: redefines-builtin-id
+        - name: unused-parameter
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: unexported-return
+        - name: time-naming
+        - name: empty-block
+    staticcheck:
+      checks:
+        - all
+        # Exclude the following checks temporarily.
+        # Will fix the issues in the following PRs.
+        # Issue: https://github.com/karmada-io/karmada/issues/6273.
+        - "-QF1008"
+        - "-ST1019"
+        - "-ST1005"
+        - "-QF1004"
+        - "-ST1011"
+        - "-QF1003"
+        - "-QF1001"
+        - "-ST1000"
+  exclusions:
+    generated: lax
+    presets:
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - hack/tools/preferredimports
+      - (^|/)vendor($|/)
+      - (^|/)third_party($|/)
+      - pkg/util/lifted
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - Standard
+        - Default
+        - Prefix(github.com/karmada-io/karmada)
+    goimports:
+      local-prefixes:
+        - github.com/karmada-io/karmada
+  exclusions:
+    generated: lax
+    paths:
+      - hack/tools/preferredimports
+      - (^|/)vendor($|/)
+      - (^|/)third_party($|/)
+      - pkg/util/lifted

--- a/hack/verify-staticcheck.sh
+++ b/hack/verify-staticcheck.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-GOLANGCI_LINT_VER="v1.64.8"
+GOLANGCI_LINT_VER="v2.0.2"
 
 cd "${REPO_ROOT}"
 source "hack/util.sh"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
This PR upgrades `golangci-lint` from `v1.64.8` to the latest stable version, `v2.0.2`. The configuration file (`.golangci.yml`) has been updated to align with the significant structural changes introduced in `v2.0`, primarily guided by the output of the `golangci-lint migrate` command and the official migration documentation.

Key changes include:

**Separation of Linters and Formatters**: `gofmt`, `goimports`, and `gci` have been moved from the `linters.enable` list to the new top-level `formatters.enable` section, reflecting their primary role. Their settings are now under `formatters.settings`.
**Implicit Standard Linters**: Linters enabled by **default** or integral to golangci-lint's core operation in v2.0 (such as `govet`, `errcheck`, `staticcheck`, `unused`, `ineffassign`, `typecheck`) are no longer explicitly listed in `linters.enable`, simplifying the configuration. Only **non-default** linters remain explicitly enabled.
**Merge of the Linters**: `staticcheck`, `stylecheck`, and `gosimple` are merged into one linter, `staticcheck`.
**New exclusions Block**: 
- The previous `issues: block` for managing exclusions is replaced by the new top-level `exclusions: block`.
- `issues.exclude-dirs` have been migrated to `exclusions.paths`.
- Standard exclusion sets are now managed via `exclusions.presets` (e.g., `common-false-positives`, `legacy`, `std-error-handling`), replacing the previous i`ssues.include` and `issues.exclude-dirs-use-default` mechanisms.
- A specific `generated: lax` setting has been added for handling generated code.
- Formatters now also have their own specific exclusions block.

Crucially, all custom rules (e.g., for `depguard`, `revive`), configurations (`gocyclo`, `gci`, `goimports`), and specific path exclusions (`hack/tools/preferredimports`, `vendor`, `third_party`, `pkg/util/lifted`) have been preserved and migrated to the new v2.0 schema. This upgrade ensures we leverage the latest improvements and features of golangci-lint while maintaining our established code quality standards.

For more details on the changes in v2.0, please refer to the official migration guide: [https://golangci-lint.run/product/migration-guide/](https://www.google.com/url?sa=E&q=https%3A%2F%2Fgolangci-lint.run%2Fproduct%2Fmigration-guide%2F)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
We are not using any deprecated linters: https://golangci-lint.run/product/migration-guide/#deprecated-linters.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Upgraded `golangci-lint` from v1.64.8 to v2.0.2. This may introduce new linting checks.
```

