### PR TITLE
Add the ClusterTaintPolicy validation

### DIFF
--- a/artifacts/deploy/karmada-webhook.yaml
+++ b/artifacts/deploy/karmada-webhook.yaml
@@ -42,6 +42,7 @@ spec:
             - --secure-port=8443
             - --cert-dir=/etc/karmada/pki/server
             - --feature-gates=AllAlpha=true,AllBeta=true
+            - --allow-no-execute-taint-policy=true
             - --v=4
           ports:
             - containerPort: 8443

--- a/artifacts/deploy/webhook-configuration.yaml
+++ b/artifacts/deploy/webhook-configuration.yaml
@@ -310,3 +310,17 @@ webhooks:
     sideEffects: NoneOnDryRun
     admissionReviewVersions: ["v1"]
     timeoutSeconds: 3
+  - name: clustertaintpolicy.karmada.io
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["policy.karmada.io"]
+        apiVersions: ["*"]
+        resources: ["clustertaintpolicies"]
+        scope: "Cluster"
+    clientConfig:
+      url: https://karmada-webhook.karmada-system.svc:443/validate-clustertaintpolicy
+      caBundle: {{caBundle}}
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: [ "v1" ]
+    timeoutSeconds: 3

--- a/cmd/webhook/app/options/options.go
+++ b/cmd/webhook/app/options/options.go
@@ -63,6 +63,10 @@ type Options struct {
 	// for serving health probes
 	// Defaults to ":8000".
 	HealthProbeBindAddress string
+	// AllowNoExecuteTaintPolicy indicates that allows configuring taints with NoExecute effect in ClusterTaintPolicy.
+	// Given the impact of NoExecute, applying such a taint to a cluster may trigger the eviction of workloads
+	// that do not explicitly tolerate it, potentially causing unexpected service disruptions.
+	AllowNoExecuteTaintPolicy bool
 
 	DefaultNotReadyTolerationSeconds    int64
 	DefaultUnreachableTolerationSeconds int64
@@ -92,6 +96,7 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 	flags.IntVar(&o.KubeAPIBurst, "kube-api-burst", 60, "Burst to use while talking with karmada-apiserver.")
 	flags.StringVar(&o.MetricsBindAddress, "metrics-bind-address", ":8080", "The TCP address that the controller should bind to for serving prometheus metrics(e.g. 127.0.0.1:8080, :8080). It can be set to \"0\" to disable the metrics serving.")
 	flags.StringVar(&o.HealthProbeBindAddress, "health-probe-bind-address", ":8000", "The TCP address that the controller should bind to for serving health probes(e.g. 127.0.0.1:8000, :8000)")
+	flags.BoolVar(&o.AllowNoExecuteTaintPolicy, "allow-no-execute-taint-policy", false, "Allows configuring taints with NoExecute effect in ClusterTaintPolicy. Given the impact of NoExecute, applying such a taint to a cluster may trigger the eviction of workloads that do not explicitly tolerate it, potentially causing unexpected service disruptions. \nThis parameter is designed to remain disabled by default and requires careful evaluation by administrators before being enabled.")
 
 	// webhook flags
 	flags.Int64Var(&o.DefaultNotReadyTolerationSeconds, "default-not-ready-toleration-seconds", 300, "Indicates the tolerationSeconds of the propagation policy toleration for notReady:NoExecute that is added by default to every propagation policy that does not already have such a toleration.")

--- a/pkg/webhook/clustertaintpolicy/validating.go
+++ b/pkg/webhook/clustertaintpolicy/validating.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustertaintpolicy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+)
+
+// ValidatingAdmission validates ClusterTaintPolicy object when creating/updating.
+type ValidatingAdmission struct {
+	Decoder                   admission.Decoder
+	AllowNoExecuteTaintPolicy bool
+}
+
+// Check if our ValidatingAdmission implements necessary interface
+var _ admission.Handler = &ValidatingAdmission{}
+
+// Handle implements admission.Handler interface.
+// It yields a response to an AdmissionRequest.
+func (v *ValidatingAdmission) Handle(_ context.Context, req admission.Request) admission.Response {
+	policy := &policyv1alpha1.ClusterTaintPolicy{}
+
+	err := v.Decoder.Decode(req, policy)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	klog.V(2).Infof("Validating ClusterTaintPolicy(%s) for request: %s", policy.Name, req.Operation)
+
+	errs := validatePolicySpec(policy.Spec, v.AllowNoExecuteTaintPolicy)
+	if len(errs) != 0 {
+		klog.Error(errs)
+		return admission.Denied(errs.ToAggregate().Error())
+	}
+
+	return admission.Allowed("")
+}
+
+func validatePolicySpec(spec policyv1alpha1.ClusterTaintPolicySpec, allowNoExecute bool) field.ErrorList {
+	var allErrs field.ErrorList
+	allErrs = append(allErrs, validatePolicyTaints(spec.Taints, field.NewPath("spec").Child("taints"), allowNoExecute)...)
+	return allErrs
+}
+
+func validatePolicyTaints(taints []policyv1alpha1.Taint, fldPath *field.Path, allowNoExecute bool) field.ErrorList {
+	var allErrs field.ErrorList
+	for i := 0; i < len(taints); i++ {
+		if !allowNoExecute && taints[i].Effect == corev1.TaintEffectNoExecute {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Index(i), "Configuring taint with NoExecute effect is not allowed, this capability must be explicitly enabled by administrators through command-line flags"))
+		}
+
+		for j := i + 1; j < len(taints); j++ {
+			if taints[i].Key == taints[j].Key && taints[i].Effect == taints[j].Effect {
+				allErrs = append(allErrs, field.Duplicate(fldPath.Index(i), fmt.Sprintf("Duplicate taint with the same key(%s) and effect(%s) is not allowed",
+					taints[i].Key, taints[i].Effect)))
+				break
+			}
+		}
+	}
+	return allErrs
+}

