### PR TITLE
Update bind addresses to use POD_IP for local-up script

### DIFF
--- a/artifacts/agent/karmada-agent.yaml
+++ b/artifacts/agent/karmada-agent.yaml
@@ -24,6 +24,11 @@ spec:
         - name: karmada-agent
           image: docker.io/karmada/karmada-agent:latest
           imagePullPolicy: {{image_pull_policy}}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           command:
             - /bin/karmada-agent
             - --karmada-kubeconfig=/etc/karmada/config/karmada.config
@@ -31,8 +36,8 @@ spec:
             - --cluster-name={{member_cluster_name}}
             - --cluster-api-endpoint={{member_cluster_api_endpoint}}
             - --cluster-status-update-frequency=10s
-            - --health-probe-bind-address=0.0.0.0:10357
-            - --metrics-bind-address=:8080
+            - --metrics-bind-address=$(POD_IP):8080
+            - --health-probe-bind-address=$(POD_IP):10357
             - --feature-gates=CustomizedClusterResourceModeling=true,MultiClusterService=true
             - --v=4
           livenessProbe:

--- a/artifacts/deploy/karmada-aggregated-apiserver.yaml
+++ b/artifacts/deploy/karmada-aggregated-apiserver.yaml
@@ -27,6 +27,11 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             privileged: false
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           command:
             - /bin/karmada-aggregated-apiserver
             - --kubeconfig=/etc/karmada/config/karmada.config
@@ -42,6 +47,7 @@ spec:
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
             - --tls-min-version=VersionTLS13
+            - --bind-address=$(POD_IP)
           resources:
             requests:
               cpu: 100m

--- a/artifacts/deploy/karmada-controller-manager.yaml
+++ b/artifacts/deploy/karmada-controller-manager.yaml
@@ -26,15 +26,20 @@ spec:
             privileged: false
           image: docker.io/karmada/karmada-controller-manager:latest
           imagePullPolicy: IfNotPresent
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           command:
             - /bin/karmada-controller-manager
             - --kubeconfig=/etc/karmada/config/karmada.config
-            - --metrics-bind-address=:8080
             - --cluster-status-update-frequency=10s
             - --failover-eviction-timeout=30s
             - --controllers=*,hpaScaleTargetMarker,deploymentReplicasSyncer
             - --feature-gates=AllAlpha=true,AllBeta=true
-            - --health-probe-bind-address=0.0.0.0:10357
+            - --metrics-bind-address=$(POD_IP):8080
+            - --health-probe-bind-address=$(POD_IP):10357
             - --v=4
           livenessProbe:
             httpGet:

--- a/artifacts/deploy/karmada-descheduler.yaml
+++ b/artifacts/deploy/karmada-descheduler.yaml
@@ -26,11 +26,16 @@ spec:
             privileged: false
           image: docker.io/karmada/karmada-descheduler:latest
           imagePullPolicy: IfNotPresent
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           command:
             - /bin/karmada-descheduler
             - --kubeconfig=/etc/karmada/config/karmada.config
-            - --metrics-bind-address=0.0.0.0:8080
-            - --health-probe-bind-address=0.0.0.0:10358
+            - --metrics-bind-address=$(POD_IP):8080
+            - --health-probe-bind-address=$(POD_IP):10358
             - --scheduler-estimator-ca-file=/etc/karmada/pki/scheduler-estimator-client/ca.crt
             - --scheduler-estimator-cert-file=/etc/karmada/pki/scheduler-estimator-client/tls.crt
             - --scheduler-estimator-key-file=/etc/karmada/pki/scheduler-estimator-client/tls.key

--- a/artifacts/deploy/karmada-metrics-adapter.yaml
+++ b/artifacts/deploy/karmada-metrics-adapter.yaml
@@ -27,10 +27,15 @@ spec:
             privileged: false
           image: docker.io/karmada/karmada-metrics-adapter:latest
           imagePullPolicy: IfNotPresent
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           command:
             - /bin/karmada-metrics-adapter
             - --kubeconfig=/etc/karmada/config/karmada.config
-            - --metrics-bind-address=:8080
+            - --metrics-bind-address=$(POD_IP):8080
             - --authentication-kubeconfig=/etc/karmada/config/karmada.config
             - --authorization-kubeconfig=/etc/karmada/config/karmada.config
             - --client-ca-file=/etc/karmada/pki/server/ca.crt
