### PR TITLE
Automated cherry pick of #6525: don't recreate resource in the member cluster when it is

### DIFF
--- a/pkg/controllers/status/work_status_controller.go
+++ b/pkg/controllers/status/work_status_controller.go
@@ -294,6 +294,11 @@ func (c *WorkStatusController) handleDeleteEvent(ctx context.Context, key keys.F
 		return nil
 	}
 
+	// skip processing as the work object is suspended for dispatching.
+	if helper.IsWorkSuspendDispatching(work) {
+		return nil
+	}
+
 	if util.GetLabelValue(work.Labels, util.PropagationInstruction) == util.PropagationInstructionSuppressed {
 		return nil
 	}


### PR DESCRIPTION
Cherry pick of #6525 on release-1.13.
#6525: don't recreate resource in the member cluster when it is
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`: Fixed the issue that resources will be recreated after being deleted on the cluster when resource is suspended for dispatching
```