### PR TITLE
detector: eliminate the mutation of the informer cache

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -657,9 +657,6 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 }
 
 // GetUnstructuredObject retrieves object by key and returned its unstructured.
-// Any updates to this resource template are not recommended as it may come from the informer cache.
-// We should abide by the principle of making a deep copy first and then modifying it.
-// See issue: https://github.com/karmada-io/karmada/issues/3878.
 func (d *ResourceDetector) GetUnstructuredObject(objectKey keys.ClusterWideKey) (*unstructured.Unstructured, error) {
 	objectGVR, err := restmapper.GetGroupVersionResource(d.RESTMapper, objectKey.GroupVersionKind())
 	if err != nil {
@@ -689,7 +686,8 @@ func (d *ResourceDetector) GetUnstructuredObject(objectKey keys.ClusterWideKey) 
 		return nil, err
 	}
 
-	return unstructuredObj, nil
+	// perform a deep copy to avoid modifying the cached object from informer
+	return unstructuredObj.DeepCopy(), nil
 }
 
 // ClaimPolicyForObject set policy identifier which the object associated with.

--- a/pkg/detector/policy.go
+++ b/pkg/detector/policy.go
@@ -270,7 +270,6 @@ func (d *ResourceDetector) removeResourceClaimMetadataIfNotMatched(objectReferen
 		return false, nil
 	}
 
-	object = object.DeepCopy()
 	util.RemoveLabels(object, labels...)
 	util.RemoveAnnotations(object, annotations...)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
When an object matches a PropagationPolicy, the detector adds metadata related to the PropagationPolicy to the object. To ensure the object used in subsequent binding generation is up-to-date, the function `ClaimPolicyForObject` directly modifies the object itself.
https://github.com/karmada-io/karmada/blob/c60a2e05f6e1f90fdfd3580a902bccd51bfdbff4/pkg/detector/detector.go#L695-L711

However, since the object is retrieved from the cache and no deep copy is made before modification, `ClaimPolicyForObject` ends up altering the informer cache.
https://github.com/karmada-io/karmada/blob/c60a2e05f6e1f90fdfd3580a902bccd51bfdbff4/pkg/detector/detector.go#L663-L670

Considering that the current implementation requires the caller to manually pass in a deep copy of the object when invoking ClaimPolicyForObject, which is not user-friendly and prone to cause similar issues again, the function was modified to perform a deep copy internally. This avoids modifying the original object. In addition, the updated objectCopy is returned to meet the needs of scenarios that require the latest object.



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-controller-manager`: Fixed the issue that the informer cache gets unexpectedly modified during usage,
```

