### PR TITLE
Bump custom-metrics-apiserver version to v1.32.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	layeh.com/gopher-json v0.0.0-20201124131017-552bb3c4c3bf
 	sigs.k8s.io/cluster-api v1.7.1
 	sigs.k8s.io/controller-runtime v0.20.4
-	sigs.k8s.io/custom-metrics-apiserver v1.30.1-0.20250418033306-136db5499fe7
+	sigs.k8s.io/custom-metrics-apiserver v1.32.0
 	sigs.k8s.io/kind v0.25.0
 	sigs.k8s.io/mcs-api v0.1.0
 	sigs.k8s.io/metrics-server v0.7.1-0.20240906155142-bb44be145648

--- a/go.sum
+++ b/go.sum
@@ -900,8 +900,8 @@ sigs.k8s.io/controller-runtime v0.6.1/go.mod h1:XRYBPdbf5XJu9kpS84VJiZ7h/u1hF3gE
 sigs.k8s.io/controller-runtime v0.20.4 h1:X3c+Odnxz+iPTRobG4tp092+CvBU9UK0t/bRf+n0DGU=
 sigs.k8s.io/controller-runtime v0.20.4/go.mod h1:xg2XB0K5ShQzAgsoujxuKN4LNXR2LfwwHsPj7Iaw+XY=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
-sigs.k8s.io/custom-metrics-apiserver v1.30.1-0.20250418033306-136db5499fe7 h1:rE07t7xwcxNzTLhlwgmwx5wYYcBwSUxcxDuqoSXHBaI=
-sigs.k8s.io/custom-metrics-apiserver v1.30.1-0.20250418033306-136db5499fe7/go.mod h1:Hek3ZRXoucoy/h9L8KgahVKh8gFpRSTfwIWiKOIO0S0=
+sigs.k8s.io/custom-metrics-apiserver v1.32.0 h1:h3V4QtkAOAqXHDeZ0e3u8A5iideb8/lJDd5gX/iWqDU=
+sigs.k8s.io/custom-metrics-apiserver v1.32.0/go.mod h1:0RwNcWSbW8bOGV3wk3OwarTBUoutrg0YEghCBfwN9TQ=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3/go.mod h1:18nIHnGi6636UCz6m8i4DhaJ65T6EruyzmoQqI2BVDo=
 sigs.k8s.io/kind v0.8.1/go.mod h1:oNKTxUVPYkV9lWzY6CVMNluVq8cBsyq+UgPJdvA3uu4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1821,7 +1821,7 @@ sigs.k8s.io/controller-runtime/pkg/webhook/admission
 sigs.k8s.io/controller-runtime/pkg/webhook/admission/metrics
 sigs.k8s.io/controller-runtime/pkg/webhook/conversion
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
-# sigs.k8s.io/custom-metrics-apiserver v1.30.1-0.20250418033306-136db5499fe7
+# sigs.k8s.io/custom-metrics-apiserver v1.32.0
 ## explicit; go 1.23.0
 sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver
 sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver/endpoints/handlers


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Bump custom-metrics-apiserver with an official release [with Kubernetes dependencies v0.32.0](https://github.com/kubernetes-sigs/custom-metrics-apiserver/releases) to include [k8s dependencies 0.32](https://github.com/kubernetes-sigs/custom-metrics-apiserver/pull/194).

**Which issue(s) this PR fixes**:
Part of #6310 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

