### PR TITLE
feature(karmadactl): support split secret layout in init command

### DIFF
--- a/.github/workflows/installation-cli.yaml
+++ b/.github/workflows/installation-cli.yaml
@@ -106,3 +106,47 @@ jobs:
         with:
           name: karmadactl_config_test_logs_${{ matrix.k8s }}
           path: ${{ github.workspace }}/karmadactl-test-logs/${{ matrix.k8s }}/config/
+
+  test-on-kubernetes-split-secret:
+    name: Test on Kubernetes (Split Secret)
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        # Latest three minor releases of Kubernetes
+        k8s: [ v1.31.0, v1.32.0, v1.33.0 ]
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: run karmadactl init test (split secret layout)
+        run: |
+          export CLUSTER_VERSION=kindest/node:${{ matrix.k8s }}
+
+          # init e2e environment with split secret layout
+          hack/cli-testing-environment-split-secret.sh
+
+          # run a single e2e
+          export PULL_BASED_CLUSTERS="split-secret-member1:${HOME}/.kube/split-secret-member1.config"  
+          export KUBECONFIG=${HOME}/.kube/karmada-host.config:${HOME}/karmada/karmada-apiserver.config
+          GO111MODULE=on go install github.com/onsi/ginkgo/v2/ginkgo
+          ginkgo -v --race --trace -p  --focus="[BasicPropagation] propagation testing deployment propagation testing"  ./test/e2e/suites/base
+      - name: export logs (split secret)
+        if: always()
+        run: |
+          export ARTIFACTS_PATH=${{ github.workspace }}/karmadactl-test-logs/${{ matrix.k8s }}/split-secret
+          mkdir -p $ARTIFACTS_PATH
+
+          mkdir -p $ARTIFACTS_PATH/karmada-host
+          kind export logs --name=karmada-host $ARTIFACTS_PATH/karmada-host
+      - name: upload logs (split secret)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: karmadactl_split_secret_test_logs_${{ matrix.k8s }}
+          path: ${{ github.workspace }}/karmadactl-test-logs/${{ matrix.k8s }}/split-secret/

--- a/hack/cli-testing-environment-split-secret.sh
+++ b/hack/cli-testing-environment-split-secret.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Copyright 2025 The Karmada Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script starts a local karmada control plane with karmadactl and with a certain number of clusters joined,
+# identical to hack/cli-testing-environment.sh except adding '--secret-layout=split' for init.
+# This script depends on utils in: ${REPO_ROOT}/hack/util.sh
+# 1. used by developer to setup develop environment quickly.
+# 2. used by e2e testing to setup test environment automatically.
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${REPO_ROOT}"/hack/util.sh
+
+# variable define
+KUBECONFIG_PATH=${KUBECONFIG_PATH:-"${HOME}/.kube"}
+HOST_CLUSTER_NAME=${HOST_CLUSTER_NAME:-"karmada-host"}
+MEMBER_CLUSTER_1_NAME=${MEMBER_CLUSTER_1_NAME:-"split-secret-member1"}
+MEMBER_CLUSTER_2_NAME=${MEMBER_CLUSTER_2_NAME:-"split-secret-member2"}
+CLUSTER_VERSION=${CLUSTER_VERSION:-"${DEFAULT_CLUSTER_VERSION}"}
+BUILD_PATH=${BUILD_PATH:-"_output/bin/linux/amd64"}
+
+# install kind and kubectl
+echo -n "Preparing: 'kind' existence check - "
+if util::cmd_exist kind; then
+  echo "passed"
+else
+  echo "not pass"
+  # Install kind using the version defined in util.sh
+  util::install_tools "sigs.k8s.io/kind" "${KIND_VERSION}"
+fi
+# get arch name and os name in bootstrap
+BS_ARCH=$(go env GOARCH)
+BS_OS=$(go env GOOS)
+# check arch and os name before installing
+util::install_environment_check "${BS_ARCH}" "${BS_OS}"
+echo -n "Preparing: 'kubectl' existence check - "
+if util::cmd_exist kubectl; then
+  echo "passed"
+else
+  echo "not pass"
+  util::install_kubectl "" "${BS_ARCH}" "${BS_OS}"
+fi
+
+# prepare the newest crds
+echo "Prepare the newest crds"
+cd  charts/karmada/
+cp -r _crds crds
+tar -zcvf ../../crds.tar.gz crds
+cd -
+
+# make images
+export VERSION="latest"
+export REGISTRY="docker.io/karmada"
+make images GOOS="linux" --directory="${REPO_ROOT}"
+
+# make karmadactl binary
+make karmadactl
+
+# create host/member1/member2 cluster
+echo "Start create clusters..."
+hack/create-cluster.sh ${HOST_CLUSTER_NAME} ${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config > /dev/null 2>&1 &
+hack/create-cluster.sh ${MEMBER_CLUSTER_1_NAME} ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_1_NAME}.config > /dev/null 2>&1 &
+hack/create-cluster.sh ${MEMBER_CLUSTER_2_NAME} ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_2_NAME}.config > /dev/null 2>&1 &
+
+# wait cluster ready
+echo "Wait clusters ready..."
+util::wait_file_exist ${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config 300
+util::wait_context_exist ${HOST_CLUSTER_NAME} ${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config 300
+kubectl wait --for=condition=Ready nodes --all --timeout=800s --kubeconfig=${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config
+util::wait_nodes_taint_disappear 800 ${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config
+
+util::wait_file_exist ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_1_NAME}.config 300
+util::wait_context_exist "${MEMBER_CLUSTER_1_NAME}" ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_1_NAME}.config 300
+kubectl wait --for=condition=Ready nodes --all --timeout=800s --kubeconfig=${KUBECONFIG_PATH}/${MEMBER_CLUSTER_1_NAME}.config
+util::wait_nodes_taint_disappear 800 ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_1_NAME}.config
+
+util::wait_file_exist ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_2_NAME}.config 300
+util::wait_context_exist "${MEMBER_CLUSTER_2_NAME}" ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_2_NAME}.config 300
+kubectl wait --for=condition=Ready nodes --all --timeout=800s --kubeconfig=${KUBECONFIG_PATH}/${MEMBER_CLUSTER_2_NAME}.config
+util::wait_nodes_taint_disappear 800 ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_2_NAME}.config
+
+# load components images to kind cluster
+kind load docker-image "${REGISTRY}/karmada-controller-manager:${VERSION}" --name="${HOST_CLUSTER_NAME}"
+kind load docker-image "${REGISTRY}/karmada-scheduler:${VERSION}" --name="${HOST_CLUSTER_NAME}"
+kind load docker-image "${REGISTRY}/karmada-webhook:${VERSION}" --name="${HOST_CLUSTER_NAME}"
+kind load docker-image "${REGISTRY}/karmada-aggregated-apiserver:${VERSION}" --name="${HOST_CLUSTER_NAME}"
+kind load docker-image "${REGISTRY}/karmada-agent:${VERSION}" --name="${MEMBER_CLUSTER_1_NAME}"
+
+# init Karmada control plane
+echo "Start init karmada control plane..."
+${BUILD_PATH}/karmadactl init --kubeconfig=${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config \
+    --karmada-controller-manager-image="${REGISTRY}/karmada-controller-manager:${VERSION}" \
+    --karmada-scheduler-image="${REGISTRY}/karmada-scheduler:${VERSION}" \
+    --karmada-webhook-image="${REGISTRY}/karmada-webhook:${VERSION}" \
+    --karmada-aggregated-apiserver-image="${REGISTRY}/karmada-aggregated-apiserver:${VERSION}" \
+    --karmada-data=${HOME}/karmada \
+    --karmada-pki=${HOME}/karmada/pki \
+    --crds=./crds.tar.gz \
+    --secret-layout='split'
+
+# join cluster
+echo "Join member clusters..."
+TOKEN_CMD=$(${BUILD_PATH}/karmadactl --kubeconfig ${HOME}/karmada/karmada-apiserver.config token create --print-register-command)
+TOKEN=$(echo "$TOKEN_CMD" | grep -o '\--token [^ ]*' | cut -d' ' -f2)
+HASH=$(echo "$TOKEN_CMD" | grep -o '\--discovery-token-ca-cert-hash [^ ]*' | cut -d' ' -f2)
+ENDPOINT=$(kubectl --kubeconfig ${HOME}/karmada/karmada-apiserver.config config view --minify -o jsonpath='{.clusters[0].cluster.server}' | sed 's|^https://||')
+
+${BUILD_PATH}/karmadactl register ${ENDPOINT} \
+    --token ${TOKEN} \
+    --discovery-token-ca-cert-hash ${HASH} \
+    --kubeconfig=${KUBECONFIG_PATH}/${MEMBER_CLUSTER_1_NAME}.config \
+    --cluster-name=${MEMBER_CLUSTER_1_NAME} \
+    --karmada-agent-image "${REGISTRY}/karmada-agent:${VERSION}" \
+    --v=4
+
+${BUILD_PATH}/karmadactl --kubeconfig ${HOME}/karmada/karmada-apiserver.config join ${MEMBER_CLUSTER_2_NAME} --cluster-kubeconfig=${KUBECONFIG_PATH}/${MEMBER_CLUSTER_2_NAME}.config
+
+kubectl wait --for=condition=Ready clusters --all --timeout=800s --kubeconfig=${HOME}/karmada/karmada-apiserver.config

--- a/pkg/cert/constants.go
+++ b/pkg/cert/constants.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cert
+
+// Package cert centralizes TLS-related constants (secret names and key names)
+// so they can be shared by cmdinit and future operator implementations.
+
+// Secret names for split-layout TLS materials
+// nolint:gosec // These are Kubernetes Secret resource names, not credentials.
+const (
+	// apiserver
+	SecretApiserverServer             = "karmada-apiserver-cert"
+	SecretApiserverEtcdClient         = "karmada-apiserver-etcd-client-cert"
+	SecretApiserverFrontProxyClient   = "karmada-apiserver-front-proxy-client-cert"
+	SecretApiserverServiceAccountKeys = "karmada-apiserver-service-account-key-pair"
+
+	// aggregated apiserver
+	SecretAggregatedAPIServerServer     = "karmada-aggregated-apiserver-cert"
+	SecretAggregatedAPIServerEtcdClient = "karmada-aggregated-apiserver-etcd-client-cert"
+
+	// kube-controller-manager
+	SecretKubeControllerManagerCA     = "kube-controller-manager-ca-cert"
+	SecretKubeControllerManagerSAKeys = "kube-controller-manager-service-account-key-pair"
+
+	// scheduler(estimator) clients
+	SecretSchedulerEstimatorClient   = "karmada-scheduler-scheduler-estimator-client-cert"
+	SecretDeschedulerEstimatorClient = "karmada-descheduler-scheduler-estimator-client-cert"
+
+	// etcd (internal)
+	SecretEtcdServer = "etcd-cert"
+	SecretEtcdClient = "etcd-etcd-client-cert"
+
+	// webhook serving cert
+	SecretWebhook = "karmada-webhook-cert"
+)
+
+// PEM key names used inside TLS secrets
+const (
+	KeyTLSCrt    = "tls.crt"
+	KeyTLSKey    = "tls.key"
+	KeyCACrt     = "ca.crt"
+	KeySAPrivate = "sa.key"
+	KeySAPublic  = "sa.pub"
+)

--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -152,6 +152,8 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 		},
 	}
 	flags := cmd.Flags()
