### PR TITLE
API Change: support time-dimension condition matching in ClusterTaintPolicy API

### DIFF
--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_clustertaintpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_clustertaintpolicies.yaml
@@ -78,6 +78,20 @@ spec:
                   - statusValues
                   type: object
                 type: array
+              addOnSeconds:
+                default: 30
+                description: |-
+                  AddOnSeconds is the duration in seconds for which the AddOnConditions
+                  must be continuously matched before adding the specified taint to the
+                  cluster. This provides stability by ensuring the condition persists
+                  long enough before taking action.
+                  All AddOnConditions should remain satisfied with the start time
+                  calculated from each condition's lastTransitionTime.
+                  It requires time synchronization between the controller and the apiserver.
+                  Defaults to 30.
+                format: int32
+                minimum: 1
+                type: integer
               removeOnConditions:
                 description: |-
                   RemoveOnConditions defines the conditions to match for triggering
@@ -111,6 +125,20 @@ spec:
                   - statusValues
                   type: object
                 type: array
+              removeOnSeconds:
+                default: 30
+                description: |-
+                  RemoveOnSeconds is the duration in seconds for which the RemoveOnConditions
+                  must be continuously unmatched before removing the taint from the cluster.
+                  This prevents premature taint removal during brief connection recoveries.
+                  The duration requirement is satisfied when any single condition do not
+                  meet the specified time duration. The evaluation uses the lastTransitionTime
+                  as the start point for duration calculation.
+                  It requires time synchronization between the controller and apiserver.
+                  Defaults to 30.
+                format: int32
+                minimum: 1
+                type: integer
               taints:
                 description: |-
                   Taints specifies the taints that need to be added or removed on

--- a/pkg/apis/policy/v1alpha1/clustertaint_types.go
+++ b/pkg/apis/policy/v1alpha1/clustertaint_types.go
@@ -58,12 +58,38 @@ type ClusterTaintPolicySpec struct {
 	// +optional
 	AddOnConditions []MatchCondition `json:"addOnConditions,omitempty"`
 
+	// AddOnSeconds is the duration in seconds for which the AddOnConditions
+	// must be continuously matched before adding the specified taint to the
+	// cluster. This provides stability by ensuring the condition persists
+	// long enough before taking action.
+	// All AddOnConditions should remain satisfied with the start time
+	// calculated from each condition's lastTransitionTime.
+	// It requires time synchronization between the controller and the apiserver.
+	// Defaults to 30.
+	// +optional
+	// +kubebuilder:default=30
+	// +kubebuilder:validation:Minimum=1
+	AddOnSeconds *int32 `json:"addOnSeconds,omitempty"`
+
 	// RemoveOnConditions defines the conditions to match for triggering
 	// the controller to remove taints from the cluster object.
 	// The match conditions are ANDed.
 	// If RemoveOnConditions is empty, no taints will be removed.
 	// +optional
 	RemoveOnConditions []MatchCondition `json:"removeOnConditions,omitempty"`
+
+	// RemoveOnSeconds is the duration in seconds for which the RemoveOnConditions
+	// must be continuously unmatched before removing the taint from the cluster.
+	// This prevents premature taint removal during brief connection recoveries.
+	// The duration requirement is satisfied when any single condition do not
+	// meet the specified time duration. The evaluation uses the lastTransitionTime
+	// as the start point for duration calculation.
+	// It requires time synchronization between the controller and apiserver.
+	// Defaults to 30.
+	// +optional
+	// +kubebuilder:default=30
+	// +kubebuilder:validation:Minimum=1
+	RemoveOnSeconds *int32 `json:"removeOnSeconds,omitempty"`
 
 	// Taints specifies the taints that need to be added or removed on
 	// the cluster object which match with TargetClusters.

--- a/pkg/apis/policy/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/policy/v1alpha1/zz_generated.deepcopy.go
@@ -342,12 +342,22 @@ func (in *ClusterTaintPolicySpec) DeepCopyInto(out *ClusterTaintPolicySpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.AddOnSeconds != nil {
+		in, out := &in.AddOnSeconds, &out.AddOnSeconds
+		*out = new(int32)
+		**out = **in
+	}
 	if in.RemoveOnConditions != nil {
 		in, out := &in.RemoveOnConditions, &out.RemoveOnConditions
 		*out = make([]MatchCondition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.RemoveOnSeconds != nil {
+		in, out := &in.RemoveOnSeconds, &out.RemoveOnSeconds
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Taints != nil {
 		in, out := &in.Taints, &out.Taints

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -4051,6 +4051,13 @@ func schema_pkg_apis_policy_v1alpha1_ClusterTaintPolicySpec(ref common.Reference
 							},
 						},
 					},
+					"addOnSeconds": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AddOnSeconds is the duration in seconds for which the AddOnConditions must be continuously matched before adding the specified taint to the cluster. This provides stability by ensuring the condition persists long enough before taking action. All AddOnConditions should remain satisfied with the start time calculated from each condition's lastTransitionTime. It requires time synchronization between the controller and the apiserver. Defaults to 30.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"removeOnConditions": {
 						SchemaProps: spec.SchemaProps{
 							Description: "RemoveOnConditions defines the conditions to match for triggering the controller to remove taints from the cluster object. The match conditions are ANDed. If RemoveOnConditions is empty, no taints will be removed.",
@@ -4063,6 +4070,13 @@ func schema_pkg_apis_policy_v1alpha1_ClusterTaintPolicySpec(ref common.Reference
 									},
 								},
 							},
+						},
+					},
+					"removeOnSeconds": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RemoveOnSeconds is the duration in seconds for which the RemoveOnConditions must be continuously unmatched before removing the taint from the cluster. This prevents premature taint removal during brief connection recoveries. The duration requirement is satisfied when any single condition do not meet the specified time duration. The evaluation uses the lastTransitionTime as the start point for duration calculation. It requires time synchronization between the controller and apiserver. Defaults to 30.",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 					"taints": {


### PR DESCRIPTION
**What type of PR is this?**

/kind api-change
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Support time-dimension condition matching in ClusterTaintPolicy API.

**Which issue(s) this PR fixes**:
Part of #6317

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
API Change: support time-dimension condition matching in ClusterTaintPolicy API
```

