### PR TITLE
Add Admission Control for Karmada Operator

### DIFF
--- a/charts/karmada-operator/templates/karmada-operator-deployment.yaml
+++ b/charts/karmada-operator/templates/karmada-operator-deployment.yaml
@@ -5,11 +5,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app: {{ include "karmada.operator.fullname" . }}
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- if .Values.operator.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.operator.labels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- if .Values.operator.annotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.operator.annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{  .Values.operator.replicaCount }}
@@ -27,33 +27,40 @@ spec:
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app: {{ include "karmada.operator.fullname" . }}
-        {{- if .Values.podLabels }}
+        {{- if .Values.operator.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.operator.podLabels "context" $) | nindent 8 }}
         {{- end }}
     spec:
       {{- include "karmada.operator.imagePullSecrets" . | indent 6 }}
       containers:
-      - name: {{ include "karmada.operator.fullname" . }}
-        image: {{ template "karmada.operator.image" . }}
-        imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
-        ports:
-        - containerPort: 8080
-          name: metrics
-          protocol: TCP
-        command:
-        - /bin/karmada-operator
-        - --leader-elect-resource-namespace={{ .Release.Namespace }}
-        - --v=2
+        - name: {{ include "karmada.operator.fullname" . }}
+          image: {{ template "karmada.operator.image" . }}
+          imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
+          ports:
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
+            - containerPort: 9443
+              name: webhook
+              protocol: TCP
+          command:
+            - /bin/karmada-operator
+            - --leader-elect-resource-namespace={{ .Release.Namespace }}
+            - --v=2
         {{- range .Values.operator.extraArgs }}
-        - {{ . }}
+            - {{ . }}
         {{- end }}
         {{- with .Values.operator.env }}
-        env:
+          env:
         {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- if .Values.operator.resources }}
-        resources: {{- toYaml .Values.operator.resources | nindent 12 }}
+          resources: {{- toYaml .Values.operator.resources | nindent 12 }}
         {{- end }}