+	// layout of secrets mounted into pods
+	flags.StringVarP(&opts.SecretLayout, "secret-layout", "", "legacy", "Secret layout mode for generated cert secrets: 'legacy' (single aggregated secret) or 'split' (per-component TLS secrets). Defaults to 'legacy'.")
 	flags.StringVarP(&opts.ImageRegistry, "private-image-registry", "", "", "Private image registry where pull images from. If set, all required images will be downloaded from it, it would be useful in offline installation scenarios.  In addition, you still can use --kube-image-registry to specify the registry for Kubernetes's images.")
 	flags.StringVarP(&opts.ImagePullPolicy, "image-pull-policy", "", string(corev1.PullIfNotPresent), "The image pull policy for all Karmada components container. One of Always, Never, IfNotPresent. Defaults to IfNotPresent.")
 	flags.StringSliceVar(&opts.PullSecrets, "image-pull-secrets", nil, "Image pull secrets are used to pull images from the private registry, could be secret list separated by comma (e.g '--image-pull-secrets PullSecret1,PullSecret2', the secrets should be pre-settled in the namespace declared by '--namespace')")

--- a/pkg/karmadactl/cmdinit/config/types.go
+++ b/pkg/karmadactl/cmdinit/config/types.go
@@ -74,6 +74,13 @@ type KarmadaInitSpec struct {
 	// WaitComponentReadyTimeout configures the timeout (in seconds) for waiting for components to be ready
 	// +optional
 	WaitComponentReadyTimeout int `json:"waitComponentReadyTimeout,omitempty" yaml:"waitComponentReadyTimeout,omitempty"`
+
+	// SecretLayout controls how certificate secrets are organized and mounted during init.
+	// One of:
+	//  - "legacy": use a single aggregated secret (default behavior prior to split-layout)
+	//  - "split":  create per-component TLS secrets (apiserver, etcd client/server, front-proxy, kcm CA/SA, webhook, etc.)
+	// +optional
+	SecretLayout string `json:"secretLayout,omitempty" yaml:"secretLayout,omitempty"`
 }
 
 // Certificates defines the configuration related to certificates

--- a/pkg/karmadactl/cmdinit/kubernetes/command.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/command.go
@@ -169,25 +169,47 @@ func (i *CommandInitOption) defaultKarmadaAggregatedAPIServerContainerCommand() 
 	if etcdServers = i.ExternalEtcdServers; etcdServers == "" {
 		etcdServers = strings.TrimRight(i.etcdServers(), ",")
 	}
