### PR TITLE
Handle cases where HasSynced is false in resource interpreter by throwing error instead of hiding it

### DIFF
--- a/pkg/controllers/applicationfailover/crb_application_failover_controller.go
+++ b/pkg/controllers/applicationfailover/crb_application_failover_controller.go
@@ -70,7 +70,11 @@ func (c *CRBApplicationFailoverController) Reconcile(ctx context.Context, req co
 		return controllerruntime.Result{}, err
 	}
 
-	if !c.clusterResourceBindingFilter(binding) {
+	filter, err := c.clusterResourceBindingFilter(binding)
+	if err != nil {
+		return controllerruntime.Result{}, err
+	}
+	if !filter {
 		c.workloadUnhealthyMap.delete(req.NamespacedName)
 		return controllerruntime.Result{}, nil
 	}
@@ -215,25 +219,28 @@ func (c *CRBApplicationFailoverController) SetupWithManager(mgr controllerruntim
 		Complete(c)
 }
 
-func (c *CRBApplicationFailoverController) clusterResourceBindingFilter(crb *workv1alpha2.ClusterResourceBinding) bool {
+func (c *CRBApplicationFailoverController) clusterResourceBindingFilter(crb *workv1alpha2.ClusterResourceBinding) (bool, error) {
 	if crb.Spec.Failover == nil || crb.Spec.Failover.Application == nil {
-		return false
+		return false, nil
 	}
 
 	if len(crb.Status.AggregatedStatus) == 0 {
-		return false
+		return false, nil
 	}
 
 	resourceKey, err := helper.ConstructClusterWideKey(crb.Spec.Resource)
 	if err != nil {
 		// Never reach
 		klog.ErrorS(err, "Failed to construct clusterWideKey from clusterResourceBinding", "name", crb.Name)
-		return false
+		return false, err
 	}
 
-	if !c.ResourceInterpreter.HookEnabled(resourceKey.GroupVersionKind(), configv1alpha1.InterpreterOperationInterpretHealth) {
-		return false
+	enabled, err := c.ResourceInterpreter.HookEnabled(resourceKey.GroupVersionKind(), configv1alpha1.InterpreterOperationInterpretHealth)
+	if err != nil {
+		klog.Errorf("Failed to check if the interpret health hook is enabled for resource(kind=%s, %s/%s): %v",
+			resourceKey.GroupVersionKind().Kind, resourceKey.Namespace, resourceKey.Name, err)
+		return false, err
 	}
 
-	return true
+	return enabled, nil
 }

--- a/pkg/controllers/applicationfailover/crb_application_failover_controller_test.go
+++ b/pkg/controllers/applicationfailover/crb_application_failover_controller_test.go
@@ -314,6 +314,7 @@ func TestCRBApplicationFailoverController_clusterResourceBindingFilter(t *testin
 		name      string
 		binding   *workv1alpha2.ClusterResourceBinding
 		expectRes bool
+		expectErr bool
 	}{
 		{
 			name: "crb.Spec.Failover and crb.Spec.Failover.Application is nil",
@@ -332,6 +333,7 @@ func TestCRBApplicationFailoverController_clusterResourceBindingFilter(t *testin
 				},
 			},
 			expectRes: false,
+			expectErr: false,
 		},
 		{
 			name: "crb.Status.AggregatedStatus is 0",
@@ -353,6 +355,7 @@ func TestCRBApplicationFailoverController_clusterResourceBindingFilter(t *testin
 				},
 			},
 			expectRes: false,
+			expectErr: false,
 		},
 		{
 			name: "error occurs in ConstructClusterWideKey",
@@ -380,13 +383,19 @@ func TestCRBApplicationFailoverController_clusterResourceBindingFilter(t *testin
 				},
 			},
 			expectRes: false,
+			expectErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := generateCRBApplicationFailoverController()
-			res := c.clusterResourceBindingFilter(tt.binding)
+			res, err := c.clusterResourceBindingFilter(tt.binding)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 			assert.Equal(t, tt.expectRes, res)
 		})
 	}

