### PR TITLE
feature(karmadactl): support new cert generate in init command split model

### DIFF
--- a/.github/workflows/installation-cli.yaml
+++ b/.github/workflows/installation-cli.yaml
@@ -106,3 +106,47 @@ jobs:
         with:
           name: karmadactl_config_test_logs_${{ matrix.k8s }}
           path: ${{ github.workspace }}/karmadactl-test-logs/${{ matrix.k8s }}/config/
+
+  test-on-kubernetes-split-secret:
+    name: Test on Kubernetes (Split Secret)
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        # Latest three minor releases of Kubernetes
+        k8s: [ v1.31.0, v1.32.0, v1.33.0 ]
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: run karmadactl init test (split secret layout)
+        run: |
+          export CLUSTER_VERSION=kindest/node:${{ matrix.k8s }}
+
+          # init e2e environment with split secret layout
+          hack/cli-testing-environment-split-secret.sh
+
+          # run a single e2e
+          export PULL_BASED_CLUSTERS="split-secret-member1:${HOME}/.kube/split-secret-member1.config"  
+          export KUBECONFIG=${HOME}/.kube/karmada-host.config:${HOME}/karmada/karmada-apiserver.config
+          GO111MODULE=on go install github.com/onsi/ginkgo/v2/ginkgo
+          ginkgo -v --race --trace -p  --focus="[BasicPropagation] propagation testing deployment propagation testing"  ./test/e2e/suites/base
+      - name: export logs (split secret)
+        if: always()
+        run: |
+          export ARTIFACTS_PATH=${{ github.workspace }}/karmadactl-test-logs/${{ matrix.k8s }}/split-secret
+          mkdir -p $ARTIFACTS_PATH
+
+          mkdir -p $ARTIFACTS_PATH/karmada-host
+          kind export logs --name=karmada-host $ARTIFACTS_PATH/karmada-host
+      - name: upload logs (split secret)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: karmadactl_split_secret_test_logs_${{ matrix.k8s }}
+          path: ${{ github.workspace }}/karmadactl-test-logs/${{ matrix.k8s }}/split-secret/

--- a/hack/cli-testing-environment-split-secret.sh
+++ b/hack/cli-testing-environment-split-secret.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Copyright 2025 The Karmada Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script starts a local karmada control plane with karmadactl and with a certain number of clusters joined,
+# identical to hack/cli-testing-environment.sh except adding '--secret-layout=split' for init.
+# This script depends on utils in: ${REPO_ROOT}/hack/util.sh
+# 1. used by developer to setup develop environment quickly.
+# 2. used by e2e testing to setup test environment automatically.
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${REPO_ROOT}"/hack/util.sh
+
+# variable define
+KUBECONFIG_PATH=${KUBECONFIG_PATH:-"${HOME}/.kube"}
+HOST_CLUSTER_NAME=${HOST_CLUSTER_NAME:-"karmada-host"}
+MEMBER_CLUSTER_1_NAME=${MEMBER_CLUSTER_1_NAME:-"split-secret-member1"}
+MEMBER_CLUSTER_2_NAME=${MEMBER_CLUSTER_2_NAME:-"split-secret-member2"}
+CLUSTER_VERSION=${CLUSTER_VERSION:-"${DEFAULT_CLUSTER_VERSION}"}
+BUILD_PATH=${BUILD_PATH:-"_output/bin/linux/amd64"}
+
+# install kind and kubectl
+echo -n "Preparing: 'kind' existence check - "
+if util::cmd_exist kind; then
+  echo "passed"
+else
+  echo "not pass"
+  # Install kind using the version defined in util.sh
+  util::install_tools "sigs.k8s.io/kind" "${KIND_VERSION}"
+fi
+# get arch name and os name in bootstrap
+BS_ARCH=$(go env GOARCH)
+BS_OS=$(go env GOOS)
+# check arch and os name before installing
+util::install_environment_check "${BS_ARCH}" "${BS_OS}"
+echo -n "Preparing: 'kubectl' existence check - "
+if util::cmd_exist kubectl; then
+  echo "passed"
+else
+  echo "not pass"
+  util::install_kubectl "" "${BS_ARCH}" "${BS_OS}"
+fi
+
+# prepare the newest crds
+echo "Prepare the newest crds"
+cd  charts/karmada/
+cp -r _crds crds
+tar -zcvf ../../crds.tar.gz crds
+cd -
+
+# make images
+export VERSION="latest"
+export REGISTRY="docker.io/karmada"
+make images GOOS="linux" --directory="${REPO_ROOT}"
+
+# make karmadactl binary
+make karmadactl
+
+# create host/member1/member2 cluster
+echo "Start create clusters..."
+hack/create-cluster.sh ${HOST_CLUSTER_NAME} ${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config > /dev/null 2>&1 &
+hack/create-cluster.sh ${MEMBER_CLUSTER_1_NAME} ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_1_NAME}.config > /dev/null 2>&1 &
+hack/create-cluster.sh ${MEMBER_CLUSTER_2_NAME} ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_2_NAME}.config > /dev/null 2>&1 &
+
+# wait cluster ready
+echo "Wait clusters ready..."
+util::wait_file_exist ${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config 300
+util::wait_context_exist ${HOST_CLUSTER_NAME} ${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config 300
+kubectl wait --for=condition=Ready nodes --all --timeout=800s --kubeconfig=${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config
+util::wait_nodes_taint_disappear 800 ${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config
+
+util::wait_file_exist ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_1_NAME}.config 300
+util::wait_context_exist "${MEMBER_CLUSTER_1_NAME}" ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_1_NAME}.config 300
+kubectl wait --for=condition=Ready nodes --all --timeout=800s --kubeconfig=${KUBECONFIG_PATH}/${MEMBER_CLUSTER_1_NAME}.config
+util::wait_nodes_taint_disappear 800 ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_1_NAME}.config
+
+util::wait_file_exist ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_2_NAME}.config 300
+util::wait_context_exist "${MEMBER_CLUSTER_2_NAME}" ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_2_NAME}.config 300
+kubectl wait --for=condition=Ready nodes --all --timeout=800s --kubeconfig=${KUBECONFIG_PATH}/${MEMBER_CLUSTER_2_NAME}.config
+util::wait_nodes_taint_disappear 800 ${KUBECONFIG_PATH}/${MEMBER_CLUSTER_2_NAME}.config
+
+# load components images to kind cluster
+kind load docker-image "${REGISTRY}/karmada-controller-manager:${VERSION}" --name="${HOST_CLUSTER_NAME}"
+kind load docker-image "${REGISTRY}/karmada-scheduler:${VERSION}" --name="${HOST_CLUSTER_NAME}"
+kind load docker-image "${REGISTRY}/karmada-webhook:${VERSION}" --name="${HOST_CLUSTER_NAME}"
+kind load docker-image "${REGISTRY}/karmada-aggregated-apiserver:${VERSION}" --name="${HOST_CLUSTER_NAME}"
+kind load docker-image "${REGISTRY}/karmada-agent:${VERSION}" --name="${MEMBER_CLUSTER_1_NAME}"
+
+# init Karmada control plane
+echo "Start init karmada control plane..."
+${BUILD_PATH}/karmadactl init --kubeconfig=${KUBECONFIG_PATH}/${HOST_CLUSTER_NAME}.config \
+    --karmada-controller-manager-image="${REGISTRY}/karmada-controller-manager:${VERSION}" \
+    --karmada-scheduler-image="${REGISTRY}/karmada-scheduler:${VERSION}" \
+    --karmada-webhook-image="${REGISTRY}/karmada-webhook:${VERSION}" \
+    --karmada-aggregated-apiserver-image="${REGISTRY}/karmada-aggregated-apiserver:${VERSION}" \
+    --karmada-data=${HOME}/karmada \
+    --karmada-pki=${HOME}/karmada/pki \
+    --crds=./crds.tar.gz \
+    --secret-layout='split'
+
+# join cluster
+echo "Join member clusters..."
+TOKEN_CMD=$(${BUILD_PATH}/karmadactl --kubeconfig ${HOME}/karmada/karmada-apiserver.config token create --print-register-command)
+TOKEN=$(echo "$TOKEN_CMD" | grep -o '\--token [^ ]*' | cut -d' ' -f2)
+HASH=$(echo "$TOKEN_CMD" | grep -o '\--discovery-token-ca-cert-hash [^ ]*' | cut -d' ' -f2)
+ENDPOINT=$(kubectl --kubeconfig ${HOME}/karmada/karmada-apiserver.config config view --minify -o jsonpath='{.clusters[0].cluster.server}' | sed 's|^https://||')
+
+${BUILD_PATH}/karmadactl register ${ENDPOINT} \
+    --token ${TOKEN} \
+    --discovery-token-ca-cert-hash ${HASH} \
+    --kubeconfig=${KUBECONFIG_PATH}/${MEMBER_CLUSTER_1_NAME}.config \
+    --cluster-name=${MEMBER_CLUSTER_1_NAME} \
+    --karmada-agent-image "${REGISTRY}/karmada-agent:${VERSION}" \
+    --v=4
+
+${BUILD_PATH}/karmadactl --kubeconfig ${HOME}/karmada/karmada-apiserver.config join ${MEMBER_CLUSTER_2_NAME} --cluster-kubeconfig=${KUBECONFIG_PATH}/${MEMBER_CLUSTER_2_NAME}.config
+
+kubectl wait --for=condition=Ready clusters --all --timeout=800s --kubeconfig=${HOME}/karmada/karmada-apiserver.config

--- a/pkg/cert/constants.go
+++ b/pkg/cert/constants.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cert
+
+// Package cert centralizes TLS-related constants (secret names and key names)
+// so they can be shared by cmdinit and future operator implementations.
+
+// Secret names for split-layout TLS materials
+// nolint:gosec // These are Kubernetes Secret resource names, not credentials.
+const (
+	// apiserver
+	SecretApiserverServer             = "karmada-apiserver-cert"
+	SecretApiserverEtcdClient         = "karmada-apiserver-etcd-client-cert"
+	SecretApiserverFrontProxyClient   = "karmada-apiserver-front-proxy-client-cert"
+	SecretApiserverServiceAccountKeys = "karmada-apiserver-service-account-key-pair"
+
+	// aggregated apiserver
+	SecretAggregatedAPIServerServer     = "karmada-aggregated-apiserver-cert"
+	SecretAggregatedAPIServerEtcdClient = "karmada-aggregated-apiserver-etcd-client-cert"
+
+	// kube-controller-manager
+	SecretKubeControllerManagerCA     = "kube-controller-manager-ca-cert"
+	SecretKubeControllerManagerSAKeys = "kube-controller-manager-service-account-key-pair"
+
+	// scheduler(estimator) clients
+	SecretSchedulerEstimatorClient   = "karmada-scheduler-scheduler-estimator-client-cert"
+	SecretDeschedulerEstimatorClient = "karmada-descheduler-scheduler-estimator-client-cert"
+
+	// etcd (internal)
+	SecretEtcdServer = "etcd-cert"
+	SecretEtcdClient = "etcd-etcd-client-cert"
+
+	// webhook serving cert
+	SecretWebhook = "karmada-webhook-cert"
+)
+
+// PEM key names used inside TLS secrets
+const (
+	KeyTLSCrt    = "tls.crt"
+	KeyTLSKey    = "tls.key"
+	KeyCACrt     = "ca.crt"
+	KeySAPrivate = "sa.key"
+	KeySAPublic  = "sa.pub"
+)

--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -152,6 +152,8 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 		},
 	}
 	flags := cmd.Flags()
+	// layout of secrets mounted into pods
+	flags.StringVarP(&opts.SecretLayout, "secret-layout", "", "legacy", "Secret layout mode for generated cert secrets: 'legacy' (single aggregated secret) or 'split' (per-component TLS secrets). Defaults to 'legacy'.")
 	flags.StringVarP(&opts.ImageRegistry, "private-image-registry", "", "", "Private image registry where pull images from. If set, all required images will be downloaded from it, it would be useful in offline installation scenarios.  In addition, you still can use --kube-image-registry to specify the registry for Kubernetes's images.")
 	flags.StringVarP(&opts.ImagePullPolicy, "image-pull-policy", "", string(corev1.PullIfNotPresent), "The image pull policy for all Karmada components container. One of Always, Never, IfNotPresent. Defaults to IfNotPresent.")
 	flags.StringSliceVar(&opts.PullSecrets, "image-pull-secrets", nil, "Image pull secrets are used to pull images from the private registry, could be secret list separated by comma (e.g '--image-pull-secrets PullSecret1,PullSecret2', the secrets should be pre-settled in the namespace declared by '--namespace')")

