### PR TITLE
Adding maxAvailableComponentSets to estimator interface

### DIFF
--- a/pkg/estimator/client/accurate.go
+++ b/pkg/estimator/client/accurate.go
@@ -67,6 +67,15 @@ func (se *SchedulerEstimator) MaxAvailableReplicas(
 	})
 }
 
+// MaxAvailableComponentSets returns the maximum number of complete multi-component sets (in terms of replicas) that each cluster can host.
+func (se *SchedulerEstimator) MaxAvailableComponentSets(
+	_ context.Context,
+	_ *ComponentSetEstimationRequest) ([]ComponentSetEstimationResponse, error) {
+	// Dummy implementation: return nothing for now
+	// TODO: Implement as part of #6734
+	return nil, nil
+}
+
 // GetUnschedulableReplicas gets the unschedulable replicas which belong to a specified workload by calling karmada-scheduler-estimator.
 func (se *SchedulerEstimator) GetUnschedulableReplicas(
 	parentCtx context.Context,

--- a/pkg/estimator/client/general.go
+++ b/pkg/estimator/client/general.go
@@ -53,6 +53,15 @@ func (ge *GeneralEstimator) MaxAvailableReplicas(_ context.Context, clusters []*
 	return availableTargetClusters, nil
 }
 
+// MaxAvailableComponentSets returns the maximum number of complete multi-component sets (in terms of replicas) that each cluster can host.
+func (ge *GeneralEstimator) MaxAvailableComponentSets(
+	_ context.Context,
+	_ *ComponentSetEstimationRequest) ([]ComponentSetEstimationResponse, error) {
+	// Dummy implementation: return nothing for now
+	// TODO: Implement as part of #6734
+	return nil, nil
+}
+
 func (ge *GeneralEstimator) maxAvailableReplicas(cluster *clusterv1alpha1.Cluster, replicaRequirements *workv1alpha2.ReplicaRequirements) int32 {
 	//Note: resourceSummary must be deep-copied before using in the function to avoid modifying the original data structure.
 	resourceSummary := cluster.Status.ResourceSummary.DeepCopy()

--- a/pkg/estimator/client/interface.go
+++ b/pkg/estimator/client/interface.go
@@ -34,9 +34,34 @@ var (
 	unschedulableReplicaEstimators = map[string]UnschedulableReplicaEstimator{}
 )
 
-// ReplicaEstimator is an estimator which estimates the maximum replicas that can be applied to the target cluster.
+// ReplicaEstimator estimates how many replicas a workload can run on each target cluster,
+// based on resource availability and node constraints.
 type ReplicaEstimator interface {
+	// MaxAvailableReplicas returns the maximum number of replicas of a single-component workload that each cluster can host.
 	MaxAvailableReplicas(ctx context.Context, clusters []*clusterv1alpha1.Cluster, replicaRequirements *workv1alpha2.ReplicaRequirements) ([]workv1alpha2.TargetCluster, error)
+	// MaxAvailableComponentSets returns the maximum number of complete multi-component sets (in terms of replicas) that each cluster can host.
+	MaxAvailableComponentSets(ctx context.Context, req *ComponentSetEstimationRequest) ([]ComponentSetEstimationResponse, error)
+}
+
+// ComponentSetEstimationRequest carries input parameters for estimating multi-component set availability per cluster.
+// Fields can be extended over time without changing the method signature.
+type ComponentSetEstimationRequest struct {
+	// Clusters represents a list of feasible clusters to estimate against.
+	Clusters []*clusterv1alpha1.Cluster
+	// Components are the components that form a multi-component workload.
+	Components []*workv1alpha2.Component
+	// Namespace is the namespace of the workload being estimated.
+	// It is used by the accurate estimator to check the quota configurations
+	// in the target member cluster. This field is required for quota-aware estimation.
+	Namespace string
+}
+
+// ComponentSetEstimationResponse represents how many complete component sets a cluster can accommodate.
+type ComponentSetEstimationResponse struct {
+	// Name is the cluster name.
+	Name string
+	// Sets is the maximum number of complete component sets that can be scheduled on the cluster.
+	Sets int32
 }
 
 // UnschedulableReplicaEstimator is an estimator which estimates the unschedulable replicas which belong to a specified workload.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Introduces a new method `MaxAvailableComponentSets` which will return a list of TargetClusters, where the replica # will correspond to the total number of component sets for multiple-component CRDs. 

I decided to add the new method as a part of a separate interface called `ComponentSetEstimator`. This was done because if you add the `MaxAvailableComponentSets`, all downstream implementers of `ReplicaEstimator` will expect an implementation of `MaxAvailableComponentSets`. 

By adding a separate extended interface, other estimators (such as GeneralEstimator) can keep their implementations of ReplicaEstimator, and only estimators that support multi-component workloads will implement ComponentSetEstimator.

**Which issue(s) this PR fixes**:
Part of #6734

**Does this PR introduce a user-facing change?**:
```release-note
Adding maxAvailableComponentSets to estimator interface
```

