### PR TITLE
design:Add component certificate identification for client components

### DIFF
--- a/artifacts/deploy/karmada-aggregated-apiserver.yaml
+++ b/artifacts/deploy/karmada-aggregated-apiserver.yaml
@@ -73,13 +73,30 @@ spec:
       volumes:
         - name: karmada-config
           secret:
-            secretName: karmada-aggregated-apiserver-config
+            secretName: karmada-aggregated-apiserver-secret
+            items:
+              - key: karmada.config
+                path: karmada.config
         - name: server-cert
           secret:
-            secretName: karmada-aggregated-apiserver-cert
+            secretName: karmada-aggregated-apiserver-secret
+            items:
+              - key: ca.crt
+                path: ca.crt
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
         - name: etcd-client-cert
           secret:
-            secretName: karmada-aggregated-apiserver-etcd-client-cert
+            secretName: karmada-aggregated-apiserver-secret
+            items:
+              - key: etcd-ca.crt
+                path: ca.crt
+              - key: etcd-client.crt
+                path: tls.crt
+              - key: etcd-client.key
+                path: tls.key
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/artifacts/deploy/karmada-apiserver.yaml
+++ b/artifacts/deploy/karmada-apiserver.yaml
@@ -106,13 +106,34 @@ spec:
       volumes:
         - name: server-cert
           secret:
-            secretName: karmada-apiserver-cert
+            secretName: karmada-apiserver-secret
+            items:
+              - key: ca.crt
+                path: ca.crt
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
         - name: etcd-client-cert
           secret:
-            secretName: karmada-apiserver-etcd-client-cert
+            secretName: karmada-apiserver-secret
+            items:
+              - key: etcd-ca.crt
+                path: ca.crt
+              - key: etcd-client.crt
+                path: tls.crt
+              - key: etcd-client.key
+                path: tls.key
         - name: front-proxy-client-cert
           secret:
-            secretName: karmada-apiserver-front-proxy-client-cert
+            secretName: karmada-apiserver-secret
+            items:
+              - key: ca.crt
+                path: ca.crt
+              - key: front-proxy-client.crt
+                path: tls.crt
+              - key: front-proxy-client.key
+                path: tls.key
         - name: service-account-key-pair
           secret:
             secretName: karmada-apiserver-service-account-key-pair

--- a/artifacts/deploy/karmada-controller-manager.yaml
+++ b/artifacts/deploy/karmada-controller-manager.yaml
@@ -17,8 +17,8 @@ spec:
     spec:
       automountServiceAccountToken: false
       tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+        - key: node-role.kubernetes.io/master
+          operator: Exists
       containers:
         - name: karmada-controller-manager
           securityContext:
@@ -50,12 +50,15 @@ spec:
               name: metrics
               protocol: TCP
           volumeMounts:
-          - name: karmada-config
-            mountPath: /etc/karmada/config
+            - name: karmada-config
+              mountPath: /etc/karmada/config
       volumes:
         - name: karmada-config
           secret:
-            secretName: karmada-controller-manager-config
+            secretName: karmada-controller-manager-secret
+            items:
+              - key: karmada.config
+                path: karmada.config
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/artifacts/deploy/karmada-descheduler.yaml
+++ b/artifacts/deploy/karmada-descheduler.yaml
@@ -57,10 +57,20 @@ spec:
       volumes:
         - name: karmada-config
           secret:
-            secretName: karmada-descheduler-config
+            secretName: karmada-descheduler-secret
+            items:
+              - key: karmada.config
+                path: karmada.config
         - name: scheduler-estimator-client-cert
           secret:
-            secretName: karmada-descheduler-scheduler-estimator-client-cert
+            secretName: karmada-descheduler-secret
+            items:
+              - key: ca.crt
+                path: ca.crt
+              - key: grpc.crt
+                path: tls.crt
+              - key: grpc.key
+                path: tls.key
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/artifacts/deploy/karmada-etcd.yaml
+++ b/artifacts/deploy/karmada-etcd.yaml
@@ -101,10 +101,24 @@ spec:
             type: DirectoryOrCreate
         - name: server-cert
           secret:
