### PR TITLE
Add feature gates support to karmada-scheduler config (Helm Chart)

### DIFF
--- a/charts/karmada/templates/_helpers.tpl
+++ b/charts/karmada/templates/_helpers.tpl
@@ -556,18 +556,22 @@ Return the proper Docker Image Registry Secret Names
 {{ include "common.images.pullSecrets" (dict "images" (list .Values.cfssl.image .Values.kubectl.image .Values.etcd.internal.image .Values.agent.image .Values.apiServer.image .Values.controllerManager.image .Values.descheduler.image .Values.schedulerEstimator.image .Values.scheduler.image .Values.webhook.image .Values.aggregatedApiServer.image .Values.metricsAdapter.image .Values.search.image .Values.kubeControllerManager.image) "global" .Values.global) }}
 {{- end -}}
 
+{{- /* 
+Generate the --feature-gates command line argument for karmada-controllerManager.
+Iterates over .Values.controllerManager.featureGates and constructs a comma-separated key=value list.
+If any feature gates are set, outputs: --feature-gates=Foo=true,Bar=false
+If none are set, outputs nothing.
+*/ -}}
 {{- define "karmada.controllerManager.featureGates" -}}
-     {{- if (not (empty .Values.controllerManager.featureGates)) }}
-          {{- $featureGatesFlag := "" -}}
+     {{- if .Values.controllerManager.featureGates -}}
+          {{- $featureGates := list -}}
           {{- range $key, $value := .Values.controllerManager.featureGates -}}
-               {{- if not (empty (toString $value)) }}
-                    {{- $featureGatesFlag = cat $featureGatesFlag $key "=" $value ","  -}}
+               {{- if not (empty (toString $value)) -}}
+                    {{- $featureGates = append $featureGates (printf "%s=%s" $key (toString $value)) -}}
                {{- end -}}
           {{- end -}}
-
-          {{- if gt (len $featureGatesFlag) 0 }}
-               {{- $featureGatesFlag := trimSuffix "," $featureGatesFlag  | nospace -}}
-               {{- printf "%s=%s" "--feature-gates" $featureGatesFlag -}}
+          {{- if $featureGates -}}
+               {{- printf "--feature-gates=%s" (join "," $featureGates) | nospace -}}
           {{- end -}}
      {{- end -}}
 {{- end -}}
@@ -579,34 +583,55 @@ If any feature gates are set, outputs: --feature-gates=Foo=true,Bar=false
 If none are set, outputs nothing.
 */ -}}
 {{- define "karmada.webhook.featureGates" -}}
-     {{- if (not (empty .Values.webhook.featureGates)) }}
-          {{- $featureGatesFlag := "" -}}
+     {{- if .Values.webhook.featureGates -}}
+          {{- $featureGates := list -}}
           {{- range $key, $value := .Values.webhook.featureGates -}}
-               {{- if not (empty (toString $value)) }}
-                    {{- $featureGatesFlag = cat $featureGatesFlag $key "=" $value ","  -}}
+               {{- if not (empty (toString $value)) -}}
+                    {{- $featureGates = append $featureGates (printf "%s=%s" $key (toString $value)) -}}
                {{- end -}}
           {{- end -}}
-
-          {{- if gt (len $featureGatesFlag) 0 }}
-               {{- $featureGatesFlag := trimSuffix "," $featureGatesFlag  | nospace -}}
-               {{- printf "%s=%s" "--feature-gates" $featureGatesFlag -}}
+          {{- if $featureGates -}}
+               {{- printf "--feature-gates=%s" (join "," $featureGates) | nospace -}}
           {{- end -}}
      {{- end -}}
 {{- end -}}
 
-{{- define "karmada.schedulerEstimator.featureGates" -}}
-     {{- $featureGatesArg := index . "featureGatesArg" -}}
-     {{- if (not (empty $featureGatesArg)) }}
-          {{- $featureGatesFlag := "" -}}
-          {{- range $key, $value := $featureGatesArg -}}
-               {{- if not (empty (toString $value)) }}
-                    {{- $featureGatesFlag = cat $featureGatesFlag $key "=" $value ","  -}}
+{{- /* 
+Generate the --feature-gates command line argument for karmada-scheduler.
+Iterates over .Values.scheduler.featureGates and constructs a comma-separated key=value list.
+If any feature gates are set, outputs: --feature-gates=Foo=true,Bar=false
+If none are set, outputs nothing.
+*/ -}}
+{{- define "karmada.scheduler.featureGates" -}}
+     {{- if .Values.scheduler.featureGates -}}
+          {{- $featureGates := list -}}
+          {{- range $key, $value := .Values.scheduler.featureGates -}}
+               {{- if not (empty (toString $value)) -}}
+                    {{- $featureGates = append $featureGates (printf "%s=%s" $key (toString $value)) -}}
                {{- end -}}
           {{- end -}}
