### PR TITLE
added validation check for the components section of resourcebinding

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -21216,12 +21216,14 @@
       "description": "Component represents the requirements for a specific component.",
       "type": "object",
       "required": [
+        "name",
         "replicas"
       ],
       "properties": {
         "name": {
           "description": "Name of this component. It is required when the resource contains multiple components to ensure proper identification, and must also be unique within the same resource.",
-          "type": "string"
+          "type": "string",
+          "default": ""
         },
         "replicaRequirements": {
           "description": "ReplicaRequirements represents the requirements required by each replica for this component.",

--- a/charts/karmada/_crds/bases/work/work.karmada.io_clusterresourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work/work.karmada.io_clusterresourcebindings.yaml
@@ -450,6 +450,7 @@ spec:
                       format: int32
                       type: integer
                   required:
+                  - name
                   - replicas
                   type: object
                 type: array

--- a/charts/karmada/_crds/bases/work/work.karmada.io_resourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work/work.karmada.io_resourcebindings.yaml
@@ -450,6 +450,7 @@ spec:
                       format: int32
                       type: integer
                   required:
+                  - name
                   - replicas
                   type: object
                 type: array

--- a/pkg/apis/work/v1alpha2/binding_types.go
+++ b/pkg/apis/work/v1alpha2/binding_types.go
@@ -229,8 +229,8 @@ type Component struct {
 	// It is required when the resource contains multiple components to ensure proper identification,
 	// and must also be unique within the same resource.
 	// +kubebuilder:validation:MaxLength=32
-	// +optional
-	Name string `json:"name,omitempty"`
+	// +required
+	Name string `json:"name"`
 
 	// Replicas represents the replica number of the resource's component.
 	// +required

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -7260,6 +7260,7 @@ func schema_pkg_apis_work_v1alpha2_Component(ref common.ReferenceCallback) commo
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name of this component. It is required when the resource contains multiple components to ensure proper identification, and must also be unique within the same resource.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7279,7 +7280,7 @@ func schema_pkg_apis_work_v1alpha2_Component(ref common.ReferenceCallback) commo
 						},
 					},
 				},