-	command := []string{
-		"/bin/karmada-aggregated-apiserver",
-		fmt.Sprintf("--kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
-		fmt.Sprintf("--authentication-kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
-		fmt.Sprintf("--authorization-kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
-		fmt.Sprintf("--etcd-servers=%s", etcdServers),
-		fmt.Sprintf("--etcd-cafile=%s/%s.crt", karmadaCertsVolumeMountPath, options.EtcdCaCertAndKeyName),
-		fmt.Sprintf("--etcd-certfile=%s/%s.crt", karmadaCertsVolumeMountPath, options.EtcdClientCertAndKeyName),
-		fmt.Sprintf("--etcd-keyfile=%s/%s.key", karmadaCertsVolumeMountPath, options.EtcdClientCertAndKeyName),
-		fmt.Sprintf("--tls-cert-file=%s/%s.crt", karmadaCertsVolumeMountPath, options.KarmadaCertAndKeyName),
-		fmt.Sprintf("--tls-private-key-file=%s/%s.key", karmadaCertsVolumeMountPath, options.KarmadaCertAndKeyName),
-		"--tls-min-version=VersionTLS13",
-		"--audit-log-path=-",
-		"--audit-log-maxage=0",
-		"--audit-log-maxbackup=0",
-		"--bind-address=$(POD_IP)",
+	var command []string
+	if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+		command = []string{
+			"/bin/karmada-aggregated-apiserver",
+			fmt.Sprintf("--kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
+			fmt.Sprintf("--authentication-kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
+			fmt.Sprintf("--authorization-kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
+			fmt.Sprintf("--etcd-servers=%s", etcdServers),
+			fmt.Sprintf("--etcd-cafile=%s/ca.crt", etcdClientCertVolumeMountPath),
+			fmt.Sprintf("--etcd-certfile=%s/tls.crt", etcdClientCertVolumeMountPath),
+			fmt.Sprintf("--etcd-keyfile=%s/tls.key", etcdClientCertVolumeMountPath),
+			fmt.Sprintf("--tls-cert-file=%s/tls.crt", serverCertVolumeMountPath),
+			fmt.Sprintf("--tls-private-key-file=%s/tls.key", serverCertVolumeMountPath),
+			"--tls-min-version=VersionTLS13",
+			"--audit-log-path=-",
+			"--audit-log-maxage=0",
+			"--audit-log-maxbackup=0",
+			"--bind-address=$(POD_IP)",
+		}
+	} else {
+		command = []string{
+			"/bin/karmada-aggregated-apiserver",
+			fmt.Sprintf("--kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
+			fmt.Sprintf("--authentication-kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
+			fmt.Sprintf("--authorization-kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
+			fmt.Sprintf("--etcd-servers=%s", etcdServers),
+			fmt.Sprintf("--etcd-cafile=%s/%s.crt", karmadaCertsVolumeMountPath, options.EtcdCaCertAndKeyName),
+			fmt.Sprintf("--etcd-certfile=%s/%s.crt", karmadaCertsVolumeMountPath, options.EtcdClientCertAndKeyName),
+			fmt.Sprintf("--etcd-keyfile=%s/%s.key", karmadaCertsVolumeMountPath, options.EtcdClientCertAndKeyName),
+			fmt.Sprintf("--tls-cert-file=%s/%s.crt", karmadaCertsVolumeMountPath, options.KarmadaCertAndKeyName),
+			fmt.Sprintf("--tls-private-key-file=%s/%s.key", karmadaCertsVolumeMountPath, options.KarmadaCertAndKeyName),
+			"--tls-min-version=VersionTLS13",
+			"--audit-log-path=-",
+			"--audit-log-maxage=0",
+			"--audit-log-maxbackup=0",
+			"--bind-address=$(POD_IP)",
+		}
 	}
 	if i.ExternalEtcdKeyPrefix != "" {
 		command = append(command, fmt.Sprintf("--etcd-prefix=%s", i.ExternalEtcdKeyPrefix))
 	}
+	
 	return command
 }

--- a/pkg/karmadactl/cmdinit/kubernetes/deployments.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deployments.go
@@ -18,6 +18,8 @@ package kubernetes
 
 import (
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -26,6 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
+	certconst "github.com/karmada-io/karmada/pkg/cert"
+	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
 	globaloptions "github.com/karmada-io/karmada/pkg/karmadactl/options"
 	"github.com/karmada-io/karmada/pkg/karmadactl/util"
 	"github.com/karmada-io/karmada/pkg/util/names"
@@ -50,12 +54,28 @@ const (
 	controllerManagerDeploymentAndServiceName                   = names.KarmadaControllerManagerComponentName
 	controllerManagerSecurePort                                 = 10357
 	webhookDeploymentAndServiceAccountAndServiceName            = names.KarmadaWebhookComponentName
-	webhookCertsName                                            = "karmada-webhook-cert"
 	webhookCertVolumeMountPath                                  = "/var/serving-cert"
 	webhookPortName                                             = "webhook"
 	webhookTargetPort                                           = 8443
 	webhookPort                                                 = 443
 	karmadaAggregatedAPIServerDeploymentAndServiceName          = names.KarmadaAggregatedAPIServerComponentName
+)
+
+var (
+	// split-layout mount paths
+	serverCertVolumeMountPath                   = "/etc/karmada/pki/server"
+	etcdClientCertVolumeMountPath               = "/etc/karmada/pki/etcd-client"
+	frontProxyClientCertVolumeMountPath         = "/etc/karmada/pki/front-proxy-client"
+	saKeyPairVolumeMountPath                    = "/etc/karmada/pki/service-account-key-pair"
+	caCertVolumeMountPath                       = "/etc/karmada/pki/ca"
+	schedulerEstimatorClientCertVolumeMountPath = "/etc/karmada/pki/scheduler-estimator-client"
+	// Volume names for split-layout mounts
+	serverCertVolumeName                   = "server-cert"
+	etcdClientCertVolumeName               = "etcd-client-cert"
+	frontProxyClientCertVolumeName         = "front-proxy-client-cert"
+	saKeyPairVolumeName                    = "service-account-key-pair"
+	caCertVolumeName                       = "ca-cert"
+	schedulerEstimatorClientCertVolumeName = "scheduler-estimator-client-cert"
 )
 
 var (
@@ -73,6 +93,81 @@ func (i *CommandInitOption) etcdServers() string {
 		etcdClusterConfig += fmt.Sprintf("https://%s-%v.%s.%s.svc.%s:%v", etcdStatefulSetAndServiceName, v, etcdStatefulSetAndServiceName, i.Namespace, i.HostClusterDomain, etcdContainerClientPort) + ","
 	}
 	return etcdClusterConfig
+}
+
+func (i *CommandInitOption) karmadaAPIServerContainerCommand() []string {
+	var etcdServers string
+	if etcdServers = i.ExternalEtcdServers; etcdServers == "" {
+		etcdServers = strings.TrimRight(i.etcdServers(), ",")
+	}
+	var command []string
+	if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+		command = []string{
+			"kube-apiserver",
+			"--allow-privileged=true",
+			"--authorization-mode=Node,RBAC",
+			fmt.Sprintf("--client-ca-file=%s/ca.crt", serverCertVolumeMountPath),
+			"--enable-bootstrap-token-auth=true",
+			fmt.Sprintf("--etcd-cafile=%s/ca.crt", etcdClientCertVolumeMountPath),
+			fmt.Sprintf("--etcd-certfile=%s/tls.crt", etcdClientCertVolumeMountPath),
+			fmt.Sprintf("--etcd-keyfile=%s/tls.key", etcdClientCertVolumeMountPath),
+			fmt.Sprintf("--etcd-servers=%s", etcdServers),
+			"--bind-address=0.0.0.0",
+			"--disable-admission-plugins=StorageObjectInUseProtection,ServiceAccount",
+			"--runtime-config=",
+			fmt.Sprintf("--apiserver-count=%v", i.KarmadaAPIServerReplicas),
+			fmt.Sprintf("--secure-port=%v", karmadaAPIServerContainerPort),
+			fmt.Sprintf("--service-account-issuer=https://kubernetes.default.svc.%s", i.HostClusterDomain),
+			fmt.Sprintf("--service-account-key-file=%s/sa.pub", saKeyPairVolumeMountPath),
+			fmt.Sprintf("--service-account-signing-key-file=%s/sa.key", saKeyPairVolumeMountPath),
+			fmt.Sprintf("--service-cluster-ip-range=%s", serviceClusterIP),
+			fmt.Sprintf("--proxy-client-cert-file=%s/tls.crt", frontProxyClientCertVolumeMountPath),
+			fmt.Sprintf("--proxy-client-key-file=%s/tls.key", frontProxyClientCertVolumeMountPath),
+			"--requestheader-allowed-names=front-proxy-client",
+			fmt.Sprintf("--requestheader-client-ca-file=%s/ca.crt", frontProxyClientCertVolumeMountPath),
+			"--requestheader-extra-headers-prefix=X-Remote-Extra-",
+			"--requestheader-group-headers=X-Remote-Group",
+			"--requestheader-username-headers=X-Remote-User",
+			fmt.Sprintf("--tls-cert-file=%s/tls.crt", serverCertVolumeMountPath),
+			fmt.Sprintf("--tls-private-key-file=%s/tls.key", serverCertVolumeMountPath),
+			"--tls-min-version=VersionTLS13",
+		}
+	} else {
+		command = []string{
+			"kube-apiserver",
+			"--allow-privileged=true",
+			"--authorization-mode=Node,RBAC",
+			fmt.Sprintf("--client-ca-file=%s/%s.crt", karmadaCertsVolumeMountPath, globaloptions.CaCertAndKeyName),
+			"--enable-bootstrap-token-auth=true",
+			fmt.Sprintf("--etcd-cafile=%s/%s.crt", karmadaCertsVolumeMountPath, options.EtcdCaCertAndKeyName),
+			fmt.Sprintf("--etcd-certfile=%s/%s.crt", karmadaCertsVolumeMountPath, options.EtcdClientCertAndKeyName),
+			fmt.Sprintf("--etcd-keyfile=%s/%s.key", karmadaCertsVolumeMountPath, options.EtcdClientCertAndKeyName),
+			fmt.Sprintf("--etcd-servers=%s", etcdServers),
+			"--bind-address=0.0.0.0",
+			"--disable-admission-plugins=StorageObjectInUseProtection,ServiceAccount",
+			"--runtime-config=",
+			fmt.Sprintf("--apiserver-count=%v", i.KarmadaAPIServerReplicas),
+			fmt.Sprintf("--secure-port=%v", karmadaAPIServerContainerPort),
+			fmt.Sprintf("--service-account-issuer=https://kubernetes.default.svc.%s", i.HostClusterDomain),
+			fmt.Sprintf("--service-account-key-file=%s/%s.key", karmadaCertsVolumeMountPath, options.KarmadaCertAndKeyName),
+			fmt.Sprintf("--service-account-signing-key-file=%s/%s.key", karmadaCertsVolumeMountPath, options.KarmadaCertAndKeyName),
+			fmt.Sprintf("--service-cluster-ip-range=%s", serviceClusterIP),
+			fmt.Sprintf("--proxy-client-cert-file=%s/%s.crt", karmadaCertsVolumeMountPath, options.FrontProxyClientCertAndKeyName),
+			fmt.Sprintf("--proxy-client-key-file=%s/%s.key", karmadaCertsVolumeMountPath, options.FrontProxyClientCertAndKeyName),
+			"--requestheader-allowed-names=front-proxy-client",
+			fmt.Sprintf("--requestheader-client-ca-file=%s/%s.crt", karmadaCertsVolumeMountPath, options.FrontProxyCaCertAndKeyName),
+			"--requestheader-extra-headers-prefix=X-Remote-Extra-",
+			"--requestheader-group-headers=X-Remote-Group",
+			"--requestheader-username-headers=X-Remote-User",
+			fmt.Sprintf("--tls-cert-file=%s/%s.crt", karmadaCertsVolumeMountPath, options.ApiserverCertAndKeyName),
+			fmt.Sprintf("--tls-private-key-file=%s/%s.key", karmadaCertsVolumeMountPath, options.ApiserverCertAndKeyName),
+			"--tls-min-version=VersionTLS13",
+		}
+	}
+	if i.ExternalEtcdKeyPrefix != "" {
+		command = append(command, fmt.Sprintf("--etcd-prefix=%s", i.ExternalEtcdKeyPrefix))
+	}
+	return command
 }
 
 func (i *CommandInitOption) makeKarmadaAPIServerDeployment() *appsv1.Deployment {
@@ -153,27 +248,32 @@ func (i *CommandInitOption) makeKarmadaAPIServerDeployment() *appsv1.Deployment 
 						Protocol:      corev1.ProtocolTCP,
 					},
 				},
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      globaloptions.KarmadaCertsName,
-						ReadOnly:  true,
-						MountPath: karmadaCertsVolumeMountPath,
-					},
-				},
+				VolumeMounts: func() []corev1.VolumeMount {
+					if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+						return []corev1.VolumeMount{
+							{Name: serverCertVolumeName, ReadOnly: true, MountPath: serverCertVolumeMountPath},
+							{Name: etcdClientCertVolumeName, ReadOnly: true, MountPath: etcdClientCertVolumeMountPath},
+							{Name: frontProxyClientCertVolumeName, ReadOnly: true, MountPath: frontProxyClientCertVolumeMountPath},
+							{Name: saKeyPairVolumeName, ReadOnly: true, MountPath: saKeyPairVolumeMountPath},
+						}
+					}
+					return []corev1.VolumeMount{{Name: globaloptions.KarmadaCertsName, ReadOnly: true, MountPath: karmadaCertsVolumeMountPath}}
+				}(),
 				LivenessProbe:  livenessProbe,
 				ReadinessProbe: readinessProbe,
 			},
 		},
-		Volumes: []corev1.Volume{
-			{
-				Name: globaloptions.KarmadaCertsName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: globaloptions.KarmadaCertsName,
-					},
-				},
-			},
-		},
+		Volumes: func() []corev1.Volume {
+			if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+				return []corev1.Volume{
+					{Name: serverCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certconst.SecretApiserverServer}}},
+					{Name: etcdClientCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certconst.SecretApiserverEtcdClient}}},
+					{Name: frontProxyClientCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certconst.SecretApiserverFrontProxyClient}}},
+					{Name: saKeyPairVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certconst.SecretApiserverServiceAccountKeys}}},
+				}
+			}
+			return []corev1.Volume{{Name: globaloptions.KarmadaCertsName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: globaloptions.KarmadaCertsName}}}}
+		}(),
 		//HostNetwork:  true,
 		Tolerations: []corev1.Toleration{
 			{
@@ -258,9 +358,46 @@ func (i *CommandInitOption) makeKarmadaKubeControllerManagerDeployment() *appsv1
 		AutomountServiceAccountToken: ptr.To[bool](false),
 		Containers: []corev1.Container{
 			{
-				Name:          kubeControllerManagerClusterRoleAndDeploymentAndServiceName,
-				Image:         i.kubeControllerManagerImage(),
-				Command:       i.KubeControllerManagerContainerCmd,
+				Name:  kubeControllerManagerClusterRoleAndDeploymentAndServiceName,
+				Image: i.kubeControllerManagerImage(),
+				Command: func() []string {
+					var clientCAFile, clusterSigningCertFile, clusterSigningKeyFile, rootCAFile, saPrivKeyFile string
+					if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+						clientCAFile = fmt.Sprintf("%s/tls.crt", caCertVolumeMountPath)
+						clusterSigningCertFile = fmt.Sprintf("%s/tls.crt", caCertVolumeMountPath)
+						clusterSigningKeyFile = fmt.Sprintf("%s/tls.key", caCertVolumeMountPath)
+						rootCAFile = fmt.Sprintf("%s/tls.crt", caCertVolumeMountPath)
+						saPrivKeyFile = fmt.Sprintf("%s/sa.key", saKeyPairVolumeMountPath)
+					} else {
+						clientCAFile = fmt.Sprintf("%s/%s.crt", karmadaCertsVolumeMountPath, globaloptions.CaCertAndKeyName)
+						clusterSigningCertFile = fmt.Sprintf("%s/%s.crt", karmadaCertsVolumeMountPath, globaloptions.CaCertAndKeyName)
+						clusterSigningKeyFile = fmt.Sprintf("%s/%s.key", karmadaCertsVolumeMountPath, globaloptions.CaCertAndKeyName)
+						rootCAFile = fmt.Sprintf("%s/%s.crt", karmadaCertsVolumeMountPath, globaloptions.CaCertAndKeyName)
+						saPrivKeyFile = fmt.Sprintf("%s/%s.key", karmadaCertsVolumeMountPath, options.KarmadaCertAndKeyName)
+					}
+					return []string{
+						"kube-controller-manager",
+						"--allocate-node-cidrs=true",
+						fmt.Sprintf("--kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
+						fmt.Sprintf("--authentication-kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
+						fmt.Sprintf("--authorization-kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
+						"--bind-address=0.0.0.0",
+						fmt.Sprintf("--client-ca-file=%s", clientCAFile),
+						"--cluster-cidr=10.244.0.0/16",
+						fmt.Sprintf("--cluster-name=%s", options.ClusterName),
+						fmt.Sprintf("--cluster-signing-cert-file=%s", clusterSigningCertFile),
+						fmt.Sprintf("--cluster-signing-key-file=%s", clusterSigningKeyFile),
+						"--controllers=namespace,garbagecollector,serviceaccount-token,ttl-after-finished,bootstrapsigner,tokencleaner,csrcleaner,csrsigning,clusterrole-aggregation",
+						"--leader-elect=true",
+						fmt.Sprintf("--leader-elect-resource-namespace=%s", i.Namespace),
+						"--node-cidr-mask-size=24",
+						fmt.Sprintf("--root-ca-file=%s", rootCAFile),
+						fmt.Sprintf("--service-account-private-key-file=%s", saPrivKeyFile),
+						fmt.Sprintf("--service-cluster-ip-range=%s", serviceClusterIP),
+						"--use-service-account-credentials=true",
+						"--v=4",
+					}
+				}(),
 				LivenessProbe: livenessProbe,
 				Ports: []corev1.ContainerPort{
 					{
@@ -269,38 +406,34 @@ func (i *CommandInitOption) makeKarmadaKubeControllerManagerDeployment() *appsv1
 						Protocol:      corev1.ProtocolTCP,
 					},
 				},
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      karmadaConfigVolumeName,
-						ReadOnly:  true,
-						MountPath: karmadaConfigVolumeMountPath,
-					},
-					{
-						Name:      globaloptions.KarmadaCertsName,
-						ReadOnly:  true,
-						MountPath: karmadaCertsVolumeMountPath,
-					},
-				},
+				VolumeMounts: func() []corev1.VolumeMount {
+					if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+						return []corev1.VolumeMount{
+							{Name: karmadaConfigVolumeName, ReadOnly: true, MountPath: karmadaConfigVolumeMountPath},
+							{Name: caCertVolumeName, ReadOnly: true, MountPath: caCertVolumeMountPath},
+							{Name: saKeyPairVolumeName, ReadOnly: true, MountPath: saKeyPairVolumeMountPath},
+						}
+					}
+					return []corev1.VolumeMount{
+						{Name: karmadaConfigVolumeName, ReadOnly: true, MountPath: karmadaConfigVolumeMountPath},
+						{Name: globaloptions.KarmadaCertsName, ReadOnly: true, MountPath: karmadaCertsVolumeMountPath},
+					}
+				}(),
 			},
 		},
-		Volumes: []corev1.Volume{
-			{
-				Name: karmadaConfigVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: util.KarmadaConfigName(names.KubeControllerManagerComponentName),
-					},
-				},
-			},
-			{
-				Name: globaloptions.KarmadaCertsName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: globaloptions.KarmadaCertsName,
-					},
-				},
-			},
-		},
+		Volumes: func() []corev1.Volume {
+			if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+				return []corev1.Volume{
+					{Name: karmadaConfigVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: util.KarmadaConfigName(names.KubeControllerManagerComponentName)}}},
+					{Name: caCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certconst.SecretKubeControllerManagerCA}}},
+					{Name: saKeyPairVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certconst.SecretKubeControllerManagerSAKeys}}},
+				}
+			}
+			return []corev1.Volume{
+				{Name: karmadaConfigVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: util.KarmadaConfigName(names.KubeControllerManagerComponentName)}}},
+				{Name: globaloptions.KarmadaCertsName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: globaloptions.KarmadaCertsName}}},
+			}
+		}(),
 		Tolerations: []corev1.Toleration{
 			{
 				Effect:   corev1.TaintEffectNoExecute,
@@ -395,7 +528,31 @@ func (i *CommandInitOption) makeKarmadaSchedulerDeployment() *appsv1.Deployment 
 						},
 					},
 				},
