### PR TITLE
FederatedResourceQuota: skip creating redundant ResourceQuotas to member clusters

### DIFF
--- a/pkg/controllers/federatedresourcequota/federated_resource_quota_status_controller.go
+++ b/pkg/controllers/federatedresourcequota/federated_resource_quota_status_controller.go
@@ -124,8 +124,14 @@ func (c *StatusController) SetupWithManager(mgr controllerruntime.Manager) error
 			}
 			return !reflect.DeepEqual(objOld.Status, objNew.Status)
 		},
-		DeleteFunc: func(event.DeleteEvent) bool {
-			return false
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			obj := deleteEvent.Object.(*workv1alpha1.Work)
+			_, namespaceExist := obj.GetLabels()[util.FederatedResourceQuotaNamespaceLabel]
+			_, nameExist := obj.GetLabels()[util.FederatedResourceQuotaNameLabel]
+			if !namespaceExist || !nameExist {
+				return false
+			}
+			return true
 		},
 		GenericFunc: func(event.GenericEvent) bool {
 			return false

--- a/test/helper/policy.go
+++ b/test/helper/policy.go
@@ -162,6 +162,16 @@ func NewClusterOverridePolicyByOverrideRules(policyName string, rsSelectors []po
 
 // NewFederatedResourceQuota will build a demo FederatedResourceQuota object.
 func NewFederatedResourceQuota(ns, name string, clusterNames []string) *policyv1alpha1.FederatedResourceQuota {
+	var staticAssignments []policyv1alpha1.StaticClusterAssignment
+	for i := range clusterNames {
+		staticAssignments = append(staticAssignments, policyv1alpha1.StaticClusterAssignment{
+			ClusterName: clusterNames[i],
+			Hard: map[corev1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		})
+	}
 	return &policyv1alpha1.FederatedResourceQuota{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
@@ -172,22 +182,7 @@ func NewFederatedResourceQuota(ns, name string, clusterNames []string) *policyv1
 				"cpu":    resource.MustParse("8"),
 				"memory": resource.MustParse("16Gi"),
 			},
-			StaticAssignments: []policyv1alpha1.StaticClusterAssignment{
-				{
-					ClusterName: clusterNames[0],
-					Hard: map[corev1.ResourceName]resource.Quantity{
-						"cpu":    resource.MustParse("1"),
-						"memory": resource.MustParse("2Gi"),
-					},
-				},
-				{
-					ClusterName: clusterNames[1],
-					Hard: map[corev1.ResourceName]resource.Quantity{
-						"cpu":    resource.MustParse("1"),
-						"memory": resource.MustParse("2Gi"),
-					},
-				},
-			},
+			StaticAssignments: staticAssignments,
 		},
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Adjust the behavior of the legacy staticAssignments to skip creating redundant ResourceQuotas to member clusters

**Which issue(s) this PR fixes**:
Parts of #6350

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