--- a/pkg/controllers/applicationfailover/rb_application_failover_controller_test.go
+++ b/pkg/controllers/applicationfailover/rb_application_failover_controller_test.go
@@ -295,6 +295,7 @@ func TestRBApplicationFailoverController_clusterResourceBindingFilter(t *testing
 		name      string
 		binding   *workv1alpha2.ResourceBinding
 		expectRes bool
+		expectErr bool
 	}{
 		{
 			name: "crb.Spec.Failover and crb.Spec.Failover.Application is nil",
@@ -313,6 +314,7 @@ func TestRBApplicationFailoverController_clusterResourceBindingFilter(t *testing
 				},
 			},
 			expectRes: false,
+			expectErr: false,
 		},
 		{
 			name: "crb.Status.AggregatedStatus is 0",
@@ -334,6 +336,7 @@ func TestRBApplicationFailoverController_clusterResourceBindingFilter(t *testing
 				},
 			},
 			expectRes: false,
+			expectErr: false,
 		},
 		{
 			name: "error occurs in ConstructClusterWideKey",
@@ -361,13 +364,19 @@ func TestRBApplicationFailoverController_clusterResourceBindingFilter(t *testing
 				},
 			},
 			expectRes: false,
+			expectErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := generateRBApplicationFailoverController()
-			res := c.bindingFilter(tt.binding)
+			res, err := c.bindingFilter(tt.binding)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 			assert.Equal(t, tt.expectRes, res)
 		})
 	}

--- a/pkg/controllers/status/common.go
+++ b/pkg/controllers/status/common.go
@@ -161,7 +161,12 @@ func updateResourceStatus(
 	}
 
 	gvk := schema.GroupVersionKind{Group: gvr.Group, Version: gvr.Version, Kind: objRef.Kind}
