### PR TITLE
Automated cherry pick of #6622: When using MCS and MCI simultaneously, prevent resource residuce caused by deleting MCS and MCI

### DIFF
--- a/pkg/controllers/mcs/service_export_controller.go
+++ b/pkg/controllers/mcs/service_export_controller.go
@@ -528,10 +528,14 @@ func getEndpointSliceWorkMeta(ctx context.Context, c client.Client, ns string, w
 		return metav1.ObjectMeta{}, err
 	}
 
+	existFinalizers := existWork.GetFinalizers()
+	finalizersToAdd := []string{util.EndpointSliceControllerFinalizer}
+	newFinalizers := util.MergeFinalizers(existFinalizers, finalizersToAdd)
+
 	workMeta := metav1.ObjectMeta{
 		Name:       workName,
 		Namespace:  ns,
-		Finalizers: []string{util.EndpointSliceControllerFinalizer},
+		Finalizers: newFinalizers,
 		Labels: map[string]string{
 			util.ServiceNamespaceLabel: endpointSlice.GetNamespace(),
 			util.ServiceNameLabel:      endpointSlice.GetLabels()[discoveryv1.LabelServiceName],

--- a/pkg/controllers/multiclusterservice/endpointslice_collect_controller.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_collect_controller.go
@@ -404,6 +404,10 @@ func getEndpointSliceWorkMeta(ctx context.Context, c client.Client, ns string, w
 		return metav1.ObjectMeta{}, err
 	}
 
+	existFinalizers := existWork.GetFinalizers()
+	finalizersToAdd := []string{util.MCSEndpointSliceDispatchControllerFinalizer}
+	newFinalizers := util.MergeFinalizers(existFinalizers, finalizersToAdd)
+
 	ls := map[string]string{
 		util.MultiClusterServiceNamespaceLabel: endpointSlice.GetNamespace(),
 		util.MultiClusterServiceNameLabel:      endpointSlice.GetLabels()[discoveryv1.LabelServiceName],
@@ -412,7 +416,12 @@ func getEndpointSliceWorkMeta(ctx context.Context, c client.Client, ns string, w
 		util.EndpointSliceWorkManagedByLabel: util.MultiClusterServiceKind,
 	}
 	if existWork.Labels == nil || (err != nil && apierrors.IsNotFound(err)) {
-		workMeta := metav1.ObjectMeta{Name: workName, Namespace: ns, Labels: ls}
+		workMeta := metav1.ObjectMeta{
+			Name:       workName,
+			Namespace:  ns,
+			Labels:     ls,
+			Finalizers: newFinalizers,
+		}
 		return workMeta, nil
 	}
 
@@ -427,7 +436,7 @@ func getEndpointSliceWorkMeta(ctx context.Context, c client.Client, ns string, w
 		Name:       workName,
 		Namespace:  ns,
 		Labels:     ls,
-		Finalizers: []string{util.MCSEndpointSliceDispatchControllerFinalizer},
+		Finalizers: newFinalizers,
 	}, nil
 }
 

--- a/pkg/util/finalizer.go
+++ b/pkg/util/finalizer.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import "k8s.io/apimachinery/pkg/util/sets"
+
+// MergeFinalizers merges the new finalizers into exist finalizers, and deduplicates the finalizers.
+// The result is sorted.
+func MergeFinalizers(existFinalizers, newFinalizers []string) []string {
+	if existFinalizers == nil && newFinalizers == nil {
+		return nil
+	}
+
+	finalizers := sets.New[string](existFinalizers...).Insert(newFinalizers...)
+	return sets.List[string](finalizers)
+}

--- a/pkg/util/finalizer_test.go
+++ b/pkg/util/finalizer_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeFinalizers(t *testing.T) {
+	tests := []struct {
+		name            string
+		existFinalizers []string
+		newFinalizers   []string
+		expectedResult  []string
+	}{
+		{
+			name:            "both nil",
+			existFinalizers: nil,
+			newFinalizers:   nil,
+			expectedResult:  nil,
+		},
+		{
+			name:            "exist finalizers is nil",
+			existFinalizers: nil,
+			newFinalizers:   []string{"finalizer1", "finalizer2"},
+			expectedResult:  []string{"finalizer1", "finalizer2"},
+		},
+		{
+			name:            "new finalizers is nil",
+			existFinalizers: []string{"finalizer1", "finalizer2"},
+			newFinalizers:   nil,
+			expectedResult:  []string{"finalizer1", "finalizer2"},
+		},
+		{
+			name:            "both empty",
+			existFinalizers: []string{},
+			newFinalizers:   []string{},
+			expectedResult:  []string{},
+		},
+		{
+			name:            "exist finalizers is empty",
+			existFinalizers: []string{},
+			newFinalizers:   []string{"finalizer1", "finalizer2"},
+			expectedResult:  []string{"finalizer1", "finalizer2"},
+		},
+		{
+			name:            "new finalizers is empty",
+			existFinalizers: []string{"finalizer1", "finalizer2"},
+			newFinalizers:   []string{},
+			expectedResult:  []string{"finalizer1", "finalizer2"},
+		},
+		{
+			name:            "no duplicates",
+			existFinalizers: []string{"finalizer1", "finalizer2"},
+			newFinalizers:   []string{"finalizer3", "finalizer4"},
+			expectedResult:  []string{"finalizer1", "finalizer2", "finalizer3", "finalizer4"},
+		},
+		{
+			name:            "with duplicates",
+			existFinalizers: []string{"finalizer1", "finalizer2"},
+			newFinalizers:   []string{"finalizer2", "finalizer3"},
+			expectedResult:  []string{"finalizer1", "finalizer2", "finalizer3"},
+		},
+		{
+			name:            "all duplicates",
+			existFinalizers: []string{"finalizer1", "finalizer2"},
+			newFinalizers:   []string{"finalizer1", "finalizer2"},
+			expectedResult:  []string{"finalizer1", "finalizer2"},
+		},
+		{
+			name:            "duplicates in exist finalizers",
+			existFinalizers: []string{"finalizer1", "finalizer2", "finalizer1"},
+			newFinalizers:   []string{"finalizer3"},
+			expectedResult:  []string{"finalizer1", "finalizer2", "finalizer3"},
+		},
+		{
+			name:            "duplicates in new finalizers",
+			existFinalizers: []string{"finalizer1"},
+			newFinalizers:   []string{"finalizer2", "finalizer3", "finalizer2"},
+			expectedResult:  []string{"finalizer1", "finalizer2", "finalizer3"},
+		},
+		{
+			name:            "duplicates in both",
+			existFinalizers: []string{"finalizer1", "finalizer2", "finalizer1"},
+			newFinalizers:   []string{"finalizer2", "finalizer3", "finalizer2"},
+			expectedResult:  []string{"finalizer1", "finalizer2", "finalizer3"},
+		},
+		{
+			name:            "single finalizer in exist",
+			existFinalizers: []string{"finalizer1"},
+			newFinalizers:   []string{"finalizer2"},
+			expectedResult:  []string{"finalizer1", "finalizer2"},
+		},
+		{
+			name:            "single duplicate finalizer",
+			existFinalizers: []string{"finalizer1"},
+			newFinalizers:   []string{"finalizer1"},
+			expectedResult:  []string{"finalizer1"},
+		},
+		{
+			name:            "sort with result",
+			existFinalizers: []string{"finalizer3", "finalizer1", "finalizer2"},
+			newFinalizers:   []string{"finalizer4", "finalizer5"},
+			expectedResult:  []string{"finalizer1", "finalizer2", "finalizer3", "finalizer4", "finalizer5"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MergeFinalizers(tt.existFinalizers, tt.newFinalizers)
+			if !reflect.DeepEqual(result, tt.expectedResult) {
+				t.Errorf("MergeFinalizers() = %v, want %v", result, tt.expectedResult)
+			}
+		})
+	}
+}

--- a/pkg/util/helper/work.go
+++ b/pkg/util/helper/work.go
@@ -88,7 +88,7 @@ func CreateOrUpdateWork(ctx context.Context, client client.Client, workMeta meta
 			runtimeObject.Spec = work.Spec
 			runtimeObject.Labels = util.DedupeAndMergeLabels(runtimeObject.Labels, work.Labels)
 			runtimeObject.Annotations = util.DedupeAndMergeAnnotations(runtimeObject.Annotations, work.Annotations)
-			runtimeObject.Finalizers = work.Finalizers
+			runtimeObject.Finalizers = util.MergeFinalizers(runtimeObject.Finalizers, work.Finalizers)
 			return nil
 		})
 		return err


### PR DESCRIPTION
Cherry pick of #6622 on release-1.12.
#6622: merge EndpointSlice Work finalizers instead of overwriting it
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`: Fixed the issue that endpointslice and work resources residuce when using MCS and MCI simultaneously and then deleting them.
```