### PR TITLE
Update bind addresses to use POD_IP for karmadactl

### DIFF
--- a/pkg/karmadactl/addons/descheduler/manifests.go
+++ b/pkg/karmadactl/addons/descheduler/manifests.go
@@ -43,11 +43,16 @@ spec:
         - name: karmada-descheduler
           image: {{ .Image }}
           imagePullPolicy: IfNotPresent
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           command:
             - /bin/karmada-descheduler
             - --kubeconfig=/etc/karmada/config/karmada.config
-            - --metrics-bind-address=0.0.0.0:8080
-            - --health-probe-bind-address=0.0.0.0:10358
+            - --metrics-bind-address=$(POD_IP):8080
+            - --health-probe-bind-address=$(POD_IP):10358
             - --leader-elect-resource-namespace={{ .Namespace }}
             - --scheduler-estimator-ca-file=/etc/karmada/pki/ca.crt
             - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada.crt

--- a/pkg/karmadactl/addons/estimator/manifests.go
+++ b/pkg/karmadactl/addons/estimator/manifests.go
@@ -45,6 +45,11 @@ spec:
         - name: karmada-scheduler-estimator
           image: {{ .Image }}
           imagePullPolicy: IfNotPresent
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           command:
             - /bin/karmada-scheduler-estimator
             - --kubeconfig=/etc/{{ .MemberClusterName}}-kubeconfig
@@ -52,8 +57,8 @@ spec:
             - --grpc-auth-cert-file=/etc/karmada/pki/karmada.crt
             - --grpc-auth-key-file=/etc/karmada/pki/karmada.key
             - --grpc-client-ca-file=/etc/karmada/pki/ca.crt
-            - --metrics-bind-address=0.0.0.0:8080
-            - --health-probe-bind-address=0.0.0.0:10351
+            - --metrics-bind-address=$(POD_IP):8080
+            - --health-probe-bind-address=$(POD_IP):10351
           livenessProbe:
             httpGet:
               path: /healthz

--- a/pkg/karmadactl/addons/metricsadapter/manifests.go
+++ b/pkg/karmadactl/addons/metricsadapter/manifests.go
@@ -44,9 +44,14 @@ spec:
         - name: karmada-metrics-adapter
           image: {{ .Image }}
           imagePullPolicy: IfNotPresent
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           command:
             - /bin/karmada-metrics-adapter
-            - --metrics-bind-address=:8080
+            - --metrics-bind-address=$(POD_IP):8080
             - --kubeconfig=/etc/karmada/config/karmada.config
             - --authentication-kubeconfig=/etc/karmada/config/karmada.config
             - --authorization-kubeconfig=/etc/karmada/config/karmada.config
@@ -57,6 +62,7 @@ spec:
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
             - --tls-min-version=VersionTLS13
+            - --bind-address=$(POD_IP)
           readinessProbe:
             httpGet:
               path: /readyz

--- a/pkg/karmadactl/addons/search/manifests.go
+++ b/pkg/karmadactl/addons/search/manifests.go
@@ -44,6 +44,11 @@ spec:
         - name: karmada-search
           image: {{ .Image }}
           imagePullPolicy: IfNotPresent
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           command:
             - /bin/karmada-search
             - --kubeconfig=/etc/karmada/config/karmada.config
@@ -60,6 +65,7 @@ spec:
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0{{- if .KeyPrefix }}
             - --etcd-prefix={{ .KeyPrefix }}{{- end }}
+            - --bind-address=$(POD_IP)
           livenessProbe:
             httpGet:
               path: /livez


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
This PR updates the listening addresses for multiple components (metrics adapter, webhook, etc.) to use the Pod's IP address via the `POD_IP` environment variable. By binding to the specific Pod IP rather than a generic address like `0.0.0.0`, the components are restricted to listening only on their assigned network interface. This improves security by reducing exposure and ensures that metrics and health probes are correctly bound to the right interface, aiding in more predictable network behavior.

**Which issue(s) this PR fixes**:
Part of #6266 

**Special notes for your reviewer**:

- The changes affect all relevant deployments.
- Ensure that after these changes, all inter-component communications (e.g., metrics scrape, liveness, and readiness probes) continue to work as expected.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```