### PR TITLE
Automated cherry pick of  #6602 #6612 #6626 on release-1.14

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -260,10 +260,9 @@ func setupControllers(ctx context.Context, mgr controllerruntime.Manager, opts *
 	sharedFactory.WaitForCacheSync(ctx.Done())
 
 	resourceInterpreter := resourceinterpreter.NewResourceInterpreter(controlPlaneInformerManager, serviceLister)
-	if err := mgr.Add(resourceInterpreter); err != nil {
-		return fmt.Errorf("failed to setup custom resource interpreter: %w", err)
+	if err := resourceInterpreter.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start resource interpreter: %w", err)
 	}
-
 	rateLimiterGetter := util.GetClusterRateLimiterGetter().SetDefaultLimits(opts.ClusterAPIQPS, opts.ClusterAPIBurst)
 	clusterClientOption := &util.ClientOption{RateLimiterGetter: rateLimiterGetter.GetRateLimiter}
 

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -839,8 +839,8 @@ func setupControllers(ctx context.Context, mgr controllerruntime.Manager, opts *
 	sharedFactory.WaitForCacheSync(ctx.Done())
 
 	resourceInterpreter := resourceinterpreter.NewResourceInterpreter(controlPlaneInformerManager, serviceLister)
-	if err := mgr.Add(resourceInterpreter); err != nil {
-		klog.Fatalf("Failed to setup custom resource interpreter: %v", err)
+	if err := resourceInterpreter.Start(ctx); err != nil {
+		klog.Fatalf("Failed to start resource interpreter: %v", err)
 	}
 	rateLimiterGetter := util.GetClusterRateLimiterGetter().SetDefaultLimits(opts.ClusterAPIQPS, opts.ClusterAPIBurst)
 	clusterClientOption := &util.ClientOption{RateLimiterGetter: rateLimiterGetter.GetRateLimiter}

--- a/pkg/resourceinterpreter/customized/declarative/configmanager/manager_test.go
+++ b/pkg/resourceinterpreter/customized/declarative/configmanager/manager_test.go
@@ -18,14 +18,17 @@ package configmanager
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/tools/cache"
 
@@ -149,4 +152,367 @@ func Test_interpreterConfigManager_LuaScriptAccessors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_interpreterConfigManager_LoadConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		configs []*configv1alpha1.ResourceInterpreterCustomization
+		want    map[schema.GroupVersionKind]CustomAccessor
+	}{
+		{
+			name:    "empty configs",
+			configs: []*configv1alpha1.ResourceInterpreterCustomization{},
+			want:    make(map[schema.GroupVersionKind]CustomAccessor),
+		},
+		{
+			name: "single config",
+			configs: []*configv1alpha1.ResourceInterpreterCustomization{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "customization01"},
+					Spec: configv1alpha1.ResourceInterpreterCustomizationSpec{
+						Target: configv1alpha1.CustomizationTarget{
+							APIVersion: appsv1.SchemeGroupVersion.String(),
+							Kind:       "Deployment",
+						},
+						Customizations: configv1alpha1.CustomizationRules{
+							Retention: &configv1alpha1.LocalValueRetention{LuaScript: "retention-script"},
+						},
+					},
+				},
+			},
+			want: map[schema.GroupVersionKind]CustomAccessor{
+				{Group: "apps", Version: "v1", Kind: "Deployment"}: &resourceCustomAccessor{
+					retention: &configv1alpha1.LocalValueRetention{LuaScript: "retention-script"},
+				},
+			},
+		},
+		{
+			name: "multiple configs for same GVK",
+			configs: []*configv1alpha1.ResourceInterpreterCustomization{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "customization01"},
+					Spec: configv1alpha1.ResourceInterpreterCustomizationSpec{
+						Target: configv1alpha1.CustomizationTarget{
+							APIVersion: appsv1.SchemeGroupVersion.String(),
+							Kind:       "Deployment",
+						},
+						Customizations: configv1alpha1.CustomizationRules{
+							Retention: &configv1alpha1.LocalValueRetention{LuaScript: "retention-script"},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "customization02"},
+					Spec: configv1alpha1.ResourceInterpreterCustomizationSpec{
+						Target: configv1alpha1.CustomizationTarget{
+							APIVersion: appsv1.SchemeGroupVersion.String(),
+							Kind:       "Deployment",
+						},
+						Customizations: configv1alpha1.CustomizationRules{
+							ReplicaResource: &configv1alpha1.ReplicaResourceRequirement{LuaScript: "replica-script"},
+						},
+					},
+				},
+			},
+			want: map[schema.GroupVersionKind]CustomAccessor{
+				{Group: "apps", Version: "v1", Kind: "Deployment"}: &resourceCustomAccessor{
+					retention:       &configv1alpha1.LocalValueRetention{LuaScript: "retention-script"},
+					replicaResource: &configv1alpha1.ReplicaResourceRequirement{LuaScript: "replica-script"},
+				},
+			},
+		},
+		{
+			name: "multiple configs for different GVKs",
+			configs: []*configv1alpha1.ResourceInterpreterCustomization{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "customization01"},
+					Spec: configv1alpha1.ResourceInterpreterCustomizationSpec{
+						Target: configv1alpha1.CustomizationTarget{
+							APIVersion: appsv1.SchemeGroupVersion.String(),
+							Kind:       "Deployment",
+						},
+						Customizations: configv1alpha1.CustomizationRules{
+							Retention: &configv1alpha1.LocalValueRetention{LuaScript: "deployment-retention"},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "customization02"},
+					Spec: configv1alpha1.ResourceInterpreterCustomizationSpec{
+						Target: configv1alpha1.CustomizationTarget{
+							APIVersion: appsv1.SchemeGroupVersion.String(),
+							Kind:       "StatefulSet",
+						},
+						Customizations: configv1alpha1.CustomizationRules{
+							ReplicaResource: &configv1alpha1.ReplicaResourceRequirement{LuaScript: "statefulset-replica"},
+						},
+					},
+				},
+			},
+			want: map[schema.GroupVersionKind]CustomAccessor{
+				{Group: "apps", Version: "v1", Kind: "Deployment"}: &resourceCustomAccessor{
+					retention: &configv1alpha1.LocalValueRetention{LuaScript: "deployment-retention"},
+				},
+				{Group: "apps", Version: "v1", Kind: "StatefulSet"}: &resourceCustomAccessor{
+					replicaResource: &configv1alpha1.ReplicaResourceRequirement{LuaScript: "statefulset-replica"},
+				},
+			},
+		},
+		{
+			name: "configs sorted by name",
+			configs: []*configv1alpha1.ResourceInterpreterCustomization{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "customization02"},
+					Spec: configv1alpha1.ResourceInterpreterCustomizationSpec{
+						Target: configv1alpha1.CustomizationTarget{
+							APIVersion: appsv1.SchemeGroupVersion.String(),
+							Kind:       "Deployment",
+						},
+						Customizations: configv1alpha1.CustomizationRules{
+							Retention: &configv1alpha1.LocalValueRetention{LuaScript: "second"},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "customization01"},
+					Spec: configv1alpha1.ResourceInterpreterCustomizationSpec{
+						Target: configv1alpha1.CustomizationTarget{
+							APIVersion: appsv1.SchemeGroupVersion.String(),
+							Kind:       "Deployment",
+						},
+						Customizations: configv1alpha1.CustomizationRules{
+							Retention: &configv1alpha1.LocalValueRetention{LuaScript: "first"},
+						},
+					},
+				},
+			},
+			want: map[schema.GroupVersionKind]CustomAccessor{
+				{Group: "apps", Version: "v1", Kind: "Deployment"}: &resourceCustomAccessor{
+					retention: &configv1alpha1.LocalValueRetention{LuaScript: "first"},
+				},
+			},
+		},
+		{
+			name: "overlapping customizations for same GVK",
+			configs: []*configv1alpha1.ResourceInterpreterCustomization{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "customization01"},
+					Spec: configv1alpha1.ResourceInterpreterCustomizationSpec{
+						Target: configv1alpha1.CustomizationTarget{
+							APIVersion: appsv1.SchemeGroupVersion.String(),
+							Kind:       "Deployment",
+						},
+						Customizations: configv1alpha1.CustomizationRules{
+							Retention:       &configv1alpha1.LocalValueRetention{LuaScript: "first-retention"},
+							ReplicaResource: &configv1alpha1.ReplicaResourceRequirement{LuaScript: "first-replica"},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "customization02"},
+					Spec: configv1alpha1.ResourceInterpreterCustomizationSpec{
+						Target: configv1alpha1.CustomizationTarget{
+							APIVersion: appsv1.SchemeGroupVersion.String(),
+							Kind:       "Deployment",
+						},
+						Customizations: configv1alpha1.CustomizationRules{
+							Retention:        &configv1alpha1.LocalValueRetention{LuaScript: "second-retention"},
+							StatusReflection: &configv1alpha1.StatusReflection{LuaScript: "second-status"},
+						},
+					},
+				},
+			},
+			want: map[schema.GroupVersionKind]CustomAccessor{
+				{Group: "apps", Version: "v1", Kind: "Deployment"}: &resourceCustomAccessor{
+					retention:        &configv1alpha1.LocalValueRetention{LuaScript: "first-retention"},
+					replicaResource:  &configv1alpha1.ReplicaResourceRequirement{LuaScript: "first-replica"},
+					statusReflection: &configv1alpha1.StatusReflection{LuaScript: "second-status"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configManager := &interpreterConfigManager{}
+			configManager.configuration.Store(make(map[schema.GroupVersionKind]CustomAccessor))
+
+			configManager.LoadConfig(tt.configs)
+
+			got := configManager.CustomAccessors()
+
+			if len(got) != len(tt.want) {
+				t.Errorf("LoadConfig() got %d accessors, want %d", len(got), len(tt.want))
+			}
+
+			for gvk, wantAccessor := range tt.want {
+				gotAccessor, exists := got[gvk]
+				if !exists {
+					t.Errorf("LoadConfig() missing accessor for GVK %v", gvk)
+					continue
+				}
+
+				if !reflect.DeepEqual(gotAccessor, wantAccessor) {
+					t.Errorf("LoadConfig() accessor for GVK %v = %v, want %v", gvk, gotAccessor, wantAccessor)
+				}
+			}
+
+			if !configManager.initialSynced.Load() {
+				t.Errorf("LoadConfig() should set initialSynced to true")
+			}
+		})
+	}
+}
+
+func Test_interpreterConfigManager_updateConfiguration(t *testing.T) {
+	tests := []struct {
+		name           string
+		setupManager   func() *interpreterConfigManager
+		wantErr        bool
+		expectedErrMsg string
+	}{
+		{
+			name: "informer not initialized",
+			setupManager: func() *interpreterConfigManager {
+				return &interpreterConfigManager{
+					informer: nil,
+				}
+			},
+			wantErr:        true,
+			expectedErrMsg: "informer manager is not configured",
+		},
+		{
+			name: "informer not synced",
+			setupManager: func() *interpreterConfigManager {
+				mockInformer := &mockSingleClusterInformerManager{
+					isSynced: false,
+				}
+				return &interpreterConfigManager{
+					informer: mockInformer,
+				}
+			},
+			wantErr:        true,
+			expectedErrMsg: "informer of ResourceInterpreterCustomization not synced",
+		},
+		{
+			name: "lister list error",
+			setupManager: func() *interpreterConfigManager {
+				mockInformer := &mockSingleClusterInformerManager{
+					isSynced: true,
+				}
+				mockLister := &mockGenericLister{
+					listErr: errors.New("list error"),
+				}
+				return &interpreterConfigManager{
+					informer: mockInformer,
+					lister:   mockLister,
+				}
+			},
+			wantErr:        true,
+			expectedErrMsg: "list error",
+		},
+		{
+			name: "successful update with empty list",
+			setupManager: func() *interpreterConfigManager {
+				mockInformer := &mockSingleClusterInformerManager{
+					isSynced: true,
+				}
+				mockLister := &mockGenericLister{
+					items: []runtime.Object{},
+				}
+				manager := &interpreterConfigManager{
+					informer: mockInformer,
+					lister:   mockLister,
+				}
+				manager.configuration.Store(make(map[schema.GroupVersionKind]CustomAccessor))
+				return manager
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configManager := tt.setupManager()
+
+			err := configManager.updateConfiguration()
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("updateConfiguration() expected error but got nil")
+					return
+				}
+				if tt.expectedErrMsg != "" && err.Error() != tt.expectedErrMsg {
+					t.Errorf("updateConfiguration() error = %v, want %v", err.Error(), tt.expectedErrMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("updateConfiguration() unexpected error = %v", err)
+				}
+			}
+		})
+	}
+}
+
+// Mock implementations for testing
+type mockSingleClusterInformerManager struct {
+	isSynced bool
+}
+
+func (m *mockSingleClusterInformerManager) IsInformerSynced(_ schema.GroupVersionResource) bool {
+	return m.isSynced
+}
+
+func (m *mockSingleClusterInformerManager) Lister(_ schema.GroupVersionResource) cache.GenericLister {
+	return nil
+}
+
+func (m *mockSingleClusterInformerManager) ForResource(_ schema.GroupVersionResource, _ cache.ResourceEventHandler) {
+}
+
+func (m *mockSingleClusterInformerManager) Start() {
+}
+
+func (m *mockSingleClusterInformerManager) Stop() {
+}
+
+func (m *mockSingleClusterInformerManager) WaitForCacheSync() map[schema.GroupVersionResource]bool {
+	return nil
+}
+
+func (m *mockSingleClusterInformerManager) WaitForCacheSyncWithTimeout(_ time.Duration) map[schema.GroupVersionResource]bool {
+	return nil
+}
+
+func (m *mockSingleClusterInformerManager) Context() context.Context {
+	return context.Background()
+}
+
+func (m *mockSingleClusterInformerManager) GetClient() dynamic.Interface {
+	return nil
+}
+
+func (m *mockSingleClusterInformerManager) IsHandlerExist(_ schema.GroupVersionResource, _ cache.ResourceEventHandler) bool {
+	return false
+}
+
+type mockGenericLister struct {
+	items   []runtime.Object
+	listErr error
+}
+
+func (m *mockGenericLister) List(_ labels.Selector) ([]runtime.Object, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	return m.items, nil
+}
+
+func (m *mockGenericLister) Get(_ string) (runtime.Object, error) {
+	return nil, nil
+}
+
+func (m *mockGenericLister) ByNamespace(_ string) cache.GenericNamespaceLister {
+	return nil
 }

