### PR TITLE
Delete the propagation.karmada.io/instruction label

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -348,7 +348,6 @@ func startExecutionController(ctx controllerscontext.Context) (bool, error) {
 		EventRecorder:      ctx.Mgr.GetEventRecorderFor(execution.ControllerName),
 		RESTMapper:         ctx.Mgr.GetRESTMapper(),
 		ObjectWatcher:      ctx.ObjectWatcher,
-		PredicateFunc:      helper.NewExecutionPredicateOnAgent(),
 		InformerManager:    genericmanager.GetInstance(),
 		RateLimiterOptions: ctx.Opts.RateLimiterOptions,
 	}
@@ -366,7 +365,6 @@ func startWorkStatusController(ctx controllerscontext.Context) (bool, error) {
 		InformerManager:             genericmanager.GetInstance(),
 		Context:                     ctx.Context,
 		ObjectWatcher:               ctx.ObjectWatcher,
-		PredicateFunc:               helper.NewExecutionPredicateOnAgent(),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 		ClusterCacheSyncTimeout:     ctx.Opts.ClusterCacheSyncTimeout,
 		ConcurrentWorkStatusSyncs:   ctx.Opts.ConcurrentWorkSyncs,

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -454,7 +454,7 @@ func startExecutionController(ctx controllerscontext.Context) (enabled bool, err
 		EventRecorder:      ctx.Mgr.GetEventRecorderFor(execution.ControllerName),
 		RESTMapper:         ctx.Mgr.GetRESTMapper(),
 		ObjectWatcher:      ctx.ObjectWatcher,
-		PredicateFunc:      helper.NewExecutionPredicate(ctx.Mgr),
+		WorkPredicateFunc:  helper.WorkWithinPushClusterPredicate(ctx.Mgr),
 		InformerManager:    genericmanager.GetInstance(),
 		RateLimiterOptions: ctx.Opts.RateLimiterOptions,
 	}
@@ -473,7 +473,7 @@ func startWorkStatusController(ctx controllerscontext.Context) (enabled bool, er
 		InformerManager:             genericmanager.GetInstance(),
 		Context:                     ctx.Context,
 		ObjectWatcher:               ctx.ObjectWatcher,
-		PredicateFunc:               helper.NewExecutionPredicate(ctx.Mgr),
+		WorkPredicateFunc:           helper.WorkWithinPushClusterPredicate(ctx.Mgr),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSet,
 		ClusterClientOption:         ctx.ClusterClientOption,
 		ClusterCacheSyncTimeout:     opts.ClusterCacheSyncTimeout,

--- a/pkg/controllers/ctrlutil/work.go
+++ b/pkg/controllers/ctrlutil/work.go
@@ -76,10 +76,7 @@ func CreateOrUpdateWork(ctx context.Context, c client.Client, workMeta metav1.Ob
 
 			// Do the same thing as the mutating webhook does, add the permanent ID to workload if not exist,
 			// This is to avoid unnecessary updates to the Work object, especially when controller starts.
-			//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
-			if runtimeObject.Labels[util.PropagationInstruction] != util.PropagationInstructionSuppressed {
-				util.SetLabelsAndAnnotationsForWorkload(resource, runtimeObject)
-			}
+			util.SetLabelsAndAnnotationsForWorkload(resource, runtimeObject)
 			workloadJSON, err := json.Marshal(resource)
 			if err != nil {
 				klog.Errorf("Failed to marshal workload(%s/%s), error: %v", resource.GetNamespace(), resource.GetName(), err)

--- a/pkg/controllers/status/work_status_controller_test.go
+++ b/pkg/controllers/status/work_status_controller_test.go
@@ -107,7 +107,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 						Data:       map[string][]byte{clusterv1alpha1.SecretTokenKey: []byte("token"), clusterv1alpha1.SecretCADataKey: testCA},
 					}).Build(),
 				InformerManager:             genericmanager.GetInstance(),
-				PredicateFunc:               helper.NewClusterPredicateOnAgent("test"),
+				WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 				ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSet,
 				ClusterCacheSyncTimeout:     metav1.Duration{},
 				RateLimiterOptions:          ratelimiterflag.Options{},
@@ -135,7 +135,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 			c: WorkStatusController{
 				Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)).Build(),
 				InformerManager:             genericmanager.GetInstance(),
-				PredicateFunc:               helper.NewClusterPredicateOnAgent("test"),
+				WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 				ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 				ClusterCacheSyncTimeout:     metav1.Duration{},
 				RateLimiterOptions:          ratelimiterflag.Options{},
@@ -163,7 +163,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 			c: WorkStatusController{
 				Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)).Build(),
 				InformerManager:             genericmanager.GetInstance(),
