### PR TITLE
Fixes Issue #6580 Install to namespaces other than karmada-system via helm chart.

### DIFF
--- a/charts/karmada/templates/_karmada_apiservice.tpl
+++ b/charts/karmada/templates/_karmada_apiservice.tpl
@@ -19,18 +19,6 @@ spec:
     namespace: {{ include "karmada.namespace" . }}
   version: v1alpha1
   versionPriority: 10
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ $name }}-aggregated-apiserver
-  namespace: {{ include "karmada.namespace" . }}
-  labels:
-    app: {{ $name }}-aggregated-apiserver
-    {{- include "karmada.commonLabels" . | nindent 4 }}
-spec:
-  type: ExternalName
-  externalName: {{ $name }}-aggregated-apiserver.{{ include "karmada.namespace" . }}.svc.{{ .Values.clusterDomain }}
 {{- end }}
 {{- if has "metricsAdapter" .Values.components }}
 ---
@@ -84,15 +72,6 @@ spec:
     namespace: {{ include "karmada.namespace" . }}
   version: v1beta1
   versionPriority: 200
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ $name }}-metrics-adapter
-  namespace: {{ include "karmada.namespace" . }}
-spec:
-  type: ExternalName
-  externalName: {{ $name }}-metrics-adapter.{{ include "karmada.namespace" . }}.svc.{{ .Values.clusterDomain }}
 {{- end }}
 {{- if has "search" .Values.components }}
 ---
@@ -113,17 +92,5 @@ spec:
     namespace: {{ include "karmada.namespace" . }}
   version: v1alpha1
   versionPriority: 10
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ $name }}-search
-  namespace: {{ include "karmada.namespace" . }}
-  labels:
-    app: {{ $name }}-search
-    {{- include "karmada.commonLabels" . | nindent 4 }}
-spec:
-  type: ExternalName
-  externalName: {{ $name }}-search.{{ include "karmada.namespace" . }}.svc.{{ .Values.clusterDomain }}
 {{- end }}
 {{- end -}}

--- a/charts/karmada/templates/_karmada_apiservice.tpl
+++ b/charts/karmada/templates/_karmada_apiservice.tpl
@@ -1,6 +1,5 @@
 {{- define "karmada.apiservice" -}}
 {{- $name := include "karmada.name" . -}}
-{{- $systemNamespace := .Values.systemNamespace -}}
 {{- if eq .Values.installMode "host" }}
 ---
 apiVersion: apiregistration.k8s.io/v1
@@ -17,7 +16,7 @@ spec:
   groupPriorityMinimum: 2000
   service:
     name: {{ $name }}-aggregated-apiserver
-    namespace: {{ $systemNamespace }}
+    namespace: {{ include "karmada.namespace" . }}
   version: v1alpha1
   versionPriority: 10
 ---
@@ -25,7 +24,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $name }}-aggregated-apiserver
-  namespace: {{ $systemNamespace }}
+  namespace: {{ include "karmada.namespace" . }}
   labels:
     app: {{ $name }}-aggregated-apiserver
     {{- include "karmada.commonLabels" . | nindent 4 }}
@@ -48,7 +47,7 @@ spec:
   groupPriorityMinimum: 100
   service:
     name: {{ $name }}-metrics-adapter
-    namespace: {{ $systemNamespace }}
+    namespace: {{ include "karmada.namespace" . }}
   version: v1beta1
   versionPriority: 200
 ---
@@ -65,7 +64,7 @@ spec:
   groupPriorityMinimum: 100
   service:
     name: {{ $name }}-metrics-adapter
-    namespace: {{ $systemNamespace }}
+    namespace: {{ include "karmada.namespace" . }}
   version: v1beta2
   versionPriority: 200
 ---
@@ -82,7 +81,7 @@ spec:
   groupPriorityMinimum: 100
   service:
     name: {{ $name }}-metrics-adapter
