### PR TITLE
Ensure EndpointSlice informer cache is synced before reporting EndpointSlice

### DIFF
--- a/pkg/controllers/mcs/service_export_controller.go
+++ b/pkg/controllers/mcs/service_export_controller.go
@@ -408,6 +408,14 @@ func (c *ServiceExportController) reportEndpointSliceWithServiceExportCreate(ctx
 		return nil
 	}
 
+	// Before retrieving EndpointSlice objects from the informer, ensure the informer cache is synced.
+	// This is necessary because the informer for EndpointSlice is created dynamically in the Reconcile() routine
+	// when a Work resource containing an ServiceExport is detected for the cluster. If the informer is not yet synced,
+	// return an error and wait a retry at the next time.
+	if !singleClusterManager.IsInformerSynced(endpointSliceGVR) {
+		return fmt.Errorf("the informer for cluster %s has not been synced, wait a retry at the next time", serviceExportKey.Cluster)
+	}
+
 	endpointSliceLister := singleClusterManager.Lister(endpointSliceGVR)
 	if endpointSliceObjects, err = endpointSliceLister.ByNamespace(serviceExportKey.Namespace).List(labels.SelectorFromSet(labels.Set{
 		discoveryv1.LabelServiceName: serviceExportKey.Name,
@@ -481,6 +489,14 @@ func (c *ServiceExportController) reportEndpointSliceWithEndpointSliceCreateOrUp
 	singleClusterManager := c.InformerManager.GetSingleClusterManager(clusterName)
 	if singleClusterManager == nil {
 		return nil
+	}
+
+	// Before retrieving ServiceExport objects from the informer, ensure the informer cache is synced.
+	// This is necessary because the informer for ServiceExport is created dynamically in the Reconcile() routine
+	// when a Work resource containing an ServiceExport is detected for the cluster. If the informer is not yet synced,
+	// return an error and wait a retry at the next time.
+	if !singleClusterManager.IsInformerSynced(serviceExportGVR) {
+		return fmt.Errorf("the informer for cluster %s has not been synced, wait a retry at the next time", clusterName)
 	}
 
 	serviceExportLister := singleClusterManager.Lister(serviceExportGVR)
@@ -614,6 +630,7 @@ func cleanEndpointSliceWork(ctx context.Context, c client.Client, work *workv1al
 			klog.Errorf("Failed to update work(%s/%s): %v", work.Namespace, work.Name, err)
 			return err
 		}
+		klog.Infof("Successfully updated work(%s/%s)", work.Namespace, work.Name)
 		return nil
 	}
 
@@ -621,6 +638,7 @@ func cleanEndpointSliceWork(ctx context.Context, c client.Client, work *workv1al
 		klog.Errorf("Failed to delete work(%s/%s), Error: %v", work.Namespace, work.Name, err)
 		return err
 	}
+	klog.Infof("Successfully deleted work(%s/%s)", work.Namespace, work.Name)
 
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

When the `karmada-controller-manager` is restarted, the `servcie-export-controller` will requeue the ServiceExport associated with the collected EndpointSlice resources for processing:

https://github.com/karmada-io/karmada/blob/bd5692f08a259c1a959dc3fd1944071be9fda729/pkg/controllers/mcs/service_export_controller.go#L149-L159

Then, during the processing, the EndpointSlice resource is obtained from the cluster cache:

https://github.com/karmada-io/karmada/blob/bd5692f08a259c1a959dc3fd1944071be9fda729/pkg/controllers/mcs/service_export_controller.go#L399-L421

The cache may not have been synchronized at this time, and an empty EndpointSlice list will be obtained, which will be deleted in the `removeOrphanWork` function.

**Which issue(s) this PR fixes**:
Fixes #6433 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
karmada-controller-manager: ensure EndpointSlice informer cache is synced before reporting EndpointSlice
```