-				Required: []string{"replicas"},
+				Required: []string{"name", "replicas"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/webhook/resourcebinding/validating_test.go
+++ b/pkg/webhook/resourcebinding/validating_test.go
@@ -398,40 +398,41 @@ func TestValidatingAdmission_Handle(t *testing.T) {
 	)
 
 	tests := []struct {
-		name               string
-		req                admission.Request
-		decoder            admission.Decoder
-		clientObjects      []client.Object
-		featureGateEnabled bool
-		wantResponse       admission.Response
+		name                                            string
+		req                                             admission.Request
+		decoder                                         admission.Decoder
+		clientObjects                                   []client.Object
+		enableFederatedQuotaEnforcementFeatureGate      bool
+		enableMultiplePodTemplatesSchedulingFeatureGate bool
+		wantResponse                                    admission.Response
 	}{
 		{
-			name:               "feature gate disabled",
-			req:                newAdmissionRequestBuilder(t, admissionv1.Create, "default", "any-rb", "fg-disabled").Build(),
-			decoder:            &fakeDecoder{},
-			clientObjects:      nil,
-			featureGateEnabled: false,
-			wantResponse:       admission.Allowed(""),
+			name:          "feature gate disabled",
+			req:           newAdmissionRequestBuilder(t, admissionv1.Create, "default", "any-rb", "fg-disabled").Build(),
+			decoder:       &fakeDecoder{},
+			clientObjects: nil,
+			enableFederatedQuotaEnforcementFeatureGate: false,
+			wantResponse: admission.Allowed(""),
 		},
 		{
 			name: "decode error on new object",
 			req: newAdmissionRequestBuilder(t, admissionv1.Create, rbForDecodeErrorCase.Namespace, rbForDecodeErrorCase.Name, "decode-err").
 				WithObject(rbForDecodeErrorCase).
 				Build(),
-			decoder:            &fakeDecoder{err: errors.New("decode failed")},
-			clientObjects:      []client.Object{frqForDecodeErrorCase},
-			featureGateEnabled: true,
-			wantResponse:       admission.Errored(http.StatusBadRequest, errors.New("decode failed")),
+			decoder:       &fakeDecoder{err: errors.New("decode failed")},
+			clientObjects: []client.Object{frqForDecodeErrorCase},
+			enableFederatedQuotaEnforcementFeatureGate: true,
+			wantResponse: admission.Errored(http.StatusBadRequest, errors.New("decode failed")),
 		},
 		{
 			name: "create operation not yet scheduled should be allowed",
 			req: newAdmissionRequestBuilder(t, admissionv1.Create, rbUnscheduledCreate.Namespace, rbUnscheduledCreate.Name, "create-unscheduled").
 				WithObject(rbUnscheduledCreate).
 				Build(),
-			decoder:            &fakeDecoder{decodeObj: rbUnscheduledCreate},
-			clientObjects:      []client.Object{frqForUnscheduledCreate},
-			featureGateEnabled: true,
-			wantResponse:       admission.Allowed(""),
+			decoder:       &fakeDecoder{decodeObj: rbUnscheduledCreate},
+			clientObjects: []client.Object{frqForUnscheduledCreate},
+			enableFederatedQuotaEnforcementFeatureGate: true,
+			wantResponse: admission.Allowed(""),
 		},
 		{
 			name: "update operation with no relevant field change should be allowed",
@@ -439,10 +440,10 @@ func TestValidatingAdmission_Handle(t *testing.T) {
 				WithObject(rbForNoChange).
 				WithOldObject(rbForNoChange).
 				Build(),
-			decoder:            &fakeDecoder{decodeObj: rbForNoChange, rawDecodedObj: rbForNoChange},
-			clientObjects:      []client.Object{frqForNoChange},
-			featureGateEnabled: true,
-			wantResponse:       admission.Allowed(""),
+			decoder:       &fakeDecoder{decodeObj: rbForNoChange, rawDecodedObj: rbForNoChange},
+			clientObjects: []client.Object{frqForNoChange},
+			enableFederatedQuotaEnforcementFeatureGate: true,
+			wantResponse: admission.Allowed(""),
 		},
 		{
 			name: "total RB delta is zero should be allowed (update with identical states)",
@@ -450,30 +451,30 @@ func TestValidatingAdmission_Handle(t *testing.T) {
 				WithObject(rbForDeltaZeroNew).
 				WithOldObject(rbForDeltaZeroOld).
 				Build(),
-			decoder:            &fakeDecoder{decodeObj: rbForDeltaZeroNew, rawDecodedObj: rbForDeltaZeroOld},
-			clientObjects:      []client.Object{frqForDeltaZero},
-			featureGateEnabled: true,
-			wantResponse:       admission.Allowed(""),
+			decoder:       &fakeDecoder{decodeObj: rbForDeltaZeroNew, rawDecodedObj: rbForDeltaZeroOld},
+			clientObjects: []client.Object{frqForDeltaZero},
+			enableFederatedQuotaEnforcementFeatureGate: true,
+			wantResponse: admission.Allowed(""),
 		},
 		{
 			name: "no FRQs found should be allowed",
 			req: newAdmissionRequestBuilder(t, admissionv1.Create, rbForNoFRQ.Namespace, rbForNoFRQ.Name, "no-frq-found").
 				WithObject(rbForNoFRQ).
 				Build(),
-			decoder:            &fakeDecoder{decodeObj: rbForNoFRQ},
-			clientObjects:      []client.Object{},
-			featureGateEnabled: true,
-			wantResponse:       admission.Allowed(""),
+			decoder:       &fakeDecoder{decodeObj: rbForNoFRQ},
+			clientObjects: []client.Object{},
+			enableFederatedQuotaEnforcementFeatureGate: true,
+			wantResponse: admission.Allowed(""),
 		},
 		{
 			name: "create quota exceeded should deny",
 			req: newAdmissionRequestBuilder(t, admissionv1.Create, rbCreateExceeds.Namespace, rbCreateExceeds.Name, "create-exceeds").
 				WithObject(rbCreateExceeds).
 				Build(),
-			decoder:            &fakeDecoder{decodeObj: rbCreateExceeds},
-			clientObjects:      []client.Object{frqForCreateExceeds},
-			featureGateEnabled: true,
-			wantResponse:       admission.Denied("FederatedResourceQuota(quota-ns/frq-create-exceeds) exceeded for resource cpu: requested sum 200m, limit 150m."),
+			decoder:       &fakeDecoder{decodeObj: rbCreateExceeds},
+			clientObjects: []client.Object{frqForCreateExceeds},
+			enableFederatedQuotaEnforcementFeatureGate: true,
+			wantResponse: admission.Denied("FederatedResourceQuota(quota-ns/frq-create-exceeds) exceeded for resource cpu: requested sum 200m, limit 150m."),
 		},
 		{
 			name: "update passes quota (allowed response, non-dryrun)",
@@ -482,10 +483,10 @@ func TestValidatingAdmission_Handle(t *testing.T) {
 				WithOldObject(commonRBUpdatePassOld).
 				WithDryRun(false).
 				Build(),
-			decoder:            &fakeDecoder{decodeObj: commonRBUpdatePassNew, rawDecodedObj: commonRBUpdatePassOld},
-			clientObjects:      []client.Object{frqForUpdatePassNonDryRun},
-			featureGateEnabled: true,
-			wantResponse:       admission.Allowed(""),
+			decoder:       &fakeDecoder{decodeObj: commonRBUpdatePassNew, rawDecodedObj: commonRBUpdatePassOld},
+			clientObjects: []client.Object{frqForUpdatePassNonDryRun},
+			enableFederatedQuotaEnforcementFeatureGate: true,
+			wantResponse: admission.Allowed(""),
 		},
 		{
 			name: "update passes quota (allowed response, dry run)",
@@ -494,10 +495,10 @@ func TestValidatingAdmission_Handle(t *testing.T) {
 				WithOldObject(commonRBUpdatePassOld).
 				WithDryRun(true).
 				Build(),
-			decoder:            &fakeDecoder{decodeObj: commonRBUpdatePassNew, rawDecodedObj: commonRBUpdatePassOld},
-			clientObjects:      []client.Object{frqForUpdatePassDryRun},
-			featureGateEnabled: true,
-			wantResponse:       admission.Allowed(""),
+			decoder:       &fakeDecoder{decodeObj: commonRBUpdatePassNew, rawDecodedObj: commonRBUpdatePassOld},
+			clientObjects: []client.Object{frqForUpdatePassDryRun},
+			enableFederatedQuotaEnforcementFeatureGate: true,
+			wantResponse: admission.Allowed(""),
 		},
 		{
 			name: "update fails quota (denied response)",
@@ -505,30 +506,104 @@ func TestValidatingAdmission_Handle(t *testing.T) {
 				WithObject(rbUpdateFailNew).
 				WithOldObject(rbUpdateFailOld).
 				Build(),
-			decoder:            &fakeDecoder{decodeObj: rbUpdateFailNew, rawDecodedObj: rbUpdateFailOld},
-			clientObjects:      []client.Object{frqForUpdateFail},
-			featureGateEnabled: true,
-			wantResponse:       admission.Denied("FederatedResourceQuota(quota-ns/frq-update-fail) exceeded for resource cpu: requested sum 110m, limit 100m."),
+			decoder:       &fakeDecoder{decodeObj: rbUpdateFailNew, rawDecodedObj: rbUpdateFailOld},
+			clientObjects: []client.Object{frqForUpdateFail},
+			enableFederatedQuotaEnforcementFeatureGate: true,
+			wantResponse: admission.Denied("FederatedResourceQuota(quota-ns/frq-update-fail) exceeded for resource cpu: requested sum 110m, limit 100m."),
+		},
+		{
+			name: "validateComponents: zero components (should allow)",
+			req: newAdmissionRequestBuilder(t, admissionv1.Create, "comp-ns", "rb-zero-components", "zero-comps").
+				WithObject(makeTestRB("comp-ns", "rb-zero-components", WithComponents(nil))).
+				Build(),
+			decoder:       &fakeDecoder{decodeObj: makeTestRB("comp-ns", "rb-zero-components", WithComponents(nil))},
+			clientObjects: nil,
+			enableFederatedQuotaEnforcementFeatureGate:      false,
+			enableMultiplePodTemplatesSchedulingFeatureGate: true,
+			wantResponse: admission.Allowed(""),
+		},
+		{
+			name: "validateComponents: one component without name (should deny)",
+			req: newAdmissionRequestBuilder(t, admissionv1.Create, "comp-ns", "rb-one-component-no-name", "one-comp-no-name").
+				WithObject(makeTestRB("comp-ns", "rb-one-component-no-name", WithComponents([]workv1alpha2.Component{{}}))).
+				Build(),
+			decoder:       &fakeDecoder{decodeObj: makeTestRB("comp-ns", "rb-one-component-no-name", WithComponents([]workv1alpha2.Component{{}}))},
+			clientObjects: nil,
+			enableFederatedQuotaEnforcementFeatureGate:      false,
+			enableMultiplePodTemplatesSchedulingFeatureGate: true,
+			wantResponse: admission.Denied("spec.components[0].name: Invalid value: \"\": component names must be non-empty"),
+		},
+		{
+			name: "validateComponents: one component with name (should allow)",
+			req: newAdmissionRequestBuilder(t, admissionv1.Create, "comp-ns", "rb-one-component-with-name", "one-comp-with-name").
+				WithObject(makeTestRB("comp-ns", "rb-one-component-with-name", WithComponents([]workv1alpha2.Component{
+					{Name: "foo"},
+				}))).
+				Build(),
+			decoder:       &fakeDecoder{decodeObj: makeTestRB("comp-ns", "rb-one-component-with-name", WithComponents([]workv1alpha2.Component{{Name: "foo"}}))},
+			clientObjects: nil,
+			enableFederatedQuotaEnforcementFeatureGate:      false,
+			enableMultiplePodTemplatesSchedulingFeatureGate: true,
+			wantResponse: admission.Allowed(""),
+		},
+		{
+			name: "validateComponents: multiple components with unique names (should allow)",
+			req: newAdmissionRequestBuilder(t, admissionv1.Create, "comp-ns", "rb-multi-unique", "multi-unique").
+				WithObject(makeTestRB("comp-ns", "rb-multi-unique", WithComponents([]workv1alpha2.Component{
+					{Name: "foo"}, {Name: "bar"},
+				}))).
+				Build(),
+			decoder:       &fakeDecoder{decodeObj: makeTestRB("comp-ns", "rb-multi-unique", WithComponents([]workv1alpha2.Component{{Name: "foo"}, {Name: "bar"}}))},
+			clientObjects: nil,
+			enableFederatedQuotaEnforcementFeatureGate:      false,
+			enableMultiplePodTemplatesSchedulingFeatureGate: true,
+			wantResponse: admission.Allowed(""),
+		},
+		{
+			name: "validateComponents: multiple components with empty name (should deny)",
+			req: newAdmissionRequestBuilder(t, admissionv1.Create, "comp-ns", "rb-multi-empty", "multi-empty").
+				WithObject(makeTestRB("comp-ns", "rb-multi-empty", WithComponents([]workv1alpha2.Component{
+					{Name: "foo"}, {Name: ""}, {Name: ""},
+				}))).
+				Build(),
+			decoder:       &fakeDecoder{decodeObj: makeTestRB("comp-ns", "rb-multi-empty", WithComponents([]workv1alpha2.Component{{Name: "foo"}, {Name: ""}}))},
+			clientObjects: nil,
+			enableFederatedQuotaEnforcementFeatureGate:      false,
+			enableMultiplePodTemplatesSchedulingFeatureGate: true,
+			wantResponse: admission.Denied("spec.components[1].name: Invalid value: \"\": component names must be non-empty"),
+		},
+		{
+			name: "validateComponents: multiple components with duplicate names (should deny)",
+			req: newAdmissionRequestBuilder(t, admissionv1.Create, "comp-ns", "rb-multi-dup", "multi-dup").
+				WithObject(makeTestRB("comp-ns", "rb-multi-dup", WithComponents([]workv1alpha2.Component{
+					{Name: "foo"}, {Name: "foo"},
+				}))).
+				Build(),
+			decoder:       &fakeDecoder{decodeObj: makeTestRB("comp-ns", "rb-multi-dup", WithComponents([]workv1alpha2.Component{{Name: "foo"}, {Name: "foo"}}))},
+			clientObjects: nil,
+			enableFederatedQuotaEnforcementFeatureGate:      false,
+			enableMultiplePodTemplatesSchedulingFeatureGate: true,
+			wantResponse: admission.Denied("spec.components[1].name: Invalid value: \"foo\": component names must be unique"),
 		},
 		{
 			name: "create with components and sufficient quota (allowed)",
 			req: newAdmissionRequestBuilder(t, admissionv1.Create, rbWithComponents.Namespace, rbWithComponents.Name, "create-components-sufficient").
 				WithObject(rbWithComponents).
 				Build(),
-			decoder:            &fakeDecoder{decodeObj: rbWithComponents},
-			clientObjects:      []client.Object{frqForComponentsSufficient},
-			featureGateEnabled: true,
-			wantResponse:       admission.Allowed(""),
+			decoder:       &fakeDecoder{decodeObj: rbWithComponents},
+			clientObjects: []client.Object{frqForComponentsSufficient},
+			enableFederatedQuotaEnforcementFeatureGate: true,
+			wantResponse: admission.Allowed(""),
 		},
 		{
 			name: "create with components and exceeded quota (denied)",
 			req: newAdmissionRequestBuilder(t, admissionv1.Create, rbWithComponents.Namespace, rbWithComponents.Name, "create-components-exceeded").
 				WithObject(rbWithComponents).
 				Build(),
-			decoder:            &fakeDecoder{decodeObj: rbWithComponents},
-			clientObjects:      []client.Object{frqForComponentsExceeded},
-			featureGateEnabled: true,
-			wantResponse:       admission.Denied("FederatedResourceQuota(quota-ns/frq-components-exceeded) exceeded for resource cpu: requested sum 160m, limit 150m."),
+			decoder:       &fakeDecoder{decodeObj: rbWithComponents},
+			clientObjects: []client.Object{frqForComponentsExceeded},
+			enableFederatedQuotaEnforcementFeatureGate: true,
+			wantResponse: admission.Denied("FederatedResourceQuota(quota-ns/frq-components-exceeded) exceeded for resource cpu: requested sum 160m, limit 150m."),
 		},
 		{
 			name: "update components passes quota (allowed response)",
@@ -536,10 +611,10 @@ func TestValidatingAdmission_Handle(t *testing.T) {
 				WithObject(rbComponentsPassNew).
 				WithOldObject(rbComponentsPassOld).
 				Build(),
-			decoder:            &fakeDecoder{decodeObj: rbComponentsPassNew, rawDecodedObj: rbComponentsPassOld},
-			clientObjects:      []client.Object{frqForComponentsPass},
-			featureGateEnabled: true,
-			wantResponse:       admission.Allowed(""),
+			decoder:       &fakeDecoder{decodeObj: rbComponentsPassNew, rawDecodedObj: rbComponentsPassOld},
+			clientObjects: []client.Object{frqForComponentsPass},
+			enableFederatedQuotaEnforcementFeatureGate: true,
+			wantResponse: admission.Allowed(""),
 		},
 		{
 			name: "update components fails quota (denied response)",
@@ -547,23 +622,24 @@ func TestValidatingAdmission_Handle(t *testing.T) {
 				WithObject(rbComponentsFailNew).
 				WithOldObject(rbComponentsFailOld).
 				Build(),
-			decoder:            &fakeDecoder{decodeObj: rbComponentsFailNew, rawDecodedObj: rbComponentsFailOld},
-			clientObjects:      []client.Object{frqForComponentsFail},
-			featureGateEnabled: true,
-			wantResponse:       admission.Denied("FederatedResourceQuota(quota-ns/frq-components-fail) exceeded for resource cpu: requested sum 110m, limit 100m."),
+			decoder:       &fakeDecoder{decodeObj: rbComponentsFailNew, rawDecodedObj: rbComponentsFailOld},
+			clientObjects: []client.Object{frqForComponentsFail},
+			enableFederatedQuotaEnforcementFeatureGate: true,
+			wantResponse: admission.Denied("FederatedResourceQuota(quota-ns/frq-components-fail) exceeded for resource cpu: requested sum 110m, limit 100m."),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			originalGateState := features.FeatureGate.Enabled(features.FederatedQuotaEnforcement)
-			if errFG := features.FeatureGate.Set(fmt.Sprintf("%s=%v", features.FederatedQuotaEnforcement, tt.featureGateEnabled)); errFG != nil {
-				t.Fatalf("Failed to set feature gate %s to %v: %v", features.FederatedQuotaEnforcement, tt.featureGateEnabled, errFG)
+			originalFeatureGates := features.FeatureGate.DeepCopy()
+			if errFG := features.FeatureGate.Set(fmt.Sprintf("%s=%v", features.FederatedQuotaEnforcement, tt.enableFederatedQuotaEnforcementFeatureGate)); errFG != nil {
+				t.Fatalf("Failed to set feature gate %s to %v: %v", features.FederatedQuotaEnforcement, tt.enableFederatedQuotaEnforcementFeatureGate, errFG)
+			}
+			if errFg := features.FeatureGate.Set(fmt.Sprintf("%s=%v", features.MultiplePodTemplatesScheduling, tt.enableMultiplePodTemplatesSchedulingFeatureGate)); errFg != nil {
+				t.Fatalf("Failed to set feature gate %s to %v: %v", features.MultiplePodTemplatesScheduling, tt.enableMultiplePodTemplatesSchedulingFeatureGate, errFg)
 			}
 			t.Cleanup(func() {
-				if errFG := features.FeatureGate.Set(fmt.Sprintf("%s=%v", features.FederatedQuotaEnforcement, originalGateState)); errFG != nil {
-					t.Logf("Warning: Failed to restore feature gate %s to %v: %v", features.FederatedQuotaEnforcement, originalGateState, errFG)
-				}
+				features.FeatureGate = originalFeatureGates
 			})
 
 			fakeClientBuilder := fake.NewClientBuilder().WithScheme(testScheme)


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind feature

**What this PR does / why we need it**:

This PR adds that enforces the name's presence and ensures the uniqueness of the component name when there are multiple components.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #6641 

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

