### PR TITLE
Fix workload scale up bypass FederatedResourceQuota check issue

### DIFF
--- a/pkg/controllers/binding/common_test.go
+++ b/pkg/controllers/binding/common_test.go
@@ -391,6 +391,34 @@ func Test_needReviseReplicas(t *testing.T) {
 		{
 			name:     "replicas is zero",
 			replicas: 0,
+			want:     false,
+		},
+		{
+			name:     "replicas is greater than zero",
+			replicas: 1,
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := needReviseReplicas(tt.replicas); got != tt.want {
+				t.Errorf("needReviseReplicas() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_needReviseJobCompletions(t *testing.T) {
+	tests := []struct {
+		name      string
+		replicas  int32
+		placement *policyv1alpha1.Placement
+		want      bool
+	}{
+		{
+			name:     "replicas is zero",
+			replicas: 0,
 			placement: &policyv1alpha1.Placement{
 				ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
 					ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided,
@@ -428,8 +456,8 @@ func Test_needReviseReplicas(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := needReviseReplicas(tt.replicas, tt.placement); got != tt.want {
-				t.Errorf("needReviseReplicas() = %v, want %v", got, tt.want)
+			if got := needReviseJobCompletions(tt.replicas, tt.placement); got != tt.want {
+				t.Errorf("needReviseJobCompletions() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/test/e2e/suites/base/scheduling_test.go
+++ b/test/e2e/suites/base/scheduling_test.go
@@ -262,6 +262,11 @@ var _ = ginkgo.Describe("propagation with label and group constraints testing", 
 			jobNamespace = testNamespace
 			jobName = policyName
 			job = helper.NewJob(jobNamespace, jobName)
+			// For fixed completion count Jobs, the actual number of pods running in parallel will not exceed the number of remaining completions.
+			// Higher values of .spec.parallelism are effectively ignored.
+			// Since .spec.parallelism will be updated to updateParallelism in the subsequent testing, .spec.completions is set to updateParallelism here to make the update of .spec.parallelism take effect.
+			// More info: https://kubernetes.io/docs/concepts/workloads/controllers/job/
+			job.Spec.Completions = ptr.To[int32](updateParallelism)
 			maxGroups = rand.Intn(2) + 1
 			minGroups = maxGroups
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
We introduced federatedresourcequota enforcement in v1.14 to achieve unified quota management across clusters. This is realized by intercepting modifications to workload requirements and the `spec.clusters` field of resource bindings. However, the federated resource quota mechanism fails when workloads scale up.

The root cause is that the binding controller synchronizes workload modifications to member clusters. When the replicas scheduling policy is set to "duplicated", the binding controller does not revise the workload's replicas according to the scheduling results in `bindingSpec.clusters`. As a result, the scale-up operations of workloads are directly synchronized to member clusters, rendering the federated resource quota ineffective.

The detailed process is as follows:
1. Edit the replicas of a workload.
2. The binding controller synchronizes the workload's replicas to member clusters.
3. Karmada-scheduler performs rescheduling, and the request to update `bindingSpec.clusters` is intercepted due to insufficient quota.

As described above, even though the update request for `bindingSpec.clusters` is blocked, the replicas of the workload in member clusters are still synchronized, leading to the failure of the federated resource quota.


This PR modifies the logic for the binding controller to sync workloads to member clusters. It syncs the replicas in `bindingSpec.clusters` to member clusters instead of the replicas of the workload.

**Which issue(s) this PR fixes**:
Parts of #6467

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Fixed the issue that a workload propagated with `duplicated mode` can bypass quota checks during scale up.
```

