### PR TITLE
Automated cherry pick of #6707: fix the issue that the binding's suspension persists when the

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -478,12 +478,7 @@ func (d *ResourceDetector) ApplyPolicy(object *unstructured.Unstructured, object
 			bindingCopy.Spec.ConflictResolution = binding.Spec.ConflictResolution
 			bindingCopy.Spec.PreserveResourcesOnDeletion = binding.Spec.PreserveResourcesOnDeletion
 			bindingCopy.Spec.SchedulePriority = binding.Spec.SchedulePriority
-			if binding.Spec.Suspension != nil {
-				if bindingCopy.Spec.Suspension == nil {
-					bindingCopy.Spec.Suspension = &workv1alpha2.Suspension{}
-				}
-				bindingCopy.Spec.Suspension.Suspension = binding.Spec.Suspension.Suspension
-			}
+			bindingCopy.Spec.Suspension = util.MergePolicySuspension(bindingCopy.Spec.Suspension, policy.Spec.Suspension)
 			excludeClusterPolicy(bindingCopy)
 			return nil
 		})
@@ -574,12 +569,7 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 				bindingCopy.Spec.ConflictResolution = binding.Spec.ConflictResolution
 				bindingCopy.Spec.PreserveResourcesOnDeletion = binding.Spec.PreserveResourcesOnDeletion
 				bindingCopy.Spec.SchedulePriority = binding.Spec.SchedulePriority
-				if binding.Spec.Suspension != nil {
-					if bindingCopy.Spec.Suspension == nil {
-						bindingCopy.Spec.Suspension = &workv1alpha2.Suspension{}
-					}
-					bindingCopy.Spec.Suspension.Suspension = binding.Spec.Suspension.Suspension
-				}
+				bindingCopy.Spec.Suspension = util.MergePolicySuspension(bindingCopy.Spec.Suspension, policy.Spec.Suspension)
 				return nil
 			})
 			return err
@@ -627,12 +617,7 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 				bindingCopy.Spec.Failover = binding.Spec.Failover
 				bindingCopy.Spec.ConflictResolution = binding.Spec.ConflictResolution
 				bindingCopy.Spec.PreserveResourcesOnDeletion = binding.Spec.PreserveResourcesOnDeletion
-				if binding.Spec.Suspension != nil {
-					if bindingCopy.Spec.Suspension == nil {
-						bindingCopy.Spec.Suspension = &workv1alpha2.Suspension{}
-					}
-					bindingCopy.Spec.Suspension.Suspension = binding.Spec.Suspension.Suspension
-				}
+				bindingCopy.Spec.Suspension = util.MergePolicySuspension(bindingCopy.Spec.Suspension, policy.Spec.Suspension)
 				return nil
 			})
 			return err

--- a/pkg/util/binding.go
+++ b/pkg/util/binding.go
@@ -113,20 +113,20 @@ func RescheduleRequired(rescheduleTriggeredAt, lastScheduledTime *metav1.Time) b
 
 // MergePolicySuspension merges the suspension configuration from policy to binding suspension.
 func MergePolicySuspension(bindingSuspension *workv1alpha2.Suspension, policySuspension *policyv1alpha1.Suspension) *workv1alpha2.Suspension {
-	if bindingSuspension == nil && policySuspension == nil {
-		return nil
-	}
-
-	if policySuspension != nil { // have to sync policy suspension to binding
+	if policySuspension != nil {
 		if bindingSuspension == nil {
 			bindingSuspension = &workv1alpha2.Suspension{}
 		}
 		bindingSuspension.Suspension = *policySuspension
-	} else { // have to clean suspension previous synced to binding if any
-		bindingSuspension.Suspension = policyv1alpha1.Suspension{}
-		if bindingSuspension.Scheduling == nil { // if the scheduling not set, no need to keep an empty struct
-			bindingSuspension = nil
-		}
+		return bindingSuspension
+	}
+	// policySuspension is nil, clean up binding's suspension part.
+	if bindingSuspension == nil {
+		return nil
+	}
+	bindingSuspension.Suspension = policyv1alpha1.Suspension{}
+	if bindingSuspension.Scheduling == nil {
+		return nil
 	}
 	return bindingSuspension
 }

--- a/pkg/util/binding.go
+++ b/pkg/util/binding.go
@@ -110,3 +110,23 @@ func RescheduleRequired(rescheduleTriggeredAt, lastScheduledTime *metav1.Time) b
 	}
 	return rescheduleTriggeredAt.After(lastScheduledTime.Time)
 }
+
+// MergePolicySuspension merges the suspension configuration from policy to binding suspension.
+func MergePolicySuspension(bindingSuspension *workv1alpha2.Suspension, policySuspension *policyv1alpha1.Suspension) *workv1alpha2.Suspension {
+	if bindingSuspension == nil && policySuspension == nil {
+		return nil
+	}
+
+	if policySuspension != nil { // have to sync policy suspension to binding
+		if bindingSuspension == nil {
+			bindingSuspension = &workv1alpha2.Suspension{}
+		}
+		bindingSuspension.Suspension = *policySuspension
+	} else { // have to clean suspension previous synced to binding if any
+		bindingSuspension.Suspension = policyv1alpha1.Suspension{}
+		if bindingSuspension.Scheduling == nil { // if the scheduling not set, no need to keep an empty struct
+			bindingSuspension = nil
+		}
+	}
+	return bindingSuspension
+}

--- a/pkg/util/binding_test.go
+++ b/pkg/util/binding_test.go
@@ -445,7 +445,7 @@ func TestMergePolicySuspension(t *testing.T) {
 			},
 		},
 		{
-			name: "binding suspension only preserves scheduling when policy suspension nil",
+			name: "cleanup of binding suspension preserves scheduling field",
 			bindingSuspension: &workv1alpha2.Suspension{
 				Suspension: policyv1alpha1.Suspension{
 					Dispatching: ptr.To(true),
@@ -499,7 +499,7 @@ func TestMergePolicySuspension(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := MergePolicySuspension(tt.bindingSuspension, tt.policySuspension)
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("UpdateBindingSuspension() got = %v, want %v", got, tt.want)
+				t.Errorf("MergePolicySuspension() got = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Cherry pick of #6707 on release-1.14.
#6707: fix the issue that the binding's suspension persists when the
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`: Fixed the issue that the binding's suspension persists when the policy deletes the suspension configuration.
```