### PR TITLE
Automated cherry pick of #6544: detector: eliminate the mutation of the informer cache

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -637,9 +637,6 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 }
 
 // GetUnstructuredObject retrieves object by key and returned its unstructured.
-// Any updates to this resource template are not recommended as it may come from the informer cache.
-// We should abide by the principle of making a deep copy first and then modifying it.
-// See issue: https://github.com/karmada-io/karmada/issues/3878.
 func (d *ResourceDetector) GetUnstructuredObject(objectKey keys.ClusterWideKey) (*unstructured.Unstructured, error) {
 	objectGVR, err := restmapper.GetGroupVersionResource(d.RESTMapper, objectKey.GroupVersionKind())
 	if err != nil {
@@ -669,7 +666,8 @@ func (d *ResourceDetector) GetUnstructuredObject(objectKey keys.ClusterWideKey) 
 		return nil, err
 	}
 
-	return unstructuredObj, nil
+	// perform a deep copy to avoid modifying the cached object from informer
+	return unstructuredObj.DeepCopy(), nil
 }
 
 // ClaimPolicyForObject set policy identifier which the object associated with.

--- a/pkg/detector/policy.go
+++ b/pkg/detector/policy.go
@@ -281,7 +281,6 @@ func (d *ResourceDetector) removeResourceClaimMetadataIfNotMatched(objectReferen
 		return false, nil
 	}
 
-	object = object.DeepCopy()
 	util.RemoveLabels(object, labels...)
 	util.RemoveAnnotations(object, annotations...)
 


### PR DESCRIPTION
Cherry pick of #6544 on release-1.12.
#6544: detector: eliminate the mutation of the informer cache
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`: Fixed the issue that the informer cache gets unexpectedly modified during usage,
```