### PR TITLE
Remove default-not-ready-toleration-seconds and default-unreachable-toleration-seconds flags

### DIFF
--- a/artifacts/deploy/karmada-webhook.yaml
+++ b/artifacts/deploy/karmada-webhook.yaml
@@ -37,8 +37,6 @@ spec:
             - --bind-address=$(POD_IP)
             - --metrics-bind-address=$(POD_IP):8080
             - --health-probe-bind-address=$(POD_IP):8000
-            - --default-not-ready-toleration-seconds=30
-            - --default-unreachable-toleration-seconds=30
             - --secure-port=8443
             - --cert-dir=/etc/karmada/pki/server
             - --feature-gates=AllAlpha=true,AllBeta=true

--- a/cmd/webhook/app/options/options.go
+++ b/cmd/webhook/app/options/options.go
@@ -68,9 +68,6 @@ type Options struct {
 	// that do not explicitly tolerate it, potentially causing unexpected service disruptions.
 	AllowNoExecuteTaintPolicy bool
 
-	DefaultNotReadyTolerationSeconds    int64
-	DefaultUnreachableTolerationSeconds int64
-
 	ProfileOpts profileflag.Options
 }
 
@@ -97,12 +94,6 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&o.MetricsBindAddress, "metrics-bind-address", ":8080", "The TCP address that the controller should bind to for serving prometheus metrics(e.g. 127.0.0.1:8080, :8080). It can be set to \"0\" to disable the metrics serving.")
 	flags.StringVar(&o.HealthProbeBindAddress, "health-probe-bind-address", ":8000", "The TCP address that the controller should bind to for serving health probes(e.g. 127.0.0.1:8000, :8000)")
 	flags.BoolVar(&o.AllowNoExecuteTaintPolicy, "allow-no-execute-taint-policy", false, "Allows configuring taints with NoExecute effect in ClusterTaintPolicy. Given the impact of NoExecute, applying such a taint to a cluster may trigger the eviction of workloads that do not explicitly tolerate it, potentially causing unexpected service disruptions. \nThis parameter is designed to remain disabled by default and requires careful evaluation by administrators before being enabled.")
-
-	// webhook flags
-	flags.Int64Var(&o.DefaultNotReadyTolerationSeconds, "default-not-ready-toleration-seconds", 300, "Indicates the tolerationSeconds of the propagation policy toleration for notReady:NoExecute that is added by default to every propagation policy that does not already have such a toleration.")
-	_ = flags.MarkDeprecated("default-not-ready-toleration-seconds", "Karmada will no longer automatically add cluster.karmada.io/not-ready:NoExecute taint to cluster objects, so there is no need to add default tolerations in propagation policy, default-not-ready-toleration-seconds is deprecated and will be removed in v1.15.")
-	flags.Int64Var(&o.DefaultUnreachableTolerationSeconds, "default-unreachable-toleration-seconds", 300, "Indicates the tolerationSeconds of the propagation policy toleration for unreachable:NoExecute that is added by default to every propagation policy that does not already have such a toleration.")
-	_ = flags.MarkDeprecated("default-unreachable-toleration-seconds", "Karmada will no longer automatically add cluster.karmada.io/unreachable:NoExecute taint to cluster objects, so there is no need to add default tolerations in propagation policy, default-unreachable-toleration-seconds is deprecated and will be removed in v1.15.")
 
 	features.FeatureGate.AddFlag(flags)
 	o.ProfileOpts.AddFlags(flags)

