### PR TITLE
Add JSON logging support for Karmada descheduler component

### DIFF
--- a/artifacts/deploy/karmada-descheduler.yaml
+++ b/artifacts/deploy/karmada-descheduler.yaml
@@ -39,6 +39,7 @@ spec:
             - --scheduler-estimator-ca-file=/etc/karmada/pki/scheduler-estimator-client/ca.crt
             - --scheduler-estimator-cert-file=/etc/karmada/pki/scheduler-estimator-client/tls.crt
             - --scheduler-estimator-key-file=/etc/karmada/pki/scheduler-estimator-client/tls.key
+            - --logging-format=json
             - --v=4
           livenessProbe:
             httpGet:

--- a/cmd/descheduler/main.go
+++ b/cmd/descheduler/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"k8s.io/component-base/cli"
+	"k8s.io/component-base/logs"
 	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
 	controllerruntime "sigs.k8s.io/controller-runtime"
 
@@ -28,7 +29,8 @@ import (
 
 func main() {
 	ctx := controllerruntime.SetupSignalHandler()
-	command := app.NewDeschedulerCommand(ctx)
-	code := cli.Run(command)
-	os.Exit(code)
+	cmd := app.NewDeschedulerCommand(ctx)
+	exitCode := cli.Run(cmd)
+	logs.FlushLogs()
+	os.Exit(exitCode)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it:**
JSON logging support. More details are highlighted https://github.com/karmada-io/karmada/issues/6230.

**Which issue(s) this PR fixes:**
Part of https://github.com/karmada-io/karmada/issues/6230

**Special notes for your reviewer:**

Does this PR introduce a user-facing change?:
```
`karmada-descheduler`: Introduced `--logging-format` flag which can be set to `json` to enable JSON logging.
```
