### PR TITLE
Update bind addresses to use POD_IP for karmada-operator

### DIFF
--- a/operator/pkg/controlplane/apiserver/manifests.go
+++ b/operator/pkg/controlplane/apiserver/manifests.go
@@ -171,6 +171,11 @@ spec:
       - name: karmada-aggregated-apiserver
         image: {{ .Image }}
         imagePullPolicy: {{ .ImagePullPolicy }}
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         command:
         - /bin/karmada-aggregated-apiserver
         - --kubeconfig=/etc/karmada/config/karmada.config
@@ -182,6 +187,7 @@ spec:
         - --audit-log-path=-
         - --audit-log-maxage=0
         - --audit-log-maxbackup=0
+        - --bind-address=$(POD_IP)
         volumeMounts:
         - name: karmada-config
           mountPath: /etc/karmada/config

--- a/operator/pkg/controlplane/manifests.go
+++ b/operator/pkg/controlplane/manifests.go
@@ -135,14 +135,19 @@ spec:
         - name: karmada-controller-manager
           image: {{ .Image }}
           imagePullPolicy: {{ .ImagePullPolicy }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           command:
             - /bin/karmada-controller-manager
             - --kubeconfig=/etc/karmada/config/karmada.config
-            - --metrics-bind-address=:8080
             - --cluster-status-update-frequency=10s
             - --failover-eviction-timeout=30s
             - --leader-elect-resource-namespace={{ .SystemNamespace }}
-            - --health-probe-bind-address=0.0.0.0:10357
+            - --metrics-bind-address=$(POD_IP):8080
+            - --health-probe-bind-address=$(POD_IP):10357
             - --v=4
           livenessProbe:
             httpGet:
@@ -197,11 +202,16 @@ spec:
         - name: karmada-scheduler
           image: {{ .Image }}
           imagePullPolicy: {{ .ImagePullPolicy }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           command:
             - /bin/karmada-scheduler
             - --kubeconfig=/etc/karmada/config/karmada.config
-            - --metrics-bind-address=0.0.0.0:8080
-            - --health-probe-bind-address=0.0.0.0:10351
+            - --metrics-bind-address=$(POD_IP):8080
+            - --health-probe-bind-address=$(POD_IP):10351
             - --enable-scheduler-estimator=true
             - --leader-elect-resource-namespace={{ .SystemNamespace }}
             - --scheduler-estimator-ca-file=/etc/karmada/pki/ca.crt
@@ -267,11 +277,16 @@ spec:
         - name: karmada-descheduler
           image: {{ .Image }}
           imagePullPolicy: {{ .ImagePullPolicy }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           command:
             - /bin/karmada-descheduler
             - --kubeconfig=/etc/karmada/config/karmada.config
-            - --metrics-bind-address=0.0.0.0:8080
-            - --health-probe-bind-address=0.0.0.0:10358
+            - --metrics-bind-address=$(POD_IP):8080
+            - --health-probe-bind-address=$(POD_IP):10358
             - --leader-elect-resource-namespace={{ .SystemNamespace }}
             - --scheduler-estimator-ca-file=/etc/karmada/pki/ca.crt
             - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada.crt

--- a/operator/pkg/controlplane/metricsadapter/manifests.go
+++ b/operator/pkg/controlplane/metricsadapter/manifests.go
@@ -48,10 +48,15 @@ spec:
         - name: karmada-metrics-adapter
           image: {{ .Image }}
           imagePullPolicy: {{ .ImagePullPolicy }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           command:
             - /bin/karmada-metrics-adapter
             - --kubeconfig=/etc/karmada/config/karmada.config
-            - --metrics-bind-address=:8080
+            - --metrics-bind-address=$(POD_IP):8080
             - --authentication-kubeconfig=/etc/karmada/config/karmada.config
             - --authorization-kubeconfig=/etc/karmada/config/karmada.config
             - --client-ca-file=/etc/karmada/pki/ca.crt
@@ -61,6 +66,7 @@ spec:
             - --audit-log-path=-
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
+            - --bind-address=$(POD_IP)
           volumeMounts:
             - name: karmada-config
               mountPath: /etc/karmada/config

--- a/operator/pkg/controlplane/search/manifests.go
+++ b/operator/pkg/controlplane/search/manifests.go
@@ -54,6 +54,11 @@ spec:
               readOnly: true
             - name: karmada-config
               mountPath: /etc/karmada/config
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           command:
             - /bin/karmada-search
             - --kubeconfig=/etc/karmada/config/karmada.config
@@ -65,6 +70,7 @@ spec:
             - --audit-log-path=-
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
+            - --bind-address=$(POD_IP)
           livenessProbe:
             httpGet:
               path: /livez

--- a/operator/pkg/controlplane/webhook/manifests.go
+++ b/operator/pkg/controlplane/webhook/manifests.go
@@ -48,11 +48,17 @@ spec:
         - name: karmada-webhook
           image: {{ .Image }}
           imagePullPolicy: {{ .ImagePullPolicy }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           command:
             - /bin/karmada-webhook
             - --kubeconfig=/etc/karmada/config/karmada.config
-            - --bind-address=0.0.0.0
-            - --metrics-bind-address=:8080
+            - --bind-address=$(POD_IP)
+            - --metrics-bind-address=$(POD_IP):8080
+            - --health-probe-bind-address=$(POD_IP):8000
             - --default-not-ready-toleration-seconds=30
             - --default-unreachable-toleration-seconds=30
             - --secure-port=8443


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
This PR updates the listening addresses for multiple components (metrics adapter, webhook, etc.) to use the Pod's IP address via the `POD_IP` environment variable. By binding to the specific Pod IP rather than a generic address like `0.0.0.0`, the components are restricted to listening only on their assigned network interface. This improves security by reducing exposure and ensures that metrics and health probes are correctly bound to the right interface, aiding in more predictable network behavior.

**Which issue(s) this PR fixes**:
Part of #6266 

**Special notes for your reviewer**:

- The changes affect all relevant deployments.
- Ensure that after these changes, all inter-component communications (e.g., metrics scrape, liveness, and readiness probes) continue to work as expected.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```