### PR TITLE
Automated cherry pick of #6270: fix the issue where discovery-timeout fails to work properly

### DIFF
--- a/pkg/karmadactl/addons/utils/helpers.go
+++ b/pkg/karmadactl/addons/utils/helpers.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +36,7 @@ var (
 	// This blocks until the Deployment's observed generation and ready replicas match the desired state,
 	// ensuring it is fully rolled out.
 	WaitForDeploymentRollout = func(c clientset.Interface, dep *appsv1.Deployment, timeoutSeconds int) error {
-		return cmdutil.WaitForDeploymentRollout(c, dep, timeoutSeconds)
+		return cmdutil.WaitForDeploymentRollout(c, dep, time.Duration(timeoutSeconds)*time.Second)
 	}
 )
 

--- a/pkg/karmadactl/cmdinit/utils/deploy.go
+++ b/pkg/karmadactl/cmdinit/utils/deploy.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"context"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,5 +33,5 @@ func CreateDeployAndWait(kubeClientSet kubernetes.Interface, deployment *appsv1.
 	if _, err := kubeClientSet.AppsV1().Deployments(deployment.GetNamespace()).Create(context.TODO(), deployment, metav1.CreateOptions{}); err != nil {
 		klog.Warning(err)
 	}
-	return util.WaitForDeploymentRollout(kubeClientSet, deployment, waitComponentReadyTimeout)
+	return util.WaitForDeploymentRollout(kubeClientSet, deployment, time.Duration(waitComponentReadyTimeout)*time.Second)
 }

--- a/pkg/karmadactl/register/register.go
+++ b/pkg/karmadactl/register/register.go
@@ -461,7 +461,7 @@ func (o *CommandRegisterOption) EnsureNecessaryResourcesExistInMemberCluster(boo
 		return err
 	}
 
-	if err = cmdutil.WaitForDeploymentRollout(o.memberClusterClient, KarmadaAgentDeployment, int(o.Timeout)); err != nil {
+	if err = cmdutil.WaitForDeploymentRollout(o.memberClusterClient, KarmadaAgentDeployment, o.Timeout); err != nil {
 		return err
 	}
 

--- a/pkg/karmadactl/util/check.go
+++ b/pkg/karmadactl/util/check.go
@@ -59,10 +59,10 @@ func WaitForStatefulSetRollout(c kubernetes.Interface, sts *appsv1.StatefulSet, 
 	return nil
 }
 
-// WaitForDeploymentRollout  wait for Deployment reaches the ready state or timeout.
-func WaitForDeploymentRollout(c kubernetes.Interface, dep *appsv1.Deployment, timeoutSeconds int) error {
+// WaitForDeploymentRollout wait for Deployment reaches the ready state or timeout.
+func WaitForDeploymentRollout(c kubernetes.Interface, dep *appsv1.Deployment, timeout time.Duration) error {
 	var lastErr error
-	pollError := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Duration(timeoutSeconds)*time.Second, true, func(ctx context.Context) (bool, error) {
+	pollError := wait.PollUntilContextTimeout(context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 		d, err := c.AppsV1().Deployments(dep.GetNamespace()).Get(ctx, dep.GetName(), metav1.GetOptions{})
 		if err != nil {
 			lastErr = err


### PR DESCRIPTION
Cherry pick of #6270 on release-1.12.
#6270: fix the issue where discovery-timeout fails to work properly
Part of #6275 
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmadactl`: Fixed the issue where option `discovery-timeout` fails to work properly
```