### PR TITLE
Create federated-resource-quota-enforcement-controller

### DIFF
--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -233,6 +233,7 @@ func init() {
 	controllers["unifiedAuth"] = startUnifiedAuthController
 	controllers["federatedResourceQuotaSync"] = startFederatedResourceQuotaSyncController
 	controllers["federatedResourceQuotaStatus"] = startFederatedResourceQuotaStatusController
+	controllers["federatedResourceQuotaEnforcement"] = startFederatedResourceQuotaEnforcementController
 	controllers["gracefulEviction"] = startGracefulEvictionController
 	controllers["applicationFailover"] = startApplicationFailoverController
 	controllers["federatedHorizontalPodAutoscaler"] = startFederatedHorizontalPodAutoscalerController
@@ -581,6 +582,20 @@ func startFederatedResourceQuotaStatusController(ctx controllerscontext.Context)
 		Client:             ctx.Mgr.GetClient(),
 		EventRecorder:      ctx.Mgr.GetEventRecorderFor(federatedresourcequota.StatusControllerName),
 		RateLimiterOptions: ctx.Opts.RateLimiterOptions,
+	}
+	if err = controller.SetupWithManager(ctx.Mgr); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func startFederatedResourceQuotaEnforcementController(ctx controllerscontext.Context) (enabled bool, err error) {
+	if !features.FeatureGate.Enabled(features.FederatedQuotaEnforcement) {
+		return false, nil
+	}
+	controller := federatedresourcequota.QuotaEnforcementController{
+		Client:        ctx.Mgr.GetClient(),
+		EventRecorder: ctx.Mgr.GetEventRecorderFor(federatedresourcequota.QuotaEnforcementControllerName),
 	}
 	if err = controller.SetupWithManager(ctx.Mgr); err != nil {
 		return false, err

--- a/pkg/controllers/federatedresourcequota/federated_resource_quota_enforcement_controller.go
+++ b/pkg/controllers/federatedresourcequota/federated_resource_quota_enforcement_controller.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package federatedresourcequota
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/events"
+	"github.com/karmada-io/karmada/pkg/util/helper"
+)
+
+const (
+	// QuotaEnforcementControllerName is the controller name that will be used when reporting events.
+	QuotaEnforcementControllerName = "federated-resource-quota-enforcement-controller"
+)
+
+// QuotaEnforcementController reflects the overall resource usage in namespaced FederatedResourceQuotas.
+// The controller will determine resource usage based off the replicaRequirements defined in the relevant
+// ResourceBindings found in the namespace where a FederatedResourceQuota is applied.
+//
+// The total sum of replicaRequirements cannot exceed the limits set by the quota.
+type QuotaEnforcementController struct {
+	client.Client // used to operate Work resources.
+	EventRecorder record.EventRecorder
+}
+
+// Reconcile performs a full reconciliation for the object referred to by the Request.
+// The SyncController will requeue the Request to be processed again if an error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (c *QuotaEnforcementController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	klog.V(4).Infof("QuotaEnforcementController reconciling %s", req.NamespacedName.String())
+
+	// First try fetching FederatedResourceQuota
+	quota := &policyv1alpha1.FederatedResourceQuota{}
+	if err := c.Get(ctx, req.NamespacedName, quota); err == nil {
+		if !quota.DeletionTimestamp.IsZero() {
+			return ctrl.Result{}, nil
+		}
+
+		if err := c.collectQuotaStatus(quota); err != nil {
+			klog.Errorf("Failed to collect status for FederatedResourceQuota(%s), error: %v", req.NamespacedName.String(), err)
+			c.EventRecorder.Eventf(quota, corev1.EventTypeWarning, events.EventReasonCollectFederatedResourceQuotaStatusFailed, err.Error())
+			return ctrl.Result{}, err
+		}
+	} else if apierrors.IsNotFound(err) {
+		// The resource may no longer exist, in which case we stop processing.
+		return ctrl.Result{}, nil
+	}
+
+	// If not FederatedResourceQuota, check if its a deleted ResourceBinding
+	binding := &workv1alpha2.ResourceBinding{}
+	if err := c.Get(ctx, req.NamespacedName, binding); err != nil {
+		if apierrors.IsNotFound(err) {
+			c.collectQuotaStatuses(ctx, binding.Namespace)
+		} else {
+			return ctrl.Result{}, err
+		}
+	}
+
+	c.EventRecorder.Eventf(quota, corev1.EventTypeNormal, events.EventReasonCollectFederatedResourceQuotaStatusSucceed, "Collect status of FederatedResourceQuota(%s) succeed.", req.NamespacedName.String())
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager creates a controller and register to controller manager.
+func (c *QuotaEnforcementController) SetupWithManager(mgr ctrl.Manager) error {
+	fn := handler.MapFunc(
+		func(ctx context.Context, obj client.Object) []reconcile.Request {
+			var quotaList policyv1alpha1.FederatedResourceQuotaList
+			if err := c.Client.List(ctx, &quotaList, client.InNamespace(obj.GetNamespace())); err != nil {
+				return nil
+			}
+
+			if len(quotaList.Items) == 0 {
+				return nil // no quotas in namespace, skip reconcile
+			}
+
+			return []reconcile.Request{{
+				NamespacedName: types.NamespacedName{
+					Namespace: obj.GetNamespace(),
+					Name:      obj.GetName(),
+				},
+			}}
+		},
+	)
+
+	resourceBindingPredicate := builder.WithPredicates(predicate.Funcs{
+		CreateFunc: func(createEvent event.CreateEvent) bool {
+			return false // ignore creates
+		},
+		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
+			return false // ignore updates
+		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			return true // only care about RB deletions
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	})
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&policyv1alpha1.FederatedResourceQuota{}).
+		Watches(&workv1alpha2.ResourceBinding{}, handler.EnqueueRequestsFromMapFunc(fn), resourceBindingPredicate).
+		Complete(c)
+}
+
+func (c *QuotaEnforcementController) collectQuotaStatuses(ctx context.Context, namespace string) error {
+	var quotaList policyv1alpha1.FederatedResourceQuotaList
+	if err := c.Client.List(ctx, &quotaList, client.InNamespace(namespace)); err != nil {
+		return err
+	}
+
+	for _, quota := range quotaList.Items {
+		err := c.collectQuotaStatus(&quota)
+		if err != nil {
+			fmt.Printf("failed to collect status for FederatedResourceQuota(%s), error: %v", klog.KObj(&quota).String(), err)
+		}
+	}
+
+	return nil
+}
+
+func (c *QuotaEnforcementController) collectQuotaStatus(quota *policyv1alpha1.FederatedResourceQuota) error {
+	klog.V(4).Infof("Collecting FederatedResourceQuota status using ResourceBindings.")
+
+	// TODO: Consider adding filtering step to ResourceBinding list once scope is added to the quota
+	bindingList, err := helper.GetResourceBindingsByNamespace(c.Client, quota.Namespace)
+	if err != nil {
+		klog.Errorf("Failed to list resourcebindings tracked by FederatedResourceQuota(%s), error: %v", klog.KObj(quota).String(), err)
+		return err
+	}
+
+	quotaStatus := quota.Status.DeepCopy()
+	quotaStatus.Overall = quota.Spec.Overall
+	quotaStatus.OverallUsed = calculateUsedWithResourceBinding(bindingList.Items)
+
+	if reflect.DeepEqual(quota.Status, *quotaStatus) {
+		klog.V(4).Infof("New quotaStatus is equal with old federatedResourceQuota(%s) status, no update required.", klog.KObj(quota).String())
+		return nil
+	}
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		_, err = helper.UpdateStatus(context.Background(), c.Client, quota, func() error {
+			quota.Status = *quotaStatus
+			return nil
+		})
+		return err
+	})
+}
+
+func calculateUsedWithResourceBinding(resourceBindings []workv1alpha2.ResourceBinding) corev1.ResourceList {
+	overallUsed := corev1.ResourceList{}
+	for _, binding := range resourceBindings {
+		// TODO: Consider skipping resourcebinding if it is not applied
+		if binding.Spec.ReplicaRequirements == nil {
+			continue
+		}
+		used := binding.Spec.ReplicaRequirements.ResourceRequest
+		replicas := binding.Spec.Replicas
+
+		for name, quantity := range used {
+			// Update quantity to reflect number of replicas in resource
+			q := quantity.DeepCopy()
+			q.Mul(int64(replicas))
+
+			// Update quantity to reflect the number of clusters resource is duplicated to
+			if binding.Spec.Placement != nil && binding.Spec.Placement.ReplicaSchedulingType() == v1alpha1.ReplicaSchedulingTypeDuplicated {
+				q.Mul(int64(len(binding.Spec.Clusters)))
+			}
+
+			existing, found := overallUsed[name]
+			if found {
+				existing.Add(q)
+				overallUsed[name] = existing
+			} else {
+				overallUsed[name] = q
+			}
+		}
+	}
+	return overallUsed
+}