-				PredicateFunc:               helper.NewClusterPredicateOnAgent("test"),
+				WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 				ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 				ClusterCacheSyncTimeout:     metav1.Duration{},
 				RateLimiterOptions:          ratelimiterflag.Options{},
@@ -192,7 +192,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 			c: WorkStatusController{
 				Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)).Build(),
 				InformerManager:             genericmanager.GetInstance(),
-				PredicateFunc:               helper.NewClusterPredicateOnAgent("test"),
+				WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 				ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 				ClusterCacheSyncTimeout:     metav1.Duration{},
 				RateLimiterOptions:          ratelimiterflag.Options{},
@@ -220,7 +220,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 			c: WorkStatusController{
 				Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)).Build(),
 				InformerManager:             genericmanager.GetInstance(),
-				PredicateFunc:               helper.NewClusterPredicateOnAgent("test"),
+				WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 				ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 				ClusterCacheSyncTimeout:     metav1.Duration{},
 				RateLimiterOptions:          ratelimiterflag.Options{},
@@ -248,7 +248,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 			c: WorkStatusController{
 				Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster1", clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)).Build(),
 				InformerManager:             genericmanager.GetInstance(),
-				PredicateFunc:               helper.NewClusterPredicateOnAgent("test"),
+				WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 				ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 				ClusterCacheSyncTimeout:     metav1.Duration{},
 				RateLimiterOptions:          ratelimiterflag.Options{},
@@ -276,7 +276,7 @@ func TestWorkStatusController_Reconcile(t *testing.T) {
 			c: WorkStatusController{
 				Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionFalse)).Build(),
 				InformerManager:             genericmanager.GetInstance(),
-				PredicateFunc:               helper.NewClusterPredicateOnAgent("test"),
+				WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 				ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 				ClusterCacheSyncTimeout:     metav1.Duration{},
 				RateLimiterOptions:          ratelimiterflag.Options{},
@@ -335,7 +335,7 @@ func TestWorkStatusController_getEventHandler(t *testing.T) {
 	c := WorkStatusController{
 		Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionFalse)).Build(),
 		InformerManager:             genericmanager.GetInstance(),
-		PredicateFunc:               helper.NewClusterPredicateOnAgent("test"),
+		WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 		ClusterCacheSyncTimeout:     metav1.Duration{},
 		RateLimiterOptions:          ratelimiterflag.Options{},
@@ -351,7 +351,7 @@ func TestWorkStatusController_RunWorkQueue(_ *testing.T) {
 	c := WorkStatusController{
 		Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionFalse)).Build(),
 		InformerManager:             genericmanager.GetInstance(),
-		PredicateFunc:               helper.NewClusterPredicateOnAgent("test"),
+		WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 		ClusterCacheSyncTimeout:     metav1.Duration{},
 		RateLimiterOptions:          ratelimiterflag.Options{},
@@ -740,7 +740,7 @@ func newWorkStatusController(cluster *clusterv1alpha1.Cluster, dynamicClientSets
 	c := WorkStatusController{
 		Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(cluster).WithStatusSubresource().Build(),
 		InformerManager:             genericmanager.GetInstance(),
-		PredicateFunc:               helper.NewClusterPredicateOnAgent("test"),
+		WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 		ClusterCacheSyncTimeout:     metav1.Duration{},
 		RateLimiterOptions:          ratelimiterflag.Options{},
@@ -874,7 +874,7 @@ func TestWorkStatusController_recreateResourceIfNeeded(t *testing.T) {
 	c := WorkStatusController{
 		Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)).Build(),
 		InformerManager:             genericmanager.GetInstance(),
-		PredicateFunc:               helper.NewClusterPredicateOnAgent("test"),
+		WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 		ClusterCacheSyncTimeout:     metav1.Duration{},
 		RateLimiterOptions:          ratelimiterflag.Options{},
@@ -921,7 +921,7 @@ func TestWorkStatusController_buildStatusIdentifier(t *testing.T) {
 	c := WorkStatusController{
 		Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)).Build(),
 		InformerManager:             genericmanager.GetInstance(),
-		PredicateFunc:               helper.NewClusterPredicateOnAgent("test"),
+		WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 		ClusterCacheSyncTimeout:     metav1.Duration{},
 		RateLimiterOptions:          ratelimiterflag.Options{},
@@ -982,7 +982,7 @@ func TestWorkStatusController_mergeStatus(t *testing.T) {
 	c := WorkStatusController{
 		Client:                      fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(newCluster("cluster", clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)).Build(),
 		InformerManager:             genericmanager.GetInstance(),
-		PredicateFunc:               helper.NewClusterPredicateOnAgent("test"),
+		WorkPredicateFunc:           helper.NewClusterPredicateOnAgent("test"),
 		ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
 		ClusterCacheSyncTimeout:     metav1.Duration{},
 		RateLimiterOptions:          ratelimiterflag.Options{},

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -40,18 +40,6 @@ const (
 	// This label indicates the name.
 	MultiClusterServiceNameLabel = "multiclusterservice.karmada.io/name"
 
-	// PropagationInstruction is used to mark a resource(like Work) propagation instruction.
-	// Valid values includes:
-	// - suppressed: indicates that the resource should not be propagated.
-	//
-	// Note: This instruction is intended to set on Work objects to indicate the Work should be ignored by
-	// execution controller. The instruction maybe deprecated once we extend the Work API and no other scenario want this.
-	//
-	// Deprecated: This label has been deprecated since v1.14, and will be replaced by the filed .spec.suspendDispatching of
-	// Work API. This label should only be used internally by Karmada, but for compatibility, the deletion will be postponed
-	// to release 1.15.
-	PropagationInstruction = "propagation.karmada.io/instruction"
-
 	// FederatedResourceQuotaNamespaceLabel is added to Work to specify associated FederatedResourceQuota's namespace.
 	FederatedResourceQuotaNamespaceLabel = "federatedresourcequota.karmada.io/namespace"
 
@@ -90,9 +78,6 @@ const (
 
 	// RetainReplicasValue is an optional value of RetainReplicasLabel, indicating retain
 	RetainReplicasValue = "true"
-
-	// PropagationInstructionSuppressed indicates that the resource should not be propagated.
-	PropagationInstructionSuppressed = "suppressed"
 )
 
 // Define annotations used by karmada system.

--- a/pkg/util/helper/predicate_test.go
+++ b/pkg/util/helper/predicate_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -27,7 +28,6 @@ import (
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
-	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
 	"github.com/karmada-io/karmada/pkg/util/names"
 )
@@ -85,7 +85,7 @@ func TestNewClusterPredicateOnAgent(t *testing.T) {
 	}
 }
 
-func TestNewExecutionPredicate(t *testing.T) {
+func TestWorkWithinPushClusterPredicate(t *testing.T) {
 	type args struct {
 		mgr controllerruntime.Manager
 		obj client.Object
@@ -98,30 +98,6 @@ func TestNewExecutionPredicate(t *testing.T) {
 		args args
 		want want
 	}{
-		{
-			name: "object is suppressed",
-			args: args{
-				mgr: &fakeManager{client: fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(
-					&clusterv1alpha1.Cluster{
-						ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-						Spec:       clusterv1alpha1.ClusterSpec{SyncMode: clusterv1alpha1.Push},
-					},
-				).Build()},
-				obj: &workv1alpha1.Work{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "work", Namespace: names.ExecutionSpacePrefix + "cluster",
-						//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
-						Labels: map[string]string{util.PropagationInstruction: util.PropagationInstructionSuppressed},
-					},
-				},
-			},
-			want: want{
-				create:  false,
-				update:  false,
-				delete:  false,
-				generic: false,
-			},
-		},
 		{
 			name: "get cluster name error",
 			args: args{
@@ -200,7 +176,7 @@ func TestNewExecutionPredicate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pred := NewExecutionPredicate(tt.args.mgr)
+			pred := WorkWithinPushClusterPredicate(tt.args.mgr)
 			if got := pred.Create(event.CreateEvent{Object: tt.args.obj}); got != tt.want.create {
 				t.Errorf("Create() got = %v, want %v", got, tt.want.create)
 				return
@@ -221,23 +197,25 @@ func TestNewExecutionPredicate(t *testing.T) {
 	}
 }
 
-func TestNewExecutionPredicate_Update(t *testing.T) {
+func TestWorkWithinPushClusterPredicate_Update(t *testing.T) {
 	mgr := &fakeManager{client: fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(
 		&clusterv1alpha1.Cluster{
-			ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster1"},
+			Spec:       clusterv1alpha1.ClusterSpec{SyncMode: clusterv1alpha1.Pull},
+		},
+		&clusterv1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster2"},
 			Spec:       clusterv1alpha1.ClusterSpec{SyncMode: clusterv1alpha1.Push},
 		},
 	).Build()}
 	unmatched := &workv1alpha1.Work{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "work", Namespace: names.ExecutionSpacePrefix + "cluster",
-			//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
-			Labels: map[string]string{util.PropagationInstruction: util.PropagationInstructionSuppressed},
+			Name: "work", Namespace: names.ExecutionSpacePrefix + "cluster1",
 		},
 	}
 	matched := &workv1alpha1.Work{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "work", Namespace: names.ExecutionSpacePrefix + "cluster",
+			Name: "work", Namespace: names.ExecutionSpacePrefix + "cluster2",
 		},
 	}
 
@@ -281,127 +259,7 @@ func TestNewExecutionPredicate_Update(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pred := NewExecutionPredicate(mgr)
-			if got := pred.Update(tt.args.event); got != tt.want {
-				t.Errorf("Update() got = %v, want %v", got, tt.want)
-				return
-			}
-		})
-	}
-}
-
-func TestNewExecutionPredicateOnAgent(t *testing.T) {
-	type want struct {
-		create, update, delete, generic bool
-	}
-
-	tests := []struct {
-		name string
-		obj  client.Object
-		want want
-	}{
-		{
-			name: "object is suppressed",
-			obj: &workv1alpha1.Work{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
-				//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
-				util.PropagationInstruction: util.PropagationInstructionSuppressed,
-			}}},
-			want: want{
-				create:  false,
-				update:  false,
-				delete:  false,
-				generic: false,
-			},
-		},
-		{
-			name: "matched",
-			obj:  &workv1alpha1.Work{ObjectMeta: metav1.ObjectMeta{}},
-			want: want{
-				create:  true,
-				update:  true,
-				delete:  true,
-				generic: false,
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			pred := NewExecutionPredicateOnAgent()
-			if got := pred.Create(event.CreateEvent{Object: tt.obj}); got != tt.want.create {
-				t.Errorf("Create() got = %v, want %v", got, tt.want.create)
-				return
-			}
-			if got := pred.Update(event.UpdateEvent{ObjectNew: tt.obj, ObjectOld: tt.obj}); got != tt.want.update {
-				t.Errorf("Update() got = %v, want %v", got, tt.want.update)
-				return
-			}
-			if got := pred.Delete(event.DeleteEvent{Object: tt.obj}); got != tt.want.delete {
-				t.Errorf("Delete() got = %v, want %v", got, tt.want.delete)
-				return
-			}
-			if got := pred.Generic(event.GenericEvent{Object: tt.obj}); got != tt.want.generic {
-				t.Errorf("Generic() got = %v, want %v", got, tt.want.generic)
-				return
-			}
-		})
-	}
-}
-
-func TestNewExecutionPredicateOnAgent_Update(t *testing.T) {
-	unmatched := &workv1alpha1.Work{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "work", Namespace: names.ExecutionSpacePrefix + "cluster",
-			//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
-			Labels: map[string]string{util.PropagationInstruction: util.PropagationInstructionSuppressed},
-		},
-	}
-	matched := &workv1alpha1.Work{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "work", Namespace: names.ExecutionSpacePrefix + "cluster",
-		},
-	}
-
-	type args struct {
-		event event.UpdateEvent
-	}
-
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{
-			name: "both old and new are unmatched",
-			args: args{
-				event: event.UpdateEvent{ObjectOld: unmatched, ObjectNew: unmatched},
-			},
-			want: false,
-		},
-		{
-			name: "old is unmatched, new is matched",
-			args: args{
-				event: event.UpdateEvent{ObjectOld: unmatched, ObjectNew: matched},
-			},
-			want: true,
-		},
-		{
-			name: "old is matched, new is unmatched",
-			args: args{
-				event: event.UpdateEvent{ObjectOld: matched, ObjectNew: unmatched},
-			},
-			want: true,
-		},
-		{
-			name: "both old and new are matched",
-			args: args{
-				event: event.UpdateEvent{ObjectOld: matched, ObjectNew: matched},
-			},
-			want: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			pred := NewExecutionPredicateOnAgent()
+			pred := WorkWithinPushClusterPredicate(mgr)
 			if got := pred.Update(tt.args.event); got != tt.want {
 				t.Errorf("Update() got = %v, want %v", got, tt.want)
 				return
@@ -435,8 +293,9 @@ func TestNewPredicateForServiceExportController(t *testing.T) {
 				obj: &workv1alpha1.Work{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "work", Namespace: names.ExecutionSpacePrefix + "cluster",
-						//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
-						Labels: map[string]string{util.PropagationInstruction: util.PropagationInstructionSuppressed},
+					},
+					Spec: workv1alpha1.WorkSpec{
+						SuspendDispatching: ptr.To(true),
 					},
 				},
 			},
@@ -556,8 +415,9 @@ func TestNewPredicateForServiceExportController_Update(t *testing.T) {
 	unmatched := &workv1alpha1.Work{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "work", Namespace: names.ExecutionSpacePrefix + "cluster",
-			//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
-			Labels: map[string]string{util.PropagationInstruction: util.PropagationInstructionSuppressed},
+		},
+		Spec: workv1alpha1.WorkSpec{
+			SuspendDispatching: ptr.To(true),
 		},
 	}
 	matched := &workv1alpha1.Work{
@@ -627,11 +487,14 @@ func TestNewPredicateForServiceExportControllerOnAgent(t *testing.T) {
 	}{
 		{
 			name: "object is suppressed",
-			obj: &workv1alpha1.Work{ObjectMeta: metav1.ObjectMeta{
-				Name: "work", Namespace: names.ExecutionSpacePrefix + "cluster",
-				//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
-				Labels: map[string]string{util.PropagationInstruction: util.PropagationInstructionSuppressed},
-			}},
+			obj: &workv1alpha1.Work{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "work", Namespace: names.ExecutionSpacePrefix + "cluster",
+				},
+				Spec: workv1alpha1.WorkSpec{
+					SuspendDispatching: ptr.To(true),
+				},
+			},
 			want: want{
 				create:  false,
 				update:  false,
@@ -702,8 +565,9 @@ func TestNewPredicateForServiceExportControllerOnAgent_Update(t *testing.T) {
 	unmatched := &workv1alpha1.Work{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "work", Namespace: names.ExecutionSpacePrefix + "cluster",
-			//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
-			Labels: map[string]string{util.PropagationInstruction: util.PropagationInstructionSuppressed},
+		},
+		Spec: workv1alpha1.WorkSpec{
+			SuspendDispatching: ptr.To(true),
 		},
 	}
 	matched := &workv1alpha1.Work{


### PR DESCRIPTION
**What type of PR is this?**

/kind deprecation
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

ref #6437 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #6437

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:

<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`Deprecation`: The deprecated label `propagation.karmada.io/instruction`, which was designed to suspend Work propagation, has now been removed.
```

