### PR TITLE
Introduce MultiplePodTemplatesScheduling feature gate

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -103,6 +103,16 @@ const (
 	// owner: @jabellard
 	// beta: v1.15
 	ContextualLogging = logsv1.ContextualLogging
+
+	// MultiplePodTemplatesScheduling enables enhanced, resource-aware scheduling for workloads with multiple pod templates.
+	// When enabled, the scheduler and resource interpreter will use the new 'GetComponentReplicas' hook and 'components' field
+	// to support accurate resource estimation and scheduling for complex CRDs (e.g., FlinkDeployments, RayJob, VolcanoJob) that consist of
+	// multiple components with different resource requirements. This allows for more precise FederatedResourceQuota
+	// calculations and better placement decisions.
+	//
+	// owner: @mszacillo, @Dyex719, @RainbowMango, @XiShanYongYe-Chang, @zhzhuang-zju, @seanlaii
+	// alpha: v1.15
+	MultiplePodTemplatesScheduling featuregate.Feature = "MultiplePodTemplatesScheduling"
 )
 
 var (
@@ -128,6 +138,7 @@ var (
 		LoggingAlphaOptions:               {Default: false, PreRelease: featuregate.Alpha},
 		LoggingBetaOptions:                {Default: true, PreRelease: featuregate.Beta},
 		ContextualLogging:                 {Default: true, PreRelease: featuregate.Beta},
+		MultiplePodTemplatesScheduling:    {Default: false, PreRelease: featuregate.Alpha},
 	}
 )
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
This PR introduces the feature gate for `MultiplePodTemplatesScheduling`, as defined in the [proposal](https://github.com/karmada-io/karmada/blob/master/docs/proposals/scheduling/multi-podtemplate-support/multiple-pod-template-support.md).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #6641

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

