### PR TITLE
feat: add resource interpreter customization for SidecarSet

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/SidecarSet/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/SidecarSet/customizations.yaml
@@ -1,0 +1,156 @@
+apiVersion: config.karmada.io/v1alpha1
+kind: ResourceInterpreterCustomization
+metadata:
+  name: declarative-configuration-sidecarset
+spec:
+  target:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: SidecarSet
+  customizations:
+    statusReflection:
+      luaScript: |
+        function ReflectStatus(observedObj)
+          if observedObj.status == nil then
+            return {}
+          end
+          return {
+            matchedPods = observedObj.status.matchedPods or 0,
+            updatedPods = observedObj.status.updatedPods or 0,
+            readyPods = observedObj.status.readyPods or 0
+          }
+        end
+    replicaResource:
+      luaScript: |
+        function GetReplicas(obj)
+          -- SidecarSet doesn't manage replicas directly, return 0
+          return 0
+        end
+    statusAggregation:
+      luaScript: |
+        function AggregateStatus(desiredObj, statusItems)
+          local matchedPods = 0
+          local updatedPods = 0
+          local readyPods = 0
+          
+          for i = 1, #statusItems do
+            local status = statusItems[i].status or {}
+            matchedPods = matchedPods + (status.matchedPods or 0)
+            updatedPods = updatedPods + (status.updatedPods or 0)
+            readyPods = readyPods + (status.readyPods or 0)
+          end
+            
+          return {
+            apiVersion = "apps.kruise.io/v1alpha1",
+            kind = "SidecarSet",
+            metadata = desiredObj.metadata,
+            status = {
+              matchedPods = matchedPods,
+              updatedPods = updatedPods,
+              readyPods = readyPods
+            }
+          }
+        end
+    retention:
+      luaScript: |
+        function Retain(desiredObj, observedObj)
+          -- No specific retention logic needed as Karmada handles status preservation
+          return desiredObj
+        end
+    healthInterpretation:
+      luaScript: |
+        function InterpretHealth(observedObj)
+          if observedObj.status == nil then
+            return false
+          end
+          local matchedPods = observedObj.status.matchedPods or 0
+          local updatedPods = observedObj.status.updatedPods or 0
+          -- If no pods are matched, consider it healthy (nothing to update)
+          if matchedPods == 0 then
+            return true
+          end
+          -- A SidecarSet is healthy if all matched pods have been updated
+          return updatedPods == matchedPods
+        end
+    dependencyInterpretation:
+      luaScript: |
+        function GetDependencies(desiredObj)
+          local dependencies = {}
+          if not desiredObj.spec then
+            return dependencies
+          end
+
+          -- Helper function to add a dependency
+          local function addDependency(kind, name, namespace)
+            table.insert(dependencies, {
+              apiVersion = "v1",
+              kind = kind,
+              name = name,
+              namespace = namespace or (desiredObj.metadata and desiredObj.metadata.namespace)
+            })
+          end
+
+          -- Check for references in containers
+          if desiredObj.spec.containers then
+            for i = 1, #desiredObj.spec.containers do
+              local container = desiredObj.spec.containers[i]
+              
+              -- Check environment variables
+              if container.env then
+                for j = 1, #container.env do
+                  local env = container.env[j]
+                  if env.valueFrom then
+                    if env.valueFrom.configMapKeyRef then
+                      addDependency("ConfigMap", env.valueFrom.configMapKeyRef.name)
+                    end
+                    if env.valueFrom.secretKeyRef then
+                      addDependency("Secret", env.valueFrom.secretKeyRef.name)
+                    end
+                  end
+                end
+              end
+              
+              -- Check envFrom
+              if container.envFrom then
+                for j = 1, #container.envFrom do
+                  local envFrom = container.envFrom[j]
+                  if envFrom.configMapRef then
+                    addDependency("ConfigMap", envFrom.configMapRef.name)
+                  end
+                  if envFrom.secretRef then
+                    addDependency("Secret", envFrom.secretRef.name)
+                  end
+                end
+              end
+            end
+          end
+
+          -- Check for volume references
+          if desiredObj.spec.volumes then
+            for i = 1, #desiredObj.spec.volumes do
+              local volume = desiredObj.spec.volumes[i]
+              
+              -- Standard volume types
+              if volume.configMap then
+                addDependency("ConfigMap", volume.configMap.name)
+              end
+              if volume.secret then
+                addDependency("Secret", volume.secret.secretName)
+              end
+              
+              -- Projected volumes
+              if volume.projected and volume.projected.sources then
+                for j = 1, #volume.projected.sources do
+                  local source = volume.projected.sources[j]
+                  if source.configMap then
+                    addDependency("ConfigMap", source.configMap.name)
+                  end
+                  if source.secret then
+                    addDependency("Secret", source.secret.name)
+                  end
+                end
+              end
+            end
+          end
+          
+          return dependencies
+        end 

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/SidecarSet/customizations_tests.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/SidecarSet/customizations_tests.yaml
@@ -1,0 +1,12 @@
+tests:
+  - desiredInputPath: testdata/desired-sidecarset-nginx.yaml
+    statusInputPath: testdata/status-file.yaml
+    operation: AggregateStatus
+  - desiredInputPath: testdata/desired-sidecarset-nginx.yaml
+    operation: InterpretDependency
+  - observedInputPath: testdata/observed-sidecarset-nginx.yaml
+    operation: InterpretReplica
+  - observedInputPath: testdata/observed-sidecarset-nginx.yaml
+    operation: InterpretHealth
+  - observedInputPath: testdata/observed-sidecarset-nginx.yaml
+    operation: InterpretStatus 

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/SidecarSet/testdata/desired-sidecarset-nginx.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/SidecarSet/testdata/desired-sidecarset-nginx.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps.kruise.io/v1alpha1
+kind: SidecarSet
+metadata:
+  labels:
+    app: sample
+  name: sample-sidecarset
+  namespace: test-sidecarset
+  generation: 1
+spec:
+  selector:
+    matchLabels:
+      app: sample
+      test: sidecarset
+  containers:
+    - name: sidecar
+      image: busybox:latest
+      env:
+        - name: CONFIG_DATA
+          valueFrom:
+            configMapKeyRef:
+              name: sidecar-config
+              key: config
+        - name: SECRET_DATA
+          valueFrom:
+            secretKeyRef:
+              name: sidecar-secret
+              key: secret
+  injectionStrategy: BeforeAppContainer
+  volumes:
+    - name: configmap
+      configMap:
+        name: sidecar-config
+    - name: secret
+      secret:
+        secretName: sidecar-secret 

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/SidecarSet/testdata/observed-sidecarset-nginx.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/SidecarSet/testdata/observed-sidecarset-nginx.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps.kruise.io/v1alpha1
+kind: SidecarSet
+metadata:
+  labels:
+    app: sample
+  name: sample-sidecarset
+  namespace: test-sidecarset
+  generation: 1
+spec:
+  selector:
+    matchLabels:
+      app: sample
+      test: sidecarset
+  containers:
+    - name: sidecar
+      image: busybox:latest
+      env:
+        - name: CONFIG_DATA
+          valueFrom:
+            configMapKeyRef:
+              name: sidecar-config
+              key: config
+        - name: SECRET_DATA
+          valueFrom:
+            secretKeyRef:
+              name: sidecar-secret
+              key: secret
+  injectionStrategy: BeforeAppContainer
+  volumes:
+    - name: configmap
+      configMap:
+        name: sidecar-config
+    - name: secret
+      secret:
+        secretName: sidecar-secret
+status:
+  matchedPods: 3
+  updatedPods: 3
+  readyPods: 3 

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/SidecarSet/testdata/status-file.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/SidecarSet/testdata/status-file.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps.kruise.io/v1alpha1
+kind: SidecarSet
+metadata:
+  name: sample-sidecarset
+  namespace: test-sidecarset
+  clusterName: member1
+status:
+  matchedPods: 2
+  updatedPods: 2
+  readyPods: 2
+---
+apiVersion: apps.kruise.io/v1alpha1
+kind: SidecarSet
+metadata:
+  name: sample-sidecarset
+  namespace: test-sidecarset
+  clusterName: member2
+status:
+  matchedPods: 1
+  updatedPods: 1
+  readyPods: 1 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds resource interpreter customization for OpenKruise SidecarSet, enabling Karmada to properly manage SidecarSet resources in multi-cluster environments. This includes:

- Status aggregation across member clusters
- Health checks for SidecarSet resources
- Dependency interpretation for ConfigMaps and Secrets
- Comprehensive test coverage

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
- Includes test cases for multi-cluster scenarios
- Verified with `karmadactl interpret` command
- Follows the same pattern as other resource interpreter customizations

**Does this PR introduce a user-facing change?**:
```release-note
feat: Add resource interpreter support for OpenKruise SidecarSet

Adds support for interpreting OpenKruise SidecarSet resources in Karmada, including:
- Multi-cluster status aggregation
- Health checks
- Dependency resolution for ConfigMaps and Secrets
- Comprehensive test coverage

Users can now properly manage SidecarSet resources across multiple clusters with Karmada.