### PR TITLE
Create RB ValidatingWebhook for FederatedResourceQuota check

### DIFF
--- a/artifacts/deploy/karmada-webhook.yaml
+++ b/artifacts/deploy/karmada-webhook.yaml
@@ -41,6 +41,7 @@ spec:
             - --default-unreachable-toleration-seconds=30
             - --secure-port=8443
             - --cert-dir=/etc/karmada/pki/server
+            - --feature-gates=AllAlpha=true,AllBeta=true
             - --v=4
           ports:
             - containerPort: 8443

--- a/artifacts/deploy/webhook-configuration.yaml
+++ b/artifacts/deploy/webhook-configuration.yaml
@@ -296,3 +296,17 @@ webhooks:
     sideEffects: None
     admissionReviewVersions: [ "v1" ]
     timeoutSeconds: 3
+  - name: resourcebinding.karmada.io
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["work.karmada.io"]
+        apiVersions: ["*"]
+        resources: ["resourcebindings"]
+        scope: "Namespaced"
+    clientConfig:
+      url: https://karmada-webhook.karmada-system.svc:443/validate-resourcebinding
+      caBundle: {{caBundle}}
+    failurePolicy: Fail
+    sideEffects: NoneOnDryRun
+    admissionReviewVersions: ["v1"]
+    timeoutSeconds: 3

--- a/charts/karmada/templates/_karmada_webhook_configuration.tpl
+++ b/charts/karmada/templates/_karmada_webhook_configuration.tpl
@@ -274,4 +274,18 @@ webhooks:
     sideEffects: None
     admissionReviewVersions: [ "v1" ]
     timeoutSeconds: 3
+  - name: resourcebinding.karmada.io
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["work.karmada.io"]
+        apiVersions: ["*"]
+        resources: ["resourcebindings"]
+        scope: "Namespaced"
+    clientConfig:
+      url: https://{{ $name }}-webhook.{{ $namespace }}.svc:443/validate-resourcebinding
+      {{- include "karmada.webhook.caBundle" . | nindent 6 }}
+    failurePolicy: Fail
+    sideEffects: NoneOnDryRun
+    admissionReviewVersions: ["v1"]
+    timeoutSeconds: 3
 {{- end -}}

--- a/cmd/webhook/app/options/options.go
+++ b/cmd/webhook/app/options/options.go
@@ -19,6 +19,7 @@ package options
 import (
 	"github.com/spf13/pflag"
 
+	"github.com/karmada-io/karmada/pkg/features"
 	"github.com/karmada-io/karmada/pkg/sharedcli/profileflag"
 )
 
@@ -96,5 +97,6 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 	flags.Int64Var(&o.DefaultNotReadyTolerationSeconds, "default-not-ready-toleration-seconds", 300, "Indicates the tolerationSeconds of the propagation policy toleration for notReady:NoExecute that is added by default to every propagation policy that does not already have such a toleration.")
 	flags.Int64Var(&o.DefaultUnreachableTolerationSeconds, "default-unreachable-toleration-seconds", 300, "Indicates the tolerationSeconds of the propagation policy toleration for unreachable:NoExecute that is added by default to every propagation policy that does not already have such a toleration.")
 
+	features.FeatureGate.AddFlag(flags)
 	o.ProfileOpts.AddFlags(flags)
 }

--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -183,6 +183,7 @@ func Run(ctx context.Context, opts *options.Options) error {
 	hookServer.Register("/mutate-federatedhpa", &webhook.Admission{Handler: &federatedhpa.MutatingAdmission{Decoder: decoder}})
 	hookServer.Register("/validate-resourcedeletionprotection", &webhook.Admission{Handler: &resourcedeletionprotection.ValidatingAdmission{Decoder: decoder}})
 	hookServer.Register("/mutate-resourcebinding", &webhook.Admission{Handler: &resourcebinding.MutatingAdmission{Decoder: decoder}})
+	hookServer.Register("/validate-resourcebinding", &webhook.Admission{Handler: &resourcebinding.ValidatingAdmission{Client: hookManager.GetClient(), Decoder: decoder}})
 	hookServer.Register("/mutate-clusterresourcebinding", &webhook.Admission{Handler: &clusterresourcebinding.MutatingAdmission{Decoder: decoder}})
 	hookServer.WebhookMux().Handle("/readyz/", http.StripPrefix("/readyz/", &healthz.Handler{}))
 

--- a/operator/pkg/karmadaresource/webhookconfiguration/manifests.go
+++ b/operator/pkg/karmadaresource/webhookconfiguration/manifests.go
@@ -320,5 +320,19 @@ webhooks:
     sideEffects: None
     admissionReviewVersions: [ "v1" ]
     timeoutSeconds: 3
+  - name: resourcebinding.karmada.io
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["work.karmada.io"]
+        apiVersions: ["*"]
+        resources: ["resourcebindings"]
+        scope: "Namespaced"
+    clientConfig:
+      url: https://{{ .Service }}.{{ .Namespace }}.svc:443/validate-resourcebinding
+      caBundle: {{ .CaBundle }}
+    failurePolicy: Fail
+    sideEffects: NoneOnDryRun
+    admissionReviewVersions: ["v1"]
+    timeoutSeconds: 3
 `
 )

--- a/pkg/karmadactl/cmdinit/karmada/webhook_configuration.go
+++ b/pkg/karmadactl/cmdinit/karmada/webhook_configuration.go
@@ -331,6 +331,20 @@ webhooks:
     sideEffects: None
     admissionReviewVersions: [ "v1" ]
     timeoutSeconds: 3
+  - name: resourcebinding.karmada.io
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["work.karmada.io"]
+        apiVersions: ["*"]
+        resources: ["resourcebindings"]
+        scope: "Namespaced"
+    clientConfig:
+      url: https://karmada-webhook.%[1]s.svc:443/validate-resourcebinding
+      caBundle: %[2]s
+    failurePolicy: Fail
+    sideEffects: NoneOnDryRun
+    admissionReviewVersions: ["v1"]
+    timeoutSeconds: 3
 `, systemNamespace, caBundle)
 }
 

