### PR TITLE
update Flink interpreter to check error when job state is not published

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/customizations.yaml
@@ -30,7 +30,7 @@ spec:
               return observedObj.status.error ~= nil or observedObj.status.jobManagerDeploymentStatus == 'ERROR'
             end
           end
-          return false
+          return observedObj.status.error ~= nil
         end
     replicaResource:
       luaScript: >


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug

-->

**What this PR does / why we need it**:

The user may have deployed a FlinkDeployment YAML with missing spec requirements, which prevents the deployment from being created. This will publish an error in status and we should treat this as a healthy user error.

The previous health check will consider this type as unhealthy and therefore reschedule the application. This fixes the behavior by checking the additional `error` field and let Karmada not reschedule the job if user error exists.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

