### PR TITLE
Use rbSpec.clusters and rbSpec.ReplicaRequirements to calculate rb' resource usage

### DIFF
--- a/pkg/controllers/federatedresourcequota/federated_resource_quota_enforcement_controller.go
+++ b/pkg/controllers/federatedresourcequota/federated_resource_quota_enforcement_controller.go
@@ -266,32 +266,50 @@ func (c *QuotaEnforcementController) collectQuotaStatus(quota *policyv1alpha1.Fe
 func calculateUsedWithResourceBinding(resourceBindings []workv1alpha2.ResourceBinding, overall corev1.ResourceList) corev1.ResourceList {
 	overallUsed := corev1.ResourceList{}
 	for _, binding := range resourceBindings {
-		if binding.Spec.ReplicaRequirements == nil || binding.Spec.Clusters == nil {
-			continue
-		}
-		used := binding.Spec.ReplicaRequirements.ResourceRequest
-		replicas := binding.Spec.Replicas
-
-		for name, quantity := range used {
-			// Update quantity to reflect number of replicas in resource
-			q := quantity.DeepCopy()
-			q.Mul(int64(replicas))
-
-			// Update quantity to reflect the number of clusters resource is duplicated to
-			if binding.Spec.Placement != nil && binding.Spec.Placement.ReplicaSchedulingType() == policyv1alpha1.ReplicaSchedulingTypeDuplicated {
-				q.Mul(int64(len(binding.Spec.Clusters)))
-			}
-
+		usage := calculateResourceUsage(&binding)
+		for name, quantity := range usage {
 			existing, found := overallUsed[name]
 			if found {
-				existing.Add(q)
+				existing.Add(quantity)
 				overallUsed[name] = existing
 			} else {
-				overallUsed[name] = q
+				overallUsed[name] = quantity
 			}
 		}
 	}
 	return filterResourceListByOverall(overallUsed, overall)
+}
+
+// calculateResourceUsage calculates the total resource usage based on the ResourceBinding.
+func calculateResourceUsage(rb *workv1alpha2.ResourceBinding) corev1.ResourceList {
+	if rb == nil || rb.Spec.ReplicaRequirements == nil || len(rb.Spec.ReplicaRequirements.ResourceRequest) == 0 || len(rb.Spec.Clusters) == 0 {
+		return corev1.ResourceList{}
+	}
+
+	totalReplicas := int32(0)
+	for _, cluster := range rb.Spec.Clusters {
+		totalReplicas += cluster.Replicas
+	}
+
+	if totalReplicas == 0 {
+		return corev1.ResourceList{}
+	}
+
+	usage := corev1.ResourceList{}
+	replicaCount := int64(totalReplicas)
+
+	for resourceName, quantityPerReplica := range rb.Spec.ReplicaRequirements.ResourceRequest {
+		if quantityPerReplica.IsZero() {
+			continue
+		}
+
+		totalQuantity := quantityPerReplica.DeepCopy()
+		totalQuantity.Mul(replicaCount)
+
+		usage[resourceName] = totalQuantity
+	}
+
+	return usage
 }
 
 // Filters source ResourceList using the keys provided by reference


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

As stated in #6467, the workload replicas of member clusters are consistent with `rb.Clusters` rather than `rb.replicas`. Therefore, when the `federated-resource-quota-enforcement-controller` periodically refreshes `overallUsage` based on `rb`, it should only use `rbSpec.clusters` and `rbSpec.ReplicaRequirements` for calculation.

For example, when a Deployment is scaled up and intercepted by the federated resource quota, its `rb` might be:

```yaml
spec:
  clusters:
  - name: member1
    replicas: 2
  - name: member2
    replicas: 2
  replicas: 3
```

- If calculated based on `rbSpec.replicas`, the total replicas = 3 * len(clusters) = 6  
- If calculated based on `rbSpec.clusters`, the total replicas = 2 + 2 = 4  

The two results are inconsistent.  

The purpose of this PR is to modify the algorithm for calculating `rb` resource usage to more accurately reflect the actual usage.

**Which issue(s) this PR fixes**:
Parts of #6467
Parts of #6486

**Special notes for your reviewer**:

The method for calculating RB resource usage selected in this PR is consistent with that of the [validation webhook](https://github.com/karmada-io/karmada/blob/2af742b2d38745007c4c8e687f8799cf422b1e36/pkg/webhook/resourcebinding/validating.go#L325-L360). A common function could be extracted to implement this logic. However, considering that the purpose of this PR is to fix a bug rather than to refactor, I decided to fix the issue first and extract the common function in a follow-up change. This approach also makes the code review and code backport easier. Of course, if you believe it's better to extract the common function right away, please let me know your thoughts.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
`karmada-controller-manager`: Fixed the issue where the federated-resource-quota-enforcement-controller miscalculates quota usage.
```

