### PR TITLE
Fixed the issue that resources will be recreated after deleted on the cluster when resource is suspended for dispatching

### DIFF
--- a/pkg/controllers/status/work_status_controller.go
+++ b/pkg/controllers/status/work_status_controller.go
@@ -291,6 +291,11 @@ func (c *WorkStatusController) handleDeleteEvent(ctx context.Context, key keys.F
 		return nil
 	}
 
+	// skip processing as the work object is suspended for dispatching.
+	if util.IsWorkSuspendDispatching(work) {
+		return nil
+	}
+
 	//nolint:staticcheck // SA1019 ignore deprecated util.PropagationInstruction
 	if util.GetLabelValue(work.Labels, util.PropagationInstruction) == util.PropagationInstructionSuppressed {
 		return nil

--- a/pkg/controllers/status/work_status_controller_test.go
+++ b/pkg/controllers/status/work_status_controller_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -579,6 +580,7 @@ func TestWorkStatusController_syncWorkStatus(t *testing.T) {
 		expectedError             bool
 		wrongWorkNS               bool
 		workApplyFunc             func(work *workv1alpha1.Work)
+		assertFunc                func(t *testing.T, dynamicClientSets *dynamicfake.FakeDynamicClient)
 	}{
 		{
 			name:                      "failed to exec NeedUpdate",
@@ -669,6 +671,23 @@ func TestWorkStatusController_syncWorkStatus(t *testing.T) {
 				work.SetDeletionTimestamp(ptr.To(metav1.Now()))
 			},
 		},
+		{
+			name:                      "resource not found, work suspendDispatching true, should not recreate resource",
+			obj:                       newPodObj("karmada-es-cluster"),
+			pod:                       nil, // Simulate the resource does not exist in the member cluster
+			raw:                       []byte(`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"pod","namespace":"default"}}`),
+			controllerWithoutInformer: true,
+			expectedError:             false,
+			workApplyFunc: func(work *workv1alpha1.Work) {
+				work.Spec.SuspendDispatching = ptr.To(true)
+			},
+			assertFunc: func(t *testing.T, dynamicClientSets *dynamicfake.FakeDynamicClient) {
+				gvr := corev1.SchemeGroupVersion.WithResource("pods")
+				obj, err := dynamicClientSets.Resource(gvr).Namespace("default").Get(context.Background(), "pod", metav1.GetOptions{})
+				assert.True(t, apierrors.IsNotFound(err), "expected a NotFound error but got: %s", err)
+				assert.Nil(t, obj)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -708,6 +727,10 @@ func TestWorkStatusController_syncWorkStatus(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+
+			if tt.assertFunc != nil {
+				tt.assertFunc(t, dynamicClientSet)
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

ref #6510

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #6510

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-controller-manager`: Fixed the issue that resources will be recreated after deleted on the cluster when resource is suspended for dispatching
```