-				Command:       i.KarmadaSchedulerContainerCmd,
+				Command: func() []string {
+					var estCAFile, estCertFile, estKeyFile string
+					if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+						estCAFile = fmt.Sprintf("%s/ca.crt", schedulerEstimatorClientCertVolumeMountPath)
+						estCertFile = fmt.Sprintf("%s/tls.crt", schedulerEstimatorClientCertVolumeMountPath)
+						estKeyFile = fmt.Sprintf("%s/tls.key", schedulerEstimatorClientCertVolumeMountPath)
+					} else {
+						estCAFile = "/etc/karmada/pki/ca.crt"
+						estCertFile = "/etc/karmada/pki/karmada.crt"
+						estKeyFile = "/etc/karmada/pki/karmada.key"
+					}
+					return []string{
+						"/bin/karmada-scheduler",
+						fmt.Sprintf("--kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
+						"--metrics-bind-address=$(POD_IP):8080",
+						"--health-probe-bind-address=$(POD_IP):10351",
+						"--enable-scheduler-estimator=true",
+						"--leader-elect=true",
+						fmt.Sprintf("--scheduler-estimator-ca-file=%s", estCAFile),
+						fmt.Sprintf("--scheduler-estimator-cert-file=%s", estCertFile),
+						fmt.Sprintf("--scheduler-estimator-key-file=%s", estKeyFile),
+						fmt.Sprintf("--leader-elect-resource-namespace=%s", i.Namespace),
+						"--v=4",
+					}
+				}(),
 				LivenessProbe: livenessProbe,
 				Ports: []corev1.ContainerPort{
 					{
@@ -404,38 +561,32 @@ func (i *CommandInitOption) makeKarmadaSchedulerDeployment() *appsv1.Deployment 
 						Protocol:      corev1.ProtocolTCP,
 					},
 				},
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      karmadaConfigVolumeName,
-						ReadOnly:  true,
-						MountPath: karmadaConfigVolumeMountPath,
-					},
-					{
-						Name:      globaloptions.KarmadaCertsName,
-						ReadOnly:  true,
-						MountPath: karmadaCertsVolumeMountPath,
-					},
-				},
+				VolumeMounts: func() []corev1.VolumeMount {
+					if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+						return []corev1.VolumeMount{
+							{Name: karmadaConfigVolumeName, ReadOnly: true, MountPath: karmadaConfigVolumeMountPath},
+							{Name: schedulerEstimatorClientCertVolumeName, ReadOnly: true, MountPath: schedulerEstimatorClientCertVolumeMountPath},
+						}
+					}
+					return []corev1.VolumeMount{
+						{Name: karmadaConfigVolumeName, ReadOnly: true, MountPath: karmadaConfigVolumeMountPath},
+						{Name: globaloptions.KarmadaCertsName, ReadOnly: true, MountPath: karmadaCertsVolumeMountPath},
+					}
+				}(),
 			},
 		},
