### PR TITLE
Introduce webster method for refactor dispenser

### DIFF
--- a/pkg/util/helper/webstermethod.go
+++ b/pkg/util/helper/webstermethod.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import (
+	"container/heap"
+	"sort"
+)
+
+// Party represents a party in the Webster apportionment method.
+type Party struct {
+	// Name is the name of the party.
+	Name string
+	// Votes is the number of votes the party received.
+	Votes int64
+	// Seats is the number of seats assigned to the party.
+	Seats int32
+}
+
+// WebsterPriorityQueue implements heap.Interface using the Webster (Sainte-Laguë) method.
+// The party with the highest Webster priority (Votes/(2*Seats+1)) is at the top.
+type WebsterPriorityQueue struct {
+	// Parties contains all the parties participating in the Webster apportionment method.
+	// Each party has a name, vote count, and current seat allocation.
+	Parties []Party
+
+	// TieBreaker is an optional function used to break ties when two parties have
+	// the same Webster priority. If nil, ties are broken by vote count, then seat count,
+	// then party name to ensure a deterministic result.
+	TieBreaker func(a Party, b Party) bool
+}
+
+// Check if our WebsterPriorityQueue implements necessary interfaces
+var _ heap.Interface = &WebsterPriorityQueue{}
+
+// Len returns the number of Parties in the queue.
+func (pq *WebsterPriorityQueue) Len() int {
+	return len(pq.Parties)
+}
+
+// Less compares two Parties by their Webster priority.
+// The party with the higher priority comes first.
+func (pq *WebsterPriorityQueue) Less(i, j int) bool {
+	// In the Webster method, compare the priority of two Parties:
+	// the one with the higher value of Votes/(2*Seats+1) gets the next seat.
+	iPriority := float64(pq.Parties[i].Votes) / (float64(2*pq.Parties[i].Seats + 1))
+	jPriority := float64(pq.Parties[j].Votes) / (float64(2*pq.Parties[j].Seats + 1))
+	if iPriority == jPriority {
+		if pq.TieBreaker != nil {
+			return pq.TieBreaker(pq.Parties[i], pq.Parties[j])
+		}
+
+		// The party with fewer seats wins the tie.
+		// This is because the Webster method inherently favors smaller parties (or, in Karmada's context, smaller clusters).
+		// In Karmada, this method is often used to assign replicas based on static or dynamic weights.
+		// The rationale is that assigning to smaller clusters earlier helps establish High Availability (HA) and enables
+		// Horizontal Pod Autoscaling (HPA) more effectively. By preferring parties (clusters) with fewer seats (replicas),
+		// we promote a more balanced and resilient distribution, which is desirable for HA scenarios.
+		if pq.Parties[i].Seats != pq.Parties[j].Seats {
+			return pq.Parties[i].Seats < pq.Parties[j].Seats
+		}
+
+		// If both parties have the same priority and the same number of seats,
+		// that means they also have the same number of votes. So we don't have to compare the votes now.
+		// The party with the lexicographically smaller name wins the tie.
+		// For example, party 'a' wins over party 'b' because 'a' < 'b' lexicographically.
+		return pq.Parties[i].Name < pq.Parties[j].Name
+	}
+
+	return iPriority > jPriority
+}
+
+// Swap swaps two Parties in the queue.
+func (pq *WebsterPriorityQueue) Swap(i, j int) {
+	pq.Parties[i], pq.Parties[j] = pq.Parties[j], pq.Parties[i]
+}
+
+// Push adds a new party to the queue.
+func (pq *WebsterPriorityQueue) Push(x interface{}) {
+	pq.Parties = append(pq.Parties, x.(Party))
+}
+
+// Pop removes and returns the party with the highest priority.
+func (pq *WebsterPriorityQueue) Pop() interface{} {
+	old := pq.Parties
+	n := len(old)
+	item := old[n-1]
+	pq.Parties = old[0 : n-1]
+	return item
+}
+
+// AllocateWebsterSeats allocates new seats using the Webster method.
+// newSeats: number of new seats to allocate across all Parties.
+// partyVotes: map of party name to number of votes.
+// initialAssignments: map of party name to initial seat assignments.
+// tieBreaker: function to break ties between two Parties.
+// Returns: slice of Party with updated Seats, sorted by Name in ascending order.
+func AllocateWebsterSeats(newSeats int32, partyVotes map[string]int64, initialAssignments map[string]int32, tieBreaker func(a, b Party) bool) []Party {
+	partiesMap := make(map[string]Party, len(partyVotes)+len(initialAssignments))
+
+	// set initial party assignments, the votes default to 0
+	// If a party is present in initialAssignments but not in partyVotes,
+	// it will be initialized with 0 votes and its initial seat count.
+	// Such a party will still be included in the allocation process, but
+	// the priority of such a party is 0, which is the lowest priority.
+	for n, s := range initialAssignments {
+		partiesMap[n] = Party{Name: n, Votes: 0, Seats: s}
+	}
+
+	for n, v := range partyVotes {
+		if p, ok := partiesMap[n]; ok {
+			p.Votes = v
+			partiesMap[n] = p
+		} else {
+			partiesMap[n] = Party{Name: n, Votes: v, Seats: 0}
+		}
+	}
+
+	pq := WebsterPriorityQueue{
+		Parties:    make([]Party, 0, len(partiesMap)),
+		TieBreaker: tieBreaker,
+	}
+
+	for _, party := range partiesMap {
+		pq.Parties = append(pq.Parties, party)
+	}
+
+	if len(pq.Parties) == 0 {
+		return nil
+	}
+
+	heap.Init(&pq)
+
+	for remaining := newSeats; remaining > 0; remaining-- {
+		nextParty := heap.Pop(&pq).(Party)
+		nextParty.Seats++
+		heap.Push(&pq, nextParty)
+	}
+
+	// sort the parties by name in ascending order, to ensure the result is deterministic.
+	// This will break the heap structure, but it is ok because we will not use the heap structure again.
+	sort.Slice(pq.Parties, func(i, j int) bool {
+		return pq.Parties[i].Name < pq.Parties[j].Name
+	})
+
+	return pq.Parties
+}

