### PR TITLE
make healthz/metrics server ports of the scheduler/descheduler unit tests to be detected automatically to avoid flaky test failures

### DIFF
--- a/cmd/descheduler/app/descheduler_test.go
+++ b/cmd/descheduler/app/descheduler_test.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -27,6 +28,7 @@ import (
 
 	"github.com/karmada-io/karmada/cmd/descheduler/app/options"
 	"github.com/karmada-io/karmada/pkg/util/names"
+	testingutil "github.com/karmada-io/karmada/pkg/util/testing"
 )
 
 func TestNewDeschedulerCommand(t *testing.T) {
@@ -66,8 +68,10 @@ func TestDeschedulerCommandFlagParsing(t *testing.T) {
 }
 
 func TestServeHealthzAndMetrics(t *testing.T) {
-	healthAddress := "127.0.0.1:8082"
-	metricsAddress := "127.0.0.1:8083"
+	ports, err := testingutil.GetFreePorts("127.0.0.1", 2)
+	require.NoError(t, err)
+	healthAddress := fmt.Sprintf("127.0.0.1:%d", ports[0])
+	metricsAddress := fmt.Sprintf("127.0.0.1:%d", ports[1])
 
 	go serveHealthzAndMetrics(healthAddress, metricsAddress)
 

--- a/cmd/scheduler/app/scheduler_test.go
+++ b/cmd/scheduler/app/scheduler_test.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -27,6 +28,7 @@ import (
 
 	"github.com/karmada-io/karmada/cmd/scheduler/app/options"
 	"github.com/karmada-io/karmada/pkg/util/names"
+	testingutil "github.com/karmada-io/karmada/pkg/util/testing"
 )
 
 func TestNewSchedulerCommand(t *testing.T) {
@@ -66,8 +68,10 @@ func TestSchedulerCommandFlagParsing(t *testing.T) {
 }
 
 func TestServeHealthzAndMetrics(t *testing.T) {
-	healthAddress := "127.0.0.1:8082"
-	metricsAddress := "127.0.0.1:8083"
+	ports, err := testingutil.GetFreePorts("127.0.0.1", 2)
+	require.NoError(t, err)
+	healthAddress := fmt.Sprintf("127.0.0.1:%d", ports[0])
+	metricsAddress := fmt.Sprintf("127.0.0.1:%d", ports[1])
 
 	go serveHealthzAndMetrics(healthAddress, metricsAddress)
 


### PR DESCRIPTION

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind failing-test

**What this PR does / why we need it**:

It makes the ports of the metrics and healthz server of the scheduler and the descheduler's unit tests to be detected automatically to avoid flaky test failures.

**Which issue(s) this PR fixes**:
Fixes #6441 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