--- a/pkg/webhook/resourcebinding/validating.go
+++ b/pkg/webhook/resourcebinding/validating.go
@@ -1,0 +1,485 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcebinding
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/features"
+	"github.com/karmada-io/karmada/pkg/util"
+)
+
+// ValidatingAdmission validates ResourceBinding object when creating/updating.
+type ValidatingAdmission struct {
+	client.Client
+	Decoder admission.Decoder
+}
+
+// Check if our ValidatingAdmission implements necessary interface
+var _ admission.Handler = &ValidatingAdmission{}
+
+type frqProcessOutcome struct {
+	validationMessages []string
+	updatedFRQCount    int
+	noFRQsFound        bool                // True if this attempt found no FRQs
+	earlyExitResponse  *admission.Response // Response if this attempt decided to exit early (denial, permanent error)
+	ProcessError       error               // Error for RetryOnConflict (e.g., conflict error or nil for success/final decision)
+}
+
+// Handle implements admission.Handler interface.
+func (v *ValidatingAdmission) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if !features.FeatureGate.Enabled(features.FederatedQuotaEnforcement) {
+		klog.V(5).Infof("FederatedQuotaEnforcement feature gate is disabled, skipping validation for ResourceBinding %s/%s", req.Namespace, req.Name)
+		return admission.Allowed("")
+	}
+
+	isDryRun := req.DryRun != nil && *req.DryRun
+
+	rb, oldRB, extractResp := v.decodeAndValidateRBs(req)
+	if extractResp != nil {
+		return *extractResp
+	}
+
+	newRbTotalUsage, oldRbTotalUsage, respCalc := v.calculateRBUsages(rb, oldRB)
+	if respCalc != nil {
+		return *respCalc
+	}
+
+	totalRbDelta := calculateDelta(newRbTotalUsage, oldRbTotalUsage)
+	klog.V(4).Infof("Calculated total RB delta for %s/%s: %v", rb.Namespace, rb.Name, totalRbDelta)
+
+	if len(totalRbDelta) == 0 {
+		klog.V(2).Infof("No effective resource quantity delta for ResourceBinding %s/%s. Skipping quota validation.", rb.Namespace, rb.Name)
+		return admission.Allowed("No effective resource quantity delta for ResourceBinding, skipping quota validation.")
+	}
+
+	frqOutcome := v.processFRQsWithRetries(ctx, rb, totalRbDelta, isDryRun)
+
+	return v.finalizeResponse(rb, frqOutcome)
+}
+
+func (v *ValidatingAdmission) processFRQsWithRetries(ctx context.Context, rb *workv1alpha2.ResourceBinding, totalRbDelta corev1.ResourceList, isDryRun bool) frqProcessOutcome {
+	var overallOutcome frqProcessOutcome
+
+	retrySystemError := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		attemptResult := v.executeFRQProcessingAttempt(ctx, rb, totalRbDelta, isDryRun)
+
+		if attemptResult.ProcessError == nil {
+			overallOutcome = attemptResult
+		}
+		return attemptResult.ProcessError
+	})
+
+	overallOutcome.ProcessError = retrySystemError
+	return overallOutcome
+}
+
+func (v *ValidatingAdmission) executeFRQProcessingAttempt(ctx context.Context, rb *workv1alpha2.ResourceBinding, totalRbDelta corev1.ResourceList, isDryRun bool) frqProcessOutcome {
+	outcome := frqProcessOutcome{}
+	var currentFrqsToUpdateStatus []*policyv1alpha1.FederatedResourceQuota
+	var currentValidationMessages []string
+
+	frqList, listResp := v.listFRQs(ctx, rb.Namespace)
+	if listResp != nil {
+		outcome.earlyExitResponse = listResp
+		return outcome // attemptError is nil, signaling non-retryable handled error
+	}
+
+	if len(frqList.Items) == 0 {
+		outcome.noFRQsFound = true
+		// validationMessages and updatedFRQCount will remain empty/zero.
+		return outcome // attemptError is nil, successful attempt (no FRQs to process)
+	}
+
+	for _, frqItem := range frqList.Items {
+		newStatus, msg, denialResp := v.processSingleFRQ(frqItem, rb.Namespace, rb.Name, totalRbDelta)
+		if denialResp != nil {
+			outcome.earlyExitResponse = denialResp
+			return outcome // attemptError is nil, request denied
+		}
+		if newStatus != nil {
+			newFRQItem := frqItem.DeepCopy()
+			newFRQItem.Status.OverallUsed = newStatus
+			currentFrqsToUpdateStatus = append(currentFrqsToUpdateStatus, newFRQItem)
+		}
+		if msg != "" {
+			currentValidationMessages = append(currentValidationMessages, msg)
+		}
+	}
+
+	updateErr := v.updateFRQStatusesWithRetrySignal(ctx, currentFrqsToUpdateStatus, isDryRun, rb.Namespace, rb.Name)
+	if updateErr != nil {
+		if apierrors.IsConflict(updateErr) {
+			klog.V(4).Infof("Conflict detected while updating FRQ status for RB %s/%s, will retry: %v", rb.Namespace, rb.Name, updateErr)
+			outcome.ProcessError = updateErr // Signal RetryOnConflict to retry
+			return outcome
+		}
+		errMsg := fmt.Sprintf("permanent error updating FRQ statuses for RB %s/%s: %v", rb.Namespace, rb.Name, updateErr)
+		klog.Error(errMsg)
+		resp := admission.Errored(http.StatusInternalServerError, errors.New(errMsg))
+		outcome.earlyExitResponse = &resp
+		return outcome // attemptError is nil, non-retryable handled error
+	}
+
+	outcome.validationMessages = currentValidationMessages
+	outcome.updatedFRQCount = len(currentFrqsToUpdateStatus)
+	return outcome // attemptError is nil, successful attempt
+}
+
+func (v *ValidatingAdmission) finalizeResponse(rb *workv1alpha2.ResourceBinding, outcome frqProcessOutcome) admission.Response {
+	if outcome.ProcessError != nil {
+		errMsg := fmt.Sprintf("failed to apply FederatedResourceQuota updates after multiple retries for RB %s/%s: %v", rb.Namespace, rb.Name, outcome.ProcessError)
+		klog.Error(errMsg)
+		return admission.Errored(http.StatusInternalServerError, errors.New(errMsg))
+	}
+
+	if outcome.earlyExitResponse != nil {
+		return *outcome.earlyExitResponse
+	}
+
+	if outcome.noFRQsFound {
+		klog.V(2).Infof("No FederatedResourceQuotas found in namespace %s for ResourceBinding %s. Allowing operation.", rb.Namespace, rb.Name)
+		return admission.Allowed("No FederatedResourceQuotas found in the namespace, skipping quota check.")
+	}
+
+	finalMessage := fmt.Sprintf("All relevant FederatedResourceQuota checks passed for ResourceBinding %s/%s.", rb.Namespace, rb.Name)
+	if len(outcome.validationMessages) > 0 {
+		finalMessage = fmt.Sprintf("%s %s", finalMessage, strings.Join(outcome.validationMessages, " "))
+	}
+	if outcome.updatedFRQCount > 0 {
+		finalMessage = fmt.Sprintf("%s %d FRQ(s) updated.", finalMessage, outcome.updatedFRQCount)
+	} else {
+		finalMessage = fmt.Sprintf("%s No FRQs required update.", finalMessage)
+	}
+	klog.V(2).Infof("Admission allowed for ResourceBinding %s/%s: %s", rb.Namespace, rb.Name, finalMessage)
+	return admission.Allowed(finalMessage)
+}
+
+// updateFRQStatusesWithRetrySignal attempts to update FRQ statuses.
+// It returns an error if any update fails. This error can be a conflict error (for retrying by RetryOnConflict)
+// or a different error (which will be treated as permanent by the caller within the retry func).
+func (v *ValidatingAdmission) updateFRQStatusesWithRetrySignal(ctx context.Context, frqsToUpdateStatus []*policyv1alpha1.FederatedResourceQuota, isDryRun bool, rbNamespace, rbName string) error {
+	if len(frqsToUpdateStatus) == 0 {
+		klog.V(4).Infof("No FederatedResourceQuotas required an update in this processing attempt for RB %s/%s.", rbNamespace, rbName)
+		return nil
+	}
+
+	klog.V(3).Infof("Attempting to update %d FederatedResourceQuotas for RB %s/%s (dryRun: %v).", len(frqsToUpdateStatus), rbNamespace, rbName, isDryRun)
+	updateOptions := []client.SubResourceUpdateOption{}
+	if isDryRun {
+		updateOptions = append(updateOptions, client.DryRunAll)
+	}
+
+	for _, frqItem := range frqsToUpdateStatus {
+		klog.V(4).Infof("Updating status of FRQ %s/%s with OverallUsed: %v for RB %s/%s",
+			frqItem.Namespace, frqItem.Name, frqItem.Status.OverallUsed, rbNamespace, rbName)
+
+		if errUpdate := v.Client.Status().Update(ctx, frqItem, updateOptions...); errUpdate != nil {
+			klog.Warningf("Failed to UPDATE status of FederatedResourceQuota %s/%s for RB %s/%s: %v. Returning error for retry evaluation.",
+				frqItem.Namespace, frqItem.Name, rbNamespace, rbName, errUpdate)
+			return errUpdate // Return the original error from Update (could be conflict)
+		}
+
+		logMsg := fmt.Sprintf("Successfully updated status of FRQ %s/%s for RB %s/%s.", frqItem.Namespace, frqItem.Name, rbNamespace, rbName)
+		if isDryRun {
+			logMsg = fmt.Sprintf("Dry run: Successfully simulated status update of FRQ %s/%s for RB %s/%s.", frqItem.Namespace, frqItem.Name, rbNamespace, rbName)
+		}
+		klog.V(2).Info(logMsg)
+	}
+	return nil
+}
+
+// decodeAndValidateRBs decodes current and old (for updates) ResourceBindings,
+// performs essential preliminary checks, and checks for relevant changes in update operations.
+// Returns the RBs or an admission response for early exit.
+func (v *ValidatingAdmission) decodeAndValidateRBs(req admission.Request) (
+	currentRB *workv1alpha2.ResourceBinding,
+	oldRB *workv1alpha2.ResourceBinding, // Will be nil if not an update or if not applicable
+	earlyExitResp *admission.Response,
+) {
+	decodedRB := &workv1alpha2.ResourceBinding{}
+	if err := v.Decoder.Decode(req, decodedRB); err != nil {
+		klog.Errorf("Failed to decode ResourceBinding %s/%s: %v", req.Namespace, req.Name, err)
+		resp := admission.Errored(http.StatusBadRequest, err)
+		return nil, nil, &resp
+	}
+	klog.V(2).Infof("Processing ResourceBinding(%s/%s) for request: %s (%s)", decodedRB.Namespace, decodedRB.Name, req.Operation, req.UID)
+
+	if req.Operation == admissionv1.Create && len(decodedRB.Spec.Clusters) == 0 {
+		klog.V(4).Infof("ResourceBinding %s/%s is being created but not yet scheduled, skipping quota validation.", decodedRB.Namespace, decodedRB.Name)
+		resp := admission.Allowed("ResourceBinding not yet scheduled for Create operation.")
+		return decodedRB, nil, &resp
+	}
+
+	var decodedOldRB *workv1alpha2.ResourceBinding
+	if req.Operation == admissionv1.Update {
+		tempOldRB := &workv1alpha2.ResourceBinding{}
+		if err := v.Decoder.DecodeRaw(req.OldObject, tempOldRB); err != nil {
+			klog.Errorf("Failed to decode old ResourceBinding %s/%s: %v", req.Namespace, req.Name, err)
+			resp := admission.Errored(http.StatusBadRequest, err)
+			return decodedRB, nil, &resp
+		}
+		decodedOldRB = tempOldRB
+
+		if !isQuotaRelevantFieldChanged(decodedOldRB, decodedRB) {
+			klog.V(4).Infof("ResourceBinding %s/%s updated, but no quota relevant fields changed, skipping quota validation.", decodedRB.Namespace, decodedRB.Name)
+			resp := admission.Allowed("No quota relevant fields changed.")
+			return decodedRB, decodedOldRB, &resp
+		}
+	}
+	return decodedRB, decodedOldRB, nil
+}
+
+func (v *ValidatingAdmission) calculateRBUsages(rb, oldRB *workv1alpha2.ResourceBinding) (corev1.ResourceList, corev1.ResourceList, *admission.Response) {
+	newRbTotalUsage, err := calculateResourceUsage(rb)
+	if err != nil {
+		klog.Errorf("Error calculating resource usage for new ResourceBinding %s/%s: %v", rb.Namespace, rb.Name, err)
+		resp := admission.Errored(http.StatusInternalServerError, err)
+		return nil, nil, &resp
+	}
+	klog.V(4).Infof("Calculated total usage for incoming RB %s/%s: %v", rb.Namespace, rb.Name, newRbTotalUsage)
+
+	oldRbTotalUsage := corev1.ResourceList{}
+	if oldRB != nil {
+		oldRbTotalUsage, err = calculateResourceUsage(oldRB)
+		if err != nil {
+			klog.Errorf("Error calculating resource usage for old ResourceBinding %s/%s: %v", oldRB.Namespace, oldRB.Name, err)
+			resp := admission.Errored(http.StatusInternalServerError, err)
+			return nil, nil, &resp
+		}
+		klog.V(4).Infof("Calculated total usage for old RB %s/%s: %v", oldRB.Namespace, oldRB.Name, oldRbTotalUsage)
+	}
+	return newRbTotalUsage, oldRbTotalUsage, nil
+}
+
+func (v *ValidatingAdmission) listFRQs(ctx context.Context, namespace string) (*policyv1alpha1.FederatedResourceQuotaList, *admission.Response) {
+	frqList := &policyv1alpha1.FederatedResourceQuotaList{}
+	if err := v.Client.List(ctx, frqList, client.InNamespace(namespace)); err != nil {
+		klog.Errorf("Failed to list FederatedResourceQuotas in namespace %s: %v", namespace, err)
+		resp := admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to list FederatedResourceQuotas: %w", err))
+		return nil, &resp
+	}
+	klog.V(2).Infof("Found %d FederatedResourceQuotas in namespace %s to evaluate.", len(frqList.Items), namespace)
+	return frqList, nil
+}
+
+func (v *ValidatingAdmission) processSingleFRQ(frqItem policyv1alpha1.FederatedResourceQuota, rbNamespace, rbName string, totalRbDelta corev1.ResourceList) (newStatusToSet corev1.ResourceList, validationMsg string, denialResp *admission.Response) {
+	klog.V(4).Infof("Evaluating FRQ %s/%s for RB %s/%s", frqItem.Namespace, frqItem.Name, rbNamespace, rbName)
+	if frqItem.Spec.Overall == nil {
+		klog.V(4).Infof("FRQ %s/%s has no spec.overall defined, skipping its evaluation.", frqItem.Namespace, frqItem.Name)
+		return nil, "", nil
+	}
+
+	deltaForThisFRQ := filterResourceListByKeys(totalRbDelta, frqItem.Spec.Overall)
+	klog.V(4).Infof("Filtered delta for FRQ %s/%s (from total RB delta %v): %v",
+		frqItem.Namespace, frqItem.Name, totalRbDelta, deltaForThisFRQ)
+
+	if isResourceListEffectivelyZero(deltaForThisFRQ, frqItem.Spec.Overall) {
+		klog.V(4).Infof("No effective resource delta for FRQ %s/%s concerning RB %s/%s. Skipping update for this FRQ.", frqItem.Namespace, frqItem.Name, rbNamespace, rbName)
+		return nil, "", nil
+	}
+
+	potentialNewOverallUsedForThisFRQ := addResourceLists(frqItem.Status.OverallUsed, deltaForThisFRQ)
+
+	if !isAllowed(potentialNewOverallUsedForThisFRQ, frqItem.Spec.Overall) {
+		errMsg := fmt.Sprintf("Quota exceeded for FederatedResourceQuota %s/%s. ResourceBinding %s/%s will be denied.",
+			frqItem.Namespace, frqItem.Name, rbNamespace, rbName)
+		klog.Warning(errMsg)
+		resp := admission.Denied(errMsg)
+		return nil, "", &resp
+	}
+
+	msg := fmt.Sprintf("Quota check passed for FRQ %s/%s.", frqItem.Namespace, frqItem.Name)
+	klog.V(3).Infof("FRQ %s/%s will be updated. New OverallUsed: %v", frqItem.Namespace, frqItem.Name, potentialNewOverallUsedForThisFRQ)
+	return potentialNewOverallUsedForThisFRQ, msg, nil
+}
+
+func calculateResourceUsage(rb *workv1alpha2.ResourceBinding) (corev1.ResourceList, error) {
+	if rb == nil || rb.Spec.ReplicaRequirements == nil || len(rb.Spec.ReplicaRequirements.ResourceRequest) == 0 || len(rb.Spec.Clusters) == 0 {
+		return corev1.ResourceList{}, nil
+	}
+
+	totalReplicas := int32(0)
+	for _, cluster := range rb.Spec.Clusters {
+		totalReplicas += cluster.Replicas
+	}
+
+	if totalReplicas == 0 {
+		return corev1.ResourceList{}, nil
+	}
+	if totalReplicas < 0 {
+		return nil, fmt.Errorf("total replicas in clusters cannot be negative for RB %s/%s: %d", rb.Namespace, rb.Name, totalReplicas)
+	}
+
+	usage := corev1.ResourceList{}
+	replicaCount := int64(totalReplicas)
+
+	for resourceName, quantityPerReplica := range rb.Spec.ReplicaRequirements.ResourceRequest {
+		if quantityPerReplica.IsZero() {
+			continue
+		}
+		if quantityPerReplica.Sign() < 0 {
+			return nil, fmt.Errorf("resource request for %s in RB %s/%s has a negative value: %s", resourceName, rb.Namespace, rb.Name, quantityPerReplica.String())
+		}
+
+		totalQuantity := quantityPerReplica.DeepCopy()
+		totalQuantity.Mul(replicaCount)
+
+		usage[resourceName] = totalQuantity
+	}
+	klog.V(4).Infof("Calculated resource usage for ResourceBinding %s/%s: %v", rb.Namespace, rb.Name, usage)
+	return usage, nil
+}
+
+func isQuotaRelevantFieldChanged(oldRB, newRB *workv1alpha2.ResourceBinding) bool {
+	if oldRB == nil || newRB == nil {
+		return true
+	}
+	oldReq := corev1.ResourceList{}
+	if oldRB.Spec.ReplicaRequirements != nil {
+		oldReq = oldRB.Spec.ReplicaRequirements.ResourceRequest
+	}
+	newReq := corev1.ResourceList{}
+	if newRB.Spec.ReplicaRequirements != nil {
+		newReq = newRB.Spec.ReplicaRequirements.ResourceRequest
+	}
+	if !areResourceListsEqual(oldReq, newReq) {
+		return true
+	}
+	oldScheduledReplicas := int32(0)
+	for _, c := range oldRB.Spec.Clusters {
+		oldScheduledReplicas += c.Replicas
+	}
+	newScheduledReplicas := int32(0)
+	for _, c := range newRB.Spec.Clusters {
+		newScheduledReplicas += c.Replicas
+	}
+	return oldScheduledReplicas != newScheduledReplicas
+}
+
+func areResourceListsEqual(a, b corev1.ResourceList) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key, valA := range a {
+		valB, ok := b[key]
+		if !ok {
+			return false
+		}
+		if valA.Cmp(valB) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// calculateDelta computes newUsage - oldUsage.
+// The resulting delta list will only contain entries with non-zero quantities.
+func calculateDelta(newUsage, oldUsage corev1.ResourceList) corev1.ResourceList {
+	delta := corev1.ResourceList{}
+	allResourceNames := make(map[corev1.ResourceName]struct{})
+	for name := range newUsage {
+		allResourceNames[name] = struct{}{}
+	}
+	for name := range oldUsage {
+		allResourceNames[name] = struct{}{}
+	}
+
+	for name := range allResourceNames {
+		newQ := newUsage[name] // .Quantity is a value type, zero if not present
+		oldQ := oldUsage[name] // .Quantity is a value type, zero if not present
+
+		deltaQ := newQ.DeepCopy()
+		deltaQ.Sub(oldQ)
+
+		if !deltaQ.IsZero() {
+			delta[name] = deltaQ
+		}
+	}
+	return delta
+}
+
+func addResourceLists(list1, list2 corev1.ResourceList) corev1.ResourceList {
+	resUtil := util.NewResource(list1)
+	resUtil.Add(list2)
+	result := resUtil.ResourceList()
+	if result == nil {
+		return corev1.ResourceList{}
+	}
+	return result
+}
+
+func isAllowed(requested, allowedLimits corev1.ResourceList) bool {
+	if allowedLimits == nil {
+		return true
+	}
+	for name, reqQty := range requested {
+		if reqQty.IsZero() {
+			continue
+		}
+		limitQty, ok := allowedLimits[name]
+		if !ok {
+			klog.V(5).Infof("Resource %s (requested sum: %s) is not defined in quota limits %v; considered allowed by this FRQ.", name, reqQty.String(), allowedLimits)
+			continue
+		}
+		if reqQty.Cmp(limitQty) > 0 {
+			klog.Warningf("Quota exceeded for resource %s: requested sum %s, limit %s", name, reqQty.String(), limitQty.String())
+			return false
+		}
+	}
+	return true
+}
+
+func filterResourceListByKeys(original corev1.ResourceList, filterKeySource corev1.ResourceList) corev1.ResourceList {
+	if original == nil || filterKeySource == nil {
+		return corev1.ResourceList{}
+	}
+	filtered := corev1.ResourceList{}
+	for keyInFilter := range filterKeySource {
+		if valInOriginal, ok := original[keyInFilter]; ok {
+			filtered[keyInFilter] = valInOriginal.DeepCopy()
+		}
+	}
+	return filtered
+}
+
+func isResourceListEffectivelyZero(listToCheck corev1.ResourceList, filterKeySource corev1.ResourceList) bool {
+	if filterKeySource == nil {
+		return true
+	}
+	for keyTrackedByFRQ := range filterKeySource {
+		quantityInList, ok := listToCheck[keyTrackedByFRQ]
+		if ok && !quantityInList.IsZero() {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/webhook/resourcebinding/validating_test.go
+++ b/pkg/webhook/resourcebinding/validating_test.go
@@ -1,0 +1,505 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcebinding
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/features"
+)
+
+// testScheme is the scheme used for fake client in tests.
+var testScheme = runtime.NewScheme()
+
+func init() {
+	_ = kubescheme.AddToScheme(testScheme)
+	_ = workv1alpha2.Install(testScheme)
+	_ = policyv1alpha1.Install(testScheme)
+}
+
+// fakeDecoder mocks admission.Decoder for testing.
+type fakeDecoder struct {
+	err           error
+	decodeObj     runtime.Object // For Decode method (Request.Object -> typed object)
+	rawDecodedObj runtime.Object // For DecodeRaw method (Request.OldObject -> typed object)
+}
+
+func (f *fakeDecoder) Decode(_ admission.Request, obj runtime.Object) error {
+	if f.err != nil {
+		return f.err
+	}
+	if f.decodeObj != nil {
+		reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(f.decodeObj).Elem())
+	}
+	return nil
+}
+
+func (f *fakeDecoder) DecodeRaw(_ runtime.RawExtension, obj runtime.Object) error {
+	if f.err != nil {
+		return f.err
+	}
+	if f.rawDecodedObj != nil {
+		reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(f.rawDecodedObj).Elem())
+	}
+	return nil
+}
+
+func marshalToRawExtension(t *testing.T, obj runtime.Object) runtime.RawExtension {
+	t.Helper()
+	raw, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatalf("Failed to marshal object %T: %v", obj, err)
+	}
+	return runtime.RawExtension{Raw: raw}
+}
+
+// --- RB Options ---
+type RBOption func(*workv1alpha2.ResourceBinding)
+
+func WithClusters(clusters []workv1alpha2.TargetCluster) RBOption {
+	return func(rb *workv1alpha2.ResourceBinding) {
+		rb.Spec.Clusters = clusters
+	}
+}
+
+func WithReplicaRequirements(reqs corev1.ResourceList) RBOption {
+	return func(rb *workv1alpha2.ResourceBinding) {
+		if reqs != nil {
+			rb.Spec.ReplicaRequirements = &workv1alpha2.ReplicaRequirements{ResourceRequest: reqs}
+		} else {
+			rb.Spec.ReplicaRequirements = nil
+		}
+	}
+}
+
+func WithResourceRef(ref workv1alpha2.ObjectReference) RBOption {
+	return func(rb *workv1alpha2.ResourceBinding) {
+		rb.Spec.Resource = ref
+	}
+}
+
+func makeTestRB(namespace, name string, opts ...RBOption) *workv1alpha2.ResourceBinding {
+	defaultResourceRef := workv1alpha2.ObjectReference{
+		APIVersion: "v1", Kind: "Pod", Name: "test-pod-" + name, Namespace: namespace,
+	}
+	rb := &workv1alpha2.ResourceBinding{
+		TypeMeta: metav1.TypeMeta{APIVersion: workv1alpha2.SchemeGroupVersion.String(), Kind: "ResourceBinding"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       types.UID(fmt.Sprintf("rb-obj-uid-%s-%s", namespace, name)), // UID for the RB object itself
+		},
+		Spec: workv1alpha2.ResourceBindingSpec{Resource: defaultResourceRef},
+	}
+	for _, opt := range opts {
+		opt(rb)
+	}
+	return rb
+}
+
+// --- FRQ Options ---
+type FRQOption func(*policyv1alpha1.FederatedResourceQuota)
+
+func WithOverallLimits(limits corev1.ResourceList) FRQOption {
+	return func(frq *policyv1alpha1.FederatedResourceQuota) {
+		frq.Spec.Overall = limits
+	}
+}
+
+func WithOverallUsed(used corev1.ResourceList) FRQOption {
+	return func(frq *policyv1alpha1.FederatedResourceQuota) {
+		if used != nil {
+			frq.Status.OverallUsed = used
+		} else {
+			frq.Status.OverallUsed = corev1.ResourceList{}
+		}
+	}
+}
+
+func makeTestFRQ(namespace, name string, opts ...FRQOption) *policyv1alpha1.FederatedResourceQuota {
+	frq := &policyv1alpha1.FederatedResourceQuota{
+		TypeMeta: metav1.TypeMeta{APIVersion: policyv1alpha1.SchemeGroupVersion.String(), Kind: "FederatedResourceQuota"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       types.UID(fmt.Sprintf("frq-obj-uid-%s-%s", namespace, name)), // UID for the FRQ object itself
+		},
+		Spec: policyv1alpha1.FederatedResourceQuotaSpec{},
+	}
+	for _, opt := range opts {
+		opt(frq)
+	}
+	return frq
+}
+
+// boolPtr returns a pointer to a boolean value.
+func boolPtr(b bool) *bool { return &b }
+
+// --- Admission Request Builder ---
+type admissionRequestBuilder struct {
+	t         *testing.T
+	operation admissionv1.Operation
+	namespace string
+	name      string // Resource Name
+	uidSuffix string // Suffix for generating a unique request UID
+	object    runtime.Object
+	oldObject runtime.Object
+	dryRun    *bool
+}
+
+func newAdmissionRequestBuilder(t *testing.T, op admissionv1.Operation, resourceNamespace, resourceName, uidSuffix string) *admissionRequestBuilder {
+	return &admissionRequestBuilder{
+		t:         t,
+		operation: op,
+		namespace: resourceNamespace,
+		name:      resourceName,
+		uidSuffix: uidSuffix,
+	}
+}
+
+func (b *admissionRequestBuilder) WithObject(obj runtime.Object) *admissionRequestBuilder {
+	b.object = obj
+	return b
+}
+
+func (b *admissionRequestBuilder) WithOldObject(oldObj runtime.Object) *admissionRequestBuilder {
+	b.oldObject = oldObj
+	return b
+}
+
+func (b *admissionRequestBuilder) WithDryRun(isDryRun bool) *admissionRequestBuilder {
+	b.dryRun = boolPtr(isDryRun)
+	return b
+}
+
+func (b *admissionRequestBuilder) Build() admission.Request {
+	// Generate a descriptive UID for the admission request itself
+	requestUID := types.UID(fmt.Sprintf("req-uid-%s-%s-%s",
+		strings.ToLower(string(b.operation)),
+		strings.ToLower(b.name), // resource name
+		b.uidSuffix))
+
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: b.operation,
+			Name:      b.name,
+			Namespace: b.namespace,
+			UID:       requestUID,
+		},
+	}
+	if b.object != nil {
+		req.Object = marshalToRawExtension(b.t, b.object)
+	}
+	if b.oldObject != nil {
+		req.OldObject = marshalToRawExtension(b.t, b.oldObject)
+	}
+	if b.dryRun != nil {
+		req.DryRun = b.dryRun
+	}
+	return req
+}
+
+func TestValidatingAdmission_Handle(t *testing.T) {
+	// --- Common Test Data ---
+	commonRBUpdatePassOld := makeTestRB("quota-ns", "rb-update-pass",
+		WithClusters([]workv1alpha2.TargetCluster{{Name: "m1", Replicas: 1}}),
+		WithReplicaRequirements(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m")}),
+	)
+	commonRBUpdatePassNew := makeTestRB("quota-ns", "rb-update-pass",
+		WithClusters([]workv1alpha2.TargetCluster{{Name: "m1", Replicas: 1}}),
+		WithReplicaRequirements(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}),
+	)
+
+	// --- Test Case Specific Data ---
+
+	// For: "decode error on new object"
+	rbForDecodeErrorCase := makeTestRB("default", "test-rb-decode-err") // A minimal RB for the request
+	frqForDecodeErrorCase := makeTestFRQ("default", "frq-for-decode-error",
+		WithOverallLimits(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")}),
+		WithOverallUsed(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}),
+	)
+
+	// For: "create operation not yet scheduled should be allowed"
+	rbUnscheduledCreate := makeTestRB("default", "rb-unscheduled",
+		WithClusters(nil),
+		WithReplicaRequirements(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}),
+	)
+	frqForUnscheduledCreate := makeTestFRQ("default", "frq-for-create-unscheduled", // Unique FRQ name
+		WithOverallLimits(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")}),
+		WithOverallUsed(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}),
+	)
+
+	// For: "update operation with no relevant field change should be allowed"
+	rbForNoChange := makeTestRB("default", "rb-nochange",
+		WithClusters([]workv1alpha2.TargetCluster{{Name: "m1", Replicas: 1}}),
+		WithReplicaRequirements(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}),
+	)
+	frqForNoChange := makeTestFRQ("default", "frq-for-nochange",
+		WithOverallLimits(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")}),
+		WithOverallUsed(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}),
+	)
+
+	// For: "total RB delta is zero should be allowed (update with identical states)"
+	rbForDeltaZeroNew := makeTestRB("default", "rb-delta-zero", // Use same name for new/old RBs in this scenario
+		WithClusters([]workv1alpha2.TargetCluster{{Name: "m1", Replicas: 1}}),
+		WithReplicaRequirements(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")}),
+	)
+	rbForDeltaZeroOld := makeTestRB("default", "rb-delta-zero",
+		WithClusters([]workv1alpha2.TargetCluster{{Name: "m2", Replicas: 2}}),
+		WithReplicaRequirements(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}),
+	)
+	frqForDeltaZero := makeTestFRQ("default", "frq-fordeltazero",
+		WithOverallLimits(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1Gi")}),
+		WithOverallUsed(nil),
+	)
+
+	// For: "no FRQs found should be allowed"
+	rbForNoFRQ := makeTestRB("ns-no-frq", "test-rb-no-frq",
+		WithClusters([]workv1alpha2.TargetCluster{{Name: "m1", Replicas: 1}}),
+		WithReplicaRequirements(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")}),
+	)
+
+	// For: "create quota exceeded should deny"
+	rbCreateExceeds := makeTestRB("quota-ns", "rb-create-exceed",
+		WithClusters([]workv1alpha2.TargetCluster{{Name: "m1", Replicas: 1}}),
+		WithReplicaRequirements(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")}),
+	)
+	frqForCreateExceeds := makeTestFRQ("quota-ns", "frq-create-exceeds",
+		WithOverallLimits(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("150m")}),
+		WithOverallUsed(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("0m")}),
+	)
+
+	// For: "update passes quota (allowed response, non-dryrun)"
+	frqForUpdatePassNonDryRun := makeTestFRQ("quota-ns", "frq-update-pass-nondryrun",
+		WithOverallLimits(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")}),
+		WithOverallUsed(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}),
+	)
+
+	// For: "update passes quota (allowed response, dry run)"
+	frqForUpdatePassDryRun := makeTestFRQ("quota-ns", "frq-update-pass-dryrun",
+		WithOverallLimits(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")}),
+		WithOverallUsed(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}),
+	)
+
+	// For: "update fails quota (denied response)"
+	rbUpdateFailOld := makeTestRB("quota-ns", "rb-update-fail",
+		WithClusters([]workv1alpha2.TargetCluster{{Name: "m1", Replicas: 1}}),
+		WithReplicaRequirements(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m")}),
+	)
+	rbUpdateFailNew := makeTestRB("quota-ns", "rb-update-fail",
+		WithClusters([]workv1alpha2.TargetCluster{{Name: "m1", Replicas: 2}}),
+		WithReplicaRequirements(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("80m")}),
+	)
+	frqForUpdateFail := makeTestFRQ("quota-ns", "frq-update-fail",
+		WithOverallLimits(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}),
+		WithOverallUsed(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("0m")}),
+	)
+
+	tests := []struct {
+		name               string
+		req                admission.Request
+		decoder            admission.Decoder
+		clientObjects      []client.Object
+		featureGateEnabled bool
+		wantResponse       admission.Response
+	}{
+		{
+			name:               "feature gate disabled",
+			req:                newAdmissionRequestBuilder(t, admissionv1.Create, "default", "any-rb", "fg-disabled").Build(),
+			decoder:            &fakeDecoder{},
+			clientObjects:      nil,
+			featureGateEnabled: false,
+			wantResponse:       admission.Allowed(""),
+		},
+		{
+			name: "decode error on new object",
+			req: newAdmissionRequestBuilder(t, admissionv1.Create, rbForDecodeErrorCase.Namespace, rbForDecodeErrorCase.Name, "decode-err").
+				WithObject(rbForDecodeErrorCase).
+				Build(),
+			decoder:            &fakeDecoder{err: errors.New("decode failed")},
+			clientObjects:      []client.Object{frqForDecodeErrorCase},
+			featureGateEnabled: true,
+			wantResponse:       admission.Errored(http.StatusBadRequest, errors.New("decode failed")),
+		},
+		{
+			name: "create operation not yet scheduled should be allowed",
+			req: newAdmissionRequestBuilder(t, admissionv1.Create, rbUnscheduledCreate.Namespace, rbUnscheduledCreate.Name, "create-unscheduled").
+				WithObject(rbUnscheduledCreate).
+				Build(),
+			decoder:            &fakeDecoder{decodeObj: rbUnscheduledCreate},
+			clientObjects:      []client.Object{frqForUnscheduledCreate},
+			featureGateEnabled: true,
+			wantResponse:       admission.Allowed("ResourceBinding not yet scheduled for Create operation."),
+		},
+		{
+			name: "update operation with no relevant field change should be allowed",
+			req: newAdmissionRequestBuilder(t, admissionv1.Update, rbForNoChange.Namespace, rbForNoChange.Name, "update-nochange").
+				WithObject(rbForNoChange).
+				WithOldObject(rbForNoChange).
+				Build(),
+			decoder:            &fakeDecoder{decodeObj: rbForNoChange, rawDecodedObj: rbForNoChange},
+			clientObjects:      []client.Object{frqForNoChange},
+			featureGateEnabled: true,
+			wantResponse:       admission.Allowed("No quota relevant fields changed."),
+		},
+		{
+			name: "total RB delta is zero should be allowed (update with identical states)",
+			req: newAdmissionRequestBuilder(t, admissionv1.Update, rbForDeltaZeroNew.Namespace, rbForDeltaZeroNew.Name, "delta-zero").
+				WithObject(rbForDeltaZeroNew).
+				WithOldObject(rbForDeltaZeroOld).
+				Build(),
+			decoder:            &fakeDecoder{decodeObj: rbForDeltaZeroNew, rawDecodedObj: rbForDeltaZeroOld},
+			clientObjects:      []client.Object{frqForDeltaZero},
+			featureGateEnabled: true,
+			wantResponse:       admission.Allowed("No effective resource quantity delta for ResourceBinding, skipping quota validation."),
+		},
+		{
+			name: "no FRQs found should be allowed",
+			req: newAdmissionRequestBuilder(t, admissionv1.Create, rbForNoFRQ.Namespace, rbForNoFRQ.Name, "no-frq-found").
+				WithObject(rbForNoFRQ).
+				Build(),
+			decoder:            &fakeDecoder{decodeObj: rbForNoFRQ},
+			clientObjects:      []client.Object{},
+			featureGateEnabled: true,
+			wantResponse:       admission.Allowed("No FederatedResourceQuotas found in the namespace, skipping quota check."),
+		},
+		{
+			name: "create quota exceeded should deny",
+			req: newAdmissionRequestBuilder(t, admissionv1.Create, rbCreateExceeds.Namespace, rbCreateExceeds.Name, "create-exceeds").
+				WithObject(rbCreateExceeds).
+				Build(),
+			decoder:            &fakeDecoder{decodeObj: rbCreateExceeds},
+			clientObjects:      []client.Object{frqForCreateExceeds},
+			featureGateEnabled: true,
+			wantResponse: admission.Denied(
+				fmt.Sprintf("Quota exceeded for FederatedResourceQuota %s/%s. ResourceBinding %s/%s will be denied.",
+					frqForCreateExceeds.Namespace, frqForCreateExceeds.Name, rbCreateExceeds.Namespace, rbCreateExceeds.Name),
+			),
+		},
+		{
+			name: "update passes quota (allowed response, non-dryrun)",
+			req: newAdmissionRequestBuilder(t, admissionv1.Update, commonRBUpdatePassNew.Namespace, commonRBUpdatePassNew.Name, "update-pass-nondryrun").
+				WithObject(commonRBUpdatePassNew).
+				WithOldObject(commonRBUpdatePassOld).
+				WithDryRun(false).
+				Build(),
+			decoder:            &fakeDecoder{decodeObj: commonRBUpdatePassNew, rawDecodedObj: commonRBUpdatePassOld},
+			clientObjects:      []client.Object{frqForUpdatePassNonDryRun},
+			featureGateEnabled: true,
+			wantResponse: admission.Allowed(
+				fmt.Sprintf("All relevant FederatedResourceQuota checks passed for ResourceBinding %s/%s. Quota check passed for FRQ %s/%s. 1 FRQ(s) updated.",
+					commonRBUpdatePassNew.Namespace, commonRBUpdatePassNew.Name, frqForUpdatePassNonDryRun.Namespace, frqForUpdatePassNonDryRun.Name),
+			),
+		},
+		{
+			name: "update passes quota (allowed response, dry run)",
+			req: newAdmissionRequestBuilder(t, admissionv1.Update, commonRBUpdatePassNew.Namespace, commonRBUpdatePassNew.Name, "update-pass-dryrun").
+				WithObject(commonRBUpdatePassNew).
+				WithOldObject(commonRBUpdatePassOld).
+				WithDryRun(true).
+				Build(),
+			decoder:            &fakeDecoder{decodeObj: commonRBUpdatePassNew, rawDecodedObj: commonRBUpdatePassOld},
+			clientObjects:      []client.Object{frqForUpdatePassDryRun},
+			featureGateEnabled: true,
+			wantResponse: admission.Allowed(
+				fmt.Sprintf("All relevant FederatedResourceQuota checks passed for ResourceBinding %s/%s. Quota check passed for FRQ %s/%s. 1 FRQ(s) updated.",
+					commonRBUpdatePassNew.Namespace, commonRBUpdatePassNew.Name, frqForUpdatePassDryRun.Namespace, frqForUpdatePassDryRun.Name),
+			),
+		},
+		{
+			name: "update fails quota (denied response)",
+			req: newAdmissionRequestBuilder(t, admissionv1.Update, rbUpdateFailNew.Namespace, rbUpdateFailNew.Name, "update-fail").
+				WithObject(rbUpdateFailNew).
+				WithOldObject(rbUpdateFailOld).
+				Build(),
+			decoder:            &fakeDecoder{decodeObj: rbUpdateFailNew, rawDecodedObj: rbUpdateFailOld},
+			clientObjects:      []client.Object{frqForUpdateFail},
+			featureGateEnabled: true,
+			wantResponse: admission.Denied(
+				fmt.Sprintf("Quota exceeded for FederatedResourceQuota %s/%s. ResourceBinding %s/%s will be denied.",
+					frqForUpdateFail.Namespace, frqForUpdateFail.Name, rbUpdateFailNew.Namespace, rbUpdateFailNew.Name),
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalGateState := features.FeatureGate.Enabled(features.FederatedQuotaEnforcement)
+			if errFG := features.FeatureGate.Set(fmt.Sprintf("%s=%v", features.FederatedQuotaEnforcement, tt.featureGateEnabled)); errFG != nil {
+				t.Fatalf("Failed to set feature gate %s to %v: %v", features.FederatedQuotaEnforcement, tt.featureGateEnabled, errFG)
+			}
+			t.Cleanup(func() {
+				if errFG := features.FeatureGate.Set(fmt.Sprintf("%s=%v", features.FederatedQuotaEnforcement, originalGateState)); errFG != nil {
+					t.Logf("Warning: Failed to restore feature gate %s to %v: %v", features.FederatedQuotaEnforcement, originalGateState, errFG)
+				}
+			})
+
+			fakeClientBuilder := fake.NewClientBuilder().WithScheme(testScheme)
+			if len(tt.clientObjects) > 0 {
+				fakeClientBuilder = fakeClientBuilder.WithObjects(tt.clientObjects...)
+			}
+			fakeClient := fakeClientBuilder.WithStatusSubresource(&policyv1alpha1.FederatedResourceQuota{}).Build()
+
+			v := ValidatingAdmission{
+				Client:  fakeClient,
+				Decoder: tt.decoder,
+			}
+			got := v.Handle(context.Background(), tt.req)
+
+			if got.Allowed != tt.wantResponse.Allowed {
+				t.Errorf("Handle() got.Allowed = %v, want %v. Got Response: %+v", got.Allowed, tt.wantResponse.Allowed, got)
+			}
+
+			if (got.Result == nil) != (tt.wantResponse.Result == nil) {
+				t.Errorf("Handle() got.Result nil status mismatch: got %v (%+v), want %v (%+v)",
+					(got.Result == nil), got.Result, (tt.wantResponse.Result == nil), tt.wantResponse.Result)
+			}
+			if got.Result != nil && tt.wantResponse.Result != nil {
+				if got.Result.Message != tt.wantResponse.Result.Message {
+					t.Errorf("Handle() got.Result.Message = %q, want %q", got.Result.Message, tt.wantResponse.Result.Message)
+				}
+				if got.Result.Code != tt.wantResponse.Result.Code {
+					t.Errorf("Handle() got.Result.Code = %d, want %d", got.Result.Code, tt.wantResponse.Result.Code)
+				}
+			}
+
+			if len(got.Patches) != 0 {
+				t.Errorf("Handle() returned %d patches, want 0 for a validating webhook. Patches: %v", len(got.Patches), got.Patches)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
The webhook intercepts `CREATE` and `UPDATE` events for `ResourceBinding` objects.
-   For `CREATE` events (when a `ResourceBinding` is scheduled, i.e., `spec.clusters` is populated): It calculates the resources requested by the `ResourceBinding` (based on `spec.clusters[].replicas` and `spec.replicaRequirements.resourceRequest`). It then checks if adding this usage to the current `FederatedResourceQuota.status.overallUsed` would exceed the `FederatedResourceQuota.spec.overall` limit. If it exceeds, the request is denied. Otherwise, `FederatedResourceQuota.status.overallUsed` is updated, and the request is allowed.
-   For `UPDATE` events on `ResourceBinding`: It calculates the delta in resource usage based on changes to `spec.clusters` and `spec.replicaRequirements`. This delta is then applied to the current `FederatedResourceQuota.status.overallUsed` to check against `FederatedResourceQuota.spec.overall`. If the new total usage exceeds the limit, the update is denied. Otherwise, the `FederatedResourceQuota.status.overallUsed` is updated, and the request is allowed.

This mechanism ensures that resource allocations scheduled by Karmada respect the defined federated quotas, preventing over-commitment of resources across member clusters at the namespace level.

**Which issue(s) this PR fixes**:
Part of #6350 

**Special notes for your reviewer**:
-   The webhook directly updates the `FederatedResourceQuota.status.overallUsed` field upon successful validation. This is done to provide immediate feedback and consistency, though it's acknowledged that updating other resources' statuses in a webhook has **atomicity considerations** if multiple `FederatedResourceQuota` objects are involved (currently, it processes each FRQ in the namespace and updates them sequentially; an error in one update stops the process).
-   Resource calculation strictly uses `ResourceBinding.spec.clusters[].replicas` multiplied by `ResourceBinding.spec.replicaRequirements.resourceRequest` for determining the total replicas and their respective resource needs.
-   The webhook handles multiple `FederatedResourceQuota` objects within the same namespace, validating against each one that tracks relevant resources.
-   Dry run requests (`req.DryRun == true`) are supported; `FederatedResourceQuota` status updates are also performed with `client.DryRunAll` in such cases.
-   Comprehensive unit tests for the webhook's `Handle` function have been added, covering various scenarios including early exits, quota checks, and dry runs.
-   The Karmada resource utility package (`github.com/karmada-io/karmada/pkg/util/resource`) is used for adding resource lists. Standard `k8s.io/apimachinery/pkg/api/resource.Quantity` methods are used for other arithmetic.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

