### PR TITLE
add: failover evictionqueue metrics

### DIFF
--- a/pkg/metrics/cluster.go
+++ b/pkg/metrics/cluster.go
@@ -37,6 +37,10 @@ const (
 	clusterCPUAllocatedMetricsName       = "cluster_cpu_allocated_number"
 	clusterPodAllocatedMetricsName       = "cluster_pod_allocated_number"
 	clusterSyncStatusDurationMetricsName = "cluster_sync_status_duration_seconds"
+	evictionQueueDepthMetricsName        = "eviction_queue_depth"
+	evictionKindTotalMetricsName         = "eviction_kind_total"
+	evictionProcessingLatencyMetricsName = "eviction_processing_latency_seconds"
+	evictionProcessingTotalMetricsName   = "eviction_processing_total"
 )
 
 var (
@@ -99,6 +103,27 @@ var (
 		Name: clusterSyncStatusDurationMetricsName,
 		Help: "Duration in seconds for syncing the status of the cluster once.",
 	}, []string{"cluster_name"})
+
+	evictionQueueMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: evictionQueueDepthMetricsName,
+		Help: "Current depth of the eviction queue",
+	}, []string{"name"})
+
+	evictionKindTotalMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: evictionKindTotalMetricsName,
+		Help: "Number of resources in the eviction queue by resource kind",
+	}, []string{"member_cluster", "resource_kind"})
+
+	evictionProcessingLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    evictionProcessingLatencyMetricsName,
+		Help:    "Latency of processing an eviction task in seconds",
+		Buckets: prometheus.ExponentialBuckets(0.001, 2, 15),
+	}, []string{"name"})
+
+	evictionProcessingTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: evictionProcessingTotalMetricsName,
+		Help: "Total number of evictions processed",
+	}, []string{"name", "result"})
 )
 
 // RecordClusterStatus records the status of the given cluster.
@@ -149,6 +174,34 @@ func CleanupMetricsForCluster(clusterName string) {
 	clusterSyncStatusDuration.DeleteLabelValues(clusterName)
 }
 
+// RecordEvictionQueueMetrics record the depth Of the EvictionQueue
+func RecordEvictionQueueMetrics(name string, depth float64) {
+	evictionQueueMetrics.WithLabelValues(name).Set(depth)
+}
+
+// RecordEvictionKindMetrics records eviction queue items by resource type
+// Increase count when true and decrease count when false
+func RecordEvictionKindMetrics(clusterName, resourceKind string, increase bool) {
+	if clusterName == "" || resourceKind == "" {
+		return
+	}
+
+	if increase {
+		evictionKindTotalMetrics.WithLabelValues(clusterName, resourceKind).Inc()
+	} else {
+		evictionKindTotalMetrics.WithLabelValues(clusterName, resourceKind).Dec()
+	}
+}
+
+// RecordEvictionProcessingMetrics records the processing delay and results of the eviction task
+func RecordEvictionProcessingMetrics(name string, err error, startTime time.Time) {
+	latency := utilmetrics.DurationInSeconds(startTime)
+	evictionProcessingLatency.WithLabelValues(name).Observe(latency)
+
+	result := utilmetrics.GetResultByError(err)
+	evictionProcessingTotal.WithLabelValues(name, result).Inc()
+}
+
 // ClusterCollectors returns the collectors about clusters.
 func ClusterCollectors() []prometheus.Collector {
 	return []prometheus.Collector{
@@ -162,5 +215,9 @@ func ClusterCollectors() []prometheus.Collector {
 		clusterCPUAllocatedGauge,
 		clusterPodAllocatedGauge,
 		clusterSyncStatusDuration,
+		evictionQueueMetrics,
+		evictionKindTotalMetrics,
+		evictionProcessingLatency,
+		evictionProcessingTotal,
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
add some metrics to evictionqueue 
**Which issue(s) this PR fixes**:
part of #6746
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
karmada-controller-manager: Added new metrics for the failover eviction queue to enhance observability.
```

