### PR TITLE
update explain cmd long message

### DIFF
--- a/pkg/karmadactl/explain/explain.go
+++ b/pkg/karmadactl/explain/explain.go
@@ -31,15 +31,14 @@ import (
 )
 
 var (
-	explainLong = templates.LongDesc(`
-		Describe fields and structure of various resources in Karmada control plane or a member cluster.
-
-		This command describes the fields associated with each supported API resource.
-		Fields are identified via a simple JSONPath identifier:
-
-			<type>.<fieldName>[.<fieldName>]
-
-		Information about each field is retrieved from the server in OpenAPI format.`)
+	explainLong = templates.LongDesc("Describe fields and structure of various resources in Karmada control plane or a member cluster.\n" +
+		"\n" +
+		"This command describes the fields associated with each supported API resource.\n" +
+		"Fields are identified via a simple JSONPath identifier:\n" +
+		"\n" +
+		"    `<type>.<fieldName>[.<fieldName>]`\n" +
+		"\n" +
+		"Information about each field is retrieved from the server in OpenAPI format.")
 
 	explainExamples = templates.Examples(`
 		# Get the documentation of the resource and its fields in Karmada control plane


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
Recently, the Karmada website has been preparing to upgrade Docusaurus from v2 to v3, which includes upgrading the MDX dependency to v3. As a result, some Markdown documents that previously compiled successfully under Docusaurus v2 may now fail to build under Docusaurus v3.

One such example is:\
https://github.com/karmada-io/website/blob/e222688eb46703f179db40fabe3a2040a59210a1/docs/reference/karmadactl/karmadactl-commands/karmadactl\_explain.md?plain=1#L13

The build error is:

<pre style="background: none"><code class="language-bash" data-language="bash" identifier="26cc901d931846e5a4fee12de5155f33-0" index="0" total="1">Error while compiling file docs/reference/karmadactl/karmadactl-commands/karmadactl_explain.md (Line=13 Column=9)
Details: Expected a closing tag for `&lt;fieldName&gt;` (13:29-13:40) before the end of `paragraph`</code></pre>

This happens because MDX v3’s stricter parser interprets `<fieldName>` as an unclosed HTML tag.

To resolve this issue, this PR wraps the <...> placeholders in the explain command’s long description with backticks (e.g., `<fieldName>`), so they are rendered as inline code instead of HTML tags.

I chose not to modify the genkarmadactldocs tool itself because the <...> pattern is widely used across many command descriptions, and a global change would have a broad impact. 



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note

```