--- a/pkg/karmadactl/cmdinit/config/types.go
+++ b/pkg/karmadactl/cmdinit/config/types.go
@@ -74,6 +74,13 @@ type KarmadaInitSpec struct {
 	// WaitComponentReadyTimeout configures the timeout (in seconds) for waiting for components to be ready
 	// +optional
 	WaitComponentReadyTimeout int `json:"waitComponentReadyTimeout,omitempty" yaml:"waitComponentReadyTimeout,omitempty"`
+
+	// SecretLayout controls how certificate secrets are organized and mounted during init.
+	// One of:
+	//  - "legacy": use a single aggregated secret (default behavior prior to split-layout)
+	//  - "split":  create per-component TLS secrets (apiserver, etcd client/server, front-proxy, kcm CA/SA, webhook, etc.)
+	// +optional
+	SecretLayout string `json:"secretLayout,omitempty" yaml:"secretLayout,omitempty"`
 }
 
 // Certificates defines the configuration related to certificates

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -60,7 +60,8 @@ var (
 		"cn":     "registry.cn-hangzhou.aliyuncs.com/google_containers",
 	}
 
-	certList = []string{
+	// Legacy minimal certificate set (old layout)
+	certListLegacy = []string{
 		globaloptions.CaCertAndKeyName,
 		options.EtcdCaCertAndKeyName,
 		options.EtcdServerCertAndKeyName,
@@ -69,6 +70,51 @@ var (
 		options.ApiserverCertAndKeyName,
 		options.FrontProxyCaCertAndKeyName,
 		options.FrontProxyClientCertAndKeyName,
+	}
+
+	// Full certificate set for split layout (independent CN per component)
+	certListSplit = []string{
+		// CAs
+		globaloptions.CaCertAndKeyName,
+		options.EtcdCaCertAndKeyName,
+		options.FrontProxyCaCertAndKeyName,
+
+		// Servers
+		options.KarmadaAPIServerCertAndKeyName,
+		options.KarmadaAggregatedAPIServerCertAndKeyName,
+		options.KarmadaWebhookCertAndKeyName,
+		options.KarmadaSearchCertAndKeyName,
+		options.KarmadaMetricsAdapterCertAndKeyName,
+		options.KarmadaSchedulerEstimatorCertAndKeyName,
+		options.EtcdServerCertAndKeyName,
+
+		// Clients
+		options.KarmadaAPIServerClientCertAndKeyName,
+		options.KarmadaAggregatedAPIServerClientCertAndKeyName,
+		options.KarmadaWebhookClientCertAndKeyName,
+		options.KarmadaSearchClientCertAndKeyName,
+		options.KarmadaMetricsAdapterClientCertAndKeyName,
+		options.KarmadaSchedulerEstimatorClientCertAndKeyName,
+		options.KarmadaControllerManagerClientCertAndKeyName,
+		options.KubeControllerManagerClientCertAndKeyName,
+		options.KarmadaSchedulerClientCertAndKeyName,
+		options.KarmadaDeschedulerClientCertAndKeyName,
+
+		// ETCD clients
+		options.KarmadaAPIServerEtcdClientCertAndKeyName,
+		options.KarmadaAggregatedAPIServerEtcdClientCertAndKeyName,
+		options.KarmadaSearchEtcdClientCertAndKeyName,
+		options.EtcdClientCertAndKeyName,
+
+		// GRPC clients
+		options.KarmadaSchedulerGrpcCertAndKeyName,
+		options.KarmadaDeschedulerGrpcCertAndKeyName,
+
+		// front proxy
+		options.FrontProxyClientCertAndKeyName,
+
+		// Admin kubeconfig client
+		options.KarmadaCertAndKeyName,
 	}
 
 	karmadaConfigList = []string{
@@ -93,6 +139,28 @@ var (
 			return emptyByteSlice, emptyByteSlice, nil
 		},
 		options.EtcdClientCertAndKeyName: func(option *CommandInitOption) (cert, key []byte, err error) {
+			if cert, err = os.ReadFile(option.ExternalEtcdClientCertPath); err != nil {
+				return
+			}
+			key, err = os.ReadFile(option.ExternalEtcdClientKeyPath)
+			return
+		},
+		// map split-layout etcd client variants to external etcd client credentials
+		options.KarmadaAPIServerEtcdClientCertAndKeyName: func(option *CommandInitOption) (cert, key []byte, err error) {
+			if cert, err = os.ReadFile(option.ExternalEtcdClientCertPath); err != nil {
+				return
+			}
+			key, err = os.ReadFile(option.ExternalEtcdClientKeyPath)
+			return
+		},
+		options.KarmadaAggregatedAPIServerEtcdClientCertAndKeyName: func(option *CommandInitOption) (cert, key []byte, err error) {
+			if cert, err = os.ReadFile(option.ExternalEtcdClientCertPath); err != nil {
+				return
+			}
+			key, err = os.ReadFile(option.ExternalEtcdClientKeyPath)
+			return
+		},
+		options.KarmadaSearchEtcdClientCertAndKeyName: func(option *CommandInitOption) (cert, key []byte, err error) {
 			if cert, err = os.ReadFile(option.ExternalEtcdClientCertPath); err != nil {
 				return
 			}
@@ -516,6 +584,112 @@ func (i *CommandInitOption) genCerts() error {
 	return nil
 }
 
+// buildDefaultAltNames builds a standard AltNames set for in-cluster service endpoints
+// of a given component, plus localhost and optional external DNS/IPs.
+func (i *CommandInitOption) buildDefaultAltNames(componentName string) certutil.AltNames {
+	defaultDNS := []string{
+		fmt.Sprintf("%s.karmada-system.svc", componentName),
+		fmt.Sprintf("%s.karmada-system.svc.cluster.local", componentName),
+		fmt.Sprintf("%s.%s.svc.%s", componentName, i.Namespace, i.HostClusterDomain),
+		"localhost",
+	}
+	defaultDNS = append(defaultDNS, utils.FlagsDNS(i.ExternalDNS)...)
+
+	defaultIPs := []net.IP{utils.StringToNetIP("127.0.0.1")}
+	defaultIPs = append(
+		defaultIPs,
+		utils.FlagsIP(i.ExternalIP)...,
+	)
+	defaultIPs = append(defaultIPs, i.KarmadaAPIServerIP...)
+	if ip, err := utils.InternetIP(); err == nil {
+		defaultIPs = append(defaultIPs, ip)
+	} else {
+		klog.Warningln("Failed to obtain internet IP. ", err)
+	}
+
+	return certutil.AltNames{DNSNames: defaultDNS, IPs: defaultIPs}
+}
+
+// buildSchedulerEstimatorAltNames returns AltNames for scheduler-estimator server
+// covering wildcard services in karmada-system and namespace-scoped services.
+func (i *CommandInitOption) buildSchedulerEstimatorAltNames() certutil.AltNames {
+	dns := []string{
+		"*.karmada-system.svc.cluster.local",
+		"*.karmada-system.svc",
+		fmt.Sprintf("*.%s.svc.%s", i.Namespace, i.HostClusterDomain),
+		"localhost",
+	}
+	ips := []net.IP{utils.StringToNetIP("127.0.0.1")}
+	dns = append(dns, utils.FlagsDNS(i.ExternalDNS)...)
+	ips = append(ips, utils.FlagsIP(i.ExternalIP)...)
+	ips = append(ips, i.KarmadaAPIServerIP...)
+	if ip, err := utils.InternetIP(); err == nil {
+		ips = append(ips, ip)
+	} else {
+		klog.Warningln("Failed to obtain internet IP. ", err)
+	}
+	return certutil.AltNames{DNSNames: dns, IPs: ips}
+}
+
+// genCertsSplitFull builds full set of component certificates (independent CN + SAN)
+// and generates them using cert.NewGenCerts with proper CA selection.
+func (i *CommandInitOption) genCertsSplitFull() error {
+	notAfter := time.Now().Add(i.CertValidity).UTC()
+
+	cfg := map[string]*cert.CertsConfig{}
+
+	// Admin kubeconfig client (for users)
+	adminAlt := i.buildDefaultAltNames("karmada-apiserver")
+	cfg[options.KarmadaCertAndKeyName] = cert.NewCertConfig("system:admin", []string{"system:masters"}, adminAlt, &notAfter)
+
+	// Servers
+	cfg[options.KarmadaAPIServerCertAndKeyName] = cert.NewCertConfig(options.KarmadaAPIServerCN, []string{}, i.buildDefaultAltNames("karmada-apiserver"), &notAfter)
+	cfg[options.KarmadaAggregatedAPIServerCertAndKeyName] = cert.NewCertConfig(options.KarmadaAggregatedAPIServerCN, []string{}, i.buildDefaultAltNames("karmada-aggregated-apiserver"), &notAfter)
+	cfg[options.KarmadaWebhookCertAndKeyName] = cert.NewCertConfig(options.KarmadaWebhookCN, []string{}, i.buildDefaultAltNames("karmada-webhook"), &notAfter)
+	cfg[options.KarmadaSearchCertAndKeyName] = cert.NewCertConfig(options.KarmadaSearchCN, []string{}, i.buildDefaultAltNames(names.KarmadaSearchComponentName), &notAfter)
+	cfg[options.KarmadaMetricsAdapterCertAndKeyName] = cert.NewCertConfig(options.KarmadaMetricsAdapterCN, []string{}, i.buildDefaultAltNames(names.KarmadaMetricsAdapterComponentName), &notAfter)
+	cfg[options.KarmadaSchedulerEstimatorCertAndKeyName] = cert.NewCertConfig(options.KarmadaSchedulerEstimatorCN, []string{}, i.buildSchedulerEstimatorAltNames(), &notAfter)
+
+	if !i.isExternalEtcdProvided() {
+		// etcd server
+		etcdDNS := []string{"localhost"}
+		for number := int32(0); number < i.EtcdReplicas; number++ {
+			etcdDNS = append(etcdDNS, fmt.Sprintf("%s-%v.%s.%s.svc.%s", etcdStatefulSetAndServiceName, number, etcdStatefulSetAndServiceName, i.Namespace, i.HostClusterDomain))
+		}
+		cfg[options.EtcdServerCertAndKeyName] = cert.NewCertConfig(options.KarmadaEtcdServerCN, []string{}, certutil.AltNames{DNSNames: etcdDNS, IPs: []net.IP{utils.StringToNetIP("127.0.0.1")}}, &notAfter)
+	}
+
+	// Clients (Org: system:masters)
+	cfg[options.KarmadaAPIServerClientCertAndKeyName] = cert.NewCertConfig(options.KarmadaAPIServerCN, []string{"system:masters"}, certutil.AltNames{}, &notAfter)
+	cfg[options.KarmadaAggregatedAPIServerClientCertAndKeyName] = cert.NewCertConfig(options.KarmadaAggregatedAPIServerCN, []string{"system:masters"}, certutil.AltNames{}, &notAfter)
+	cfg[options.KarmadaWebhookClientCertAndKeyName] = cert.NewCertConfig(options.KarmadaWebhookCN, []string{"system:masters"}, certutil.AltNames{}, &notAfter)
+	cfg[options.KarmadaSearchClientCertAndKeyName] = cert.NewCertConfig(options.KarmadaSearchCN, []string{"system:masters"}, certutil.AltNames{}, &notAfter)
+	cfg[options.KarmadaMetricsAdapterClientCertAndKeyName] = cert.NewCertConfig(options.KarmadaMetricsAdapterCN, []string{"system:masters"}, certutil.AltNames{}, &notAfter)
+	cfg[options.KarmadaSchedulerEstimatorClientCertAndKeyName] = cert.NewCertConfig(options.KarmadaSchedulerEstimatorCN, []string{"system:masters"}, certutil.AltNames{}, &notAfter)
+	cfg[options.KarmadaControllerManagerClientCertAndKeyName] = cert.NewCertConfig(options.KarmadaControllerManagerCN, []string{"system:masters"}, certutil.AltNames{}, &notAfter)
+	cfg[options.KubeControllerManagerClientCertAndKeyName] = cert.NewCertConfig(options.KubeControllerManagerCN, []string{"system:masters"}, certutil.AltNames{}, &notAfter)
+	cfg[options.KarmadaSchedulerClientCertAndKeyName] = cert.NewCertConfig(options.KarmadaSchedulerCN, []string{"system:masters"}, certutil.AltNames{}, &notAfter)
+	cfg[options.KarmadaDeschedulerClientCertAndKeyName] = cert.NewCertConfig(options.KarmadaDeschedulerCN, []string{"system:masters"}, certutil.AltNames{}, &notAfter)
+
+	// ETCD clients
+	cfg[options.KarmadaAPIServerEtcdClientCertAndKeyName] = cert.NewCertConfig(options.KarmadaAPIServerEtcdClientCN, []string{"system:masters"}, certutil.AltNames{}, &notAfter)
+	cfg[options.KarmadaAggregatedAPIServerEtcdClientCertAndKeyName] = cert.NewCertConfig(options.KarmadaAggregatedAPIServerEtcdClientCN, []string{"system:masters"}, certutil.AltNames{}, &notAfter)
+	cfg[options.KarmadaSearchEtcdClientCertAndKeyName] = cert.NewCertConfig(options.KarmadaSearchEtcdClientCN, []string{"system:masters"}, certutil.AltNames{}, &notAfter)
+	cfg[options.EtcdClientCertAndKeyName] = cert.NewCertConfig(options.KarmadaEtcdClientCN, []string{""}, certutil.AltNames{}, &notAfter)
+
+	// GRPC clients
+	cfg[options.KarmadaSchedulerGrpcCertAndKeyName] = cert.NewCertConfig(options.KarmadaSchedulerGrpcCN, []string{"system:masters"}, certutil.AltNames{}, &notAfter)
+	cfg[options.KarmadaDeschedulerGrpcCertAndKeyName] = cert.NewCertConfig(options.KarmadaDeschedulerGrpcCN, []string{"system:masters"}, certutil.AltNames{}, &notAfter)
+
+	// front-proxy client
+	cfg[options.FrontProxyClientCertAndKeyName] = cert.NewCertConfig(options.KarmadaFrontProxyClientCN, []string{}, certutil.AltNames{}, &notAfter)
+
+	if err := cert.NewGenCerts(i.KarmadaPkiPath, i.CaCertFile, i.CaKeyFile, cfg); err != nil {
+		return err
+	}
+	return nil
+}
+
 // prepareCRD download or unzip `crds.tar.gz` to `options.DataPath`
 func (i *CommandInitOption) prepareCRD() error {
 	var filename string
@@ -581,7 +755,7 @@ func (i *CommandInitOption) createCertsSecrets() error {
 	}
 
 	karmadaCert := map[string]string{}
-	for _, v := range certList {
+	for _, v := range certListLegacy {
 		karmadaCert[fmt.Sprintf("%s.crt", v)] = string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", v)])
 		karmadaCert[fmt.Sprintf("%s.key", v)] = string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", v)])
 	}
@@ -604,36 +778,66 @@ func (i *CommandInitOption) createCertsSecrets() error {
 
 // createSplitCertsSecrets creates per-component TLS secrets following the deploy-karmada.sh layout
 func (i *CommandInitOption) createSplitCertsSecrets() error {
-	// Kubeconfig for components (unchanged)
-	karmadaServerURL := fmt.Sprintf("https://%s.%s.svc.%s:%v", karmadaAPIServerDeploymentAndServiceName, i.Namespace, i.HostClusterDomain, karmadaAPIServerContainerPort)
-	config := utils.CreateWithCerts(karmadaServerURL, options.UserName, options.UserName, i.CertAndKeyFileData[fmt.Sprintf("%s.crt", globaloptions.CaCertAndKeyName)],
-		i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaCertAndKeyName)], i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaCertAndKeyName)])
-	configBytes, err := clientcmd.Write(*config)
-	if err != nil {
-		return fmt.Errorf("failure while serializing admin kubeConfig. %v", err)
+	// Kubeconfig for components (each uses its own client cert)
+	karmadaServerURL := fmt.Sprintf("https://%s.%s.svc.%s:%v", "karmada-apiserver", i.Namespace, i.HostClusterDomain, karmadaAPIServerContainerPort)
+
+	// helper to create kubeconfig secret by client cert name
+	createCfg := func(secretName, clientCertName string) error {
+		cfg := utils.CreateWithCerts(
+			karmadaServerURL,
+			options.UserName,
+			options.UserName,
+			i.CertAndKeyFileData[fmt.Sprintf("%s.crt", globaloptions.CaCertAndKeyName)],
+			i.CertAndKeyFileData[fmt.Sprintf("%s.key", clientCertName)],
+			i.CertAndKeyFileData[fmt.Sprintf("%s.crt", clientCertName)],
+		)
+		b, err := clientcmd.Write(*cfg)
+		if err != nil {
+			return fmt.Errorf("failure while serializing component kubeConfig for %s: %v", secretName, err)
+		}
+		sec := i.SecretFromSpec(secretName, corev1.SecretTypeOpaque, map[string]string{util.KarmadaConfigFieldName: string(b)})
+		return util.CreateOrUpdateSecret(i.KubeClientSet, sec)
 	}
 
-	for _, karmadaConfigSecretName := range karmadaConfigList {
-		karmadaConfigSecret := i.SecretFromSpec(karmadaConfigSecretName, corev1.SecretTypeOpaque, map[string]string{util.KarmadaConfigFieldName: string(configBytes)})
-		if err = util.CreateOrUpdateSecret(i.KubeClientSet, karmadaConfigSecret); err != nil {
+	// mapping from component config secret to its client cert name
+	cfgMapping := map[string]string{
+		util.KarmadaConfigName(names.KarmadaAggregatedAPIServerComponentName): options.KarmadaAggregatedAPIServerClientCertAndKeyName,
+		util.KarmadaConfigName(names.KarmadaControllerManagerComponentName):   options.KarmadaControllerManagerClientCertAndKeyName,
+		util.KarmadaConfigName(names.KubeControllerManagerComponentName):      options.KubeControllerManagerClientCertAndKeyName,
+		util.KarmadaConfigName(names.KarmadaSchedulerComponentName):           options.KarmadaSchedulerClientCertAndKeyName,
+		util.KarmadaConfigName(names.KarmadaDeschedulerComponentName):         options.KarmadaDeschedulerClientCertAndKeyName,
+		util.KarmadaConfigName(names.KarmadaMetricsAdapterComponentName):      options.KarmadaMetricsAdapterClientCertAndKeyName,
+		util.KarmadaConfigName(names.KarmadaSearchComponentName):              options.KarmadaSearchClientCertAndKeyName,
+		util.KarmadaConfigName(names.KarmadaWebhookComponentName):             options.KarmadaWebhookClientCertAndKeyName,
+	}
+
+	for secretName, client := range cfgMapping {
+		if err := createCfg(secretName, client); err != nil {
 			return err
 		}
 	}
 
 	caCrt := string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", globaloptions.CaCertAndKeyName)])
 	caKey := string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", globaloptions.CaCertAndKeyName)])
-	karmadaCrt := string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaCertAndKeyName)])
-	karmadaKey := string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaCertAndKeyName)])
-	apiserverCrt := string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.ApiserverCertAndKeyName)])
-	apiserverKey := string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.ApiserverCertAndKeyName)])
+	apiserverCrt := string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaAPIServerCertAndKeyName)])
+	apiserverKey := string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaAPIServerCertAndKeyName)])
+	aggregatedCrt := string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaAggregatedAPIServerCertAndKeyName)])
+	aggregatedKey := string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaAggregatedAPIServerCertAndKeyName)])
+	webhookServerCrt := string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaWebhookCertAndKeyName)])
+	webhookServerKey := string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaWebhookCertAndKeyName)])
 	frontProxyCaCrt := string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.FrontProxyCaCertAndKeyName)])
 	frontProxyClientCrt := string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.FrontProxyClientCertAndKeyName)])
 	frontProxyClientKey := string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.FrontProxyClientCertAndKeyName)])
 	etcdCaCrt := string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.EtcdCaCertAndKeyName)])
 	etcdServerCrt := string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.EtcdServerCertAndKeyName)])
 	etcdServerKey := string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.EtcdServerCertAndKeyName)])