@@ -40,6 +45,7 @@ spec:
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
             - --tls-min-version=VersionTLS13
+            - --bind-address=$(POD_IP)
           readinessProbe:
             httpGet:
               path: /readyz

--- a/artifacts/deploy/karmada-scheduler-estimator.yaml
+++ b/artifacts/deploy/karmada-scheduler-estimator.yaml
@@ -26,6 +26,11 @@ spec:
             privileged: false
           image: docker.io/karmada/karmada-scheduler-estimator:latest
           imagePullPolicy: IfNotPresent
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           command:
             - /bin/karmada-scheduler-estimator
             - --kubeconfig=/etc/{{member_cluster_name}}-kubeconfig
@@ -33,8 +38,8 @@ spec:
             - --grpc-auth-cert-file=/etc/karmada/pki/server/tls.crt
             - --grpc-auth-key-file=/etc/karmada/pki/server/tls.key
             - --grpc-client-ca-file=/etc/karmada/pki/server/ca.crt
-            - --metrics-bind-address=0.0.0.0:8080
-            - --health-probe-bind-address=0.0.0.0:10351
+            - --metrics-bind-address=$(POD_IP):8080
+            - --health-probe-bind-address=$(POD_IP):10351
           livenessProbe:
             httpGet:
               path: /healthz

--- a/artifacts/deploy/karmada-scheduler.yaml
+++ b/artifacts/deploy/karmada-scheduler.yaml
@@ -39,11 +39,16 @@ spec:
             - containerPort: 8080
               name: metrics
               protocol: TCP
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           command:
             - /bin/karmada-scheduler
             - --kubeconfig=/etc/karmada/config/karmada.config
-            - --metrics-bind-address=0.0.0.0:8080
-            - --health-probe-bind-address=0.0.0.0:10351
+            - --metrics-bind-address=$(POD_IP):8080
+            - --health-probe-bind-address=$(POD_IP):10351
             - --enable-scheduler-estimator=true
             - --scheduler-estimator-ca-file=/etc/karmada/pki/scheduler-estimator-client/ca.crt
             - --scheduler-estimator-cert-file=/etc/karmada/pki/scheduler-estimator-client/tls.crt

--- a/artifacts/deploy/karmada-search.yaml
+++ b/artifacts/deploy/karmada-search.yaml
@@ -27,6 +27,11 @@ spec:
             privileged: false
           image: docker.io/karmada/karmada-search:latest
           imagePullPolicy: IfNotPresent
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           command:
             - /bin/karmada-search
             - --kubeconfig=/etc/karmada/config/karmada.config
@@ -42,6 +47,7 @@ spec:
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
             - --tls-min-version=VersionTLS13
+            - --bind-address=$(POD_IP)
           livenessProbe:
             httpGet:
               path: /livez

--- a/artifacts/deploy/karmada-webhook.yaml
+++ b/artifacts/deploy/karmada-webhook.yaml
@@ -26,11 +26,17 @@ spec:
             privileged: false
           image: docker.io/karmada/karmada-webhook:latest
           imagePullPolicy: IfNotPresent
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           command:
             - /bin/karmada-webhook
             - --kubeconfig=/etc/karmada/config/karmada.config
-            - --bind-address=0.0.0.0
-            - --metrics-bind-address=:8080
+            - --bind-address=$(POD_IP)
+            - --metrics-bind-address=$(POD_IP):8080
+            - --health-probe-bind-address=$(POD_IP):8000
             - --default-not-ready-toleration-seconds=30
             - --default-unreachable-toleration-seconds=30
             - --secure-port=8443


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
This PR updates the listening addresses for multiple components (agent, metrics adapter, webhook, etc.) to use the Pod's IP address via the `POD_IP` environment variable. By binding to the specific Pod IP rather than a generic address like `0.0.0.0`, the components are restricted to listening only on their assigned network interface. This improves security by reducing exposure, and ensures that metrics and health probes are correctly bound to the right interface, aiding in more predictable network behavior.

**Which issue(s) this PR fixes**:
Part of #6266 

**Special notes for your reviewer**:

- The changes affect all relevant deployments.
- Ensure that after these changes, all inter-component communications (e.g., metrics scrape, liveness, and readiness probes) continue to work as expected.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

