### PR TITLE
hack/local-up-karmada.sh supports WSL2

### DIFF
--- a/hack/setup-dev-base.sh
+++ b/hack/setup-dev-base.sh
@@ -83,10 +83,15 @@ else
 fi
 
 #step1. create host cluster and member clusters in parallel
-# host IP address: script parameter ahead of macOS IP
+# host IP address: script parameter ahead of WSL2 or macOS IP
 if [[ -z "${HOST_IPADDRESS}" ]]; then
-  util::get_macos_ipaddress # Adapt for macOS
-  HOST_IPADDRESS=${MAC_NIC_IPADDRESS:-}
+  if util::is_wsl2; then
+    util::get_wsl2_ipaddress # adapt for WSL2
+    HOST_IPADDRESS=${WSL2_HOST_IP_ADDRESS:-}
+  else
+    util::get_macos_ipaddress # Adapt for macOS
+    HOST_IPADDRESS=${MAC_NIC_IPADDRESS:-}
+  fi
 fi
 #prepare for kindClusterConfig
 TEMP_PATH=$(mktemp -d)


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind bug

**What this PR does / why we need it**:

Previously `hack/local-up-karmada.sh` does not work on WSL2 environment. This issue was already mentioned in https://github.com/karmada-io/karmada/issues/3140 and a solution was proposed there. This PR merged the solution into the shell script and therefore fixed the issue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #6572 

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**: 
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

