### PR TITLE
Fix lint issue ST1011

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,7 +71,6 @@ linters:
         # Exclude the following checks temporarily.
         # Will fix the issues in the following PRs.
         # Issue: https://github.com/karmada-io/karmada/issues/6273.
-        - "-ST1011"
         - "-ST1000"
   exclusions:
     generated: lax

--- a/cmd/service-name-resolution-detector-example/app/options/coredns.go
+++ b/cmd/service-name-resolution-detector-example/app/options/coredns.go
@@ -25,7 +25,7 @@ import (
 
 // CorednsOptions contains options for coredns detector.
 type CorednsOptions struct {
-	PeriodSeconds    time.Duration
+	Period           time.Duration
 	SuccessThreshold time.Duration
 	FailureThreshold time.Duration
 	StaleThreshold   time.Duration
@@ -38,7 +38,7 @@ func NewCorednsOptions() *CorednsOptions {
 
 // AddFlags adds flags of coredns detector to the specified FlagSet.
 func (o *CorednsOptions) AddFlags(fs *pflag.FlagSet) {
-	fs.DurationVar(&o.PeriodSeconds, "coredns-detect-period", 5*time.Second,
+	fs.DurationVar(&o.Period, "coredns-detect-period", 5*time.Second,
 		"Specifies how often detector detects coredns health status.")
 	fs.DurationVar(&o.SuccessThreshold, "coredns-success-threshold", 30*time.Second,
 		"The duration of successes for the coredns to be considered healthy after recovery.")

--- a/cmd/service-name-resolution-detector-example/app/service-name-resolution-detector.go
+++ b/cmd/service-name-resolution-detector-example/app/service-name-resolution-detector.go
@@ -159,7 +159,7 @@ func createDetectorContext(opts *options.Options) (detectorContext, error) {
 		clusterName:        opts.Generic.ClusterName,
 		detectors:          opts.Generic.Detectors,
 		corednsConfig: &coredns.Config{
-			PeriodSeconds:    opts.Coredns.PeriodSeconds,
+			Period:           opts.Coredns.Period,
 			SuccessThreshold: opts.Coredns.SuccessThreshold,
 			FailureThreshold: opts.Coredns.FailureThreshold,
 			StaleThreshold:   opts.Coredns.StaleThreshold,

--- a/pkg/servicenameresolutiondetector/coredns/detector.go
+++ b/pkg/servicenameresolutiondetector/coredns/detector.go
@@ -61,7 +61,7 @@ var localReference = &corev1.ObjectReference{
 
 // Config contains config of coredns detector.
 type Config struct {
-	PeriodSeconds    time.Duration
+	Period           time.Duration
 	SuccessThreshold time.Duration
 	FailureThreshold time.Duration
 	StaleThreshold   time.Duration
@@ -74,7 +74,7 @@ type Detector struct {
 
 	lec leaderelection.LeaderElectionConfig
 
-	periodSeconds time.Duration
+	period time.Duration
 
 	conditionCache store.ConditionCache
 	conditionStore store.ConditionStore
@@ -116,7 +116,7 @@ func NewCorednsDetector(memberClusterClient kubernetes.Interface, karmadaClient 
 		karmadaClient:       karmadaClient,
 		nodeName:            hostName,
 		clusterName:         clusterName,
-		periodSeconds:       cfg.PeriodSeconds,
+		period:              cfg.Period,
 		conditionCache:      store.NewConditionCache(cfg.SuccessThreshold, cfg.FailureThreshold),
 		conditionStore:      store.NewNodeConditionStore(memberClusterClient.CoreV1().Nodes(), nodeInformer.Lister(), condType, cfg.StaleThreshold),
 		cacheSynced:         []cache.InformerSynced{nodeInformer.Informer().HasSynced},
@@ -166,7 +166,7 @@ func (d *Detector) Run(ctx context.Context) {
 				return
 			}
 			d.queue.Add(0)
-		}, d.periodSeconds, ctx.Done())
+		}, d.period, ctx.Done())
 	}()
 
 	if d.lec.Lock != nil {

--- a/pkg/servicenameresolutiondetector/coredns/detector_test.go
+++ b/pkg/servicenameresolutiondetector/coredns/detector_test.go
@@ -113,7 +113,7 @@ func TestNewCorednsDetector(t *testing.T) {
 			informerFactory := informers.NewSharedInformerFactory(memberClusterClient, 0)
 
 			cfg := &Config{
-				PeriodSeconds:    time.Second,
+				Period:           time.Second,
 				SuccessThreshold: time.Minute,
 				FailureThreshold: time.Minute,
 				StaleThreshold:   time.Minute,
@@ -315,7 +315,7 @@ func TestDetectorRun(t *testing.T) {
 			informerFactory := informers.NewSharedInformerFactory(memberClusterClient, 0)
 
 			cfg := &Config{
-				PeriodSeconds:    time.Second,
+				Period:           time.Second,
 				SuccessThreshold: time.Minute,
 				FailureThreshold: time.Minute,
 				StaleThreshold:   time.Minute,
@@ -394,7 +394,7 @@ func TestDetectorWorker(t *testing.T) {
 			informerFactory := informers.NewSharedInformerFactory(memberClusterClient, 0)
 
 			cfg := &Config{
-				PeriodSeconds:    time.Second,
+				Period:           time.Second,
 				SuccessThreshold: time.Minute,
 				FailureThreshold: time.Minute,
 				StaleThreshold:   time.Minute,
@@ -469,7 +469,7 @@ func TestDetectorProcessNextWorkItem(t *testing.T) {
 			informerFactory := informers.NewSharedInformerFactory(memberClusterClient, 0)
 
 			cfg := &Config{
-				PeriodSeconds:    time.Second,
+				Period:           time.Second,
 				SuccessThreshold: time.Minute,
 				FailureThreshold: time.Minute,
 				StaleThreshold:   time.Minute,


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Fix lint issue - `ST1011: var periodSeconds is of type time.Duration; don't use unit-specific suffix "Seconds" (staticcheck)`.
For more details: https://staticcheck.dev/docs/checks#ST1011

**Which issue(s) this PR fixes**:
Part of #6273

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

