### PR TITLE
cleanup: refactor GenerateTaintsMessage method

### DIFF
--- a/pkg/util/helper/taint.go
+++ b/pkg/util/helper/taint.go
@@ -218,26 +218,23 @@ func GenerateTaintsMessage(taints []corev1.Taint) string {
 		return "cluster now does not have taints"
 	}
 
-	var msg string
+	var builder strings.Builder
 	for i, taint := range taints {
 		if i != 0 {
-			msg += ","
+			builder.WriteString(",")
 		}
 		if taint.Value != "" {
-			msg += strings.Join([]string{`{`,
-				`Key:` + fmt.Sprintf("%v", taint.Key) + `,`,
-				`Value:` + fmt.Sprintf("%v", taint.Value) + `,`,
-				`Effect:` + fmt.Sprintf("%v", taint.Effect),
-				`}`,
-			}, "")
+			builder.WriteString("{")
+			builder.WriteString("Key:" + fmt.Sprintf("%v", taint.Key) + ",")
+			builder.WriteString("Value:" + fmt.Sprintf("%v", taint.Value) + ",")
+			builder.WriteString("Effect:" + fmt.Sprintf("%v", taint.Effect))
+			builder.WriteString("}")
 		} else {
-			msg += strings.Join([]string{`{`,
-				`Key:` + fmt.Sprintf("%v", taint.Key) + `,`,
-				`Effect:` + fmt.Sprintf("%v", taint.Effect),
-				`}`,
-			}, "")
+			builder.WriteString("{")
+			builder.WriteString("Key:" + fmt.Sprintf("%v", taint.Key) + ",")
+			builder.WriteString("Effect:" + fmt.Sprintf("%v", taint.Effect))
+			builder.WriteString("}")
 		}
 	}
-
-	return fmt.Sprintf("cluster now has taints([%s])", msg)
+	return fmt.Sprintf("cluster now has taints([%s])", builder.String())
 }

--- a/pkg/util/helper/taint_test.go
+++ b/pkg/util/helper/taint_test.go
@@ -703,3 +703,53 @@ func TestNewUnreachableToleration(t *testing.T) {
 		t.Errorf("NewUnreachableToleration() = %v, want %v", actualToleration, expectedToleration)
 	}
 }
+
+func TestGenerateTaintsMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		taints   []corev1.Taint
+		expected string
+	}{
+		{
+			name:     "no taint",
+			taints:   []corev1.Taint{},
+			expected: "cluster now does not have taints",
+		},
+		{
+			name: "single taint with value",
+			taints: []corev1.Taint{
+				{
+					Key:    "key1",
+					Value:  "value1",
+					Effect: corev1.TaintEffectNoSchedule,
+				},
+			},
+			expected: "cluster now has taints([{Key:key1,Value:value1,Effect:NoSchedule}])",
+		},
+		{
+			name: "multiple taints with no value",
+			taints: []corev1.Taint{
+				{
+					Key:    "key1",
+					Value:  "value1",
+					Effect: corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "key2",
+					Value:  "",
+					Effect: corev1.TaintEffectPreferNoSchedule,
+				},
+			},
+			expected: "cluster now has taints([{Key:key1,Value:value1,Effect:NoSchedule},{Key:key2,Effect:PreferNoSchedule}])",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GenerateTaintsMessage(tt.taints)
+			if result != tt.expected {
+				t.Errorf("test failed: %s, expected: %s, actual: %s", tt.name, tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Using a `strings.Builder` for concatenating the taint messages in GenerateTaintsMessage to improve performance and readability when processing a larger number of taints.

As comment in https://github.com/karmada-io/karmada/pull/6368#discussion_r2092411890

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