+          volumeMounts:
+            - name: karmada-operator-webhook-cert
+              mountPath: /tmp/k8s-webhook-server/serving-certs
+              readOnly: true
       serviceAccountName: {{ include "karmada.operator.fullname" . }}
       {{- if .Values.operator.affinity }}
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.operator.affinity "context" $) | nindent 8 }}
@@ -64,3 +71,7 @@ spec:
       {{- if .Values.operator.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.operator.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      volumes:
+        - name: karmada-operator-webhook-cert
+          secret:
+            secretName: karmada-operator-webhook-cert

--- a/charts/karmada-operator/templates/webhook-cert.yaml
+++ b/charts/karmada-operator/templates/webhook-cert.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: karmada-operator-webhook-cert
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: karmada-operator-webhook-cert
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: karmada-operator-webhook-cert
+  issuerRef:
+    kind: Issuer
+    name: karmada-operator-webhook-cert
+  dnsNames:
+    - karmada-operator-webhook
+    - karmada-operator-webhook.{{ .Release.Namespace }}
+    - karmada-operator-webhook.{{ .Release.Namespace }}.svc
+    - karmada-operator-webhook.{{ .Release.Namespace }}.svc.cluster.local
+
+

--- a/charts/karmada-operator/templates/webhook-configs.yaml
+++ b/charts/karmada-operator/templates/webhook-configs.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: karmada-mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/karmada-operator-webhook-cert
+webhooks:
+  - name: karmada-v1alpha1.kb.io
+    admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: karmada-operator-webhook
+        namespace: {{ .Release.Namespace }}
+        path: /mutate-operator-karmada-io-v1alpha1-karmada
+    failurePolicy: Fail
+    sideEffects: None
+    rules:
+      - apiGroups: ["operator.karmada.io"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE","UPDATE"]
+        resources: ["karmadas"]
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: karmada-validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/karmada-operator-webhook-cert
+webhooks:
+  - name: karmada-v1alpha1.kb.io
+    admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: karmada-operator-webhook
+        namespace: {{ .Release.Namespace }}
+        path: /validate-operator-karmada-io-v1alpha1-karmada
+    failurePolicy: Fail
+    sideEffects: None
+    rules:
+      - apiGroups: ["operator.karmada.io"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE","UPDATE"]
+        resources: ["karmadas"]
+        

--- a/charts/karmada-operator/templates/webhook-service.yaml
+++ b/charts/karmada-operator/templates/webhook-service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: karmada-operator-webhook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "karmada.operator.fullname" . }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: webhook
+      port: 443
+      targetPort: webhook
+      protocol: TCP
+  selector:
+    app: {{ include "karmada.operator.fullname" . }}
+    

--- a/charts/karmada-operator/values.yaml
+++ b/charts/karmada-operator/values.yaml
@@ -39,6 +39,8 @@ kubectl:
 operator:
   ## @param operator.labels
   labels: {}
+  ## @param operator.annotations Operator deployment annotations
+  annotations: {}
   ## @param operator.replicaCount target replicas
   replicaCount: 1
   ## @param operator.podAnnotations

--- a/hack/deploy-karmada-operator.sh
+++ b/hack/deploy-karmada-operator.sh
@@ -60,14 +60,14 @@ kind load docker-image "${REGISTRY}/karmada-operator:${VERSION}" --name="${CONTE
 # create namespace `karmada-system`
 kubectl --kubeconfig="${KUBECONFIG}" --context="${CONTEXT_NAME}" apply -f "${REPO_ROOT}/artifacts/deploy/namespace.yaml"
 
-# install Karmada operator crds
-kubectl --kubeconfig="${KUBECONFIG}" --context="${CONTEXT_NAME}" apply -f operator/config/crds/
+# deploy karmada-operator using Helm
+echo "Installing Karmada operator using Helm"
+cd "${REPO_ROOT}/charts/karmada-operator"
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm dependency build
+helm --kubeconfig "${KUBECONFIG}" --kube-context "${CONTEXT_NAME}" install --namespace ${KARMADA_SYSTEM_NAMESPACE} karmada-operator .
+cd -
 
-# deploy karmada-operator
-kubectl --kubeconfig="${KUBECONFIG}" --context="${CONTEXT_NAME}" apply -f "${REPO_ROOT}/operator/config/deploy/karmada-operator-clusterrole.yaml"
-kubectl --kubeconfig="${KUBECONFIG}" --context="${CONTEXT_NAME}" apply -f "${REPO_ROOT}/operator/config/deploy/karmada-operator-clusterrolebinding.yaml"
-kubectl --kubeconfig="${KUBECONFIG}" --context="${CONTEXT_NAME}" apply -f "${REPO_ROOT}/operator/config/deploy/karmada-operator-serviceaccount.yaml"
-kubectl --kubeconfig="${KUBECONFIG}" --context="${CONTEXT_NAME}" apply -f "${REPO_ROOT}/operator/config/deploy/karmada-operator-deployment.yaml"
-
-# wait karmada-operator ready
+# Await Karmada operator ready status
 kubectl --kubeconfig="${KUBECONFIG}" --context="${CONTEXT_NAME}" wait --for=condition=Ready --timeout=30s pods -l app.kubernetes.io/name=karmada-operator -n ${KARMADA_SYSTEM_NAMESPACE}
+echo "Successfully installed Karmada operator using Helm."

--- a/hack/local-up-karmada-by-operator.sh
+++ b/hack/local-up-karmada-by-operator.sh
@@ -88,6 +88,9 @@ OPERATOR_POD_NAME=$(kubectl --kubeconfig="${MAIN_KUBECONFIG}" --context="${HOST_
 kubectl --kubeconfig="${MAIN_KUBECONFIG}" --context="${HOST_CLUSTER_NAME}" exec -i ${OPERATOR_POD_NAME} -n ${KARMADA_SYSTEM_NAMESPACE} -- mkdir -p ${CRD_CACHE_DIR}
 kubectl --kubeconfig="${MAIN_KUBECONFIG}" --context="${HOST_CLUSTER_NAME}" cp ${REPO_ROOT}/crds.tar.gz ${KARMADA_SYSTEM_NAMESPACE}/${OPERATOR_POD_NAME}:${CRD_CACHE_DIR}
 
+echo "Installing cert-manager in host cluster"
+kubectl --kubeconfig="${MAIN_KUBECONFIG}" --context="${HOST_CLUSTER_NAME}" apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.19.0/cert-manager.yaml
+
 # step3.3 install karmada instance
 "${REPO_ROOT}"/hack/deploy-karmada-by-operator.sh "${MAIN_KUBECONFIG}" "${HOST_CLUSTER_NAME}" "${KARMADA_APISERVER_CLUSTER_NAME}" "latest" true "${CRDTARBALL_URL}"
 

--- a/operator/README.md
+++ b/operator/README.md
@@ -19,6 +19,11 @@ This section describes how to install `karmada-operator` and create a Karmada in
 - Kubernetes 1.16+
 - Helm v3+
 
+### Install `cert-manager`
+
+`cert-manager` is used to provision and manage the certificate for the operator's webhook server. Please follow [these instructions](https://cert-manager.io/docs/installation/) to download `cert-manager` on the host cluster
+where the Karmada operator is to be installed.
+
 ### Deploy `karmada-operator`
 
 #### Helm install

--- a/operator/internal/webhook/v1alpha1/karmada_webhook.go
+++ b/operator/internal/webhook/v1alpha1/karmada_webhook.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	operatorv1alpha1 "github.com/karmada-io/karmada/operator/pkg/apis/operator/v1alpha1"
+	"github.com/karmada-io/karmada/operator/pkg/controller/karmada"
+)
+
+// SetupKarmadaWebhookWithManager registers the webhook for Karmada in the manager.
+func SetupKarmadaWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&operatorv1alpha1.Karmada{}).
+		WithValidator(&KarmadaCustomValidator{}).
+		WithDefaulter(&KarmadaCustomDefaulter{}).
+		Complete()
+}
+
+// KarmadaCustomDefaulter sets default values on Karmada objects.
+// +kubebuilder:object:generate=false
+type KarmadaCustomDefaulter struct{}
+
+var _ webhook.CustomDefaulter = &KarmadaCustomDefaulter{}
+
+// Default implements webhook.CustomDefaulter so a mutating webhook will be registered for Karmada.
+func (d *KarmadaCustomDefaulter) Default(_ context.Context, obj runtime.Object) error {
+	k, ok := obj.(*operatorv1alpha1.Karmada)
+	if !ok {
+		return fmt.Errorf("expected a Karmada object but got %T", obj)
+	}
+
+	// Ensure labels map exists.
+	if k.Labels == nil {
+		k.Labels = map[string]string{}
+	}
+	// Default the cascading-deletion label to "false" if not present.
+	if _, exists := k.Labels[karmada.DisableCascadingDeletionLabel]; !exists {
+		merged := labels.Merge(k.GetLabels(), labels.Set{karmada.DisableCascadingDeletionLabel: "false"})
+		k.SetLabels(merged)
+		klog.V(2).InfoS("Defaulted label", "namespace", k.Namespace, "name", k.Name, "key", karmada.DisableCascadingDeletionLabel, "value", "false")
+	}
+
+	// Apply defaults
+	operatorv1alpha1.SetObjectDefaultsKarmada(k)
+
+	klog.V(2).InfoS("Defaulted Karmada", "namespace", k.Namespace, "name", k.Name)
+	return nil
+}
+
+// KarmadaCustomValidator validates Karmada resources on create/update/delete.
+// +kubebuilder:object:generate=false
+type KarmadaCustomValidator struct{}
+
+var _ webhook.CustomValidator = &KarmadaCustomValidator{}
+
+// ValidateCreate validates creation of a Karmada object
+func (v *KarmadaCustomValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	k, ok := obj.(*operatorv1alpha1.Karmada)
+	if !ok {
+		return nil, fmt.Errorf("expected a Karmada but got %T", obj)
+	}
+
+	// Enforce validation rules
+	if err := validateKarmada(k); err != nil {
+		klog.ErrorS(err, "Validation failed for Karmada (create)", "namespace", k.Namespace, "name", k.Name)
+		return nil, err
+	}
+
+	klog.V(2).InfoS("Validated Karmada (create)", "namespace", k.Namespace, "name", k.Name)
+	return nil, nil
+}
+
+// ValidateUpdate validates updates of a Karmada object
+func (v *KarmadaCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	oldK, okOld := oldObj.(*operatorv1alpha1.Karmada)
+	newK, okNew := newObj.(*operatorv1alpha1.Karmada)
+	if !okOld || !okNew {
+		return nil, fmt.Errorf("expected a Karmada but got %T -> %T", oldObj, newObj)
+	}
+
+	// Enforce validation rules
+	if err := validateKarmada(newK); err != nil {
+		klog.ErrorS(err, "Validation failed for Karmada (update)",
+			"namespace", newK.Namespace, "name", newK.Name,
+			"oldResourceVersion", oldK.ResourceVersion, "newResourceVersion", newK.ResourceVersion)
+		return nil, err
+	}
+
+	klog.V(2).InfoS("Validated Karmada (update)",
+		"namespace", newK.Namespace, "name", newK.Name,
+		"oldResourceVersion", oldK.ResourceVersion, "newResourceVersion", newK.ResourceVersion)
+	return nil, nil
+}
+
+// ValidateDelete validates deletion of a Karmada object
+func (v *KarmadaCustomValidator) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	k, ok := obj.(*operatorv1alpha1.Karmada)
+	if !ok {
+		return nil, fmt.Errorf("expected a Karmada but got %T", obj)
+	}
+	klog.V(2).InfoS("Validated Karmada (delete)", "namespace", k.Namespace, "name", k.Name)
+	return nil, nil
+}
+
+func validateKarmada(k *operatorv1alpha1.Karmada) error {
+	err := karmada.Validate(k)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/operator/pkg/controller/karmada/validating_test.go
+++ b/operator/pkg/controller/karmada/validating_test.go
@@ -201,9 +201,9 @@ func Test_validate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validate(tt.karmada)
+			err := Validate(tt.karmada)
 			if (err != nil && !tt.wantErr) || (err == nil && tt.wantErr) {
-				t.Errorf("validate() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind feature

**What this PR does / why we need it**:
Please see #6819 

**Which issue(s) this PR fixes**: 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #6819 

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-operator`: In-controller validating and defaulting logic has been moved to admission webhooks. cert-manager is now required as a pre-requisite for installing the Karmada operator via the Helm chart, and will be used to provision the certificate for the operator's webhook server.
```