-	if !interpreter.HookEnabled(gvk, configv1alpha1.InterpreterOperationAggregateStatus) {
+	enable, err := interpreter.HookEnabled(gvk, configv1alpha1.InterpreterOperationAggregateStatus)
+	if err != nil {
+		klog.Errorf("Failed to check hook enabled for gvk(%s), Error: %v", gvk, err)
+		return err
+	}
+	if !enable {
 		return nil
 	}
 

--- a/pkg/controllers/status/work_status_controller_test.go
+++ b/pkg/controllers/status/work_status_controller_test.go
@@ -1082,7 +1082,8 @@ func TestWorkStatusController_interpretHealth(t *testing.T) {
 			obj, err := helper.ToUnstructured(tt.clusterObj)
 			assert.NoError(t, err)
 
-			resourceHealth := c.interpretHealth(obj, work)
+			resourceHealth, err := c.interpretHealth(obj, work)
+			assert.NoError(t, err)
 			assert.Equalf(t, tt.expectedResourceHealth, resourceHealth, "expected resource health %v, got %v", tt.expectedResourceHealth, resourceHealth)
 
 			eventRecorder := c.EventRecorder.(*record.FakeRecorder)

--- a/pkg/dependenciesdistributor/dependencies_distributor.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor.go
@@ -274,7 +274,13 @@ func (d *DependenciesDistributor) Reconcile(ctx context.Context, request reconci
 		return reconcile.Result{}, err
 	}
 
-	if !d.ResourceInterpreter.HookEnabled(workload.GroupVersionKind(), configv1alpha1.InterpreterOperationInterpretDependency) {
+	enable, err := d.ResourceInterpreter.HookEnabled(workload.GroupVersionKind(), configv1alpha1.InterpreterOperationInterpretDependency)
+	if err != nil {
+		klog.Errorf("Failed to check if the interpret dependency hook is enabled for resource(kind=%s, %s/%s): %v",
+			workload.GetKind(), workload.GetNamespace(), workload.GetName(), err)
+		return reconcile.Result{}, err
+	}
+	if !enable {
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -761,7 +761,13 @@ func (d *ResourceDetector) BuildResourceBinding(object *unstructured.Unstructure
 
 	claimFunc(propagationBinding, policyID, policyMeta)
 
-	if d.ResourceInterpreter.HookEnabled(object.GroupVersionKind(), configv1alpha1.InterpreterOperationInterpretReplica) {
+	enable, err := d.ResourceInterpreter.HookEnabled(object.GroupVersionKind(), configv1alpha1.InterpreterOperationInterpretReplica)
+	if err != nil {
+		klog.Errorf("Failed to check if the interpret replica hook is enabled for resource(kind=%s, %s/%s): %v",
+			object.GetKind(), object.GetNamespace(), object.GetName(), err)
+		return nil, err
+	}
+	if enable {
 		replicas, replicaRequirements, err := d.ResourceInterpreter.GetReplicas(object)
 		if err != nil {
 			klog.Errorf("Failed to customize replicas for %s(%s), %v", object.GroupVersionKind(), object.GetName(), err)
@@ -835,7 +841,13 @@ func (d *ResourceDetector) BuildClusterResourceBinding(object *unstructured.Unst
 
 	AddCPPClaimMetadata(binding, policyID, policyMeta)
 
-	if d.ResourceInterpreter.HookEnabled(object.GroupVersionKind(), configv1alpha1.InterpreterOperationInterpretReplica) {
+	enable, err := d.ResourceInterpreter.HookEnabled(object.GroupVersionKind(), configv1alpha1.InterpreterOperationInterpretReplica)
+	if err != nil {
+		klog.Errorf("Failed to check if the interpret replica hook is enabled for resource(kind=%s, %s/%s): %v",
+			object.GetKind(), object.GetNamespace(), object.GetName(), err)
+		return nil, err
+	}
+	if enable {
 		replicas, replicaRequirements, err := d.ResourceInterpreter.GetReplicas(object)
 		if err != nil {
 			klog.Errorf("Failed to customize replicas for %s(%s), %v", object.GroupVersionKind(), object.GetName(), err)

--- a/pkg/detector/detector_test.go
+++ b/pkg/detector/detector_test.go
@@ -1048,8 +1048,8 @@ func (m *mockResourceInterpreter) Start(_ context.Context) error {
 	return nil
 }
 
-func (m *mockResourceInterpreter) HookEnabled(_ schema.GroupVersionKind, _ configv1alpha1.InterpreterOperation) bool {
-	return false
+func (m *mockResourceInterpreter) HookEnabled(_ schema.GroupVersionKind, _ configv1alpha1.InterpreterOperation) (bool, error) {
+	return false, nil
 }
 
 func (m *mockResourceInterpreter) GetReplicas(_ *unstructured.Unstructured) (int32, *workv1alpha2.ReplicaRequirements, error) {

--- a/pkg/resourceinterpreter/customized/webhook/customized.go
+++ b/pkg/resourceinterpreter/customized/webhook/customized.go
@@ -18,6 +18,7 @@ package webhook
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -78,17 +79,18 @@ func NewCustomizedInterpreter(informer genericmanager.SingleClusterInformerManag
 }
 
 // HookEnabled tells if any hook exist for specific resource gvk and operation type.
-func (e *CustomizedInterpreter) HookEnabled(objGVK schema.GroupVersionKind, operation configv1alpha1.InterpreterOperation) bool {
+func (e *CustomizedInterpreter) HookEnabled(objGVK schema.GroupVersionKind, operation configv1alpha1.InterpreterOperation) (bool, error) {
 	if !e.hookManager.HasSynced() {
-		klog.Errorf("not yet ready to handle request")
-		return false
+		err := errors.New("not yet ready to handle request")
+		klog.Errorf("HookEnabled failed: %v", err)
+		return false, err
 	}
 
 	hook := e.getFirstRelevantHook(objGVK, operation)
 	if hook == nil {
 		klog.V(4).Infof("Hook interpreter is not enabled for kind %q with operation %q.", objGVK, operation)
 	}
-	return hook != nil
+	return hook != nil, nil
 }
 
 // GetReplicas returns the desired replicas of the object as well as the requirements of each replica.

--- a/pkg/resourceinterpreter/customized/webhook/customized_test.go
+++ b/pkg/resourceinterpreter/customized/webhook/customized_test.go
@@ -157,7 +157,12 @@ func TestHookEnabled(t *testing.T) {
 				},
 			}
 
-			got := interpreter.HookEnabled(tt.gvk, tt.operation)
+			got, err := interpreter.HookEnabled(tt.gvk, tt.operation)
+			if tt.hasSynced {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/resourceinterpreter/default/native/default.go
+++ b/pkg/resourceinterpreter/default/native/default.go
@@ -55,39 +55,39 @@ func NewDefaultInterpreter() *DefaultInterpreter {
 }
 
 // HookEnabled tells if any hook exist for specific resource type and operation type.
-func (e *DefaultInterpreter) HookEnabled(kind schema.GroupVersionKind, operationType configv1alpha1.InterpreterOperation) bool {
+func (e *DefaultInterpreter) HookEnabled(kind schema.GroupVersionKind, operationType configv1alpha1.InterpreterOperation) (bool, error) {
 	switch operationType {
 	case configv1alpha1.InterpreterOperationInterpretReplica:
 		if _, exist := e.replicaHandlers[kind]; exist {
-			return true
+			return true, nil
 		}
 	case configv1alpha1.InterpreterOperationReviseReplica:
 		if _, exist := e.reviseReplicaHandlers[kind]; exist {
-			return true
+			return true, nil
 		}
 	case configv1alpha1.InterpreterOperationRetain:
 		if _, exist := e.retentionHandlers[kind]; exist {
-			return true
+			return true, nil
 		}
 	case configv1alpha1.InterpreterOperationAggregateStatus:
 		if _, exist := e.aggregateStatusHandlers[kind]; exist {
-			return true
+			return true, nil
 		}
 	case configv1alpha1.InterpreterOperationInterpretDependency:
 		if _, exist := e.dependenciesHandlers[kind]; exist {
-			return true
+			return true, nil
 		}
 	case configv1alpha1.InterpreterOperationInterpretStatus:
-		return true
+		return true, nil
 	case configv1alpha1.InterpreterOperationInterpretHealth:
 		if _, exist := e.healthHandlers[kind]; exist {
-			return true
+			return true, nil
 		}
 		// TODO(RainbowMango): more cases should be added here
 	}
 
 	klog.V(4).Infof("Default interpreter is not enabled for kind %q with operation %q.", kind, operationType)
-	return false
+	return false, nil
 }
 
 // GetReplicas returns the desired replicas of the object as well as the requirements of each replica.

--- a/pkg/resourceinterpreter/default/native/default_test.go
+++ b/pkg/resourceinterpreter/default/native/default_test.go
@@ -117,7 +117,10 @@ func TestHookEnabled(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := e.HookEnabled(tt.kind, tt.operationType)
+			got, err := e.HookEnabled(tt.kind, tt.operationType)
+			if err != nil {
+				t.Errorf("HookEnabled() err = %v", err)
+			}
 			if got != tt.want {
 				t.Errorf("HookEnabled() = %v, want %v", got, tt.want)
 			}

--- a/pkg/resourceinterpreter/default/thirdparty/thirdparty.go
+++ b/pkg/resourceinterpreter/default/thirdparty/thirdparty.go
@@ -39,14 +39,14 @@ type ConfigurableInterpreter struct {
 }
 
 // HookEnabled tells if any hook exist for specific resource gvk and operation type.
-func (p *ConfigurableInterpreter) HookEnabled(kind schema.GroupVersionKind, operationType configv1alpha1.InterpreterOperation) bool {
+func (p *ConfigurableInterpreter) HookEnabled(kind schema.GroupVersionKind, operationType configv1alpha1.InterpreterOperation) (bool, error) {
 	customAccessor, exist := p.getCustomAccessor(kind)
 	if !exist {
-		return exist
+		return exist, nil
 	}
 	if operationType == configv1alpha1.InterpreterOperationInterpretDependency {
 		scripts := customAccessor.GetDependencyInterpretationLuaScripts()
-		return scripts != nil
+		return scripts != nil, nil
 	}
 	var script string
 	switch operationType {
@@ -63,7 +63,7 @@ func (p *ConfigurableInterpreter) HookEnabled(kind schema.GroupVersionKind, oper
 	case configv1alpha1.InterpreterOperationReviseReplica:
 		script = customAccessor.GetReplicaRevisionLuaScript()
 	}
-	return len(script) > 0
+	return len(script) > 0, nil
 }
 
 // GetReplicas returns the desired replicas of the object as well as the requirements of each replica.

--- a/pkg/resourceinterpreter/interpreter.go
+++ b/pkg/resourceinterpreter/interpreter.go
@@ -41,7 +41,7 @@ type ResourceInterpreter interface {
 	Start(ctx context.Context) (err error)
 
 	// HookEnabled tells if any hook exist for specific resource type and operation.
-	HookEnabled(objGVK schema.GroupVersionKind, operationType configv1alpha1.InterpreterOperation) bool
+	HookEnabled(objGVK schema.GroupVersionKind, operationType configv1alpha1.InterpreterOperation) (bool, error)
 
 	// GetReplicas returns the desired replicas of the object as well as the requirements of each replica.
 	GetReplicas(object *unstructured.Unstructured) (replica int32, replicaRequires *workv1alpha2.ReplicaRequirements, err error)
@@ -106,11 +106,23 @@ func (i *customResourceInterpreterImpl) Start(ctx context.Context) (err error) {
 }
 
 // HookEnabled tells if any hook exist for specific resource type and operation.
-func (i *customResourceInterpreterImpl) HookEnabled(objGVK schema.GroupVersionKind, operation configv1alpha1.InterpreterOperation) bool {
-	return i.defaultInterpreter.HookEnabled(objGVK, operation) ||
-		i.thirdpartyInterpreter.HookEnabled(objGVK, operation) ||
-		i.configurableInterpreter.HookEnabled(objGVK, operation) ||
-		i.customizedInterpreter.HookEnabled(objGVK, operation)
+func (i *customResourceInterpreterImpl) HookEnabled(objGVK schema.GroupVersionKind, operation configv1alpha1.InterpreterOperation) (bool, error) {
+	hookEnabled, err := i.defaultInterpreter.HookEnabled(objGVK, operation)
+	if err != nil || hookEnabled {
+		return hookEnabled, err
+	}
+
+	hookEnabled, err = i.thirdpartyInterpreter.HookEnabled(objGVK, operation)
+	if err != nil || hookEnabled {
+		return hookEnabled, err
+	}
+
+	hookEnabled, err = i.configurableInterpreter.HookEnabled(objGVK, operation)
+	if err != nil || hookEnabled {
+		return hookEnabled, err
+	}
+
+	return i.customizedInterpreter.HookEnabled(objGVK, operation)
 }
 
 // GetReplicas returns the desired replicas of the object as well as the requirements of each replica.

--- a/pkg/util/objectwatcher/objectwatcher.go
+++ b/pkg/util/objectwatcher/objectwatcher.go
@@ -168,7 +168,12 @@ func (o *objectWatcherImpl) Update(ctx context.Context, clusterName string, desi
 	}
 
 	desireObj = o.retainClusterFields(desireObj, clusterObj)
-	if o.resourceInterpreter.HookEnabled(desireObj.GroupVersionKind(), configv1alpha1.InterpreterOperationRetain) {
+	enable, err := o.resourceInterpreter.HookEnabled(desireObj.GroupVersionKind(), configv1alpha1.InterpreterOperationRetain)
+	if err != nil {
+		klog.Errorf("Failed to check if the retain hook is enabled for resource(kind=%s, %s/%s) in cluster %s: %v", desireObj.GetKind(), desireObj.GetNamespace(), desireObj.GetName(), clusterName, err)
+		return OperationResultNone, err
+	}
+	if enable {
 		desireObj, err = o.resourceInterpreter.Retain(desireObj, clusterObj)
 		if err != nil {
 			klog.Errorf("Failed to retain fields for resource(kind=%s, %s/%s) in cluster %s: %v", clusterObj.GetKind(), clusterObj.GetNamespace(), clusterObj.GetName(), clusterName, err)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
ref https://github.com/karmada-io/karmada/issues/6600

**Which issue(s) this PR fixes**:
Part of #6600

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-controller-manager`: Fixed an issue where errors were hidden when HasSynced returned false in the resource interpreter, and changed to actively throw errors to prevent field modifications caused by interpreter desynchronization.
```