--- a/pkg/resourceinterpreter/customized/webhook/configmanager/manager.go
+++ b/pkg/resourceinterpreter/customized/webhook/configmanager/manager.go
@@ -17,13 +17,13 @@ limitations under the License.
 package configmanager
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"sync/atomic"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
@@ -48,6 +48,7 @@ type ConfigManager interface {
 // interpreterConfigManager collect the resource interpreter webhook configuration.
 type interpreterConfigManager struct {
 	configuration atomic.Value
+	informer      genericmanager.SingleClusterInformerManager
 	lister        cache.GenericLister
 	initialSynced atomic.Bool
 }
@@ -63,16 +64,12 @@ func (m *interpreterConfigManager) HasSynced() bool {
 		return true
 	}
 
-	if configuration, err := m.lister.List(labels.Everything()); err == nil && len(configuration) == 0 {
-		// the empty list we initially stored is valid to use.
-		// Setting initialSynced to true, so subsequent checks
-		// would be able to take the fast path on the atomic boolean in a
-		// cluster without any webhooks configured.
-		m.initialSynced.Store(true)
-		// the informer has synced, and we don't have any items
-		return true
+	err := m.updateConfiguration()
+	if err != nil {
+		klog.ErrorS(err, "error updating configuration")
+		return false
 	}
-	return false
+	return true
 }
 
 // NewExploreConfigManager return a new interpreterConfigManager with resourceinterpreterwebhookconfigurations handlers.
@@ -83,42 +80,53 @@ func NewExploreConfigManager(inform genericmanager.SingleClusterInformerManager)
 
 	manager.configuration.Store([]WebhookAccessor{})
 
+	manager.informer = inform
 	configHandlers := fedinformer.NewHandlerOnEvents(
-		func(_ interface{}) { manager.updateConfiguration() },
-		func(_, _ interface{}) { manager.updateConfiguration() },
-		func(_ interface{}) { manager.updateConfiguration() })
+		func(_ interface{}) { _ = manager.updateConfiguration() },
+		func(_, _ interface{}) { _ = manager.updateConfiguration() },
+		func(_ interface{}) { _ = manager.updateConfiguration() })
 	inform.ForResource(resourceExploringWebhookConfigurationsGVR, configHandlers)
 
 	return manager
 }
 