-		Volumes: []corev1.Volume{
-			{
-				Name: karmadaConfigVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: util.KarmadaConfigName(names.KarmadaSchedulerComponentName),
-					},
-				},
-			},
-			{
-				Name: globaloptions.KarmadaCertsName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: globaloptions.KarmadaCertsName,
-					},
-				},
-			},
-		},
+		Volumes: func() []corev1.Volume {
+			if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+				return []corev1.Volume{
+					{Name: karmadaConfigVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: util.KarmadaConfigName(names.KarmadaSchedulerComponentName)}}},
+					{Name: schedulerEstimatorClientCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certconst.SecretSchedulerEstimatorClient}}},
+				}
+			}
+			return []corev1.Volume{
+				{Name: karmadaConfigVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: util.KarmadaConfigName(names.KarmadaSchedulerComponentName)}}},
+				{Name: globaloptions.KarmadaCertsName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: globaloptions.KarmadaCertsName}}},
+			}
+		}(),
 		Tolerations: []corev1.Toleration{
 			{
 				Effect:   corev1.TaintEffectNoExecute,
@@ -658,7 +809,24 @@ func (i *CommandInitOption) makeKarmadaWebhookDeployment() *appsv1.Deployment {
 						},
 					},
 				},
-				Command: i.KarmadaWebhookContainerCmd,
+				Command: func() []string {
+					var certDir string
+					if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+						certDir = serverCertVolumeMountPath
+					} else {
+						certDir = webhookCertVolumeMountPath
+					}
+					return []string{
+						"/bin/karmada-webhook",
+						fmt.Sprintf("--kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
+						"--bind-address=$(POD_IP)",
+						"--metrics-bind-address=$(POD_IP):8080",
+						"--health-probe-bind-address=$(POD_IP):8000",
+						fmt.Sprintf("--secure-port=%v", webhookTargetPort),
+						fmt.Sprintf("--cert-dir=%s", certDir),
+						"--v=4",
+					}
+				}(),
 				Ports: []corev1.ContainerPort{
 					{
 						Name:          webhookPortName,
@@ -671,39 +839,33 @@ func (i *CommandInitOption) makeKarmadaWebhookDeployment() *appsv1.Deployment {
 						Protocol:      corev1.ProtocolTCP,
 					},
 				},
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      karmadaConfigVolumeName,
-						ReadOnly:  true,
-						MountPath: karmadaConfigVolumeMountPath,
-					},
-					{
-						Name:      webhookCertsName,
-						ReadOnly:  true,
-						MountPath: webhookCertVolumeMountPath,
-					},
-				},
+				VolumeMounts: func() []corev1.VolumeMount {
+					if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+						return []corev1.VolumeMount{
+							{Name: karmadaConfigVolumeName, ReadOnly: true, MountPath: karmadaConfigVolumeMountPath},
+							{Name: serverCertVolumeName, ReadOnly: true, MountPath: serverCertVolumeMountPath},
+						}
+					}
+					return []corev1.VolumeMount{
+						{Name: karmadaConfigVolumeName, ReadOnly: true, MountPath: karmadaConfigVolumeMountPath},
+						{Name: certconst.SecretWebhook, ReadOnly: true, MountPath: webhookCertVolumeMountPath},
+					}
+				}(),
 				ReadinessProbe: readinesProbe,
 			},
 		},
