### PR TITLE
Ensure in directly purgeMode: resources removed from old cluster before being created in new cluster

### DIFF
--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -19,6 +19,7 @@ package binding
 import (
 	"context"
 	"strconv"
+	"time"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +40,11 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/helper"
 	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/pkg/util/overridemanager"
+)
+
+const (
+	// requeueIntervalForDirectlyPurge is the requeue interval for binding when there are works in clusters with PurgeMode 'Directly'.
+	requeueIntervalForDirectlyPurge = 5 * time.Second
 )
 
 // ensureWork ensure Work to be created or updated.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
Support cluster failover for stateful workloads, ref https://github.com/karmada-io/karmada/pull/6495.

**Which issue(s) this PR fixes**:
Part of https://github.com/karmada-io/karmada/issues/6593

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

