### PR TITLE
Implement MaxAvailableComponentSets for general estimator

### DIFF
--- a/pkg/estimator/client/general.go
+++ b/pkg/estimator/client/general.go
@@ -53,15 +53,6 @@ func (ge *GeneralEstimator) MaxAvailableReplicas(_ context.Context, clusters []*
 	return availableTargetClusters, nil
 }
 
-// MaxAvailableComponentSets returns the maximum number of complete multi-component sets (in terms of replicas) that each cluster can host.
-func (ge *GeneralEstimator) MaxAvailableComponentSets(
-	_ context.Context,
-	_ *ComponentSetEstimationRequest) ([]ComponentSetEstimationResponse, error) {
-	// Dummy implementation: return nothing for now
-	// TODO: Implement as part of #6734
-	return nil, nil
-}
-
 func (ge *GeneralEstimator) maxAvailableReplicas(cluster *clusterv1alpha1.Cluster, replicaRequirements *workv1alpha2.ReplicaRequirements) int32 {
 	//Note: resourceSummary must be deep-copied before using in the function to avoid modifying the original data structure.
 	resourceSummary := cluster.Status.ResourceSummary.DeepCopy()
@@ -100,6 +91,132 @@ func (ge *GeneralEstimator) maxAvailableReplicas(cluster *clusterv1alpha1.Cluste
 	}
 
 	return int32(maximumReplicas) // #nosec G115: integer overflow conversion int64 -> int32
+}
+
+// MaxAvailableComponentSets (generic estimator) – resourceSummary only.
+func (ge *GeneralEstimator) MaxAvailableComponentSets(
+	ctx context.Context,
+	req *ComponentSetEstimationRequest,
+) ([]ComponentSetEstimationResponse, error) {
+	responses := make([]ComponentSetEstimationResponse, len(req.Clusters))
+	for i, cluster := range req.Clusters {
+		maxComponentSets := ge.maxAvailableComponentSets(cluster, req.Components)
+		responses[i] = ComponentSetEstimationResponse{Name: cluster.Name, Sets: maxComponentSets}
+	}
+	return responses, nil
+}
+
+func (ge *GeneralEstimator) maxAvailableComponentSets(cluster *clusterv1alpha1.Cluster, components []*workv1alpha2.Component) int32 {
+	// Compute per-set aggregate requirement (e.g. CPU, Memory)
+	setCPU, setMem := perSetRequirement(components)
+	resourceSummary := cluster.Status.ResourceSummary.DeepCopy()
+	if resourceSummary == nil {
+		return 0
+	}
+
+	// Upper bound by pods
+	maxSets := getAllowedPodNumber(resourceSummary)
+	if maxSets <= 0 {
+		return 0
+	}
+
+	// Fallback to allowedPodNumber if there is no resourceRequirement
+	if setCPU == 0 && setMem == 0 {
+		return int32(maxSets)
+	}
+
+	// Upper bound by aggregate CPU/Memory
+	num := getMaximumSetsBasedOnClusterSummary(resourceSummary, setCPU, setMem)
+	if num < maxSets {
+		maxSets = num
+	}
+
+	// Optional refinement with ResourceModels (if feature gate enabled)
+	if features.FeatureGate.Enabled(features.CustomizedClusterResourceModeling) &&
+		len(cluster.Status.ResourceSummary.AllocatableModelings) > 0 {
+
+		num, err := getMaximumSetsBasedOnResourceModels(cluster, components)
+		if err == nil && num < maxSets {
+			maxSets = num
+		}
+	}
+
+	return int32(maxSets)
+}
+
+// perSetRequirement computes aggregate CPU/Memory demand of one set of components.
+func perSetRequirement(components []*workv1alpha2.Component) (cpuMilli int64, memBytes int64) {
+	for _, c := range components {
+		if c.ReplicaRequirements == nil || c.ReplicaRequirements.ResourceRequest == nil {
+			continue
+		}
+		replicas := int64(c.Replicas)
+		reqs := c.ReplicaRequirements.ResourceRequest
+
+		if cpuQty, ok := reqs[corev1.ResourceCPU]; ok {
+			cpuMilli += replicas * cpuQty.MilliValue()
+		}
+		if memQty, ok := reqs[corev1.ResourceMemory]; ok {
+			memBytes += replicas * memQty.Value()
+		}
+	}
+	return
+}
+
+// getMaximumSetsBasedOnClusterSummary checks aggregate resource limits.
+func getMaximumSetsBasedOnClusterSummary(resourceSummary *clusterv1alpha1.ResourceSummary, setCPU, setMem int64) int64 {
+	availCPU := availableQuantity(resourceSummary, corev1.ResourceCPU)
+	availMem := availableQuantity(resourceSummary, corev1.ResourceMemory)
+
+	if availCPU <= 0 || availMem <= 0 {
+		return 0
+	}
+
+	switch {
+	case setCPU > 0 && setMem > 0:
+		return min64(availCPU/setCPU, availMem/setMem)
+	case setCPU > 0:
+		return availCPU / setCPU
+	case setMem > 0:
+		return availMem / setMem
+	default:
+		return math.MaxInt64
+	}
+}
+
+// getMaximumSetsBasedOnResourceModels is a placeholder for future implementation.
+// It should refine the maximum sets based on cluster resource models, similar
+// to getMaximumReplicasBasedOnResourceModels but adapted to full component sets.
+func getMaximumSetsBasedOnResourceModels(_ *clusterv1alpha1.Cluster, _ []*workv1alpha2.Component) (int64, error) {
+	// TODO: implement logic based on cluster.Spec.ResourceModels
+	// For now, just return MaxInt64 so it never reduces the upper bound.
+	return math.MaxInt64, nil
+}
+
+// availableQuantity = allocatable - allocated - allocating
+// Returns CPU in millicores, Memory in bytes.
+func availableQuantity(rs *clusterv1alpha1.ResourceSummary, key corev1.ResourceName) int64 {
+	allocatable, ok := rs.Allocatable[key]
+	if !ok {
+		return 0
+	}
+	allocated := rs.Allocated[key]
+	allocating := rs.Allocating[key]
+
+	allocatable.Sub(allocated)
+	allocatable.Sub(allocating)
+
+	if key == corev1.ResourceCPU {
+		return allocatable.MilliValue() // millicores
+	}
+	return allocatable.Value() // bytes for memory, count for pods, etc.
+}
+
+func min64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 func getAllowedPodNumber(resourceSummary *clusterv1alpha1.ResourceSummary) int64 {

--- a/pkg/estimator/client/general_test.go
+++ b/pkg/estimator/client/general_test.go
@@ -800,3 +800,169 @@ func TestMinimumModelIndex(t *testing.T) {
 		})
 	}
 }
