### PR TITLE
Automated cherry pick of #6477: use rbSpec.clusters and rbSpec.ReplicaRequirements to

### DIFF
--- a/pkg/controllers/federatedresourcequota/federated_resource_quota_enforcement_controller.go
+++ b/pkg/controllers/federatedresourcequota/federated_resource_quota_enforcement_controller.go
@@ -266,32 +266,50 @@ func (c *QuotaEnforcementController) collectQuotaStatus(quota *policyv1alpha1.Fe
 func calculateUsedWithResourceBinding(resourceBindings []workv1alpha2.ResourceBinding, overall corev1.ResourceList) corev1.ResourceList {
 	overallUsed := corev1.ResourceList{}
 	for _, binding := range resourceBindings {
-		if binding.Spec.ReplicaRequirements == nil || binding.Spec.Clusters == nil {
-			continue
-		}
-		used := binding.Spec.ReplicaRequirements.ResourceRequest
-		replicas := binding.Spec.Replicas
-
-		for name, quantity := range used {
-			// Update quantity to reflect number of replicas in resource
-			q := quantity.DeepCopy()
-			q.Mul(int64(replicas))
-
-			// Update quantity to reflect the number of clusters resource is duplicated to
-			if binding.Spec.Placement != nil && binding.Spec.Placement.ReplicaSchedulingType() == policyv1alpha1.ReplicaSchedulingTypeDuplicated {
-				q.Mul(int64(len(binding.Spec.Clusters)))
-			}
-
+		usage := calculateResourceUsage(&binding)
+		for name, quantity := range usage {
 			existing, found := overallUsed[name]
 			if found {
-				existing.Add(q)
+				existing.Add(quantity)
 				overallUsed[name] = existing
 			} else {
-				overallUsed[name] = q
+				overallUsed[name] = quantity
 			}
 		}
 	}
 	return filterResourceListByOverall(overallUsed, overall)
+}
+
+// calculateResourceUsage calculates the total resource usage based on the ResourceBinding.
+func calculateResourceUsage(rb *workv1alpha2.ResourceBinding) corev1.ResourceList {
+	if rb == nil || rb.Spec.ReplicaRequirements == nil || len(rb.Spec.ReplicaRequirements.ResourceRequest) == 0 || len(rb.Spec.Clusters) == 0 {
+		return corev1.ResourceList{}
+	}
+
+	totalReplicas := int32(0)
+	for _, cluster := range rb.Spec.Clusters {
+		totalReplicas += cluster.Replicas
+	}
+
+	if totalReplicas == 0 {
+		return corev1.ResourceList{}
+	}
+
+	usage := corev1.ResourceList{}
+	replicaCount := int64(totalReplicas)
+
+	for resourceName, quantityPerReplica := range rb.Spec.ReplicaRequirements.ResourceRequest {
+		if quantityPerReplica.IsZero() {
+			continue
+		}
+
+		totalQuantity := quantityPerReplica.DeepCopy()
+		totalQuantity.Mul(replicaCount)
+
+		usage[resourceName] = totalQuantity
+	}
+
+	return usage
 }
 
 // Filters source ResourceList using the keys provided by reference


### PR DESCRIPTION
Cherry pick of #6477 on release-1.14.
#6477: use rbSpec.clusters and rbSpec.ReplicaRequirements to
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`: Fixed the issue where the federated-resource-quota-enforcement-controller miscalculates quota usage.
```