### PR TITLE
fix: Address all `govet` printf issues across the codebase

### DIFF
--- a/pkg/controllers/binding/binding_controller.go
+++ b/pkg/controllers/binding/binding_controller.go
@@ -137,7 +137,7 @@ func (c *ResourceBindingController) syncBinding(ctx context.Context, binding *wo
 	}
 
 	msg := fmt.Sprintf("Sync work of resourceBinding(%s/%s) successful.", binding.Namespace, binding.Name)
-	klog.V(4).Infof(msg)
+	klog.V(4).Info(msg)
 	c.EventRecorder.Event(binding, corev1.EventTypeNormal, events.EventReasonSyncWorkSucceed, msg)
 	c.EventRecorder.Event(workload, corev1.EventTypeNormal, events.EventReasonSyncWorkSucceed, msg)
 	return controllerruntime.Result{}, nil

--- a/pkg/controllers/binding/cluster_resource_binding_controller.go
+++ b/pkg/controllers/binding/cluster_resource_binding_controller.go
@@ -136,7 +136,7 @@ func (c *ClusterResourceBindingController) syncBinding(ctx context.Context, bind
 	}
 
 	msg := fmt.Sprintf("Sync work of clusterResourceBinding(%s) successful.", binding.GetName())
-	klog.V(4).Infof(msg)
+	klog.V(4).Info(msg)
 	c.EventRecorder.Event(binding, corev1.EventTypeNormal, events.EventReasonSyncWorkSucceed, msg)
 	c.EventRecorder.Event(workload, corev1.EventTypeNormal, events.EventReasonSyncWorkSucceed, msg)
 	return controllerruntime.Result{}, nil