+	// Component-specific etcd client certs
 	etcdClientCrt := string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.EtcdClientCertAndKeyName)])
 	etcdClientKey := string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.EtcdClientCertAndKeyName)])
+	apiserverEtcdClientCrt := string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaAPIServerEtcdClientCertAndKeyName)])
+	apiserverEtcdClientKey := string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaAPIServerEtcdClientCertAndKeyName)])
+	aggregatedEtcdClientCrt := string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaAggregatedAPIServerEtcdClientCertAndKeyName)])
+	aggregatedEtcdClientKey := string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaAggregatedAPIServerEtcdClientCertAndKeyName)])
 
 	saPriv, saPub, err := generateServiceAccountKeyPairPEM()
 	if err != nil {
@@ -642,8 +846,15 @@ func (i *CommandInitOption) createSplitCertsSecrets() error {
 	saPrivStr := string(saPriv)
 	saPubStr := string(saPub)
 
-	err = i.createSecret(caCrt, caKey, karmadaCrt, karmadaKey, apiserverCrt, apiserverKey,
-		frontProxyCaCrt, frontProxyClientCrt, frontProxyClientKey, etcdCaCrt, etcdServerCrt, etcdServerKey, etcdClientCrt, etcdClientKey, saPrivStr, saPubStr)
+	err = i.createSecret(caCrt, caKey,
+		aggregatedCrt, aggregatedKey,
+		apiserverCrt, apiserverKey,
+		frontProxyCaCrt, frontProxyClientCrt, frontProxyClientKey,
+		etcdCaCrt, etcdServerCrt, etcdServerKey, etcdClientCrt, etcdClientKey,
+		apiserverEtcdClientCrt, apiserverEtcdClientKey,
+		aggregatedEtcdClientCrt, aggregatedEtcdClientKey,
+		saPrivStr, saPubStr,
+		webhookServerCrt, webhookServerKey)
 	if err != nil {
 		return err
 	}
@@ -657,13 +868,20 @@ func (i *CommandInitOption) createSplitCertsSecrets() error {
 	return nil
 }
 
-func (i *CommandInitOption) createSecret(caCrt, caKey, karmadaCrt, karmadaKey, apiserverCrt, apiserverKey,
-	frontProxyCaCrt, frontProxyClientCrt, frontProxyClientKey, etcdCaCrt, etcdServerCrt, etcdServerKey, etcdClientCrt, etcdClientKey, saPriv, saPub string) error {
+func (i *CommandInitOption) createSecret(caCrt, caKey string,
+	aggregatedCrt, aggregatedKey string,
+	apiserverCrt, apiserverKey string,
+	frontProxyCaCrt, frontProxyClientCrt, frontProxyClientKey string,
+	etcdCaCrt, etcdServerCrt, etcdServerKey, etcdClientCrt, etcdClientKey string,
+	apiserverEtcdClientCrt, apiserverEtcdClientKey string,
+	aggregatedEtcdClientCrt, aggregatedEtcdClientKey string,
+	saPriv, saPub string,
+	webhookServerCrt, webhookServerKey string) error {
 	// Delegate secret creation to helper functions
-	if err := i.createAPIServerSecret(caCrt, apiserverCrt, apiserverKey, etcdCaCrt, etcdClientCrt, etcdClientKey, frontProxyCaCrt, frontProxyClientCrt, frontProxyClientKey, saPriv, saPub); err != nil {
+	if err := i.createAPIServerSecret(caCrt, apiserverCrt, apiserverKey, etcdCaCrt, apiserverEtcdClientCrt, apiserverEtcdClientKey, frontProxyCaCrt, frontProxyClientCrt, frontProxyClientKey, saPriv, saPub); err != nil {
 		return err
 	}
-	if err := i.createAggregatedAPIServerSecret(caCrt, karmadaCrt, karmadaKey, etcdCaCrt, etcdClientCrt, etcdClientKey); err != nil {
+	if err := i.createAggregatedAPIServerSecret(caCrt, aggregatedCrt, aggregatedKey, etcdCaCrt, aggregatedEtcdClientCrt, aggregatedEtcdClientKey); err != nil {
 		return err
 	}
 	if err := i.createEtcdSecret(etcdCaCrt, etcdServerCrt, etcdServerKey, etcdClientCrt, etcdClientKey); err != nil {
@@ -672,13 +890,19 @@ func (i *CommandInitOption) createSecret(caCrt, caKey, karmadaCrt, karmadaKey, a
 	if err := i.createKubeControllerManagerSecret(caCrt, caKey, saPriv, saPub); err != nil {
 		return err
 	}
-	if err := i.createKarmadaWebhookSecret(caCrt, karmadaCrt, karmadaKey); err != nil {
+	if err := i.createKarmadaWebhookSecret(caCrt, webhookServerCrt, webhookServerKey); err != nil {
 		return err
 	}
-	if err := i.createKarmadaSchedulerEstimatorSecret(caCrt, karmadaCrt, karmadaKey); err != nil {
+	// scheduler estimator client
+	schedEstCrt := string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaSchedulerEstimatorClientCertAndKeyName)])
+	schedEstKey := string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaSchedulerEstimatorClientCertAndKeyName)])
+	if err := i.createKarmadaSchedulerEstimatorSecret(caCrt, schedEstCrt, schedEstKey); err != nil {
 		return err
 	}
-	if err := i.createKarmadaDeschedulerEstimatorSecret(caCrt, karmadaCrt, karmadaKey); err != nil {
+	// descheduler estimator client (reuse descheduler client cert)
+	deschedEstCrt := string(i.CertAndKeyFileData[fmt.Sprintf("%s.crt", options.KarmadaDeschedulerClientCertAndKeyName)])
+	deschedEstKey := string(i.CertAndKeyFileData[fmt.Sprintf("%s.key", options.KarmadaDeschedulerClientCertAndKeyName)])
+	if err := i.createKarmadaDeschedulerEstimatorSecret(caCrt, deschedEstCrt, deschedEstKey); err != nil {
 		return err
 	}
 
@@ -892,16 +1116,23 @@ func (i *CommandInitOption) readExternalEtcdCert(name string) (isExternalEtcdCer
 	return
 }
 
-// RunInit Deploy karmada in kubernetes
-func (i *CommandInitOption) RunInit(parentCommand string) error {
-	// generate certificate
-	if err := i.genCerts(); err != nil {
-		return fmt.Errorf("certificate generation failed.%v", err)
+// generateCertsForLayout selects and generates certificates according to secret layout.
+func (i *CommandInitOption) generateCertsForLayout() error {
+	if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+		return i.genCertsSplitFull()
 	}
+	return i.genCerts()
+}
 
+// loadCertsIntoMap populates CertAndKeyFileData either from disk or external etcd inputs.
+func (i *CommandInitOption) loadCertsIntoMap() error {
 	i.CertAndKeyFileData = map[string][]byte{}
 
-	for _, v := range certList {
+	list := certListLegacy
+	if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+		list = certListSplit
+	}
+	for _, v := range list {
 		if isExternalEtcdCert, err := i.readExternalEtcdCert(v); err != nil {
 			return fmt.Errorf("read external etcd certificate failed, %s. %v", v, err)
 		} else if isExternalEtcdCert {
@@ -919,6 +1150,27 @@ func (i *CommandInitOption) RunInit(parentCommand string) error {
 		}
 		i.CertAndKeyFileData[fmt.Sprintf("%s.key", v)] = key
 	}
+	return nil
+}
+
+// createNamespaceAndSecrets ensures target namespace exists and uploads certs as secrets.
+func (i *CommandInitOption) createNamespaceAndSecrets() error {
+	if err := util.CreateOrUpdateNamespace(i.KubeClientSet, util.NewNamespace(i.Namespace)); err != nil {
+		return fmt.Errorf("create namespace %s failed: %v", i.Namespace, err)
+	}
+	return i.createCertsSecrets()
+}
+
+// RunInit Deploy karmada in kubernetes
+func (i *CommandInitOption) RunInit(parentCommand string) error {
+	// generate certificates
+	if err := i.generateCertsForLayout(); err != nil {
+		return fmt.Errorf("certificate generation failed.%v", err)
+	}
+
+	if err := i.loadCertsIntoMap(); err != nil {
+		return err
+	}
 
 	// prepare karmada CRD resources
 	if err := i.prepareCRD(); err != nil {
@@ -926,18 +1178,12 @@ func (i *CommandInitOption) RunInit(parentCommand string) error {
 	}
 
 	// Create karmada kubeconfig
-	err := i.createKarmadaConfig()
-	if err != nil {
+	if err := i.createKarmadaConfig(); err != nil {
 		return fmt.Errorf("create karmada kubeconfig failed.%v", err)
 	}
 
-	// Create ns
-	if err := util.CreateOrUpdateNamespace(i.KubeClientSet, util.NewNamespace(i.Namespace)); err != nil {
-		return fmt.Errorf("create namespace %s failed: %v", i.Namespace, err)
-	}
-
-	// Create Secrets
-	if err := i.createCertsSecrets(); err != nil {
+	// Create namespace and secrets
+	if err := i.createNamespaceAndSecrets(); err != nil {
 		return err
 	}
 

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -30,6 +31,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/config"
+	initopt "github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
 	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/utils"
 )
 
@@ -732,4 +734,169 @@ func parseDuration(durationStr string) time.Duration {
 		return 0
 	}
 	return duration
+}
+
+// ===== Additional tests for split certificate design =====
+
+func containsString(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+func containsIP(ss []net.IP, s string) bool {
+	want := utils.StringToNetIP(s)
+	for _, v := range ss {
+		if v.Equal(want) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBuildDefaultAltNames(t *testing.T) {
+	i := &CommandInitOption{
+		Namespace:          "ns",
+		HostClusterDomain:  "cluster.local",
+		ExternalDNS:        "a.example.com,b.example.com",
+		ExternalIP:         "1.1.1.1,2.2.2.2",
+		KarmadaAPIServerIP: []net.IP{utils.StringToNetIP("10.0.0.1")},
+	}
+
+	alt := i.buildDefaultAltNames("karmada-apiserver")
+
+	if !containsString(alt.DNSNames, "karmada-apiserver.karmada-system.svc") {
+		t.Fatalf("missing dns: karmada-apiserver.karmada-system.svc")
+	}
+	if !containsString(alt.DNSNames, "karmada-apiserver.karmada-system.svc.cluster.local") {
+		t.Fatalf("missing dns: karmada-apiserver.karmada-system.svc.cluster.local")
+	}
+	if !containsString(alt.DNSNames, "karmada-apiserver.ns.svc.cluster.local") {
+		t.Fatalf("missing dns: karmada-apiserver.ns.svc.cluster.local")
+	}
+	if !containsString(alt.DNSNames, "localhost") {
+		t.Fatalf("missing dns: localhost")
+	}
+
+	for _, ip := range []string{"127.0.0.1", "1.1.1.1", "2.2.2.2", "10.0.0.1"} {
+		if !containsIP(alt.IPs, ip) {
+			t.Fatalf("missing ip: %s", ip)
+		}
+	}
+}
+
+func TestBuildSchedulerEstimatorAltNames(t *testing.T) {
+	i := &CommandInitOption{
+		Namespace:          "ns",
+		HostClusterDomain:  "cluster.local",
+		ExternalDNS:        "d1,d2",
+		ExternalIP:         "3.3.3.3",
+		KarmadaAPIServerIP: []net.IP{utils.StringToNetIP("10.0.0.2")},
+	}
+	alt := i.buildSchedulerEstimatorAltNames()
+
+	wants := []string{
+		"*.karmada-system.svc.cluster.local",
+		"*.karmada-system.svc",
+		"*.ns.svc.cluster.local",
+		"localhost",
+	}
+	for _, w := range wants {
+		if !containsString(alt.DNSNames, w) {
+			t.Fatalf("missing dns: %s", w)
+		}
+	}
+	for _, ip := range []string{"127.0.0.1", "3.3.3.3", "10.0.0.2"} {
+		if !containsIP(alt.IPs, ip) {
+			t.Fatalf("missing ip: %s", ip)
+		}
+	}
+}
+
+func exists(t *testing.T, dir, name string) {
+	t.Helper()
+	for _, ext := range []string{".crt", ".key"} {
+		if _, err := os.Stat(filepath.Join(dir, name+ext)); err != nil {
+			t.Fatalf("expected %s%s to exist: %v", name, ext, err)
+		}
+	}
+}
+
+func TestGenCertsSplitFull_GeneratesExpectedSubset(t *testing.T) {
+	dir := t.TempDir()
+	opt := &CommandInitOption{
+		CertValidity:      24 * time.Hour,
+		EtcdReplicas:      1,
+		Namespace:         "karmada",
+		HostClusterDomain: "cluster.local",
+		KarmadaPkiPath:    dir,
+	}
+
+	if err := opt.genCertsSplitFull(); err != nil {
+		t.Fatalf("genCertsSplitFull error: %v", err)
+	}
+
+	subset := []string{
+		initopt.EtcdCaCertAndKeyName,
+		initopt.FrontProxyCaCertAndKeyName,
+		initopt.KarmadaAPIServerCertAndKeyName,
+		initopt.KarmadaAggregatedAPIServerCertAndKeyName,
+		initopt.KarmadaAPIServerClientCertAndKeyName,
+		initopt.KarmadaAggregatedAPIServerEtcdClientCertAndKeyName,
+		initopt.EtcdClientCertAndKeyName,
+		initopt.FrontProxyClientCertAndKeyName,
+		initopt.EtcdServerCertAndKeyName,
+	}
+	for _, n := range subset {
+		exists(t, dir, n)
+	}
+}
+
+func TestReadExternalEtcdCert_SplitVariants(t *testing.T) {
+	dir := t.TempDir()
+	ca := filepath.Join(dir, "ca.crt")
+	cert := filepath.Join(dir, "client.crt")
+	key := filepath.Join(dir, "client.key")
+	mustWrite := func(p, s string) {
+		if err := os.WriteFile(p, []byte(s), 0600); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+	mustWrite(ca, "CA")
+	mustWrite(cert, "ECC")
+	mustWrite(key, "ECK")
+
+	opt := &CommandInitOption{
+		ExternalEtcdServers:        "https://etcd:2379",
+		ExternalEtcdCACertPath:     ca,
+		ExternalEtcdClientCertPath: cert,
+		ExternalEtcdClientKeyPath:  key,
+		CertAndKeyFileData:         map[string][]byte{},
+	}
+
+	names := []string{
+		initopt.EtcdClientCertAndKeyName,
+		initopt.KarmadaAPIServerEtcdClientCertAndKeyName,
+		initopt.KarmadaAggregatedAPIServerEtcdClientCertAndKeyName,
+		initopt.KarmadaSearchEtcdClientCertAndKeyName,
+	}
+	for _, n := range names {
+		ok, err := opt.readExternalEtcdCert(n)
+		if err != nil || !ok {
+			t.Fatalf("readExternalEtcdCert(%s) ok=%v err=%v", n, ok, err)
+		}
+		if string(opt.CertAndKeyFileData[n+".crt"]) != "ECC" || string(opt.CertAndKeyFileData[n+".key"]) != "ECK" {
+			t.Fatalf("unexpected data for %s", n)
+		}
+	}
+
+	if ok, err := opt.readExternalEtcdCert(initopt.EtcdServerCertAndKeyName); err != nil || !ok {
+		t.Fatalf("readExternalEtcdCert(etcd-server) ok=%v err=%v", ok, err)
+	}
+	if len(opt.CertAndKeyFileData[initopt.EtcdServerCertAndKeyName+".crt"]) != 0 || len(opt.CertAndKeyFileData[initopt.EtcdServerCertAndKeyName+".key"]) != 0 {
+		t.Fatalf("expected empty data for etcd-server under external etcd")
+	}
 }

--- a/pkg/karmadactl/cmdinit/kubernetes/deployments.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deployments.go
@@ -18,6 +18,8 @@ package kubernetes
 
 import (
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -26,6 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
+	certconst "github.com/karmada-io/karmada/pkg/cert"
+	"github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
 	globaloptions "github.com/karmada-io/karmada/pkg/karmadactl/options"
 	"github.com/karmada-io/karmada/pkg/karmadactl/util"
 	"github.com/karmada-io/karmada/pkg/util/names"
@@ -50,12 +54,28 @@ const (
 	controllerManagerDeploymentAndServiceName                   = names.KarmadaControllerManagerComponentName
 	controllerManagerSecurePort                                 = 10357
 	webhookDeploymentAndServiceAccountAndServiceName            = names.KarmadaWebhookComponentName
-	webhookCertsName                                            = "karmada-webhook-cert"
 	webhookCertVolumeMountPath                                  = "/var/serving-cert"
 	webhookPortName                                             = "webhook"
 	webhookTargetPort                                           = 8443
 	webhookPort                                                 = 443
 	karmadaAggregatedAPIServerDeploymentAndServiceName          = names.KarmadaAggregatedAPIServerComponentName
+)
+
+var (
+	// split-layout mount paths
+	serverCertVolumeMountPath                   = "/etc/karmada/pki/server"
+	etcdClientCertVolumeMountPath               = "/etc/karmada/pki/etcd-client"
+	frontProxyClientCertVolumeMountPath         = "/etc/karmada/pki/front-proxy-client"
+	saKeyPairVolumeMountPath                    = "/etc/karmada/pki/service-account-key-pair"
+	caCertVolumeMountPath                       = "/etc/karmada/pki/ca"
+	schedulerEstimatorClientCertVolumeMountPath = "/etc/karmada/pki/scheduler-estimator-client"
+	// Volume names for split-layout mounts
+	serverCertVolumeName                   = "server-cert"
+	etcdClientCertVolumeName               = "etcd-client-cert"
+	frontProxyClientCertVolumeName         = "front-proxy-client-cert"
+	saKeyPairVolumeName                    = "service-account-key-pair"
+	caCertVolumeName                       = "ca-cert"
+	schedulerEstimatorClientCertVolumeName = "scheduler-estimator-client-cert"
 )
 
 var (
@@ -73,6 +93,81 @@ func (i *CommandInitOption) etcdServers() string {
 		etcdClusterConfig += fmt.Sprintf("https://%s-%v.%s.%s.svc.%s:%v", etcdStatefulSetAndServiceName, v, etcdStatefulSetAndServiceName, i.Namespace, i.HostClusterDomain, etcdContainerClientPort) + ","
 	}
 	return etcdClusterConfig
+}
+
+func (i *CommandInitOption) karmadaAPIServerContainerCommand() []string {
+	var etcdServers string
+	if etcdServers = i.ExternalEtcdServers; etcdServers == "" {
+		etcdServers = strings.TrimRight(i.etcdServers(), ",")
+	}
+	var command []string
+	if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+		command = []string{
+			"kube-apiserver",
+			"--allow-privileged=true",
+			"--authorization-mode=Node,RBAC",
+			fmt.Sprintf("--client-ca-file=%s/ca.crt", serverCertVolumeMountPath),
+			"--enable-bootstrap-token-auth=true",
+			fmt.Sprintf("--etcd-cafile=%s/ca.crt", etcdClientCertVolumeMountPath),
+			fmt.Sprintf("--etcd-certfile=%s/tls.crt", etcdClientCertVolumeMountPath),
+			fmt.Sprintf("--etcd-keyfile=%s/tls.key", etcdClientCertVolumeMountPath),
+			fmt.Sprintf("--etcd-servers=%s", etcdServers),
+			"--bind-address=0.0.0.0",
+			"--disable-admission-plugins=StorageObjectInUseProtection,ServiceAccount",
+			"--runtime-config=",
+			fmt.Sprintf("--apiserver-count=%v", i.KarmadaAPIServerReplicas),
+			fmt.Sprintf("--secure-port=%v", karmadaAPIServerContainerPort),
+			fmt.Sprintf("--service-account-issuer=https://kubernetes.default.svc.%s", i.HostClusterDomain),
+			fmt.Sprintf("--service-account-key-file=%s/sa.pub", saKeyPairVolumeMountPath),
+			fmt.Sprintf("--service-account-signing-key-file=%s/sa.key", saKeyPairVolumeMountPath),
+			fmt.Sprintf("--service-cluster-ip-range=%s", serviceClusterIP),
+			fmt.Sprintf("--proxy-client-cert-file=%s/tls.crt", frontProxyClientCertVolumeMountPath),
+			fmt.Sprintf("--proxy-client-key-file=%s/tls.key", frontProxyClientCertVolumeMountPath),
+			"--requestheader-allowed-names=front-proxy-client",
+			fmt.Sprintf("--requestheader-client-ca-file=%s/ca.crt", frontProxyClientCertVolumeMountPath),
+			"--requestheader-extra-headers-prefix=X-Remote-Extra-",
+			"--requestheader-group-headers=X-Remote-Group",
+			"--requestheader-username-headers=X-Remote-User",
+			fmt.Sprintf("--tls-cert-file=%s/tls.crt", serverCertVolumeMountPath),
+			fmt.Sprintf("--tls-private-key-file=%s/tls.key", serverCertVolumeMountPath),
+			"--tls-min-version=VersionTLS13",
+		}
+	} else {
+		command = []string{
+			"kube-apiserver",
+			"--allow-privileged=true",
+			"--authorization-mode=Node,RBAC",
+			fmt.Sprintf("--client-ca-file=%s/%s.crt", karmadaCertsVolumeMountPath, globaloptions.CaCertAndKeyName),
+			"--enable-bootstrap-token-auth=true",
+			fmt.Sprintf("--etcd-cafile=%s/%s.crt", karmadaCertsVolumeMountPath, options.EtcdCaCertAndKeyName),
+			fmt.Sprintf("--etcd-certfile=%s/%s.crt", karmadaCertsVolumeMountPath, options.EtcdClientCertAndKeyName),
+			fmt.Sprintf("--etcd-keyfile=%s/%s.key", karmadaCertsVolumeMountPath, options.EtcdClientCertAndKeyName),
+			fmt.Sprintf("--etcd-servers=%s", etcdServers),
+			"--bind-address=0.0.0.0",
+			"--disable-admission-plugins=StorageObjectInUseProtection,ServiceAccount",
+			"--runtime-config=",
+			fmt.Sprintf("--apiserver-count=%v", i.KarmadaAPIServerReplicas),
+			fmt.Sprintf("--secure-port=%v", karmadaAPIServerContainerPort),
+			fmt.Sprintf("--service-account-issuer=https://kubernetes.default.svc.%s", i.HostClusterDomain),
+			fmt.Sprintf("--service-account-key-file=%s/%s.key", karmadaCertsVolumeMountPath, options.KarmadaCertAndKeyName),
+			fmt.Sprintf("--service-account-signing-key-file=%s/%s.key", karmadaCertsVolumeMountPath, options.KarmadaCertAndKeyName),
+			fmt.Sprintf("--service-cluster-ip-range=%s", serviceClusterIP),
+			fmt.Sprintf("--proxy-client-cert-file=%s/%s.crt", karmadaCertsVolumeMountPath, options.FrontProxyClientCertAndKeyName),
+			fmt.Sprintf("--proxy-client-key-file=%s/%s.key", karmadaCertsVolumeMountPath, options.FrontProxyClientCertAndKeyName),
+			"--requestheader-allowed-names=front-proxy-client",
+			fmt.Sprintf("--requestheader-client-ca-file=%s/%s.crt", karmadaCertsVolumeMountPath, options.FrontProxyCaCertAndKeyName),
+			"--requestheader-extra-headers-prefix=X-Remote-Extra-",
+			"--requestheader-group-headers=X-Remote-Group",
+			"--requestheader-username-headers=X-Remote-User",
+			fmt.Sprintf("--tls-cert-file=%s/%s.crt", karmadaCertsVolumeMountPath, options.ApiserverCertAndKeyName),
+			fmt.Sprintf("--tls-private-key-file=%s/%s.key", karmadaCertsVolumeMountPath, options.ApiserverCertAndKeyName),
+			"--tls-min-version=VersionTLS13",
+		}
+	}
+	if i.ExternalEtcdKeyPrefix != "" {
+		command = append(command, fmt.Sprintf("--etcd-prefix=%s", i.ExternalEtcdKeyPrefix))
+	}
+	return command
 }
 
 func (i *CommandInitOption) makeKarmadaAPIServerDeployment() *appsv1.Deployment {
@@ -153,27 +248,32 @@ func (i *CommandInitOption) makeKarmadaAPIServerDeployment() *appsv1.Deployment 
 						Protocol:      corev1.ProtocolTCP,
 					},
 				},
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      globaloptions.KarmadaCertsName,
-						ReadOnly:  true,
-						MountPath: karmadaCertsVolumeMountPath,
-					},
-				},
+				VolumeMounts: func() []corev1.VolumeMount {
+					if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+						return []corev1.VolumeMount{
+							{Name: serverCertVolumeName, ReadOnly: true, MountPath: serverCertVolumeMountPath},
+							{Name: etcdClientCertVolumeName, ReadOnly: true, MountPath: etcdClientCertVolumeMountPath},
+							{Name: frontProxyClientCertVolumeName, ReadOnly: true, MountPath: frontProxyClientCertVolumeMountPath},
+							{Name: saKeyPairVolumeName, ReadOnly: true, MountPath: saKeyPairVolumeMountPath},
+						}
+					}
+					return []corev1.VolumeMount{{Name: globaloptions.KarmadaCertsName, ReadOnly: true, MountPath: karmadaCertsVolumeMountPath}}
+				}(),
 				LivenessProbe:  livenessProbe,
 				ReadinessProbe: readinessProbe,
 			},
 		},
-		Volumes: []corev1.Volume{
-			{
-				Name: globaloptions.KarmadaCertsName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: globaloptions.KarmadaCertsName,
-					},
-				},
-			},
-		},
+		Volumes: func() []corev1.Volume {
+			if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+				return []corev1.Volume{
+					{Name: serverCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certconst.SecretApiserverServer}}},
+					{Name: etcdClientCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certconst.SecretApiserverEtcdClient}}},
+					{Name: frontProxyClientCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certconst.SecretApiserverFrontProxyClient}}},
+					{Name: saKeyPairVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certconst.SecretApiserverServiceAccountKeys}}},
+				}
+			}
+			return []corev1.Volume{{Name: globaloptions.KarmadaCertsName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: globaloptions.KarmadaCertsName}}}}
+		}(),
 		//HostNetwork:  true,
 		Tolerations: []corev1.Toleration{
 			{
@@ -258,9 +358,46 @@ func (i *CommandInitOption) makeKarmadaKubeControllerManagerDeployment() *appsv1
 		AutomountServiceAccountToken: ptr.To[bool](false),
 		Containers: []corev1.Container{
 			{
-				Name:          kubeControllerManagerClusterRoleAndDeploymentAndServiceName,
-				Image:         i.kubeControllerManagerImage(),
-				Command:       i.KubeControllerManagerContainerCmd,
+				Name:  kubeControllerManagerClusterRoleAndDeploymentAndServiceName,
+				Image: i.kubeControllerManagerImage(),
+				Command: func() []string {
+					var clientCAFile, clusterSigningCertFile, clusterSigningKeyFile, rootCAFile, saPrivKeyFile string
+					if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+						clientCAFile = fmt.Sprintf("%s/tls.crt", caCertVolumeMountPath)
+						clusterSigningCertFile = fmt.Sprintf("%s/tls.crt", caCertVolumeMountPath)
+						clusterSigningKeyFile = fmt.Sprintf("%s/tls.key", caCertVolumeMountPath)
+						rootCAFile = fmt.Sprintf("%s/tls.crt", caCertVolumeMountPath)
+						saPrivKeyFile = fmt.Sprintf("%s/sa.key", saKeyPairVolumeMountPath)
+					} else {
+						clientCAFile = fmt.Sprintf("%s/%s.crt", karmadaCertsVolumeMountPath, globaloptions.CaCertAndKeyName)
+						clusterSigningCertFile = fmt.Sprintf("%s/%s.crt", karmadaCertsVolumeMountPath, globaloptions.CaCertAndKeyName)
+						clusterSigningKeyFile = fmt.Sprintf("%s/%s.key", karmadaCertsVolumeMountPath, globaloptions.CaCertAndKeyName)
+						rootCAFile = fmt.Sprintf("%s/%s.crt", karmadaCertsVolumeMountPath, globaloptions.CaCertAndKeyName)
+						saPrivKeyFile = fmt.Sprintf("%s/%s.key", karmadaCertsVolumeMountPath, options.KarmadaCertAndKeyName)
+					}
+					return []string{
+						"kube-controller-manager",
+						"--allocate-node-cidrs=true",
+						fmt.Sprintf("--kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
+						fmt.Sprintf("--authentication-kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
+						fmt.Sprintf("--authorization-kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
+						"--bind-address=0.0.0.0",
+						fmt.Sprintf("--client-ca-file=%s", clientCAFile),
+						"--cluster-cidr=10.244.0.0/16",
+						fmt.Sprintf("--cluster-name=%s", options.ClusterName),
+						fmt.Sprintf("--cluster-signing-cert-file=%s", clusterSigningCertFile),
+						fmt.Sprintf("--cluster-signing-key-file=%s", clusterSigningKeyFile),
+						"--controllers=namespace,garbagecollector,serviceaccount-token,ttl-after-finished,bootstrapsigner,tokencleaner,csrcleaner,csrsigning,clusterrole-aggregation",
+						"--leader-elect=true",
+						fmt.Sprintf("--leader-elect-resource-namespace=%s", i.Namespace),
+						"--node-cidr-mask-size=24",
+						fmt.Sprintf("--root-ca-file=%s", rootCAFile),
+						fmt.Sprintf("--service-account-private-key-file=%s", saPrivKeyFile),
+						fmt.Sprintf("--service-cluster-ip-range=%s", serviceClusterIP),
+						"--use-service-account-credentials=true",
+						"--v=4",
+					}
+				}(),
 				LivenessProbe: livenessProbe,
 				Ports: []corev1.ContainerPort{
 					{
@@ -269,38 +406,34 @@ func (i *CommandInitOption) makeKarmadaKubeControllerManagerDeployment() *appsv1
 						Protocol:      corev1.ProtocolTCP,
 					},
 				},
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      karmadaConfigVolumeName,
-						ReadOnly:  true,
-						MountPath: karmadaConfigVolumeMountPath,
-					},
-					{
-						Name:      globaloptions.KarmadaCertsName,
-						ReadOnly:  true,
-						MountPath: karmadaCertsVolumeMountPath,
-					},
-				},
+				VolumeMounts: func() []corev1.VolumeMount {
+					if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+						return []corev1.VolumeMount{
+							{Name: karmadaConfigVolumeName, ReadOnly: true, MountPath: karmadaConfigVolumeMountPath},
+							{Name: caCertVolumeName, ReadOnly: true, MountPath: caCertVolumeMountPath},
+							{Name: saKeyPairVolumeName, ReadOnly: true, MountPath: saKeyPairVolumeMountPath},
+						}
+					}
+					return []corev1.VolumeMount{
+						{Name: karmadaConfigVolumeName, ReadOnly: true, MountPath: karmadaConfigVolumeMountPath},
+						{Name: globaloptions.KarmadaCertsName, ReadOnly: true, MountPath: karmadaCertsVolumeMountPath},
+					}
+				}(),
 			},
 		},
-		Volumes: []corev1.Volume{
-			{
-				Name: karmadaConfigVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: util.KarmadaConfigName(names.KubeControllerManagerComponentName),
-					},
-				},
-			},
-			{
-				Name: globaloptions.KarmadaCertsName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: globaloptions.KarmadaCertsName,
-					},
-				},
-			},
-		},
+		Volumes: func() []corev1.Volume {
+			if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+				return []corev1.Volume{
+					{Name: karmadaConfigVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: util.KarmadaConfigName(names.KubeControllerManagerComponentName)}}},
+					{Name: caCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certconst.SecretKubeControllerManagerCA}}},
+					{Name: saKeyPairVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certconst.SecretKubeControllerManagerSAKeys}}},
+				}
+			}
+			return []corev1.Volume{
+				{Name: karmadaConfigVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: util.KarmadaConfigName(names.KubeControllerManagerComponentName)}}},
+				{Name: globaloptions.KarmadaCertsName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: globaloptions.KarmadaCertsName}}},
+			}
+		}(),
 		Tolerations: []corev1.Toleration{
 			{
 				Effect:   corev1.TaintEffectNoExecute,
@@ -395,7 +528,31 @@ func (i *CommandInitOption) makeKarmadaSchedulerDeployment() *appsv1.Deployment 
 						},
 					},
 				},