-func (m *interpreterConfigManager) updateConfiguration() {
+// updateConfiguration is used as the event handler for the ResourceInterpreterWebhookConfiguration resource.
+// Any changes (add, update, delete) to these resources will trigger this method, which loads all
+// ResourceInterpreterWebhookConfiguration resources and refreshes the internal cache accordingly.
+// Note: During startup, some events may be missed if the informer has not yet synced. If all events
+// are missed during startup, updateConfiguration will be called when HasSynced() is invoked for the
+// first time, ensuring the cache is updated on first use.
+func (m *interpreterConfigManager) updateConfiguration() error {
+	if m.informer == nil {
+		return errors.New("informer manager is not configured")
+	}
+	if !m.informer.IsInformerSynced(resourceExploringWebhookConfigurationsGVR) {
+		return errors.New("informer of ResourceInterpreterWebhookConfiguration not synced")
+	}
+
 	configurations, err := m.lister.List(labels.Everything())
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("error updating configuration: %v", err))
-		return
+		return err
 	}
 
 	configs := make([]*configv1alpha1.ResourceInterpreterWebhookConfiguration, 0)
 	for _, c := range configurations {
 		unstructuredConfig, err := helper.ToUnstructured(c)
 		if err != nil {
-			klog.Errorf("Failed to transform ResourceInterpreterWebhookConfiguration: %v", err)
-			return
+			return err
 		}
 
 		config := &configv1alpha1.ResourceInterpreterWebhookConfiguration{}
 		err = helper.ConvertToTypedObject(unstructuredConfig, config)
 		if err != nil {
-			gvk := unstructuredConfig.GroupVersionKind().String()
-			klog.Errorf("Failed to convert object(%s), err: %v", gvk, err)
-			return
+			return err
 		}
 		configs = append(configs, config)
 	}
 
 	m.configuration.Store(mergeResourceExploreWebhookConfigurations(configs))
 	m.initialSynced.Store(true)