--- a/pkg/controllers/federatedresourcequota/federated_resource_quota_enforcement_controller_test.go
+++ b/pkg/controllers/federatedresourcequota/federated_resource_quota_enforcement_controller_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package federatedresourcequota
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+)
+
+func TestCalculateUsedWithResourceBinding(t *testing.T) {
+	tests := []struct {
+		name     string
+		bindings []workv1alpha2.ResourceBinding
+		expected corev1.ResourceList
+	}{
+		{
+			name: "single binding, 3 replicas",
+			bindings: []workv1alpha2.ResourceBinding{
+				makeBinding("500m", "128Mi", int32(3), v1alpha1.ReplicaSchedulingTypeDivided),
+			},
+			expected: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1500m"),
+				corev1.ResourceMemory: resource.MustParse("384Mi"),
+			},
+		},
+		{
+			name: "multiple bindings, mixed scheduling strategies",
+			bindings: []workv1alpha2.ResourceBinding{
+				makeBinding("1", "2Gi", 2, v1alpha1.ReplicaSchedulingTypeDivided),
+				makeBinding("500m", "500Mi", 2, v1alpha1.ReplicaSchedulingTypeDuplicated),
+				makeBinding("2", "1Gi", 2, v1alpha1.ReplicaSchedulingTypeDivided),
+			},
+			expected: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("8"),
+				corev1.ResourceMemory: resource.MustParse("8144Mi"),
+			},
+		},
+		{
+			name: "skip binding with nil ResourceRequest",
+			bindings: []workv1alpha2.ResourceBinding{
+				{
+					Spec: workv1alpha2.ResourceBindingSpec{
+						Clusters: []workv1alpha2.TargetCluster{
+							{Name: "cluster1"},
+							{Name: "cluster2"},
+						},
+						ReplicaRequirements: &workv1alpha2.ReplicaRequirements{
+							ResourceRequest: nil,
+						},
+						Replicas: 2,
+						Placement: &policyv1alpha1.Placement{
+							ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+								ReplicaSchedulingType: v1alpha1.ReplicaSchedulingTypeDuplicated,
+							},
+						},
+					},
+				},
+				makeBinding("200m", "128Mi", 2, v1alpha1.ReplicaSchedulingTypeDivided),
+			},
+			expected: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("400m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+		},
+		{
+			name:     "empty binding list",
+			bindings: []workv1alpha2.ResourceBinding{},
+			expected: corev1.ResourceList{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			used := calculateUsedWithResourceBinding(tt.bindings)
+			for res, expectedQuantity := range tt.expected {
+				actualQuantity, exists := used[res]
+				require.True(t, exists, "expected resource %s to exist", res)
+				require.Equal(t, expectedQuantity.String(), actualQuantity.String(), "resource %s mismatch", res)
+			}
+			// Double check there are no unexpected resources
+			require.Equal(t, len(tt.expected), len(used), "expected resource count mismatch")
+		})
+	}
+}
+
+func makeBinding(cpu string, memory string, replicas int32, strategy v1alpha1.ReplicaSchedulingType) workv1alpha2.ResourceBinding {
+	schedulingStrategy := &policyv1alpha1.ReplicaSchedulingStrategy{
+		ReplicaSchedulingType: strategy,
+	}
+	return workv1alpha2.ResourceBinding{
+		Spec: workv1alpha2.ResourceBindingSpec{
+			Clusters: []workv1alpha2.TargetCluster{
+				{Name: "cluster1"},
+				{Name: "cluster2"},
+			},
+			ReplicaRequirements: &workv1alpha2.ReplicaRequirements{
+				ResourceRequest: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceCPU:    resource.MustParse(cpu),
+					corev1.ResourceMemory: resource.MustParse(memory),
+				},
+			},
+			Replicas: replicas,
+			Placement: &policyv1alpha1.Placement{
+				ReplicaScheduling: schedulingStrategy,
+			},
+		},
+	}
+}

