### PR TITLE
Remove failover-eviction-timeout flag in the karmada-controller-manager

### DIFF
--- a/artifacts/deploy/karmada-controller-manager.yaml
+++ b/artifacts/deploy/karmada-controller-manager.yaml
@@ -35,7 +35,6 @@ spec:
             - /bin/karmada-controller-manager
             - --kubeconfig=/etc/karmada/config/karmada.config
             - --cluster-status-update-frequency=10s
-            - --failover-eviction-timeout=30s
             - --controllers=*,hpaScaleTargetMarker,deploymentReplicasSyncer
             - --feature-gates=AllAlpha=true,AllBeta=true
             - --metrics-bind-address=$(POD_IP):8080

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -54,8 +54,6 @@ type Options struct {
 	// ClusterStatusUpdateFrequency is the frequency that controller computes and report cluster status.
 	// It must work with ClusterMonitorGracePeriod(--cluster-monitor-grace-period) in karmada-controller-manager.
 	ClusterStatusUpdateFrequency metav1.Duration
-	// FailoverEvictionTimeout is the grace period for deleting scheduling result on failed clusters.
-	FailoverEvictionTimeout metav1.Duration
 	// ClusterLeaseDuration is a duration that candidates for a lease need to wait to force acquire it.
 	// This is measure against time of last observed lease RenewTime.
 	ClusterLeaseDuration metav1.Duration
@@ -199,9 +197,6 @@ func (o *Options) AddFlags(flags *pflag.FlagSet, allControllers, disabledByDefau
 		"Specifies the grace period of allowing a running cluster to be unresponsive before marking it unhealthy.")
 	flags.DurationVar(&o.ClusterStartupGracePeriod.Duration, "cluster-startup-grace-period", 60*time.Second,
 		"Specifies the grace period of allowing a cluster to be unresponsive during startup before marking it unhealthy.")
-	flags.DurationVar(&o.FailoverEvictionTimeout.Duration, "failover-eviction-timeout", 5*time.Minute,
-		"Specifies the grace period for deleting scheduling result on failed clusters.")
-	_ = flags.MarkDeprecated("failover-eviction-timeout", "This flag was previously used to control the delay time for the cluster-controller to mark NoExecute taints when detecting cluster failures. Now that the cluster-controller no longer automatically marks NoExecute taints, this flag has become obsolete. It is marked as deprecated instead of being directly removed to maintain backward compatibility and ensure it does not block upgrade processes.")
 	flags.StringVar(&o.SkippedPropagatingAPIs, "skipped-propagating-apis", "", "Semicolon separated resources that should be skipped from propagating in addition to the default skip list(cluster.karmada.io;policy.karmada.io;work.karmada.io). Supported formats are:\n"+
 		"<group> for skip resources with a specific API group(e.g. networking.k8s.io),\n"+
 		"<group>/<version> for skip resources with a specific API version(e.g. networking.k8s.io/v1beta1),\n"+

--- a/operator/pkg/controlplane/manifests.go
+++ b/operator/pkg/controlplane/manifests.go
@@ -144,7 +144,6 @@ spec:
             - /bin/karmada-controller-manager
             - --kubeconfig=/etc/karmada/config/karmada.config
             - --cluster-status-update-frequency=10s
-            - --failover-eviction-timeout=30s
             - --leader-elect-resource-namespace={{ .SystemNamespace }}
             - --metrics-bind-address=$(POD_IP):8080
             - --health-probe-bind-address=$(POD_IP):10357


### PR DESCRIPTION
**What type of PR is this?**

/kind deprecation
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

In v1.14, we have deprecated the `failover-eviction-timeout` flag, now, we can remove it in v1.15.

**Which issue(s) this PR fixes**:
Part of #6428

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmaa-controller-manager`: The flag `--failover-eviction-timeout` has been deprecated in release-1.14, now has been removed. 
```

