### PR TITLE
Introduce components field to webhook interpreter response

### DIFF
--- a/pkg/apis/config/v1alpha1/interpretercontext_types.go
+++ b/pkg/apis/config/v1alpha1/interpretercontext_types.go
@@ -118,6 +118,16 @@ type ResourceInterpreterResponse struct {
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
 
+	// Components represents the requirements of multiple pod templates of the referencing resource.
+	// It is designed to support workloads that consist of multiple pod templates,
+	// such as distributed training jobs (e.g., PyTorch, TensorFlow) and big data workloads (e.g., FlinkDeployment),
+	// where each workload is composed of more than one pod template. It is also capable of representing
+	// single-component workloads, such as Deployment.
+	//
+	// Required if InterpreterOperation is InterpreterOperationInterpretComponent.
+	// +optional
+	Components []workv1alpha2.Component `json:"components,omitempty"`
+
 	// Dependencies represents the reference of dependencies object.
 	// Required if InterpreterOperation is InterpreterOperationInterpretDependency.
 	// +optional

--- a/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -408,6 +408,13 @@ func (in *ResourceInterpreterResponse) DeepCopyInto(out *ResourceInterpreterResp
 		*out = new(int32)
 		**out = **in
 	}
+	if in.Components != nil {
+		in, out := &in.Components, &out.Components
+		*out = make([]v1alpha2.Component, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Dependencies != nil {
 		in, out := &in.Dependencies, &out.Dependencies
 		*out = make([]DependentObjectReference, len(*in))

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -2679,6 +2679,20 @@ func schema_pkg_apis_config_v1alpha1_ResourceInterpreterResponse(ref common.Refe
 							Format:      "int32",
 						},
 					},
+					"components": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Components represents the requirements of multiple pod templates of the referencing resource. It is designed to support workloads that consist of multiple pod templates, such as distributed training jobs (e.g., PyTorch, TensorFlow) and big data workloads (e.g., FlinkDeployment), where each workload is composed of more than one pod template. It is also capable of representing single-component workloads, such as Deployment.\n\nRequired if InterpreterOperation is InterpreterOperationInterpretComponent.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/karmada-io/karmada/pkg/apis/work/v1alpha2.Component"),
+									},
+								},
+							},
+						},
+					},
 					"dependencies": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Dependencies represents the reference of dependencies object. Required if InterpreterOperation is InterpreterOperationInterpretDependency.",
@@ -2711,7 +2725,7 @@ func schema_pkg_apis_config_v1alpha1_ResourceInterpreterResponse(ref common.Refe
 			},
 		},
 		Dependencies: []string{
-			"github.com/karmada-io/karmada/pkg/apis/config/v1alpha1.DependentObjectReference", "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1.RequestStatus", "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2.ReplicaRequirements", "k8s.io/apimachinery/pkg/runtime.RawExtension"},
+			"github.com/karmada-io/karmada/pkg/apis/config/v1alpha1.DependentObjectReference", "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1.RequestStatus", "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2.Component", "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2.ReplicaRequirements", "k8s.io/apimachinery/pkg/runtime.RawExtension"},
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind api-change

**What this PR does / why we need it**:
This PR introduces multiple components to support the webhook interpreter.

**Which issue(s) this PR fixes**:
Part of #6734

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`API Change`: Introduced `Components` field to `ResourceInterpreterContext` in the `ResourceInterpreterResponse` to support interpreting components for webhook interpreter. 
```

