### PR TITLE
Make sure CRDs are updated on upgrades

### DIFF
--- a/operator/pkg/tasks/init/karmadaresource.go
+++ b/operator/pkg/tasks/init/karmadaresource.go
@@ -112,8 +112,8 @@ func runCrds(r workflow.RunData) error {
 		return err
 	}
 
-	if err := createCrds(crdsClient, crdsPath); err != nil {
-		return fmt.Errorf("failed to create karmada crds, err: %w", err)
+	if err := applyCrds(crdsClient, crdsPath); err != nil {
+		return fmt.Errorf("failed to apply karmada crds, err: %w", err)
 	}
 
 	cert := data.GetCert(constants.CaCertAndKeyName)
@@ -130,7 +130,7 @@ func runCrds(r workflow.RunData) error {
 	return nil
 }
 
-func createCrds(crdsClient *crdsclient.Clientset, crdsPath string) error {
+func applyCrds(crdsClient *crdsclient.Clientset, crdsPath string) error {
 	for _, file := range util.ListFileWithSuffix(crdsPath, ".yaml") {
 		crdBytes, err := util.ReadYamlFile(file.AbsPath)
 		if err != nil {
@@ -142,7 +142,7 @@ func createCrds(crdsClient *crdsclient.Clientset, crdsPath string) error {
 			klog.ErrorS(err, "error when converting json byte to apiExtensionsV1 CustomResourceDefinition struct")
 			return err
 		}
-		if err := apiclient.CreateCustomResourceDefinitionIfNeed(crdsClient, &obj); err != nil {
+		if err := apiclient.ApplyCRD(crdsClient, &obj); err != nil {
 			return err
 		}
 	}

--- a/operator/pkg/util/apiclient/idempotency.go
+++ b/operator/pkg/util/apiclient/idempotency.go
@@ -209,7 +209,6 @@ func CreateOrUpdateAPIService(apiRegistrationClient aggregator.Interface, apiser
 
 // ApplyCRD applies the CRD to the Karmada API server
 func ApplyCRD(client *crdsclient.Clientset, obj *apiextensionsv1.CustomResourceDefinition) error {
-
 	data, err := json.Marshal(obj)
 	if err != nil {
 		klog.V(5).ErrorS(err, "Failed to marshall CRD data", "crd", obj.Name)

--- a/operator/pkg/util/apiclient/idempotency.go
+++ b/operator/pkg/util/apiclient/idempotency.go
@@ -18,6 +18,7 @@ package apiclient
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -37,6 +38,7 @@ import (
 	"k8s.io/klog/v2"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	aggregator "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
+	"k8s.io/utils/ptr"
 
 	"github.com/karmada-io/karmada/operator/pkg/constants"
 )
@@ -205,19 +207,32 @@ func CreateOrUpdateAPIService(apiRegistrationClient aggregator.Interface, apiser
 	return nil
 }
 
-// CreateCustomResourceDefinitionIfNeed creates a CustomResourceDefinition if the target resource doesn't exist. If the resource exists already, this function will update the resource instead.
-func CreateCustomResourceDefinitionIfNeed(client *crdsclient.Clientset, obj *apiextensionsv1.CustomResourceDefinition) error {
-	crdClient := client.ApiextensionsV1().CustomResourceDefinitions()
-	if _, err := crdClient.Create(context.TODO(), obj, metav1.CreateOptions{}); err != nil {
-		if !apierrors.IsAlreadyExists(err) {
-			return err
-		}
+// ApplyCRD applies the CRD to the Karmada API server
+func ApplyCRD(client *crdsclient.Clientset, obj *apiextensionsv1.CustomResourceDefinition) error {
 
-		klog.V(5).InfoS("Skip already exist crd", "crd", obj.Name)
-		return nil
+	data, err := json.Marshal(obj)
+	if err != nil {
+		klog.V(5).ErrorS(err, "Failed to marshall CRD data", "crd", obj.Name)
+		return err
 	}
 
-	klog.V(5).InfoS("Successfully created crd", "crd", obj.Name)
+	crdClient := client.ApiextensionsV1().CustomResourceDefinitions()
+	_, err = crdClient.Patch(
+		context.TODO(),
+		obj.Name,
+		types.ApplyPatchType,
+		data,
+		metav1.PatchOptions{
+			FieldManager: "karmada-operator",
+			Force:        ptr.To(true),
+		},
+	)
+	if err != nil {
+		klog.V(5).ErrorS(err, "Failed to apply CRD", "crd", obj.Name)
+		return err
+	}
+
+	klog.V(5).InfoS("Successfully applied CRD", "crd", obj.Name)
 	return nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind bug

**What this PR does / why we need it**:
When I upgrade a Karmada instance managed by the operator, if a CRD has changed, then I expect that CRD to be updated in the Karmada API server accordingly. Currently, the operator will try to create a CRD and if that fails because the CRD already exist, then it will just skip applying it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #6776

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

