### PR TITLE
Fix unreasonable informer manager stop behavior

### DIFF
--- a/pkg/controllers/federatedhpa/federatedhpa_controller.go
+++ b/pkg/controllers/federatedhpa/federatedhpa_controller.go
@@ -577,7 +577,6 @@ func (c *FHPAController) buildPodInformerForCluster(clusterScaleClient *util.Clu
 		return nil
 	}(); err != nil {
 		klog.ErrorS(err, "Failed to sync cache for cluster", "cluster", clusterScaleClient.ClusterName)
-		c.TypedInformerManager.Stop(clusterScaleClient.ClusterName)
 		return nil, err
 	}
 

--- a/pkg/controllers/mcs/service_export_controller.go
+++ b/pkg/controllers/mcs/service_export_controller.go
@@ -285,7 +285,6 @@ func (c *ServiceExportController) registerInformersAndStart(cluster *clusterv1al
 		return nil
 	}(); err != nil {
 		klog.ErrorS(err, "Failed to sync cache for cluster", "cluster", cluster.Name)
-		c.InformerManager.Stop(cluster.Name)
 		return err
 	}
 

--- a/pkg/controllers/multiclusterservice/endpointslice_collect_controller.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_collect_controller.go
@@ -224,7 +224,6 @@ func (c *EndpointSliceCollectController) registerInformersAndStart(cluster *clus
 		return nil
 	}(); err != nil {
 		klog.ErrorS(err, "Failed to sync cache for cluster", "cluster", cluster.Name)
-		c.InformerManager.Stop(cluster.Name)
 		return err
 	}
 

--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -390,7 +390,6 @@ func (c *ClusterStatusController) buildInformerForCluster(clusterClient *util.Cl
 		return nil
 	}(); err != nil {
 		klog.ErrorS(err, "Failed to sync cache for cluster", "cluster", clusterClient.ClusterName)
-		c.TypedInformerManager.Stop(clusterClient.ClusterName)
 		return nil, err
 	}
 

--- a/pkg/controllers/status/work_status_controller.go
+++ b/pkg/controllers/status/work_status_controller.go
@@ -498,7 +498,6 @@ func (c *WorkStatusController) registerInformersAndStart(cluster *clusterv1alpha
 		return nil
 	}(); err != nil {
 		klog.ErrorS(err, "Failed to sync cache for cluster", "cluster", cluster.Name)
-		c.InformerManager.Stop(cluster.Name)
 		return err
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
Ref to #6598, the unreasonable SingleClusterInformerManager stop behavior has a cascading effect on other controllers that are actively utilizing informers for the same cluster, thereby broadening the impact radius beyond the original failing component. So, in this pr, we try to remove the unreasonable SingleClusterInformerManager stop behaviors.

Fixed behavior:

1. pkg/controllers/mcs/service_export_controller.go#L275-L290
2. pkg/controllers/multiclusterservice/endpointslice_collect_controller.go#L212-L229
3. pkg/controllers/status/work_status_controller.go#L488-L502
4. pkg/controllers/status/cluster_status_controller.go#L380-L395

When `InformerManager.WaitForCacheSyncWithTimeout` returns a result that doesn't contain the target GVR, it will return an error and re-enter reconcile.

5. pkg/controllers/federatedhpa/federatedhpa_controller.go#L569-L582

When a single cluster's `InformerManager.WaitForCacheSyncWithTimeout` returns a result that doesn't contain the target GVR, this error will be ignored unless all target clusters encounter similar issues. The federated_hpa_controller will re-enter reconcile every HorizontalPodAutoscalerSyncPeriod, so it has the opportunity to re-execute `WaitForCacheSyncWithTimeout`.

In summary, all the above controllers have the opportunity to retry when the `WaitForCacheSyncWithTimeout` result doesn't meet expectations. And retries should be able to resolve most failures, except for the issues documented in https://github.com/karmada-io/karmada/issues/6598#issuecomment-3154216918. However, this issue was not introduced by this PR, so it's not considered in this PR.



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #6598

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
5. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
7. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-controller-manager/karmada-agent`:  Fixed the issue that informer cache sync failures for specific resources incorrectly shut down all informers for that cluster, affecting resource distribution and work status synchronization.
```

