### PR TITLE
Support Suspension of Reconciliation for Karmada Control Planes

### DIFF
--- a/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
+++ b/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
@@ -5294,6 +5294,12 @@ spec:
                 required:
                 - registry
                 type: object
+              suspend:
+                description: |-
+                  Suspend indicates that the operator should suspend reconciliation
+                  for this Karmada control plane and all its managed resources.
+                  Karmada instances for which this field is not explicitly set to `true` will continue to be reconciled as usual.
+                type: boolean
             type: object
           status:
             description: Most recently observed status of the Karmada.

--- a/hack/local-up-karmada-by-operator.sh
+++ b/hack/local-up-karmada-by-operator.sh
@@ -56,6 +56,7 @@ source "${REPO_ROOT}"/hack/util.sh
 KARMADA_SYSTEM_NAMESPACE="karmada-system"
 
 # variable define
+export COPYFILE_DISABLE=1
 export KUBECONFIG_PATH=${KUBECONFIG_PATH:-"${HOME}/.kube"}
 export MAIN_KUBECONFIG=${MAIN_KUBECONFIG:-"${KUBECONFIG_PATH}/karmada.config"}
 export HOST_CLUSTER_NAME=${HOST_CLUSTER_NAME:-"karmada-host"}

--- a/hack/local-up-karmada-by-operator.sh
+++ b/hack/local-up-karmada-by-operator.sh
@@ -56,7 +56,6 @@ source "${REPO_ROOT}"/hack/util.sh
 KARMADA_SYSTEM_NAMESPACE="karmada-system"
 
 # variable define
-export COPYFILE_DISABLE=1
 export KUBECONFIG_PATH=${KUBECONFIG_PATH:-"${HOME}/.kube"}
 export MAIN_KUBECONFIG=${MAIN_KUBECONFIG:-"${KUBECONFIG_PATH}/karmada.config"}
 export HOST_CLUSTER_NAME=${HOST_CLUSTER_NAME:-"karmada-host"}

--- a/operator/config/crds/operator.karmada.io_karmadas.yaml
+++ b/operator/config/crds/operator.karmada.io_karmadas.yaml
@@ -5294,6 +5294,12 @@ spec:
                 required:
                 - registry
                 type: object
+              suspend:
+                description: |-
+                  Suspend indicates that the operator should suspend reconciliation
+                  for this Karmada control plane and all its managed resources.
+                  Karmada instances for which this field is not explicitly set to `true` will continue to be reconciled as usual.
+                type: boolean
             type: object
           status:
             description: Most recently observed status of the Karmada.

--- a/operator/pkg/apis/operator/v1alpha1/type.go
+++ b/operator/pkg/apis/operator/v1alpha1/type.go
@@ -120,6 +120,12 @@ type KarmadaSpec struct {
 	// Currently, it only supports customizing the CA certificate for limited components.
 	// +optional
 	CustomCertificate *CustomCertificate `json:"customCertificate,omitempty"`
+
+	// Suspend indicates that the operator should suspend reconciliation
+	// for this Karmada control plane and all its managed resources.
+	// Karmada instances for which this field is not explicitly set to `true` will continue to be reconciled as usual.
+	// +optional
+	Suspend *bool `json:"suspend,omitempty"`
 }
 
 // CustomCertificate holds the configuration for generating the certificate.

--- a/operator/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -675,6 +675,11 @@ func (in *KarmadaSpec) DeepCopyInto(out *KarmadaSpec) {
 		*out = new(CustomCertificate)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Suspend != nil {
+		in, out := &in.Suspend, &out.Suspend
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Implementation of this [proposal](https://github.com/karmada-io/karmada/pull/6358).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-operator`: The new optional `spec.suspend` field can be used to temporarily pause/suspend the reconciliation of a `Karmada` object.
```

