### PR TITLE
Add the ClusterTaintPolicy controller to handle taints on the clusters

### DIFF
--- a/pkg/controllers/cluster/cluster_controller.go
+++ b/pkg/controllers/cluster/cluster_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strings"
 	"sync"
 	"time"
 
@@ -693,36 +692,7 @@ func (c *Controller) updateClusterTaints(ctx context.Context, taintsToAdd, taint
 		c.EventRecorder.Event(cluster, corev1.EventTypeWarning, events.EventReasonTaintClusterFailed, err.Error())
 		return err
 	}
-	msg := fmt.Sprintf("Taint cluster succeed: %s.", generateEventMessage(taints))
+	msg := fmt.Sprintf("Taint cluster succeed: %s.", utilhelper.GenerateTaintsMessage(taints))
 	c.EventRecorder.Event(cluster, corev1.EventTypeNormal, events.EventReasonTaintClusterSucceed, msg)
 	return nil
-}
-
-func generateEventMessage(taints []corev1.Taint) string {
-	if len(taints) == 0 {
-		return "cluster now does not have taints"
-	}
-
-	var msg string
-	for i, taint := range taints {
-		if i != 0 {
-			msg += ","
-		}
-		if taint.Value != "" {
-			msg += strings.Join([]string{`{`,
-				`Key:` + fmt.Sprintf("%v", taint.Key) + `,`,
-				`Value:` + fmt.Sprintf("%v", taint.Value) + `,`,
-				`Effect:` + fmt.Sprintf("%v", taint.Effect),
-				`}`,
-			}, "")
-		} else {
-			msg += strings.Join([]string{`{`,
-				`Key:` + fmt.Sprintf("%v", taint.Key) + `,`,
-				`Effect:` + fmt.Sprintf("%v", taint.Effect),
-				`}`,
-			}, "")
-		}
-	}
-
-	return fmt.Sprintf("cluster now has taints([%s])", msg)
 }