+          {{- if $featureGates -}}
+               {{- printf "--feature-gates=%s" (join "," $featureGates) | nospace -}}
+          {{- end -}}
+     {{- end -}}
+{{- end -}}
 
-          {{- if gt (len $featureGatesFlag) 0 }}
-               {{- $featureGatesFlag := trimSuffix "," $featureGatesFlag  | nospace -}}
-               {{- printf "%s=%s" "--feature-gates" $featureGatesFlag -}}
+{{- /* 
+Generate the --feature-gates command line argument for karmada-schedulerEstimator.
+Iterates over .Values.schedulerEstimator.featureGates and constructs a comma-separated key=value list.
+If any feature gates are set, outputs: --feature-gates=Foo=true,Bar=false
+If none are set, outputs nothing.
+*/ -}}
+{{- define "karmada.schedulerEstimator.featureGates" -}}
+     {{- if .Values.schedulerEstimator.featureGates -}}
+          {{- $featureGates := list -}}
+          {{- range $key, $value := .Values.schedulerEstimator.featureGates -}}
+               {{- if not (empty (toString $value)) -}}
+                    {{- $featureGates = append $featureGates (printf "%s=%s" $key (toString $value)) -}}
+               {{- end -}}
+          {{- end -}}
+          {{- if $featureGates -}}
+               {{- printf "--feature-gates=%s" (join "," $featureGates) | nospace -}}
           {{- end -}}
      {{- end -}}
 {{- end -}}

--- a/charts/karmada/templates/karmada-scheduler-estimator.yaml
+++ b/charts/karmada/templates/karmada-scheduler-estimator.yaml
@@ -55,9 +55,14 @@ spec:
             - --grpc-client-ca-file=/etc/karmada/pki/server-ca.crt
             - --metrics-bind-address=$(POD_IP):8080
             - --health-probe-bind-address=$(POD_IP):10351
-            {{- with (include "karmada.schedulerEstimator.featureGates" (dict "featureGatesArg" $.Values.schedulerEstimator.featureGates)) }}
+            {{- /*
+            We use '$' to refer to the root context.
+            Inside this 'range' loop, '.' refers to the current item from '.Values.schedulerEstimator.memberClusters'.
+            Using '$' ensures that we can access the top-level '.Values.schedulerEstimator.featureGates'.
+            */}}
+            {{- with (include "karmada.schedulerEstimator.featureGates" $) }}
             - {{ . }}
-            {{- end}}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/karmada/templates/karmada-scheduler.yaml
+++ b/charts/karmada/templates/karmada-scheduler.yaml
@@ -61,6 +61,9 @@ spec:
             {{- if .Values.scheduler.enableSchedulerEstimator }}
             - --enable-scheduler-estimator=true
             {{- end }}
+            {{- with (include "karmada.scheduler.featureGates" .) }}
+            - {{ . }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -245,6 +245,8 @@ scheduler:
   priorityClassName: "system-node-critical"
   ## @param scheduler.enableSchedulerEstimator enable scheduler estimator
   enableSchedulerEstimator: false
+  ## @param scheduler.featureGates A set of key=value pairs that describe feature gates for karmada-scheduler
+  featureGates: {}
 
 ## webhook config
 webhook:
@@ -299,11 +301,11 @@ webhook:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 50%
-  ## @param apiServer.podDisruptionBudget
+  ## @param webhook.podDisruptionBudget
   podDisruptionBudget: *podDisruptionBudget
   ## @param webhook.priorityClassName the priority class name for the karmada-webhook
   priorityClassName: "system-node-critical"
-  ## @param featureGate to webhook
+  ## @param webhook.featureGates A set of key=value pairs that describe feature gates for karmada-webhook
   featureGates: {}
 
 ## controller manager config


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
This PR adds feature gates support to the `karmada-scheduler` Helm Chart configuration. Users can now configure feature gates for the scheduler component via the `scheduler.featureGates` field in `values.yaml`, similar to other components like [controllerManager](https://github.com/karmada-io/karmada/blob/master/charts/karmada/values.yaml#L353) and [schedulerEstimator](https://github.com/karmada-io/karmada/blob/master/charts/karmada/values.yaml#L890). This provides a consistent and flexible way to enable or disable scheduler features across all installation modes.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`Helm Chart`: Users can now configure feature gates for karmada-scheduler via the Helm Chart using the `scheduler.featureGates` field in values.yaml.
```

