### PR TITLE
Automated cherry pick of #6369: fix the issue where bindings that fails

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -796,7 +796,7 @@ func (s *Scheduler) handleErr(err error, bindingInfo *internalqueue.QueuedBindin
 	}
 
 	var unschedulableErr *framework.UnschedulableError
-	if !errors.As(err, &unschedulableErr) {
+	if errors.As(err, &unschedulableErr) {
 		s.priorityQueue.PushUnschedulableIfNotPresent(bindingInfo)
 	} else {
 		s.priorityQueue.PushBackoffIfNotPresent(bindingInfo)


### PR DESCRIPTION
Cherry pick of #6369 on release-1.13.
#6369: fix the issue where bindings that fails
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-scheduler`: Fixed the issue where bindings that fail occasionally will be treated as unschedulableBindings when feature gate PriorityBasedScheduling is enabled.
```