### PR TITLE
flakey test: Retry on failed deployment update

### DIFF
--- a/test/e2e/framework/deployment.go
+++ b/test/e2e/framework/deployment.go
@@ -19,6 +19,7 @@ package framework
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -53,15 +54,23 @@ func UpdateDeploymentPaused(client kubernetes.Interface, deployment *appsv1.Depl
 	})
 }
 
-// UpdateDeploymentWithSpec update deployment with the given spec.
-func UpdateDeploymentWithSpec(client kubernetes.Interface, namespace, name string, spec appsv1.DeploymentSpec) {
+// UpdateDeploymentWith update deployment with the given mutate function.
+func UpdateDeploymentWith(client kubernetes.Interface, namespace, name string, mutateFunc func(deploy *appsv1.Deployment)) {
 	ginkgo.By(fmt.Sprintf("Update Deployment(%s/%s)", namespace, name), func() {
-		newDeployment, err := client.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		gomega.Eventually(func() error {
+			deploy, err := client.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
 
-		newDeployment.Spec = spec
-		_, err = client.AppsV1().Deployments(namespace).Update(context.TODO(), newDeployment, metav1.UpdateOptions{})
-		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			deployCopy := deploy.DeepCopy()
+			mutateFunc(deployCopy)
+			if reflect.DeepEqual(deploy, deployCopy) {
+				return nil
+			}
+			_, err = client.AppsV1().Deployments(namespace).Update(context.TODO(), deployCopy, metav1.UpdateOptions{})
+			return err
+		}, PollTimeout, PollInterval).ShouldNot(gomega.HaveOccurred())
 	})
 }
 

--- a/test/e2e/suites/base/federatedresourcequota_test.go
+++ b/test/e2e/suites/base/federatedresourcequota_test.go
@@ -350,12 +350,13 @@ var _ = ginkgo.Describe("FederatedResourceQuota enforcement testing", func() {
 
 		ginkgo.It("Intercept update requests for requirements if they exceed the quota.", func() {
 			ginkgo.By("update the requirements of the deployment", func() {
-				newSpec := deployment.Spec.DeepCopy()
-				newSpec.Template.Spec.Containers[0].Resources.Requests = corev1.ResourceList{
-					"cpu": resource.MustParse("20m"),
+				mutateFunc := func(deploy *appsv1.Deployment) {
+					deploy.Spec.Template.Spec.Containers[0].Resources.Requests = corev1.ResourceList{
+						"cpu": resource.MustParse("20m"),
+					}
 				}
 
-				framework.UpdateDeploymentWithSpec(kubeClient, deploymentNamespace, deploymentName, *newSpec)
+				framework.UpdateDeploymentWith(kubeClient, deploymentNamespace, deploymentName, mutateFunc)
 			})
 
 			ginkgo.By("The quota has been exceeded, so the update request for the requirements in resourcebinding will be intercepted.", func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind flake
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
```md
      Operation cannot be fulfilled on deployments.apps "deploy-c6rvt": the object has been modified; please apply your changes to the latest version and try again
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "Operation cannot be fulfilled on deployments.apps \"deploy-c6rvt\": the object has been modified; please apply your changes to the latest version and try again",
              Reason: "Conflict",
              Details: {Name: "deploy-c6rvt", Group: "apps", Kind: "deployments", UID: "", Causes: nil, RetryAfterSeconds: 0},
              Code: 409,
          },
      }
```

Ref to https://github.com/karmada-io/karmada/actions/runs/15630222414/job/44032968282?pr=6452#step:6:4149, we should retry on failed deployment update.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