--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -187,8 +187,7 @@ func Run(ctx context.Context, opts *options.Options) error {
 	// ClusterOverridePolicy
 	hookServer.Register("/validate-clusteroverridepolicy", &webhook.Admission{Handler: &clusteroverridepolicy.ValidatingAdmission{Decoder: decoder}})
 	// ClusterPropagationPolicy
-	hookServer.Register("/mutate-clusterpropagationpolicy", &webhook.Admission{Handler: clusterpropagationpolicy.NewMutatingHandler(
-		opts.DefaultNotReadyTolerationSeconds, opts.DefaultUnreachableTolerationSeconds, decoder)})
+	hookServer.Register("/mutate-clusterpropagationpolicy", &webhook.Admission{Handler: clusterpropagationpolicy.NewMutatingHandler(decoder)})
 	hookServer.Register("/validate-clusterpropagationpolicy", &webhook.Admission{Handler: &clusterpropagationpolicy.ValidatingAdmission{Decoder: decoder}})
 	// ClusterTaintPolicy
 	hookServer.Register("/validate-clustertaintpolicy", &webhook.Admission{Handler: &clustertaintpolicy.ValidatingAdmission{Decoder: decoder, AllowNoExecuteTaintPolicy: opts.AllowNoExecuteTaintPolicy}})
@@ -198,8 +197,7 @@ func Run(ctx context.Context, opts *options.Options) error {
 	hookServer.Register("/mutate-overridepolicy", &webhook.Admission{Handler: &overridepolicy.MutatingAdmission{Decoder: decoder}})
 	hookServer.Register("/validate-overridepolicy", &webhook.Admission{Handler: &overridepolicy.ValidatingAdmission{Decoder: decoder}})
 	// PropagationPolicy
-	hookServer.Register("/mutate-propagationpolicy", &webhook.Admission{Handler: propagationpolicy.NewMutatingHandler(
-		opts.DefaultNotReadyTolerationSeconds, opts.DefaultUnreachableTolerationSeconds, decoder)})
+	hookServer.Register("/mutate-propagationpolicy", &webhook.Admission{Handler: propagationpolicy.NewMutatingHandler(decoder)})
 	hookServer.Register("/validate-propagationpolicy", &webhook.Admission{Handler: &propagationpolicy.ValidatingAdmission{Decoder: decoder}})
 
 	// work group

--- a/operator/pkg/controlplane/webhook/manifests.go
+++ b/operator/pkg/controlplane/webhook/manifests.go
@@ -59,8 +59,6 @@ spec:
             - --bind-address=$(POD_IP)
             - --metrics-bind-address=$(POD_IP):8080
             - --health-probe-bind-address=$(POD_IP):8000
-            - --default-not-ready-toleration-seconds=30
-            - --default-unreachable-toleration-seconds=30
             - --secure-port=8443
             - --cert-dir=/var/serving-cert
             - --v=4

--- a/pkg/util/helper/taint.go
+++ b/pkg/util/helper/taint.go
@@ -192,26 +192,6 @@ func GetMatchingTolerations(taints []corev1.Taint, tolerations []corev1.Tolerati
 	return true, result
 }
 
-// NewNotReadyToleration returns a default not ready toleration.
-func NewNotReadyToleration(tolerationSeconds int64) *corev1.Toleration {
-	return &corev1.Toleration{
-		Key:               clusterv1alpha1.TaintClusterNotReady,
-		Operator:          corev1.TolerationOpExists,
-		Effect:            corev1.TaintEffectNoExecute,
-		TolerationSeconds: &tolerationSeconds,
-	}
-}
-
-// NewUnreachableToleration returns a default unreachable toleration.
-func NewUnreachableToleration(tolerationSeconds int64) *corev1.Toleration {
-	return &corev1.Toleration{
-		Key:               clusterv1alpha1.TaintClusterUnreachable,
-		Operator:          corev1.TolerationOpExists,
-		Effect:            corev1.TaintEffectNoExecute,
-		TolerationSeconds: &tolerationSeconds,
-	}
-}
-
 // GenerateTaintsMessage returns a string that describes the taints of a cluster.
 func GenerateTaintsMessage(taints []corev1.Taint) string {
 	if len(taints) == 0 {

--- a/pkg/util/helper/taint_test.go
+++ b/pkg/util/helper/taint_test.go
@@ -666,44 +666,6 @@ func TestGetMatchingTolerations(t *testing.T) {
 	}
 }
 
-func TestNewNotReadyToleration(t *testing.T) {
-	expectedKey := clusterv1alpha1.TaintClusterNotReady
-	expectedOperator := corev1.TolerationOpExists
-	expectedEffect := corev1.TaintEffectNoExecute
-	expectedSeconds := int64(123)
-
-	toleration := NewNotReadyToleration(expectedSeconds)
-
-	if toleration.Key != expectedKey {
-		t.Errorf("Expected key %q but got %q", expectedKey, toleration.Key)
-	}
-	if toleration.Operator != expectedOperator {
-		t.Errorf("Expected operator %q but got %q", expectedOperator, toleration.Operator)
-	}
-	if toleration.Effect != expectedEffect {
-		t.Errorf("Expected effect %q but got %q", expectedEffect, toleration.Effect)
-	}
-	if *toleration.TolerationSeconds != expectedSeconds {
-		t.Errorf("Expected seconds %d but got %d", expectedSeconds, *toleration.TolerationSeconds)
-	}
-}
-
-func TestNewUnreachableToleration(t *testing.T) {
-	tolerationSeconds := int64(300)
-	expectedToleration := &corev1.Toleration{
-		Key:               clusterv1alpha1.TaintClusterUnreachable,
-		Operator:          corev1.TolerationOpExists,
-		Effect:            corev1.TaintEffectNoExecute,
-		TolerationSeconds: &tolerationSeconds,
-	}
-
-	actualToleration := NewUnreachableToleration(tolerationSeconds)
-
-	if !reflect.DeepEqual(actualToleration, expectedToleration) {
-		t.Errorf("NewUnreachableToleration() = %v, want %v", actualToleration, expectedToleration)
-	}
-}
-
 func TestGenerateTaintsMessage(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/webhook/clusterpropagationpolicy/mutating.go
+++ b/pkg/webhook/clusterpropagationpolicy/mutating.go
@@ -35,20 +35,15 @@ import (
 // MutatingAdmission mutates API request if necessary.
 type MutatingAdmission struct {
 	Decoder admission.Decoder
-
-	DefaultNotReadyTolerationSeconds    int64
-	DefaultUnreachableTolerationSeconds int64
 }
 
 // Check if our MutatingAdmission implements necessary interface
 var _ admission.Handler = &MutatingAdmission{}
 
 // NewMutatingHandler builds a new admission.Handler.
-func NewMutatingHandler(notReadyTolerationSeconds, unreachableTolerationSeconds int64, decoder admission.Decoder) admission.Handler {
+func NewMutatingHandler(decoder admission.Decoder) admission.Handler {
 	return &MutatingAdmission{
-		DefaultNotReadyTolerationSeconds:    notReadyTolerationSeconds,
-		DefaultUnreachableTolerationSeconds: unreachableTolerationSeconds,
-		Decoder:                             decoder,
+		Decoder: decoder,
 	}
 }
 
@@ -64,8 +59,6 @@ func (a *MutatingAdmission) Handle(_ context.Context, req admission.Request) adm
 
 	// Set default spread constraints if both 'SpreadByField' and 'SpreadByLabel' not set.
 	helper.SetDefaultSpreadConstraints(policy.Spec.Placement.SpreadConstraints)
-	helper.AddTolerations(&policy.Spec.Placement, helper.NewNotReadyToleration(a.DefaultNotReadyTolerationSeconds),
-		helper.NewUnreachableToleration(a.DefaultUnreachableTolerationSeconds))
 
 	if helper.ContainsServiceImport(policy.Spec.ResourceSelectors) {
 		policy.Spec.PropagateDeps = true

--- a/pkg/webhook/propagationpolicy/mutating.go
+++ b/pkg/webhook/propagationpolicy/mutating.go
@@ -35,20 +35,15 @@ import (
 // MutatingAdmission mutates API request if necessary.
 type MutatingAdmission struct {
 	Decoder admission.Decoder
-
-	DefaultNotReadyTolerationSeconds    int64
-	DefaultUnreachableTolerationSeconds int64
 }
 
 // Check if our MutatingAdmission implements necessary interface
 var _ admission.Handler = &MutatingAdmission{}
 
 // NewMutatingHandler builds a new admission.Handler.
-func NewMutatingHandler(notReadyTolerationSeconds, unreachableTolerationSeconds int64, decoder admission.Decoder) admission.Handler {
+func NewMutatingHandler(decoder admission.Decoder) admission.Handler {
 	return &MutatingAdmission{
-		DefaultNotReadyTolerationSeconds:    notReadyTolerationSeconds,
-		DefaultUnreachableTolerationSeconds: unreachableTolerationSeconds,
-		Decoder:                             decoder,
+		Decoder: decoder,
 	}
 }
 
@@ -75,8 +70,6 @@ func (a *MutatingAdmission) Handle(_ context.Context, req admission.Request) adm
 
 	// Set default spread constraints if both 'SpreadByField' and 'SpreadByLabel' not set.
 	helper.SetDefaultSpreadConstraints(policy.Spec.Placement.SpreadConstraints)
-	helper.AddTolerations(&policy.Spec.Placement, helper.NewNotReadyToleration(a.DefaultNotReadyTolerationSeconds),
-		helper.NewUnreachableToleration(a.DefaultUnreachableTolerationSeconds))
 
 	if helper.ContainsServiceImport(policy.Spec.ResourceSelectors) {
 		policy.Spec.PropagateDeps = true

--- a/pkg/webhook/propagationpolicy/mutating_test.go
+++ b/pkg/webhook/propagationpolicy/mutating_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
@@ -34,13 +33,10 @@ import (
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/util"
-	"github.com/karmada-io/karmada/pkg/util/helper"
 )
 
 var (
-	notReadyTolerationSeconds    int64 = 300
-	unreachableTolerationSeconds int64 = 300
-	failOverGracePeriodSeconds   int32 = 600
+	failOverGracePeriodSeconds int32 = 600
 )
 
 type fakeMutationDecoder struct {
@@ -89,9 +85,7 @@ func TestMutatingAdmission_Handle(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := NewMutatingHandler(
-				notReadyTolerationSeconds, unreachableTolerationSeconds, tt.decoder,
-			)
+			m := NewMutatingHandler(tt.decoder)
 			got := m.Handle(context.Background(), tt.req)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Handle() = %v, want %v", got, tt.want)
@@ -166,10 +160,6 @@ func TestMutatingAdmission_Handle_FullCoverage(t *testing.T) {
 					ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
 					ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceWeighted,
 				},
-				ClusterTolerations: []corev1.Toleration{
-					*helper.NewNotReadyToleration(notReadyTolerationSeconds),
-					*helper.NewUnreachableToleration(unreachableTolerationSeconds),
-				},
 			},
 			PropagateDeps: true,
 			ResourceSelectors: []policyv1alpha1.ResourceSelector{
@@ -202,9 +192,7 @@ func TestMutatingAdmission_Handle_FullCoverage(t *testing.T) {
 	req.Object.Raw = wantBytes
 
 	// Instantiate the mutating handler.
-	mutatingHandler := NewMutatingHandler(
-		notReadyTolerationSeconds, unreachableTolerationSeconds, decoder,
-	)
+	mutatingHandler := NewMutatingHandler(decoder)
 
 	// Call the Handle function.
 	got := mutatingHandler.Handle(context.Background(), req)

--- a/test/e2e/suites/base/clusteraffinities_test.go
+++ b/test/e2e/suites/base/clusteraffinities_test.go
@@ -26,9 +26,9 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/utils/ptr"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
-	"github.com/karmada-io/karmada/pkg/util/helper"
 	"github.com/karmada-io/karmada/test/e2e/framework"
 	testhelper "github.com/karmada-io/karmada/test/helper"
 )
@@ -396,8 +396,12 @@ var _ = ginkgo.Describe("[ClusterAffinities] propagation testing", func() {
 				},
 			}, policyv1alpha1.Placement{
 				ClusterTolerations: []corev1.Toleration{
-					*helper.NewNotReadyToleration(2),
-					*helper.NewUnreachableToleration(2),
+					{
+						Key:               framework.TaintClusterNotReady,
+						Operator:          corev1.TolerationOpExists,
+						Effect:            corev1.TaintEffectNoExecute,
+						TolerationSeconds: ptr.To[int64](2),
+					},
 				},
 				ClusterAffinities: []policyv1alpha1.ClusterAffinityTerm{
 					{

--- a/test/e2e/suites/base/failover_test.go
+++ b/test/e2e/suites/base/failover_test.go
@@ -75,8 +75,12 @@ var _ = framework.SerialDescribe("failover testing", func() {
 					},
 				},
 				ClusterTolerations: []corev1.Toleration{
-					*helper.NewNotReadyToleration(2),
-					*helper.NewUnreachableToleration(2),
+					{
+						Key:               framework.TaintClusterNotReady,
+						Operator:          corev1.TolerationOpExists,
+						Effect:            corev1.TaintEffectNoExecute,
+						TolerationSeconds: ptr.To[int64](2),
+					},
 				},
 				SpreadConstraints: []policyv1alpha1.SpreadConstraint{
 					{


### PR DESCRIPTION
**What type of PR is this?**

/kind deprecation
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

We have deprecated `default-not-ready-toleration-seconds` and `default-unreachable-toleration-seconds` flags for `karmada-webhook` in v1.14: #6373, now, we can remove them.

**Which issue(s) this PR fixes**:
Part of #6428

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-webhook`: The `--default-not-ready-toleration-seconds` and `--default-unreachable-toleration-seconds` flags which were deprecated in release-1.14, now has been removed.
```

