### PR TITLE
No longer add terminting NoExecute taint for the Deleting Cluster

### DIFF
--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -248,15 +248,13 @@ func startClusterController(ctx controllerscontext.Context) (enabled bool, err e
 	opts := ctx.Opts
 
 	clusterController := &cluster.Controller{
-		Client:                             mgr.GetClient(),
-		EventRecorder:                      mgr.GetEventRecorderFor(cluster.ControllerName),
-		ClusterMonitorPeriod:               opts.ClusterMonitorPeriod.Duration,
-		ClusterMonitorGracePeriod:          opts.ClusterMonitorGracePeriod.Duration,
-		ClusterStartupGracePeriod:          opts.ClusterStartupGracePeriod.Duration,
-		EnableTaintManager:                 ctx.Opts.EnableTaintManager,
-		ClusterTaintEvictionRetryFrequency: 10 * time.Second,
-		ExecutionSpaceRetryFrequency:       10 * time.Second,
-		RateLimiterOptions:                 ctx.Opts.RateLimiterOptions,
+		Client:                    mgr.GetClient(),
+		EventRecorder:             mgr.GetEventRecorderFor(cluster.ControllerName),
+		ClusterMonitorPeriod:      opts.ClusterMonitorPeriod.Duration,
+		ClusterMonitorGracePeriod: opts.ClusterMonitorGracePeriod.Duration,
+		ClusterStartupGracePeriod: opts.ClusterStartupGracePeriod.Duration,
+		CleanupCheckInterval:      10 * time.Second,
+		RateLimiterOptions:        ctx.Opts.RateLimiterOptions,
 	}
 	if err := clusterController.SetupWithManager(mgr); err != nil {
 		return false, err

--- a/pkg/apis/cluster/v1alpha1/well_known_constants.go
+++ b/pkg/apis/cluster/v1alpha1/well_known_constants.go
@@ -27,8 +27,6 @@ const (
 	// (corresponding to ClusterConditionReady status ConditionUnknown)
 	// and removed when cluster becomes reachable (ClusterConditionReady status ConditionTrue).
 	TaintClusterUnreachable = "cluster.karmada.io/unreachable"
-	// TaintClusterTerminating will be added when cluster is terminating.
-	TaintClusterTerminating = "cluster.karmada.io/terminating"
 
 	// CacheSourceAnnotationKey is the annotation that added to a resource to
 	// represent which cluster it cached from.

--- a/pkg/controllers/cluster/cluster_controller_test.go
+++ b/pkg/controllers/cluster/cluster_controller_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	"github.com/karmada-io/karmada/pkg/util/indexregistry"
-	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 func newClusterController() *Controller {
@@ -65,7 +64,6 @@ func newClusterController() *Controller {
 		Client:                    client,
 		EventRecorder:             record.NewFakeRecorder(1024),
 		clusterHealthMap:          newClusterHealthMap(),
-		EnableTaintManager:        true,
 		ClusterMonitorGracePeriod: 40 * time.Second,
 	}
 }
@@ -248,41 +246,6 @@ func TestController_Reconcile(t *testing.T) {
 			},
 			want:    controllerruntime.Result{},
 			wantErr: false,
-		},
-		{
-			name: "remove cluster failed",
-			cluster: &clusterv1alpha1.Cluster{
-				ObjectMeta: controllerruntime.ObjectMeta{
-					Name:       "test-cluster",
-					Finalizers: []string{util.ClusterControllerFinalizer},
-				},
-				Spec: clusterv1alpha1.ClusterSpec{
-					SyncMode: clusterv1alpha1.Pull,
-				},
-				Status: clusterv1alpha1.ClusterStatus{
-					Conditions: []metav1.Condition{
-						{
-							Type:   clusterv1alpha1.ClusterConditionReady,
-							Status: metav1.ConditionFalse,
-						},
-					},
-				},
-			},
-			ns: &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: names.GenerateExecutionSpaceName("test-cluster"),
-				},
-			},
-			work: &workv1alpha1.Work{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "test-work",
-					Namespace:  names.GenerateExecutionSpaceName("test-cluster"),
-					Finalizers: []string{util.ExecutionControllerFinalizer},
-				},
-			},
-			del:     true,
-			want:    controllerruntime.Result{},
-			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/scheduler/event_handler.go
+++ b/pkg/scheduler/event_handler.go
@@ -268,10 +268,12 @@ func (s *Scheduler) updateCluster(oldObj, newObj interface{}) {
 	}
 
 	switch {
+	case oldCluster.DeletionTimestamp.IsZero() && !newCluster.DeletionTimestamp.IsZero():
+		s.clusterReconcileWorker.Add(newCluster)
 	case !equality.Semantic.DeepEqual(oldCluster.Labels, newCluster.Labels):
 		fallthrough
 	case oldCluster.Generation != newCluster.Generation:
-		// To distinguish the obd and new cluster objects, we need to add the entire object
+		// To distinguish the old and new cluster objects, we need to add the entire object
 		// to the worker. Therefore, call Add func instead of Enqueue func.
 		s.clusterReconcileWorker.Add(oldCluster)
 		s.clusterReconcileWorker.Add(newCluster)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

No longer add the NoExecute taint for the Deleting Cluster.

**Which issue(s) this PR fixes**:
Part of #6317 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller`: The `cluster-controller` no longer relies on taints to clean up resources on clusters scheduled for deletion, but instead depends on the scheduler to reschedule workloads to other available clusters.
```