--- a/pkg/controllers/taint/clustertaintpolicy_controller.go
+++ b/pkg/controllers/taint/clustertaintpolicy_controller.go
@@ -1,0 +1,244 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taint
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/events"
+	"github.com/karmada-io/karmada/pkg/sharedcli/ratelimiterflag"
+	"github.com/karmada-io/karmada/pkg/util"
+	utilhelper "github.com/karmada-io/karmada/pkg/util/helper"
+)
+
+// ControllerName is the controller name that will be used when reporting events.
+const ControllerName = "cluster-taint-policy-controller"
+
+// ClusterTaintPolicyController is to sync ClusterTaintPolicy.
+type ClusterTaintPolicyController struct {
+	client.Client
+	EventRecorder      record.EventRecorder
+	RateLimiterOptions ratelimiterflag.Options
+}
+
+// Reconcile performs a full reconciliation for the object referred to by the Request.
+// The Controller will requeue the Request to be processed again if an error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (c *ClusterTaintPolicyController) Reconcile(ctx context.Context, req controllerruntime.Request) (controllerruntime.Result, error) {
+	klog.V(4).Infof("Reconciling Cluster %s.", req.Name)
+
+	clusterObj := &clusterv1alpha1.Cluster{}
+	if err := c.Client.Get(ctx, req.NamespacedName, clusterObj); err != nil {
+		klog.Errorf("Failed to get Cluster(%s), error: %v", req.Name, err)
+		return controllerruntime.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if !clusterObj.DeletionTimestamp.IsZero() {
+		klog.V(4).Infof("Cluster(%s) is deleting.", req.Name)
+		return controllerruntime.Result{}, nil
+	}
+
+	clusterTaintPolicyList := &policyv1alpha1.ClusterTaintPolicyList{}
+	listOption := &client.ListOptions{UnsafeDisableDeepCopy: ptr.To(true)}
+	if err := c.Client.List(ctx, clusterTaintPolicyList, listOption); err != nil {
+		klog.Errorf("Failed to list ClusterTaintPolicy, error: %v", err)
+		return controllerruntime.Result{}, err
+	}
+
+	clusterCopyObj := clusterObj.DeepCopy()
+	for _, policy := range clusterTaintPolicyList.Items {
+		if policy.Spec.TargetClusters != nil && !util.ClusterMatches(clusterCopyObj, *policy.Spec.TargetClusters) {
+			continue
+		}
+
+		if conditionMatches(clusterCopyObj.Status.Conditions, policy.Spec.MatchConditions) {
+			clusterCopyObj.Spec.Taints = addTaintsOnCluster(clusterCopyObj, policy.Spec.Taints, metav1.Now())
+		} else {
+			clusterCopyObj.Spec.Taints = removeTaintsFromCluster(clusterCopyObj, policy.Spec.Taints)
+		}
+	}
+
+	if !reflect.DeepEqual(clusterObj.Spec.Taints, clusterCopyObj.Spec.Taints) {
+		objPatch := client.MergeFrom(clusterObj)
+		err := c.Client.Patch(ctx, clusterCopyObj, objPatch)
+		if err != nil {
+			klog.Errorf("Failed to patch Cluster(%s), error: %v", req.Name, err)
+			c.EventRecorder.Event(clusterCopyObj, corev1.EventTypeWarning, events.EventReasonTaintClusterFailed, err.Error())
+			return controllerruntime.Result{}, err
+		}
+
+		msg := fmt.Sprintf("Update Cluster(%s) with taints(%v) succeed", req.Name,
+			utilhelper.GenerateTaintsMessage(clusterCopyObj.Spec.Taints))
+		klog.Info(msg)
+		c.EventRecorder.Event(clusterCopyObj, corev1.EventTypeNormal, events.EventReasonTaintClusterSucceed, msg)
+		return controllerruntime.Result{}, nil
+	}
+	klog.V(4).Infof("Cluster(%s) taints are up to date.", req.Name)
+	return controllerruntime.Result{}, nil
+}
+
+// conditionMatches returns true if the conditions matches the matchConditions.
+// The match conditions are ANDed.
+// If the match conditions are empty, it will return false.
+func conditionMatches(conditions []metav1.Condition, matchConditions []policyv1alpha1.MatchCondition) bool {
+	if len(matchConditions) == 0 {
+		return false
+	}
+
+	matches := true
+	for _, matchCondition := range matchConditions {
+		match := false
+		for _, clusterCondition := range conditions {
+			if clusterCondition.Type != matchCondition.ConditionType {
+				continue
+			}
+
+			switch matchCondition.Operator {
+			case policyv1alpha1.MatchConditionOpIn:
+				for _, value := range matchCondition.StatusValues {
+					if clusterCondition.Status == value {
+						match = true
+						break
+					}
+				}
+			case policyv1alpha1.MatchConditionOpNotIn:
+				match = true
+				for _, value := range matchCondition.StatusValues {
+					if clusterCondition.Status == value {
+						match = false
+						break
+					}
+				}
+			default:
+				klog.Errorf("Unsupported MatchCondition operator: %s", matchCondition.Operator)
+				return false
+			}
+		}
+
+		if !match {
+			matches = false
+			break
+		}
+	}
+	return matches
+}
+
+// addTaintsOnCluster adds taints on the cluster.
+// If the taint already exists, it will not be added.
+// Use now to set the TimeAdded field of the taint.
+// It's convenient for testing.
+func addTaintsOnCluster(cluster *clusterv1alpha1.Cluster, taints []policyv1alpha1.Taint, now metav1.Time) []corev1.Taint {
+	clusterTaints := cluster.Spec.Taints
+	for _, taint := range taints {
+		exist := false
+		for _, clusterTaint := range clusterTaints {
+			if clusterTaint.Effect == taint.Effect &&
+				clusterTaint.Key == taint.Key {
+				exist = true
+				break
+			}
+		}
+
+		if !exist {
+			clusterTaints = append(clusterTaints, corev1.Taint{
+				Key:       taint.Key,
+				Value:     taint.Value,
+				Effect:    taint.Effect,
+				TimeAdded: &now,
+			})
+		}
+	}
+
+	return clusterTaints
+}
+
+// removeTaintsFromCluster removes taints from the cluster.
+// If the taint does not exist, it will not be removed.
+func removeTaintsFromCluster(cluster *clusterv1alpha1.Cluster, taints []policyv1alpha1.Taint) []corev1.Taint {
+	clusterTaints := cluster.Spec.Taints
+	for _, taint := range taints {
+		for index, clusterTaint := range clusterTaints {
+			if clusterTaint.Effect == taint.Effect &&
+				clusterTaint.Key == taint.Key {
+				clusterTaints = append(clusterTaints[:index], clusterTaints[index+1:]...)
+				break
+			}
+		}
+	}
+	return clusterTaints
+}
+
+// SetupWithManager creates a controller and register to controller manager.
+func (c *ClusterTaintPolicyController) SetupWithManager(mgr controllerruntime.Manager) error {
+	clusterStatusConditionPredicateFn := predicate.Funcs{
+		CreateFunc: func(_ event.CreateEvent) bool {
+			// After controller reboot, it will reconcile all clusters.
+			return true
+		},
+		UpdateFunc: func(event event.UpdateEvent) bool {
+			oldCluster := event.ObjectOld.(*clusterv1alpha1.Cluster)
+			newCluster := event.ObjectNew.(*clusterv1alpha1.Cluster)
+			return !reflect.DeepEqual(oldCluster.Status.Conditions, newCluster.Status.Conditions)
+		},
+		DeleteFunc: func(_ event.DeleteEvent) bool { return false },
+	}
+
+	clusterTaintPolicyMapFunc := handler.MapFunc(
+		func(ctx context.Context, policyObj client.Object) []reconcile.Request {
+			clusterList := &clusterv1alpha1.ClusterList{}
+			listOption := &client.ListOptions{UnsafeDisableDeepCopy: ptr.To(true)}
+			if err := c.Client.List(ctx, clusterList, listOption); err != nil {
+				klog.Errorf("Failed to list Cluster, error: %v", err)
+				return nil
+			}
+
+			policy := policyObj.(*policyv1alpha1.ClusterTaintPolicy)
+			var requests []reconcile.Request
+			for _, cluster := range clusterList.Items {
+				if policy.Spec.TargetClusters == nil ||
+					util.ClusterMatches(&cluster, *policy.Spec.TargetClusters) {
+					requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKey{Name: cluster.Name}})
+				}
+			}
+			return requests
+		})
+
+	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(ControllerName).
+		For(&clusterv1alpha1.Cluster{}, builder.WithPredicates(clusterStatusConditionPredicateFn)).
+		Watches(&policyv1alpha1.ClusterTaintPolicy{}, handler.EnqueueRequestsFromMapFunc(clusterTaintPolicyMapFunc)).
+		WithOptions(controller.Options{RateLimiter: ratelimiterflag.DefaultControllerRateLimiter[controllerruntime.Request](c.RateLimiterOptions)}).
+		Complete(c)
+}

