### PR TITLE
karmada-operator: Optimize the startup process of Karmada components

### DIFF
--- a/operator/pkg/tasks/init/component.go
+++ b/operator/pkg/tasks/init/component.go
@@ -174,15 +174,6 @@ func runDeployMetricAdapter(r workflow.RunData) error {
 
 	klog.V(2).InfoS("[DeployMetricAdapter] Successfully applied karmada-metrics-adapter component", "karmada", klog.KObj(data))
 
-	if *cfg.KarmadaMetricsAdapter.Replicas != 0 {
-		waiter := apiclient.NewKarmadaWaiter(data.ControlplaneConfig(), data.RemoteClient(), time.Second*30)
-		if err = waiter.WaitForSomePods(karmadaMetricAdapterLabels.String(), data.GetNamespace(), 1); err != nil {
-			return fmt.Errorf("waiting for karmada-metrics-adapter to ready timeout, err: %w", err)
-		}
-
-		klog.V(2).InfoS("[DeployMetricAdapter] the karmada-metrics-adapter is ready", "karmada", klog.KObj(data))
-	}
-
 	return nil
 }
 

--- a/operator/pkg/util/apiclient/wait.go
+++ b/operator/pkg/util/apiclient/wait.go
@@ -152,6 +152,9 @@ func (w *KarmadaWaiter) WaitForPods(label, namespace string) error {
 // WaitForSomePods lookup pods with the given label and wait until desired number of pods
 // reporting status as running.
 func (w *KarmadaWaiter) WaitForSomePods(label, namespace string, podNum int32) error {
+	if podNum == 0 {
+		return nil
+	}
 	return wait.PollUntilContextTimeout(context.TODO(), APICallRetryInterval, w.timeout, true, func(ctx context.Context) (bool, error) {
 		listOpts := metav1.ListOptions{LabelSelector: label}
 		pods, err := w.client.CoreV1().Pods(namespace).List(ctx, listOpts)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
https://github.com/karmada-io/karmada/blob/0b75a70173ee6d68ed1b112c7cac0b1a89b48448/operator/pkg/tasks/init/apiserver.go#L116-L131

In the process of starting a Karmada instance, the operator ensures that components start in the correct order to ensure they can run normally. For example, before starting aggregated-apiserver, it needs to wait until karmada-apiserver is ready. When deploying multiple Karmada instances in the same namespace, relying solely on karmadaApiserverLabels.String() cannot correctly match the target karmada instance's karmada-apiserver;
```bash
$ kubectl get pods --namespace test -l app.kubernetes.io/name=karmada-apiserver
NAME                                       READY   STATUS    RESTARTS   AGE
karmada-demo4-apiserver-54668d8b8b-k7jbw   1/1     Running   0          134m
karmada-demo5-apiserver-86b4f5dc98-kkvk2   1/1     Running   0          133m
karmada-demo6-apiserver-78f58db558-dg2t6   1/1     Running   0          124m
karmada-demo7-apiserver-76776d9778-8kfbz   1/1     Running   0          119m
karmada-demo8-apiserver-869dcf599d-ppwsl   1/1     Running   0          109m
karmada-demo9-apiserver-54bd885fb6-2472d   1/1     Running   0          17m

$ kubectl get pods --namespace test -l app.kubernetes.io/name=karmada-apiserver
,app.kubernetes.io/instance=karmada-demo4
NAME                                       READY   STATUS    RESTARTS   AGE
karmada-demo4-apiserver-54668d8b8b-k7jbw   1/1     Running   0          136m
```

As a result, subsequent installations of Karmada instances fail to start components in the correct sequence, leading to issues such as aggregated-apiserver restarting.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This pr includes:
- Add the karmada instance label in the waitPodReady process
- Use a unified way to wait for different component pods to be ready

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