-				Command:       i.KarmadaSchedulerContainerCmd,
+				Command: func() []string {
+					var estCAFile, estCertFile, estKeyFile string
+					if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+						estCAFile = fmt.Sprintf("%s/ca.crt", schedulerEstimatorClientCertVolumeMountPath)
+						estCertFile = fmt.Sprintf("%s/tls.crt", schedulerEstimatorClientCertVolumeMountPath)
+						estKeyFile = fmt.Sprintf("%s/tls.key", schedulerEstimatorClientCertVolumeMountPath)
+					} else {
+						estCAFile = "/etc/karmada/pki/ca.crt"
+						estCertFile = "/etc/karmada/pki/karmada.crt"
+						estKeyFile = "/etc/karmada/pki/karmada.key"
+					}
+					return []string{
+						"/bin/karmada-scheduler",
+						fmt.Sprintf("--kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
+						"--metrics-bind-address=$(POD_IP):8080",
+						"--health-probe-bind-address=$(POD_IP):10351",
+						"--enable-scheduler-estimator=true",
+						"--leader-elect=true",
+						fmt.Sprintf("--scheduler-estimator-ca-file=%s", estCAFile),
+						fmt.Sprintf("--scheduler-estimator-cert-file=%s", estCertFile),
+						fmt.Sprintf("--scheduler-estimator-key-file=%s", estKeyFile),
+						fmt.Sprintf("--leader-elect-resource-namespace=%s", i.Namespace),
+						"--v=4",
+					}
+				}(),
 				LivenessProbe: livenessProbe,
 				Ports: []corev1.ContainerPort{
 					{
@@ -404,38 +561,32 @@ func (i *CommandInitOption) makeKarmadaSchedulerDeployment() *appsv1.Deployment 
 						Protocol:      corev1.ProtocolTCP,
 					},
 				},
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      karmadaConfigVolumeName,
-						ReadOnly:  true,
-						MountPath: karmadaConfigVolumeMountPath,
-					},
-					{
-						Name:      globaloptions.KarmadaCertsName,
-						ReadOnly:  true,
-						MountPath: karmadaCertsVolumeMountPath,
-					},
-				},
+				VolumeMounts: func() []corev1.VolumeMount {
+					if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+						return []corev1.VolumeMount{
+							{Name: karmadaConfigVolumeName, ReadOnly: true, MountPath: karmadaConfigVolumeMountPath},
+							{Name: schedulerEstimatorClientCertVolumeName, ReadOnly: true, MountPath: schedulerEstimatorClientCertVolumeMountPath},
+						}
+					}
+					return []corev1.VolumeMount{
+						{Name: karmadaConfigVolumeName, ReadOnly: true, MountPath: karmadaConfigVolumeMountPath},
+						{Name: globaloptions.KarmadaCertsName, ReadOnly: true, MountPath: karmadaCertsVolumeMountPath},
+					}
+				}(),
 			},
 		},
