### PR TITLE
Fix wrong log format in scheduling_queue.go

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -206,7 +206,7 @@ func (bq *prioritySchedulingQueue) flushBackoffQCompleted() {
 		}
 		_, err := bq.backoffQ.Pop()
 		if err != nil {
-			klog.Error(err, "Unable to pop binding from backoff queue despite backoff completion", "binding", bInfo.NamespacedKey)
+			klog.ErrorS(err, "Unable to pop binding from backoff queue despite backoff completion", "binding", bInfo.NamespacedKey)
 			break
 		}
 		bq.moveToActiveQ(bInfo)
@@ -289,7 +289,7 @@ func (bq *prioritySchedulingQueue) PushUnschedulableIfNotPresent(bindingInfo *Qu
 	}
 
 	bq.unschedulableBindings.addOrUpdate(bindingInfo)
-	klog.V(4).Info("Binding moved to an internal scheduling queue", "binding", bindingInfo.NamespacedKey, "queue", unschedulableBindings)
+	klog.V(4).InfoS("Binding moved to an internal scheduling queue", "binding", bindingInfo.NamespacedKey, "queue", unschedulableBindings)
 }
 
 func (bq *prioritySchedulingQueue) PushBackoffIfNotPresent(bindingInfo *QueuedBindingInfo) {
@@ -301,7 +301,7 @@ func (bq *prioritySchedulingQueue) PushBackoffIfNotPresent(bindingInfo *QueuedBi
 	}
 
 	bq.backoffQ.AddOrUpdate(bindingInfo)
-	klog.V(4).Info("Binding moved to an internal scheduling queue", "binding", bindingInfo.NamespacedKey, "queue", backoffQ)
+	klog.V(4).InfoS("Binding moved to an internal scheduling queue", "binding", bindingInfo.NamespacedKey, "queue", backoffQ)
 }
 
 // Done must be called for binding returned by Pop. This allows the queue to
@@ -326,7 +326,7 @@ func (bq *prioritySchedulingQueue) moveToActiveQ(bindingInfo *QueuedBindingInfo)
 	bq.activeQ.Push(bindingInfo)
 	_ = bq.backoffQ.Delete(bindingInfo) // just ignore this not-found error
 	bq.unschedulableBindings.delete(bindingInfo.NamespacedKey)
-	klog.V(4).Info("Binding moved to an internal scheduling queue", "binding", bindingInfo.NamespacedKey, "queue", activeQ)
+	klog.V(4).InfoS("Binding moved to an internal scheduling queue", "binding", bindingInfo.NamespacedKey, "queue", activeQ)
 }
 
 // UnschedulableBindings holds bindings that cannot be scheduled. This data structure


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

I discovered a malformed log output in the scheduler:

```log
2025-09-28T22:02:17.993101169Z stderr F {"ts":1759096937993.0269,"caller":"queue/scheduling_queue.go:329","msg":"Binding moved to an internal scheduling queuebindingkarmadatest-r2lnx/deploy-wsc95-deploymentqueueActive","v":4}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

