### PR TITLE
helm: support rotating cert when helm upgrade

### DIFF
--- a/charts/karmada/templates/post-upgrade-job.yaml
+++ b/charts/karmada/templates/post-upgrade-job.yaml
@@ -1,0 +1,52 @@
+{{- $name := include "karmada.name" . -}}
+{{- $namespace := include "karmada.namespace" . -}}
+{{- if eq .Values.installMode "host" }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ $name }}-post-upgrade"
+  namespace: {{ $namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ $name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": {{ .Values.postInstallJob.hookDeletePolicy }}
+spec:
+  parallelism: 1
+  completions: 1
+  template:
+    metadata:
+      name: {{ $name }}-post-upgrade
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ $name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      {{- include "karmada.imagePullSecrets" . | nindent 6 }}
+      {{- with .Values.postInstallJob.tolerations}}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postInstallJob.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ $name }}-hook-job
+      restartPolicy: Never
+      containers:
+      - name: post-upgrade
+        image: {{ template "karmada.kubectl.image" . }}
+        imagePullPolicy: {{ .Values.kubectl.image.pullPolicy }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -ex
+          {{- if .Values.certs.rotateWhenUpgrade }}
+          kubectl rollout restart statefulset --namespace {{ $namespace }} -l app.kubernetes.io/managed-by={{ .Release.Service | quote }}
+          kubectl rollout restart deployment --namespace {{ $namespace }} -l app.kubernetes.io/managed-by={{ .Release.Service | quote }}
+          {{- end }}
+{{- end }}

--- a/charts/karmada/templates/pre-install-job.yaml
+++ b/charts/karmada/templates/pre-install-job.yaml
@@ -388,6 +388,7 @@ data:
       {{- print "webhook_in_resourcebindings.yaml: " | nindent 6 }} |-
         {{- include "karmada.crd.patch.webhook.resourcebinding" . | nindent 8 }}
 
+{{- if or .Release.IsInstall (and .Values.certs.rotateWhenUpgrade .Release.IsUpgrade) }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -397,7 +398,7 @@ metadata:
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "3"
     "helm.sh/hook-delete-policy": {{ .Values.preInstallJob.hookDeletePolicy }}
   {{- if "karmada.preInstallJob.labels" }}
@@ -484,7 +485,7 @@ spec:
         - |
           bash <<'EOF'
           set -ex
-          kubectl apply --server-side -f /opt/configs/
+          kubectl apply --server-side --force-conflicts -f /opt/configs/
           EOF
         volumeMounts:
         - name: mount
@@ -498,5 +499,6 @@ spec:
       - name: configs
         emptyDir: {}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/karmada/templates/pre-upgrade-job.yaml
+++ b/charts/karmada/templates/pre-upgrade-job.yaml
@@ -2,6 +2,7 @@
 {{- $namespace := include "karmada.namespace" . -}}
 {{- if eq .Values.installMode "host" }}
 {{- if eq .Values.certs.mode "auto" }}
+{{- if not .Values.certs.rotateWhenUpgrade }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -94,5 +95,6 @@ spec:
           limits:
             cpu: 100m
             memory: 128Mi
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -149,6 +149,8 @@ certs:
     ]
     ## @param certs.auto.rsaSize rsa key size of the certificate
     rsaSize: 3072
+    ## @param rotateWhenUpgrade Whether to rotate certificate during helm upgrade. When set to true, new CA will be generated and all Karmada components (Deployment/StatefulSet) will be forcefully restarted during upgrade.
+    rotateWhenUpgrade: false
   custom:
     ## @param certs.custom.caCrt ca of the certificate
     caCrt: |


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
In #6395, we added support for upgrading Karmada instances using `helm upgrade`. In this PR, I introduced the value `.Values.certs.rotateWhenUpgrade` to control whether certificates need to be rotated during the `helm upgrade` process. If set to `true`, it will regenerate the CA certificate and identity certificates during `helm upgrade`, and finally restart the Karmada components to apply the latest certificates. This feature will help users better control certificates in the following scenarios:
- Wanting to add domains to certificates
- Needing to replace certificates when the CA certificate is about to expire

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->
Test report: 
1. Set up Karmada by `helm install`
```bash
$ helm install karmada -n karmada-system --create-namespace --dependency-update ./charts/karmada --set apiServer.hostNetwork=true,apiServer.serviceType=NodePort
NAME: karmada
LAST DEPLOYED: Fri Jul 18 14:23:57 2025
NAMESPACE: karmada-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
```
2. Export kubeconfig and deploy a deployment and propagationpolicy
```bash
$ kubectl get secret -n karmada-system karmada-kubeconfig -o jsonpath={.data.kubeconfig} | base64 -d > karmada-apiserver.config 
$ kubectl --kubeconfig karmada-apiserver.config apply -f samples/nginx/propagationpolicy.yaml
$ kubectl --kubeconfig karmada-apiserver.config apply -f samples/nginx/de
ployment.yaml
```
3. helm upgrade by setting `certs.rotateWhenUpgrade` to true
```bash
$ helm upgrade karmada -n karmada-system --create-namespace --dependency-update ./charts/karmada --set apiServer.hostNetwork=true,apiServer.serviceType=NodePort,certs.rotateWhenUpgrade=true
```
Using the previous kubeconfig will result in an error:
```bash
Unable to connect to the server: tls: failed to verify certificate: x509: certificate signed by unknown authority (possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate "ca")
```
4. Regenerate the kubeconfig
```bash
$ kubectl get secret -n karmada-system karmada-kubeconfig -o jsonpath={.data.kubeconfig} | base64 -d > karmada-apiserver.config
$ kubectl --kubeconfig karmada-apiserver.config get rb
NAME               SCHEDULED   FULLYAPPLIED   AGE
nginx-deployment   False                      5m31s
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
5. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
6. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`helm`: support rotating cert when helm upgrade
```