--- a/pkg/webhook/clustertaintpolicy/validating_test.go
+++ b/pkg/webhook/clustertaintpolicy/validating_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustertaintpolicy
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+)
+
+func TestValidatePolicyTaints(t *testing.T) {
+	tests := []struct {
+		name           string
+		taints         []policyv1alpha1.Taint
+		allowNoExecute bool
+		expected       field.ErrorList
+	}{
+		{
+			name: "Non-repeating key-value pairs",
+			taints: []policyv1alpha1.Taint{
+				{Key: "key1", Effect: "NoSchedule"},
+				{Key: "key2", Effect: "PreferNoSchedule"},
+			},
+			allowNoExecute: true,
+			expected:       field.ErrorList{},
+		},
+		{
+			name: "There are duplicate key-value pairs",
+			taints: []policyv1alpha1.Taint{
+				{Key: "key1", Effect: "NoSchedule"},
+				{Key: "key1", Effect: "NoSchedule", Value: "value1"},
+			},
+			allowNoExecute: true,
+			expected: field.ErrorList{
+				field.Duplicate(field.NewPath("spec").Child("taints").Index(0), "Duplicate taint with the same key(key1) and effect(NoSchedule) is not allowed"),
+			},
+		},
+		{
+			name: "Some duplicate key-value pairs",
+			taints: []policyv1alpha1.Taint{
+				{Key: "key1", Effect: "NoSchedule"},
+				{Key: "key2", Effect: "PreferNoSchedule"},
+				{Key: "key1", Effect: "NoSchedule"},
+			},
+			allowNoExecute: true,
+			expected: field.ErrorList{
+				field.Duplicate(field.NewPath("spec").Child("taints").Index(0), "Duplicate taint with the same key(key1) and effect(NoSchedule) is not allowed"),
+			},
+		},
+		{
+			name: "Multi duplicate key-value pairs",
+			taints: []policyv1alpha1.Taint{
+				{Key: "key1", Effect: "NoSchedule"},
+				{Key: "key2", Effect: "SelectiveNoSchedule", Value: "value1"},
+				{Key: "key1", Effect: "NoSchedule"},
+				{Key: "key3", Effect: "NoExecute"},
+				{Key: "key2", Effect: "SelectiveNoSchedule"},
+			},
+			allowNoExecute: true,
+			expected: field.ErrorList{
+				field.Duplicate(field.NewPath("spec").Child("taints").Index(0), "Duplicate taint with the same key(key1) and effect(NoSchedule) is not allowed"),
+				field.Duplicate(field.NewPath("spec").Child("taints").Index(1), "Duplicate taint with the same key(key2) and effect(SelectiveNoSchedule) is not allowed"),
+			},
+		},
+		{
+			name: "NoExecute effect is not allowed",
+			taints: []policyv1alpha1.Taint{
+				{Key: "key1", Effect: "NoExecute"},
+			},
+			allowNoExecute: false,
+			expected: field.ErrorList{
+				field.Forbidden(field.NewPath("spec").Child("taints").Index(0), "Configuring taint with NoExecute effect is not allowed, this capability must be explicitly enabled by administrators through command-line flags"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := validatePolicyTaints(tt.taints, field.NewPath("spec").Child("taints"), tt.allowNoExecute)
+			if len(actual) != len(tt.expected) {
+				t.Errorf("test failed: %s, expected %v, actual %v", tt.name, tt.expected, actual)
+				return
+			}
+			for i := range actual {
+				if actual[i].Error() != tt.expected[i].Error() {
+					t.Errorf("test failed: %s, expected %v, actual %v", tt.name, tt.expected[i], actual[i])
+				}
+			}
+		})
+	}
+}
+
+func TestHandle(t *testing.T) {
+	tests := []struct {
+		name         string
+		decodeErr    error
+		decodeObj    runtime.Object
+		expectedCode int32
+		expectedMsg  string
+	}{
+		{
+			name:         "Decoding failed",
+			decodeErr:    errors.New("decode error"),
+			expectedCode: http.StatusBadRequest,
+			expectedMsg:  "decode error",
+		},
+		{
+			name: "Validation success",
+			decodeObj: &policyv1alpha1.ClusterTaintPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "policy1",
+				},
+				Spec: policyv1alpha1.ClusterTaintPolicySpec{
+					Taints: []policyv1alpha1.Taint{
+						{Key: "key1", Effect: "NoSchedule"},
+						{Key: "key2", Effect: "PreferNoSchedule"},
+					},
+				},
+			},
+			expectedCode: http.StatusOK,
+			expectedMsg:  "",
+		},
+		{
+			name: "Validation failed",
+			decodeObj: &policyv1alpha1.ClusterTaintPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "policy1",
+				},
+				Spec: policyv1alpha1.ClusterTaintPolicySpec{
+					Taints: []policyv1alpha1.Taint{
+						{Key: "key1", Effect: "NoSchedule"},
+						{Key: "key2", Effect: "PreferNoSchedule"},
+						{Key: "key1", Effect: "NoSchedule"},
+					},
+				},
+			},
+			expectedCode: http.StatusForbidden,
+			expectedMsg:  "spec.taints[0]: Duplicate value: \"Duplicate taint with the same key(key1) and effect(NoSchedule) is not allowed\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &ValidatingAdmission{
+				Decoder: &fakeValidationDecoder{err: tt.decodeErr, obj: tt.decodeObj},
+			}
+			resp := v.Handle(context.TODO(), admission.Request{})
+
+			assert.Equal(t, tt.expectedCode, resp.Result.Code)
+			assert.Contains(t, resp.Result.Message, tt.expectedMsg)
+		})
+	}
+}
+
+type fakeValidationDecoder struct {
+	err error
+	obj runtime.Object
+}
+
+// Decode mocks the Decode method of admission.Decoder.
+func (f *fakeValidationDecoder) Decode(_ admission.Request, obj runtime.Object) error {
+	if f.err != nil {
+		return f.err
+	}
+	if f.obj != nil {
+		reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(f.obj).Elem())
+	}
+	return nil
+}
+
+// DecodeRaw mocks the DecodeRaw method of admission.Decoder.
+func (f *fakeValidationDecoder) DecodeRaw(_ runtime.RawExtension, obj runtime.Object) error {
+	if f.err != nil {
+		return f.err
+	}
+	if f.obj != nil {
+		reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(f.obj).Elem())
+	}
+	return nil
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Add the ClusterTaintPolicy validation

**Which issue(s) this PR fixes**:
Part of #6317 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-webhook`: Added the ClusterTaintPolicy validation webhook, and added `--allow-no-execute-taint-policy` flag.
```

