### PR TITLE
don't add cluster name to hostname field when aggregate service status

### DIFF
--- a/pkg/resourceinterpreter/default/native/aggregatestatus.go
+++ b/pkg/resourceinterpreter/default/native/aggregatestatus.go
@@ -145,13 +145,6 @@ func aggregateServiceStatus(object *unstructured.Unstructured, aggregatedStatusI
 		klog.V(3).Infof("Grab service(%s/%s) status from cluster(%s), loadBalancer status: %v",
 			service.Namespace, service.Name, item.ClusterName, temp.LoadBalancer)
 
-		// Set cluster name as Hostname by default to indicate the status is collected from which member cluster.
-		for i := range temp.LoadBalancer.Ingress {
-			if temp.LoadBalancer.Ingress[i].Hostname == "" {
-				temp.LoadBalancer.Ingress[i].Hostname = item.ClusterName
-			}
-		}
-
 		newStatus.LoadBalancer.Ingress = append(newStatus.LoadBalancer.Ingress, temp.LoadBalancer.Ingress...)
 	}
 
@@ -183,13 +176,6 @@ func aggregateIngressStatus(object *unstructured.Unstructured, aggregatedStatusI
 		}
 		klog.V(3).Infof("Grab ingress(%s/%s) status from cluster(%s), loadBalancer status: %v",
 			ingress.Namespace, ingress.Name, item.ClusterName, temp.LoadBalancer)
-
-		// Set cluster name as Hostname by default to indicate the status is collected from which member cluster.
-		for i := range temp.LoadBalancer.Ingress {
-			if temp.LoadBalancer.Ingress[i].Hostname == "" {
-				temp.LoadBalancer.Ingress[i].Hostname = item.ClusterName
-			}
-		}
 
 		newStatus.LoadBalancer.Ingress = append(newStatus.LoadBalancer.Ingress, temp.LoadBalancer.Ingress...)
 	}

--- a/pkg/resourceinterpreter/default/native/aggregatestatus_test.go
+++ b/pkg/resourceinterpreter/default/native/aggregatestatus_test.go
@@ -129,7 +129,7 @@ func TestAggregateServiceStatus(t *testing.T) {
 	newServiceLoadBalancer := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: corev1.SchemeGroupVersion.String()},
 		Spec:     corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
-		Status:   corev1.ServiceStatus{LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: "8.8.8.8", Hostname: "member1"}}}},
+		Status:   corev1.ServiceStatus{LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: "8.8.8.8"}}}},
 	}
 	oldObjServiceLoadBalancer, _ := helper.ToUnstructured(oldServiceLoadBalancer)
 	newObjServiceLoadBalancer, _ := helper.ToUnstructured(newServiceLoadBalancer)
@@ -192,7 +192,7 @@ func TestAggregateIngressStatus(t *testing.T) {
 	}
 	newIngress := &networkingv1.Ingress{
 		TypeMeta: metav1.TypeMeta{Kind: "Ingress", APIVersion: networkingv1.SchemeGroupVersion.String()},
-		Status:   networkingv1.IngressStatus{LoadBalancer: networkingv1.IngressLoadBalancerStatus{Ingress: []networkingv1.IngressLoadBalancerIngress{{IP: "8.8.8.8", Hostname: "member1"}}}},
+		Status:   networkingv1.IngressStatus{LoadBalancer: networkingv1.IngressLoadBalancerStatus{Ingress: []networkingv1.IngressLoadBalancerIngress{{IP: "8.8.8.8"}}}},
 	}
 	oldObj, _ := helper.ToUnstructured(oldIngress)
 	newObj, _ := helper.ToUnstructured(newIngress)

--- a/test/e2e/suites/base/resource_test.go
+++ b/test/e2e/suites/base/resource_test.go
@@ -175,9 +175,8 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 					ingresses := []corev1.LoadBalancerIngress{{IP: fmt.Sprintf("172.19.1.%d", index+6)}}
 					for _, ingress := range ingresses {
 						svcLoadBalancer.Ingress = append(svcLoadBalancer.Ingress, corev1.LoadBalancerIngress{
-							IP:       ingress.IP,
-							Hostname: clusterName,
-							IPMode:   ingress.IPMode,
+							IP:     ingress.IP,
+							IPMode: ingress.IPMode,
 						})
 					}
 
@@ -323,8 +322,7 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 					ingresses := []networkingv1.IngressLoadBalancerIngress{{IP: fmt.Sprintf("172.19.2.%d", index+6)}}
 					for _, ingress := range ingresses {
 						ingLoadBalancer.Ingress = append(ingLoadBalancer.Ingress, networkingv1.IngressLoadBalancerIngress{
-							IP:       ingress.IP,
-							Hostname: clusterName,
+							IP: ingress.IP,
 						})
 					}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

see #6248

**Which issue(s) this PR fixes**:
Fixes #6248

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-controller-manager: The default resource interpreter will no longer populate the `.status.LoadBalancer.Ingress[].Hostname` field with the member cluster name for Service and Ingress resources.
```

