### PR TITLE
Suppress ApplyPolicyFailed events for AlreadyExists conflicts

### DIFF
--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -39,6 +39,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/helper"
 	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/pkg/util/overridemanager"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // ensureWork ensure Work to be created or updated.
@@ -133,6 +134,10 @@ func ensureWork(
 			ctrlutil.WithSuspendDispatching(shouldSuspendDispatching(bindingSpec.Suspension, targetCluster)),
 			ctrlutil.WithPreserveResourcesOnDeletion(ptr.Deref(bindingSpec.PreserveResourcesOnDeletion, false)),
 		); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				klog.V(4).Infof("Work %s/%s already exists, skipping update", workMeta.Namespace, workMeta.Name)
+				continue
+			}
 			errs = append(errs, err)
 			continue
 		}


### PR DESCRIPTION
### What this PR does / why we need it
When applying cluster policies, Karmada generates `ApplyPolicyFailed` warning events for transient "AlreadyExists" conflicts during Work creation. This PR suppresses these warnings to reduce alert noise.

### Which issue this PR fixes
Fixes #6267

### Special notes for your reviewer
- **Change:** Added error handling in `ensureWork` to skip `AlreadyExists` errors during Work creation/update.
- **Impact:** "Already exists" conflicts no longer trigger `Warning` events.