### PR TITLE
fix: ensure APIEnablement plugin never deletes scheduled resources

### DIFF
--- a/pkg/scheduler/framework/plugins/apienablement/api_enablement_test.go
+++ b/pkg/scheduler/framework/plugins/apienablement/api_enablement_test.go
@@ -93,7 +93,7 @@ func TestAPIEnablement_Filter(t *testing.T) {
 			expectError:  true,
 		},
 		{
-			name: "cluster in target list with incomplete API enablements",
+			name: "cluster in target list with API not enabled",
 			bindingSpec: &workv1alpha2.ResourceBindingSpec{
 				Resource: workv1alpha2.ObjectReference{
 					APIVersion: "custom.io/v1",
@@ -110,10 +110,14 @@ func TestAPIEnablement_Filter(t *testing.T) {
 					Name: "cluster1",
 				},
 				Status: clusterv1alpha1.ClusterStatus{
-					Conditions: []metav1.Condition{
+					APIEnablements: []clusterv1alpha1.APIEnablement{
 						{
-							Type:   clusterv1alpha1.ClusterConditionCompleteAPIEnablements,
-							Status: metav1.ConditionFalse,
+							GroupVersion: "apps/v1",
+							Resources: []clusterv1alpha1.APIResource{
+								{
+									Kind: "Deployment",
+								},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Modifies the `APIEnablement` plugin to never delete scheduled resources, even if their API (CRD) is temporarily unavailable. This prevents resource deletion when users accidentally delete and reinstall CRDs in member clusters.

**Which issue(s) this PR fixes**:
Fixes #6461 

**Special notes for your reviewer**: NA

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