--- a/pkg/controllers/federatedresourcequota/federated_resource_quota_enforcement_controller_test.go
+++ b/pkg/controllers/federatedresourcequota/federated_resource_quota_enforcement_controller_test.go
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 )
@@ -32,13 +31,15 @@ func TestCalculateUsedWithResourceBinding(t *testing.T) {
 	tests := []struct {
 		name     string
 		bindings []workv1alpha2.ResourceBinding
+		overall  corev1.ResourceList
 		expected corev1.ResourceList
 	}{
 		{
 			name: "single binding, 3 replicas",
 			bindings: []workv1alpha2.ResourceBinding{
-				makeBinding("500m", "128Mi", int32(3), v1alpha1.ReplicaSchedulingTypeDivided),
+				makeBinding("500m", "128Mi", int32(3), policyv1alpha1.ReplicaSchedulingTypeDivided),
 			},
+			overall: makeResourceRequest("2000m", "1Gi"),
 			expected: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("1500m"),
 				corev1.ResourceMemory: resource.MustParse("384Mi"),
@@ -47,13 +48,24 @@ func TestCalculateUsedWithResourceBinding(t *testing.T) {
 		{
 			name: "multiple bindings, mixed scheduling strategies",
 			bindings: []workv1alpha2.ResourceBinding{
-				makeBinding("1", "2Gi", 2, v1alpha1.ReplicaSchedulingTypeDivided),
-				makeBinding("500m", "500Mi", 2, v1alpha1.ReplicaSchedulingTypeDuplicated),
-				makeBinding("2", "1Gi", 2, v1alpha1.ReplicaSchedulingTypeDivided),
+				makeBinding("1", "2Gi", 2, policyv1alpha1.ReplicaSchedulingTypeDivided),
+				makeBinding("500m", "500Mi", 2, policyv1alpha1.ReplicaSchedulingTypeDuplicated),
+				makeBinding("2", "1Gi", 2, policyv1alpha1.ReplicaSchedulingTypeDivided),
 			},
+			overall: makeResourceRequest("10", "10Gi"),
 			expected: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("8"),
 				corev1.ResourceMemory: resource.MustParse("8144Mi"),
+			},
+		},
+		{
+			name: "single binding, overall only includes cpu",
+			bindings: []workv1alpha2.ResourceBinding{
+				makeBinding("500m", "1Gi", int32(3), policyv1alpha1.ReplicaSchedulingTypeDivided),
+			},
+			overall: makeResourceRequest("10", ""),
+			expected: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("1500m"),
 			},
 		},
 		{
@@ -71,13 +83,14 @@ func TestCalculateUsedWithResourceBinding(t *testing.T) {
 						Replicas: 2,
 						Placement: &policyv1alpha1.Placement{
 							ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
-								ReplicaSchedulingType: v1alpha1.ReplicaSchedulingTypeDuplicated,
+								ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDuplicated,
 							},
 						},
 					},
 				},
-				makeBinding("200m", "128Mi", 2, v1alpha1.ReplicaSchedulingTypeDivided),
+				makeBinding("200m", "128Mi", 2, policyv1alpha1.ReplicaSchedulingTypeDivided),
 			},