-            secretName: etcd-cert
+            secretName: etcd-secret
+            items:
+              - key: ca.crt
+                path: ca.crt
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
         - name: etcd-client-cert
           secret:
-            secretName: etcd-etcd-client-cert
+            secretName: etcd-secret
+            items:
+              - key: ca.crt
+                path: ca.crt
+              - key: etcd-client.crt
+                path: tls.crt
+              - key: etcd-client.key
+                path: tls.key
       priorityClassName: system-node-critical
 ---
 

--- a/artifacts/deploy/karmada-metrics-adapter.yaml
+++ b/artifacts/deploy/karmada-metrics-adapter.yaml
@@ -70,10 +70,20 @@ spec:
       volumes:
         - name: karmada-config
           secret:
-            secretName: karmada-metrics-adapter-config
+            secretName: karmada-metrics-adapter-secret
+            items:
+              - key: karmada.config
+                path: karmada.config
         - name: server-cert
           secret:
-            secretName: karmada-metrics-adapter-cert
+            secretName: karmada-metrics-adapter-secret
+            items:
+              - key: ca.crt
+                path: ca.crt
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/artifacts/deploy/karmada-scheduler-estimator.yaml
+++ b/artifacts/deploy/karmada-scheduler-estimator.yaml
@@ -58,7 +58,14 @@ spec:
       volumes:
         - name: server-cert
           secret:
-            secretName: karmada-scheduler-estimator-cert
+            secretName: karmada-scheduler-estimator-secret
+            items:
+              - key: ca.crt
+                path: ca.crt
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
         - name: member-kubeconfig
           secret:
             secretName: {{member_cluster_name}}-kubeconfig

--- a/artifacts/deploy/karmada-scheduler.yaml
+++ b/artifacts/deploy/karmada-scheduler.yaml
@@ -59,10 +59,20 @@ spec:
       volumes:
         - name: karmada-config
           secret:
-            secretName: karmada-scheduler-config
+            secretName: karmada-scheduler-secret
+            items:
+              - key: karmada.config
+                path: karmada.config
         - name: scheduler-estimator-client-cert
           secret:
-            secretName: karmada-scheduler-scheduler-estimator-client-cert
+            secretName: karmada-scheduler-secret
+            items:
+              - key: ca.crt
+                path: ca.crt
+              - key: grpc.crt
+                path: tls.crt
+              - key: grpc.key
+                path: tls.key
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/artifacts/deploy/karmada-search.yaml
+++ b/artifacts/deploy/karmada-search.yaml
@@ -66,13 +66,30 @@ spec:
       volumes:
         - name: karmada-config
           secret:
-            secretName: karmada-search-config
+            secretName: karmada-search-secret
+            items:
+              - key: karmada.config
+                path: karmada.config
         - name: server-cert
           secret:
-            secretName: karmada-search-cert
+            secretName: karmada-search-secret
+            items:
+              - key: ca.crt
+                path: ca.crt
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
         - name: etcd-client-cert
           secret:
-            secretName: karmada-search-etcd-client-cert
+            secretName: karmada-search-secret
+            items:
+              - key: etcd-ca.crt
+                path: ca.crt
+              - key: etcd-client.crt
+                path: tls.crt
+              - key: etcd-client.key
+                path: tls.key
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/artifacts/deploy/karmada-webhook.yaml
+++ b/artifacts/deploy/karmada-webhook.yaml
@@ -55,10 +55,20 @@ spec:
       volumes:
         - name: karmada-config
           secret:
-            secretName: karmada-webhook-config
+            secretName: karmada-webhook-secret
+            items:
+              - key: karmada.config
+                path: karmada.config
         - name: server-cert
           secret:
