### PR TITLE
fix zones match

### DIFF
--- a/pkg/util/selector.go
+++ b/pkg/util/selector.go
@@ -204,11 +204,11 @@ func extractClusterFields(cluster *clusterv1alpha1.Cluster) labels.Set {
 	return clusterFieldsMap
 }
 
-// matchZones checks if zoneMatchExpression can match zones and returns true if it matches.
+// matchZones checks whether the zone selector matches the cluster zones.
 // For unknown operators, matchZones always returns false.
 // The matching rules are as follows:
-// 1. When the operator is "In", zoneMatchExpression must contain all zones, otherwise it doesn't match.
-// 2. When the operator is "NotIn", zoneMatchExpression mustn't contain any one of zones, otherwise it doesn't match.
+// 1. When the operator is "In", any overlapping zone is enough for a match.
+// 2. When the operator is "NotIn", none of the cluster zones can appear in the expression values.
 // 3. When the operator is "Exists", zones mustn't be empty, otherwise it doesn't match.
 // 4. When the operator is "DoesNotExist", zones must be empty, otherwise it doesn't match.
 func matchZones(zoneMatchExpression *corev1.NodeSelectorRequirement, zones []string) bool {
@@ -218,11 +218,11 @@ func matchZones(zoneMatchExpression *corev1.NodeSelectorRequirement, zones []str
 			return false
 		}
 		for _, zone := range zones {
-			if !slices.Contains(zoneMatchExpression.Values, zone) {
-				return false
+			if slices.Contains(zoneMatchExpression.Values, zone) {
+				return true
 			}
 		}
-		return true
+		return false
 	case corev1.NodeSelectorOpNotIn:
 		for _, zone := range zones {
 			if slices.Contains(zoneMatchExpression.Values, zone) {

--- a/pkg/util/selector_test.go
+++ b/pkg/util/selector_test.go
@@ -600,7 +600,7 @@ func TestClusterMatches(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "test field selector zone not matched",
+			name: "test field selector zone partially matched",
 			affinity: policyv1alpha1.ClusterAffinity{
 				ClusterNames: []string{cluster.Name},
 				FieldSelector: &policyv1alpha1.FieldSelector{
@@ -621,7 +621,7 @@ func TestClusterMatches(t *testing.T) {
 					},
 				},
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "test field selector region matched",
@@ -1009,14 +1009,14 @@ func Test_matchZones(t *testing.T) {
 			matched: false,
 		},
 		{
-			name: "partial zones for In operator",
+			name: "overlapping zones for In operator",
 			zoneMatchExpression: &corev1.NodeSelectorRequirement{
 				Key:      ZoneField,
 				Operator: corev1.NodeSelectorOpIn,
 				Values:   []string{"foo"},
 			},
 			zones:   []string{"foo", "bar"},
-			matched: false,
+			matched: true,
 		},
 		{
 			name: "all zones for In operator",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
For clusters across multiple AZs, should we relax the restrictions so that as long as there is a matching zone attribute, the cluster can be used as a scheduling candidate cluster? Otherwise, the scheduling results cannot be calculated in many scenarios.
![111](https://github.com/user-attachments/assets/5271497c-0457-4ed9-bb65-8e2a3e13006d)


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-scheduler`: Relaxed zone affinity matching for multi-zone clusters, so a cluster is eligible when any configured zone overlaps the selector.
```