-		Volumes: []corev1.Volume{
-			{
-				Name: karmadaConfigVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: util.KarmadaConfigName(names.KarmadaSchedulerComponentName),
-					},
-				},
-			},
-			{
-				Name: globaloptions.KarmadaCertsName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: globaloptions.KarmadaCertsName,
-					},
-				},
-			},
-		},
+		Volumes: func() []corev1.Volume {
+			if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+				return []corev1.Volume{
+					{Name: karmadaConfigVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: util.KarmadaConfigName(names.KarmadaSchedulerComponentName)}}},
+					{Name: schedulerEstimatorClientCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certconst.SecretSchedulerEstimatorClient}}},
+				}
+			}
+			return []corev1.Volume{
+				{Name: karmadaConfigVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: util.KarmadaConfigName(names.KarmadaSchedulerComponentName)}}},
+				{Name: globaloptions.KarmadaCertsName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: globaloptions.KarmadaCertsName}}},
+			}
+		}(),
 		Tolerations: []corev1.Toleration{
 			{
 				Effect:   corev1.TaintEffectNoExecute,
@@ -658,7 +809,24 @@ func (i *CommandInitOption) makeKarmadaWebhookDeployment() *appsv1.Deployment {
 						},
 					},
 				},
-				Command: i.KarmadaWebhookContainerCmd,
+				Command: func() []string {
+					var certDir string
+					if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+						certDir = serverCertVolumeMountPath
+					} else {
+						certDir = webhookCertVolumeMountPath
+					}
+					return []string{
+						"/bin/karmada-webhook",
+						fmt.Sprintf("--kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
+						"--bind-address=$(POD_IP)",
+						"--metrics-bind-address=$(POD_IP):8080",
+						"--health-probe-bind-address=$(POD_IP):8000",
+						fmt.Sprintf("--secure-port=%v", webhookTargetPort),
+						fmt.Sprintf("--cert-dir=%s", certDir),
+						"--v=4",
+					}
+				}(),
 				Ports: []corev1.ContainerPort{
 					{
 						Name:          webhookPortName,
@@ -671,39 +839,33 @@ func (i *CommandInitOption) makeKarmadaWebhookDeployment() *appsv1.Deployment {
 						Protocol:      corev1.ProtocolTCP,
 					},
 				},
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      karmadaConfigVolumeName,
-						ReadOnly:  true,
-						MountPath: karmadaConfigVolumeMountPath,
-					},
-					{
-						Name:      webhookCertsName,
-						ReadOnly:  true,
-						MountPath: webhookCertVolumeMountPath,
-					},
-				},
+				VolumeMounts: func() []corev1.VolumeMount {
+					if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+						return []corev1.VolumeMount{
+							{Name: karmadaConfigVolumeName, ReadOnly: true, MountPath: karmadaConfigVolumeMountPath},
+							{Name: serverCertVolumeName, ReadOnly: true, MountPath: serverCertVolumeMountPath},
+						}
+					}
+					return []corev1.VolumeMount{
+						{Name: karmadaConfigVolumeName, ReadOnly: true, MountPath: karmadaConfigVolumeMountPath},
+						{Name: certconst.SecretWebhook, ReadOnly: true, MountPath: webhookCertVolumeMountPath},
+					}
+				}(),
 				ReadinessProbe: readinesProbe,
 			},
 		},
