### PR TITLE
Add support for specifying env vars and extra args for the Karmada operator

### DIFF
--- a/charts/karmada-operator/templates/karmada-operator-deployment.yaml
+++ b/charts/karmada-operator/templates/karmada-operator-deployment.yaml
@@ -44,6 +44,13 @@ spec:
         - /bin/karmada-operator
         - --leader-elect-resource-namespace={{ .Release.Namespace }}
         - --v=2
+        {{- range .Values.operator.extraArgs }}
+        - {{ . }}
+        {{- end }}
+        {{- with .Values.operator.env }}
+        env:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
         {{- if .Values.operator.resources }}
         resources: {{- toYaml .Values.operator.resources | nindent 12 }}
         {{- end }}

--- a/charts/karmada-operator/values.yaml
+++ b/charts/karmada-operator/values.yaml
@@ -58,7 +58,31 @@ operator:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
-  ## @param.resources
+
+  ## @param operator.env List of environment variables to inject
+  ##
+  ## - Each entry must be a valid Kubernetes EnvVar object.
+  ## - Supports both literal values and valueFrom references (ConfigMap, Secret, fieldRef, etc.).
+  ## - If omitted or set to an empty array (`[]`), no env stanza will be included.
+  ##
+  ## A sample stanza is shown below.
+  ##
+#  env:
+#    - name: http_proxy
+#      value: "http://best-awesome-proxy.com:8080"
+#    - name: https_proxy
+#      value: "http://best-awesome-proxy.com:8080"
+#    - name: no_proxy
+#      value: "localhost,127.0.0.1,*.svc,*.cluster.local"
+
+  ## @param operator.extraArgs List of extra arguments for the operator binary
+  ##
+  ## A sample stanza is shown below.
+  ##
+#  extraArgs:
+#    - --arg1=val1
+#    - --arg2
+
   resources: {}
     # If you do want to specify resources, uncomment the following
     # lines, adjust them as necessary, and remove the curly braces after 'resources:'.


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind feature

**What this PR does / why we need it**:
This PR adds support for injecting arbitrary environment variables (e.g., http proxy env vars)  into the Karmada Operator deployment.
It also adds supports for specifying extra arguments (e.g., `--log-format=json`) for the operator binary.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: Fixes #<issue number>, or Fixes (paste link of issue).*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: Part of #<issue number>, or Part of (paste link of issue).*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`Helm chart`: Karmada Operator chart now possible to set environment variables and extra arguments for the Karmada operator deployment.
```