### PR TITLE
CI: add Gemini assist for code reviews

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,36 @@
+# Config for the Gemini Pull Request Review Bot.
+# https://github.com/marketplace/gemini-code-assist
+
+# Enables fun features such as a poem in the initial pull request summary.
+# Type: boolean, default: false.
+have_fun: false
+
+code_review:
+  # Disables Gemini from acting on PRs.
+  # Type: boolean, default: false.
+  disable: false
+
+  # Minimum severity of comments to post (LOW, MEDIUM, HIGH, CRITICAL).
+  # Type: string, default: MEDIUM.
+  comment_severity_threshold: MEDIUM
+
+  # Max number of review comments (-1 for unlimited).
+  # Type: integer, default: -1.
+  max_review_comments: -1
+
+  pull_request_opened:
+    # Post helpful instructions when PR is opened.
+    # Type: boolean, default: false.
+    help: true
+
+    # Post PR summary when opened.
+    # Type boolean, default: true.
+    summary: true 
+
+    # Post code review on PR open.
+    # Type boolean, default: true.
+    code_review: true
+
+# List of glob patterns to ignore (files and directories).
+# Type: array of string, default: [].
+ignore_patterns: []


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

https://github.com/marketplace/gemini-code-assist

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note

```