+	return nil
 }
 
 func mergeResourceExploreWebhookConfigurations(configurations []*configv1alpha1.ResourceInterpreterWebhookConfiguration) []WebhookAccessor {

--- a/pkg/resourceinterpreter/customized/webhook/configmanager/manager_test.go
+++ b/pkg/resourceinterpreter/customized/webhook/configmanager/manager_test.go
@@ -17,14 +17,17 @@ limitations under the License.
 package configmanager
 
 import (
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/cache"
 
 	configv1alpha1 "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1"
@@ -62,6 +65,10 @@ func TestNewExploreConfigManager(t *testing.T) {
 
 			assert.NotNil(t, manager, "Manager should not be nil")
 			assert.NotNil(t, manager.HookAccessors(), "Accessors should be initialized")
+
+			internalManager, ok := manager.(*interpreterConfigManager)
+			assert.True(t, ok)
+			assert.Equal(t, informerManager, internalManager.informer)
 		})
 	}
 }
@@ -70,6 +77,7 @@ func TestHasSynced(t *testing.T) {
 	tests := []struct {
 		name           string
 		initialSynced  bool
+		informer       genericmanager.SingleClusterInformerManager
 		listErr        error
 		listResult     []runtime.Object
 		expectedSynced bool
@@ -80,24 +88,47 @@ func TestHasSynced(t *testing.T) {
 			expectedSynced: true,
 		},
 		{
-			name:           "not synced but empty list",
+			name:           "informer not configured",
 			initialSynced:  false,
+			informer:       nil,
+			expectedSynced: false,
+		},
+		{
+			name:          "informer not synced",
+			initialSynced: false,
+			informer: &mockSingleClusterInformerManager{
+				isSynced: false,
+			},
+			expectedSynced: false,
+		},
+		{
+			name:          "sync with empty list",
+			initialSynced: false,
+			informer: &mockSingleClusterInformerManager{
+				isSynced: true,
+			},
 			listResult:     []runtime.Object{},
 			expectedSynced: true,
 		},
 		{
-			name:          "not synced with items",
+			name:          "sync with items",
 			initialSynced: false,
+			informer: &mockSingleClusterInformerManager{
+				isSynced: true,
+			},
 			listResult: []runtime.Object{
 				&configv1alpha1.ResourceInterpreterWebhookConfiguration{
 					ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				},
 			},
-			expectedSynced: false,
+			expectedSynced: true,
 		},
 		{
-			name:           "list error",
-			initialSynced:  false,
+			name:          "list error",
+			initialSynced: false,
+			informer: &mockSingleClusterInformerManager{
+				isSynced: true,
+			},
 			listErr:        fmt.Errorf("test error"),
 			expectedSynced: false,
 		},
@@ -106,6 +137,7 @@ func TestHasSynced(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			manager := &interpreterConfigManager{
+				informer: tt.informer,
 				lister: &mockLister{
 					err:   tt.listErr,
 					items: tt.listResult,
@@ -181,12 +213,30 @@ func TestUpdateConfiguration(t *testing.T) {
 		name          string
 		configs       []runtime.Object
 		listErr       error
+		informer      genericmanager.SingleClusterInformerManager
 		expectedCount int
 		wantSynced    bool
 	}{
 		{
-			name:          "empty configuration",
-			configs:       []runtime.Object{},
+			name:          "informer not configured",
+			informer:      nil,
+			expectedCount: 0,
+			wantSynced:    false,
+		},
+		{
+			name: "informer not synced",
+			informer: &mockSingleClusterInformerManager{
+				isSynced: false,
+			},
+			expectedCount: 0,
+			wantSynced:    false,
+		},
+		{
+			name:    "empty configuration",
+			configs: []runtime.Object{},
+			informer: &mockSingleClusterInformerManager{
+				isSynced: true,
+			},
 			expectedCount: 0,
 			wantSynced:    true,
 		},
@@ -204,13 +254,19 @@ func TestUpdateConfiguration(t *testing.T) {
 					},
 				},
 			},
+			informer: &mockSingleClusterInformerManager{
+				isSynced: true,
+			},
 			expectedCount: 1,
 			wantSynced:    true,
 		},
 		{
-			name:          "list error",
-			configs:       []runtime.Object{},
-			listErr:       fmt.Errorf("test error"),
+			name:    "list error",
+			configs: []runtime.Object{},
+			listErr: fmt.Errorf("test error"),
+			informer: &mockSingleClusterInformerManager{
+				isSynced: true,
+			},
 			expectedCount: 0,
 			wantSynced:    false,
 		},
@@ -223,20 +279,62 @@ func TestUpdateConfiguration(t *testing.T) {
 					items: tt.configs,
 					err:   tt.listErr,
 				},
+				informer: tt.informer,
 			}
 			manager.configuration.Store([]WebhookAccessor{})
 			manager.initialSynced.Store(false)
 
-			manager.updateConfiguration()
+			synced := manager.HasSynced()
+			assert.Equal(t, tt.wantSynced, synced)
 
 			accessors := manager.HookAccessors()
 			assert.Equal(t, tt.expectedCount, len(accessors))
-			assert.Equal(t, tt.wantSynced, manager.HasSynced())
 		})
 	}
 }
 
 // Mock Implementations