+			overall: makeResourceRequest("10", "10Gi"),
 			expected: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("400m"),
 				corev1.ResourceMemory: resource.MustParse("256Mi"),
@@ -86,13 +99,14 @@ func TestCalculateUsedWithResourceBinding(t *testing.T) {
 		{
 			name:     "empty binding list",
 			bindings: []workv1alpha2.ResourceBinding{},
+			overall:  makeResourceRequest("10", "10Gi"),
 			expected: corev1.ResourceList{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			used := calculateUsedWithResourceBinding(tt.bindings)
+			used := calculateUsedWithResourceBinding(tt.bindings, tt.overall)
 			for res, expectedQuantity := range tt.expected {
 				actualQuantity, exists := used[res]
 				require.True(t, exists, "expected resource %s to exist", res)
@@ -104,7 +118,7 @@ func TestCalculateUsedWithResourceBinding(t *testing.T) {
 	}
 }
 
-func makeBinding(cpu string, memory string, replicas int32, strategy v1alpha1.ReplicaSchedulingType) workv1alpha2.ResourceBinding {
+func makeBinding(cpu string, memory string, replicas int32, strategy policyv1alpha1.ReplicaSchedulingType) workv1alpha2.ResourceBinding {
 	schedulingStrategy := &policyv1alpha1.ReplicaSchedulingStrategy{
 		ReplicaSchedulingType: strategy,
 	}
@@ -115,15 +129,28 @@ func makeBinding(cpu string, memory string, replicas int32, strategy v1alpha1.Re
 				{Name: "cluster2"},
 			},
 			ReplicaRequirements: &workv1alpha2.ReplicaRequirements{
-				ResourceRequest: map[corev1.ResourceName]resource.Quantity{
-					corev1.ResourceCPU:    resource.MustParse(cpu),
-					corev1.ResourceMemory: resource.MustParse(memory),
-				},
+				ResourceRequest: makeResourceRequest(cpu, memory),
 			},
 			Replicas: replicas,
 			Placement: &policyv1alpha1.Placement{
 				ReplicaScheduling: schedulingStrategy,
 			},
 		},
+	}
+}
+
+func makeResourceRequest(cpu string, memory string) map[corev1.ResourceName]resource.Quantity {
+	if cpu != "" && memory != "" {
+		return map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceCPU:    resource.MustParse(cpu),
+			corev1.ResourceMemory: resource.MustParse(memory),
+		}
+	} else if cpu != "" {
+		return map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceCPU: resource.MustParse(cpu),
+		}
+	}
+	return map[corev1.ResourceName]resource.Quantity{
+		corev1.ResourceMemory: resource.MustParse(memory),
 	}
 }

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -102,6 +102,10 @@ const (
 	EventReasonCollectFederatedResourceQuotaStatusFailed = "AggregateStatusFailed"
 	// EventReasonCollectFederatedResourceQuotaStatusSucceed indicates that aggregate status succeed.
 	EventReasonCollectFederatedResourceQuotaStatusSucceed = "AggregateStatusSucceed"
+	// EventReasonCollectFederatedResourceQuotaOverallStatusFailed indicates that Collect Overall Status failed.
+	EventReasonCollectFederatedResourceQuotaOverallStatusFailed = "CollectOverallStatusFailed"
+	// EventReasonCollectFederatedResourceQuotaOverallStatusSucceed indicates that Collect Overall Status succeed.
+	EventReasonCollectFederatedResourceQuotaOverallStatusSucceed = "CollectOverallStatusSucceed"
 )
 
 // Define events for resource templates.