-    namespace: {{ $systemNamespace }}
+    namespace: {{ include "karmada.namespace" . }}
   version: v1beta1
   versionPriority: 200
 ---
@@ -90,7 +89,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $name }}-metrics-adapter
-  namespace: {{ $systemNamespace }}
+  namespace: {{ include "karmada.namespace" . }}
 spec:
   type: ExternalName
   externalName: {{ $name }}-metrics-adapter.{{ include "karmada.namespace" . }}.svc.{{ .Values.clusterDomain }}
@@ -111,7 +110,7 @@ spec:
   groupPriorityMinimum: 2000
   service:
     name: {{ $name }}-search
-    namespace: {{ $systemNamespace }}
+    namespace: {{ include "karmada.namespace" . }}
   version: v1alpha1
   versionPriority: 10
 ---
@@ -119,7 +118,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $name }}-search
-  namespace: {{ $systemNamespace }}
+  namespace: {{ include "karmada.namespace" . }}
   labels:
     app: {{ $name }}-search
     {{- include "karmada.commonLabels" . | nindent 4 }}

--- a/charts/karmada/templates/_karmada_apiservice.tpl
+++ b/charts/karmada/templates/_karmada_apiservice.tpl
@@ -1,5 +1,6 @@
 {{- define "karmada.apiservice" -}}
 {{- $name := include "karmada.name" . -}}
+{{- $systemNamespace := .Values.systemNamespace -}}
 {{- if eq .Values.installMode "host" }}
 ---
 apiVersion: apiregistration.k8s.io/v1
@@ -19,6 +20,18 @@ spec:
     namespace: {{ include "karmada.namespace" . }}
   version: v1alpha1
   versionPriority: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}-aggregated-apiserver
+  namespace: {{ $systemNamespace }}
+  labels:
+    app: {{ $name }}-aggregated-apiserver
+    {{- include "karmada.commonLabels" . | nindent 4 }}
+spec:
+  type: ExternalName
+  externalName: {{ $name }}-aggregated-apiserver.{{ include "karmada.namespace" . }}.svc.{{ .Values.clusterDomain }}
 {{- end }}
 {{- if has "metricsAdapter" .Values.components }}
 ---
@@ -72,6 +85,15 @@ spec:
     namespace: {{ include "karmada.namespace" . }}
   version: v1beta1
   versionPriority: 200
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}-metrics-adapter
+  namespace: {{ $systemNamespace }}
+spec:
+  type: ExternalName
+  externalName: {{ $name }}-metrics-adapter.{{ include "karmada.namespace" . }}.svc.{{ .Values.clusterDomain }}
 {{- end }}
 {{- if has "search" .Values.components }}
 ---
@@ -92,5 +114,17 @@ spec:
     namespace: {{ include "karmada.namespace" . }}
   version: v1alpha1
   versionPriority: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}-search
+  namespace: {{ $systemNamespace }}
+  labels:
+    app: {{ $name }}-search
+    {{- include "karmada.commonLabels" . | nindent 4 }}
+spec:
+  type: ExternalName
+  externalName: {{ $name }}-search.{{ include "karmada.namespace" . }}.svc.{{ .Values.clusterDomain }}
 {{- end }}
 {{- end -}}

--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -41,6 +41,8 @@ installMode: "host"
 ## @param clusterDomain default domain for karmada
 clusterDomain: "cluster.local"
 
+## @param systemNamespace the namespace used for system resources
+## This can be different from the namespace where Karmada components are deployed
 systemNamespace: "karmada-system"
 
 ## @param components component list


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
this PR fixes a issue where the karmada helm chart could only be installed in the `karmada-system` namespace previously, attempting to install karmada in any other namespace would result in controller crashes and certificate verification errors

**Which issue(s) this PR fixes**:
when users tried to install karmada using helm in a namespace other than `karmada-system`, they encountered errors

Fixes #6580 

the following chnages are tested and verified 
@zhzhuang-zju please review this PR and request if any further chnages are required !!




