### PR TITLE
Fix unreasonable informer stop behavior

### DIFF
--- a/pkg/controllers/federatedhpa/federatedhpa_controller.go
+++ b/pkg/controllers/federatedhpa/federatedhpa_controller.go
@@ -577,7 +577,6 @@ func (c *FHPAController) buildPodInformerForCluster(clusterScaleClient *util.Clu
 		return nil
 	}(); err != nil {
 		klog.Errorf("Failed to sync cache for cluster: %s, error: %v", clusterScaleClient.ClusterName, err)
-		c.TypedInformerManager.Stop(clusterScaleClient.ClusterName)
 		return nil, err
 	}
 

--- a/pkg/controllers/mcs/service_export_controller.go
+++ b/pkg/controllers/mcs/service_export_controller.go
@@ -273,7 +273,6 @@ func (c *ServiceExportController) registerInformersAndStart(cluster *clusterv1al
 		return nil
 	}(); err != nil {
 		klog.Errorf("Failed to sync cache for cluster: %s, error: %v", cluster.Name, err)
-		c.InformerManager.Stop(cluster.Name)
 		return err
 	}
 

--- a/pkg/controllers/multiclusterservice/endpointslice_collect_controller.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_collect_controller.go
@@ -215,7 +215,6 @@ func (c *EndpointSliceCollectController) registerInformersAndStart(cluster *clus
 		return nil
 	}(); err != nil {
 		klog.Errorf("Failed to sync cache for cluster: %s, error: %v", cluster.Name, err)
-		c.InformerManager.Stop(cluster.Name)
 		return err
 	}
 

--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -391,7 +391,6 @@ func (c *ClusterStatusController) buildInformerForCluster(clusterClient *util.Cl
 		return nil
 	}(); err != nil {
 		klog.Errorf("Failed to sync cache for cluster: %s, error: %v", clusterClient.ClusterName, err)
-		c.TypedInformerManager.Stop(clusterClient.ClusterName)
 		return nil, err
 	}
 

--- a/pkg/controllers/status/work_status_controller.go
+++ b/pkg/controllers/status/work_status_controller.go
@@ -504,7 +504,6 @@ func (c *WorkStatusController) registerInformersAndStart(cluster *clusterv1alpha
 		return nil
 	}(); err != nil {
 		klog.Errorf("Failed to sync cache for cluster: %s, error: %v", cluster.Name, err)
-		c.InformerManager.Stop(cluster.Name)
 		return err
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Special note to the reviewer**:
This is the release note of the PR #6647
```
`karmada-controller-manager/karmada-agent`:  Fixed the issue that informer cache sync failures for specific resources incorrectly shut down all informers for that cluster, affecting resource distribution and work status synchronization.
```