--- a/pkg/controllers/federatedhpa/federatedhpa_controller.go
+++ b/pkg/controllers/federatedhpa/federatedhpa_controller.go
@@ -517,7 +517,7 @@ func (c *FHPAController) scaleForTargetCluster(ctx context.Context, clusters []s
 		if err != nil {
 			errMsg := fmt.Sprintf("couldn't convert selector into a corresponding internal selector object: %v", err)
 			c.EventRecorder.Event(hpa, corev1.EventTypeWarning, "InvalidSelector", errMsg)
-			setCondition(hpa, autoscalingv2.ScalingActive, corev1.ConditionFalse, "InvalidSelector", errMsg)
+			setCondition(hpa, autoscalingv2.ScalingActive, corev1.ConditionFalse, "InvalidSelector", "%s", errMsg)
 			continue
 		}
 
@@ -633,7 +633,7 @@ func (c *FHPAController) computeReplicasForMetrics(ctx context.Context, hpa *aut
 	// return an error and set the condition of the hpa based on the first invalid metric.
 	// Otherwise set the condition as scaling active as we're going to scale
 	if invalidMetricsCount >= len(metricSpecs) || (invalidMetricsCount > 0 && replicas < specReplicas) {
-		setCondition(hpa, invalidMetricCondition.Type, invalidMetricCondition.Status, invalidMetricCondition.Reason, invalidMetricCondition.Message)
+		setCondition(hpa, invalidMetricCondition.Type, invalidMetricCondition.Status, invalidMetricCondition.Reason, "%s", invalidMetricCondition.Message)
 		return -1, "", statuses, time.Time{}, invalidMetricError
 	}
 	setCondition(hpa, autoscalingv2.ScalingActive, corev1.ConditionTrue, "ValidMetricFound", "the HPA was able to successfully calculate a replica count from %s", metric)
@@ -678,7 +678,7 @@ func (c *FHPAController) validateAndParseSelector(hpa *autoscalingv1alpha1.Feder
 	if err != nil {
 		errMsg := fmt.Sprintf("couldn't convert selector into a corresponding internal selector object: %v", err)
 		c.EventRecorder.Event(hpa, corev1.EventTypeWarning, "InvalidSelector", errMsg)
-		setCondition(hpa, autoscalingv2.ScalingActive, corev1.ConditionFalse, "InvalidSelector", errMsg)
+		setCondition(hpa, autoscalingv2.ScalingActive, corev1.ConditionFalse, "InvalidSelector", "%s", errMsg)
 		return nil, errors.New(errMsg)
 	}
 
@@ -693,7 +693,7 @@ func (c *FHPAController) validateAndParseSelector(hpa *autoscalingv1alpha1.Feder
 	if len(selectingHpas) > 1 {
 		errMsg := fmt.Sprintf("pods by selector %v are controlled by multiple HPAs: %v", selector, selectingHpas)
 		c.EventRecorder.Event(hpa, corev1.EventTypeWarning, "AmbiguousSelector", errMsg)
-		setCondition(hpa, autoscalingv2.ScalingActive, corev1.ConditionFalse, "AmbiguousSelector", errMsg)
+		setCondition(hpa, autoscalingv2.ScalingActive, corev1.ConditionFalse, "AmbiguousSelector", "%s", errMsg)
 		return nil, errors.New(errMsg)
 	}
 
@@ -969,9 +969,9 @@ func (c *FHPAController) normalizeDesiredReplicas(hpa *autoscalingv1alpha1.Feder
 	desiredReplicas, condition, reason := convertDesiredReplicasWithRules(currentReplicas, stabilizedRecommendation, minReplicas, hpa.Spec.MaxReplicas)
 
 	if desiredReplicas == stabilizedRecommendation {
-		setCondition(hpa, autoscalingv2.ScalingLimited, corev1.ConditionFalse, condition, reason)
+		setCondition(hpa, autoscalingv2.ScalingLimited, corev1.ConditionFalse, condition, "%s", reason)
 	} else {
-		setCondition(hpa, autoscalingv2.ScalingLimited, corev1.ConditionTrue, condition, reason)
+		setCondition(hpa, autoscalingv2.ScalingLimited, corev1.ConditionTrue, condition, "%s", reason)
 	}
 
 	return desiredReplicas
@@ -1007,15 +1007,15 @@ func (c *FHPAController) normalizeDesiredReplicasWithBehaviors(hpa *autoscalingv
 	normalizationArg.DesiredReplicas = stabilizedRecommendation
 	if stabilizedRecommendation != prenormalizedDesiredReplicas {
 		// "ScaleUpStabilized" || "ScaleDownStabilized"
-		setCondition(hpa, autoscalingv2.AbleToScale, corev1.ConditionTrue, reason, message)
+		setCondition(hpa, autoscalingv2.AbleToScale, corev1.ConditionTrue, reason, "%s", message)
 	} else {
 		setCondition(hpa, autoscalingv2.AbleToScale, corev1.ConditionTrue, "ReadyForNewScale", "recommended size matches current size")
 	}
 	desiredReplicas, reason, message := c.convertDesiredReplicasWithBehaviorRate(normalizationArg)
 	if desiredReplicas == stabilizedRecommendation {
-		setCondition(hpa, autoscalingv2.ScalingLimited, corev1.ConditionFalse, reason, message)
+		setCondition(hpa, autoscalingv2.ScalingLimited, corev1.ConditionFalse, reason, "%s", message)
 	} else {
-		setCondition(hpa, autoscalingv2.ScalingLimited, corev1.ConditionTrue, reason, message)
+		setCondition(hpa, autoscalingv2.ScalingLimited, corev1.ConditionTrue, reason, "%s", message)
 	}
 
 	return desiredReplicas

--- a/pkg/karmadactl/cmdinit/kubernetes/statefulset_test.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/statefulset_test.go
@@ -63,7 +63,7 @@ func TestCommandInitIOption_etcdVolume(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, got := tt.opt.etcdVolume()
 			if (got == nil) != tt.claimIsNil {
-				t.Errorf(tt.errorMsg)
+				t.Error(tt.errorMsg)
 			}
 		})
 	}

--- a/pkg/karmadactl/register/register.go
+++ b/pkg/karmadactl/register/register.go
@@ -846,7 +846,7 @@ func (o *CommandRegisterOption) constructKubeConfig(bootstrapClient *kubeclient.
 	if err != nil {
 		return nil, err
 	}
-	klog.V(1).Infof(fmt.Sprintf("Waiting for the client certificate %s to be issued", csrName))
+	klog.V(1).Infof("Waiting for the client certificate %s to be issued", csrName)
 	err = wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, o.Timeout, false, func(context.Context) (done bool, err error) {
 		csrOK, err := bootstrapClient.CertificatesV1().CertificateSigningRequests().Get(context.TODO(), csrName, metav1.GetOptions{})
 		if err != nil {
@@ -854,12 +854,12 @@ func (o *CommandRegisterOption) constructKubeConfig(bootstrapClient *kubeclient.
 		}
 
 		if csrOK.Status.Certificate != nil {
-			klog.V(1).Infof(fmt.Sprintf("Signing certificate of csr %s successfully", csrName))
+			klog.V(1).Infof("Signing certificate of csr %s successfully", csrName)
 			cert = csrOK.Status.Certificate
 			return true, nil
 		}
 
-		klog.V(1).Infof(fmt.Sprintf("Waiting for the client certificate of csr %s to be issued", csrName))
+		klog.V(1).Infof("Waiting for the client certificate of csr %s to be issued", csrName)
 		klog.V(1).Infof("Approve the CSR %s manually by executing `kubectl certificate approve %s` on the control plane\nOr enable the agentcsrapproving controller of karmada-controller-manager to automatically approve agent CSR.", csrName, csrName)
 		return false, nil
 	})

--- a/pkg/util/lifted/lua/string_safe.go
+++ b/pkg/util/lifted/lua/string_safe.go
@@ -152,7 +152,7 @@ func strFind(L *lua.LState) int {
 
 	mds, err := pm.Find(pattern, unsafeFastStringToReadOnlyBytes(str), init, 1)
 	if err != nil {
-		L.RaiseError(err.Error())
+		L.RaiseError("%s", err.Error())
 	}
 	if len(mds) == 0 {
 		L.Push(lua.LNil)
@@ -231,7 +231,7 @@ func strGmatch(L *lua.LState) int {
 	validateStrParamsLen(L, pattern)
 	mds, err := pm.Find(pattern, []byte(str), 0, -1)
 	if err != nil {
-		L.RaiseError(err.Error())
+		L.RaiseError("%s", err.Error())
 	}
 	L.Push(L.Get(lua.UpvalueIndex(1)))
 	ud := L.NewUserData()
@@ -270,7 +270,7 @@ func strMatch(L *lua.LState) int {
 
 	mds, err := pm.Find(pattern, unsafeFastStringToReadOnlyBytes(str), offset, 1)
 	if err != nil {
-		L.RaiseError(err.Error())
+		L.RaiseError("%s", err.Error())
 	}
 	if len(mds) == 0 {
 		L.Push(lua.LNil)
@@ -382,7 +382,7 @@ func raiseErrorIfContextIsDone(L *lua.LState) {
 
 	select {
 	case <-L.Context().Done():
-		L.RaiseError(L.Context().Err().Error())
+		L.RaiseError("%s", L.Context().Err().Error())
 	default:
 	}
 }

--- a/pkg/util/lifted/scheduler/cache/cache.go
+++ b/pkg/util/lifted/scheduler/cache/cache.go
@@ -21,6 +21,7 @@ limitations under the License.
 package cache
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -296,7 +297,7 @@ func (cache *cacheImpl) UpdateSnapshot(nodeSnapshot *Snapshot) error {
 		// We will try to recover by re-creating the lists for the next scheduling cycle, but still return an
 		// error to surface the problem, the error will likely cause a failure to the current scheduling cycle.
 		cache.updateNodeInfoSnapshotList(nodeSnapshot, true)
-		return fmt.Errorf(errMsg)
+		return errors.New(errMsg)
 	}
 
 	return nil

--- a/pkg/util/lifted/selectors/bimultimap_test.go
+++ b/pkg/util/lifted/selectors/bimultimap_test.go
@@ -235,7 +235,7 @@ func TestAssociations(t *testing.T) {
 					// Run consistency check after every operation.
 					err := consistencyCheck(multimap)
 					if err != nil {
-						t.Fatalf(err.Error())
+						t.Fatal(err.Error())
 					}
 				}
 				for _, expect := range tc.want {
@@ -261,7 +261,7 @@ func TestEfficientAssociation(t *testing.T) {
 
 	err := forwardSelect(key("hpa-1"), key("pod-1"), key("pod-2"))(m)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 }
 

--- a/pkg/util/overridemanager/overridemanager.go
+++ b/pkg/util/overridemanager/overridemanager.go
@@ -424,7 +424,7 @@ func applyFieldOverriders(rawObj *unstructured.Unstructured, FieldOverriders []p
 		}
 		if kind != reflect.String {
 			errMsg := fmt.Sprintf("Get object's value by overrider's path(%s) is not string", FieldOverriders[index].FieldPath)
-			klog.Errorf(errMsg)
+			klog.Error(errMsg)
 			return errors.New(errMsg)
 		}
 		dataBytes := []byte(res.(string))


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
This PR resolves all `non-constant format string` errors reported by `govet` across the codebase when upgrading to **Go 1.24**.

These errors began causing [CI failures](https://github.com/karmada-io/karmada/pull/6490) in `golangci-lint` and `make test` when building with newer Go toolchains (e.g., **Go 1.24+**). This cleanup is a necessary prerequisite to unblock the main goal of upgrading the project's Go version. By fixing these issues now, we can ensure the subsequent version bump PR is clean and focused solely on the upgrade itself.

**Which issue(s) this PR fixes**:
Fixes #6489

**Special notes for your reviewer**:
The changes in this PR are purely mechanical refactoring and do not alter any program logic. The modifications consistently follow two main patterns:
- `fmt.Errorf(variable)` has been replaced with `errors.New(variable)` for creating simple errors from a pre-existing string.
- `klog.V(X).Infof(variable)` has been replaced with `klog.V(X).Info(variable)` for logging a pre-existing message without formatting.

This approach ensures the codebase is compliant with stricter govet checks while using the most idiomatic Go constructs for each case.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
None
```

