### PR TITLE
Update bind addresses to use POD_IP for helm

### DIFF
--- a/charts/karmada/templates/_helpers.tpl
+++ b/charts/karmada/templates/_helpers.tpl
@@ -152,7 +152,6 @@ app: {{$name}}-controller-manager
 {{- end }}
 {{- end -}}
 
-
 {{- define "karmada.scheduler.labels" -}}
 {{ $name :=  include "karmada.name" . }}
 {{- if .Values.scheduler.labels -}}
@@ -172,7 +171,6 @@ app: {{$name}}-scheduler
 {{- end }}
 {{- end }}
 {{- end -}}
-
 
 {{- define "karmada.descheduler.labels" -}}
 {{ $name :=  include "karmada.name" . }}
@@ -206,7 +204,6 @@ app: {{$name}}
     secretName: {{ .Values.descheduler.kubeconfig }}
 {{- end -}}
 {{- end -}}
-
 
 {{- define "karmada.webhook.labels" -}}
 {{ $name :=  include "karmada.name" .}}
@@ -354,6 +351,16 @@ app: {{- include "karmada.name" .}}-search
 - name: karmada-certs
   secret:
     secretName: {{ $name }}-cert
+{{- end -}}
+
+{{/*
+Common env for POD_IP
+*/}}
+{{- define "karmada.env.podIP" -}}
+- name: POD_IP
+  valueFrom:
+    fieldRef:
+      fieldPath: status.podIP
 {{- end -}}
 
 {{/*

--- a/charts/karmada/templates/karmada-agent.yaml
+++ b/charts/karmada/templates/karmada-agent.yaml
@@ -101,6 +101,8 @@ spec:
         - name: {{ $name }}
           image: {{ template "karmada.agent.image" . }}
           imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+          env:
+            {{- include "karmada.env.podIP" . | nindent 12 }}
           command:
             - /bin/karmada-agent
             - --karmada-kubeconfig=/etc/kubeconfig/kubeconfig
@@ -110,7 +112,8 @@ spec:
             {{- end }}
             - --cluster-status-update-frequency=10s
             - --leader-elect-resource-namespace={{ include "karmada.namespace" . }}
-            - --health-probe-bind-address=0.0.0.0:10357
+            - --metrics-bind-address=$(POD_IP):8080
+            - --health-probe-bind-address=$(POD_IP):10357
             - --v=4
           livenessProbe:
             httpGet:

--- a/charts/karmada/templates/karmada-aggregated-apiserver.yaml
+++ b/charts/karmada/templates/karmada-aggregated-apiserver.yaml
@@ -43,6 +43,8 @@ spec:
             - name: apiserver-cert
               mountPath: /etc/kubernetes/pki
               readOnly: true
+          env:
+            {{- include "karmada.env.podIP" . | nindent 12 }}
           command:
             - /bin/karmada-aggregated-apiserver
             - --kubeconfig=/etc/kubeconfig
@@ -67,6 +69,7 @@ spec:
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
             - --tls-min-version=VersionTLS13
+            - --bind-address=$(POD_IP)
           resources:
             {{- toYaml .Values.aggregatedApiServer.resources | nindent 12 }}
           readinessProbe:

--- a/charts/karmada/templates/karmada-controller-manager.yaml
+++ b/charts/karmada/templates/karmada-controller-manager.yaml
@@ -50,13 +50,15 @@ spec:
         - name: {{ $name }}-controller-manager
           image: {{ template "karmada.controllerManager.image" . }}
           imagePullPolicy: {{ .Values.controllerManager.image.pullPolicy }}
+          env:
+            {{- include "karmada.env.podIP" . | nindent 12 }}
           command:
             - /bin/karmada-controller-manager
             - --kubeconfig=/etc/kubeconfig
             - --cluster-status-update-frequency=10s
             - --leader-elect-resource-namespace={{ $systemNamespace }}
-            - --health-probe-bind-address=0.0.0.0:10357
-            - --metrics-bind-address=:8080
+            - --metrics-bind-address=$(POD_IP):8080
+            - --health-probe-bind-address=$(POD_IP):10357
             - --v=2
             {{- if .Values.controllerManager.controllers }}
             - --controllers={{ .Values.controllerManager.controllers }}

--- a/charts/karmada/templates/karmada-descheduler.yaml
+++ b/charts/karmada/templates/karmada-descheduler.yaml
@@ -47,11 +47,13 @@ spec:
         - name: {{ $name }}-descheduler
           image: {{ template "karmada.descheduler.image" . }}
           imagePullPolicy: {{ .Values.descheduler.image.pullPolicy }}
+          env:
+            {{- include "karmada.env.podIP" . | nindent 12 }}
           command:
             - /bin/karmada-descheduler
             - --kubeconfig=/etc/kubeconfig
-            - --metrics-bind-address=0.0.0.0:8080
-            - --health-probe-bind-address=0.0.0.0:10358
+            - --metrics-bind-address=$(POD_IP):8080
+            - --health-probe-bind-address=$(POD_IP):10358
             - --leader-elect-resource-namespace={{ $systemNamespace }}
             - --scheduler-estimator-ca-file=/etc/karmada/pki/server-ca.crt
             - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada.crt

--- a/charts/karmada/templates/karmada-metrics-adapter.yaml
+++ b/charts/karmada/templates/karmada-metrics-adapter.yaml
@@ -41,10 +41,12 @@ spec:
             - name: apiserver-cert
               mountPath: /etc/kubernetes/pki
               readOnly: true
+          env:
+            {{- include "karmada.env.podIP" . | nindent 12 }}
           command:
             - /bin/karmada-metrics-adapter
             - --kubeconfig=/etc/kubeconfig
-            - --metrics-bind-address=:8080
+            - --metrics-bind-address=$(POD_IP):8080
             - --authentication-kubeconfig=/etc/kubeconfig
             - --authorization-kubeconfig=/etc/kubeconfig
             - --tls-cert-file=/etc/kubernetes/pki/karmada.crt
@@ -53,6 +55,7 @@ spec:
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
             - --tls-min-version=VersionTLS13
+            - --bind-address=$(POD_IP)
           resources:
             {{- toYaml .Values.metricsAdapter.resources | nindent 12 }}
           readinessProbe:

--- a/charts/karmada/templates/karmada-scheduler-estimator.yaml
+++ b/charts/karmada/templates/karmada-scheduler-estimator.yaml
@@ -44,6 +44,8 @@ spec:
         - name: karmada-scheduler-estimator
           image: {{ template "karmada.schedulerEstimator.image" $ }}
           imagePullPolicy: {{ $.Values.schedulerEstimator.image.pullPolicy }}
+          env:
+            {{- include "karmada.env.podIP" . | nindent 12 }}
           command:
             - /bin/karmada-scheduler-estimator
             - --kubeconfig=/etc/{{ $clusterName }}-kubeconfig
@@ -51,8 +53,8 @@ spec:
             - --grpc-auth-cert-file=/etc/karmada/pki/karmada.crt
             - --grpc-auth-key-file=/etc/karmada/pki/karmada.key
             - --grpc-client-ca-file=/etc/karmada/pki/server-ca.crt
-            - --metrics-bind-address=0.0.0.0:8080
-            - --health-probe-bind-address=0.0.0.0:10351
+            - --metrics-bind-address=$(POD_IP):8080
+            - --health-probe-bind-address=$(POD_IP):10351
             {{- with (include "karmada.schedulerEstimator.featureGates" (dict "featureGatesArg" $.Values.schedulerEstimator.featureGates)) }}
             - {{ . }}
             {{- end}}

--- a/charts/karmada/templates/karmada-scheduler.yaml
+++ b/charts/karmada/templates/karmada-scheduler.yaml
@@ -47,11 +47,13 @@ spec:
         - name: {{ $name }}-scheduler
           image: {{ template "karmada.scheduler.image" .}}
           imagePullPolicy: {{ .Values.scheduler.image.pullPolicy }}
+          env:
+            {{- include "karmada.env.podIP" . | nindent 12 }}
           command:
             - /bin/karmada-scheduler
             - --kubeconfig=/etc/kubeconfig
-            - --metrics-bind-address=0.0.0.0:8080
-            - --health-probe-bind-address=0.0.0.0:10351
+            - --metrics-bind-address=$(POD_IP):8080
+            - --health-probe-bind-address=$(POD_IP):10351
             - --leader-elect-resource-namespace={{ $systemNamespace }}
             - --scheduler-estimator-ca-file=/etc/karmada/pki/server-ca.crt
             - --scheduler-estimator-cert-file=/etc/karmada/pki/karmada.crt

--- a/charts/karmada/templates/karmada-search.yaml
+++ b/charts/karmada/templates/karmada-search.yaml
@@ -56,6 +56,8 @@ spec:
             - name: kubeconfig-secret
               subPath: kubeconfig
               mountPath: /etc/kubeconfig
+          env:
+            {{- include "karmada.env.podIP" . | nindent 12 }}
           command:
             - /bin/karmada-search
             - --kubeconfig=/etc/kubeconfig
@@ -80,6 +82,7 @@ spec:
             - --audit-log-maxage=0
             - --audit-log-maxbackup=0
             - --tls-min-version=VersionTLS13
+            - --bind-address=$(POD_IP)
           livenessProbe:
             httpGet:
               path: /livez

--- a/charts/karmada/templates/karmada-webhook.yaml
+++ b/charts/karmada/templates/karmada-webhook.yaml
@@ -47,10 +47,14 @@ spec:
         - name: {{ $name }}-webhook
           image: {{ template "karmada.webhook.image" . }}
           imagePullPolicy: {{ .Values.webhook.image.pullPolicy }}
+          env:
+            {{- include "karmada.env.podIP" . | nindent 12 }}
           command:
             - /bin/karmada-webhook
             - --kubeconfig=/etc/kubeconfig
-            - --bind-address=0.0.0.0
+            - --bind-address=$(POD_IP)
+            - --metrics-bind-address=$(POD_IP):8080
+            - --health-probe-bind-address=$(POD_IP):8000
             - --secure-port=8443
             - --cert-dir=/var/serving-cert
           ports:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
This PR updates the listening addresses for multiple components (metrics adapter, webhook, etc.) to use the Pod's IP address via the `POD_IP` environment variable. By binding to the specific Pod IP rather than a generic address like `0.0.0.0`, the components are restricted to listening only on their assigned network interface. This improves security by reducing exposure and ensures that metrics and health probes are correctly bound to the right interface, aiding in more predictable network behavior.

**Which issue(s) this PR fixes**:
Part of #6266 

**Special notes for your reviewer**:

- The changes affect all relevant deployments.
- Ensure that after these changes, all inter-component communications (e.g., metrics scrape, liveness, and readiness probes) continue to work as expected.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```