--- a/pkg/controllers/taint/clustertaintpolicy_controller_test.go
+++ b/pkg/controllers/taint/clustertaintpolicy_controller_test.go
@@ -1,0 +1,297 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taint
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+)
+
+func TestConditionMatches(t *testing.T) {
+	tests := []struct {
+		name            string
+		conditions      []metav1.Condition
+		matchConditions []policyv1alpha1.MatchCondition
+		expected        bool
+	}{
+		{
+			name: "empty match conditions",
+			conditions: []metav1.Condition{
+				{Type: "Ready", Status: "True"},
+			},
+			matchConditions: []policyv1alpha1.MatchCondition{},
+			expected:        false,
+		},
+		{
+			name: "match: operator is In",
+			conditions: []metav1.Condition{
+				{Type: "Ready", Status: "True"},
+			},
+			matchConditions: []policyv1alpha1.MatchCondition{
+				{
+					ConditionType: "Ready",
+					Operator:      policyv1alpha1.MatchConditionOpIn,
+					StatusValues:  []metav1.ConditionStatus{metav1.ConditionTrue},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "don't match: operator is In",
+			conditions: []metav1.Condition{
+				{Type: "Ready", Status: "False"},
+			},
+			matchConditions: []policyv1alpha1.MatchCondition{
+				{
+					ConditionType: "Ready",
+					Operator:      policyv1alpha1.MatchConditionOpIn,
+					StatusValues:  []metav1.ConditionStatus{metav1.ConditionTrue},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "match: operator is NotIn",
+			conditions: []metav1.Condition{
+				{Type: "Ready", Status: "False"},
+			},
+			matchConditions: []policyv1alpha1.MatchCondition{
+				{
+					ConditionType: "Ready",
+					Operator:      policyv1alpha1.MatchConditionOpNotIn,
+					StatusValues:  []metav1.ConditionStatus{metav1.ConditionTrue, metav1.ConditionUnknown},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "don't match: operator is NotIn",
+			conditions: []metav1.Condition{
+				{Type: "Ready", Status: "False"},
+			},
+			matchConditions: []policyv1alpha1.MatchCondition{
+				{
+					ConditionType: "Ready",
+					Operator:      policyv1alpha1.MatchConditionOpNotIn,
+					StatusValues:  []metav1.ConditionStatus{metav1.ConditionFalse},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "match: multiple conditions",
+			conditions: []metav1.Condition{
+				{Type: "Ready", Status: "Unknown"},
+				{Type: "NetworkReady", Status: "False"},
+				{Type: "StorageReady", Status: "True"},
+			},
+			matchConditions: []policyv1alpha1.MatchCondition{
+				{
+					ConditionType: "Ready",
+					Operator:      policyv1alpha1.MatchConditionOpIn,
+					StatusValues:  []metav1.ConditionStatus{metav1.ConditionFalse, metav1.ConditionUnknown},
+				},
+				{
+					ConditionType: "NetworkReady",
+					Operator:      policyv1alpha1.MatchConditionOpNotIn,
+					StatusValues:  []metav1.ConditionStatus{metav1.ConditionTrue},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "don't match: multiple conditions",
+			conditions: []metav1.Condition{
+				{Type: "Ready", Status: "True"},
+				{Type: "NetworkReady", Status: "False"},
+				{Type: "StorageReady", Status: "True"},
+			},
+			matchConditions: []policyv1alpha1.MatchCondition{
+				{
+					ConditionType: "Ready",
+					Operator:      policyv1alpha1.MatchConditionOpIn,
+					StatusValues:  []metav1.ConditionStatus{metav1.ConditionFalse, metav1.ConditionUnknown},
+				},
+				{
+					ConditionType: "NetworkReady",
+					Operator:      policyv1alpha1.MatchConditionOpNotIn,
+					StatusValues:  []metav1.ConditionStatus{metav1.ConditionTrue},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := conditionMatches(tt.conditions, tt.matchConditions)
+			if result != tt.expected {
+				t.Errorf("test failed: %s, expected: %v, actual: %v", tt.name, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestAddTaintsOnCluster(t *testing.T) {
+	now := metav1.Now()
+	oneMinuteAgo := metav1.NewTime(now.Add(time.Duration(-1) * time.Minute))
+
+	tests := []struct {
+		name           string
+		cluster        *clusterv1alpha1.Cluster
+		taints         []policyv1alpha1.Taint
+		now            metav1.Time
+		expectedTaints []corev1.Taint
+	}{
+		{
+			name: "add new taint",
+			cluster: &clusterv1alpha1.Cluster{
+				Spec: clusterv1alpha1.ClusterSpec{
+					Taints: []corev1.Taint{},
+				},
+			},
+			taints: []policyv1alpha1.Taint{
+				{Key: "key1", Value: "value1", Effect: corev1.TaintEffectNoSchedule},
+			},
+			now: now,
+			expectedTaints: []corev1.Taint{
+				{Key: "key1", Value: "value1", Effect: corev1.TaintEffectNoSchedule, TimeAdded: &now},
+			},
+		},
+		{
+			name: "add the existing taint, don't update TimeAdded",
+			cluster: &clusterv1alpha1.Cluster{
+				Spec: clusterv1alpha1.ClusterSpec{
+					Taints: []corev1.Taint{
+						{Key: "key1", Value: "value1", Effect: corev1.TaintEffectNoSchedule, TimeAdded: &oneMinuteAgo},
+					},
+				},
+			},
+			taints: []policyv1alpha1.Taint{
+				{Key: "key1", Value: "value1", Effect: corev1.TaintEffectNoSchedule},
+			},
+			now: now,
+			expectedTaints: []corev1.Taint{
+				{Key: "key1", Value: "value1", Effect: corev1.TaintEffectNoSchedule, TimeAdded: &oneMinuteAgo},
+			},
+		},
+		{
+			name: "add multi taints",
+			cluster: &clusterv1alpha1.Cluster{
+				Spec: clusterv1alpha1.ClusterSpec{
+					Taints: []corev1.Taint{
+						{Key: "key2", Value: "value2", Effect: corev1.TaintEffectPreferNoSchedule, TimeAdded: &oneMinuteAgo},
+					},
+				},
+			},
+			taints: []policyv1alpha1.Taint{
+				{Key: "key1", Value: "value1", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "key3", Value: "value3", Effect: corev1.TaintEffectNoExecute},
+			},
+			now: now,
+			expectedTaints: []corev1.Taint{
+				{Key: "key2", Value: "value2", Effect: corev1.TaintEffectPreferNoSchedule, TimeAdded: &oneMinuteAgo},
+				{Key: "key1", Value: "value1", Effect: corev1.TaintEffectNoSchedule, TimeAdded: &now},
+				{Key: "key3", Value: "value3", Effect: corev1.TaintEffectNoExecute, TimeAdded: &now},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := addTaintsOnCluster(tt.cluster, tt.taints, tt.now)
+			if !reflect.DeepEqual(result, tt.expectedTaints) {
+				t.Errorf("test failed, expected: %v, actual: %v", tt.expectedTaints, result)
+			}
+		})
+	}
+}
+
+func TestRemoveTaintsOnCluster(t *testing.T) {
+	now := metav1.Now()
+	oneMinuteAgo := metav1.NewTime(now.Add(time.Duration(-1) * time.Minute))
+
+	tests := []struct {
+		name           string
+		cluster        *clusterv1alpha1.Cluster
+		taintsToRemove []policyv1alpha1.Taint
+		expected       []corev1.Taint
+	}{
+		{
+			name: "remove a taint",
+			cluster: &clusterv1alpha1.Cluster{
+				Spec: clusterv1alpha1.ClusterSpec{
+					Taints: []corev1.Taint{
+						{Key: "key1", Effect: corev1.TaintEffectNoSchedule, TimeAdded: &oneMinuteAgo},
+					},
+				},
+			},
+			taintsToRemove: []policyv1alpha1.Taint{
+				{Key: "key1", Effect: corev1.TaintEffectNoSchedule},
+			},
+			expected: []corev1.Taint{},
+		},
+		{
+			name: "remove multiple matched taints",
+			cluster: &clusterv1alpha1.Cluster{
+				Spec: clusterv1alpha1.ClusterSpec{
+					Taints: []corev1.Taint{
+						{Key: "key1", Effect: corev1.TaintEffectNoSchedule, TimeAdded: &oneMinuteAgo},
+						{Key: "key2", Effect: corev1.TaintEffectNoExecute, TimeAdded: &now},
+					},
+				},
+			},
+			taintsToRemove: []policyv1alpha1.Taint{
+				{Key: "key1", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "key2", Effect: corev1.TaintEffectNoExecute},
+			},
+			expected: []corev1.Taint{},
+		},
+		{
+			name: "no matched taints",
+			cluster: &clusterv1alpha1.Cluster{
+				Spec: clusterv1alpha1.ClusterSpec{
+					Taints: []corev1.Taint{
+						{Key: "key1", Effect: corev1.TaintEffectNoSchedule, TimeAdded: &oneMinuteAgo},
+					},
+				},
+			},
+			taintsToRemove: []policyv1alpha1.Taint{
+				{Key: "key2", Effect: corev1.TaintEffectNoExecute},
+			},
+			expected: []corev1.Taint{
+				{Key: "key1", Effect: corev1.TaintEffectNoSchedule, TimeAdded: &oneMinuteAgo},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := removeTaintsFromCluster(tt.cluster, tt.taintsToRemove)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("test failed, expected: %v, actual: %v", tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/util/helper/taint.go
+++ b/pkg/util/helper/taint.go
@@ -17,6 +17,8 @@ limitations under the License.
 package helper
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -208,4 +210,34 @@ func NewUnreachableToleration(tolerationSeconds int64) *corev1.Toleration {
 		Effect:            corev1.TaintEffectNoExecute,
 		TolerationSeconds: &tolerationSeconds,
 	}
+}
+
+// GenerateTaintsMessage returns a string that describes the taints of a cluster.
+func GenerateTaintsMessage(taints []corev1.Taint) string {
+	if len(taints) == 0 {
+		return "cluster now does not have taints"
+	}
+
+	var msg string
+	for i, taint := range taints {
+		if i != 0 {
+			msg += ","
+		}
+		if taint.Value != "" {
+			msg += strings.Join([]string{`{`,
+				`Key:` + fmt.Sprintf("%v", taint.Key) + `,`,
+				`Value:` + fmt.Sprintf("%v", taint.Value) + `,`,
+				`Effect:` + fmt.Sprintf("%v", taint.Effect),
+				`}`,
+			}, "")
+		} else {
+			msg += strings.Join([]string{`{`,
+				`Key:` + fmt.Sprintf("%v", taint.Key) + `,`,
+				`Effect:` + fmt.Sprintf("%v", taint.Effect),
+				`}`,
+			}, "")
+		}
+	}
+
+	return fmt.Sprintf("cluster now has taints([%s])", msg)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Add the ClusterTaintPolicy controller to handle taints on the clusters

**Which issue(s) this PR fixes**:
Part of #6317

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Added the `clustertaintpolicy` controller to manage cluster taint based on ClusterTaintPolicy.
```

