### PR TITLE
fix the issue that omitempty json tag is not consistent with required mark

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -18894,7 +18894,8 @@
       "properties": {
         "name": {
           "description": "Name is the name of the cluster to be selected.",
-          "type": "string"
+          "type": "string",
+          "default": ""
         }
       }
     },

--- a/operator/pkg/apis/operator/v1alpha1/type.go
+++ b/operator/pkg/apis/operator/v1alpha1/type.go
@@ -59,7 +59,7 @@ const (
 type HTTPSource struct {
 	// URL specifies the URL of the CRD tarball resource.
 	// +required
-	URL string `json:"url,omitempty"`
+	URL string `json:"url"`
 
 	// Proxy specifies the configuration of a proxy server to use when downloading the CRD tarball.
 	// When set, the operator will use the configuration to determine how to establish a connection to the proxy to fetch the tarball from the URL specified above.
@@ -179,7 +179,7 @@ type ImageRegistry struct {
 type KarmadaComponents struct {
 	// Etcd holds configuration for etcd.
 	// +required
-	Etcd *Etcd `json:"etcd,omitempty"`
+	Etcd *Etcd `json:"etcd"`
 
 	// KarmadaAPIServer holds settings to kube-apiserver component. Currently, kube-apiserver
 	// is used as the apiserver of karmada. we had the same experience as k8s apiserver.

--- a/pkg/apis/networking/v1alpha1/service_types.go
+++ b/pkg/apis/networking/v1alpha1/service_types.go
@@ -112,7 +112,7 @@ type MultiClusterServiceSpec struct {
 type ClusterSelector struct {
 	// Name is the name of the cluster to be selected.
 	// +required
-	Name string `json:"name,omitempty"`
+	Name string `json:"name"`
 }
 
 // ExposureType describes how to expose the service.

--- a/pkg/apis/policy/v1alpha1/override_types.go
+++ b/pkg/apis/policy/v1alpha1/override_types.go
@@ -148,7 +148,7 @@ type LabelAnnotationOverrider struct {
 	// Items in Value which match in annotations/labels will be deleted when Operator is 'remove'.
 	// Items in Value which match in annotations/labels will be replaced when Operator is 'replace'.
 	// +required
-	Value map[string]string `json:"value,omitempty"`
+	Value map[string]string `json:"value"`
 }
 
 // ImageOverrider represents the rules dedicated to handling image overrides.

--- a/pkg/apis/search/searchregistry_types.go
+++ b/pkg/apis/search/searchregistry_types.go
@@ -92,7 +92,7 @@ type OpenSearchConfig struct {
 	// - secret.data.userName
 	// - secret.data.password
 	// +required
-	SecretRef clusterv1alpha1.LocalSecretReference `json:"secretRef,omitempty"`
+	SecretRef clusterv1alpha1.LocalSecretReference `json:"secretRef"`
 
 	// More configurations such as transport, index should be added from here.
 }

--- a/pkg/apis/search/v1alpha1/searchregistry_types.go
+++ b/pkg/apis/search/v1alpha1/searchregistry_types.go
@@ -104,7 +104,7 @@ type OpenSearchConfig struct {
 	// - secret.data.userName
 	// - secret.data.password
 	// +required
-	SecretRef clusterv1alpha1.LocalSecretReference `json:"secretRef,omitempty"`
+	SecretRef clusterv1alpha1.LocalSecretReference `json:"secretRef"`
 
 	// More configurations such as transport, index should be added from here.
 }

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -3083,6 +3083,7 @@ func schema_pkg_apis_networking_v1alpha1_ClusterSelector(ref common.ReferenceCal
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name is the name of the cluster to be selected.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:

As refered in issue #6750, fix the issue that omitempty tag is not consistent with required mark in operator api definitions

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #6750 