+
+func TestGetMaxAvailableComponentSetsGeneral(t *testing.T) {
+	tests := []struct {
+		name       string
+		cluster    *clusterv1alpha1.Cluster
+		components []*workv1alpha2.Component
+		expected   int32
+	}{
+		{
+			name: "nil resource summary",
+			cluster: &clusterv1alpha1.Cluster{
+				Status: clusterv1alpha1.ClusterStatus{},
+			},
+			expected: 0,
+		},
+		{
+			name: "no allowed pods",
+			cluster: &clusterv1alpha1.Cluster{
+				Status: clusterv1alpha1.ClusterStatus{
+					ResourceSummary: &clusterv1alpha1.ResourceSummary{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourcePods: resource.MustParse("10"),
+						},
+						Allocated: corev1.ResourceList{
+							corev1.ResourcePods: resource.MustParse("10"),
+						},
+					},
+				},
+			},
+			expected: 0,
+		},
+		{
+			name: "empty component list",
+			cluster: &clusterv1alpha1.Cluster{
+				Status: clusterv1alpha1.ClusterStatus{
+					ResourceSummary: &clusterv1alpha1.ResourceSummary{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourcePods: resource.MustParse("10"),
+						},
+					},
+				},
+			},
+			expected: 10,
+		},
+		{
+			name: "basic resource estimation",
+			cluster: &clusterv1alpha1.Cluster{
+				Status: clusterv1alpha1.ClusterStatus{
+					ResourceSummary: &clusterv1alpha1.ResourceSummary{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourcePods:   resource.MustParse("100"),
+							corev1.ResourceCPU:    resource.MustParse("10"),
+							corev1.ResourceMemory: resource.MustParse("8Gi"),
+						},
+						Allocated: corev1.ResourceList{
+							corev1.ResourcePods:   resource.MustParse("20"),
+							corev1.ResourceCPU:    resource.MustParse("0"),
+							corev1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+					},
+				},
+			},
+			components: []*workv1alpha2.Component{
+				{
+					Name:     "jobmanager",
+					Replicas: 1,
+					ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+						ResourceRequest: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						},
+					},
+				},
+				{
+					Name:     "taskmanager",
+					Replicas: 2,
+					ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+						ResourceRequest: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1.5"),
+						},
+					},
+				},
+			},
+			expected: 2,
+		},
+		{
+			name: "resource estimation with mixed components",
+			cluster: &clusterv1alpha1.Cluster{
+				Status: clusterv1alpha1.ClusterStatus{
+					ResourceSummary: &clusterv1alpha1.ResourceSummary{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourcePods:   resource.MustParse("100"),
+							corev1.ResourceCPU:    resource.MustParse("10"),
+							corev1.ResourceMemory: resource.MustParse("8Gi"),
+						},
+						Allocated: corev1.ResourceList{
+							corev1.ResourcePods:   resource.MustParse("20"),
+							corev1.ResourceCPU:    resource.MustParse("0"),
+							corev1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+					},
+				},
+			},
+			components: []*workv1alpha2.Component{
+				{
+					Name:     "jobmanager",
+					Replicas: 1,
+					ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+						ResourceRequest: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+					},
+				},
+				{
+					Name:     "taskmanager",
+					Replicas: 2,
+					ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+						ResourceRequest: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("2000m"),
+							corev1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+					},
+				},
+			},
+			// CPU set total    = 5, estimation 10 / 5 = 2
+			// Memory set total = 6Gi, estimation 6Gi / 6 = 1
+			// min*(2,1) = 1 set
+			expected: 1,
+		},
+		{
+			name: "estimation limited by pod count",
+			cluster: &clusterv1alpha1.Cluster{
+				Status: clusterv1alpha1.ClusterStatus{
+					ResourceSummary: &clusterv1alpha1.ResourceSummary{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourcePods:   resource.MustParse("3"),
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("1Ti"),
+						},
+					},
+				},
+			},
+			components: []*workv1alpha2.Component{
+				{
+					Name:     "small-component",
+					Replicas: 1,
+					ReplicaRequirements: &workv1alpha2.ComponentReplicaRequirements{
+						ResourceRequest: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+							corev1.ResourceMemory: resource.MustParse("1Mi"),
+						},
+					},
+				},
+			},
+			expected: 3, // limited by pods
+		},
+	}
+
+	estimator := NewGeneralEstimator()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := estimator.maxAvailableComponentSets(tt.cluster, tt.components)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Implements MaxAvailableComponentSets method for general estimator. Currently, this implementation just relies on the cluster resource summary. We will need to file a follow-up task to implement `getMaximumSetsBasedOnResourceModels` which currently is a stub method.

**Which issue(s) this PR fixes**:
Part of #6734 

**Does this PR introduce a user-facing change?**:
Yes

```release-note
Implement MaxAvailableComponentSets for general estimator
```