-		Volumes: []corev1.Volume{
-			{
-				Name: karmadaConfigVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: util.KarmadaConfigName(names.KarmadaWebhookComponentName),
-					},
-				},
-			},
-			{
-				Name: webhookCertsName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: webhookCertsName,
-					},
-				},
-			},
-		},
+		Volumes: func() []corev1.Volume {
+			if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+				return []corev1.Volume{
+					{Name: karmadaConfigVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: util.KarmadaConfigName(names.KarmadaWebhookComponentName)}}},
+					{Name: serverCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certconst.SecretWebhook}}},
+				}
+			}
+			return []corev1.Volume{
+				{Name: karmadaConfigVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: util.KarmadaConfigName(names.KarmadaWebhookComponentName)}}},
+				{Name: certconst.SecretWebhook, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certconst.SecretWebhook}}},
+			}
+		}(),
 		Tolerations: []corev1.Toleration{
 			{
 				Effect:   corev1.TaintEffectNoExecute,
@@ -776,6 +938,51 @@ func (i *CommandInitOption) makeKarmadaAggregatedAPIServerDeployment() *appsv1.D
 		TimeoutSeconds:      15,
 	}
 
+	var etcdServers string
+	if etcdServers = i.ExternalEtcdServers; etcdServers == "" {
+		etcdServers = strings.TrimRight(i.etcdServers(), ",")
+	}
+	var command []string
+	if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+		command = []string{
+			"/bin/karmada-aggregated-apiserver",
+			fmt.Sprintf("--kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
+			fmt.Sprintf("--authentication-kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
+			fmt.Sprintf("--authorization-kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
+			fmt.Sprintf("--etcd-servers=%s", etcdServers),
+			fmt.Sprintf("--etcd-cafile=%s/ca.crt", etcdClientCertVolumeMountPath),
+			fmt.Sprintf("--etcd-certfile=%s/tls.crt", etcdClientCertVolumeMountPath),
+			fmt.Sprintf("--etcd-keyfile=%s/tls.key", etcdClientCertVolumeMountPath),
+			fmt.Sprintf("--tls-cert-file=%s/tls.crt", serverCertVolumeMountPath),
+			fmt.Sprintf("--tls-private-key-file=%s/tls.key", serverCertVolumeMountPath),
+			"--tls-min-version=VersionTLS13",
+			"--audit-log-path=-",
+			"--audit-log-maxage=0",
+			"--audit-log-maxbackup=0",
+			"--bind-address=$(POD_IP)",
+		}
+	} else {
+		command = []string{
+			"/bin/karmada-aggregated-apiserver",
+			fmt.Sprintf("--kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
+			fmt.Sprintf("--authentication-kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
+			fmt.Sprintf("--authorization-kubeconfig=%s", filepath.Join(karmadaConfigVolumeMountPath, util.KarmadaConfigFieldName)),
+			fmt.Sprintf("--etcd-servers=%s", etcdServers),
+			fmt.Sprintf("--etcd-cafile=%s/%s.crt", karmadaCertsVolumeMountPath, options.EtcdCaCertAndKeyName),
+			fmt.Sprintf("--etcd-certfile=%s/%s.crt", karmadaCertsVolumeMountPath, options.EtcdClientCertAndKeyName),
+			fmt.Sprintf("--etcd-keyfile=%s/%s.key", karmadaCertsVolumeMountPath, options.EtcdClientCertAndKeyName),
+			fmt.Sprintf("--tls-cert-file=%s/%s.crt", karmadaCertsVolumeMountPath, options.KarmadaCertAndKeyName),
+			fmt.Sprintf("--tls-private-key-file=%s/%s.key", karmadaCertsVolumeMountPath, options.KarmadaCertAndKeyName),
+			"--tls-min-version=VersionTLS13",
+			"--audit-log-path=-",
+			"--audit-log-maxage=0",
+			"--audit-log-maxbackup=0",
+			"--bind-address=$(POD_IP)",
+		}
+	}
+	if i.ExternalEtcdKeyPrefix != "" {
+		command = append(command, fmt.Sprintf("--etcd-prefix=%s", i.ExternalEtcdKeyPrefix))
+	}
 	podSpec := corev1.PodSpec{
 		ImagePullSecrets:  i.getImagePullSecrets(),
 		PriorityClassName: i.KarmadaAggregatedAPIServerPriorityClass,
@@ -821,38 +1028,34 @@ func (i *CommandInitOption) makeKarmadaAggregatedAPIServerDeployment() *appsv1.D
 						corev1.ResourceCPU: resource.MustParse("100m"),
 					},
 				},
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      karmadaConfigVolumeName,
-						ReadOnly:  true,
-						MountPath: karmadaConfigVolumeMountPath,
-					},
-					{
-						Name:      globaloptions.KarmadaCertsName,
-						ReadOnly:  true,
-						MountPath: karmadaCertsVolumeMountPath,
-					},
-				},
+				VolumeMounts: func() []corev1.VolumeMount {
+					if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+						return []corev1.VolumeMount{
+							{Name: karmadaConfigVolumeName, ReadOnly: true, MountPath: karmadaConfigVolumeMountPath},
+							{Name: serverCertVolumeName, ReadOnly: true, MountPath: serverCertVolumeMountPath},
+							{Name: etcdClientCertVolumeName, ReadOnly: true, MountPath: etcdClientCertVolumeMountPath},
+						}
+					}
+					return []corev1.VolumeMount{
+						{Name: karmadaConfigVolumeName, ReadOnly: true, MountPath: karmadaConfigVolumeMountPath},
+						{Name: globaloptions.KarmadaCertsName, ReadOnly: true, MountPath: karmadaCertsVolumeMountPath},
+					}
+				}(),
 			},
 		},
