### PR TITLE
Automated cherry pick of #6434: wait for EndpointSlice informer synced when report

### DIFF
--- a/pkg/controllers/mcs/service_export_controller.go
+++ b/pkg/controllers/mcs/service_export_controller.go
@@ -396,6 +396,14 @@ func (c *ServiceExportController) reportEndpointSliceWithServiceExportCreate(ctx
 		return nil
 	}
 
+	// Before retrieving EndpointSlice objects from the informer, ensure the informer cache is synced.
+	// This is necessary because the informer for EndpointSlice is created dynamically in the Reconcile() routine
+	// when a Work resource containing an ServiceExport is detected for the cluster. If the informer is not yet synced,
+	// return an error and wait a retry at the next time.
+	if !singleClusterManager.IsInformerSynced(endpointSliceGVR) {
+		return fmt.Errorf("the informer for cluster %s has not been synced, wait a retry at the next time", serviceExportKey.Cluster)
+	}
+
 	endpointSliceLister := singleClusterManager.Lister(endpointSliceGVR)
 	if endpointSliceObjects, err = endpointSliceLister.ByNamespace(serviceExportKey.Namespace).List(labels.SelectorFromSet(labels.Set{
 		discoveryv1.LabelServiceName: serviceExportKey.Name,
@@ -469,6 +477,14 @@ func (c *ServiceExportController) reportEndpointSliceWithEndpointSliceCreateOrUp
 	singleClusterManager := c.InformerManager.GetSingleClusterManager(clusterName)
 	if singleClusterManager == nil {
 		return nil
+	}
+
+	// Before retrieving ServiceExport objects from the informer, ensure the informer cache is synced.
+	// This is necessary because the informer for ServiceExport is created dynamically in the Reconcile() routine
+	// when a Work resource containing an ServiceExport is detected for the cluster. If the informer is not yet synced,
+	// return an error and wait a retry at the next time.
+	if !singleClusterManager.IsInformerSynced(serviceExportGVR) {
+		return fmt.Errorf("the informer for cluster %s has not been synced, wait a retry at the next time", clusterName)
 	}
 
 	serviceExportLister := singleClusterManager.Lister(serviceExportGVR)
@@ -603,6 +619,7 @@ func cleanEndpointSliceWork(ctx context.Context, c client.Client, work *workv1al
 			klog.Errorf("Failed to update work(%s/%s): %v", work.Namespace, work.Name, err)
 			return err
 		}
+		klog.Infof("Successfully updated work(%s/%s)", work.Namespace, work.Name)
 		return nil
 	}
 
@@ -610,6 +627,7 @@ func cleanEndpointSliceWork(ctx context.Context, c client.Client, work *workv1al
 		klog.Errorf("Failed to delete work(%s/%s), Error: %v", work.Namespace, work.Name, err)
 		return err
 	}
+	klog.Infof("Successfully deleted work(%s/%s)", work.Namespace, work.Name)
 
 	return nil
 }


### PR DESCRIPTION
Cherry pick of #6434 on release-1.13.
#6434: wait for EndpointSlice informer synced when report
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`: Fixed the issue that EndpointSlice are deleted unexpectedly due to the EndpointSlice informer cache not being synced
```