### PR TITLE
Bump controller-gen version to v0.18.0

### DIFF
--- a/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
+++ b/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: karmadas.operator.karmada.io
 spec:
   group: operator.karmada.io

--- a/charts/karmada/_crds/bases/apps/apps.karmada.io_workloadrebalancers.yaml
+++ b/charts/karmada/_crds/bases/apps/apps.karmada.io_workloadrebalancers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: workloadrebalancers.apps.karmada.io
 spec:
   group: apps.karmada.io

--- a/charts/karmada/_crds/bases/autoscaling/autoscaling.karmada.io_cronfederatedhpas.yaml
+++ b/charts/karmada/_crds/bases/autoscaling/autoscaling.karmada.io_cronfederatedhpas.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: cronfederatedhpas.autoscaling.karmada.io
 spec:
   group: autoscaling.karmada.io

--- a/charts/karmada/_crds/bases/autoscaling/autoscaling.karmada.io_federatedhpas.yaml
+++ b/charts/karmada/_crds/bases/autoscaling/autoscaling.karmada.io_federatedhpas.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: federatedhpas.autoscaling.karmada.io
 spec:
   group: autoscaling.karmada.io

--- a/charts/karmada/_crds/bases/config/config.karmada.io_resourceinterpretercustomizations.yaml
+++ b/charts/karmada/_crds/bases/config/config.karmada.io_resourceinterpretercustomizations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: resourceinterpretercustomizations.config.karmada.io
 spec:
   group: config.karmada.io

--- a/charts/karmada/_crds/bases/config/config.karmada.io_resourceinterpreterwebhookconfigurations.yaml
+++ b/charts/karmada/_crds/bases/config/config.karmada.io_resourceinterpreterwebhookconfigurations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: resourceinterpreterwebhookconfigurations.config.karmada.io
 spec:
   group: config.karmada.io

--- a/charts/karmada/_crds/bases/networking/networking.karmada.io_multiclusteringresses.yaml
+++ b/charts/karmada/_crds/bases/networking/networking.karmada.io_multiclusteringresses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: multiclusteringresses.networking.karmada.io
 spec:
   group: networking.karmada.io

--- a/charts/karmada/_crds/bases/networking/networking.karmada.io_multiclusterservices.yaml
+++ b/charts/karmada/_crds/bases/networking/networking.karmada.io_multiclusterservices.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: multiclusterservices.networking.karmada.io
 spec:
   group: networking.karmada.io

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_clusteroverridepolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_clusteroverridepolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: clusteroverridepolicies.policy.karmada.io
 spec:
   group: policy.karmada.io

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_clusterpropagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_clusterpropagationpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: clusterpropagationpolicies.policy.karmada.io
 spec:
   group: policy.karmada.io

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_clustertaintpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_clustertaintpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: clustertaintpolicies.policy.karmada.io
 spec:
   group: policy.karmada.io

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_federatedresourcequotas.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_federatedresourcequotas.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: federatedresourcequotas.policy.karmada.io
 spec:
   group: policy.karmada.io

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_overridepolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_overridepolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: overridepolicies.policy.karmada.io
 spec:
   group: policy.karmada.io

--- a/charts/karmada/_crds/bases/policy/policy.karmada.io_propagationpolicies.yaml
+++ b/charts/karmada/_crds/bases/policy/policy.karmada.io_propagationpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: propagationpolicies.policy.karmada.io
 spec:
   group: policy.karmada.io

--- a/charts/karmada/_crds/bases/remedy/remedy.karmada.io_remedies.yaml
+++ b/charts/karmada/_crds/bases/remedy/remedy.karmada.io_remedies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: remedies.remedy.karmada.io
 spec:
   group: remedy.karmada.io

--- a/charts/karmada/_crds/bases/work/work.karmada.io_clusterresourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work/work.karmada.io_clusterresourcebindings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: clusterresourcebindings.work.karmada.io
 spec:
   group: work.karmada.io

--- a/charts/karmada/_crds/bases/work/work.karmada.io_resourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work/work.karmada.io_resourcebindings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: resourcebindings.work.karmada.io
 spec:
   group: work.karmada.io

--- a/charts/karmada/_crds/bases/work/work.karmada.io_works.yaml
+++ b/charts/karmada/_crds/bases/work/work.karmada.io_works.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: works.work.karmada.io
 spec:
   group: work.karmada.io

--- a/examples/customresourceinterpreter/apis/workload.example.io_workloads.yaml
+++ b/examples/customresourceinterpreter/apis/workload.example.io_workloads.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: workloads.workload.example.io
 spec:
   group: workload.example.io

--- a/hack/update-crdgen.sh
+++ b/hack/update-crdgen.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 CONTROLLER_GEN_PKG="sigs.k8s.io/controller-tools/cmd/controller-gen"
-CONTROLLER_GEN_VER="v0.17.3"
+CONTROLLER_GEN_VER="v0.18.0"
 
 source hack/util.sh
 

--- a/operator/config/crds/operator.karmada.io_karmadas.yaml
+++ b/operator/config/crds/operator.karmada.io_karmadas.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: karmadas.operator.karmada.io
 spec:
   group: operator.karmada.io


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
Bump controller-gen version to v0.18.0 to include k8s 1.33.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #6489
<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
Dependencies: Upgraded controller-gen to v0.18.0.
```