### PR TITLE
Avoid reconcile conflict in cluster controller

### DIFF
--- a/pkg/controllers/cluster/cluster_controller_test.go
+++ b/pkg/controllers/cluster/cluster_controller_test.go
@@ -249,7 +249,7 @@ func TestController_Reconcile(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "remove cluster failed",
+			name: "remove cluster successfully",
 			cluster: &clusterv1alpha1.Cluster{
 				ObjectMeta: controllerruntime.ObjectMeta{
 					Name:       "test-cluster",
@@ -281,7 +281,7 @@ func TestController_Reconcile(t *testing.T) {
 			},
 			del:     true,
 			want:    controllerruntime.Result{},
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
The cluster controller updates the Cluster object twice during a single reconciliation.
- taint cluster by condition
- add/remove finalizer

The second update will fail due to a conflict.
```bash
Controller.Reconcile() error = Operation cannot be fulfilled on clusters.cluster.karmada.io "test-cluster": object was modified
```

Given that additional operations such as creating or deleting ExecutionSpace take place between the two updates, and considering the significant impact of taints on scheduling and related features, timely updates are crucial. As a result, this fix chooses to replace UPDATE operations with PATCH to prevent conflicts, instead of merging the two updates into a single operation at the end of the reconcile loop.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