-            secretName: karmada-webhook-cert
+            secretName: karmada-webhook-secret
+            items:
+              - key: ca.crt
+                path: ca.crt
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/artifacts/secret/karmada-apiserver-secret.yaml
+++ b/artifacts/secret/karmada-apiserver-secret.yaml
@@ -1,0 +1,44 @@
+# Secret for the karmada-apiserver component
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${component}-secret
+  namespace: karmada-system
+type: Opaque
+data:
+  ca.crt: ${ca_crt}
+  
+  tls.crt: ${tls_crt}
+  tls.key: ${tls_key}
+  
+  client.crt: ${client_crt}
+  client.key: ${client_key}
+  
+  etcd-ca.crt: ${etcd_ca_crt}
+  etcd-client.crt: ${etcd_client_crt}
+  etcd-client.key: ${etcd_client_key}
+
+  front-proxy-client.crt: ${front_proxy_client_crt}
+  front-proxy-client.key: ${front_proxy_client_key}
+  
+stringData:
+  karmada.config: |-
+    apiVersion: v1
+    kind: Config
+    preferences: {}
+    clusters:
+    - name: karmada-apiserver
+      cluster:
+        certificate-authority-data: ${ca_crt}
+        server: https://karmada-apiserver.karmada-system.svc.cluster.local:5443
+    users:
+    - name: karmada-apiserver
+      user:
+        client-certificate-data: ${client_crt}
+        client-key-data: ${client_key}
+    contexts:
+    - name: karmada-apiserver
+      context:
+        cluster: karmada-apiserver
+        user: karmada-apiserver
+    current-context: karmada-apiserver

--- a/artifacts/secret/karmada-client-grpc-secret.yaml
+++ b/artifacts/secret/karmada-client-grpc-secret.yaml
@@ -1,0 +1,37 @@
+# Secret for components requiring GRPC client certificates (e.g., karmada-scheduler, karmada-descheduler)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${component}-secret
+  namespace: karmada-system
+type: Opaque
+data:
+  ca.crt: ${ca_crt}
+  
+  client.crt: ${client_crt}
+  client.key: ${client_key}
+
+  grpc.crt: ${grpc_crt}
+  grpc.key: ${grpc_key}
+  
+stringData:
+  karmada.config: |-
+    apiVersion: v1
+    kind: Config
+    preferences: {}
+    clusters:
+    - name: karmada-apiserver
+      cluster:
+        certificate-authority-data: ${ca_crt}
+        server: https://karmada-apiserver.karmada-system.svc.cluster.local:5443
+    users:
+    - name: karmada-apiserver
+      user:
+        client-certificate-data: ${client_crt}
+        client-key-data: ${client_key}
+    contexts:
+    - name: karmada-apiserver
+      context:
+        cluster: karmada-apiserver
+        user: karmada-apiserver
+    current-context: karmada-apiserver

--- a/artifacts/secret/karmada-client-secret.yaml
+++ b/artifacts/secret/karmada-client-secret.yaml
@@ -1,0 +1,34 @@
+# Secret for client-only components (e.g., karmada-controller-manager, karmadactl, karmada-agent)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${component}-secret
+  namespace: karmada-system
+type: Opaque
+data:
+  ca.crt: ${ca_crt}
+  
+  client.crt: ${client_crt}
+  client.key: ${client_key}
+  
+stringData:
+  karmada.config: |-
+    apiVersion: v1
+    kind: Config
+    preferences: {}
+    clusters:
+    - name: karmada-apiserver
+      cluster:
+        certificate-authority-data: ${ca_crt}
+        server: https://karmada-apiserver.karmada-system.svc.cluster.local:5443
+    users:
+    - name: karmada-apiserver
+      user:
+        client-certificate-data: ${client_crt}
+        client-key-data: ${client_key}
+    contexts:
+    - name: karmada-apiserver
+      context:
+        cluster: karmada-apiserver
+        user: karmada-apiserver
+    current-context: karmada-apiserver

--- a/artifacts/secret/karmada-etcd-secret.yaml
+++ b/artifacts/secret/karmada-etcd-secret.yaml
@@ -1,0 +1,15 @@
+# Secret for the karmada-etcd component
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${component}-secret
+  namespace: karmada-system
+type: Opaque
+data:
+  ca.crt: ${ca_crt}
+
+  tls.crt: ${tls_crt}
+  tls.key: ${tls_key}
+  
+  etcd-client.crt: ${etcd_client_crt}
+  etcd-client.key: ${etcd_client_key}

