### PR TITLE
Automated cherry pick of #6474: fix the issue where federatedresourcequota becomes invalid

### DIFF
--- a/pkg/controllers/binding/common_test.go
+++ b/pkg/controllers/binding/common_test.go
@@ -391,6 +391,34 @@ func Test_needReviseReplicas(t *testing.T) {
 		{
 			name:     "replicas is zero",
 			replicas: 0,
+			want:     false,
+		},
+		{
+			name:     "replicas is greater than zero",
+			replicas: 1,
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := needReviseReplicas(tt.replicas); got != tt.want {
+				t.Errorf("needReviseReplicas() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_needReviseJobCompletions(t *testing.T) {
+	tests := []struct {
+		name      string
+		replicas  int32
+		placement *policyv1alpha1.Placement
+		want      bool
+	}{
+		{
+			name:     "replicas is zero",
+			replicas: 0,
 			placement: &policyv1alpha1.Placement{
 				ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
 					ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided,
@@ -428,8 +456,8 @@ func Test_needReviseReplicas(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := needReviseReplicas(tt.replicas, tt.placement); got != tt.want {
-				t.Errorf("needReviseReplicas() = %v, want %v", got, tt.want)
+			if got := needReviseJobCompletions(tt.replicas, tt.placement); got != tt.want {
+				t.Errorf("needReviseJobCompletions() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/test/e2e/suites/base/federatedresourcequota_test.go
+++ b/test/e2e/suites/base/federatedresourcequota_test.go
@@ -350,12 +350,13 @@ var _ = ginkgo.Describe("FederatedResourceQuota enforcement testing", func() {
 
 		ginkgo.It("Intercept update requests for requirements if they exceed the quota.", func() {
 			ginkgo.By("update the requirements of the deployment", func() {
-				newSpec := deployment.Spec.DeepCopy()
-				newSpec.Template.Spec.Containers[0].Resources.Requests = corev1.ResourceList{
-					"cpu": resource.MustParse("20m"),
+				mutateFunc := func(deploy *appsv1.Deployment) {
+					deploy.Spec.Template.Spec.Containers[0].Resources.Requests = corev1.ResourceList{
+						"cpu": resource.MustParse("20m"),
+					}
 				}
 
-				framework.UpdateDeploymentWithSpec(kubeClient, deploymentNamespace, deploymentName, *newSpec)
+				framework.UpdateDeploymentWith(kubeClient, deploymentNamespace, deploymentName, mutateFunc)
 			})
 
 			ginkgo.By("The quota has been exceeded, so the update request for the requirements in resourcebinding will be intercepted.", func() {

--- a/test/e2e/suites/base/scheduling_test.go
+++ b/test/e2e/suites/base/scheduling_test.go
@@ -262,6 +262,11 @@ var _ = ginkgo.Describe("propagation with label and group constraints testing", 
 			jobNamespace = testNamespace
 			jobName = policyName
 			job = helper.NewJob(jobNamespace, jobName)
+			// For fixed completion count Jobs, the actual number of pods running in parallel will not exceed the number of remaining completions.
+			// Higher values of .spec.parallelism are effectively ignored.
+			// Since .spec.parallelism will be updated to updateParallelism in the subsequent testing, .spec.completions is set to updateParallelism here to make the update of .spec.parallelism take effect.
+			// More info: https://kubernetes.io/docs/concepts/workloads/controllers/job/
+			job.Spec.Completions = ptr.To[int32](updateParallelism)
 			maxGroups = rand.Intn(2) + 1
 			minGroups = maxGroups
 


### PR DESCRIPTION
Cherry pick of #6474 on release-1.14.
#6474: fix the issue where federatedresourcequota becomes invalid
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`: Fixed the issue that a workload propagated with `duplicated mode` can bypass quota checks during scale up.
```