--- a/pkg/util/helper/binding.go
+++ b/pkg/util/helper/binding.go
@@ -349,6 +349,14 @@ func GetResourceBindings(c client.Client, ls labels.Set) (*workv1alpha2.Resource
 	return bindings, c.List(context.TODO(), bindings, listOpt)
 }
 
+// GetResourceBindingsByNamespace returns a ResourceBindingList by namespace
+func GetResourceBindingsByNamespace(c client.Client, namespace string) (*workv1alpha2.ResourceBindingList, error) {
+	bindings := &workv1alpha2.ResourceBindingList{}
+	listOpt := &client.ListOptions{Namespace: namespace}
+
+	return bindings, c.List(context.TODO(), bindings, listOpt)
+}
+
 // DeleteWorks will delete all Work objects by labels.
 func DeleteWorks(ctx context.Context, c client.Client, namespace, name, bindingID string) error {
 	workList, err := GetWorksByBindingID(ctx, c, bindingID, namespace != "")


### PR DESCRIPTION
**What type of PR is this?**

Adds the federated-resource-quota-enforcement controller. 

Reconciles in response to one of the following events:
1. Creation or update of a FederatedResourceQuota
2. Deletion of a ResourceBinding

At the moment I did not include the third planned reconcile: `Periodically recalculate FRQ status`, since I was worried about using `RequeueAfter` and hammering the controller with too many reconcile events. Perhaps we can add this as a follow-up iteration task. 

/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of #6350.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-controller-manager`: Added `federated-resource-quota-enforcement-controller` as part of ResourceQuotaEnforcement feature.
```

