### PR TITLE
Fix: add default timeout for member cluster client (#6829)

### DIFF
--- a/pkg/util/membercluster_client.go
+++ b/pkg/util/membercluster_client.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,6 +36,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+)
+
+const (
+	defaultTimeout = 32 * time.Second
 )
 
 // ClusterClient stands for a cluster Clientset for the given member cluster
@@ -215,6 +220,7 @@ func BuildClusterConfig(clusterName string,
 	clusterConfig := &rest.Config{
 		BearerToken: string(token),
 		Host:        apiEndpoint,
+		Timeout:     defaultTimeout,
 	}
 
 	// Handle TLS configuration.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
This PR adds a default timeout (32s) for the member cluster client to prevent the controller from blocking indefinitely when a member cluster does not respond.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #6829

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-controller-manager`: Added a default timeout (32s) for the member cluster client to avoid the controller hanging when the member cluster does not respond.
```

