### PR TITLE
fix: remove zero replicas clusters of descheduled results

### DIFF
--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -224,6 +224,7 @@ func (d *Descheduler) updateScheduleResult(h *core.SchedulingResultHelper) error
 	if unschedulableSum == 0 {
 		return nil
 	}
+	binding.Spec.Clusters = util.RemoveZeroReplicasCluster(binding.Spec.Clusters)
 	message += fmt.Sprintf(", %d total descheduled replica(s)", unschedulableSum)
 
 	var err error

--- a/pkg/descheduler/descheduler_test.go
+++ b/pkg/descheduler/descheduler_test.go
@@ -455,13 +455,8 @@ func TestDescheduler_worker(t *testing.T) {
 				name:      "foo",
 				namespace: "default",
 			},
-			wantResponse: []workv1alpha2.TargetCluster{
-				{
-					Name:     "member1",
-					Replicas: 0,
-				},
-			},
-			wantErr: false,
+			wantResponse: []workv1alpha2.TargetCluster{},
+			wantErr:      false,
 		},
 		{
 			name: "1 cluster with 4 ready replicas and 2 unschedulable replicas",

--- a/pkg/scheduler/core/common.go
+++ b/pkg/scheduler/core/common.go
@@ -25,6 +25,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/scheduler/core/spreadconstraint"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework"
 	"github.com/karmada-io/karmada/pkg/scheduler/metrics"
+	"github.com/karmada-io/karmada/pkg/util"
 )
 
 // SelectClusters selects clusters based on the placement and resource binding spec.
@@ -62,7 +63,7 @@ func AssignReplicas(
 		if err != nil {
 			return nil, err
 		}
-		return removeZeroReplicasCluster(assignResults), nil
+		return util.RemoveZeroReplicasCluster(assignResults), nil
 	}
 
 	// If not workload, assign all clusters without considering replicas.

--- a/pkg/scheduler/core/util.go
+++ b/pkg/scheduler/core/util.go
@@ -119,14 +119,3 @@ func attachZeroReplicasCluster(clusters []spreadconstraint.ClusterDetailInfo,
 	}
 	return targetClusters
 }
-
-// removeZeroReplicasCLuster remove the cluster with 0 replicas in assignResults
-func removeZeroReplicasCluster(assignResults []workv1alpha2.TargetCluster) []workv1alpha2.TargetCluster {
-	targetClusters := make([]workv1alpha2.TargetCluster, 0, len(assignResults))
-	for _, cluster := range assignResults {
-		if cluster.Replicas > 0 {
-			targetClusters = append(targetClusters, workv1alpha2.TargetCluster{Name: cluster.Name, Replicas: cluster.Replicas})
-		}
-	}
-	return targetClusters
-}

--- a/pkg/util/binding.go
+++ b/pkg/util/binding.go
@@ -130,3 +130,14 @@ func MergePolicySuspension(bindingSuspension *workv1alpha2.Suspension, policySus
 	}
 	return bindingSuspension
 }
+
+// RemoveZeroReplicasCluster remove the cluster with 0 replicas in assignResults
+func RemoveZeroReplicasCluster(assignResults []workv1alpha2.TargetCluster) []workv1alpha2.TargetCluster {
+	targetClusters := make([]workv1alpha2.TargetCluster, 0, len(assignResults))
+	for _, cluster := range assignResults {
+		if cluster.Replicas > 0 {
+			targetClusters = append(targetClusters, cluster)
+		}
+	}
+	return targetClusters
+}

--- a/pkg/util/binding_test.go
+++ b/pkg/util/binding_test.go
@@ -504,3 +504,82 @@ func TestMergePolicySuspension(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveZeroReplicasCluster(t *testing.T) {
+	tests := []struct {
+		name          string
+		assignResults []workv1alpha2.TargetCluster
+		expected      []workv1alpha2.TargetCluster
+	}{
+		{
+			name:          "empty assign results",
+			assignResults: []workv1alpha2.TargetCluster{},
+			expected:      []workv1alpha2.TargetCluster{},
+		},
+		{
+			name: "all clusters with replicas greater than 0",
+			assignResults: []workv1alpha2.TargetCluster{
+				{
+					Name:     ClusterMember1,
+					Replicas: 1,
+				},
+				{
+					Name:     ClusterMember2,
+					Replicas: 2,
+				},
+			},
+			expected: []workv1alpha2.TargetCluster{
+				{
+					Name:     ClusterMember1,
+					Replicas: 1,
+				},
+				{
+					Name:     ClusterMember2,
+					Replicas: 2,
+				},
+			},
+		},
+		{
+			name: "some clusters with 0 replicas",
+			assignResults: []workv1alpha2.TargetCluster{
+				{
+					Name:     ClusterMember1,
+					Replicas: 1,
+				},
+				{
+					Name:     ClusterMember2,
+					Replicas: 0,
+				},
+			},
+			expected: []workv1alpha2.TargetCluster{
+				{
+					Name:     ClusterMember1,
+					Replicas: 1,
+				},
+			},
+		},
+		{
+			name: "all clusters with 0 replicas",
+			assignResults: []workv1alpha2.TargetCluster{
+				{
+					Name:     ClusterMember1,
+					Replicas: 0,
+				},
+				{
+					Name:     ClusterMember2,
+					Replicas: 0,
+				},
+			},
+			expected: []workv1alpha2.TargetCluster{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RemoveZeroReplicasCluster(tt.assignResults)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("RemoveZeroReplicasCluster() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind bug

**What this PR does / why we need it**:
If `cluster.Spec` equals to `cluster.Unschedulable`, `binding.Spec.Cluster[i].Replicas` will be zero, which means there will be 0 replicas workload (i.e. deployment) remaining in the previous clusters.

https://github.com/karmada-io/karmada/blob/9f3ca5ce457cb7799da4286cfddfba298848716f/pkg/descheduler/descheduler.go#L213-L218

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

