### PR TITLE
Add feature gates support to karmada-webhook config (Helm Chart)

### DIFF
--- a/charts/karmada/templates/_helpers.tpl
+++ b/charts/karmada/templates/_helpers.tpl
@@ -568,6 +568,28 @@ Return the proper Docker Image Registry Secret Names
      {{- end -}}
 {{- end -}}
 
+{{- /* 
+Generate the --feature-gates command line argument for karmada-webhook.
+Iterates over .Values.webhook.featureGates and constructs a comma-separated key=value list.
+If any feature gates are set, outputs: --feature-gates=Foo=true,Bar=false
+If none are set, outputs nothing.
+*/ -}}
+{{- define "karmada.webhook.featureGates" -}}
+     {{- if (not (empty .Values.webhook.featureGates)) }}
+          {{- $featureGatesFlag := "" -}}
+          {{- range $key, $value := .Values.webhook.featureGates -}}
+               {{- if not (empty (toString $value)) }}
+                    {{- $featureGatesFlag = cat $featureGatesFlag $key "=" $value ","  -}}
+               {{- end -}}
+          {{- end -}}
+
+          {{- if gt (len $featureGatesFlag) 0 }}
+               {{- $featureGatesFlag := trimSuffix "," $featureGatesFlag  | nospace -}}
+               {{- printf "%s=%s" "--feature-gates" $featureGatesFlag -}}
+          {{- end -}}
+     {{- end -}}
+{{- end -}}
+
 {{- define "karmada.schedulerEstimator.featureGates" -}}
      {{- $featureGatesArg := index . "featureGatesArg" -}}
      {{- if (not (empty $featureGatesArg)) }}

--- a/charts/karmada/templates/karmada-webhook.yaml
+++ b/charts/karmada/templates/karmada-webhook.yaml
@@ -57,6 +57,9 @@ spec:
             - --health-probe-bind-address=$(POD_IP):8000
             - --secure-port=8443
             - --cert-dir=/var/serving-cert
+            {{- with (include "karmada.webhook.featureGates" .) }}
+            - {{ . }}
+            {{- end }}
           ports:
             - containerPort: 8443
             - containerPort: 8080

--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -294,6 +294,8 @@ webhook:
   podDisruptionBudget: *podDisruptionBudget
   ## @param webhook.priorityClassName the priority class name for the karmada-webhook
   priorityClassName: "system-node-critical"
+  ## @param featureGate to webhook
+  featureGates: {}
 
 ## controller manager config
 controllerManager:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
This PR adds feature gates support to the `karmada-webhook` Helm Chart configuration. Users can now configure feature gates for the webhook component via the `webhook.featureGates` field in `values.yaml`, similar to other components like [controllerManager](https://github.com/karmada-io/karmada/blob/master/charts/karmada/values.yaml#L353) and [schedulerEstimator](https://github.com/karmada-io/karmada/blob/master/charts/karmada/values.yaml#L890). This provides a consistent and flexible way to enable or disable webhook features across all installation modes.

**Which issue(s) this PR fixes**:
Part of #6350 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`Helm Chart`: Users can now configure feature gates for karmada-webhook via the Helm Chart using the `webhook.featureGates` field in values.yaml.
```

