### PR TITLE
JSON logging support for Karmada controller manager component

### DIFF
--- a/artifacts/deploy/karmada-controller-manager.yaml
+++ b/artifacts/deploy/karmada-controller-manager.yaml
@@ -41,6 +41,7 @@ spec:
             - --metrics-bind-address=$(POD_IP):8080
             - --health-probe-bind-address=$(POD_IP):10357
             - --enable-no-execute-taint-eviction=true
+            - --logging-format=json
             - --v=4
           livenessProbe:
             httpGet:

--- a/cmd/controller-manager/controller-manager.go
+++ b/cmd/controller-manager/controller-manager.go
@@ -20,8 +20,8 @@ import (
 	"os"
 
 	"k8s.io/component-base/cli"
-	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
-	"k8s.io/klog/v2"
+	"k8s.io/component-base/logs"
+	_ "k8s.io/component-base/logs/json/register" // To enable JSON log format support
 	controllerruntime "sigs.k8s.io/controller-runtime"
 
 	"github.com/karmada-io/karmada/cmd/controller-manager/app"
@@ -29,13 +29,9 @@ import (
 
 func main() {
 	ctx := controllerruntime.SetupSignalHandler()
-	// Starting from version 0.15.0, controller-runtime expects its consumers to set a logger through log.SetLogger.
-	// If SetLogger is not called within the first 30 seconds of a binaries lifetime, it will get
-	// set to a NullLogSink and report an error. Here's to silence the "log.SetLogger(...) was never called; logs will not be displayed" error
-	// by setting a logger through log.SetLogger.
-	// More info refer to: https://github.com/karmada-io/karmada/pull/4885.
-	controllerruntime.SetLogger(klog.Background())
 	cmd := app.NewControllerManagerCommand(ctx)
-	code := cli.Run(cmd)
-	os.Exit(code)
+	exitCode := cli.Run(cmd)
+	// Ensure any buffered log entries are flushed
+	logs.FlushLogs()
+	os.Exit(exitCode)
 }

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -19,6 +19,7 @@ package features
 import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/component-base/featuregate"
+	logsv1 "k8s.io/component-base/logs/api/v1"
 )
 
 const (
@@ -79,6 +80,29 @@ const (
 	// owner: @mszacillo, @RainbowMango, @zhzhuang-zju, @seanlaii, @liwang0513
 	// alpha: v1.14
 	FederatedQuotaEnforcement featuregate.Feature = "FederatedQuotaEnforcement"
+
+	// LoggingAlphaOptions allows fine-tuning of experimental, alpha-quality logging options.
+	// Inherited from Kubernetes. Ref: https://github.com/kubernetes/component-base/blob/release-1.32/logs/api/v1/kube_features.go#L45
+	//
+	// owner: @jabellard
+	// alpha: v1.15
+	LoggingAlphaOptions = logsv1.LoggingAlphaOptions
+
+	// LoggingBetaOptions allows fine-tuning of experimental, beta-quality logging options.
+	// Inherited from Kubernetes. Ref: https://github.com/kubernetes/component-base/blob/release-1.32/logs/api/v1/kube_features.go#L54
+	//
+	// owner: @jabellard
+	// beta: v1.15
+	LoggingBetaOptions = logsv1.LoggingBetaOptions
+
+	// ContextualLogging enables looking up a logger from a context.Context instead of using
+	// the global fallback logger and manipulating the logger that is
+	// used by a call chain.
+	// Inherited from Kubernetes. Ref: https://github.com/kubernetes/component-base/blob/release-1.32/logs/api/v1/kube_features.go#L32
+	//
+	// owner: @jabellard
+	// beta: v1.15
+	ContextualLogging = logsv1.ContextualLogging
 )
 
 var (
@@ -101,6 +125,9 @@ var (
 		StatefulFailoverInjection:         {Default: false, PreRelease: featuregate.Alpha},
 		PriorityBasedScheduling:           {Default: false, PreRelease: featuregate.Alpha},
 		FederatedQuotaEnforcement:         {Default: false, PreRelease: featuregate.Alpha},
+		LoggingAlphaOptions:               {Default: false, PreRelease: featuregate.Alpha},
+		LoggingBetaOptions:                {Default: true, PreRelease: featuregate.Beta},
+		ContextualLogging:                 {Default: true, PreRelease: featuregate.Beta},
 	}
 )
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
JSON logging support.  More details are highlighted in #6230.

**Which issue(s) this PR fixes**:
Fixes #
Partof #6230 

**Tests with feature off**:
```text
I0526 21:00:08.993241   36799 controllermanager.go:151] karmada-controller-manager version: version.Info{GitVersion:"v0.0.0-master", GitCommit:"unknown", GitShortCommit:"unknown", GitTreeState:"unknown", BuildDate:"unknown", GoVersion:"go1.24.1", Compiler:"gc", Platform:"darwin/arm64"}
I0526 21:00:08.994271   36799 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
I0526 21:00:08.994291   36799 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
I0526 21:00:08.994293   36799 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
I0526 21:00:08.994295   36799 envvar.go:172] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
```

**Tests with feature on**:
```text
{"ts":1748307573644.736,"caller":"app/controllermanager.go:151","msg":"karmada-controller-manager version: version.Info{GitVersion:\"v0.0.0-master\", GitCommit:\"unknown\", GitShortCommit:\"unknown\", GitTreeState:\"unknown\", BuildDate:\"unknown\", GoVersion:\"go1.24.1\", Compiler:\"gc\", Platform:\"darwin/arm64\"}","v":0}
{"ts":1748307573647.104,"caller":"features/envvar.go:172","msg":"Feature gate default state","v":1,"feature":"WatchListClient","enabled":false}
{"ts":1748307573647.1328,"caller":"features/envvar.go:172","msg":"Feature gate default state","v":1,"feature":"ClientsAllowCBOR","enabled":false}
{"ts":1748307573647.136,"caller":"features/envvar.go:172","msg":"Feature gate default state","v":1,"feature":"ClientsPreferCBOR","enabled":false}
{"ts":1748307573647.138,"caller":"features/envvar.go:172","msg":"Feature gate default state","v":1,"feature":"InformerResourceVersion","enabled":false}

```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Introduced `--logging-format` flag which can be set to `json` to enable JSON logging.
```

