### PR TITLE
update default node image to v1.33.1

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -40,7 +40,7 @@ KARMADA_GO_PACKAGE="github.com/karmada-io/karmada"
 
 MIN_GO_VERSION="go$(go list -m -f {{.GoVersion}})"
 
-DEFAULT_CLUSTER_VERSION="kindest/node:v1.31.2"
+DEFAULT_CLUSTER_VERSION="kindest/node:v1.33.1"
 
 # KIND_VERSION defines the version of Kind (Kubernetes IN Docker) tool to be used
 # across all scripts in the project. This version is referenced by:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
Consistent with the node image default used by kind v0.29.0
https://github.com/kubernetes-sigs/kind/releases
```md
The default node image is now 

kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note

```

