### PR TITLE
Fix the issue that the cache is out of sync within the resource inter…

### DIFF
--- a/pkg/karmadactl/promote/promote.go
+++ b/pkg/karmadactl/promote/promote.go
@@ -462,10 +462,6 @@ func (o *CommandPromoteOption) promoteDeps(memberClusterFactory cmdutil.Factory,
 	serviceLister := sharedFactory.Core().V1().Services().Lister()
 	sharedFactory.Start(ctx.Done())
 	sharedFactory.WaitForCacheSync(ctx.Done())
-	controlPlaneInformerManager.Start()
-	if sync := controlPlaneInformerManager.WaitForCacheSync(); sync == nil {
-		return errors.New("informer factory for cluster does not exist")
-	}
 
 	defaultInterpreter := native.NewDefaultInterpreter()
 	thirdpartyInterpreter := thirdparty.NewConfigurableInterpreter()
@@ -473,6 +469,11 @@ func (o *CommandPromoteOption) promoteDeps(memberClusterFactory cmdutil.Factory,
 	customizedInterpreter, err := webhook.NewCustomizedInterpreter(controlPlaneInformerManager, serviceLister)
 	if err != nil {
 		return fmt.Errorf("failed to create customized interpreter: %v", err)
+	}
+
+	controlPlaneInformerManager.Start()
+	if syncs := controlPlaneInformerManager.WaitForCacheSync(); len(syncs) == 0 {
+		return errors.New("no informers registered in the informer factory")
 	}
 
 	// check if the resource interpreter supports to interpret dependencies


### PR DESCRIPTION
…preter when using karmadactl promote

**What type of PR is this?**

/kind bug

**Special notes for your reviewer**:

This is a cherry pick pr .
The release notes of PR #6669 are as follows-
```
`karmadactl`: Fixed the issue of `promote` command that the interpreter cache is out of sync before first use.

```



