### PR TITLE
feat: add resource interpreter customization for UnitedDeployment

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/customizations.yaml
@@ -1,0 +1,171 @@
+apiVersion: config.karmada.io/v1alpha1
+kind: ResourceInterpreterCustomization
+metadata:
+  name: declarative-configuration-uniteddeployment
+spec:
+  target:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: UnitedDeployment
+  customizations:
+    replicaResource:
+      luaScript: >
+        local kube = require("kube")
+        function GetReplicas(obj)
+          local replica = obj.spec.replicas
+          local requirement = kube.accuratePodRequirements(obj.spec.template)
+          return replica, requirement
+        end
+    replicaRevision:
+      luaScript: >
+        function ReviseReplica(obj, desiredReplica)
+          obj.spec.replicas = desiredReplica
+          return obj
+        end
+    statusAggregation:
+      luaScript: >
+        function AggregateStatus(desiredObj, statusItems)
+          if desiredObj.status == nil then
+            desiredObj.status = {}
+          end
+          if desiredObj.metadata.generation == nil then
+            desiredObj.metadata.generation = 0
+          end
+          if desiredObj.status.observedGeneration == nil then
+            desiredObj.status.observedGeneration = 0
+          end
+
+          -- Initialize status fields if status does not exist
+          -- If the UnitedDeployment is not spread to any cluster,
+          -- its status also should be aggregated
+          if statusItems == nil then
+            desiredObj.status.observedGeneration = desiredObj.metadata.generation
+            desiredObj.status.replicas = 0
+            desiredObj.status.readyReplicas = 0
+            desiredObj.status.updatedReplicas = 0
+            desiredObj.status.availableReplicas = 0
+            desiredObj.status.unavailableReplicas = 0
+            return desiredObj
+          end
+
+          local generation = desiredObj.metadata.generation
+          local observedGeneration = desiredObj.status.observedGeneration
+          local replicas = 0
+          local updatedReplicas = 0
+          local readyReplicas = 0
+          local availableReplicas = 0
+          local unavailableReplicas = 0
+
+          -- Use a map to merge conditions by type
+          local conditionsMap = {}
+
+          -- Count all members that their status is updated to the latest generation
+          local observedResourceTemplateGenerationCount = 0
+
+          for i = 1, #statusItems do
+            local itemStatus = statusItems[i].status
+            if itemStatus ~= nil then
+              replicas = replicas + (itemStatus.replicas or 0)
+              updatedReplicas = updatedReplicas + (itemStatus.updatedReplicas or 0)
+              readyReplicas = readyReplicas + (itemStatus.readyReplicas or 0)
+              availableReplicas = availableReplicas + (itemStatus.availableReplicas or 0)
+              unavailableReplicas = unavailableReplicas + (itemStatus.unavailableReplicas or 0)
+
+              -- Merge conditions from all clusters using a map
+              if itemStatus.conditions ~= nil then
+                for _, condition in ipairs(itemStatus.conditions) do
+                  conditionsMap[condition.type] = condition
+                end
+              end
+
+              -- Check if the member's status is updated to the latest generation
+              local resourceTemplateGeneration = itemStatus.resourceTemplateGeneration or 0
+              local memberGeneration = itemStatus.generation or 0
+              local memberObservedGeneration = itemStatus.observedGeneration or 0
+              if resourceTemplateGeneration == generation and memberGeneration == memberObservedGeneration then
+                observedResourceTemplateGenerationCount = observedResourceTemplateGenerationCount + 1
+              end
+            end
+          end
+
+          -- Convert conditionsMap back to a list
+          local conditions = {}
+          for _, condition in pairs(conditionsMap) do
+            table.insert(conditions, condition)
+          end
+
+          -- Update the observed generation based on the observedResourceTemplateGenerationCount
+          if observedResourceTemplateGenerationCount == #statusItems then
+            desiredObj.status.observedGeneration = generation
+          else
+            desiredObj.status.observedGeneration = observedGeneration
+          end
+
+          desiredObj.status.replicas = replicas
+          desiredObj.status.updatedReplicas = updatedReplicas
+          desiredObj.status.readyReplicas = readyReplicas
+          desiredObj.status.availableReplicas = availableReplicas
+          desiredObj.status.unavailableReplicas = unavailableReplicas
+
+          if #conditions > 0 then
+            desiredObj.status.conditions = conditions
+          end
+
+          return desiredObj
+        end
+    statusReflection:
+      luaScript: >
+        function ReflectStatus(observedObj)
+          local status = {}
+          if observedObj == nil or observedObj.status == nil then
+            return status
+          end
+
+          status.replicas = observedObj.status.replicas
+          status.updatedReplicas = observedObj.status.updatedReplicas
+          status.readyReplicas = observedObj.status.readyReplicas
+          status.availableReplicas = observedObj.status.availableReplicas
+          status.unavailableReplicas = observedObj.status.unavailableReplicas
+          status.observedGeneration = observedObj.status.observedGeneration
+          status.conditions = observedObj.status.conditions
+
+          -- handle member resource generation report
+          if observedObj.metadata ~= nil then
+            status.generation = observedObj.metadata.generation
+
+            -- handle resource template generation report
+            if observedObj.metadata.annotations ~= nil then
+              local resourceTemplateGeneration = tonumber(observedObj.metadata.annotations["resourcetemplate.karmada.io/generation"])
+              if resourceTemplateGeneration ~= nil then
+                status.resourceTemplateGeneration = resourceTemplateGeneration
+              end
+            end
+          end
+
+          return status
+        end
+    healthInterpretation:
+      luaScript: >
+        function InterpretHealth(observedObj)
+          if observedObj == nil or observedObj.status == nil or observedObj.metadata == nil or observedObj.spec == nil then
+            return false
+          end
+          if observedObj.status.observedGeneration ~= observedObj.metadata.generation then
+            return false
+          end
+          if observedObj.spec.replicas ~= nil then
+            if observedObj.status.updatedReplicas < observedObj.spec.replicas then
+              return false
+            end
+          end
+          if observedObj.status.availableReplicas < observedObj.status.updatedReplicas then
+            return false
+          end
+          return true
+        end
+    dependencyInterpretation:
+      luaScript: >
+        local kube = require("kube")
+        function GetDependencies(desiredObj)
+          local refs = kube.getPodDependencies(desiredObj.spec.template, desiredObj.metadata.namespace)
+          return refs
+        end

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/customizations_tests.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/customizations_tests.yaml
@@ -1,0 +1,15 @@
+tests:
+  - desiredInputPath: testdata/desired-uniteddeployment.yaml
+    statusInputPath: testdata/status-file.yaml
+    operation: AggregateStatus
+  - desiredInputPath: testdata/desired-uniteddeployment.yaml
+    operation: InterpretDependency
+  - observedInputPath: testdata/observed-uniteddeployment.yaml
+    operation: InterpretReplica
+  - observedInputPath: testdata/observed-uniteddeployment.yaml
+    operation: ReviseReplica
+    desiredReplicas: 1
+  - observedInputPath: testdata/observed-uniteddeployment.yaml
+    operation: InterpretHealth
+  - observedInputPath: testdata/observed-uniteddeployment.yaml
+    operation: InterpretStatus

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/desired-uniteddeployment.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/desired-uniteddeployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps.kruise.io/v1alpha1
+kind: UnitedDeployment
+metadata:
+  name: sample-uniteddeployment
+  namespace: test-namespace
+  generation: 1
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: sample
+  template:
+    metadata:
+      labels:
+        app: sample
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest
+          env:
+            - name: CONFIG_DATA
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: config
+            - name: SECRET_DATA
+              valueFrom:
+                secretKeyRef:
+                  name: app-secret
+                  key: token
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+      volumes:
+        - name: config-volume
+          configMap:
+            name: app-config
+  topologySpread:
+    - topologyKey: kubernetes.io/hostname
+      maxSkew: 1

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/observed-uniteddeployment.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/observed-uniteddeployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps.kruise.io/v1alpha1
+kind: UnitedDeployment
+metadata:
+  name: sample-uniteddeployment
+  namespace: test-namespace
+  generation: 1
+  resourceVersion: "12345"
+  uid: "a1b2c3d4-5678-90ef-ghij-klmnopqrstuv"
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: sample
+  template:
+    metadata:
+      labels:
+        app: sample
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest
+          env:
+            - name: CONFIG_DATA
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: config
+            - name: SECRET_DATA
+              valueFrom:
+                secretKeyRef:
+                  name: app-secret
+                  key: token
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+      volumes:
+        - name: config-volume
+          configMap:
+            name: app-config
+  topologySpread:
+    - topologyKey: kubernetes.io/hostname
+      maxSkew: 1
+status:
+  replicas: 3
+  readyReplicas: 3
+  updatedReplicas: 3
+  availableReplicas: 3
+  collisionCount: 0
+  observedGeneration: 1
+  conditions:
+    - type: Available
+      status: "True"
+      lastTransitionTime: "2023-01-01T00:00:00Z"
+      reason: MinimumReplicasAvailable
+      message: Deployment has minimum availability.
+    - type: Progressing
+      status: "True"
+      lastTransitionTime: "2023-01-01T00:00:00Z"
+      reason: NewReplicaSetAvailable
+      message: ReplicaSet has successfully progressed.

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/status-file.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/status-file.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps.kruise.io/v1alpha1
+kind: UnitedDeployment
+metadata:
+  name: sample-uniteddeployment
+  namespace: test-namespace
+  clusterName: member1
+status:
+  replicas: 2
+  readyReplicas: 2
+  updatedReplicas: 2
+  availableReplicas: 2
+  collisionCount: 0
+  observedGeneration: 1
+---
+apiVersion: apps.kruise.io/v1alpha1
+kind: UnitedDeployment
+metadata:
+  name: sample-uniteddeployment
+  namespace: test-namespace
+  clusterName: member2
+status:
+  replicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1
+  availableReplicas: 1
+  collisionCount: 0
+  observedGeneration: 1


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
Adds resource interpreter customization for OpenKruise UnitedDeployment, enabling Karmada to properly manage UnitedDeployment resources in multi-cluster environments. This PR introduces:

- Status aggregation logic for UnitedDeployment across member clusters
- Health interpretation for UnitedDeployment resources
- Dependency extraction for ConfigMaps and Secrets referenced in the pod template
- Lua scripts for all required interpreter hooks (replica, status, health, dependency, etc.)
- Test data and validation using `karmadactl interpret` to ensure correct behavior

Special notes for your reviewer:
- The customization follows the established pattern for resource interpreter customizations in Karmada
- All interpreter rules pass with the provided test data
- Includes comprehensive test coverage for typical UnitedDeployment scenarios

Does this PR introduce a user-facing change?:

```release-note
feat: Add resource interpreter support for OpenKruise UnitedDeployment

Karmada can now interpret and manage OpenKruise UnitedDeployment resources across clusters, including:
- Multi-cluster status aggregation
- Health checks
- Dependency resolution for ConfigMaps and Secrets
- Comprehensive test coverage
```