--- a/pkg/util/helper/webstermethod_test.go
+++ b/pkg/util/helper/webstermethod_test.go
@@ -1,0 +1,313 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func ExampleAllocateWebsterSeats() {
+	partiesVotes := map[string]int64{
+		"Alpha": 1200,
+		"Beta":  900,
+		"Gamma": 400,
+	}
+	totalSeats := int32(4)
+	result := AllocateWebsterSeats(totalSeats, partiesVotes, nil, nil)
+	for _, p := range result {
+		fmt.Printf("%s: %d seats\n", p.Name, p.Seats)
+	}
+	// Output:
+	// Alpha: 2 seats
+	// Beta: 1 seats
+	// Gamma: 1 seats
+}
+
+func TestAllocateWebsterSeats(t *testing.T) {
+	// This is used for test the classic example from https://en.wikipedia.org/wiki/Sainte-Lagu%C3%AB_method,
+	// where 230,000 voters allocate 8 seats among 4 Parties.
+	// The expected seat distribution after each round matches the step-by-step allocation shown in the Wikipedia.
+	partiesVotes := map[string]int64{
+		"PartyA": 100000,
+		"PartyB": 80000,
+		"PartyC": 30000,
+		"PartyD": 20000,
+	}
+
+	tests := []struct {
+		name               string
+		newSeats           int32
+		partyVotes         map[string]int64
+		initialAssignments map[string]int32
+		tieBreaker         func(a, b Party) bool
+		expected           []Party
+	}{
+		{
+			name:               "classic example, round 1",
+			newSeats:           1,
+			partyVotes:         partiesVotes,
+			initialAssignments: nil,
+			tieBreaker:         nil,
+			expected: []Party{
+				{Name: "PartyA", Votes: 100000, Seats: 1},
+				{Name: "PartyB", Votes: 80000, Seats: 0},
+				{Name: "PartyC", Votes: 30000, Seats: 0},
+				{Name: "PartyD", Votes: 20000, Seats: 0},
+			},
+		},
+		{
+			name:               "classic example, round 2",
+			newSeats:           2,
+			partyVotes:         partiesVotes,
+			initialAssignments: nil,
+			tieBreaker:         nil,
+			expected: []Party{
+				{Name: "PartyA", Votes: 100000, Seats: 1},
+				{Name: "PartyB", Votes: 80000, Seats: 1},
+				{Name: "PartyC", Votes: 30000, Seats: 0},
+				{Name: "PartyD", Votes: 20000, Seats: 0},
+			},
+		},
+		{
+			name:               "classic example, round 3",
+			newSeats:           3,
+			partyVotes:         partiesVotes,
+			initialAssignments: nil,
+			tieBreaker:         nil,
+			expected: []Party{
+				{Name: "PartyA", Votes: 100000, Seats: 2},
+				{Name: "PartyB", Votes: 80000, Seats: 1},
+				{Name: "PartyC", Votes: 30000, Seats: 0},
+				{Name: "PartyD", Votes: 20000, Seats: 0},
+			},
+		},
+		{
+			name:               "classic example, round 4",
+			newSeats:           4,
+			partyVotes:         partiesVotes,
+			initialAssignments: nil,
+			tieBreaker:         nil,
+			expected: []Party{
+				{Name: "PartyA", Votes: 100000, Seats: 2},
+				{Name: "PartyB", Votes: 80000, Seats: 1},
+				{Name: "PartyC", Votes: 30000, Seats: 1},
+				{Name: "PartyD", Votes: 20000, Seats: 0},
+			},
+		},
+		{
+			name:               "classic example, round 5",
+			newSeats:           5,
+			partyVotes:         partiesVotes,
+			initialAssignments: nil,
+			tieBreaker:         nil,
+			expected: []Party{
+				{Name: "PartyA", Votes: 100000, Seats: 2},
+				{Name: "PartyB", Votes: 80000, Seats: 2},
+				{Name: "PartyC", Votes: 30000, Seats: 1},
+				{Name: "PartyD", Votes: 20000, Seats: 0},
+			},
+		},
+		{
+			name:               "classic example, round 6",
+			newSeats:           6,
+			partyVotes:         partiesVotes,
+			initialAssignments: nil,
+			tieBreaker:         nil,
+			expected: []Party{
+				{Name: "PartyA", Votes: 100000, Seats: 2},
+				{Name: "PartyB", Votes: 80000, Seats: 2},
+				{Name: "PartyC", Votes: 30000, Seats: 1},
+				{Name: "PartyD", Votes: 20000, Seats: 1},
+			},
+		},
+		{
+			name:               "classic example, round 7",
+			newSeats:           7,
+			partyVotes:         partiesVotes,
+			initialAssignments: nil,
+			tieBreaker:         nil,
+			expected: []Party{
+				{Name: "PartyA", Votes: 100000, Seats: 3},
+				{Name: "PartyB", Votes: 80000, Seats: 2},
+				{Name: "PartyC", Votes: 30000, Seats: 1},
+				{Name: "PartyD", Votes: 20000, Seats: 1},
+			},
+		},
+		{
+			name:               "classic example, round 8",
+			newSeats:           8,
+			partyVotes:         partiesVotes,
+			initialAssignments: nil,
+			tieBreaker:         nil,
+			expected: []Party{
+				{Name: "PartyA", Votes: 100000, Seats: 3},
+				{Name: "PartyB", Votes: 80000, Seats: 3},
+				{Name: "PartyC", Votes: 30000, Seats: 1},
+				{Name: "PartyD", Votes: 20000, Seats: 1},
+			},
+		},
+		{
+			name:               "empty party votes, expect nil result",
+			newSeats:           1,
+			partyVotes:         map[string]int64{},
+			initialAssignments: nil,
+			tieBreaker:         nil,
+			expected:           nil,
+		},
+		{
+			name:               "party votes not empty, newSeats is 0, expect all seats 0",
+			newSeats:           0,
+			partyVotes:         map[string]int64{"PartyA": 100, "PartyB": 200},
+			initialAssignments: nil,
+			tieBreaker:         nil,
+			expected: []Party{
+				{Name: "PartyA", Votes: 100, Seats: 0},
+				{Name: "PartyB", Votes: 200, Seats: 0},
+			},
+		},
+		{
+			name:               "both party votes and newSeats are 0, expect nil result",
+			newSeats:           0,
+			partyVotes:         map[string]int64{},
+			initialAssignments: nil,
+			tieBreaker:         nil,
+			expected:           nil,
+		},
+		{
+			name:     "tie-breaker is nil, expect break tie by seats",
+			newSeats: 1,
+			partyVotes: map[string]int64{
+				"PartyA": 3,
+				"PartyB": 1,
+			},
+			initialAssignments: map[string]int32{
+				"PartyA": 1,
+				"PartyB": 0,
+			},
+			tieBreaker: nil,
+			expected: []Party{
+				{Name: "PartyA", Votes: 3, Seats: 1},
+				{Name: "PartyB", Votes: 1, Seats: 1},
+			},
+		},
+		{
+			name:     "tie-breaker is nil, expect break tie by name",
+			newSeats: 1,
+			partyVotes: map[string]int64{
+				"PartyA": 1,
+				"PartyB": 1,
+			},
+			initialAssignments: nil,
+			tieBreaker:         nil,
+			expected: []Party{
+				{Name: "PartyA", Votes: 1, Seats: 1},
+				{Name: "PartyB", Votes: 1, Seats: 0},
+			},
+		},
+		{
+			name:     "custom tie-breaker returns true, expect custom tie-breaker controls seat",
+			newSeats: 1,
+			partyVotes: map[string]int64{
+				"PartyA": 1,
+				"PartyB": 1,
+			},
+			initialAssignments: nil,
+			tieBreaker: func(a, b Party) bool {
+				return a.Name < b.Name
+			},
+			expected: []Party{
+				{Name: "PartyA", Votes: 1, Seats: 1},
+				{Name: "PartyB", Votes: 1, Seats: 0},
+			},
+		},
+		{
+			name:     "custom tie-breaker returns false, expect custom tie-breaker controls seat",
+			newSeats: 1,
+			partyVotes: map[string]int64{
+				"PartyA": 1,
+				"PartyB": 1,
+			},
+			initialAssignments: nil,
+			tieBreaker: func(a, b Party) bool {
+				return a.Name > b.Name
+			},
+			expected: []Party{
+				{Name: "PartyA", Votes: 1, Seats: 0},
+				{Name: "PartyB", Votes: 1, Seats: 1},
+			},
+		},
+		{
+			name:     "non-initial allocation, new party joins, only new party gets new seats",
+			newSeats: 2,
+			partyVotes: map[string]int64{
+				"NewParty1": 1,
+				"NewParty2": 1,
+			},
+			initialAssignments: map[string]int32{
+				"OldParty": 0,
+			},
+			tieBreaker: nil,
+			expected: []Party{
+				{Name: "NewParty1", Votes: 1, Seats: 1},
+				{Name: "NewParty2", Votes: 1, Seats: 1},
+				{Name: "OldParty", Votes: 0, Seats: 0},
+			},
+		},
+		{
+			name:     "non-initial allocation, both new and old parties compete for new seats",
+			newSeats: 2,
+			partyVotes: map[string]int64{
+				"OldParty": 1,
+				"NewParty": 1,
+			},
+			initialAssignments: map[string]int32{
+				"OldParty": 1,
+			},
+			tieBreaker: nil,
+			expected: []Party{
+				{Name: "NewParty", Votes: 1, Seats: 2},
+				{Name: "OldParty", Votes: 1, Seats: 1},
+			},
+		},
+		{
+			name:     "non-initial allocation, initialAssignments party not in partyVotes, expect no new seats for that party",
+			newSeats: 2,
+			partyVotes: map[string]int64{
+				"PartyA": 100,
+			},
+			initialAssignments: map[string]int32{
+				"PartyB": 3,
+			},
+			tieBreaker: nil,
+			expected: []Party{
+				{Name: "PartyA", Votes: 100, Seats: 2},
+				{Name: "PartyB", Votes: 0, Seats: 3},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := AllocateWebsterSeats(test.newSeats, test.partyVotes, test.initialAssignments, test.tieBreaker)
+			if !reflect.DeepEqual(got, test.expected) {
+				t.Errorf("expected %v, got %v", test.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR introduces a WebsterPriorityQueue, which implements [the Webster method, also called the Sainte-Laguë method](https://en.wikipedia.org/wiki/Sainte-Lagu%C3%AB_method), the queue will be used by dividing replicas among clusters according to static/dynamic weight. 

PS: The rest of the tasks are tracked by #6739. 

**Which issue(s) this PR fixes**:
Part of #6739 
Original issue #6735

**Special notes for your reviewer**:
This PR implements **Webster’s method** (Sainte-Laguë) for proportional replica scheduling. Unlike D’Hondt, which favors larger clusters, Webster’s approach minimizes seat-to-vote ratio deviations and ensures smaller clusters receive replicas sooner. This is critical for:  
1. **High Availability (HA)**: Faster distribution across clusters, even with low replica counts.  
2. **HPA Activation**: Guarantees ≥1 replica per cluster to trigger autoscaling immediately.  

D’Hondt was rejected because its large-cluster bias delays HA readiness for small clusters and risks leaving clusters replica-less (breaking HPA). Webster aligns better with Karmada’s goals of fairness and resilience.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

