### PR TITLE
correct the controller-manager long message

### DIFF
--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -119,9 +119,9 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use: names.KarmadaControllerManagerComponentName,
-		Long: `The karmada-controller-manager runs various controllers.
-		The controllers watch Karmada objects and then talk to the underlying
-		clusters' API servers to create regular Kubernetes resources.`,
+		Long: "The karmada-controller-manager runs various controllers.\n" +
+			"The controllers watch Karmada objects and then talk to the underlying\n" +
+			"clusters' API servers to create regular Kubernetes resources.",
 
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 			if err := logsv1.ValidateAndApply(logConfig, features.FeatureGate); err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
Ref to https://github.com/karmada-io/website/pull/888#discussion_r2332606135, the indentation for these lines is incorrect.
Before:
```bash
$ _output/bin/linux/amd64/karmada-controller-manager --help
The karmada-controller-manager runs various controllers.
                The controllers watch Karmada objects and then talk to the underlying
                clusters' API servers to create regular Kubernetes resources.
```
 Now:
```bash
$ _output/bin/linux/amd64/karmada-controller-manager --help
The karmada-controller-manager runs various controllers.
The controllers watch Karmada objects and then talk to the underlying
clusters' API servers to create regular Kubernetes resources.
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
None.
```

