### PR TITLE
Automated cherry pick of #6188: Fix Missing Role, RoleBinding, and ServiceAccount for Custom

### DIFF
--- a/charts/karmada/templates/pre-install-job.yaml
+++ b/charts/karmada/templates/pre-install-job.yaml
@@ -182,6 +182,58 @@ data:
     {{- $.Files.Get $path | nindent 8 }}
   {{ end }}
 
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}-hook-job
+  namespace: {{ $namespace }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "1"
+  {{- if "karmada.preInstallJob.labels" }}
+  labels:
+    {{- include "karmada.preInstallJob.labels" . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $name }}-hook-job
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "1"
+  {{- if "karmada.preInstallJob.labels" }}
+  labels:
+    {{- include "karmada.preInstallJob.labels" . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups: ['*']
+    resources: ['*']
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+  - nonResourceURLs: ['*']
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $name }}-hook-job
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "1"
+  {{- if "karmada.preInstallJob.labels" }}
+  labels:
+    {{- include "karmada.preInstallJob.labels" . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $name }}-hook-job
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}-hook-job
+    namespace: {{ $namespace }}
+
 {{- if eq .Values.certs.mode "custom" }}
 ---
 apiVersion: v1
@@ -445,57 +497,6 @@ spec:
           name: {{ $name }}-config
       - name: configs
         emptyDir: {}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ $name }}-hook-job
-  namespace: {{ $namespace }}
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "1"
-  {{- if "karmada.preInstallJob.labels" }}
-  labels:
-    {{- include "karmada.preInstallJob.labels" . | nindent 4 }}
-  {{- end }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ $name }}-hook-job
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "1"
-  {{- if "karmada.preInstallJob.labels" }}
-  labels:
-    {{- include "karmada.preInstallJob.labels" . | nindent 4 }}
-  {{- end }}
-rules:
-  - apiGroups: ['*']
-    resources: ['*']
-    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
-  - nonResourceURLs: ['*']
-    verbs: ["get"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ $name }}-hook-job
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "1"
-  {{- if "karmada.preInstallJob.labels" }}
-  labels:
-    {{- include "karmada.preInstallJob.labels" . | nindent 4 }}
-  {{- end }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ $name }}-hook-job
-subjects:
-  - kind: ServiceAccount
-    name: {{ $name }}-hook-job
-    namespace: {{ $namespace }}
 ---
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Cherry pick of #6188 on release-1.13.
#6188: Fix Missing Role, RoleBinding, and ServiceAccount for Custom
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
helm: Fixed the issue where the required ServiceAccount was missing when the certificate mode was set to custom. 
```