### PR TITLE
JSON logging support for Karmada scheduler-estimator

### DIFF
--- a/artifacts/deploy/karmada-scheduler-estimator.yaml
+++ b/artifacts/deploy/karmada-scheduler-estimator.yaml
@@ -40,6 +40,7 @@ spec:
             - --grpc-client-ca-file=/etc/karmada/pki/server/ca.crt
             - --metrics-bind-address=$(POD_IP):8080
             - --health-probe-bind-address=$(POD_IP):10351
+            - --logging-format=json
           livenessProbe:
             httpGet:
               path: /healthz

--- a/cmd/scheduler-estimator/main.go
+++ b/cmd/scheduler-estimator/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"k8s.io/component-base/cli"
+	"k8s.io/component-base/logs"
 	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
 	controllerruntime "sigs.k8s.io/controller-runtime"
 
@@ -30,5 +31,7 @@ func main() {
 	ctx := controllerruntime.SetupSignalHandler()
 	cmd := app.NewSchedulerEstimatorCommand(ctx)
 	code := cli.Run(cmd)
+	// Ensure any buffered log entries are flushed
+	logs.FlushLogs()
 	os.Exit(code)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

JSON logging support. More details are highlighted in https://github.com/karmada-io/karmada/issues/6230.

**Which issue(s) this PR fixes:**

Part of https://github.com/karmada-io/karmada/issues/6230

**Special notes for your reviewer**:

* New Flags after change:

```text
--log-flush-frequency duration
          Maximum number of seconds between log flushes (default 5s)
--log-json-info-buffer-size quantity
          [Alpha] In JSON format with split output streams, the info messages can be buffered for a while to increase performance. The default value of zero bytes disables
          buffering. The size can be specified as number of bytes (512), multiples of 1000 (1K), multiples of 1024 (2Ki), or powers of those (3M, 4G, 5Mi, 6Gi). Enable the
          LoggingAlphaOptions feature gate to use this.
--log-json-split-stream
          [Alpha] In JSON format, write error messages to stderr and info messages to stdout. The default is to write a single stream to stdout. Enable the LoggingAlphaOptions
          feature gate to use this.
--log-text-info-buffer-size quantity
          [Alpha] In text format with split output streams, the info messages can be buffered for a while to increase performance. The default value of zero bytes disables
          buffering. The size can be specified as number of bytes (512), multiples of 1000 (1K), multiples of 1024 (2Ki), or powers of those (3M, 4G, 5Mi, 6Gi). Enable the
          LoggingAlphaOptions feature gate to use this.
--log-text-split-stream
          [Alpha] In text format, write error messages to stderr and info messages to stdout. The default is to write a single stream to stdout. Enable the LoggingAlphaOptions
          feature gate to use this.
--logging-format string
          Sets the log format. Permitted formats: "json" (gated by LoggingBetaOptions), "text". (default "text")
```

* Tests with feature on `--logging-format=json`:

```json
{"ts":1750012793460.6665,"caller":"app/scheduler-estimator.go:128","msg":"karmada-scheduler-estimator version: version.Info{GitVersion:\"v0.0.0-master\", GitCommit:\"unknown\", GitShortCommit:\"unknown\", GitTreeState:\"unknown\", BuildDate:\"unknown\", GoVersion:\"go1.23.8\", Compiler:\"gc\", Platform:\"linux/amd64\"}","v":0}
{"ts":1750012793460.8223,"caller":"app/scheduler-estimator.go:216","msg":"Starting healthz server on :10351","v":0}
{"ts":1750012793470.4717,"caller":"app/scheduler-estimator.go:216","msg":"Starting metrics server on :8080","v":0}
{"ts":1750012793565.2925,"caller":"server/server.go:151","msg":"Starting karmada cluster(kind-sandbox) accurate scheduler estimator","v":0}
{"ts":1750012793765.8005,"caller":"server/server.go:167","msg":"Listening port: 10352","v":0}


{"ts":1750012796884.5916,"caller":"server/server.go:188","msg":"Shutting down cluster(kind-sandbox) accurate scheduler estimator","v":0}
```

* Tests with feature off (no `--logging-format` or `--logging-format=text`):

```text
I0615 15:11:27.975343  164993 scheduler-estimator.go:128] karmada-scheduler-estimator version: version.Info{GitVersion:"v0.0.0-master", GitCommit:"unknown", GitShortCommit:"unknown", GitTreeState:"unknown", BuildDate:"unknown", GoVersion:"go1.23.8", Compiler:"gc", Platform:"linux/amd64"}
I0615 15:11:27.975666  164993 scheduler-estimator.go:216] Starting healthz server on :10351
I0615 15:11:27.983868  164993 scheduler-estimator.go:216] Starting metrics server on :8080
I0615 15:11:28.148858  164993 server.go:151] Starting karmada cluster(kind-sandbox) accurate scheduler estimator
I0615 15:11:28.350408  164993 server.go:167] Listening port: 10352


I0615 15:11:31.627490  164993 server.go:188] Shutting down cluster(kind-sandbox) accurate scheduler estimator
```

**Does this PR introduce a user-facing change?**:

```release-note
`karmada-scheduler-estimator`: Introduced `--logging-format` flag which can be set to `json` to enable JSON logging.
```
