### PR TITLE
chore: update maintained versions to `1.14` and bump imageTag to `v1.14.0`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,12 @@ updates:
 
 - package-ecosystem: docker
   directory: /cluster/images/
+  target-branch: "release-1.14"
+  schedule:
+    interval: weekly
+
+- package-ecosystem: docker
+  directory: /cluster/images/
   target-branch: "release-1.13"
   schedule:
     interval: weekly
@@ -26,11 +32,5 @@ updates:
 - package-ecosystem: docker
   directory: /cluster/images/
   target-branch: "release-1.12"
-  schedule:
-    interval: weekly
-
-- package-ecosystem: docker
-  directory: /cluster/images/
-  target-branch: "release-1.11"
   schedule:
     interval: weekly

--- a/.github/workflows/ci-image-scanning-on-schedule.yml
+++ b/.github/workflows/ci-image-scanning-on-schedule.yml
@@ -27,7 +27,7 @@ jobs:
           - karmada-search
           - karmada-operator
           - karmada-metrics-adapter
-        karmada-version: [ release-1.13, release-1.12, release-1.11 ]
+        karmada-version: [ release-1.14, release-1.13, release-1.12 ]
     steps:
       - name: checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci-schedule-compatibility.yaml
+++ b/.github/workflows/ci-schedule-compatibility.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         kubeapiserver-version: [ v1.23.4, v1.24.2, v1.25.0, v1.26.0, v1.27.3, v1.28.0, v1.29.0, v1.30.0, v1.31.0, v1.32.0 ]
-        karmada-version: [ master, release-1.13, release-1.12, release-1.11 ]
+        karmada-version: [ master, release-1.14, release-1.13, release-1.12 ]
     env:
       KARMADA_APISERVER_VERSION: ${{ matrix.kubeapiserver-version }}
     steps:

--- a/operator/config/samples/karmada.yaml
+++ b/operator/config/samples/karmada.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   crdTarball:
     httpSource: 
-      url: "https://github.com/karmada-io/karmada/releases/download/v1.13.0/crds.tar.gz"
+      url: "https://github.com/karmada-io/karmada/releases/download/v1.14.0/crds.tar.gz"
   components:
     etcd:
       local:
@@ -34,19 +34,19 @@ spec:
       serviceSubnet: 10.96.0.0/12
     karmadaAggregatedAPIServer:
       imageRepository: docker.io/karmada/karmada-aggregated-apiserver
-      imageTag: v1.13.0
+      imageTag: v1.14.0
       replicas: 1
     karmadaControllerManager:
       imageRepository: docker.io/karmada/karmada-controller-manager
-      imageTag: v1.13.0
+      imageTag: v1.14.0
       replicas: 1
     karmadaScheduler:
       imageRepository: docker.io/karmada/karmada-scheduler
-      imageTag: v1.13.0
+      imageTag: v1.14.0
       replicas: 1
     karmadaWebhook:
       imageRepository: docker.io/karmada/karmada-webhook
-      imageTag: v1.13.0
+      imageTag: v1.14.0
       replicas: 1
     kubeControllerManager:
       imageRepository: registry.k8s.io/kube-controller-manager
@@ -54,15 +54,15 @@ spec:
       replicas: 1
     karmadaMetricsAdapter:
       imageRepository: docker.io/karmada/karmada-metrics-adapter
-      imageTag: v1.13.0
+      imageTag: v1.14.0
       replicas: 2
     # karmadaSearch: # the component `Karmadasearch` is not installed by default, if you need to install it, uncomment it and note the formatting
       # imageRepository: docker.io/karmada/karmada-search
-      # imageTag: v1.13.0
+      # imageTag: v1.14.0
       # replicas: 1
     # karmadaDescheduler: # the component `KarmadaDescheduler` is not installed by default, if you need to install it, uncomment it and note the formatting
       # imageRepository: docker.io/karmada/karmada-descheduler
-      # imageTag: v1.13.0
+      # imageTag: v1.14.0
       # replicas: 1
   hostCluster:
     networking:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of #6451 

**Special notes for your reviewer**: NA

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

