### PR TITLE
Fix cluster status update interval not hornor `--cluster-status-update-frequency` issue

### DIFF
--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -173,7 +173,7 @@ func (c *ClusterStatusController) SetupWithManager(mgr controllerruntime.Manager
 	}
 	return controllerruntime.NewControllerManagedBy(mgr).
 		Named(ControllerName).
-		For(&clusterv1alpha1.Cluster{}, builder.WithPredicates(c.PredicateFunc)).
+		For(&clusterv1alpha1.Cluster{}, builder.WithPredicates(c.PredicateFunc, predicate.GenerationChangedPredicate{})).
 		WithOptions(controller.Options{
 			RateLimiter: ratelimiterflag.DefaultControllerRateLimiter[controllerruntime.Request](c.RateLimiterOptions),
 		}).Complete(c)


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes Issue：[6281 ](https://github.com/karmada-io/karmada/issues/6281)
Fixes #6281

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-controller-manager`/`karmada-agent`: Fixed the issue that cluster status update interval shorter than configured `--cluster-status-update-frequency`.
```

