### PR TITLE
staticAssignment only updates AggregatedStatus

### DIFF
--- a/pkg/controllers/federatedresourcequota/federated_resource_quota_status_controller.go
+++ b/pkg/controllers/federatedresourcequota/federated_resource_quota_status_controller.go
@@ -43,6 +43,7 @@ import (
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/events"
+	"github.com/karmada-io/karmada/pkg/features"
 	"github.com/karmada-io/karmada/pkg/sharedcli/ratelimiterflag"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/helper"
@@ -163,9 +164,11 @@ func (c *StatusController) collectQuotaStatus(ctx context.Context, quota *policy
 	}
 
 	quotaStatus := quota.Status.DeepCopy()
-	quotaStatus.Overall = quota.Spec.Overall
 	quotaStatus.AggregatedStatus = aggregatedStatuses
-	quotaStatus.OverallUsed = calculateUsed(aggregatedStatuses)
+	if !features.FeatureGate.Enabled(features.FederatedQuotaEnforcement) {
+		quotaStatus.Overall = quota.Spec.Overall
+		quotaStatus.OverallUsed = calculateUsed(aggregatedStatuses)
+	}
 
 	if reflect.DeepEqual(quota.Status, *quotaStatus) {
 		klog.V(4).Infof("New quotaStatus are equal with old federatedResourceQuota(%s) status, no update required.", klog.KObj(quota).String())


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Update `federated-resource-quota-status-controller` so that staticAssignment only updates `AggregatedStatus`

**Which issue(s) this PR fixes**:
Parts of #6350 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-controller-manager`: The `federated-resource-quota-status-controller` will skip reflecting overall and overall used in case the Federated Resource Quota Enforcement feature is on.
```

