### PR TITLE
added json logging support in karmada-agent

### DIFF
--- a/artifacts/agent/karmada-agent.yaml
+++ b/artifacts/agent/karmada-agent.yaml
@@ -39,6 +39,7 @@ spec:
             - --metrics-bind-address=$(POD_IP):8080
             - --health-probe-bind-address=$(POD_IP):10357
             - --feature-gates=CustomizedClusterResourceModeling=true,MultiClusterService=true
+            - --logging-format=json
             - --v=4
           livenessProbe:
             httpGet:

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"k8s.io/component-base/cli"
+	"k8s.io/component-base/logs"
 	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
 	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -37,5 +38,7 @@ func main() {
 	controllerruntime.SetLogger(klog.Background())
 	cmd := app.NewAgentCommand(ctx)
 	code := cli.Run(cmd)
+	// Ensure any buffered log entries are flushed
+	logs.FlushLogs()
 	os.Exit(code)
 }


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature

**What this PR does / why we need it**:

JSON logging support. More details are highlighted in https://github.com/karmada-io/karmada/issues/6230.

**Which issue(s) this PR fixes**:

Part of https://github.com/karmada-io/karmada/issues/6230

**Special notes for your reviewer**:

Example output log with `--logging-format json` set:
```
{"ts":1749695644313.8142,"caller":"app/agent.go:148","msg":"karmada-agent version: version.Info{GitVersion:\"\", GitCommit:\"a1b734cfac92bf2ad728a7029d2549ab755c1886\", GitShortCommit:\"a1b734cfa\", GitTreeState:\"dirty\", BuildDate:\"2025-06-11T23:24:24Z\", GoVersion:\"go1.24.2\", Compiler:\"gc\", Platform:\"linux/amd64\"}","v":0}
{"ts":1749695644324.9548,"caller":"cli/run.go:72","msg":"command failed","err":"Get \"https://127.0.0.1:40227/api/v1/namespaces/kube-system\": dial tcp 127.0.0.1:40227: connect: connection refused"}
```

Newly added CLI flags after making this change:
```
      --log-flush-frequency duration         Maximum number of seconds between log flushes (default 5s)
      --log-json-info-buffer-size quantity   [Alpha] In JSON format with split output streams, the info messages can be buffered for a while to increase performance. The default value of zero bytes disables buffering. The size can be specified as number of bytes (512), multiples of 1000 (1K), multiples of 1024 (2Ki), or powers of those (3M, 4G, 5Mi, 6Gi). Enable the LoggingAlphaOptions feature gate to use this.
      --log-json-split-stream                [Alpha] In JSON format, write error messages to stderr and info messages to stdout. The default is to write a single stream to stdout. Enable the LoggingAlphaOptions feature gate to use this.
      --log-text-info-buffer-size quantity   [Alpha] In text format with split output streams, the info messages can be buffered for a while to increase performance. The default value of zero bytes disables buffering. The size can be specified as number of bytes (512), multiples of 1000 (1K), multiples of 1024 (2Ki), or powers of those (3M, 4G, 5Mi, 6Gi). Enable the LoggingAlphaOptions feature gate to use this.
      --log-text-split-stream                [Alpha] In text format, write error messages to stderr and info messages to stdout. The default is to write a single stream to stdout. Enable the LoggingAlphaOptions feature gate to use this.
      --logging-format string                Sets the log format. Permitted formats: "json" (gated by LoggingBetaOptions), "text". (default "text")
 
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Introduced `--logging-format` flag which can be set to `json` to enable JSON logging in karmada-agent.
```

