### PR TITLE
Automated cherry pick of #6519: Eliminate Trivy abnormal alerts
#6514: Bump aquasecurity/trivy-action from 0.31.0 to 0.32.0

### DIFF
--- a/.github/workflows/ci-image-scanning-on-schedule.yml
+++ b/.github/workflows/ci-image-scanning-on-schedule.yml
@@ -47,7 +47,7 @@ jobs:
           export REGISTRY="docker.io/karmada"
           make image-${{ matrix.target }}
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.29.0
+        uses: aquasecurity/trivy-action@0.32.0
         env:
           ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
@@ -56,15 +56,17 @@ jobs:
           format: 'sarif'
           ignore-unfixed: true
           vuln-type: 'os,library'
+          cache: false
           output: '${{ matrix.target }}:${{ matrix.karmada-version }}.trivy-results.sarif'
       - name: display scan results
-        uses: aquasecurity/trivy-action@0.29.0
+        uses: aquasecurity/trivy-action@0.32.0
         env:
           TRIVY_SKIP_DB_UPDATE: true # Avoid updating the vulnerability db as it was cached in the previous step.
         with:
           image-ref: 'docker.io/karmada/${{ matrix.target }}:${{ matrix.karmada-version }}'
           format: 'table'
           ignore-unfixed: true
+          cache: false
           vuln-type: 'os,library'
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/ci-image-scanning.yaml
+++ b/.github/workflows/ci-image-scanning.yaml
@@ -32,6 +32,10 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v4
+        with:
+         # fetch-depth:
+          # 0 indicates all history for all branches and tags.
+          fetch-depth: 0
       - name: install Go
         uses: actions/setup-go@v5
         with:
@@ -42,7 +46,7 @@ jobs:
           export REGISTRY="docker.io/karmada"
           make image-${{ matrix.target }}
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.29.0
+        uses: aquasecurity/trivy-action@0.32.0
         env:
           ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
@@ -52,8 +56,9 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           output: 'trivy-results.sarif'
+          cache: false
       - name: display scan results
-        uses: aquasecurity/trivy-action@0.29.0
+        uses: aquasecurity/trivy-action@0.32.0
         env:
           TRIVY_SKIP_DB_UPDATE: true # Avoid updating the vulnerability db as it was cached in the previous step.
         with:
@@ -61,6 +66,7 @@ jobs:
           format: 'table'
           ignore-unfixed: true
           vuln-type: 'os,library'
+          cache: false
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Generate sbom for karmada file system
-      uses: aquasecurity/trivy-action@0.29.0
+      uses: aquasecurity/trivy-action@0.32.0
       with:
         scan-type: 'fs'
         format: 'spdx'


### PR DESCRIPTION
Cherry pick of #6519 #6514 on release-1.12.
#6519: Eliminate Trivy abnormal alerts
#6514: Bump aquasecurity/trivy-action from 0.31.0 to 0.32.0
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
```