-		Volumes: []corev1.Volume{
-			{
-				Name: karmadaConfigVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: util.KarmadaConfigName(names.KarmadaWebhookComponentName),
-					},
-				},
-			},
-			{
-				Name: webhookCertsName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: webhookCertsName,
-					},
-				},
-			},
-		},
+		Volumes: func() []corev1.Volume {
+			if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+				return []corev1.Volume{
+					{Name: karmadaConfigVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: util.KarmadaConfigName(names.KarmadaWebhookComponentName)}}},
+					{Name: serverCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certconst.SecretWebhook}}},
+				}
+			}
+			return []corev1.Volume{
+				{Name: karmadaConfigVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: util.KarmadaConfigName(names.KarmadaWebhookComponentName)}}},
+				{Name: certconst.SecretWebhook, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certconst.SecretWebhook}}},
+			}
+		}(),
 		Tolerations: []corev1.Toleration{
 			{
 				Effect:   corev1.TaintEffectNoExecute,
@@ -776,6 +938,10 @@ func (i *CommandInitOption) makeKarmadaAggregatedAPIServerDeployment() *appsv1.D
 		TimeoutSeconds:      15,
 	}
 
+	var etcdServers string
+	if etcdServers = i.ExternalEtcdServers; etcdServers == "" {
+		etcdServers = strings.TrimRight(i.etcdServers(), ",")
+	}
 	podSpec := corev1.PodSpec{
 		ImagePullSecrets:  i.getImagePullSecrets(),
 		PriorityClassName: i.KarmadaAggregatedAPIServerPriorityClass,
@@ -821,38 +987,34 @@ func (i *CommandInitOption) makeKarmadaAggregatedAPIServerDeployment() *appsv1.D
 						corev1.ResourceCPU: resource.MustParse("100m"),
 					},
 				},
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      karmadaConfigVolumeName,
-						ReadOnly:  true,
-						MountPath: karmadaConfigVolumeMountPath,
-					},
-					{
-						Name:      globaloptions.KarmadaCertsName,
-						ReadOnly:  true,
-						MountPath: karmadaCertsVolumeMountPath,
-					},
-				},
+				VolumeMounts: func() []corev1.VolumeMount {
+					if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+						return []corev1.VolumeMount{
+							{Name: karmadaConfigVolumeName, ReadOnly: true, MountPath: karmadaConfigVolumeMountPath},
+							{Name: serverCertVolumeName, ReadOnly: true, MountPath: serverCertVolumeMountPath},
+							{Name: etcdClientCertVolumeName, ReadOnly: true, MountPath: etcdClientCertVolumeMountPath},
+						}
+					}
+					return []corev1.VolumeMount{
+						{Name: karmadaConfigVolumeName, ReadOnly: true, MountPath: karmadaConfigVolumeMountPath},
+						{Name: globaloptions.KarmadaCertsName, ReadOnly: true, MountPath: karmadaCertsVolumeMountPath},
+					}
+				}(),
 			},
 		},