-		Volumes: []corev1.Volume{
-			{
-				Name: karmadaConfigVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: util.KarmadaConfigName(names.KarmadaAggregatedAPIServerComponentName),
-					},
-				},
-			},
-			{
-				Name: globaloptions.KarmadaCertsName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: globaloptions.KarmadaCertsName,
-					},
-				},
-			},
-		},
+		Volumes: func() []corev1.Volume {
+			if strings.ToLower(i.SecretLayout) == secretLayoutSplit {
+				return []corev1.Volume{
+					{Name: karmadaConfigVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: util.KarmadaConfigName(names.KarmadaAggregatedAPIServerComponentName)}}},
+					{Name: serverCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certconst.SecretAggregatedAPIServerServer}}},
+					{Name: etcdClientCertVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certconst.SecretAggregatedAPIServerEtcdClient}}},
+				}
+			}
+			return []corev1.Volume{
+				{Name: karmadaConfigVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: util.KarmadaConfigName(names.KarmadaAggregatedAPIServerComponentName)}}},
+				{Name: globaloptions.KarmadaCertsName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: globaloptions.KarmadaCertsName}}},
+			}
+		}(),
 		Tolerations: []corev1.Toleration{
 			{
 				Effect:   corev1.TaintEffectNoExecute,

--- a/pkg/karmadactl/cmdinit/kubernetes/deployments_test.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deployments_test.go
@@ -17,7 +17,18 @@ limitations under the License.
 package kubernetes
 
 import (
+	"context"
+	"fmt"
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	certconst "github.com/karmada-io/karmada/pkg/cert"
+	initopt "github.com/karmada-io/karmada/pkg/karmadactl/cmdinit/options"
+	globalopt "github.com/karmada-io/karmada/pkg/karmadactl/options"
+	"github.com/karmada-io/karmada/pkg/karmadactl/util"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 func TestCommandInitOption_etcdServers(t *testing.T) {
@@ -80,5 +91,175 @@ func TestCommandInitOption_makeKarmadaAggregatedAPIServerDeployment(t *testing.T
 	deployment := cmdOpt.makeKarmadaAggregatedAPIServerDeployment()
 	if deployment == nil {
 		t.Error("CommandInitOption.makeKarmadaAggregatedAPIServerDeployment() returns nil")
+	}
+}
+
+// helpers
+func hasFlag(cmd []string, want string) bool {
+	for _, c := range cmd {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestKarmadaAPIServerContainerCommand_Flags_SplitAndLegacy(t *testing.T) {
+	// split
+	split := CommandInitOption{
+		SecretLayout: "split",
+		Namespace:    "karmada",
+		EtcdReplicas: 1,
+	}
+	scmd := split.karmadaAPIServerContainerCommand()
+	if !hasFlag(scmd, fmt.Sprintf("--client-ca-file=%s/ca.crt", serverCertVolumeMountPath)) {
+		t.Fatalf("split: missing --client-ca-file=%s/ca.crt", serverCertVolumeMountPath)
+	}
+	if !hasFlag(scmd, fmt.Sprintf("--etcd-cafile=%s/ca.crt", etcdClientCertVolumeMountPath)) ||
+		!hasFlag(scmd, fmt.Sprintf("--etcd-certfile=%s/tls.crt", etcdClientCertVolumeMountPath)) ||
+		!hasFlag(scmd, fmt.Sprintf("--etcd-keyfile=%s/tls.key", etcdClientCertVolumeMountPath)) {
+		t.Fatalf("split: etcd client flags not using etcd-client mount path")
+	}
+	if !hasFlag(scmd, fmt.Sprintf("--tls-cert-file=%s/tls.crt", serverCertVolumeMountPath)) ||
+		!hasFlag(scmd, fmt.Sprintf("--tls-private-key-file=%s/tls.key", serverCertVolumeMountPath)) {
+		t.Fatalf("split: server tls flags not using server mount path")
+	}
+
+	// legacy
+	legacy := CommandInitOption{
+		Namespace:    "karmada",
+		EtcdReplicas: 1,
+	}
+	lcmd := legacy.karmadaAPIServerContainerCommand()
+	if !hasFlag(lcmd, fmt.Sprintf("--client-ca-file=%s/%s.crt", karmadaCertsVolumeMountPath, globalopt.CaCertAndKeyName)) {
+		t.Fatalf("legacy: missing client-ca-file from karmada-cert")
+	}
+	if !hasFlag(lcmd, fmt.Sprintf("--etcd-cafile=%s/%s.crt", karmadaCertsVolumeMountPath, initopt.EtcdCaCertAndKeyName)) ||
+		!hasFlag(lcmd, fmt.Sprintf("--etcd-certfile=%s/%s.crt", karmadaCertsVolumeMountPath, initopt.EtcdClientCertAndKeyName)) ||
+		!hasFlag(lcmd, fmt.Sprintf("--etcd-keyfile=%s/%s.key", karmadaCertsVolumeMountPath, initopt.EtcdClientCertAndKeyName)) {
+		t.Fatalf("legacy: missing etcd client flags from karmada-cert")
+	}
+}
+
+func TestMakeKarmadaAPIServerDeployment_SplitVolumesAndSecrets(t *testing.T) {
+	opt := CommandInitOption{Namespace: "karmada", SecretLayout: "split"}
+	dep := opt.makeKarmadaAPIServerDeployment()
+	ps := dep.Spec.Template.Spec
+
+	// volume mounts present with expected mount paths
+	wantMounts := map[string]string{
+		serverCertVolumeName:           serverCertVolumeMountPath,
+		etcdClientCertVolumeName:       etcdClientCertVolumeMountPath,
+		frontProxyClientCertVolumeName: frontProxyClientCertVolumeMountPath,
+		saKeyPairVolumeName:            saKeyPairVolumeMountPath,
+	}
+	for name, path := range wantMounts {
+		found := false
+		for _, m := range ps.Containers[0].VolumeMounts {
+			if m.Name == name && m.MountPath == path {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("split: missing VolumeMount %q at %q", name, path)
+		}
+	}
+
+	// volumes should reference expected secret names
+	wantSecrets := map[string]string{
+		serverCertVolumeName:           certconst.SecretApiserverServer,
+		etcdClientCertVolumeName:       certconst.SecretApiserverEtcdClient,
+		frontProxyClientCertVolumeName: certconst.SecretApiserverFrontProxyClient,
+		saKeyPairVolumeName:            certconst.SecretApiserverServiceAccountKeys,
+	}
+	for vname, sname := range wantSecrets {
+		found := false
+		for _, v := range ps.Volumes {
+			if v.Name == vname && v.VolumeSource.Secret != nil && v.VolumeSource.Secret.SecretName == sname {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("split: volume %q missing or secretName != %q", vname, sname)
+		}
+	}
+}
+
+func TestCreateSplitCertsSecrets_CreatesExpectedSecrets(t *testing.T) {
+	opt := CommandInitOption{
+		Namespace:     "karmada",
+		KubeClientSet: fake.NewClientset(),
+	}
+	// Minimal fake data for required certs/keys
+	opt.CertAndKeyFileData = map[string][]byte{
+		fmt.Sprintf("%s.crt", globalopt.CaCertAndKeyName):             []byte("CA"),
+		fmt.Sprintf("%s.key", globalopt.CaCertAndKeyName):             []byte("CAK"),
+		fmt.Sprintf("%s.crt", initopt.KarmadaCertAndKeyName):          []byte("KAR"),
+		fmt.Sprintf("%s.key", initopt.KarmadaCertAndKeyName):          []byte("KARK"),
+		fmt.Sprintf("%s.crt", initopt.ApiserverCertAndKeyName):        []byte("APS"),
+		fmt.Sprintf("%s.key", initopt.ApiserverCertAndKeyName):        []byte("APSK"),
+		fmt.Sprintf("%s.crt", initopt.FrontProxyCaCertAndKeyName):     []byte("FPCA"),
+		fmt.Sprintf("%s.crt", initopt.FrontProxyClientCertAndKeyName): []byte("FPC"),
+		fmt.Sprintf("%s.key", initopt.FrontProxyClientCertAndKeyName): []byte("FPCK"),
+		fmt.Sprintf("%s.crt", initopt.EtcdCaCertAndKeyName):           []byte("ECA"),
+		fmt.Sprintf("%s.crt", initopt.EtcdServerCertAndKeyName):       []byte("ESC"),
+		fmt.Sprintf("%s.key", initopt.EtcdServerCertAndKeyName):       []byte("ESK"),
+		fmt.Sprintf("%s.crt", initopt.EtcdClientCertAndKeyName):       []byte("ECC"),
+		fmt.Sprintf("%s.key", initopt.EtcdClientCertAndKeyName):       []byte("ECK"),
+	}
+
+	if err := opt.createSplitCertsSecrets(); err != nil {
+		t.Fatalf("createSplitCertsSecrets error: %v", err)
+	}
+
+	// pick representative secrets to assert
+	secretNames := []string{
+		certconst.SecretApiserverServer,
+		certconst.SecretApiserverEtcdClient,
+		certconst.SecretAggregatedAPIServerServer,
+		certconst.SecretEtcdServer,
+		certconst.SecretKubeControllerManagerCA,
+		certconst.SecretWebhook,
+		certconst.SecretSchedulerEstimatorClient,
+		globalopt.KarmadaCertsName, // CA-only compat
+	}
+	for _, n := range secretNames {
+		s, err := opt.KubeClientSet.CoreV1().Secrets(opt.Namespace).Get(context.Background(), n, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected secret %q to exist: %v", n, err)
+		}
+		switch n {
+		case globalopt.KarmadaCertsName:
+			if _, ok := s.StringData[certconst.KeyCACrt]; !ok {
+				t.Fatalf("compat secret %q missing %q", n, certconst.KeyCACrt)
+			}
+		case certconst.SecretApiserverServiceAccountKeys, certconst.SecretKubeControllerManagerSAKeys:
+			if _, ok := s.StringData[certconst.KeySAPrivate]; !ok {
+				t.Fatalf("secret %q missing %q", n, certconst.KeySAPrivate)
+			}
+			if _, ok := s.StringData[certconst.KeySAPublic]; !ok {
+				t.Fatalf("secret %q missing %q", n, certconst.KeySAPublic)
+			}
+		default:
+			if _, ok := s.StringData[certconst.KeyTLSCrt]; !ok {
+				t.Fatalf("secret %q missing %q", n, certconst.KeyTLSCrt)
+			}
+			if _, ok := s.StringData[certconst.KeyTLSKey]; !ok {
+				t.Fatalf("secret %q missing %q", n, certconst.KeyTLSKey)
+			}
+		}
+	}
+
+	// also ensure a few config secrets exist (created from karmadaConfigList)
+	confNames := []string{
+		util.KarmadaConfigName(names.KarmadaAggregatedAPIServerComponentName),
+		util.KarmadaConfigName(names.KubeControllerManagerComponentName),
+	}
+	for _, cn := range confNames {
+		if _, err := opt.KubeClientSet.CoreV1().Secrets(opt.Namespace).Get(context.Background(), cn, metav1.GetOptions{}); err != nil {
+			t.Fatalf("expected config secret %q to exist: %v", cn, err)
+		}
 	}
 }

--- a/pkg/karmadactl/cmdinit/options/global.go
+++ b/pkg/karmadactl/cmdinit/options/global.go
@@ -17,26 +17,122 @@ limitations under the License.
 package options
 
 const (
-	// EtcdCaCertAndKeyName etcd ca certificate key name
-	EtcdCaCertAndKeyName = "etcd-ca"
-	// EtcdServerCertAndKeyName etcd server certificate key name
-	EtcdServerCertAndKeyName = "etcd-server"
-	// EtcdClientCertAndKeyName etcd client certificate key name
-	EtcdClientCertAndKeyName = "etcd-client"
-	// KarmadaCertAndKeyName karmada certificate key name
+	// KarmadaCertAndKeyName is the default admin kubeconfig client cert/key base name.
 	KarmadaCertAndKeyName = "karmada"
-	// ApiserverCertAndKeyName karmada apiserver certificate key name
-	ApiserverCertAndKeyName = "apiserver"
-	// FrontProxyCaCertAndKeyName front-proxy-client  certificate key name
+	// EtcdCaCertAndKeyName is the etcd CA cert/key base name.
+	EtcdCaCertAndKeyName = "etcd-ca"
+	// FrontProxyCaCertAndKeyName is the front-proxy CA cert/key base name.
 	FrontProxyCaCertAndKeyName = "front-proxy-ca"
-	// FrontProxyClientCertAndKeyName front-proxy-client  certificate key name
+	// EtcdServerCertAndKeyName is the etcd server cert/key base name.
+	EtcdServerCertAndKeyName = "etcd-server"
+	// EtcdClientCertAndKeyName is the etcd client cert/key base name.
+	EtcdClientCertAndKeyName = "etcd-client"
+	// ApiserverCertAndKeyName is the legacy karmada apiserver cert/key base name.
+	ApiserverCertAndKeyName = "apiserver"
+	// FrontProxyClientCertAndKeyName is the front-proxy client cert/key base name.
 	FrontProxyClientCertAndKeyName = "front-proxy-client"
-	// ClusterName karmada cluster name
+
+	// KarmadaAPIServerCertAndKeyName is the split-layout server cert/key base name for karmada-apiserver.
+	KarmadaAPIServerCertAndKeyName = "karmada-apiserver"
+	// KarmadaAggregatedAPIServerCertAndKeyName is the split-layout server cert/key base name for karmada-aggregated-apiserver.
+	KarmadaAggregatedAPIServerCertAndKeyName = "karmada-aggregated-apiserver"
+	// KarmadaWebhookCertAndKeyName is the server cert/key base name for karmada-webhook.
+	KarmadaWebhookCertAndKeyName = "karmada-webhook"
+	// KarmadaSearchCertAndKeyName is the server cert/key base name for karmada-search.
+	KarmadaSearchCertAndKeyName = "karmada-search"
+	// KarmadaMetricsAdapterCertAndKeyName is the server cert/key base name for karmada-metrics-adapter.
+	KarmadaMetricsAdapterCertAndKeyName = "karmada-metrics-adapter"
+	// KarmadaSchedulerEstimatorCertAndKeyName is the server cert/key base name for karmada-scheduler-estimator.
+	KarmadaSchedulerEstimatorCertAndKeyName = "karmada-scheduler-estimator"
+
+	// KarmadaAPIServerClientCertAndKeyName is the client cert/key base name for karmada-apiserver.
+	KarmadaAPIServerClientCertAndKeyName = "karmada-apiserver-client"
+	// KarmadaAggregatedAPIServerClientCertAndKeyName is the client cert/key base name for karmada-aggregated-apiserver.
+	KarmadaAggregatedAPIServerClientCertAndKeyName = "karmada-aggregated-apiserver-client"
+	// KarmadaWebhookClientCertAndKeyName is the client cert/key base name for karmada-webhook.
+	KarmadaWebhookClientCertAndKeyName = "karmada-webhook-client"
+	// KarmadaSearchClientCertAndKeyName is the client cert/key base name for karmada-search.
+	KarmadaSearchClientCertAndKeyName = "karmada-search-client"
+	// KarmadaMetricsAdapterClientCertAndKeyName is the client cert/key base name for karmada-metrics-adapter.
+	KarmadaMetricsAdapterClientCertAndKeyName = "karmada-metrics-adapter-client"
+	// KarmadaSchedulerEstimatorClientCertAndKeyName is the client cert/key base name for karmada-scheduler-estimator.
+	KarmadaSchedulerEstimatorClientCertAndKeyName = "karmada-scheduler-estimator-client"
+	// KarmadaControllerManagerClientCertAndKeyName is the client cert/key base name for karmada-controller-manager.
+	KarmadaControllerManagerClientCertAndKeyName = "karmada-controller-manager-client"
+	// KubeControllerManagerClientCertAndKeyName is the client cert/key base name for kube-controller-manager.
+	KubeControllerManagerClientCertAndKeyName = "kube-controller-manager-client"
+	// KarmadaSchedulerClientCertAndKeyName is the client cert/key base name for karmada-scheduler.
+	KarmadaSchedulerClientCertAndKeyName = "karmada-scheduler-client"
+	// KarmadaDeschedulerClientCertAndKeyName is the client cert/key base name for karmada-descheduler.
+	KarmadaDeschedulerClientCertAndKeyName = "karmada-descheduler-client"
+
+	// KarmadaAPIServerEtcdClientCertAndKeyName is the etcd client cert/key base name for karmada-apiserver.
+	KarmadaAPIServerEtcdClientCertAndKeyName = "karmada-apiserver-etcd-client"
+	// KarmadaAggregatedAPIServerEtcdClientCertAndKeyName is the etcd client cert/key base name for karmada-aggregated-apiserver.
+	KarmadaAggregatedAPIServerEtcdClientCertAndKeyName = "karmada-aggregated-apiserver-etcd-client"
+	// KarmadaSearchEtcdClientCertAndKeyName is the etcd client cert/key base name for karmada-search.
+	KarmadaSearchEtcdClientCertAndKeyName = "karmada-search-etcd-client"
+
+	// KarmadaSchedulerGrpcCertAndKeyName is the gRPC client cert/key base name for karmada-scheduler.
+	KarmadaSchedulerGrpcCertAndKeyName = "karmada-scheduler-grpc"
+	// KarmadaDeschedulerGrpcCertAndKeyName is the gRPC client cert/key base name for karmada-descheduler.
+	KarmadaDeschedulerGrpcCertAndKeyName = "karmada-descheduler-grpc"
+	// ClusterName is the karmada cluster name.
 	ClusterName = "karmada-apiserver"
-	// UserName karmada cluster user name
+	// UserName is the karmada cluster user name.
 	UserName = "karmada-admin"
-	// KarmadaKubeConfigName karmada kubeconfig name
+	// KarmadaKubeConfigName is the kubeconfig file name for karmada.
 	KarmadaKubeConfigName = "karmada-apiserver.config"
-	// WaitComponentReadyTimeout wait component ready time
+	// WaitComponentReadyTimeout is the seconds to wait for components ready.
 	WaitComponentReadyTimeout = 120
+)
+
+// CN (CommonName) for certificates
+const (
+	// KarmadaEtcdServerCN is the CommonName for etcd server certificate.
+	KarmadaEtcdServerCN = "system:karmada:etcd-server"
+	// KarmadaEtcdClientCN is the CommonName for etcd client certificate.
+	KarmadaEtcdClientCN = "system:karmada:etcd-etcd-client"
+
+	// KarmadaAPIServerCN is the CommonName for karmada-apiserver.
+	KarmadaAPIServerCN = "system:karmada:karmada-apiserver"
+	// KarmadaAPIServerEtcdClientCN is the CommonName for karmada-apiserver etcd client.
+	KarmadaAPIServerEtcdClientCN = "system:karmada:karmada-apiserver-etcd-client"
+
+	// KarmadaAggregatedAPIServerCN is the CommonName for karmada-aggregated-apiserver.
+	KarmadaAggregatedAPIServerCN = "system:karmada:karmada-aggregated-apiserver"
+	// KarmadaAggregatedAPIServerEtcdClientCN is the CommonName for karmada-aggregated-apiserver etcd client.
+	KarmadaAggregatedAPIServerEtcdClientCN = "system:karmada:karmada-aggregated-apiserver-etcd-client"
+
+	// KarmadaWebhookCN is the CommonName for karmada-webhook.
+	KarmadaWebhookCN = "system:karmada:karmada-webhook"
+
+	// KarmadaSearchCN is the CommonName for karmada-search.
+	KarmadaSearchCN = "system:karmada:karmada-search"
+	// KarmadaSearchEtcdClientCN is the CommonName for karmada-search etcd client.
+	KarmadaSearchEtcdClientCN = "system:karmada:karmada-search-etcd-client"
+
+	// KarmadaMetricsAdapterCN is the CommonName for karmada-metrics-adapter.
+	KarmadaMetricsAdapterCN = "system:karmada:karmada-metrics-adapter"
+
+	// KarmadaSchedulerEstimatorCN is the CommonName for karmada-scheduler-estimator.
+	KarmadaSchedulerEstimatorCN = "system:karmada:karmada-scheduler-estimator"
+
+	// KarmadaControllerManagerCN is the CommonName for karmada-controller-manager.
+	KarmadaControllerManagerCN = "system:karmada:karmada-controller-manager"
+	// KubeControllerManagerCN is the CommonName for kube-controller-manager.
+	KubeControllerManagerCN = "system:karmada:kube-controller-manager"
+
+	// KarmadaSchedulerCN is the CommonName for karmada-scheduler.
+	KarmadaSchedulerCN = "system:karmada:karmada-scheduler"
+	// KarmadaSchedulerGrpcCN is the CommonName for karmada-scheduler gRPC.
+	KarmadaSchedulerGrpcCN = "system:karmada:karmada-scheduler-grpc"
+
+	// KarmadaDeschedulerCN is the CommonName for karmada-descheduler.
+	KarmadaDeschedulerCN = "system:karmada:karmada-descheduler"
+	// KarmadaDeschedulerGrpcCN is the CommonName for karmada-descheduler gRPC.
+	KarmadaDeschedulerGrpcCN = "system:karmada:karmada-descheduler-grpc"
+
+	// KarmadaFrontProxyClientCN is the CommonName for the front-proxy client.
+	KarmadaFrontProxyClientCN = "front-proxy-client"
 )


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
Part of #6670 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #6670 

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->
This commit allows karmadactl init to generate certificates with a new architecture (unique CN/SAN for each) when using the --secret-layout flag. This PR, combined with #6788 , completes the transition to the new self-signed certificate generation mechanism for karmadactl.

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->
@chaosi-zju
@zhzhuang-zju
@XiShanYongYe-Chang

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note

```

