### PR TITLE
cluster-controller no longer taints clusters based on conditions

### DIFF
--- a/pkg/controllers/cluster/cluster_controller.go
+++ b/pkg/controllers/cluster/cluster_controller.go
@@ -44,7 +44,6 @@ import (
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/events"
-	"github.com/karmada-io/karmada/pkg/features"
 	"github.com/karmada-io/karmada/pkg/sharedcli/ratelimiterflag"
 	"github.com/karmada-io/karmada/pkg/util"
 	utilhelper "github.com/karmada-io/karmada/pkg/util/helper"
@@ -157,10 +156,9 @@ func (n *clusterHealthMap) delete(name string) {
 }
 
 type clusterHealthData struct {
-	probeTimestamp           metav1.Time
-	readyTransitionTimestamp metav1.Time
-	status                   *clusterv1alpha1.ClusterStatus
-	lease                    *coordinationv1.Lease
+	probeTimestamp metav1.Time
+	status         *clusterv1alpha1.ClusterStatus
+	lease          *coordinationv1.Lease
 }
 
 func (n *clusterHealthData) deepCopy() *clusterHealthData {
@@ -168,10 +166,9 @@ func (n *clusterHealthData) deepCopy() *clusterHealthData {
 		return nil
 	}
 	return &clusterHealthData{
-		probeTimestamp:           n.probeTimestamp,
-		readyTransitionTimestamp: n.readyTransitionTimestamp,
-		status:                   n.status.DeepCopy(),
-		lease:                    n.lease.DeepCopy(),
+		probeTimestamp: n.probeTimestamp,
+		status:         n.status.DeepCopy(),
+		lease:          n.lease.DeepCopy(),
 	}
 }
 
@@ -454,10 +451,9 @@ func (c *Controller) monitorClusterHealth(ctx context.Context) (err error) {
 	clusters := clusterList.Items
 	for i := range clusters {
 		cluster := &clusters[i]
-		var observedReadyCondition, currentReadyCondition *metav1.Condition
 		if err = wait.PollUntilContextTimeout(ctx, MonitorRetrySleepTime, MonitorRetrySleepTime*HealthUpdateRetry, true, func(ctx context.Context) (bool, error) {
 			// Cluster object may be changed in this function.
-			observedReadyCondition, currentReadyCondition, err = c.tryUpdateClusterHealth(ctx, cluster)
+			err = c.tryUpdateClusterHealth(ctx, cluster)
 			if err == nil {
 				return true, nil
 			}
@@ -475,13 +471,6 @@ func (c *Controller) monitorClusterHealth(ctx context.Context) (err error) {
 			klog.Errorf("Update health of Cluster '%v' from Controller error: %v. Skipping.", cluster.Name, err)
 			continue
 		}
-
-		if currentReadyCondition != nil {
-			if err = c.processTaintBaseEviction(ctx, cluster, observedReadyCondition); err != nil {
-				klog.Errorf("Failed to process taint base eviction error: %v. Skipping.", err)
-				continue
-			}
-		}
 	}
 
 	return nil
@@ -490,7 +479,7 @@ func (c *Controller) monitorClusterHealth(ctx context.Context) (err error) {
 // tryUpdateClusterHealth checks a given cluster's conditions and tries to update it.
 //
 //nolint:gocyclo
-func (c *Controller) tryUpdateClusterHealth(ctx context.Context, cluster *clusterv1alpha1.Cluster) (*metav1.Condition, *metav1.Condition, error) {
+func (c *Controller) tryUpdateClusterHealth(ctx context.Context, cluster *clusterv1alpha1.Cluster) error {
 	// Step 1: Get the last cluster heath from `clusterHealthMap`.
 	clusterHealth := c.clusterHealthMap.getDeepCopy(cluster.Name)
 	defer func() {
@@ -515,9 +504,8 @@ func (c *Controller) tryUpdateClusterHealth(ctx context.Context, cluster *cluste
 			clusterHealth.status = &cluster.Status
 		} else {
 			clusterHealth = &clusterHealthData{
-				status:                   &cluster.Status,
-				probeTimestamp:           cluster.CreationTimestamp,
-				readyTransitionTimestamp: cluster.CreationTimestamp,
+				status:         &cluster.Status,
+				probeTimestamp: cluster.CreationTimestamp,
 			}
 		}
 	} else {
@@ -539,24 +527,18 @@ func (c *Controller) tryUpdateClusterHealth(ctx context.Context, cluster *cluste
 	// Otherwise, we only update the probeTimestamp.
 	if clusterHealth == nil {
 		clusterHealth = &clusterHealthData{
-			status:                   cluster.Status.DeepCopy(),
-			probeTimestamp:           metav1.Now(),
-			readyTransitionTimestamp: metav1.Now(),
+			status:         cluster.Status.DeepCopy(),
+			probeTimestamp: metav1.Now(),
 		}
 	} else if !equality.Semantic.DeepEqual(savedCondition, currentReadyCondition) {
-		transitionTime := metav1.Now()
-		if savedCondition != nil && currentReadyCondition != nil && savedCondition.LastTransitionTime == currentReadyCondition.LastTransitionTime {
-			transitionTime = clusterHealth.readyTransitionTimestamp
-		}
 		clusterHealth = &clusterHealthData{
-			status:                   cluster.Status.DeepCopy(),
-			probeTimestamp:           metav1.Now(),
-			readyTransitionTimestamp: transitionTime,
+			status:         cluster.Status.DeepCopy(),
+			probeTimestamp: metav1.Now(),
 		}
 	}
 
 	if cluster.Spec.SyncMode == clusterv1alpha1.Push {
-		return observedReadyCondition, currentReadyCondition, nil
+		return nil
 	}
 
 	// Always update the probe time if cluster lease is renewed.
@@ -605,47 +587,14 @@ func (c *Controller) tryUpdateClusterHealth(ctx context.Context, cluster *cluste
 		if !equality.Semantic.DeepEqual(currentReadyCondition, observedReadyCondition) {
 			if err := c.Status().Update(ctx, cluster); err != nil {
 				klog.Errorf("Error updating cluster %s: %v", cluster.Name, err)
-				return observedReadyCondition, currentReadyCondition, err
+				return err
 			}
 			clusterHealth = &clusterHealthData{
-				status:                   &cluster.Status,
-				probeTimestamp:           clusterHealth.probeTimestamp,
-				readyTransitionTimestamp: metav1.Now(),
-				lease:                    observedLease,
+				status:         &cluster.Status,
+				probeTimestamp: clusterHealth.probeTimestamp,
+				lease:          observedLease,
 			}
-			return observedReadyCondition, currentReadyCondition, nil
-		}
-	}
-	return observedReadyCondition, currentReadyCondition, nil
-}
-
-func (c *Controller) processTaintBaseEviction(ctx context.Context, cluster *clusterv1alpha1.Cluster, observedReadyCondition *metav1.Condition) error {
-	decisionTimestamp := metav1.Now()
-	clusterHealth := c.clusterHealthMap.getDeepCopy(cluster.Name)
-	if clusterHealth == nil {
-		return fmt.Errorf("health data doesn't exist for cluster %q", cluster.Name)
-	}
-	// Check eviction timeout against decisionTimestamp
-	switch observedReadyCondition.Status {
-	case metav1.ConditionFalse:
-		if features.FeatureGate.Enabled(features.Failover) && decisionTimestamp.After(clusterHealth.readyTransitionTimestamp.Add(c.FailoverEvictionTimeout)) {
-			// We want to update the taint straight away if Cluster is already tainted with the UnreachableTaint
-			taintToAdd := *NotReadyTaintTemplate
-			if err := c.updateClusterTaints(ctx, []*corev1.Taint{&taintToAdd}, []*corev1.Taint{UnreachableTaintTemplate}, cluster); err != nil {
-				klog.ErrorS(err, "Failed to instantly update UnreachableTaint to NotReadyTaint, will try again in the next cycle.", "cluster", cluster.Name)
-			}
-		}
-	case metav1.ConditionUnknown:
-		if features.FeatureGate.Enabled(features.Failover) && decisionTimestamp.After(clusterHealth.probeTimestamp.Add(c.FailoverEvictionTimeout)) {
-			// We want to update the taint straight away if Cluster is already tainted with the UnreachableTaint
-			taintToAdd := *UnreachableTaintTemplate
-			if err := c.updateClusterTaints(ctx, []*corev1.Taint{&taintToAdd}, []*corev1.Taint{NotReadyTaintTemplate}, cluster); err != nil {
-				klog.ErrorS(err, "Failed to instantly swap NotReadyTaint to UnreachableTaint, will try again in the next cycle.", "cluster", cluster.Name)
-			}
-		}
-	case metav1.ConditionTrue:
-		if err := c.updateClusterTaints(ctx, nil, []*corev1.Taint{NotReadyTaintTemplate, UnreachableTaintTemplate}, cluster); err != nil {
-			klog.ErrorS(err, "Failed to remove taints from cluster, will retry in next iteration.", "cluster", cluster.Name)
+			return nil
 		}
 	}
 	return nil

--- a/pkg/controllers/cluster/cluster_controller_test.go
+++ b/pkg/controllers/cluster/cluster_controller_test.go
@@ -363,12 +363,7 @@ func TestController_monitorClusterHealth(t *testing.T) {
 				},
 				Spec: clusterv1alpha1.ClusterSpec{
 					SyncMode: clusterv1alpha1.Pull,
-					Taints: []corev1.Taint{
-						{
-							Key:    clusterv1alpha1.TaintClusterUnreachable,
-							Effect: corev1.TaintEffectNoExecute,
-						},
-					},
+					Taints:   []corev1.Taint{},
 				},
 				Status: clusterv1alpha1.ClusterStatus{
 					Conditions: []metav1.Condition{{

--- a/test/e2e/framework/constant.go
+++ b/test/e2e/framework/constant.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package framework
 
-import "time"
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
 
 const (
 	// PollInterval defines the interval time for a poll operation.
@@ -25,4 +29,56 @@ const (
 	PollTimeout = 420 * time.Second
 	// metricsCreationDelay defines the maximum time metrics not yet available for pod.
 	metricsCreationDelay = 2 * time.Minute
+)
+
+const (
+	// TaintClusterUnscheduler will be added when cluster becomes unschedulable
+	// and removed when cluster becomes schedulable.
+	TaintClusterUnscheduler = "unschedulable"
+	// TaintClusterNotReady will be added when cluster is not ready
+	// and removed when cluster becomes ready.
+	TaintClusterNotReady = "not-ready"
+	// TaintClusterUnreachable will be added when cluster becomes unreachable
+	// (corresponding to ClusterConditionReady status ConditionUnknown)
+	// and removed when cluster becomes reachable (ClusterConditionReady status ConditionTrue).
+	TaintClusterUnreachable = "unreachable"
+	// TaintClusterTerminating will be added when cluster is terminating.
+	TaintClusterTerminating = "terminating"
+)
+
+var (
+	// UnreachableTaintTemplate is the taint for when a cluster becomes unreachable.
+	// Used for taint based eviction.
+	UnreachableTaintTemplate = &corev1.Taint{
+		Key:    TaintClusterUnreachable,
+		Effect: corev1.TaintEffectNoExecute,
+	}
+
+	// UnreachableTaintTemplateForSched is the taint for when a cluster becomes unreachable.
+	// Used for taint based schedule.
+	UnreachableTaintTemplateForSched = &corev1.Taint{
+		Key:    TaintClusterUnreachable,
+		Effect: corev1.TaintEffectNoSchedule,
+	}
+
+	// NotReadyTaintTemplate is the taint for when a cluster is not ready for executing resources.
+	// Used for taint based eviction.
+	NotReadyTaintTemplate = &corev1.Taint{
+		Key:    TaintClusterNotReady,
+		Effect: corev1.TaintEffectNoExecute,
+	}
+
+	// NotReadyTaintTemplateForSched is the taint for when a cluster is not ready for executing resources.
+	// Used for taint based schedule.
+	NotReadyTaintTemplateForSched = &corev1.Taint{
+		Key:    TaintClusterNotReady,
+		Effect: corev1.TaintEffectNoSchedule,
+	}
+
+	// TerminatingTaintTemplate is the taint for when a cluster is terminating executing resources.
+	// Used for taint based eviction.
+	TerminatingTaintTemplate = &corev1.Taint{
+		Key:    TaintClusterTerminating,
+		Effect: corev1.TaintEffectNoExecute,
+	}
 )

--- a/test/e2e/suites/base/karmadactl_test.go
+++ b/test/e2e/suites/base/karmadactl_test.go
@@ -44,6 +44,7 @@ import (
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	controllercluster "github.com/karmada-io/karmada/pkg/controllers/cluster"
 	"github.com/karmada-io/karmada/pkg/karmadactl/cordon"
 	"github.com/karmada-io/karmada/pkg/karmadactl/options"
 	cmdutil "github.com/karmada-io/karmada/pkg/karmadactl/util"
@@ -379,11 +380,8 @@ var _ = framework.SerialDescribe("Karmadactl join/unjoin testing", ginkgo.Labels
 			})
 
 			ginkgo.By(fmt.Sprintf("Disable cluster: %s", clusterName), func() {
-				err := disableCluster(controlPlaneClient, clusterName)
+				err := framework.AddClusterTaint(controlPlaneClient, clusterName, *controllercluster.NotReadyTaintTemplate)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-				framework.WaitClusterFitWith(controlPlaneClient, clusterName, func(cluster *clusterv1alpha1.Cluster) bool {
-					return meta.IsStatusConditionPresentAndEqual(cluster.Status.Conditions, clusterv1alpha1.ClusterConditionReady, metav1.ConditionFalse)
-				})
 			})
 
 			ginkgo.By(fmt.Sprintf("Unjoinning cluster: %s", clusterName), func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Remove the behavior of automatically adding not-ready and unreachable NoExecute taints

**Which issue(s) this PR fixes**:
Part of [#6317](https://github.com/karmada-io/karmada/issues/6317)

**Special notes for your reviewer**:
@XiShanYongYe-Chang 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: The clusters-controller no longer automatically adds NoExecute taints to clusters.
```

