### PR TITLE
additional print columns for CRDs FederatedResourceQuota

### DIFF
--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_federatedresourcequotas.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_federatedresourcequotas.yaml
@@ -16,7 +16,14 @@ spec:
     singular: federatedresourcequota
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.overall
+      name: OVERALL
+      type: string
+    - jsonPath: .status.overallUsed
+      name: OVERALL_USED
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: FederatedResourceQuota sets aggregate quota restrictions enforced

--- a/pkg/apis/policy/v1alpha1/federatedresourcequota_types.go
+++ b/pkg/apis/policy/v1alpha1/federatedresourcequota_types.go
@@ -37,6 +37,8 @@ const (
 // +kubebuilder:resource:path=federatedresourcequotas,scope=Namespaced,categories={karmada-io}
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:JSONPath=`.status.overall`,name=`OVERALL`,type=string
+// +kubebuilder:printcolumn:JSONPath=`.status.overallUsed`,name=`OVERALL_USED`,type=string
 
 // FederatedResourceQuota sets aggregate quota restrictions enforced per namespace across all clusters.
 type FederatedResourceQuota struct {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
I would like to improve the output of `kubectl/karmadactl get federatedResourceQuota`. The current output looks like this:
```bash
✗ kubectl get federatedresourcequotas.policy.karmada.io                                       
NAME   AGE
test   3m59s
```
There is no useful information currently. We can also add the overall and overallUsed fields to the output, like:
```bash
kubectl get federatedresourcequotas.policy.karmada.io
NAME   OVERALL          OVERALL_USED
test   {"cpu":"100m"}   
```

**Which issue(s) this PR fixes**:
Parts of #6350 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`FederatedResourceQuota`: Added two additional printer columns, `OVERALL` and `OVERALL_USED`, to represent the enforced hard limits and current total usage; these columns will be displayed in the output of kubectl/karmadactl get.
```

