### PR TITLE
fixed the issue where resource scheduling suspension may become ineffective

### DIFF
--- a/pkg/scheduler/event_handler.go
+++ b/pkg/scheduler/event_handler.go
@@ -332,6 +332,12 @@ func (s *Scheduler) enqueueAffectedBindings(cluster *clusterv1alpha1.Cluster) er
 			// never reach here
 			continue
 		}
+		if !schedulerNameFilter(s.schedulerName, binding.Spec.SchedulerName) {
+			continue
+		}
+		if binding.Spec.SchedulingSuspended() {
+			continue
+		}
 
 		var affinity *policyv1alpha1.ClusterAffinity
 		if placementPtr.ClusterAffinities != nil {
@@ -340,9 +346,7 @@ func (s *Scheduler) enqueueAffectedBindings(cluster *clusterv1alpha1.Cluster) er
 				// for scheduling or its status has not been synced to the
 				// cache. Just enqueue the binding to avoid missing the cluster
 				// update event.
-				if schedulerNameFilter(s.schedulerName, binding.Spec.SchedulerName) {
-					s.onResourceBindingRequeue(binding, metrics.ClusterChanged)
-				}
+				s.onResourceBindingRequeue(binding, metrics.ClusterChanged)
 				continue
 			}
 			affinityIndex := getAffinityIndex(placementPtr.ClusterAffinities, binding.Status.SchedulerObservedAffinityName)
@@ -357,9 +361,7 @@ func (s *Scheduler) enqueueAffectedBindings(cluster *clusterv1alpha1.Cluster) er
 			fallthrough
 		case util.ClusterMatches(cluster, *affinity):
 			// If the cluster manifest match the affinity, add it to the queue, trigger rescheduling
-			if schedulerNameFilter(s.schedulerName, binding.Spec.SchedulerName) {
-				s.onResourceBindingRequeue(binding, metrics.ClusterChanged)
-			}
+			s.onResourceBindingRequeue(binding, metrics.ClusterChanged)
 		}
 	}
 
@@ -377,6 +379,12 @@ func (s *Scheduler) enqueueAffectedCRBs(cluster *clusterv1alpha1.Cluster) error 
 			// never reach here
 			continue
 		}
+		if !schedulerNameFilter(s.schedulerName, binding.Spec.SchedulerName) {
+			continue
+		}
+		if binding.Spec.SchedulingSuspended() {
+			continue
+		}
 
 		var affinity *policyv1alpha1.ClusterAffinity
 		if placementPtr.ClusterAffinities != nil {
@@ -385,9 +393,7 @@ func (s *Scheduler) enqueueAffectedCRBs(cluster *clusterv1alpha1.Cluster) error 
 				// for scheduling or its status has not been synced to the
 				// cache. Just enqueue the binding to avoid missing the cluster
 				// update event.
-				if schedulerNameFilter(s.schedulerName, binding.Spec.SchedulerName) {
-					s.onClusterResourceBindingRequeue(binding, metrics.ClusterChanged)
-				}
+				s.onClusterResourceBindingRequeue(binding, metrics.ClusterChanged)
 				continue
 			}
 			affinityIndex := getAffinityIndex(placementPtr.ClusterAffinities, binding.Status.SchedulerObservedAffinityName)
@@ -402,9 +408,7 @@ func (s *Scheduler) enqueueAffectedCRBs(cluster *clusterv1alpha1.Cluster) error 
 			fallthrough
 		case util.ClusterMatches(cluster, *affinity):
 			// If the cluster manifest match the affinity, add it to the queue, trigger rescheduling
-			if schedulerNameFilter(s.schedulerName, binding.Spec.SchedulerName) {
-				s.onClusterResourceBindingRequeue(binding, metrics.ClusterChanged)
-			}
+			s.onClusterResourceBindingRequeue(binding, metrics.ClusterChanged)
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Ref to #6354, karmada-scheduler should not enqueue rbs/crbs when the cluster is updated if `binding.spec.suspension.scheduling` is set to true.

**Which issue(s) this PR fixes**:
Fixes #6354

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-scheduler`: Fixed the issue where resource scheduling suspension may become ineffective during a cluster update.
```