-		Volumes: []corev1.Volume{
-			{
-				Name: karmadaConfigVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: util.KarmadaConfigName(names.KarmadaAggregatedAPIServerComponentName),
-					},
-				},
-			},
-			{
-				Name: globaloptions.KarmadaCertsName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: globaloptions.KarmadaCertsName,
-					},
-				},
-			},
-		},
+		Volumes: func() []corev1.Volume {
+			if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+				return []corev1.Volume{
+					{Name: karmadaConfigVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: util.KarmadaConfigName(names.KarmadaAggregatedAPIServerComponentName)}}},
+					{Name: serverCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certconst.SecretAggregatedAPIServerServer}}},
+					{Name: etcdClientCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certconst.SecretAggregatedAPIServerEtcdClient}}},
+				}
+			}
+			return []corev1.Volume{
+				{Name: karmadaConfigVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: util.KarmadaConfigName(names.KarmadaAggregatedAPIServerComponentName)}}},
+				{Name: globaloptions.KarmadaCertsName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: globaloptions.KarmadaCertsName}}},
+			}
+		}(),
 		Tolerations: []corev1.Toleration{
 			{
 				Effect:   corev1.TaintEffectNoExecute,

--- a/pkg/karmadactl/cmdinit/kubernetes/deployments_test.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deployments_test.go
@@ -17,7 +17,18 @@ limitations under the License.
 package kubernetes
 
 import (
+	"context"
+	"fmt"
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	certconst "github.com/karmada-io/karmada/pkg/cert"
+	initopt "github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
+	globalopt "github.com/karmada-io/karmada/pkg/karmadactl/options"
+	"github.com/karmada-io/karmada/pkg/karmadactl/util"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 func TestCommandInitOption_etcdServers(t *testing.T) {
@@ -80,5 +91,175 @@ func TestCommandInitOption_makeKarmadaAggregatedAPIServerDeployment(t *testing.T
 	deployment := cmdOpt.makeKarmadaAggregatedAPIServerDeployment()
 	if deployment == nil {
 		t.Error("CommandInitOption.makeKarmadaAggregatedAPIServerDeployment() returns nil")
+	}
+}
+
+// helpers
+func hasFlag(cmd []string, want string) bool {
+	for _, c := range cmd {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestKarmadaAPIServerContainerCommand_Flags_SplitAndLegacy(t *testing.T) {
+	// split
+	split := CommandInitOption{
+		SecretLayout: "split",
+		Namespace:    "karmada",
+		EtcdReplicas: 1,
+	}
+	scmd := split.karmadaAPIServerContainerCommand()
+	if !hasFlag(scmd, fmt.Sprintf("--client-ca-file=%s/ca.crt", serverCertVolumeMountPath)) {
+		t.Fatalf("split: missing --client-ca-file=%s/ca.crt", serverCertVolumeMountPath)
+	}
+	if !hasFlag(scmd, fmt.Sprintf("--etcd-cafile=%s/ca.crt", etcdClientCertVolumeMountPath)) ||
+		!hasFlag(scmd, fmt.Sprintf("--etcd-certfile=%s/tls.crt", etcdClientCertVolumeMountPath)) ||
+		!hasFlag(scmd, fmt.Sprintf("--etcd-keyfile=%s/tls.key", etcdClientCertVolumeMountPath)) {
+		t.Fatalf("split: etcd client flags not using etcd-client mount path")
+	}
+	if !hasFlag(scmd, fmt.Sprintf("--tls-cert-file=%s/tls.crt", serverCertVolumeMountPath)) ||
+		!hasFlag(scmd, fmt.Sprintf("--tls-private-key-file=%s/tls.key", serverCertVolumeMountPath)) {
+		t.Fatalf("split: server tls flags not using server mount path")
+	}
+
+	// legacy
+	legacy := CommandInitOption{
+		Namespace:    "karmada",
+		EtcdReplicas: 1,
+	}
+	lcmd := legacy.karmadaAPIServerContainerCommand()
+	if !hasFlag(lcmd, fmt.Sprintf("--client-ca-file=%s/%s.crt", karmadaCertsVolumeMountPath, globalopt.CaCertAndKeyName)) {
+		t.Fatalf("legacy: missing client-ca-file from karmada-cert")
+	}
+	if !hasFlag(lcmd, fmt.Sprintf("--etcd-cafile=%s/%s.crt", karmadaCertsVolumeMountPath, initopt.EtcdCaCertAndKeyName)) ||
+		!hasFlag(lcmd, fmt.Sprintf("--etcd-certfile=%s/%s.crt", karmadaCertsVolumeMountPath, initopt.EtcdClientCertAndKeyName)) ||
+		!hasFlag(lcmd, fmt.Sprintf("--etcd-keyfile=%s/%s.key", karmadaCertsVolumeMountPath, initopt.EtcdClientCertAndKeyName)) {
+		t.Fatalf("legacy: missing etcd client flags from karmada-cert")
+	}
+}
+
+func TestMakeKarmadaAPIServerDeployment_SplitVolumesAndSecrets(t *testing.T) {
+	opt := CommandInitOption{Namespace: "karmada", SecretLayout: "split"}
+	dep := opt.makeKarmadaAPIServerDeployment()
+	ps := dep.Spec.Template.Spec
+
+	// volume mounts present with expected mount paths
+	wantMounts := map[string]string{
+		serverCertVolumeName:           serverCertVolumeMountPath,
+		etcdClientCertVolumeName:       etcdClientCertVolumeMountPath,
+		frontProxyClientCertVolumeName: frontProxyClientCertVolumeMountPath,
+		saKeyPairVolumeName:            saKeyPairVolumeMountPath,
+	}
+	for name, path := range wantMounts {
+		found := false
+		for _, m := range ps.Containers[0].VolumeMounts {
+			if m.Name == name && m.MountPath == path {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("split: missing VolumeMount %q at %q", name, path)
+		}
+	}
+
+	// volumes should reference expected secret names
+	wantSecrets := map[string]string{
+		serverCertVolumeName:           certconst.SecretApiserverServer,
+		etcdClientCertVolumeName:       certconst.SecretApiserverEtcdClient,
+		frontProxyClientCertVolumeName: certconst.SecretApiserverFrontProxyClient,
+		saKeyPairVolumeName:            certconst.SecretApiserverServiceAccountKeys,
+	}
+	for vname, sname := range wantSecrets {
+		found := false
+		for _, v := range ps.Volumes {
+			if v.Name == vname && v.VolumeSource.Secret != nil && v.VolumeSource.Secret.SecretName == sname {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("split: volume %q missing or secretName != %q", vname, sname)
+		}
+	}
+}
+
+func TestCreateSplitCertsSecrets_CreatesExpectedSecrets(t *testing.T) {
+	opt := CommandInitOption{
+		Namespace:     "karmada",
+		KubeClientSet: fake.NewClientset(),
+	}
+	// Minimal fake data for required certs/keys
+	opt.CertAndKeyFileData = map[string][]byte{
+		fmt.Sprintf("%s.crt", globalopt.CaCertAndKeyName):             []byte("CA"),
+		fmt.Sprintf("%s.key", globalopt.CaCertAndKeyName):             []byte("CAK"),
+		fmt.Sprintf("%s.crt", initopt.KarmadaCertAndKeyName):          []byte("KAR"),
+		fmt.Sprintf("%s.key", initopt.KarmadaCertAndKeyName):          []byte("KARK"),
+		fmt.Sprintf("%s.crt", initopt.ApiserverCertAndKeyName):        []byte("APS"),
+		fmt.Sprintf("%s.key", initopt.ApiserverCertAndKeyName):        []byte("APSK"),
+		fmt.Sprintf("%s.crt", initopt.FrontProxyCaCertAndKeyName):     []byte("FPCA"),
+		fmt.Sprintf("%s.crt", initopt.FrontProxyClientCertAndKeyName): []byte("FPC"),
+		fmt.Sprintf("%s.key", initopt.FrontProxyClientCertAndKeyName): []byte("FPCK"),
+		fmt.Sprintf("%s.crt", initopt.EtcdCaCertAndKeyName):           []byte("ECA"),
+		fmt.Sprintf("%s.crt", initopt.EtcdServerCertAndKeyName):       []byte("ESC"),
+		fmt.Sprintf("%s.key", initopt.EtcdServerCertAndKeyName):       []byte("ESK"),
+		fmt.Sprintf("%s.crt", initopt.EtcdClientCertAndKeyName):       []byte("ECC"),
+		fmt.Sprintf("%s.key", initopt.EtcdClientCertAndKeyName):       []byte("ECK"),
+	}
+
+	if err := opt.createSplitCertsSecrets(); err != nil {
+		t.Fatalf("createSplitCertsSecrets error: %v", err)
+	}
+
+	// pick representative secrets to assert
+	secretNames := []string{
+		certconst.SecretApiserverServer,
+		certconst.SecretApiserverEtcdClient,
+		certconst.SecretAggregatedAPIServerServer,
+		certconst.SecretEtcdServer,
+		certconst.SecretKubeControllerManagerCA,
+		certconst.SecretWebhook,
+		certconst.SecretSchedulerEstimatorClient,
+		globalopt.KarmadaCertsName, // CA-only compat
+	}
+	for _, n := range secretNames {
+		s, err := opt.KubeClientSet.CoreV1().Secrets(opt.Namespace).Get(context.Background(), n, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected secret %q to exist: %v", n, err)
+		}
+		switch n {
+		case globalopt.KarmadaCertsName:
+			if _, ok := s.StringData[certconst.KeyCACrt]; !ok {
+				t.Fatalf("compat secret %q missing %q", n, certconst.KeyCACrt)
+			}
+		case certconst.SecretApiserverServiceAccountKeys, certconst.SecretKubeControllerManagerSAKeys:
+			if _, ok := s.StringData[certconst.KeySAPrivate]; !ok {
+				t.Fatalf("secret %q missing %q", n, certconst.KeySAPrivate)
+			}
+			if _, ok := s.StringData[certconst.KeySAPublic]; !ok {
+				t.Fatalf("secret %q missing %q", n, certconst.KeySAPublic)
+			}
+		default:
+			if _, ok := s.StringData[certconst.KeyTLSCrt]; !ok {
+				t.Fatalf("secret %q missing %q", n, certconst.KeyTLSCrt)
+			}
+			if _, ok := s.StringData[certconst.KeyTLSKey]; !ok {
+				t.Fatalf("secret %q missing %q", n, certconst.KeyTLSKey)
+			}
+		}
+	}
+
+	// also ensure a few config secrets exist (created from karmadaConfigList)
+	confNames := []string{
+		util.KarmadaConfigName(names.KarmadaAggregatedAPIServerComponentName),
+		util.KarmadaConfigName(names.KubeControllerManagerComponentName),
+	}
+	for _, cn := range confNames {
+		if _, err := opt.KubeClientSet.CoreV1().Secrets(opt.Namespace).Get(context.Background(), cn, metav1.GetOptions{}); err != nil {
+			t.Fatalf("expected config secret %q to exist: %v", cn, err)
+		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
Part of #6670 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #6670 

This commit introduces the capability for the `karmadactl init` command to deploy Karmada components using a split-style secret layout.

This change is part of a larger effort to refactor the certificate deployment mechanism within the `karmadactl` tool. It allows for a more granular and secure management of component certificates.

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->
@chaosi-zju 
@zhzhuang-zju 
@XiShanYongYe-Chang 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmadactl`: Added the `--secret-layout` flag to the `init` command to support deploying with split certificate secrets.
```

