### PR TITLE
Implement the `GetComponents()` for `Webhook Interpreter`

### DIFF
--- a/pkg/resourceinterpreter/customized/webhook/customized.go
+++ b/pkg/resourceinterpreter/customized/webhook/customized.go
@@ -92,7 +92,7 @@ func (e *CustomizedInterpreter) HookEnabled(objGVK schema.GroupVersionKind, oper
 }
 
 // GetReplicas returns the desired replicas of the object as well as the requirements of each replica.
-// return matched value to indicate whether there is a matching hook.
+// It also returns a matched value to indicate whether there is a matching hook.
 func (e *CustomizedInterpreter) GetReplicas(ctx context.Context, attributes *request.Attributes) (replica int32, requires *workv1alpha2.ReplicaRequirements, matched bool, err error) {
 	klog.V(4).Infof("Get replicas for object: %v %s/%s with webhook interpreter.",
 		attributes.Object.GroupVersionKind(), attributes.Object.GetNamespace(), attributes.Object.GetName())
@@ -108,8 +108,25 @@ func (e *CustomizedInterpreter) GetReplicas(ctx context.Context, attributes *req
 	return response.Replicas, response.ReplicaRequirements, matched, nil
 }
 
+// GetComponents returns the desired components of the object.
+// It also returns a matched value to indicate whether there is a matching hook.
+func (e *CustomizedInterpreter) GetComponents(ctx context.Context, attributes *request.Attributes) (components []workv1alpha2.Component, matched bool, err error) {
+	klog.V(4).Infof("Get components for object: %v %s/%s with webhook interpreter.",
+		attributes.Object.GroupVersionKind(), attributes.Object.GetNamespace(), attributes.Object.GetName())
+	var response *request.ResponseAttributes
+	response, matched, err = e.interpret(ctx, attributes)
+	if err != nil {
+		return
+	}
+	if !matched {
+		return
+	}
+
+	return response.Components, matched, nil
+}
+
 // Patch returns the Unstructured object that applied patch response that based on the RequestAttributes.
-// return matched value to indicate whether there is a matching hook.
+// It also returns a matched value to indicate whether there is a matching hook.
 func (e *CustomizedInterpreter) Patch(ctx context.Context, attributes *request.Attributes) (obj *unstructured.Unstructured, matched bool, err error) {
 	var response *request.ResponseAttributes
 	response, matched, err = e.interpret(ctx, attributes)
@@ -312,7 +329,7 @@ func applyPatch(object *unstructured.Unstructured, patch []byte, patchType confi
 }
 
 // GetDependencies returns the dependencies of give object.
-// return matched value to indicate whether there is a matching hook.
+// It also returns a matched value to indicate whether there is a matching hook.
 func (e *CustomizedInterpreter) GetDependencies(ctx context.Context, attributes *request.Attributes) (dependencies []configv1alpha1.DependentObjectReference, matched bool, err error) {
 	var response *request.ResponseAttributes
 	response, matched, err = e.interpret(ctx, attributes)
@@ -327,7 +344,7 @@ func (e *CustomizedInterpreter) GetDependencies(ctx context.Context, attributes 
 }
 
 // ReflectStatus returns the status of the object.
-// return matched value to indicate whether there is a matching hook.
+// It also returns a matched value to indicate whether there is a matching hook.
 func (e *CustomizedInterpreter) ReflectStatus(ctx context.Context, attributes *request.Attributes) (status *runtime.RawExtension, matched bool, err error) {
 	var response *request.ResponseAttributes
 	response, matched, err = e.interpret(ctx, attributes)
@@ -342,7 +359,7 @@ func (e *CustomizedInterpreter) ReflectStatus(ctx context.Context, attributes *r
 }
 
 // InterpretHealth returns the health state of the object.
-// return matched value to indicate whether there is a matching hook.
+// It also returns a matched value to indicate whether there is a matching hook.
 func (e *CustomizedInterpreter) InterpretHealth(ctx context.Context, attributes *request.Attributes) (healthy bool, matched bool, err error) {
 	var response *request.ResponseAttributes
 	response, matched, err = e.interpret(ctx, attributes)

--- a/pkg/resourceinterpreter/customized/webhook/request/attributes.go
+++ b/pkg/resourceinterpreter/customized/webhook/request/attributes.go
@@ -44,4 +44,5 @@ type ResponseAttributes struct {
 	PatchType           configv1alpha1.PatchType
 	RawStatus           runtime.RawExtension
 	Healthy             bool
+	Components          []workv1alpha2.Component
 }

--- a/pkg/resourceinterpreter/customized/webhook/request/resourceinterpretercontext.go
+++ b/pkg/resourceinterpreter/customized/webhook/request/resourceinterpretercontext.go
@@ -114,6 +114,9 @@ func verifyResourceInterpreterContext(operation configv1alpha1.InterpreterOperat
 		res.Replicas = *response.Replicas
 		res.ReplicaRequirements = response.ReplicaRequirements
 		return res, nil
+	case configv1alpha1.InterpreterOperationInterpretComponent:
+		res.Components = response.Components
+		return res, nil
 	case configv1alpha1.InterpreterOperationInterpretDependency:
 		err := validation.VerifyDependencies(response.Dependencies)
 		if err != nil {

--- a/pkg/resourceinterpreter/customized/webhook/request/resourceinterpretercontext_test.go
+++ b/pkg/resourceinterpreter/customized/webhook/request/resourceinterpretercontext_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	configv1alpha1 "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 )
 
 func TestCreateResourceInterpreterContext(t *testing.T) {
@@ -324,6 +325,17 @@ func TestVerifyResourceInterpreterContextByOperation(t *testing.T) {
 		invalidOpType  = "invalid-operation"
 	)
 
+	testComponents := []workv1alpha2.Component{
+		{
+			Name:     "test-component1",
+			Replicas: int32(1),
+		},
+		{
+			Name:     "test-component2",
+			Replicas: int32(2),
+		},
+	}
+
 	tests := []struct {
 		name          string
 		operation     configv1alpha1.InterpreterOperation
@@ -353,6 +365,29 @@ func TestVerifyResourceInterpreterContextByOperation(t *testing.T) {
 			},
 			wantError:     true,
 			errorContains: "nil response.replicas",
+		},
+		{
+			name:      "interpret component with valid response",
+			operation: configv1alpha1.InterpreterOperationInterpretComponent,
+			response: &configv1alpha1.ResourceInterpreterResponse{
+				UID:        types.UID(testUID),
+				Successful: true,
+				Components: testComponents,
+			},
+			checkFunc: func(t *testing.T, attr *ResponseAttributes) {
+				assert.Equal(t, testComponents, attr.Components)
+			},
+		},
+		{
+			name:      "interpret component with nil components",
+			operation: configv1alpha1.InterpreterOperationInterpretComponent,
+			response: &configv1alpha1.ResourceInterpreterResponse{
+				UID:        types.UID(testUID),
+				Successful: true,
+			},
+			checkFunc: func(t *testing.T, attr *ResponseAttributes) {
+				assert.Nil(t, attr.Components)
+			},
 		},
 		{
 			name:      "interpret dependency with valid response",

--- a/pkg/resourceinterpreter/interpreter.go
+++ b/pkg/resourceinterpreter/interpreter.go
@@ -216,6 +216,17 @@ func (i *customResourceInterpreterImpl) GetComponents(object *unstructured.Unstr
 		return components, nil
 	}
 
+	components, hookEnabled, err = i.customizedInterpreter.GetComponents(context.TODO(), &request.Attributes{
+		Operation: configv1alpha1.InterpreterOperationInterpretComponent,
+		Object:    object,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if hookEnabled {
+		return components, nil
+	}
+
 	components, hookEnabled, err = i.thirdpartyInterpreter.GetComponents(object)
 	if err != nil {
 		return nil, err

--- a/pkg/webhook/configuration/validating.go
+++ b/pkg/webhook/configuration/validating.go
@@ -74,6 +74,7 @@ func (v *ValidatingAdmission) Handle(_ context.Context, req admission.Request) a
 var supportedInterpreterOperation = sets.NewString(
 	string(configv1alpha1.InterpreterOperationAll),
 	string(configv1alpha1.InterpreterOperationInterpretReplica),
+	string(configv1alpha1.InterpreterOperationInterpretComponent),
 	string(configv1alpha1.InterpreterOperationInterpretDependency),
 	string(configv1alpha1.InterpreterOperationReviseReplica),
 	string(configv1alpha1.InterpreterOperationRetain),


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
Implement the [GetComponents()](https://github.com/karmada-io/karmada/blob/b0b0bb482e6a963d10850b8b72723079c83588af/pkg/resourceinterpreter/interpreter.go#L63C2-L63C15) for [webhook interpreter](https://github.com/karmada-io/karmada/tree/master/pkg/resourceinterpreter/customized/webhook).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #6734

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`ResourceInterpreter`: Enable `GetComponents` interpreter operation through Webhook Interpreter
```

