### PR TITLE
Twist the behavior of staticAssignments in FederatedResourceQuota

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -18792,7 +18792,7 @@
           }
         },
         "staticAssignments": {
-          "description": "StaticAssignments represents the subset of desired hard limits for each cluster. Note: for clusters not present in this list, Karmada will set an empty ResourceQuota to them, which means these clusters will have no quotas in the referencing namespace.",
+          "description": "StaticAssignments specifies ResourceQuota settings for specific clusters. If non-empty, Karmada will create ResourceQuotas in the corresponding clusters. Clusters not listed here or when StaticAssignments is empty will have no ResourceQuotas created.\n\nThis field addresses multi-cluster configuration management challenges by allowing centralized control over ResourceQuotas across clusters.\n\nNote: The Karmada scheduler currently does NOT use this configuration for scheduling decisions. Future updates may integrate it into the scheduling logic.",
           "type": "array",
           "items": {
             "default": {},

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_federatedresourcequotas.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_federatedresourcequotas.yaml
@@ -54,9 +54,15 @@ spec:
                 type: object
               staticAssignments:
                 description: |-
-                  StaticAssignments represents the subset of desired hard limits for each cluster.
-                  Note: for clusters not present in this list, Karmada will set an empty ResourceQuota to them, which means these
-                  clusters will have no quotas in the referencing namespace.
+                  StaticAssignments specifies ResourceQuota settings for specific clusters.
+                  If non-empty, Karmada will create ResourceQuotas in the corresponding clusters.
+                  Clusters not listed here or when StaticAssignments is empty will have no ResourceQuotas created.
+
+                  This field addresses multi-cluster configuration management challenges by allowing centralized
+                  control over ResourceQuotas across clusters.
+
+                  Note: The Karmada scheduler currently does NOT use this configuration for scheduling decisions.
+                  Future updates may integrate it into the scheduling logic.
                 items:
                   description: StaticClusterAssignment represents the set of desired
                     hard limits for a specific cluster.

--- a/pkg/apis/policy/v1alpha1/federatedresourcequota_types.go
+++ b/pkg/apis/policy/v1alpha1/federatedresourcequota_types.go
@@ -58,9 +58,16 @@ type FederatedResourceQuotaSpec struct {
 	// +required
 	Overall corev1.ResourceList `json:"overall"`
 
-	// StaticAssignments represents the subset of desired hard limits for each cluster.
-	// Note: for clusters not present in this list, Karmada will set an empty ResourceQuota to them, which means these
-	// clusters will have no quotas in the referencing namespace.
+	// StaticAssignments specifies ResourceQuota settings for specific clusters.
+	// If non-empty, Karmada will create ResourceQuotas in the corresponding clusters.
+	// Clusters not listed here or when StaticAssignments is empty will have no ResourceQuotas created.
+	//
+	// This field addresses multi-cluster configuration management challenges by allowing centralized
+	// control over ResourceQuotas across clusters.
+	//
+	// Note: The Karmada scheduler currently does NOT use this configuration for scheduling decisions.
+	// Future updates may integrate it into the scheduling logic.
+	//
 	// +optional
 	StaticAssignments []StaticClusterAssignment `json:"staticAssignments,omitempty"`
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -4135,7 +4135,7 @@ func schema_pkg_apis_policy_v1alpha1_FederatedResourceQuotaSpec(ref common.Refer
 					},
 					"staticAssignments": {
 						SchemaProps: spec.SchemaProps{
-							Description: "StaticAssignments represents the subset of desired hard limits for each cluster. Note: for clusters not present in this list, Karmada will set an empty ResourceQuota to them, which means these clusters will have no quotas in the referencing namespace.",
+							Description: "StaticAssignments specifies ResourceQuota settings for specific clusters. If non-empty, Karmada will create ResourceQuotas in the corresponding clusters. Clusters not listed here or when StaticAssignments is empty will have no ResourceQuotas created.\n\nThis field addresses multi-cluster configuration management challenges by allowing centralized control over ResourceQuotas across clusters.\n\nNote: The Karmada scheduler currently does NOT use this configuration for scheduling decisions. Future updates may integrate it into the scheduling logic.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind api-change
/kind feature

**What this PR does / why we need it**:

This PR clarifies the intent and usage of StaticAssignments in FederatedResourceQuota:
- Clusters ​​not explicitly listed​​ in StaticAssignments will ​​no longer have a ResourceQuota created​​ (previously, an empty ResourceQuota was generated for them).
- The previous behavior of creating empty ResourceQuotas for all clusters was ​​error-prone and non-functional​​, as empty ResourceQuotas provide no enforcement (they cannot block pod creation) and have no practical use case.

This change ​​clarifies the intent and usage​​ of StaticAssignments:
- Explicitly listed clusters receive ResourceQuotas with defined limits.
- Unlisted clusters are excluded entirely, avoiding unnecessary objects.

Updated comments now clearly document this behavior and the field’s purpose (centralized ResourceQuota management for multi-cluster scenarios).

**Which issue(s) this PR fixes**:
Part of #6350

**Special notes for your reviewer**:
This PR only included API change, the following will cover the controller change.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Clusters not explicitly listed in `StaticAssignments` of `FederatedResourceQuota` will no longer have an empty ResourceQuota created.
```

