### PR TITLE
Automated cherry pick of #6446: register ResourceBindingIndexByFieldCluster without the

### DIFF
--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -248,6 +248,15 @@ func startClusterController(ctx controllerscontext.Context) (enabled bool, err e
 	mgr := ctx.Mgr
 	opts := ctx.Opts
 
+	// Indexes are added to help the cluster-controller and TaintManager quickly locate ResourceBinding
+	// and ClusterResourceBinding resources associated with a given cluster when eviction is needed.
+	if err := indexregistry.RegisterResourceBindingIndexByFieldCluster(ctx.Context, mgr); err != nil {
+		return false, err
+	}
+	if err := indexregistry.RegisterClusterResourceBindingIndexByFieldCluster(ctx.Context, mgr); err != nil {
+		return false, err
+	}
+
 	clusterController := &cluster.Controller{
 		Client:                    mgr.GetClient(),
 		EventRecorder:             mgr.GetEventRecorderFor(cluster.ControllerName),
@@ -263,14 +272,6 @@ func startClusterController(ctx controllerscontext.Context) (enabled bool, err e
 
 	// Taint-based eviction should only take effect if the Failover feature is enabled
 	if ctx.Opts.EnableTaintManager && features.FeatureGate.Enabled(features.Failover) {
-		// Indexes are added to help the TaintManager quickly locate ResourceBinding and ClusterResourceBinding resources
-		// associated with a given cluster when eviction is needed.
-		if err := indexregistry.RegisterResourceBindingIndexByFieldCluster(ctx.Context, mgr); err != nil {
-			return false, err
-		}
-		if err := indexregistry.RegisterClusterResourceBindingIndexByFieldCluster(ctx.Context, mgr); err != nil {
-			return false, err
-		}
 		taintManager := &cluster.NoExecuteTaintManager{
 			Client:                             mgr.GetClient(),
 			EventRecorder:                      mgr.GetEventRecorderFor(cluster.TaintManagerName),


### PR DESCRIPTION
Cherry pick of #6446 on release-1.14.
#6446: register ResourceBindingIndexByFieldCluster without the
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
```