### PR TITLE
Fix the issue that the cache is out of sync within the resource inter…

### DIFF
--- a/pkg/karmadactl/promote/promote.go
+++ b/pkg/karmadactl/promote/promote.go
@@ -18,6 +18,7 @@ package promote
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -447,12 +448,9 @@ func (o *CommandPromoteOption) promoteDeps(memberClusterFactory cmdutil.Factory,
 	controlPlaneKubeClientSet := kubeclientset.NewForConfigOrDie(config)
 	sharedFactory := informers.NewSharedInformerFactory(controlPlaneKubeClientSet, 0)
 	serviceLister := sharedFactory.Core().V1().Services().Lister()
+
 	sharedFactory.Start(stopCh)
 	sharedFactory.WaitForCacheSync(stopCh)
-	controlPlaneInformerManager.Start()
-	if sync := controlPlaneInformerManager.WaitForCacheSync(); sync == nil {
-		return fmt.Errorf("informer factory for cluster does not exist")
-	}
 
 	defaultInterpreter := native.NewDefaultInterpreter()
 	thirdpartyInterpreter := thirdparty.NewConfigurableInterpreter()
@@ -460,6 +458,11 @@ func (o *CommandPromoteOption) promoteDeps(memberClusterFactory cmdutil.Factory,
 	customizedInterpreter, err := webhook.NewCustomizedInterpreter(controlPlaneInformerManager, serviceLister)
 	if err != nil {
 		return fmt.Errorf("failed to create customized interpreter: %v", err)
+	}
+
+	controlPlaneInformerManager.Start()
+	if syncs := controlPlaneInformerManager.WaitForCacheSync(); len(syncs) == 0 {
+		return errors.New("no informers registered in the informer factory")
 	}
 
 	// check if the resource interpreter supports to interpret dependencies


### PR DESCRIPTION

**What type of PR is this?**

/kind bug


**Special notes for your reviewer**:

This is a cherry pick PR. 
The release notes for PR #6669:

```
`karmadactl`: Fixed the issue of `promote` command that the interpreter cache is out of sync before first use.
```
