### PR TITLE
Fixes the TODO comment in resource_test.go that referenced https://github.com/karmada-io/karmada/pull/5141

### DIFF
--- a/test/e2e/suites/base/resource_test.go
+++ b/test/e2e/suites/base/resource_test.go
@@ -193,13 +193,6 @@ var _ = ginkgo.Describe("[resource-status collection] resource status collection
 					latestSvc, err := kubeClient.CoreV1().Services(serviceNamespace).Get(context.TODO(), serviceName, metav1.GetOptions{})
 					g.Expect(err).NotTo(gomega.HaveOccurred())
 
-					// TODO:  Once karmada-apiserver v1.30 deploy by default,delete the following five lines, see https://github.com/karmada-io/karmada/pull/5141
-					for i := range latestSvc.Status.LoadBalancer.Ingress {
-						if latestSvc.Status.LoadBalancer.Ingress[i].IPMode != nil {
-							latestSvc.Status.LoadBalancer.Ingress[i].IPMode = nil
-						}
-					}
-					klog.Infof("the latest serviceStatus loadBalancer: %v", latestSvc.Status.LoadBalancer)
 					return reflect.DeepEqual(latestSvc.Status.LoadBalancer.Ingress, svcLoadBalancer.Ingress), nil
 				}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 			})


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
This PR removes a workaround code block in the LoadBalancer service status test that was clearing the IPMode field from LoadBalancer Ingress status. The workaround was originally needed when karmada-apiserver was using Kubernetes v1.30, but now that the project uses Kubernetes v1.33.2, the IPMode field is properly handled by the apiserver and no longer needs to be cleared for test comparisons.

The removed code included:
- A TODO comment referencing the original issue.
- A loop that cleared IPMode fields from LoadBalancer Ingress.
- A debug log statement.

This cleanup improves test reliability and removes technical debt that was no longer necessary.


**Which issue(s) this PR fixes**:
Fixes #6606


**Special notes for your reviewer**:
This change addresses the TODO comment in test/e2e/suites/base/resource_test.go that referenced https://github.com/karmada-io/karmada/pull/5141. The test should continue to pass as the IPMode field is now properly handled by the Kubernetes v1.33.2 apiserver.

**Does this PR introduce a user-facing change?**:
```
NONE
```

