### PR TITLE
fix fhpa metrics issue introduced by #6300

### DIFF
--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_controller.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_controller.go
@@ -78,7 +78,9 @@ func (c *CronFHPAController) Reconcile(ctx context.Context, req controllerruntim
 
 	var err error
 	startTime := time.Now()
-	defer metrics.ObserveProcessCronFederatedHPALatency(err, startTime)
+	defer func() {
+		metrics.ObserveProcessCronFederatedHPALatency(err, startTime)
+	}()
 
 	origRuleSets := sets.New[string]()
 	for _, history := range cronFHPA.Status.ExecutionHistories {

--- a/pkg/controllers/federatedhpa/federatedhpa_controller.go
+++ b/pkg/controllers/federatedhpa/federatedhpa_controller.go
@@ -176,7 +176,9 @@ func (c *FHPAController) Reconcile(ctx context.Context, req controllerruntime.Re
 	// observe process FederatedHPA latency
 	var err error
 	startTime := time.Now()
-	defer metrics.ObserveProcessFederatedHPALatency(err, startTime)
+	defer func() {
+		metrics.ObserveProcessFederatedHPALatency(err, startTime)
+	}()
 
 	err = c.reconcileAutoscaler(ctx, hpa)
 	if err != nil {

--- a/pkg/controllers/federatedhpa/metrics/client.go
+++ b/pkg/controllers/federatedhpa/metrics/client.go
@@ -70,7 +70,9 @@ func (c *resourceMetricsClient) GetResourceMetric(ctx context.Context, resource 
 	// observe pull ResourceMetric latency
 	var err error
 	startTime := time.Now()
-	defer metrics.ObserveFederatedHPAPullMetricsLatency(err, "ResourceMetric", startTime)
+	defer func() {
+		metrics.ObserveFederatedHPAPullMetricsLatency(err, "ResourceMetric", startTime)
+	}()
 
 	podMetrics, err := c.client.PodMetricses(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
 	if err != nil {
@@ -154,7 +156,9 @@ func (c *customMetricsClient) GetRawMetric(metricName string, namespace string, 
 	// observe pull RawMetric latency
 	var err error
 	startTime := time.Now()
-	defer metrics.ObserveFederatedHPAPullMetricsLatency(err, "RawMetric", startTime)
+	defer func() {
+		metrics.ObserveFederatedHPAPullMetricsLatency(err, "RawMetric", startTime)
+	}()
 
 	metricList, err := c.client.NamespacedMetrics(namespace).GetForObjects(schema.GroupKind{Kind: "Pod"}, selector, metricName, metricSelector)
 	if err != nil {
@@ -191,7 +195,9 @@ func (c *customMetricsClient) GetObjectMetric(metricName string, namespace strin
 	// observe pull ObjectMetric latency
 	var err error
 	startTime := time.Now()
-	defer metrics.ObserveFederatedHPAPullMetricsLatency(err, "ObjectMetric", startTime)
+	defer func() {
+		metrics.ObserveFederatedHPAPullMetricsLatency(err, "ObjectMetric", startTime)
+	}()
 
 	gvk := schema.FromAPIVersionAndKind(objectRef.APIVersion, objectRef.Kind)
 	var metricValue *customapi.MetricValue
@@ -223,7 +229,9 @@ func (c *externalMetricsClient) GetExternalMetric(metricName, namespace string, 
 	// observe pull ExternalMetric latency
 	var err error
 	startTime := time.Now()
-	defer metrics.ObserveFederatedHPAPullMetricsLatency(err, "ExternalMetric", startTime)
+	defer func() {
+		metrics.ObserveFederatedHPAPullMetricsLatency(err, "ExternalMetric", startTime)
+	}()
 
 	externalMetrics, err := c.client.NamespacedMetrics(namespace).List(metricName, selector)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
Modify the calling methods of the following metric functions in FHPA：
metrics.ObserveProcessCronFederatedHPALatency
metrics.ObserveProcessFederatedHPALatency
metrics.ObserveFederatedHPAPullMetricsLatency

**What this PR does / why we need it**:
Get the final execution error status of FHPA logic

**Which issue(s) this PR fixes**:
Fixes #6300

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`Instrumentation`: `karmada-controller-manager`: Fixed the issue that the result label of `federatedhpa_pull_metrics_duration_seconds` is always `success`.
```

