### PR TITLE
Add json logging support for karmada scheduler

### DIFF
--- a/artifacts/deploy/karmada-scheduler.yaml
+++ b/artifacts/deploy/karmada-scheduler.yaml
@@ -54,6 +54,7 @@ spec:
             - --scheduler-estimator-cert-file=/etc/karmada/pki/scheduler-estimator-client/tls.crt
             - --scheduler-estimator-key-file=/etc/karmada/pki/scheduler-estimator-client/tls.key
             - --feature-gates=AllAlpha=true,AllBeta=true
+            - --logging-format=json
             - --v=4
           volumeMounts:
             - name: karmada-config

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"k8s.io/component-base/cli"
+	"k8s.io/component-base/logs"
 	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
 	controllerruntime "sigs.k8s.io/controller-runtime"
 
@@ -30,5 +31,7 @@ func main() {
 	ctx := controllerruntime.SetupSignalHandler()
 	command := app.NewSchedulerCommand(ctx)
 	code := cli.Run(command)
+	// Ensure any buffered log entries are flushed
+	logs.FlushLogs()
 	os.Exit(code)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
JSON logging support. More details are highlighted in https://github.com/karmada-io/karmada/issues/6230.

**Which issue(s) this PR fixes**:
Part of https://github.com/karmada-io/karmada/issues/6230

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-scheduler`: Introduced `--logging-format` flag, which can be set to `json` to enable JSON logging.
```

