### PR TITLE
e2e: cleanup all namespaces created both in control plane and member clusters

### DIFF
--- a/test/e2e/suites/base/search_test.go
+++ b/test/e2e/suites/base/search_test.go
@@ -54,6 +54,7 @@ var _ = ginkgo.Describe("[karmada-search] karmada search testing", ginkgo.Ordere
 	var member1, member2 string
 	var member1NodeName, member2NodeName string
 	var member1PodName, member2PodName string
+	var secondaryTestNamespace string
 	var existsDeploymentName = "coredns"
 	var existsServiceName = "kubernetes"
 	var existsDaemonsetName = "kube-proxy"
@@ -72,6 +73,10 @@ var _ = ginkgo.Describe("[karmada-search] karmada search testing", ginkgo.Ordere
 	// var pathWithLabel = pathPrefix + "apis/apps/v1/namespaces/kube-system/deployments?labelSelector=k8s-app=kube-dns"
 
 	ginkgo.BeforeAll(func() {
+		secondaryTestNamespace = fmt.Sprintf("karmadatest-%s", rand.String(RandomStrLength))
+		err := setupTestNamespace(secondaryTestNamespace, kubeClient)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
 		// get clusters' name
 		pushModeClusters := framework.ClusterNamesWithSyncMode(clusterv1alpha1.Push)
 		ginkgo.By(fmt.Sprintf("get %v clusters in push mode", len(pushModeClusters)))
@@ -88,6 +93,11 @@ var _ = ginkgo.Describe("[karmada-search] karmada search testing", ginkgo.Ordere
 
 		// clean ResourceRegistries before test
 		gomega.Expect(karmadaClient.SearchV1alpha1().ResourceRegistries().DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})).Should(gomega.Succeed())
+	})
+
+	ginkgo.AfterAll(func() {
+		err := cleanupTestNamespace(secondaryTestNamespace, kubeClient)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	})
 
 	// use service as search object

--- a/test/e2e/suites/base/suite_test.go
+++ b/test/e2e/suites/base/suite_test.go
@@ -118,13 +118,10 @@ var (
 	controlPlaneClient client.Client
 	// testNamespace is the main namespace for testing.
 	// It is the default namespace where most test resources are created and validated.
-	testNamespace string
-	// secondaryTestNamespace is an additional namespace used for testing.
-	// It is only required in specific scenarios where resources need to be created and tested across multiple namespaces.
-	secondaryTestNamespace string
-	clusterProvider        *cluster.Provider
-	clusterLabels          = map[string]string{"location": "CHN"}
-	pushModeClusterLabels  = map[string]string{"sync-mode": "Push"}
+	testNamespace         string
+	clusterProvider       *cluster.Provider
+	clusterLabels         = map[string]string{"location": "CHN"}
+	pushModeClusterLabels = map[string]string{"sync-mode": "Push"}
 )
 
 func init() {
@@ -190,10 +187,6 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 
 	testNamespace = fmt.Sprintf("karmadatest-%s", rand.String(RandomStrLength))
 	err = setupTestNamespace(testNamespace, kubeClient)
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-
-	secondaryTestNamespace = fmt.Sprintf("karmadatest-%s", rand.String(RandomStrLength))
-	err = setupTestNamespace(secondaryTestNamespace, kubeClient)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	framework.WaitNamespacePresentOnClusters(framework.ClusterNames(), testNamespace)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
In the `ginkgo.SynchronizedBeforeSuite`, we create two namespaces: testNamespace and secondaryTestNamespace. However, during the cleanup phase, only testNamespace will be cleaned up, resulting in a leftover namespace.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