+
+type mockSingleClusterInformerManager struct {
+	isSynced bool
+}
+
+func (m *mockSingleClusterInformerManager) IsInformerSynced(_ schema.GroupVersionResource) bool {
+	return m.isSynced
+}
+
+func (m *mockSingleClusterInformerManager) Lister(_ schema.GroupVersionResource) cache.GenericLister {
+	return nil
+}
+
+func (m *mockSingleClusterInformerManager) ForResource(_ schema.GroupVersionResource, _ cache.ResourceEventHandler) {
+}
+
+func (m *mockSingleClusterInformerManager) Start() {
+}
+
+func (m *mockSingleClusterInformerManager) Stop() {
+}
+
+func (m *mockSingleClusterInformerManager) WaitForCacheSync() map[schema.GroupVersionResource]bool {
+	return nil
+}
+
+func (m *mockSingleClusterInformerManager) WaitForCacheSyncWithTimeout(_ time.Duration) map[schema.GroupVersionResource]bool {
+	return nil
+}
+
+func (m *mockSingleClusterInformerManager) Context() context.Context {
+	return context.Background()
+}
+
+func (m *mockSingleClusterInformerManager) GetClient() dynamic.Interface {
+	return nil
+}
+
+func (m *mockSingleClusterInformerManager) IsHandlerExist(_ schema.GroupVersionResource, _ cache.ResourceEventHandler) bool {
+	return false
+}
 
 type mockLister struct {
 	items []runtime.Object

--- a/pkg/resourceinterpreter/customized/webhook/customized.go
+++ b/pkg/resourceinterpreter/customized/webhook/customized.go
@@ -355,3 +355,8 @@ func (e *CustomizedInterpreter) InterpretHealth(ctx context.Context, attributes 
 
 	return response.Healthy, matched, nil
 }
+
+// LoadConfig loads the webhook configurations.
+func (e *CustomizedInterpreter) LoadConfig(webhookConfigurations []*configv1alpha1.ResourceInterpreterWebhookConfiguration) {
+	e.hookManager.LoadConfig(webhookConfigurations)
+}

--- a/pkg/resourceinterpreter/customized/webhook/customized_test.go
+++ b/pkg/resourceinterpreter/customized/webhook/customized_test.go
@@ -1085,6 +1085,12 @@ func (m *mockConfigManager) HookAccessors() []configmanager.WebhookAccessor {
 	return m.hooks
 }
 
+func (m *mockConfigManager) LoadConfig(_ []*configv1alpha1.ResourceInterpreterWebhookConfiguration) {
+	// Mock implementation: in a real test, we might want to process the configurations
+	// and update the hooks accordingly. For now, this is a no-op implementation.
+	// This allows the mock to satisfy the ConfigManager interface.
+}
+
 // mockWebhookAccessor implements configmanager.WebhookAccessor interface for testing
 type mockWebhookAccessor struct {
 	uid             string

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -21,6 +21,7 @@ import (
 
 	discoveryv1 "k8s.io/api/discovery/v1"
 
+	configv1alpha1 "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 )
 
@@ -247,6 +248,15 @@ const (
 var (
 	// EndpointSliceGVK is the GroupVersionKind of K8s native EndpointSlice.
 	EndpointSliceGVK = discoveryv1.SchemeGroupVersion.WithKind("EndpointSlice")
+)
+
+// Define resource group version resource.
+var (
+	// ResourceInterpreterCustomizationsGVR is the GroupVersionResource of ResourceInterpreterCustomizations.
+	ResourceInterpreterCustomizationsGVR = configv1alpha1.SchemeGroupVersion.WithResource("resourceinterpretercustomizations")
+
+	// ResourceInterpreterWebhookConfigurationsGVR is the GroupVersionResource of ResourceInterpreterWebhookConfigurations.
+	ResourceInterpreterWebhookConfigurationsGVR = configv1alpha1.SchemeGroupVersion.WithResource("resourceinterpreterwebhookconfigurations")
 )
 
 const (


### PR DESCRIPTION
Cherry pick of #6602 #6612 #6626 on release-1.14.
#6602: Fixed an issue where the ConfigurableInterpreter could report as synced before its underlying informer cache was fully synchronized, preventing potential out-of-sync errors during startup.
#6612:  Fixed an issue where the HookInterpreter could report as synced before its underlying informer cache was fully synchronized, preventing potential out-of-sync errors during startup.
#6626: Fixed the issue that ensures resource interpreter cache sync before starting controllers.
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`: Fixed an issue where the ResourceInterpreter could report as synced before its underlying informer cache was fully synchronized, preventing potential out-of-sync errors during startup.
```