### PR TITLE
fix: Update Karmada search template to use search.resources for resources

### DIFF
--- a/charts/karmada/templates/karmada-search.yaml
+++ b/charts/karmada/templates/karmada-search.yaml
@@ -93,7 +93,7 @@ spec:
             periodSeconds: 15
             timeoutSeconds: 5
           resources:
-          {{- toYaml .Values.apiServer.resources | nindent 12 }}
+          {{- toYaml .Values.search.resources | nindent 12 }}
       priorityClassName: {{ .Values.search.priorityClassName }}
       volumes:
       {{- include "karmada.search.kubeconfig.volume" . | nindent 8 }}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
Update Karmada search helm chart template to use `search.resources` for deployment resources. It originally uses the `apiServer.resource`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-search`: karmada-search helm chart template now references the resources from `search.resources`.
```

