### PR TITLE
improve code quality and documentation across multiple packages

### DIFF
--- a/cmd/aggregated-apiserver/app/options/options.go
+++ b/cmd/aggregated-apiserver/app/options/options.go
@@ -140,7 +140,7 @@ func (o *Options) Run(ctx context.Context) error {
 
 // Config returns config for the api server given Options
 func (o *Options) Config() (*aggregatedapiserver.Config, error) {
-	// TODO have a "real" external address
+	// TODO: Have a "real" external address
 	if err := o.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{netutils.ParseIPSloppy("127.0.0.1")}); err != nil {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
 	}

--- a/cmd/karmada-search/app/karmada-search.go
+++ b/cmd/karmada-search/app/karmada-search.go
@@ -177,7 +177,7 @@ func run(ctx context.Context, o *options.Options, registryOptions ...Option) err
 
 // `config` returns config for the api server given Options
 func config(o *options.Options, outOfTreeRegistryOptions ...Option) (*search.Config, error) {
-	// TODO have a "real" external address
+	// TODO: Have a "real" external address
 	if err := o.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{netutils.ParseIPSloppy("127.0.0.1")}); err != nil {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
 	}

--- a/pkg/apis/cluster/scheme/register.go
+++ b/pkg/apis/cluster/scheme/register.go
@@ -39,6 +39,6 @@ func init() {
 	clusterinstall.Install(Scheme)
 
 	// we need to add the options to empty v1
-	// TODO fix the server code to avoid this
+	// TODO: Fix the server code to avoid this
 	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
 }

--- a/pkg/apis/search/scheme/register.go
+++ b/pkg/apis/search/scheme/register.go
@@ -43,6 +43,6 @@ func init() {
 	utilruntime.Must(internalversion.AddToScheme(Scheme))
 
 	// we need to add the options to empty v1
-	// TODO fix the server code to avoid this
+	// TODO: Fix the server code to avoid this
 	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
 }

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -782,7 +782,7 @@ func (d *ResourceDetector) BuildResourceBinding(object *unstructured.Unstructure
 			}
 			bindingSchedulePriority = &workv1alpha2.SchedulePriority{
 				Priority: kubePriorityClass.Value,
-				// TODO add preemptionpolicy
+				// TODO: Add preemptionpolicy
 				// PreemptionPolicy: kubePriorityClass.PreemptionPolicy,
 			}
 		case policyv1alpha1.PodPriorityClass:

--- a/pkg/generated/informers/externalversions/generic.go
+++ b/pkg/generated/informers/externalversions/generic.go
@@ -58,7 +58,7 @@ func (f *genericInformer) Lister() cache.GenericLister {
 }
 
 // ForResource gives generic access to a shared informer of the matching type
-// TODO extend this to unknown resources with a client pool
+// TODO: Extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
 	// Group=apps.karmada.io, Version=v1alpha1

--- a/pkg/karmadactl/util/testing/fake.go
+++ b/pkg/karmadactl/util/testing/fake.go
@@ -40,12 +40,12 @@ func NewTestFactory() *TestFactory {
 
 // KarmadaClientSet returns a karmada clientset
 func (t *TestFactory) KarmadaClientSet() (versioned.Interface, error) {
-	// TODO implement me
+	// TODO: Implement me
 	panic("implement me")
 }
 
 // FactoryForMemberCluster returns a cmdutil.Factory for the member cluster
 func (t *TestFactory) FactoryForMemberCluster(_ string) (cmdutil.Factory, error) {
-	// TODO implement me
+	// TODO: Implement me
 	panic("implement me")
 }

--- a/pkg/search/controller.go
+++ b/pkg/search/controller.go
@@ -350,12 +350,12 @@ func (c *Controller) getRegistryBackendHandler(cluster string, matchedRegistries
 }
 
 var clusterDynamicClientBuilder = func(cluster string, controlPlaneClient client.Client) (*util.DynamicClusterClient, error) {
-	// TODO: Add "--cluster-api-qps" and "--cluster-api-burst" flags to karmada-search and pass them via clientOption， instead of passing a "nil" here
+	// TODO: Add "--cluster-api-qps" and "--cluster-api-burst" flags to karmada-search and pass them via clientOption, instead of passing a "nil" here
 	return util.NewClusterDynamicClientSet(cluster, controlPlaneClient, nil)
 }
 
 // doCacheCluster processes the resourceRegistry object
-// TODO: update status
+// TODO: Update status
 func (c *Controller) doCacheCluster(cluster string) error {
 	// STEP0: stop informer manager for the cluster which does not exist anymore or is not ready.
 	cls, able, err := c.clusterAbleToCache(cluster)

--- a/pkg/search/proxy/store/util.go
+++ b/pkg/search/proxy/store/util.go
@@ -93,7 +93,7 @@ func (m *multiClusterResourceVersion) String() string {
 	if m.isZero {
 		return "0"
 	}
-	// todo consider to separate this two scenarios:
+	// TODO: Consider to separate these two scenarios:
 	// 1. client do not send ResourceVersion
 	// 2. client send ResourceVersion with empty cluster.
 	if len(m.rvs) == 0 {

--- a/pkg/util/lifted/lua/oslib_safe.go
+++ b/pkg/util/lifted/lua/oslib_safe.go
@@ -64,7 +64,7 @@ func osTime(L *lua.LState) int {
 		year := getIntField(tbl, "year", -1)
 		isdst := getBoolField(tbl, "isdst", false)
 		t := time.Date(year, time.Month(month), day, hour, min, sec, 0, time.Local)
-		// TODO dst
+		// TODO: dst
 		if false {
 			print(isdst)
 		}
@@ -110,7 +110,7 @@ func osDate(L *lua.LState) int {
 			ret.RawSetString("min", lua.LNumber(t.Minute()))
 			ret.RawSetString("sec", lua.LNumber(t.Second()))
 			ret.RawSetString("wday", lua.LNumber(t.Weekday()+1))
-			// TODO yday & dst
+			// TODO: yday & dst
 			ret.RawSetString("yday", lua.LNumber(0))
 			ret.RawSetString("isdst", lua.LFalse)
 			L.Push(ret)

--- a/pkg/util/lifted/requestinfo.go
+++ b/pkg/util/lifted/requestinfo.go
@@ -57,7 +57,7 @@ var namespaceSubresources = sets.NewString("status", "finalize")
 // +lifted:source=https://github.com/kubernetes/apiserver/blob/release-1.26/pkg/endpoints/request/requestinfo.go#L88-L247
 // +lifted:changed
 
-// TODO write an integration test against the swagger doc to test the RequestInfo and match up behavior to responses
+// TODO: Write an integration test against the swagger doc to test the RequestInfo and match up behavior to responses
 // NewRequestInfo returns the information from the http request.  If error is not nil, RequestInfo holds the information as best it is known before the failure
 // It handles both resource and non-resource requests and fills in all the pertinent information for each.
 // Valid Inputs:

--- a/pkg/util/proxy/proxy.go
+++ b/pkg/util/proxy/proxy.go
@@ -41,6 +41,11 @@ import (
 	clusterapis "github.com/karmada-io/karmada/pkg/apis/cluster"
 )
 
+const (
+	// DefaultUpgradeDialerPingPeriod represents the default ping period for upgrade dialer.
+	DefaultUpgradeDialerPingPeriod = 5 * time.Second
+)
+
 // SecretGetterFunc is a function to get secret.
 type SecretGetterFunc func(context.Context, string, string) (*corev1.Secret, error)
 
@@ -106,7 +111,7 @@ func newProxyHandler(location *url.URL, proxyTransport http.RoundTripper, cluste
 		upgradeDialer := NewUpgradeDialerWithConfig(UpgradeDialerWithConfig{
 			TLS:        tlsConfig,
 			Proxier:    http.ProxyURL(proxyURL),
-			PingPeriod: time.Second * 5,
+			PingPeriod: DefaultUpgradeDialerPingPeriod,
 			Header:     ParseProxyHeaders(cluster.Spec.ProxyHeader),
 		})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind cleanup


**What this PR does / why we need it**:
This PR improves code quality, documentation, and maintainability across multiple packages in the Karmada project by:
- Removing outdated IPMode workaround in e2e tests (now compatible with Kubernetes v1.33+)
- Fixing typos in TODO comments (e.g., "bug" → "but", "indenpent" → "independent")
- Replacing hardcoded timeout values with named constants for better maintainability
- Improving TODO comment clarity and formatting for better developer guidance
- Adding constants for poll intervals and timeouts in test and operator packages
- Enhancing documentation for future configurability options
- Fixing improperly formatted TODO comments throughout the codebase
- Improving comments for skipped tests and future implementations
- Adding better context to existing TODO comments

These improvements enhance developer experience, improve code maintainability, and maintain high code quality standards across the project.

**Which issue(s) this PR fixes**:
Fixes #6629 


**Special notes for your reviewer**:
- All changes are in existing files with no new files created
- Changes focus on code quality improvements and documentation enhancements
- No functional changes to the core logic
- All TODO comment improvements maintain the original intent while improving clarity
- Constants added follow Go naming conventions and include proper documentation

**Does this PR introduce a user-facing change?**:
```
NONE
```

