### PR TITLE
feat: introduce ControllerPriorityQueue feature gate

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -34,6 +34,7 @@ import (
 	logsv1 "k8s.io/component-base/logs/api/v1"
 	"k8s.io/component-base/term"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/config"
@@ -225,6 +226,7 @@ func run(ctx context.Context, opts *options.Options) error {
 				clusterv1alpha1.SchemeGroupVersion.WithKind("Cluster").GroupKind().String(): opts.ConcurrentClusterSyncs,
 			},
 			CacheSyncTimeout: opts.ClusterCacheSyncTimeout.Duration,
+			UsePriorityQueue: ptr.To(features.FeatureGate.Enabled(features.ControllerPriorityQueue)),
 		},
 		NewCache: func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
 			opts.DefaultTransform = fedinformer.StripUnusedFields

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -38,6 +38,7 @@ import (
 	resourceclient "k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1"
 	"k8s.io/metrics/pkg/client/custom_metrics"
 	"k8s.io/metrics/pkg/client/external_metrics"
+	"k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/config"
@@ -193,6 +194,7 @@ func Run(ctx context.Context, opts *options.Options) error {
 				schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}.GroupKind().String(): opts.ConcurrentNamespaceSyncs,
 			},
 			CacheSyncTimeout: opts.ClusterCacheSyncTimeout.Duration,
+			UsePriorityQueue: ptr.To(features.FeatureGate.Enabled(features.ControllerPriorityQueue)),
 		},
 		NewCache: func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
 			opts.DefaultTransform = fedinformer.StripUnusedFields

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -113,6 +113,20 @@ const (
 	// owner: @mszacillo, @Dyex719, @RainbowMango, @XiShanYongYe-Chang, @zhzhuang-zju, @seanlaii
 	// alpha: v1.15
 	MultiplePodTemplatesScheduling featuregate.Feature = "MultiplePodTemplatesScheduling"
+
+	// ControllerPriorityQueue controls whether the controller-runtime Priority Queue for controllers is enabled.
+	// When enabled, during the startup phase of karmada-controller-manager and karmada-agent,
+	// controllers implemented with controller-runtime will prioritize processing recent cluster changes first,
+	// while deferring items without recent updates that still need to be processed to the end of the queue.
+	// This helps the system quickly catch up with the latest state and reduces the perceived
+	// backlog from external users.
+	// However, enabling this feature may increase the overall number of reconciliations. This is
+	// because newer events spend less time in the queue, which reduces the chance of them being
+	// deduplicated before processing.
+	//
+	// owner: @zach593
+	// alpha: v1.15
+	ControllerPriorityQueue featuregate.Feature = "ControllerPriorityQueue"
 )
 
 var (
@@ -139,6 +153,7 @@ var (
 		LoggingBetaOptions:                {Default: true, PreRelease: featuregate.Beta},
 		ContextualLogging:                 {Default: true, PreRelease: featuregate.Beta},
 		MultiplePodTemplatesScheduling:    {Default: false, PreRelease: featuregate.Alpha},
+		ControllerPriorityQueue:           {Default: false, PreRelease: featuregate.Alpha},
 	}
 )
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

This PR introduces a new feature gate `ControllerPriorityQueue` for controller-runtime based controllers in karmada-controller-manager and karmada-agent.

With this feature enabled, controllers give higher priority to recent cluster changes and postpone processing less urgent items in the queue. This significantly improves responsiveness during startup, as controllers can quickly catch up with the latest 
state and reduce the visible backlog from the user’s perspective.

However, enabling this feature may lead to an increase in reconciliation frequency, as newer events spend less time in the queue and therefore have fewer opportunities to be deduplicated. Additionally, within controller-runtime, this feature is currently in beta and has not yet reached full stability. It is also important to note that not all controllers in Karmada are implemented with controller-runtime. Moving forward, I plan to gradually migrate async-worker based controllers to controller-runtime, or alternatively extend this feature to the async-worker workqueue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Part of #6516
<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

First, the feature is functional, but its effectiveness is not easy to demonstrate through test reports. Given that this feature may introduce additional reconciliations, I conducted tests focusing on reconciliation counts.

I compared this version of karmada-controller-manager with the current master (b1ea33254) under the following configuration:

```
        - --concurrent-propagation-policy-syncs=5
        - --concurrent-resource-template-syncs=40
        - --concurrent-resourcebinding-syncs=40
        - --concurrent-work-syncs=120
        - --cluster-api-qps=20000
        - --cluster-api-burst=20000
        - --kube-api-qps=20000
        - --kube-api-burst=20000
```

In this setup, I created 5000 Deployments and propagated them to two member clusters. After the propagation completed, I deleted them and then compared whether enabling this feature would result in additional reconciliations.

I ran the tests multiple times, and the following screenshot shows the total reconciliations from one of the runs.

current master:     
<img width="1590" height="892" alt="image" src="https://github.com/user-attachments/assets/c9abf25f-f5ef-4848-aa94-29da9856e328" />

with priority queue enabled:     
<img width="1593" height="713" alt="image" src="https://github.com/user-attachments/assets/b28e4fa6-fee4-4094-873a-c2746317ef91" />

It can be observed that for the resource-binding-status-controller, enabling this feature introduces approximately 10% additional reconciliations. Since these resources also generate events under normal conditions, hundreds of coordinated errors were observed between the completion of propagation and the start of deletion, but this did not affect the overall conclusions.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->

```release-note
karmada-controller-manager, karmada-agent: Add a feature gate `ControllerPriorityQueue` that allows controllers to prioritize recent events, improving responsiveness during startup but potentially increasing the overall reconciliation frequency.
```