--- a/artifacts/secret/karmada-server-client-etcd-secret.yaml
+++ b/artifacts/secret/karmada-server-client-etcd-secret.yaml
@@ -1,0 +1,41 @@
+# Secret for components requiring Server, Client, and ETCD Client certificates (e.g., karmada-aggregated-apiserver, karmada-search)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${component}-secret
+  namespace: karmada-system
+type: Opaque
+data:
+  ca.crt: ${ca_crt}
+  
+  tls.crt: ${tls_crt}
+  tls.key: ${tls_key}
+  
+  client.crt: ${client_crt}
+  client.key: ${client_key}
+  
+  etcd-ca.crt: ${etcd_ca_crt}
+  etcd-client.crt: ${etcd_client_crt}
+  etcd-client.key: ${etcd_client_key}
+  
+stringData:
+  karmada.config: |-
+    apiVersion: v1
+    kind: Config
+    preferences: {}
+    clusters:
+    - name: karmada-apiserver
+      cluster:
+        certificate-authority-data: ${ca_crt}
+        server: https://karmada-apiserver.karmada-system.svc.cluster.local:5443
+    users:
+    - name: karmada-apiserver
+      user:
+        client-certificate-data: ${client_crt}
+        client-key-data: ${client_key}
+    contexts:
+    - name: karmada-apiserver
+      context:
+        cluster: karmada-apiserver
+        user: karmada-apiserver
+    current-context: karmada-apiserver

--- a/artifacts/secret/karmada-server-client-secret.yaml
+++ b/artifacts/secret/karmada-server-client-secret.yaml
@@ -1,0 +1,37 @@
+# Secret for components requiring Server and Client certificates (e.g., karmada-scheduler-estimator, karmada-metrics-adapter, karmada-webhook)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${component}-secret
+  namespace: karmada-system
+type: Opaque
+data:
+  ca.crt: ${ca_crt}
+  
+  tls.crt: ${tls_crt}
+  tls.key: ${tls_key}
+  
+  client.crt: ${client_crt}
+  client.key: ${client_key}
+  
+stringData:
+  karmada.config: |-
+    apiVersion: v1
+    kind: Config
+    preferences: {}
+    clusters:
+    - name: karmada-apiserver
+      cluster:
+        certificate-authority-data: ${ca_crt}
+        server: https://karmada-apiserver.karmada-system.svc.cluster.local:5443
+    users:
+    - name: karmada-apiserver
+      user:
+        client-certificate-data: ${client_crt}
+        client-key-data: ${client_key}
+    contexts:
+    - name: karmada-apiserver
+      context:
+        cluster: karmada-apiserver
+        user: karmada-apiserver
+    current-context: karmada-apiserver

