### PR TITLE
Cancel the redundancy setting for gracePeriod in cluster-controller

### DIFF
--- a/pkg/controllers/cluster/cluster_controller.go
+++ b/pkg/controllers/cluster/cluster_controller.go
@@ -498,7 +498,7 @@ func (c *Controller) tryUpdateClusterHealth(ctx context.Context, cluster *cluste
 	}()
 
 	// Step 2: Get the cluster ready condition.
-	var gracePeriod time.Duration
+	gracePeriod := c.ClusterMonitorGracePeriod
 	var observedReadyCondition *metav1.Condition
 	currentReadyCondition := meta.FindStatusCondition(cluster.Status.Conditions, clusterv1alpha1.ClusterConditionReady)
 	if currentReadyCondition == nil {
@@ -510,7 +510,6 @@ func (c *Controller) tryUpdateClusterHealth(ctx context.Context, cluster *cluste
 			Status:             metav1.ConditionUnknown,
 			LastTransitionTime: cluster.CreationTimestamp,
 		}
-		gracePeriod = c.ClusterStartupGracePeriod
 		if clusterHealth != nil {
 			clusterHealth.status = &cluster.Status
 		} else {
@@ -523,7 +522,6 @@ func (c *Controller) tryUpdateClusterHealth(ctx context.Context, cluster *cluste
 	} else {
 		// If ready condition is not nil, make a copy of it, since we may modify it in place later.
 		observedReadyCondition = currentReadyCondition.DeepCopy()
-		gracePeriod = c.ClusterMonitorGracePeriod
 	}
 
 	// Step 3: Get the last condition and lease from `clusterHealth`.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

No matter whether it is on the if branch or the else branch, the assignment of `gracePeriod` is the same, so it can be assigned in advance.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

