### PR TITLE
Add failover flags to control the behavior of NoExecute

### DIFF
--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -18,7 +18,6 @@ package app
 
 import (
 	"context"
-	"flag"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -30,7 +29,6 @@ import (
 	kubeclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
-	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/term"
 	"k8s.io/klog/v2"
 	resourceclient "k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1"
@@ -78,7 +76,6 @@ import (
 	"github.com/karmada-io/karmada/pkg/metrics"
 	"github.com/karmada-io/karmada/pkg/resourceinterpreter"
 	"github.com/karmada-io/karmada/pkg/sharedcli"
-	"github.com/karmada-io/karmada/pkg/sharedcli/klogflag"
 	"github.com/karmada-io/karmada/pkg/sharedcli/profileflag"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer"
@@ -97,7 +94,7 @@ import (
 
 // NewControllerManagerCommand creates a *cobra.Command object with default parameters
 func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
-	opts := options.NewOptions()
+	opts := options.NewKarmadaControllerManagerOptions()
 
 	cmd := &cobra.Command{
 		Use: names.KarmadaControllerManagerComponentName,
@@ -114,67 +111,57 @@ to create regular Kubernetes resources.`,
 		},
 	}
 
-	fss := cliflag.NamedFlagSets{}
-
-	genericFlagSet := fss.FlagSet("generic")
-	// Add the flag(--kubeconfig) that is added by controller-runtime
-	// (https://github.com/kubernetes-sigs/controller-runtime/blob/v0.11.1/pkg/client/config/config.go#L39),
-	// and update the flag usage.
-	genericFlagSet.AddGoFlagSet(flag.CommandLine)
-	genericFlagSet.Lookup("kubeconfig").Usage = "Path to karmada control plane kubeconfig file."
-	opts.AddFlags(genericFlagSet, controllers.ControllerNames(), sets.List(controllersDisabledByDefault))
-
-	// Set klog flags
-	logsFlagSet := fss.FlagSet("logs")
-	klogflag.Add(logsFlagSet)
+	fs := cmd.Flags()
+	namedFlagSets := opts.Flags(controllers.ControllerNames(), sets.List(controllersDisabledByDefault))
+	for _, f := range namedFlagSets.FlagSets {
+		fs.AddFlagSet(f)
+	}
 
 	cmd.AddCommand(sharedcommand.NewCmdVersion(names.KarmadaControllerManagerComponentName))
-	cmd.Flags().AddFlagSet(genericFlagSet)
-	cmd.Flags().AddFlagSet(logsFlagSet)
 
 	cols, _, _ := term.TerminalSize(cmd.OutOrStdout())
-	sharedcli.SetUsageAndHelpFunc(cmd, fss, cols)
+	sharedcli.SetUsageAndHelpFunc(cmd, namedFlagSets, cols)
 	return cmd
 }
 
 // Run runs the controller-manager with options. This should never exit.
-func Run(ctx context.Context, opts *options.Options) error {
+func Run(ctx context.Context, opts *options.KarmadaControllerManagerOptions) error {
 	klog.Infof("karmada-controller-manager version: %s", version.Get())
 
-	profileflag.ListenAndServe(opts.ProfileOpts)
+	profileflag.ListenAndServe(opts.Generic.ProfileOpts)
 
 	controlPlaneRestConfig, err := controllerruntime.GetConfig()
 	if err != nil {
 		panic(err)
 	}
-	controlPlaneRestConfig.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(opts.KubeAPIQPS, opts.KubeAPIBurst)
+	controlPlaneRestConfig.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(opts.Generic.KubeAPIQPS, opts.Generic.KubeAPIBurst)
 	controllerManager, err := controllerruntime.NewManager(controlPlaneRestConfig, controllerruntime.Options{
 		Logger:                     klog.Background(),
 		Scheme:                     gclient.NewSchema(),
-		Cache:                      cache.Options{SyncPeriod: &opts.ResyncPeriod.Duration},
-		LeaderElection:             opts.LeaderElection.LeaderElect,
-		LeaderElectionID:           opts.LeaderElection.ResourceName,
-		LeaderElectionNamespace:    opts.LeaderElection.ResourceNamespace,
-		LeaseDuration:              &opts.LeaderElection.LeaseDuration.Duration,
-		RenewDeadline:              &opts.LeaderElection.RenewDeadline.Duration,
-		RetryPeriod:                &opts.LeaderElection.RetryPeriod.Duration,
-		LeaderElectionResourceLock: opts.LeaderElection.ResourceLock,
-		HealthProbeBindAddress:     opts.HealthProbeBindAddress,
+		Cache:                      cache.Options{SyncPeriod: &opts.Generic.ResyncPeriod.Duration},
+		LeaderElection:             opts.Generic.LeaderElection.LeaderElect,
+		LeaderElectionID:           opts.Generic.LeaderElection.ResourceName,
+		LeaderElectionNamespace:    opts.Generic.LeaderElection.ResourceNamespace,
+		LeaseDuration:              &opts.Generic.LeaderElection.LeaseDuration.Duration,
+		RenewDeadline:              &opts.Generic.LeaderElection.RenewDeadline.Duration,
+		RetryPeriod:                &opts.Generic.LeaderElection.RetryPeriod.Duration,
+		LeaderElectionResourceLock: opts.Generic.LeaderElection.ResourceLock,
+		HealthProbeBindAddress:     opts.Generic.HealthProbeBindAddress,
 		LivenessEndpointName:       "/healthz",
-		Metrics:                    metricsserver.Options{BindAddress: opts.MetricsBindAddress},
+		Metrics:                    metricsserver.Options{BindAddress: opts.Generic.MetricsBindAddress},
 		MapperProvider:             restmapper.MapperProvider,
 		BaseContext: func() context.Context {
 			return ctx
 		},
 		Controller: config.Controller{
 			GroupKindConcurrency: map[string]int{
-				workv1alpha1.SchemeGroupVersion.WithKind("Work").GroupKind().String():                     opts.ConcurrentWorkSyncs,
-				workv1alpha2.SchemeGroupVersion.WithKind("ResourceBinding").GroupKind().String():          opts.ConcurrentResourceBindingSyncs,
-				workv1alpha2.SchemeGroupVersion.WithKind("ClusterResourceBinding").GroupKind().String():   opts.ConcurrentClusterResourceBindingSyncs,
-				clusterv1alpha1.SchemeGroupVersion.WithKind("Cluster").GroupKind().String():               opts.ConcurrentClusterSyncs,
-				schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}.GroupKind().String(): opts.ConcurrentNamespaceSyncs,
+				workv1alpha1.SchemeGroupVersion.WithKind("Work").GroupKind().String():                     opts.Generic.ConcurrentWorkSyncs,
+				workv1alpha2.SchemeGroupVersion.WithKind("ResourceBinding").GroupKind().String():          opts.Generic.ConcurrentResourceBindingSyncs,
+				workv1alpha2.SchemeGroupVersion.WithKind("ClusterResourceBinding").GroupKind().String():   opts.Generic.ConcurrentClusterResourceBindingSyncs,
+				clusterv1alpha1.SchemeGroupVersion.WithKind("Cluster").GroupKind().String():               opts.Generic.ConcurrentClusterSyncs,
+				schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}.GroupKind().String(): opts.Generic.ConcurrentNamespaceSyncs,
 			},
-			CacheSyncTimeout: opts.ClusterCacheSyncTimeout.Duration,
+			CacheSyncTimeout: opts.Generic.ClusterCacheSyncTimeout.Duration,
 		},
 		NewCache: func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
 			opts.DefaultTransform = fedinformer.StripUnusedFields
@@ -810,7 +797,7 @@ func startClusterTaintPolicyController(ctx controllerscontext.Context) (enabled 
 }
 
 // setupControllers initialize controllers and setup one by one.
-func setupControllers(ctx context.Context, mgr controllerruntime.Manager, opts *options.Options) {
+func setupControllers(ctx context.Context, mgr controllerruntime.Manager, opts *options.KarmadaControllerManagerOptions) {
 	restConfig := mgr.GetConfig()
 	dynamicClientSet := dynamic.NewForConfigOrDie(restConfig)
 	discoverClientSet := discovery.NewDiscoveryClientForConfigOrDie(restConfig)
@@ -818,15 +805,15 @@ func setupControllers(ctx context.Context, mgr controllerruntime.Manager, opts *
 
 	overrideManager := overridemanager.New(mgr.GetClient(), mgr.GetEventRecorderFor(overridemanager.OverrideManagerName))
 	skippedResourceConfig := util.NewSkippedResourceConfig()
-	if err := skippedResourceConfig.Parse(opts.SkippedPropagatingAPIs); err != nil {
+	if err := skippedResourceConfig.Parse(opts.Generic.SkippedPropagatingAPIs); err != nil {
 		// The program will never go here because the parameters have been checked
 		return
 	}
 
-	controlPlaneInformerManager := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClientSet, opts.ResyncPeriod.Duration)
+	controlPlaneInformerManager := genericmanager.NewSingleClusterInformerManager(ctx, dynamicClientSet, opts.Generic.ResyncPeriod.Duration)
 	// We need a service lister to build a resource interpreter with `ClusterIPServiceResolver`
 	// witch allows connection to the customized interpreter webhook without a cluster DNS service.
-	sharedFactory := informers.NewSharedInformerFactory(kubeClientSet, opts.ResyncPeriod.Duration)
+	sharedFactory := informers.NewSharedInformerFactory(kubeClientSet, opts.Generic.ResyncPeriod.Duration)
 	serviceLister := sharedFactory.Core().V1().Services().Lister()
 	sharedFactory.Start(ctx.Done())
 	sharedFactory.WaitForCacheSync(ctx.Done())
@@ -835,7 +822,7 @@ func setupControllers(ctx context.Context, mgr controllerruntime.Manager, opts *
 	if err := mgr.Add(resourceInterpreter); err != nil {
 		klog.Fatalf("Failed to setup custom resource interpreter: %v", err)
 	}
-	rateLimiterGetter := util.GetClusterRateLimiterGetter().SetDefaultLimits(opts.ClusterAPIQPS, opts.ClusterAPIBurst)
+	rateLimiterGetter := util.GetClusterRateLimiterGetter().SetDefaultLimits(opts.Generic.ClusterAPIQPS, opts.Generic.ClusterAPIBurst)
 	clusterClientOption := &util.ClientOption{RateLimiterGetter: rateLimiterGetter.GetRateLimiter}
 	objectWatcher := objectwatcher.NewObjectWatcher(mgr.GetClient(), mgr.GetRESTMapper(), util.NewClusterDynamicClientSet, clusterClientOption, resourceInterpreter)
 
@@ -847,13 +834,13 @@ func setupControllers(ctx context.Context, mgr controllerruntime.Manager, opts *
 		RESTMapper:                              mgr.GetRESTMapper(),
 		DynamicClient:                           dynamicClientSet,
 		SkippedResourceConfig:                   skippedResourceConfig,
-		SkippedPropagatingNamespaces:            opts.SkippedNamespacesRegexps(),
+		SkippedPropagatingNamespaces:            opts.Generic.SkippedNamespacesRegexps(),
 		ResourceInterpreter:                     resourceInterpreter,
 		EventRecorder:                           mgr.GetEventRecorderFor("resource-detector"),
-		ConcurrentPropagationPolicySyncs:        opts.ConcurrentPropagationPolicySyncs,
-		ConcurrentClusterPropagationPolicySyncs: opts.ConcurrentClusterPropagationPolicySyncs,
-		ConcurrentResourceTemplateSyncs:         opts.ConcurrentResourceTemplateSyncs,
-		RateLimiterOptions:                      opts.RateLimiterOpts,
+		ConcurrentPropagationPolicySyncs:        opts.Generic.ConcurrentPropagationPolicySyncs,
+		ConcurrentClusterPropagationPolicySyncs: opts.Generic.ConcurrentClusterPropagationPolicySyncs,
+		ConcurrentResourceTemplateSyncs:         opts.Generic.ConcurrentResourceTemplateSyncs,
+		RateLimiterOptions:                      opts.Generic.RateLimiterOpts,
 	}
 
 	if err := mgr.Add(resourceDetector); err != nil {
@@ -867,36 +854,36 @@ func setupControllers(ctx context.Context, mgr controllerruntime.Manager, opts *
 			ResourceInterpreter:              resourceInterpreter,
 			RESTMapper:                       mgr.GetRESTMapper(),
 			EventRecorder:                    mgr.GetEventRecorderFor("dependencies-distributor"),
-			RateLimiterOptions:               opts.RateLimiterOpts,
-			ConcurrentDependentResourceSyncs: opts.ConcurrentDependentResourceSyncs,
+			RateLimiterOptions:               opts.Generic.RateLimiterOpts,
+			ConcurrentDependentResourceSyncs: opts.Generic.ConcurrentDependentResourceSyncs,
 		}
 		if err := dependenciesDistributor.SetupWithManager(mgr); err != nil {
 			klog.Fatalf("Failed to setup dependencies distributor: %v", err)
 		}
 	}
-	setupClusterAPIClusterDetector(ctx, mgr, opts)
+	setupClusterAPIClusterDetector(ctx, mgr, opts.Generic)
 	controllerContext := controllerscontext.Context{
 		Mgr:           mgr,
 		ObjectWatcher: objectWatcher,
 		Opts: controllerscontext.Options{
-			Controllers:                       opts.Controllers,
-			ClusterMonitorPeriod:              opts.ClusterMonitorPeriod,
-			ClusterMonitorGracePeriod:         opts.ClusterMonitorGracePeriod,
-			ClusterStartupGracePeriod:         opts.ClusterStartupGracePeriod,
-			ClusterStatusUpdateFrequency:      opts.ClusterStatusUpdateFrequency,
-			FailoverEvictionTimeout:           opts.FailoverEvictionTimeout,
-			ClusterLeaseDuration:              opts.ClusterLeaseDuration,
-			ClusterLeaseRenewIntervalFraction: opts.ClusterLeaseRenewIntervalFraction,
-			ClusterSuccessThreshold:           opts.ClusterSuccessThreshold,
-			ClusterFailureThreshold:           opts.ClusterFailureThreshold,
-			ClusterCacheSyncTimeout:           opts.ClusterCacheSyncTimeout,
-			SkippedPropagatingNamespaces:      opts.SkippedNamespacesRegexps(),
-			ConcurrentWorkSyncs:               opts.ConcurrentWorkSyncs,
-			EnableTaintManager:                opts.EnableTaintManager,
-			RateLimiterOptions:                opts.RateLimiterOpts,
-			GracefulEvictionTimeout:           opts.GracefulEvictionTimeout,
-			EnableClusterResourceModeling:     opts.EnableClusterResourceModeling,
-			HPAControllerConfiguration:        opts.HPAControllerConfiguration,
+			Controllers:                       opts.Generic.Controllers,
+			ClusterMonitorPeriod:              opts.Generic.ClusterMonitorPeriod,
+			ClusterMonitorGracePeriod:         opts.Generic.ClusterMonitorGracePeriod,
+			ClusterStartupGracePeriod:         opts.Generic.ClusterStartupGracePeriod,
+			ClusterStatusUpdateFrequency:      opts.Generic.ClusterStatusUpdateFrequency,
+			FailoverEvictionTimeout:           opts.Generic.FailoverEvictionTimeout,
+			ClusterLeaseDuration:              opts.Generic.ClusterLeaseDuration,
+			ClusterLeaseRenewIntervalFraction: opts.Generic.ClusterLeaseRenewIntervalFraction,
+			ClusterSuccessThreshold:           opts.Generic.ClusterSuccessThreshold,
+			ClusterFailureThreshold:           opts.Generic.ClusterFailureThreshold,
+			ClusterCacheSyncTimeout:           opts.Generic.ClusterCacheSyncTimeout,
+			SkippedPropagatingNamespaces:      opts.Generic.SkippedNamespacesRegexps(),
+			ConcurrentWorkSyncs:               opts.Generic.ConcurrentWorkSyncs,
+			EnableTaintManager:                opts.Generic.EnableTaintManager,
+			RateLimiterOptions:                opts.Generic.RateLimiterOpts,
+			GracefulEvictionTimeout:           opts.Generic.GracefulEvictionTimeout,
+			EnableClusterResourceModeling:     opts.Generic.EnableClusterResourceModeling,
+			HPAControllerConfiguration:        opts.Generic.HPAControllerConfiguration,
 		},
 		Context:                     ctx,
 		DynamicClientSet:            dynamicClientSet,
@@ -919,7 +906,7 @@ func setupControllers(ctx context.Context, mgr controllerruntime.Manager, opts *
 }
 
 // setupClusterAPIClusterDetector initialize Cluster detector with the cluster-api management cluster.
-func setupClusterAPIClusterDetector(ctx context.Context, mgr controllerruntime.Manager, opts *options.Options) {
+func setupClusterAPIClusterDetector(ctx context.Context, mgr controllerruntime.Manager, opts *options.GenericOptions) {
 	if len(opts.ClusterAPIKubeconfig) == 0 {
 		return
 	}

--- a/cmd/controller-manager/app/options/failover.go
+++ b/cmd/controller-manager/app/options/failover.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// FailoverOptions holds the Failover configurations.
+type FailoverOptions struct {
+	// EnablePassiveMigration determines if the controller should respect NoExecute taints
+	// and enable passive pod migration.
+	EnablePassiveMigration bool
+	// NoExecutePurgeMode defines the behavior of pod eviction during passive migration.
+	// Valid modes:
+	// - "gracefully": the system will wait for workload become healthy on the new cluster.
+	// - "immediately": the system will immediately evict the legacy workload.
+	// Default: "gracefully".
+	PassiveMigrationMode string
+}
+
+// NewFailoverOptions creates a new FailoverOptions object with default parameters.
+func NewFailoverOptions() *FailoverOptions {
+	return &FailoverOptions{}
+}
+
+func (o *FailoverOptions) AddFlags(flags *pflag.FlagSet) {
+	if o == nil {
+		return
+	}
+
+	flags.BoolVar(&o.EnablePassiveMigration, "enable-passive-migration", false, "It determines if the controller should respect NoExecute taints and enable passive pod migration.")
+	flags.StringVar(&o.PassiveMigrationMode, "passive-migration-mode", "gracefully", "It defines the behavior of workload eviction during passive migration. Valid modes: \"gracefully\" and \"immediately\".")
+
+}
+
+// Validate checks FailoverOptions and return a slice of found errs.
+func (o *FailoverOptions) Validate() field.ErrorList {
+	errs := field.ErrorList{}
+	return errs
+}

--- a/cmd/controller-manager/app/options/generic.go
+++ b/cmd/controller-manager/app/options/generic.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2020 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	componentbaseconfig "k8s.io/component-base/config"
+
+	"github.com/karmada-io/karmada/pkg/controllers/federatedhpa/config"
+	"github.com/karmada-io/karmada/pkg/features"
+	"github.com/karmada-io/karmada/pkg/sharedcli/profileflag"
+	"github.com/karmada-io/karmada/pkg/sharedcli/ratelimiterflag"
+	"github.com/karmada-io/karmada/pkg/util"
+	"github.com/karmada-io/karmada/pkg/util/names"
+)
+
+var (
+	defaultElectionLeaseDuration = metav1.Duration{Duration: 15 * time.Second}
+	defaultElectionRenewDeadline = metav1.Duration{Duration: 10 * time.Second}
+	defaultElectionRetryPeriod   = metav1.Duration{Duration: 2 * time.Second}
+)
+
+// GenericOptions holds the options which are generic.
+type GenericOptions struct {
+	// Controllers is the list of controllers to enable or disable
+	// '*' means "all enabled by default controllers"
+	// 'foo' means "enable 'foo'"
+	// '-foo' means "disable 'foo'"
+	// first item for a particular name wins
+	Controllers []string
+	// LeaderElection defines the configuration of leader election client.
+	LeaderElection componentbaseconfig.LeaderElectionConfiguration
+	// ClusterStatusUpdateFrequency is the frequency that controller computes and report cluster status.
+	// It must work with ClusterMonitorGracePeriod(--cluster-monitor-grace-period) in karmada-controller-manager.
+	ClusterStatusUpdateFrequency metav1.Duration
+	// FailoverEvictionTimeout is the grace period for deleting scheduling result on failed clusters.
+	FailoverEvictionTimeout metav1.Duration
+	// ClusterLeaseDuration is a duration that candidates for a lease need to wait to force acquire it.
+	// This is measure against time of last observed lease RenewTime.
+	ClusterLeaseDuration metav1.Duration
+	// ClusterLeaseRenewIntervalFraction is a fraction coordinated with ClusterLeaseDuration that
+	// how long the current holder of a lease has last updated the lease.
+	ClusterLeaseRenewIntervalFraction float64
+	// ClusterSuccessThreshold is the duration of successes for the cluster to be considered healthy after recovery.
+	ClusterSuccessThreshold metav1.Duration
+	// ClusterFailureThreshold is the duration of failure for the cluster to be considered unhealthy.
+	ClusterFailureThreshold metav1.Duration
+	// ClusterMonitorPeriod represents cluster-controller monitoring period, i.e. how often does
+	// cluster-controller check cluster health signal posted from cluster-status-controller.
+	// This value should be lower than ClusterMonitorGracePeriod.
+	ClusterMonitorPeriod metav1.Duration
+	// ClusterMonitorGracePeriod represents the grace period after last cluster health probe time.
+	// If it doesn't receive update for this amount of time, it will start posting
+	// "ClusterReady==ConditionUnknown".
+	ClusterMonitorGracePeriod metav1.Duration
+	// When cluster is just created, e.g. agent bootstrap or cluster join, we give a longer grace period.
+	ClusterStartupGracePeriod metav1.Duration
+	// SkippedPropagatingAPIs indicates comma separated resources that should be skipped for propagating.
+	SkippedPropagatingAPIs string
+	// SkippedPropagatingNamespaces is a list of namespaces that will be skipped for propagating.
+	SkippedPropagatingNamespaces []string
+	// ClusterAPIContext is the name of the cluster context in cluster-api management cluster KUBECONFIG file.
+	// Default value is the current-context.
+	ClusterAPIContext string
+	// ClusterAPIKubeconfig holds the cluster-api management cluster KUBECONFIG file path.
+	ClusterAPIKubeconfig string
+	// ClusterAPIQPS is the QPS to use while talking with cluster kube-apiserver.
+	ClusterAPIQPS float32
+	// ClusterAPIBurst is the burst to allow while talking with cluster kube-apiserver.
+	ClusterAPIBurst int
+	// KubeAPIQPS is the QPS to use while talking with karmada-apiserver.
+	KubeAPIQPS float32
+	// KubeAPIBurst is the burst to allow while talking with karmada-apiserver.
+	KubeAPIBurst int
+	// ClusterCacheSyncTimeout is the timeout period waiting for cluster cache to sync
+	ClusterCacheSyncTimeout metav1.Duration
+	// ResyncPeriod is the base frequency the informers are resynced.
+	// Defaults to 0, which means the created informer will never do resyncs.
+	ResyncPeriod metav1.Duration
+	// MetricsBindAddress is the TCP address that the controller should bind to
+	// for serving prometheus metrics.
+	// It can be set to "0" to disable the metrics serving.
+	// Defaults to ":8080".
+	MetricsBindAddress string
+	// HealthProbeBindAddress is the TCP address that the controller should bind to
+	// for serving health probes
+	// It can be set to "0" to disable serving the health probe.
+	// Defaults to ":10357".
+	HealthProbeBindAddress string
+	// ConcurrentClusterSyncs is the number of cluster objects that are
+	// allowed to sync concurrently.
+	ConcurrentClusterSyncs int
+	// ConcurrentClusterResourceBindingSyncs is the number of clusterresourcebinding objects that are
+	// allowed to sync concurrently.
+	ConcurrentClusterResourceBindingSyncs int
+	// ConcurrentWorkSyncs is the number of Work objects that are
+	// allowed to sync concurrently.
+	ConcurrentWorkSyncs int
+	// ConcurrentResourceBindingSyncs is the number of resourcebinding objects that are
+	// allowed to sync concurrently.
+	ConcurrentResourceBindingSyncs int
+	// ConcurrentNamespaceSyncs is the number of Namespace objects that are
+	// allowed to sync concurrently.
+	ConcurrentNamespaceSyncs int
+	// ConcurrentPropagationPolicySyncs is the number of PropagationPolicy that are allowed to sync concurrently.
+	ConcurrentPropagationPolicySyncs int
+	// ConcurrentClusterPropagationPolicySyncs is the number of ClusterPropagationPolicy that are allowed to sync concurrently.
+	ConcurrentClusterPropagationPolicySyncs int
+	// ConcurrentResourceTemplateSyncs is the number of resource templates that are allowed to sync concurrently.
+	ConcurrentResourceTemplateSyncs int
+	// ConcurrentDependentResourceSyncs is the number of dependent resource that are allowed to sync concurrently.
+	ConcurrentDependentResourceSyncs int
+	// If set to true enables NoExecute Taints and will evict all not-tolerating
+	// objects propagating on Clusters tainted with this kind of Taints.
+	EnableTaintManager bool
+	// GracefulEvictionTimeout is the timeout period waiting for the grace-eviction-controller performs the final
+	// removal since the workload(resource) has been moved to the graceful eviction tasks.
+	GracefulEvictionTimeout metav1.Duration
+
+	RateLimiterOpts            ratelimiterflag.Options
+	ProfileOpts                profileflag.Options
+	HPAControllerConfiguration config.HPAControllerConfiguration
+	// EnableClusterResourceModeling indicates if enable cluster resource modeling.
+	// The resource modeling might be used by the scheduler to make scheduling decisions
+	// in scenario of dynamic replica assignment based on cluster free resources.
+	// Disable if it does not fit your cases for better performance.
+	EnableClusterResourceModeling bool
+}
+
+// NewGenericOptions returns generic configuration default values for karmada-controller-manager.
+// And common changes should be made here.
+func NewGenericOptions() *GenericOptions {
+	return &GenericOptions{
+		LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
+			LeaderElect:       true,
+			ResourceLock:      resourcelock.LeasesResourceLock,
+			ResourceNamespace: names.NamespaceKarmadaSystem,
+			ResourceName:      names.KarmadaControllerManagerComponentName,
+		},
+	}
+}
+
+// AddFlags adds flags to the specified FlagSet.
+func (o *GenericOptions) AddFlags(flags *pflag.FlagSet, allControllers, disabledByDefaultControllers []string) {
+	flags.StringSliceVar(&o.Controllers, "controllers", []string{"*"}, fmt.Sprintf(
+		"A list of controllers to enable. '*' enables all on-by-default controllers, 'foo' enables the controller named 'foo', '-foo' disables the controller named 'foo'. \nAll controllers: %s.\nDisabled-by-default controllers: %s",
+		strings.Join(allControllers, ", "), strings.Join(disabledByDefaultControllers, ", "),
+	))
+	flags.DurationVar(&o.ClusterStatusUpdateFrequency.Duration, "cluster-status-update-frequency", 10*time.Second,
+		"Specifies how often karmada-controller-manager posts cluster status to karmada-apiserver.")
+	flags.BoolVar(&o.LeaderElection.LeaderElect, "leader-elect", true, "Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.")
+	flags.StringVar(&o.LeaderElection.ResourceNamespace, "leader-elect-resource-namespace", names.NamespaceKarmadaSystem, "The namespace of resource object that is used for locking during leader election.")
+	flags.DurationVar(&o.LeaderElection.LeaseDuration.Duration, "leader-elect-lease-duration", defaultElectionLeaseDuration.Duration, ""+
+		"The duration that non-leader candidates will wait after observing a leadership "+
+		"renewal until attempting to acquire leadership of a led but unrenewed leader "+
+		"slot. This is effectively the maximum duration that a leader can be stopped "+
+		"before it is replaced by another candidate. This is only applicable if leader "+
+		"election is enabled.")
+	flags.DurationVar(&o.LeaderElection.RenewDeadline.Duration, "leader-elect-renew-deadline", defaultElectionRenewDeadline.Duration, ""+
+		"The interval between attempts by the acting master to renew a leadership slot "+
+		"before it stops leading. This must be less than or equal to the lease duration. "+
+		"This is only applicable if leader election is enabled.")
+	flags.DurationVar(&o.LeaderElection.RetryPeriod.Duration, "leader-elect-retry-period", defaultElectionRetryPeriod.Duration, ""+
+		"The duration the clients should wait between attempting acquisition and renewal "+
+		"of a leadership. This is only applicable if leader election is enabled.")
+	flags.DurationVar(&o.ClusterLeaseDuration.Duration, "cluster-lease-duration", 40*time.Second,
+		"Specifies the expiration period of a cluster lease.")
+	flags.Float64Var(&o.ClusterLeaseRenewIntervalFraction, "cluster-lease-renew-interval-fraction", 0.25,
+		"Specifies the cluster lease renew interval fraction.")
+	flags.DurationVar(&o.ClusterSuccessThreshold.Duration, "cluster-success-threshold", 30*time.Second, "The duration of successes for the cluster to be considered healthy after recovery.")
+	flags.DurationVar(&o.ClusterFailureThreshold.Duration, "cluster-failure-threshold", 30*time.Second, "The duration of failure for the cluster to be considered unhealthy.")
+	flags.DurationVar(&o.ClusterMonitorPeriod.Duration, "cluster-monitor-period", 5*time.Second,
+		"Specifies how often karmada-controller-manager monitors cluster health status.")
+	flags.DurationVar(&o.ClusterMonitorGracePeriod.Duration, "cluster-monitor-grace-period", 40*time.Second,
+		"Specifies the grace period of allowing a running cluster to be unresponsive before marking it unhealthy.")
+	flags.DurationVar(&o.ClusterStartupGracePeriod.Duration, "cluster-startup-grace-period", 60*time.Second,
+		"Specifies the grace period of allowing a cluster to be unresponsive during startup before marking it unhealthy.")
+	flags.DurationVar(&o.FailoverEvictionTimeout.Duration, "failover-eviction-timeout", 5*time.Minute,
+		"Specifies the grace period for deleting scheduling result on failed clusters.")
+	flags.StringVar(&o.SkippedPropagatingAPIs, "skipped-propagating-apis", "", "Semicolon separated resources that should be skipped from propagating in addition to the default skip list(cluster.karmada.io;policy.karmada.io;work.karmada.io). Supported formats are:\n"+
+		"<group> for skip resources with a specific API group(e.g. networking.k8s.io),\n"+
+		"<group>/<version> for skip resources with a specific API version(e.g. networking.k8s.io/v1beta1),\n"+
+		"<group>/<version>/<kind>,<kind> for skip one or more specific resource(e.g. networking.k8s.io/v1beta1/Ingress,IngressClass) where the kinds are case-insensitive.")
+	flags.StringSliceVar(&o.SkippedPropagatingNamespaces, "skipped-propagating-namespaces", []string{"kube-.*"},
+		"Comma-separated namespaces that should be skipped from propagating.\n"+
+			"Note: 'karmada-system', 'karmada-cluster' and 'karmada-es-.*' are Karmada reserved namespaces that will always be skipped.")
+	flags.StringVar(&o.ClusterAPIContext, "cluster-api-context", "", "Name of the cluster context in cluster-api management cluster kubeconfig file.")
+	flags.StringVar(&o.ClusterAPIKubeconfig, "cluster-api-kubeconfig", "", "Path to the cluster-api management cluster kubeconfig file.")
+	flags.Float32Var(&o.ClusterAPIQPS, "cluster-api-qps", 40.0, "QPS to use while talking with cluster kube-apiserver.")
+	flags.IntVar(&o.ClusterAPIBurst, "cluster-api-burst", 60, "Burst to use while talking with cluster kube-apiserver.")
+	flags.Float32Var(&o.KubeAPIQPS, "kube-api-qps", 40.0, "QPS to use while talking with karmada-apiserver.")
+	flags.IntVar(&o.KubeAPIBurst, "kube-api-burst", 60, "Burst to use while talking with karmada-apiserver.")
+	flags.DurationVar(&o.ClusterCacheSyncTimeout.Duration, "cluster-cache-sync-timeout", util.CacheSyncTimeout, "Timeout period waiting for cluster cache to sync.")
+	flags.DurationVar(&o.ResyncPeriod.Duration, "resync-period", 0, "Base frequency the informers are resynced.")
+	flags.StringVar(&o.MetricsBindAddress, "metrics-bind-address", ":8080", "The TCP address that the controller should bind to for serving prometheus metrics(e.g. 127.0.0.1:8080, :8080). It can be set to \"0\" to disable the metrics serving.")
+	flags.StringVar(&o.HealthProbeBindAddress, "health-probe-bind-address", ":10357", "The TCP address that the controller should bind to for serving health probes(e.g. 127.0.0.1:10357, :10357). It can be set to \"0\" to disable serving the health probe. Defaults to 0.0.0.0:10357.")
+	flags.IntVar(&o.ConcurrentClusterSyncs, "concurrent-cluster-syncs", 5, "The number of Clusters that are allowed to sync concurrently.")
+	flags.IntVar(&o.ConcurrentClusterResourceBindingSyncs, "concurrent-clusterresourcebinding-syncs", 5, "The number of ClusterResourceBindings that are allowed to sync concurrently.")
+	flags.IntVar(&o.ConcurrentResourceBindingSyncs, "concurrent-resourcebinding-syncs", 5, "The number of ResourceBindings that are allowed to sync concurrently.")
+	flags.IntVar(&o.ConcurrentWorkSyncs, "concurrent-work-syncs", 5, "The number of Works that are allowed to sync concurrently.")
+	flags.IntVar(&o.ConcurrentNamespaceSyncs, "concurrent-namespace-syncs", 1, "The number of Namespaces that are allowed to sync concurrently.")
+	flags.IntVar(&o.ConcurrentPropagationPolicySyncs, "concurrent-propagation-policy-syncs", 1, "The number of PropagationPolicy that are allowed to sync concurrently.")
+	flags.IntVar(&o.ConcurrentClusterPropagationPolicySyncs, "concurrent-cluster-propagation-policy-syncs", 1, "The number of ClusterPropagationPolicy that are allowed to sync concurrently.")
+	flags.IntVar(&o.ConcurrentResourceTemplateSyncs, "concurrent-resource-template-syncs", 5, "The number of resource templates that are allowed to sync concurrently.")
+	flags.IntVar(&o.ConcurrentDependentResourceSyncs, "concurrent-dependent-resource-syncs", 2, "The number of dependent resource that are allowed to sync concurrently.")
+	flags.BoolVar(&o.EnableTaintManager, "enable-taint-manager", true, "If set to true enables NoExecute Taints and will evict all not-tolerating objects propagating on Clusters tainted with this kind of Taints.")
+	flags.DurationVar(&o.GracefulEvictionTimeout.Duration, "graceful-eviction-timeout", 10*time.Minute, "Specifies the timeout period waiting for the graceful-eviction-controller performs the final removal since the workload(resource) has been moved to the graceful eviction tasks.")
+	flags.BoolVar(&o.EnableClusterResourceModeling, "enable-cluster-resource-modeling", true, "Enable means controller would build resource modeling for each cluster by syncing Nodes and Pods resources.\n"+
+		"The resource modeling might be used by the scheduler to make scheduling decisions in scenario of dynamic replica assignment based on cluster free resources.\n"+
+		"Disable if it does not fit your cases for better performance.")
+
+	o.RateLimiterOpts.AddFlags(flags)
+	o.ProfileOpts.AddFlags(flags)
+	o.HPAControllerConfiguration.AddFlags(flags)
+	features.FeatureGate.AddFlag(flags)
+}
+
+// SkippedNamespacesRegexps precompiled regular expressions
+func (o *GenericOptions) SkippedNamespacesRegexps() []*regexp.Regexp {
+	skippedPropagatingNamespaces := make([]*regexp.Regexp, len(o.SkippedPropagatingNamespaces))
+	for index, ns := range o.SkippedPropagatingNamespaces {
+		skippedPropagatingNamespaces[index] = regexp.MustCompile(fmt.Sprintf("^%s$", ns))
+	}
+	return skippedPropagatingNamespaces
+}

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Karmada Authors.
+Copyright 2025 The Karmada Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,232 +14,57 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package options provides the flags for the karmada-controller-manager.
 package options
 
 import (
-	"fmt"
-	"regexp"
-	"strings"
-	"time"
+	"flag"
 
-	"github.com/spf13/pflag"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/leaderelection/resourcelock"
-	componentbaseconfig "k8s.io/component-base/config"
-
-	"github.com/karmada-io/karmada/pkg/controllers/federatedhpa/config"
-	"github.com/karmada-io/karmada/pkg/features"
-	"github.com/karmada-io/karmada/pkg/sharedcli/profileflag"
-	"github.com/karmada-io/karmada/pkg/sharedcli/ratelimiterflag"
-	"github.com/karmada-io/karmada/pkg/util"
-	"github.com/karmada-io/karmada/pkg/util/names"
+	"github.com/karmada-io/karmada/pkg/sharedcli/klogflag"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	cliflag "k8s.io/component-base/cli/flag"
 )
 
-var (
-	defaultElectionLeaseDuration = metav1.Duration{Duration: 15 * time.Second}
-	defaultElectionRenewDeadline = metav1.Duration{Duration: 10 * time.Second}
-	defaultElectionRetryPeriod   = metav1.Duration{Duration: 2 * time.Second}
-)
+// KarmadaControllerManagerOptions is the main context object for the karmada-controller-manager.
+type KarmadaControllerManagerOptions struct {
+	Generic *GenericOptions
 
-// Options contains everything necessary to create and run controller-manager.
-type Options struct {
-	// Controllers is the list of controllers to enable or disable
-	// '*' means "all enabled by default controllers"
-	// 'foo' means "enable 'foo'"
-	// '-foo' means "disable 'foo'"
-	// first item for a particular name wins
-	Controllers []string
-	// LeaderElection defines the configuration of leader election client.
-	LeaderElection componentbaseconfig.LeaderElectionConfiguration
-	// ClusterStatusUpdateFrequency is the frequency that controller computes and report cluster status.
-	// It must work with ClusterMonitorGracePeriod(--cluster-monitor-grace-period) in karmada-controller-manager.
-	ClusterStatusUpdateFrequency metav1.Duration
-	// FailoverEvictionTimeout is the grace period for deleting scheduling result on failed clusters.
-	FailoverEvictionTimeout metav1.Duration
-	// ClusterLeaseDuration is a duration that candidates for a lease need to wait to force acquire it.
-	// This is measure against time of last observed lease RenewTime.
-	ClusterLeaseDuration metav1.Duration
-	// ClusterLeaseRenewIntervalFraction is a fraction coordinated with ClusterLeaseDuration that
-	// how long the current holder of a lease has last updated the lease.
-	ClusterLeaseRenewIntervalFraction float64
-	// ClusterSuccessThreshold is the duration of successes for the cluster to be considered healthy after recovery.
-	ClusterSuccessThreshold metav1.Duration
-	// ClusterFailureThreshold is the duration of failure for the cluster to be considered unhealthy.
-	ClusterFailureThreshold metav1.Duration
-	// ClusterMonitorPeriod represents cluster-controller monitoring period, i.e. how often does
-	// cluster-controller check cluster health signal posted from cluster-status-controller.
-	// This value should be lower than ClusterMonitorGracePeriod.
-	ClusterMonitorPeriod metav1.Duration
-	// ClusterMonitorGracePeriod represents the grace period after last cluster health probe time.
-	// If it doesn't receive update for this amount of time, it will start posting
-	// "ClusterReady==ConditionUnknown".
-	ClusterMonitorGracePeriod metav1.Duration
-	// When cluster is just created, e.g. agent bootstrap or cluster join, we give a longer grace period.
-	ClusterStartupGracePeriod metav1.Duration
-	// SkippedPropagatingAPIs indicates comma separated resources that should be skipped for propagating.
-	SkippedPropagatingAPIs string
-	// SkippedPropagatingNamespaces is a list of namespaces that will be skipped for propagating.
-	SkippedPropagatingNamespaces []string
-	// ClusterAPIContext is the name of the cluster context in cluster-api management cluster KUBECONFIG file.
-	// Default value is the current-context.
-	ClusterAPIContext string
-	// ClusterAPIKubeconfig holds the cluster-api management cluster KUBECONFIG file path.
-	ClusterAPIKubeconfig string
-	// ClusterAPIQPS is the QPS to use while talking with cluster kube-apiserver.
-	ClusterAPIQPS float32
-	// ClusterAPIBurst is the burst to allow while talking with cluster kube-apiserver.
-	ClusterAPIBurst int
-	// KubeAPIQPS is the QPS to use while talking with karmada-apiserver.
-	KubeAPIQPS float32
-	// KubeAPIBurst is the burst to allow while talking with karmada-apiserver.
-	KubeAPIBurst int
-	// ClusterCacheSyncTimeout is the timeout period waiting for cluster cache to sync
-	ClusterCacheSyncTimeout metav1.Duration
-	// ResyncPeriod is the base frequency the informers are resynced.
-	// Defaults to 0, which means the created informer will never do resyncs.
-	ResyncPeriod metav1.Duration
-	// MetricsBindAddress is the TCP address that the controller should bind to
-	// for serving prometheus metrics.
-	// It can be set to "0" to disable the metrics serving.
-	// Defaults to ":8080".
-	MetricsBindAddress string
-	// HealthProbeBindAddress is the TCP address that the controller should bind to
-	// for serving health probes
-	// It can be set to "0" to disable serving the health probe.
-	// Defaults to ":10357".
-	HealthProbeBindAddress string
-	// ConcurrentClusterSyncs is the number of cluster objects that are
-	// allowed to sync concurrently.
-	ConcurrentClusterSyncs int
-	// ConcurrentClusterResourceBindingSyncs is the number of clusterresourcebinding objects that are
-	// allowed to sync concurrently.
-	ConcurrentClusterResourceBindingSyncs int
-	// ConcurrentWorkSyncs is the number of Work objects that are
-	// allowed to sync concurrently.
-	ConcurrentWorkSyncs int
-	// ConcurrentResourceBindingSyncs is the number of resourcebinding objects that are
-	// allowed to sync concurrently.
-	ConcurrentResourceBindingSyncs int
-	// ConcurrentNamespaceSyncs is the number of Namespace objects that are
-	// allowed to sync concurrently.
-	ConcurrentNamespaceSyncs int
-	// ConcurrentPropagationPolicySyncs is the number of PropagationPolicy that are allowed to sync concurrently.
-	ConcurrentPropagationPolicySyncs int
-	// ConcurrentClusterPropagationPolicySyncs is the number of ClusterPropagationPolicy that are allowed to sync concurrently.
-	ConcurrentClusterPropagationPolicySyncs int
-	// ConcurrentResourceTemplateSyncs is the number of resource templates that are allowed to sync concurrently.
-	ConcurrentResourceTemplateSyncs int
-	// ConcurrentDependentResourceSyncs is the number of dependent resource that are allowed to sync concurrently.
-	ConcurrentDependentResourceSyncs int
-	// If set to true enables NoExecute Taints and will evict all not-tolerating
-	// objects propagating on Clusters tainted with this kind of Taints.
-	EnableTaintManager bool
-	// GracefulEvictionTimeout is the timeout period waiting for the grace-eviction-controller performs the final
-	// removal since the workload(resource) has been moved to the graceful eviction tasks.
-	GracefulEvictionTimeout metav1.Duration
-
-	RateLimiterOpts            ratelimiterflag.Options
-	ProfileOpts                profileflag.Options
-	HPAControllerConfiguration config.HPAControllerConfiguration
-	// EnableClusterResourceModeling indicates if enable cluster resource modeling.
-	// The resource modeling might be used by the scheduler to make scheduling decisions
-	// in scenario of dynamic replica assignment based on cluster free resources.
-	// Disable if it does not fit your cases for better performance.
-	EnableClusterResourceModeling bool
+	Failover *FailoverOptions
 }
 
-// NewOptions builds an empty options.
-func NewOptions() *Options {
-	return &Options{
-		LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
-			LeaderElect:       true,
-			ResourceLock:      resourcelock.LeasesResourceLock,
-			ResourceNamespace: names.NamespaceKarmadaSystem,
-			ResourceName:      names.KarmadaControllerManagerComponentName,
-		},
+// NewKarmadaControllerManagerOptions creates a new KarmadaControllerManagerOptions object with default parameters.
+func NewKarmadaControllerManagerOptions() *KarmadaControllerManagerOptions {
+	return &KarmadaControllerManagerOptions{
+		Generic:  NewGenericOptions(),
+		Failover: NewFailoverOptions(),
 	}
 }
 
-// AddFlags adds flags to the specified FlagSet.
-func (o *Options) AddFlags(flags *pflag.FlagSet, allControllers, disabledByDefaultControllers []string) {
-	flags.StringSliceVar(&o.Controllers, "controllers", []string{"*"}, fmt.Sprintf(
-		"A list of controllers to enable. '*' enables all on-by-default controllers, 'foo' enables the controller named 'foo', '-foo' disables the controller named 'foo'. \nAll controllers: %s.\nDisabled-by-default controllers: %s",
-		strings.Join(allControllers, ", "), strings.Join(disabledByDefaultControllers, ", "),
-	))
-	flags.DurationVar(&o.ClusterStatusUpdateFrequency.Duration, "cluster-status-update-frequency", 10*time.Second,
-		"Specifies how often karmada-controller-manager posts cluster status to karmada-apiserver.")
-	flags.BoolVar(&o.LeaderElection.LeaderElect, "leader-elect", true, "Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.")
-	flags.StringVar(&o.LeaderElection.ResourceNamespace, "leader-elect-resource-namespace", names.NamespaceKarmadaSystem, "The namespace of resource object that is used for locking during leader election.")
-	flags.DurationVar(&o.LeaderElection.LeaseDuration.Duration, "leader-elect-lease-duration", defaultElectionLeaseDuration.Duration, ""+
-		"The duration that non-leader candidates will wait after observing a leadership "+
-		"renewal until attempting to acquire leadership of a led but unrenewed leader "+
-		"slot. This is effectively the maximum duration that a leader can be stopped "+
-		"before it is replaced by another candidate. This is only applicable if leader "+
-		"election is enabled.")
-	flags.DurationVar(&o.LeaderElection.RenewDeadline.Duration, "leader-elect-renew-deadline", defaultElectionRenewDeadline.Duration, ""+
-		"The interval between attempts by the acting master to renew a leadership slot "+
-		"before it stops leading. This must be less than or equal to the lease duration. "+
-		"This is only applicable if leader election is enabled.")
-	flags.DurationVar(&o.LeaderElection.RetryPeriod.Duration, "leader-elect-retry-period", defaultElectionRetryPeriod.Duration, ""+
-		"The duration the clients should wait between attempting acquisition and renewal "+
-		"of a leadership. This is only applicable if leader election is enabled.")
-	flags.DurationVar(&o.ClusterLeaseDuration.Duration, "cluster-lease-duration", 40*time.Second,
-		"Specifies the expiration period of a cluster lease.")
-	flags.Float64Var(&o.ClusterLeaseRenewIntervalFraction, "cluster-lease-renew-interval-fraction", 0.25,
-		"Specifies the cluster lease renew interval fraction.")
-	flags.DurationVar(&o.ClusterSuccessThreshold.Duration, "cluster-success-threshold", 30*time.Second, "The duration of successes for the cluster to be considered healthy after recovery.")
-	flags.DurationVar(&o.ClusterFailureThreshold.Duration, "cluster-failure-threshold", 30*time.Second, "The duration of failure for the cluster to be considered unhealthy.")
-	flags.DurationVar(&o.ClusterMonitorPeriod.Duration, "cluster-monitor-period", 5*time.Second,
-		"Specifies how often karmada-controller-manager monitors cluster health status.")
-	flags.DurationVar(&o.ClusterMonitorGracePeriod.Duration, "cluster-monitor-grace-period", 40*time.Second,
-		"Specifies the grace period of allowing a running cluster to be unresponsive before marking it unhealthy.")
-	flags.DurationVar(&o.ClusterStartupGracePeriod.Duration, "cluster-startup-grace-period", 60*time.Second,
-		"Specifies the grace period of allowing a cluster to be unresponsive during startup before marking it unhealthy.")
-	flags.DurationVar(&o.FailoverEvictionTimeout.Duration, "failover-eviction-timeout", 5*time.Minute,
-		"Specifies the grace period for deleting scheduling result on failed clusters.")
-	flags.StringVar(&o.SkippedPropagatingAPIs, "skipped-propagating-apis", "", "Semicolon separated resources that should be skipped from propagating in addition to the default skip list(cluster.karmada.io;policy.karmada.io;work.karmada.io). Supported formats are:\n"+
-		"<group> for skip resources with a specific API group(e.g. networking.k8s.io),\n"+
-		"<group>/<version> for skip resources with a specific API version(e.g. networking.k8s.io/v1beta1),\n"+
-		"<group>/<version>/<kind>,<kind> for skip one or more specific resource(e.g. networking.k8s.io/v1beta1/Ingress,IngressClass) where the kinds are case-insensitive.")
-	flags.StringSliceVar(&o.SkippedPropagatingNamespaces, "skipped-propagating-namespaces", []string{"kube-.*"},
-		"Comma-separated namespaces that should be skipped from propagating.\n"+
-			"Note: 'karmada-system', 'karmada-cluster' and 'karmada-es-.*' are Karmada reserved namespaces that will always be skipped.")
-	flags.StringVar(&o.ClusterAPIContext, "cluster-api-context", "", "Name of the cluster context in cluster-api management cluster kubeconfig file.")
-	flags.StringVar(&o.ClusterAPIKubeconfig, "cluster-api-kubeconfig", "", "Path to the cluster-api management cluster kubeconfig file.")
-	flags.Float32Var(&o.ClusterAPIQPS, "cluster-api-qps", 40.0, "QPS to use while talking with cluster kube-apiserver.")
-	flags.IntVar(&o.ClusterAPIBurst, "cluster-api-burst", 60, "Burst to use while talking with cluster kube-apiserver.")
-	flags.Float32Var(&o.KubeAPIQPS, "kube-api-qps", 40.0, "QPS to use while talking with karmada-apiserver.")
-	flags.IntVar(&o.KubeAPIBurst, "kube-api-burst", 60, "Burst to use while talking with karmada-apiserver.")
-	flags.DurationVar(&o.ClusterCacheSyncTimeout.Duration, "cluster-cache-sync-timeout", util.CacheSyncTimeout, "Timeout period waiting for cluster cache to sync.")
-	flags.DurationVar(&o.ResyncPeriod.Duration, "resync-period", 0, "Base frequency the informers are resynced.")
-	flags.StringVar(&o.MetricsBindAddress, "metrics-bind-address", ":8080", "The TCP address that the controller should bind to for serving prometheus metrics(e.g. 127.0.0.1:8080, :8080). It can be set to \"0\" to disable the metrics serving.")
-	flags.StringVar(&o.HealthProbeBindAddress, "health-probe-bind-address", ":10357", "The TCP address that the controller should bind to for serving health probes(e.g. 127.0.0.1:10357, :10357). It can be set to \"0\" to disable serving the health probe. Defaults to 0.0.0.0:10357.")
-	flags.IntVar(&o.ConcurrentClusterSyncs, "concurrent-cluster-syncs", 5, "The number of Clusters that are allowed to sync concurrently.")
-	flags.IntVar(&o.ConcurrentClusterResourceBindingSyncs, "concurrent-clusterresourcebinding-syncs", 5, "The number of ClusterResourceBindings that are allowed to sync concurrently.")
-	flags.IntVar(&o.ConcurrentResourceBindingSyncs, "concurrent-resourcebinding-syncs", 5, "The number of ResourceBindings that are allowed to sync concurrently.")
-	flags.IntVar(&o.ConcurrentWorkSyncs, "concurrent-work-syncs", 5, "The number of Works that are allowed to sync concurrently.")
-	flags.IntVar(&o.ConcurrentNamespaceSyncs, "concurrent-namespace-syncs", 1, "The number of Namespaces that are allowed to sync concurrently.")
-	flags.IntVar(&o.ConcurrentPropagationPolicySyncs, "concurrent-propagation-policy-syncs", 1, "The number of PropagationPolicy that are allowed to sync concurrently.")
-	flags.IntVar(&o.ConcurrentClusterPropagationPolicySyncs, "concurrent-cluster-propagation-policy-syncs", 1, "The number of ClusterPropagationPolicy that are allowed to sync concurrently.")
-	flags.IntVar(&o.ConcurrentResourceTemplateSyncs, "concurrent-resource-template-syncs", 5, "The number of resource templates that are allowed to sync concurrently.")
-	flags.IntVar(&o.ConcurrentDependentResourceSyncs, "concurrent-dependent-resource-syncs", 2, "The number of dependent resource that are allowed to sync concurrently.")
-	flags.BoolVar(&o.EnableTaintManager, "enable-taint-manager", true, "If set to true enables NoExecute Taints and will evict all not-tolerating objects propagating on Clusters tainted with this kind of Taints.")
-	flags.DurationVar(&o.GracefulEvictionTimeout.Duration, "graceful-eviction-timeout", 10*time.Minute, "Specifies the timeout period waiting for the graceful-eviction-controller performs the final removal since the workload(resource) has been moved to the graceful eviction tasks.")
-	flags.BoolVar(&o.EnableClusterResourceModeling, "enable-cluster-resource-modeling", true, "Enable means controller would build resource modeling for each cluster by syncing Nodes and Pods resources.\n"+
-		"The resource modeling might be used by the scheduler to make scheduling decisions in scenario of dynamic replica assignment based on cluster free resources.\n"+
-		"Disable if it does not fit your cases for better performance.")
+// Flags returns flags for a specific KarmadaControllerManager by section name.
+func (s *KarmadaControllerManagerOptions) Flags(allControllers, disabledByDefaultControllers []string) cliflag.NamedFlagSets {
+	fss := cliflag.NamedFlagSets{}
 
-	o.RateLimiterOpts.AddFlags(flags)
-	o.ProfileOpts.AddFlags(flags)
-	o.HPAControllerConfiguration.AddFlags(flags)
-	features.FeatureGate.AddFlag(flags)
+	// Set generic flags
+	genericFlagSet := fss.FlagSet("generic")
+	// Add the flag(--kubeconfig) that is added by controller-runtime
+	// (https://github.com/kubernetes-sigs/controller-runtime/blob/v0.11.1/pkg/client/config/config.go#L39),
+	// and update the flag usage.
+	genericFlagSet.AddGoFlagSet(flag.CommandLine)
+	genericFlagSet.Lookup("kubeconfig").Usage = "Path to karmada control plane kubeconfig file."
+	s.Generic.AddFlags(genericFlagSet, allControllers, disabledByDefaultControllers)
+
+	s.Failover.AddFlags(fss.FlagSet("failover"))
+
+	// Set klog flags
+	klogflag.Add(fss.FlagSet("logs"))
+
+	return fss
 }
 
-// SkippedNamespacesRegexps precompiled regular expressions
-func (o *Options) SkippedNamespacesRegexps() []*regexp.Regexp {
-	skippedPropagatingNamespaces := make([]*regexp.Regexp, len(o.SkippedPropagatingNamespaces))
-	for index, ns := range o.SkippedPropagatingNamespaces {
-		skippedPropagatingNamespaces[index] = regexp.MustCompile(fmt.Sprintf("^%s$", ns))
-	}
-	return skippedPropagatingNamespaces
+// Validate checks Options and return a slice of found errs.
+func (o *KarmadaControllerManagerOptions) Validate() field.ErrorList {
+	errs := field.ErrorList{}
+	errs = append(errs, o.Generic.Validate()...)
+	errs = append(errs, o.Failover.Validate()...)
+	return errs
 }

--- a/cmd/controller-manager/app/options/validation_generic.go
+++ b/cmd/controller-manager/app/options/validation_generic.go
@@ -25,10 +25,10 @@ import (
 	"github.com/karmada-io/karmada/pkg/util"
 )
 
-// Validate checks Options and return a slice of found errs.
-func (o *Options) Validate() field.ErrorList {
+// Validate checks GenericOptions and return a slice of found errs.
+func (o *GenericOptions) Validate() field.ErrorList {
 	errs := field.ErrorList{}
-	newPath := field.NewPath("Options")
+	newPath := field.NewPath("GenericOptions")
 
 	skippedResourceConfig := util.NewSkippedResourceConfig()
 	if err := skippedResourceConfig.Parse(o.SkippedPropagatingAPIs); err != nil {

--- a/cmd/controller-manager/app/options/validation_generic_test.go
+++ b/cmd/controller-manager/app/options/validation_generic_test.go
@@ -25,11 +25,11 @@ import (
 )
 
 // a callback function to modify options
-type ModifyOptions func(option *Options)
+type ModifyOptions func(option *GenericOptions)
 
-// New an Options with default parameters
-func New(modifyOptions ModifyOptions) Options {
-	option := Options{
+// New an GenericOptions with default parameters
+func New(modifyOptions ModifyOptions) GenericOptions {
+	option := GenericOptions{
 		SkippedPropagatingAPIs:       "cluster.karmada.io;policy.karmada.io;work.karmada.io",
 		ClusterStatusUpdateFrequency: metav1.Duration{Duration: 10 * time.Second},
 		ClusterLeaseDuration:         metav1.Duration{Duration: 10 * time.Second},
@@ -45,7 +45,7 @@ func New(modifyOptions ModifyOptions) Options {
 }
 
 func TestValidateControllerManagerConfiguration(t *testing.T) {
-	successCases := []Options{
+	successCases := []GenericOptions{
 		New(nil),
 	}
 
@@ -55,43 +55,43 @@ func TestValidateControllerManagerConfiguration(t *testing.T) {
 		}
 	}
 
-	newPath := field.NewPath("Options")
+	newPath := field.NewPath("GenericOptions")
 	testCases := map[string]struct {
-		opt          Options
+		opt          GenericOptions
 		expectedErrs field.ErrorList
 	}{
 		"invalid SkippedPropagatingAPIs": {
-			opt: New(func(options *Options) {
+			opt: New(func(options *GenericOptions) {
 				options.SkippedPropagatingAPIs = "a/b/c/d?"
 			}),
 			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("SkippedPropagatingAPIs"), "a/b/c/d?", "Invalid API string")},
 		},
 		"invalid ClusterStatusUpdateFrequency": {
-			opt: New(func(options *Options) {
+			opt: New(func(options *GenericOptions) {
 				options.ClusterStatusUpdateFrequency.Duration = -10 * time.Second
 			}),
 			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("ClusterStatusUpdateFrequency"), metav1.Duration{Duration: -10 * time.Second}, "must be greater than 0")},
 		},
 		"invalid ClusterLeaseDuration": {
-			opt: New(func(options *Options) {
+			opt: New(func(options *GenericOptions) {
 				options.ClusterLeaseDuration.Duration = -40 * time.Second
 			}),
 			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("ClusterLeaseDuration"), metav1.Duration{Duration: -40 * time.Second}, "must be greater than 0")},
 		},
 		"invalid ClusterMonitorPeriod": {
-			opt: New(func(options *Options) {
+			opt: New(func(options *GenericOptions) {
 				options.ClusterMonitorPeriod.Duration = -40 * time.Second
 			}),
 			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("ClusterMonitorPeriod"), metav1.Duration{Duration: -40 * time.Second}, "must be greater than 0")},
 		},
 		"invalid ClusterMonitorGracePeriod": {
-			opt: New(func(options *Options) {
+			opt: New(func(options *GenericOptions) {
 				options.ClusterMonitorGracePeriod.Duration = -40 * time.Second
 			}),
 			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("ClusterMonitorGracePeriod"), metav1.Duration{Duration: -40 * time.Second}, "must be greater than 0")},
 		},
 		"invalid ClusterStartupGracePeriod": {
-			opt: New(func(options *Options) {
+			opt: New(func(options *GenericOptions) {
 				options.ClusterStartupGracePeriod.Duration = 0 * time.Second
 			}),
 			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("ClusterStartupGracePeriod"), metav1.Duration{Duration: 0 * time.Second}, "must be greater than 0")},


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

NoExecute is a passive migration mode, which is dangerous. We add a controller and disable it by default.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-controller-manager: add failover flags to control the behavior of NoExecute.
```

