### PR TITLE
JSON logging support for Karmada Webhook component

### DIFF
--- a/artifacts/deploy/karmada-webhook.yaml
+++ b/artifacts/deploy/karmada-webhook.yaml
@@ -43,6 +43,7 @@ spec:
             - --cert-dir=/etc/karmada/pki/server
             - --feature-gates=AllAlpha=true,AllBeta=true
             - --allow-no-execute-taint-policy=true
+            - --logging-format=json
             - --v=4
           ports:
             - containerPort: 8443

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -20,8 +20,8 @@ import (
 	"os"
 
 	"k8s.io/component-base/cli"
+	"k8s.io/component-base/logs"
 	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
-	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 
 	"github.com/karmada-io/karmada/cmd/webhook/app"
@@ -29,13 +29,9 @@ import (
 
 func main() {
 	ctx := controllerruntime.SetupSignalHandler()
-	// Starting from version 0.15.0, controller-runtime expects its consumers to set a logger through log.SetLogger.
-	// If SetLogger is not called within the first 30 seconds of a binaries lifetime, it will get
-	// set to a NullLogSink and report an error. Here's to silence the "log.SetLogger(...) was never called; logs will not be displayed" error
-	// by setting a logger through log.SetLogger.
-	// More info refer to: https://github.com/karmada-io/karmada/pull/4885.
-	controllerruntime.SetLogger(klog.Background())
 	cmd := app.NewWebhookCommand(ctx)
-	code := cli.Run(cmd)
-	os.Exit(code)
+	exitCode := cli.Run(cmd)
+	// Ensure any buffered log entries are flushed
+	logs.FlushLogs()
+	os.Exit(exitCode)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
JSON logging support. More details are highlighted in https://github.com/karmada-io/karmada/issues/6230.

**Which issue(s) this PR fixes**:
Part of #6230 

**Special notes for your reviewer**:
Tests with feature on:
```
{"ts":1749182199458.613,"caller":"app/webhook.go:126","msg":"karmada-webhook version: version.Info{GitVersion:\"v1.14.0-10-gbc4348d4a-dirty\", GitCommit:\"bc4348d4a0d15dc06b724d115ade2f5a01c10904\", GitShortCommit:\"bc4348d4a\", GitTreeState:\"dirty\", BuildDate:\"2025-06-06T03:53:39Z\", GoVersion:\"go1.24.2\", Compiler:\"gc\", Platform:\"linux/arm64\"}","v":0}
{"ts":1749182199465.4758,"caller":"features/envvar.go:172","msg":"Feature gate default state","v":1,"feature":"ClientsPreferCBOR","enabled":false}
{"ts":1749182199465.6233,"caller":"features/envvar.go:172","msg":"Feature gate default state","v":1,"feature":"InformerResourceVersion","enabled":false}
{"ts":1749182199465.6404,"caller":"features/envvar.go:172","msg":"Feature gate default state","v":1,"feature":"WatchListClient","enabled":false}
{"ts":1749182199465.6487,"caller":"features/envvar.go:172","msg":"Feature gate default state","v":1,"feature":"ClientsAllowCBOR","enabled":false}
{"ts":1749182199475.0796,"caller":"app/webhook.go:174","msg":"Registering webhooks to the webhook server","v":0}
{"ts":1749182199475.2085,"logger":"controller-runtime.webhook","caller":"webhook/server.go:183","msg":"Registering webhook","path":"/validate-cronfederatedhpa","v":0}
```

New Flags after change:
```
--log-flush-frequency duration                                                
            Maximum number of seconds between log flushes (default 5s)
--log-json-info-buffer-size quantity                                          
            [Alpha] In JSON format with split output streams, the info messages can
            be buffered for a while to increase performance. The default value of
            zero bytes disables buffering. The size can be specified as number of
            bytes (512), multiples of 1000 (1K), multiples of 1024 (2Ki), or powers
            of those (3M, 4G, 5Mi, 6Gi). Enable the LoggingAlphaOptions feature
            gate to use this.
--log-json-split-stream                                                       
            [Alpha] In JSON format, write error messages to stderr and info
            messages to stdout. The default is to write a single stream to stdout.
            Enable the LoggingAlphaOptions feature gate to use this.
--log-text-info-buffer-size quantity                                          
            [Alpha] In text format with split output streams, the info messages can
            be buffered for a while to increase performance. The default value of
            zero bytes disables buffering. The size can be specified as number of
            bytes (512), multiples of 1000 (1K), multiples of 1024 (2Ki), or powers
            of those (3M, 4G, 5Mi, 6Gi). Enable the LoggingAlphaOptions feature
            gate to use this.
--log-text-split-stream                                                       
            [Alpha] In text format, write error messages to stderr and info
            messages to stdout. The default is to write a single stream to stdout.
            Enable the LoggingAlphaOptions feature gate to use this.
--logging-format string                                                       
            Sets the log format. Permitted formats: "json" (gated by
            LoggingBetaOptions), "text". (default "text")
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-webhook`: Introduced `--logging-format` flag which can be set to `json` to enable JSON logging.
```

