### PR TITLE
feat(operator): support loadBalancerClass for karmadaAPIServer

### DIFF
--- a/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
+++ b/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
@@ -2493,6 +2493,17 @@ spec:
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
+                      loadBalancerClass:
+                        description: |-
+                          LoadBalancerClass specifies the load balancer implementation class for the Karmada API server.
+                          This field is applicable only when ServiceType is set to LoadBalancer.
+                          If specified, the service will be processed by the load balancer implementation that matches the specified class.
+                          By default, this is not set and the LoadBalancer type of Service uses the cloud provider's default load balancer
+                          implementation.
+                          Once set, it cannot be changed. The value must be a label-style identifier, with an optional prefix such as
+                          "internal-vip" or "example.com/internal-vip".
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class
+                        type: string
                       priorityClassName:
                         default: system-node-critical
                         description: |-

--- a/operator/config/crds/operator.karmada.io_karmadas.yaml
+++ b/operator/config/crds/operator.karmada.io_karmadas.yaml
@@ -2493,6 +2493,17 @@ spec:
                           and services.
                           More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
+                      loadBalancerClass:
+                        description: |-
+                          LoadBalancerClass specifies the load balancer implementation class for the Karmada API server.
+                          This field is applicable only when ServiceType is set to LoadBalancer.
+                          If specified, the service will be processed by the load balancer implementation that matches the specified class.
+                          By default, this is not set and the LoadBalancer type of Service uses the cloud provider's default load balancer
+                          implementation.
+                          Once set, it cannot be changed. The value must be a label-style identifier, with an optional prefix such as
+                          "internal-vip" or "example.com/internal-vip".
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class
+                        type: string
                       priorityClassName:
                         default: system-node-critical
                         description: |-

--- a/operator/pkg/apis/operator/v1alpha1/type.go
+++ b/operator/pkg/apis/operator/v1alpha1/type.go
@@ -312,6 +312,17 @@ type KarmadaAPIServer struct {
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 
+	// LoadBalancerClass specifies the load balancer implementation class for the Karmada API server.
+	// This field is applicable only when ServiceType is set to LoadBalancer.
+	// If specified, the service will be processed by the load balancer implementation that matches the specified class.
+	// By default, this is not set and the LoadBalancer type of Service uses the cloud provider's default load balancer
+	// implementation.
+	// Once set, it cannot be changed. The value must be a label-style identifier, with an optional prefix such as
+	// "internal-vip" or "example.com/internal-vip".
+	// More info: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class
+	// +optional
+	LoadBalancerClass *string `json:"loadBalancerClass,omitempty"`
+
 	// ServiceAnnotations is an extra set of annotations for service of karmada apiserver.
 	// more info: https://github.com/karmada-io/karmada/issues/4634
 	// +optional

--- a/operator/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -306,6 +306,11 @@ func (in *KarmadaAPIServer) DeepCopyInto(out *KarmadaAPIServer) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.LoadBalancerClass != nil {
+		in, out := &in.LoadBalancerClass, &out.LoadBalancerClass
+		*out = new(string)
+		**out = **in
+	}
 	if in.ServiceAnnotations != nil {
 		in, out := &in.ServiceAnnotations, &out.ServiceAnnotations
 		*out = make(map[string]string, len(*in))

--- a/operator/pkg/controlplane/apiserver/apiserver.go
+++ b/operator/pkg/controlplane/apiserver/apiserver.go
@@ -111,6 +111,11 @@ func createKarmadaAPIServerService(client clientset.Interface, cfg *operatorv1al
 	// merge annotations with configuration of karmada apiserver.
 	karmadaApiserverService.Annotations = labels.Merge(karmadaApiserverService.Annotations, cfg.ServiceAnnotations)
 
+	// Set LoadBalancerClass if ServiceType is LoadBalancer and LoadBalancerClass is specified
+	if karmadaApiserverService.Spec.Type == corev1.ServiceTypeLoadBalancer && cfg.LoadBalancerClass != nil {
+		karmadaApiserverService.Spec.LoadBalancerClass = cfg.LoadBalancerClass
+	}
+
 	if err := apiclient.CreateOrUpdateService(client, karmadaApiserverService); err != nil {
 		return fmt.Errorf("err when creating service for %s, err: %w", karmadaApiserverService.Name, err)
 	}


### PR DESCRIPTION
This commit introduces support for the `loadBalancerClass` field in the Karmada operator CRD for the `karmadaAPIServer` component.

When the `serviceType` for `karmadaAPIServer` is set to `LoadBalancer`, users can now specify a `loadBalancerClass` to select a specific load balancer implementation, aligning with Kubernetes Service behavior.

Changes include:
- Added `loadBalancerClass` field to the `karmadas.operator.karmada.io` CRD.
- Added `LoadBalancerClass` field to the `KarmadaAPIServer` struct in Go types.
- Updated the `createKarmadaAPIServerService` function to set the `spec.loadBalancerClass` on the Service object when applicable.

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-operator`: Introduced support for the `loadBalancerClass` field in the Karmada operator CRD for the `karmadaAPIServer` component.
```

