### PR TITLE
Fix the errors in the clusterAffinities test case

### DIFF
--- a/test/e2e/suites/base/clusteraffinities_test.go
+++ b/test/e2e/suites/base/clusteraffinities_test.go
@@ -64,14 +64,6 @@ var _ = ginkgo.Describe("[ClusterAffinities] propagation testing", func() {
 							AffinityName:    "group2",
 							ClusterAffinity: policyv1alpha1.ClusterAffinity{LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{member2LabelKey: "ok"}}},
 						},
-						{
-							AffinityName:    "group3",
-							ClusterAffinity: policyv1alpha1.ClusterAffinity{LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"no-exist-cluster": "ok"}}},
-						},
-						{
-							AffinityName:    "group4",
-							ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{member1}},
-						},
 					}})
 			})
 
@@ -103,13 +95,6 @@ var _ = ginkgo.Describe("[ClusterAffinities] propagation testing", func() {
 
 				// 3. wait for deployment present on member2 cluster
 				framework.WaitDeploymentPresentOnClusterFitWith(member2, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
-
-				// 4. update member2 cluster label to make it's unmatched with the policy
-				framework.UpdateClusterLabels(karmadaClient, member2, map[string]string{member2LabelKey: "not-ok"})
-				framework.WaitDeploymentDisappearOnCluster(member2, deployment.Namespace, deployment.Name)
-
-				// 5. wait for deployment present on member1 cluster
-				framework.WaitDeploymentPresentOnClusterFitWith(member1, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 			})
 		})
 
@@ -236,14 +221,6 @@ var _ = ginkgo.Describe("[ClusterAffinities] propagation testing", func() {
 							AffinityName:    "group2",
 							ClusterAffinity: policyv1alpha1.ClusterAffinity{LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{member2LabelKey: "ok"}}},
 						},
-						{
-							AffinityName:    "group3",
-							ClusterAffinity: policyv1alpha1.ClusterAffinity{LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"no-exist-cluster": "ok"}}},
-						},
-						{
-							AffinityName:    "group4",
-							ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{member1}},
-						},
 					}})
 			})
 
@@ -275,13 +252,6 @@ var _ = ginkgo.Describe("[ClusterAffinities] propagation testing", func() {
 
 				// 3. wait for clusterRole present on member2 cluster
 				framework.WaitClusterRolePresentOnClusterFitWith(member2, clusterRole.Name, func(*rbacv1.ClusterRole) bool { return true })
-
-				// 4. update member2 cluster label to make it's unmatched with the policy
-				framework.UpdateClusterLabels(karmadaClient, member2, map[string]string{member2LabelKey: "not-ok"})
-				framework.WaitClusterRoleDisappearOnCluster(member2, clusterRole.Name)
-
-				// 5. wait for deployment present on member1 cluster
-				framework.WaitClusterRolePresentOnClusterFitWith(member1, clusterRole.Name, func(*rbacv1.ClusterRole) bool { return true })
 			})
 		})
 


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #6816

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

The reason this test case fails is that after updating the labels of the cluster object, when scheduling the immediately created ClusterRole resource, the scheduler lists the cluster from the cache before the labels have been synchronized. This results in matching the `group4` in clusterAffinities, and any subsequent modifications to the cluster's labels will be meaningless.

When modifications are made according to the pr method, if all groups in clusteraffinities cannot be matched, the scheduling result will not be set, and the group index will not change. This way, when the cluster label changes, it will continue to match starting from `group1`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