--- a/hack/deploy-karmada.sh
+++ b/hack/deploy-karmada.sh
@@ -98,24 +98,39 @@ function generate_cert_related_secrets {
 
     # Generate specific secrets for etcd and karmada-apiserver
     generate_etcd_secret "etcd" "${karmada_ca}" "${ETCD_SERVER_CRT}" "${ETCD_SERVER_KEY}" "${ETCD_CLIENT_CRT}" "${ETCD_CLIENT_KEY}"
+    
     generate_apiserver_secret "karmada-apiserver" "${karmada_ca}" \
         "${KARMADA_APISERVER_SERVER_CRT}" "${KARMADA_APISERVER_SERVER_KEY}" \
         "${KARMADA_APISERVER_CLIENT_CRT}" "${KARMADA_APISERVER_CLIENT_KEY}" \
         "${KARMADA_APISERVER_ETCD_CLIENT_CRT}" "${KARMADA_APISERVER_ETCD_CLIENT_KEY}" \
         "${FRONT_PROXY_CLIENT_CRT}" "${FRONT_PROXY_CLIENT_KEY}"
+    
+    generate_server_client_etcd_secret "karmada-aggregated-apiserver" "${karmada_ca}" \
+        "${KARMADA_AGGREGATED_APISERVER_SERVER_CRT}" "${KARMADA_AGGREGATED_APISERVER_SERVER_KEY}" \
+        "${CLIENT_CRT}" "${CLIENT_KEY}" \
+        "${ETCD_CLIENT_CRT}" "${ETCD_CLIENT_KEY}"
+        
+    generate_server_client_etcd_secret "karmada-search" "${karmada_ca}" \
+        "${KARMADA_SEARCH_SERVER_CRT}" "${KARMADA_SEARCH_SERVER_KEY}" \
+        "${CLIENT_CRT}" "${CLIENT_KEY}" \
+        "${ETCD_CLIENT_CRT}" "${ETCD_CLIENT_KEY}"
+        
+    generate_server_client_secret "karmada-webhook" "${karmada_ca}" \
+        "${KARMADA_WEBHOOK_SERVER_CRT}" "${KARMADA_WEBHOOK_SERVER_KEY}" \
+        "${CLIENT_CRT}" "${CLIENT_KEY}"
+        
+    generate_server_client_secret "karmada-metrics-adapter" "${karmada_ca}" \
+        "${KARMADA_METRICS_ADAPTER_SERVER_CRT}" "${KARMADA_METRICS_ADAPTER_SERVER_KEY}" \
+        "${CLIENT_CRT}" "${CLIENT_KEY}"
+        
+    generate_server_client_secret "karmada-scheduler-estimator" "${karmada_ca}" \
+        "${KARMADA_SCHEDULER_ESTIMATOR_SERVER_CRT}" "${KARMADA_SCHEDULER_ESTIMATOR_SERVER_KEY}" \
+        "${CLIENT_CRT}" "${CLIENT_KEY}"
 
     # 1. generate secret with secret cert
-    generate_cert_secret karmada-aggregated-apiserver ${karmada_ca} ${SERVER_CRT} ${SERVER_KEY}
-    generate_cert_secret karmada-metrics-adapter ${karmada_ca} ${SERVER_CRT} ${SERVER_KEY}
-    generate_cert_secret karmada-search ${karmada_ca} ${SERVER_CRT} ${SERVER_KEY}
-    generate_cert_secret karmada-webhook ${karmada_ca} ${SERVER_CRT} ${SERVER_KEY}
     generate_cert_secret karmada-interpreter-webhook-example ${karmada_ca} ${SERVER_CRT} ${SERVER_KEY}
-    generate_cert_secret karmada-scheduler-estimator ${karmada_ca} ${SERVER_CRT} ${SERVER_KEY}
 
     # 2. generate secret with client cert
-    generate_cert_secret karmada-aggregated-apiserver-etcd-client ${karmada_ca} ${ETCD_CLIENT_CRT} ${ETCD_CLIENT_KEY}
-    generate_cert_secret karmada-search-etcd-client ${karmada_ca} ${ETCD_CLIENT_CRT} ${ETCD_CLIENT_KEY}
-    generate_cert_secret etcd-etcd-client ${karmada_ca} ${ETCD_CLIENT_CRT} ${ETCD_CLIENT_KEY}
     generate_cert_secret karmada-scheduler-scheduler-estimator-client ${karmada_ca} ${CLIENT_CRT} ${CLIENT_KEY}
     generate_cert_secret karmada-descheduler-scheduler-estimator-client ${karmada_ca} ${CLIENT_CRT} ${CLIENT_KEY}
 
@@ -222,6 +237,54 @@ function generate_key_pair_secret() {
   kubectl --context="${HOST_CLUSTER_NAME}" apply -f "${TEMP_PATH}"/${component}-key-pair-secret.yaml
 }
 
+# Generate Secret for Server + Client + ETCD Client components
+# Includes: ca.crt, tls.crt (server), tls.key (server), client.crt, client.key,
+#           etcd-ca.crt, etcd-client.crt, etcd-client.key
+function generate_server_client_etcd_secret() {
+    local component=$1
+    local ca_crt=$2
+    local tls_crt=$3
+    local tls_key=$4
+    local client_crt=$5
+    local client_key=$6
+    local etcd_client_crt=$7
+    local etcd_client_key=$8
+
+    cp "${REPO_ROOT}/artifacts/secret/karmada-server-client-etcd-secret.yaml" "${TEMP_PATH}/${component}-secret.yaml"
+    sed -i'' -e "s/\${component}/${component}/g" "${TEMP_PATH}/${component}-secret.yaml"
+    sed -i'' -e "s/\${ca_crt}/${ca_crt}/g" "${TEMP_PATH}/${component}-secret.yaml"
+    sed -i'' -e "s/\${tls_crt}/${tls_crt}/g" "${TEMP_PATH}/${component}-secret.yaml"
+    sed -i'' -e "s/\${tls_key}/${tls_key}/g" "${TEMP_PATH}/${component}-secret.yaml"
+    sed -i'' -e "s/\${client_crt}/${client_crt}/g" "${TEMP_PATH}/${component}-secret.yaml"
+    sed -i'' -e "s/\${client_key}/${client_key}/g" "${TEMP_PATH}/${component}-secret.yaml"
+    sed -i'' -e "s/\${etcd_ca_crt}/${ca_crt}/g" "${TEMP_PATH}/${component}-secret.yaml"
+    sed -i'' -e "s/\${etcd_client_crt}/${etcd_client_crt}/g" "${TEMP_PATH}/${component}-secret.yaml"
+    sed -i'' -e "s/\${etcd_client_key}/${etcd_client_key}/g" "${TEMP_PATH}/${component}-secret.yaml"
+
+    kubectl --context="${HOST_CLUSTER_NAME}" apply -f "${TEMP_PATH}/${component}-secret.yaml"
+}
+
+# Generate Secret for Server + Client components
+# Includes: ca.crt, tls.crt (server), tls.key (server), client.crt, client.key
+function generate_server_client_secret() {
+    local component=$1
+    local ca_crt=$2
+    local tls_crt=$3
+    local tls_key=$4
+    local client_crt=$5
+    local client_key=$6
+
+    cp "${REPO_ROOT}/artifacts/secret/karmada-server-client-secret.yaml" "${TEMP_PATH}/${component}-secret.yaml"
+    sed -i'' -e "s/\${component}/${component}/g" "${TEMP_PATH}/${component}-secret.yaml"
+    sed -i'' -e "s/\${ca_crt}/${ca_crt}/g" "${TEMP_PATH}/${component}-secret.yaml"
+    sed -i'' -e "s/\${tls_crt}/${tls_crt}/g" "${TEMP_PATH}/${component}-secret.yaml"
+    sed -i'' -e "s/\${tls_key}/${tls_key}/g" "${TEMP_PATH}/${component}-secret.yaml"
+    sed -i'' -e "s/\${client_crt}/${client_crt}/g" "${TEMP_PATH}/${component}-secret.yaml"
+    sed -i'' -e "s/\${client_key}/${client_key}/g" "${TEMP_PATH}/${component}-secret.yaml"
+
+    kubectl --context="${HOST_CLUSTER_NAME}" apply -f "${TEMP_PATH}/${component}-secret.yaml"
+}
+
 # install Karmada's APIs
 function installCRDs() {
     local context_name=$1
@@ -246,6 +309,10 @@ util::create_signing_certkey "" "${CERT_DIR}" ca karmada '"client auth","server 
 # Define SAN names for each server component
 karmadaAltNames=("*.karmada-system.svc.cluster.local" "*.karmada-system.svc" "localhost" "127.0.0.1" $(util::get_apiserver_ip_from_kubeconfig "${HOST_CLUSTER_NAME}") "${interpreter_webhook_example_service_external_ip_address}")
 karmada_apiserver_alt_names=("karmada-apiserver.karmada-system.svc.cluster.local" "karmada-apiserver.karmada-system.svc" "localhost" "127.0.0.1" $(util::get_apiserver_ip_from_kubeconfig "${HOST_CLUSTER_NAME}"))
+karmada_aggregated_apiserver_alt_names=("karmada-aggregated-apiserver.karmada-system.svc.cluster.local" "karmada-aggregated-apiserver.karmada-system.svc" "localhost" "127.0.0.1")
+karmada_webhook_alt_names=("karmada-webhook.karmada-system.svc.cluster.local" "karmada-webhook.karmada-system.svc" "localhost" "127.0.0.1")
+karmada_search_alt_names=("karmada-search.karmada-system.svc.cluster.local" "karmada-search.karmada-system.svc" "localhost" "127.0.0.1")
+karmada_metrics_adapter_alt_names=("karmada-metrics-adapter.karmada-system.svc.cluster.local" "karmada-metrics-adapter.karmada-system.svc" "localhost" "127.0.0.1")
 etcd_server_alt_names=("etcd.karmada-system.svc.cluster.local" "etcd.karmada-system.svc" "etcd-client.karmada-system.svc.cluster.local" "etcd-client.karmada-system.svc" "localhost" "127.0.0.1")
 
 # Generate certificates for common usage
@@ -253,17 +320,27 @@ util::create_certkey "" "${CERT_DIR}" "ca" server server "" "${karmadaAltNames[@
 util::create_certkey "" "${CERT_DIR}" "ca" client system:admin system:masters "${karmadaAltNames[@]}"
 util::create_certkey "" "${CERT_DIR}" "ca" front-proxy-client front-proxy-client "" "${karmadaAltNames[@]}"
 
-# Generate certificates for karmada-apiserver and etcd
+# Generate server certificates for each component with specific SANs
 util::create_certkey "" "${CERT_DIR}" "ca" karmada-apiserver "system:karmada:karmada-apiserver" "" "${karmada_apiserver_alt_names[@]}"
-util::create_certkey "" "${CERT_DIR}" "ca" karmada-apiserver-client "system:karmada:karmada-apiserver" "system:masters" 
-util::create_certkey "" "${CERT_DIR}" "ca" karmada-apiserver-etcd-client "system:karmada:karmada-apiserver-etcd-client" "system:masters"
+util::create_certkey "" "${CERT_DIR}" "ca" karmada-aggregated-apiserver "system:karmada:karmada-aggregated-apiserver" "" "${karmada_aggregated_apiserver_alt_names[@]}"
+util::create_certkey "" "${CERT_DIR}" "ca" karmada-webhook "system:karmada:karmada-webhook" "" "${karmada_webhook_alt_names[@]}"
+util::create_certkey "" "${CERT_DIR}" "ca" karmada-search "system:karmada:karmada-search" "" "${karmada_search_alt_names[@]}"
+util::create_certkey "" "${CERT_DIR}" "ca" karmada-metrics-adapter "system:karmada:karmada-metrics-adapter" "" "${karmada_metrics_adapter_alt_names[@]}"
+util::create_certkey "" "${CERT_DIR}" "ca" karmada-scheduler-estimator "system:karmada:karmada-scheduler-estimator" "" "${karmadaAltNames[@]}"
 util::create_certkey "" "${CERT_DIR}" "ca" etcd-server "system:karmada:etcd-server" "" "${etcd_server_alt_names[@]}"
+
+# Special client certificates (no SAN needed)
+util::create_certkey "" "${CERT_DIR}" "ca" karmada-apiserver-client "system:karmada:karmada-apiserver" "system:masters"
+util::create_certkey "" "${CERT_DIR}" "ca" karmada-apiserver-etcd-client "system:karmada:karmada-apiserver-etcd-client" "system:masters"
 util::create_certkey "" "${CERT_DIR}" "ca" etcd-client "system:karmada:etcd-client" ""
+
+# Create service account key pair
 util::create_key_pair "" "${CERT_DIR}" "sa"
 
 # create namespace for control plane components
 kubectl --context="${HOST_CLUSTER_NAME}" apply -f "${REPO_ROOT}/artifacts/deploy/namespace.yaml"
 
+# Base64 encode all certificates for embedding in secrets
 SERVER_CRT=$(base64 < "${CERT_DIR}/server.crt" | tr -d '\r\n')
 SERVER_KEY=$(base64 < "${CERT_DIR}/server.key" | tr -d '\r\n')
 CLIENT_CRT=$(base64 < "${CERT_DIR}/client.crt" | tr -d '\r\n')
@@ -271,9 +348,21 @@ CLIENT_KEY=$(base64 < "${CERT_DIR}/client.key" | tr -d '\r\n')
 FRONT_PROXY_CLIENT_CRT=$(base64 < "${CERT_DIR}/front-proxy-client.crt" | tr -d '\r\n')
 FRONT_PROXY_CLIENT_KEY=$(base64 < "${CERT_DIR}/front-proxy-client.key" | tr -d '\r\n')
 
-# Add new certificate variables for karmada-apiserver
+# Server certificates for each component
 KARMADA_APISERVER_SERVER_CRT=$(base64 < "${CERT_DIR}/karmada-apiserver.crt" | tr -d '\r\n')
 KARMADA_APISERVER_SERVER_KEY=$(base64 < "${CERT_DIR}/karmada-apiserver.key" | tr -d '\r\n')
+KARMADA_AGGREGATED_APISERVER_SERVER_CRT=$(base64 < "${CERT_DIR}/karmada-aggregated-apiserver.crt" | tr -d '\r\n')
+KARMADA_AGGREGATED_APISERVER_SERVER_KEY=$(base64 < "${CERT_DIR}/karmada-aggregated-apiserver.key" | tr -d '\r\n')
+KARMADA_WEBHOOK_SERVER_CRT=$(base64 < "${CERT_DIR}/karmada-webhook.crt" | tr -d '\r\n')
+KARMADA_WEBHOOK_SERVER_KEY=$(base64 < "${CERT_DIR}/karmada-webhook.key" | tr -d '\r\n')
+KARMADA_SEARCH_SERVER_CRT=$(base64 < "${CERT_DIR}/karmada-search.crt" | tr -d '\r\n')
+KARMADA_SEARCH_SERVER_KEY=$(base64 < "${CERT_DIR}/karmada-search.key" | tr -d '\r\n')
+KARMADA_METRICS_ADAPTER_SERVER_CRT=$(base64 < "${CERT_DIR}/karmada-metrics-adapter.crt" | tr -d '\r\n')
+KARMADA_METRICS_ADAPTER_SERVER_KEY=$(base64 < "${CERT_DIR}/karmada-metrics-adapter.key" | tr -d '\r\n')
+KARMADA_SCHEDULER_ESTIMATOR_SERVER_CRT=$(base64 < "${CERT_DIR}/karmada-scheduler-estimator.crt" | tr -d '\r\n')
+KARMADA_SCHEDULER_ESTIMATOR_SERVER_KEY=$(base64 < "${CERT_DIR}/karmada-scheduler-estimator.key" | tr -d '\r\n')
+
+# Special client certificates
 KARMADA_APISERVER_CLIENT_CRT=$(base64 < "${CERT_DIR}/karmada-apiserver-client.crt" | tr -d '\r\n')
 KARMADA_APISERVER_CLIENT_KEY=$(base64 < "${CERT_DIR}/karmada-apiserver-client.key" | tr -d '\r\n')
 KARMADA_APISERVER_ETCD_CLIENT_CRT=$(base64 < "${CERT_DIR}/karmada-apiserver-etcd-client.crt" | tr -d '\r\n')


### PR DESCRIPTION
**What type of PR is this?**
/kind design
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
This pr is about [issue#6091](https://github.com/karmada-io/karmada/issues/6091)

Previously, all Karmada components shared a set of similar certificates. In this case, we cannot identify the request source by the certificate used in the request, which may lead to some ambiguities. This PR aims to propose a design for testing purposes so that once we confirm there are no issues with the implementation, we can synchronize it to the deployment methods used in production environments, such as in `karmadactl` and `karmada-operator`.

**Which issue(s) this PR fixes**:
Fixes [#6091](https://github.com/karmada-io/karmada/issues/6091)

**Special notes for your reviewer**:
@XiShanYongYe-Chang 
@zhzhuang-zju 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

