### PR TITLE
Fix flaky test failures in taint manager due to time differences

### DIFF
--- a/pkg/util/helper/taint.go
+++ b/pkg/util/helper/taint.go
@@ -118,8 +118,9 @@ func GetNoExecuteTaints(taints []corev1.Taint) []corev1.Taint {
 	return result
 }
 
-// GetMinTolerationTime returns minimal toleration time from the given slice, or -1 if it's infinite.
-func GetMinTolerationTime(noExecuteTaints []corev1.Taint, usedTolerations []corev1.Toleration) time.Duration {
+// GetMinTolerationTimeWithCurrentTime returns minimal toleration time from the given slice, or -1 if it's infinite.
+// This function accepts a currentTime parameter to enable deterministic testing.
+func GetMinTolerationTimeWithCurrentTime(noExecuteTaints []corev1.Taint, usedTolerations []corev1.Toleration, currentTime time.Time) time.Duration {
 	if len(noExecuteTaints) == 0 {
 		return -1
 	}
@@ -160,11 +161,11 @@ func GetMinTolerationTime(noExecuteTaints []corev1.Taint, usedTolerations []core
 	}
 
 	// If trigger time is up, don't tolerate.
-	if t.Before(time.Now()) {
+	if t.Before(currentTime) {
 		return 0
 	}
 
-	return time.Until(t)
+	return t.Sub(currentTime)
 }
 
 // GetMatchingTolerations returns true and list of Tolerations matching all Taints if all are tolerated, or false otherwise.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

https://github.com/karmada-io/karmada/actions/runs/17933081090/job/50994164390

The test TestNoExecuteTaintManager_needEviction/taint_tolerated_with_positive_toleration_seconds_-_wait_for_toleration_time was experiencing intermittent failures due to timing issues. The test expected a specific toleration time (e.g., 59s) but got slightly different values (e.g., 57.995129913s) because of the time elapsed between different time.Now() calls during test execution.

**Root Cause**

The GetMinTolerationTime function used time.Now() and time.Until() internally, which introduced non-deterministic timing behavior in tests. When taints had TimeAdded values and tolerations had TolerationSeconds, the calculated remaining time varied depending on when exactly the function was called.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

In addition to the modification method used in the current PR, there are other modification methods available, and you can refer to the following analysis of their advantages and disadvantages.

<details>
  <summary>unflod me</summary>

## 1. **Current Approach: Time Parameter Injection** 
```go
func needEvictionWithCurrentTime(cluster string, annotations map[string]string, currentTime time.Time)
```
**Pros:** Fully deterministic, backward compatible, no external deps  
**Cons:** Slightly more complex API, duplicate functions

## 2. **Time Tolerance Range**
```go
if tolerationTime < expected-2s || tolerationTime > expected+2s { /* fail */ }
```
**Pros:** Minimal code change, simple  
**Cons:** Still flaky, imprecise testing, hard to tune tolerance

## 3. **Time Mocking Library** 
```go
func GetMinTolerationTime(taints, tolerations, clock Clock)
```
**Pros:** Industry standard, full time control  
**Cons:** External dependency, major refactoring needed

## 4. **Global Time Function Override**
```go
var timeNow = time.Now  // Override in tests
```
**Pros:** No API changes, deterministic  
**Cons:** Global state, concurrency issues, not thread-safe

## 5. **Environment Variable Control**
```go
if testTime := os.Getenv("TEST_FIXED_TIME"); testTime != "" { /* use fixed time */ }
```
**Pros:** External control, minimal changes  
**Cons:** Production code pollution, environment management complexity

## 6. **Behavioral Testing Only**
```go
// Only test needEviction bool, ignore tolerationTime precision
assert.Equal(t, expectedNeedEviction, needEviction)
```
**Pros:** No production changes, robust  
**Cons:** Reduced test coverage, misses timing bugs

## 7. **Build Tags Separation**
```go
// +build !test
func GetMinTolerationTime() { /* production */ }
// +build test  
func GetMinTolerationTime() { /* test version */ }
```
**Pros:** Complete separation  
**Cons:** Build complexity, maintenance overhead

---

## **Ranking:**
1. **Time Parameter Injection** - Best balance of reliability and maintainability
2. **Time Mocking Library** - If already using similar patterns
3. **Global Function Override** - Quick fix but risky
4. **Time Tolerance** - Simple but unreliable
5. **Behavioral Testing** - Safe but incomplete
6. **Environment Variables** - Not recommended
7. **Build Tags** - Overcomplicated

</details>

**Winner: Current approach** provides deterministic testing with minimal architectural impact.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

