### PR TITLE
Reduce unnecessary watch events in cluster-status-controller

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -322,7 +322,7 @@ func startClusterStatusController(ctx controllerscontext.Context) (bool, error) 
 		Client:                            ctx.Mgr.GetClient(),
 		KubeClient:                        kubeclientset.NewForConfigOrDie(ctx.Mgr.GetConfig()),
 		EventRecorder:                     ctx.Mgr.GetEventRecorderFor(status.ControllerName),
-		PredicateFunc:                     helper.NewClusterPredicateOnAgent(ctx.Opts.ClusterName),
+		PredicateFunc:                     helper.NewClusterStatusControllerPredicateOnAgent(ctx.Opts.ClusterName),
 		TypedInformerManager:              typedmanager.GetInstance(),
 		GenericInformerManager:            genericmanager.GetInstance(),
 		ClusterClientSetFunc:              util.NewClusterClientSetForAgent,

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -326,14 +326,10 @@ func startClusterStatusController(ctx controllerscontext.Context) (enabled bool,
 
 			return obj.Spec.SyncMode == clusterv1alpha1.Push
 		},
-		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
-			obj := updateEvent.ObjectNew.(*clusterv1alpha1.Cluster)
-
-			if obj.Spec.SecretRef == nil {
-				return false
-			}
-
-			return obj.Spec.SyncMode == clusterv1alpha1.Push
+		UpdateFunc: func(event.UpdateEvent) bool {
+			// cluster-status-controller will reconcile cluster status periodically,
+			// so we don't need to handle update events
+			return false
 		},
 		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
 			obj := deleteEvent.Object.(*clusterv1alpha1.Cluster)

--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -172,7 +172,8 @@ func (c *ClusterStatusController) SetupWithManager(mgr controllerruntime.Manager
 	}
 	return controllerruntime.NewControllerManagedBy(mgr).
 		Named(ControllerName).
-		For(&clusterv1alpha1.Cluster{}, builder.WithPredicates(c.PredicateFunc, predicate.GenerationChangedPredicate{})).
+		For(&clusterv1alpha1.Cluster{}, builder.WithPredicates(c.PredicateFunc)).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		WithOptions(controller.Options{
 			RateLimiter: ratelimiterflag.DefaultControllerRateLimiter[controllerruntime.Request](c.RateLimiterOptions),
 		}).Complete(c)

--- a/pkg/controllers/status/cluster_status_controller_test.go
+++ b/pkg/controllers/status/cluster_status_controller_test.go
@@ -45,7 +45,6 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/genericmanager"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/typedmanager"
 	"github.com/karmada-io/karmada/pkg/util/gclient"
-	"github.com/karmada-io/karmada/pkg/util/helper"
 )
 
 // copy from go/src/net/http/internal/testcert/testcert.go
@@ -212,7 +211,7 @@ func TestClusterStatusController_syncClusterStatus(t *testing.T) {
 				Duration: time.Duration(1000),
 			},
 			clusterConditionCache: clusterConditionStore{},
-			PredicateFunc:         helper.NewClusterPredicateOnAgent("test"),
+			PredicateFunc:         nil,
 			RateLimiterOptions: ratelimiterflag.Options{
 				RateLimiterBaseDelay:  time.Duration(1000),
 				RateLimiterMaxDelay:   time.Duration(1000),
@@ -255,7 +254,7 @@ func TestClusterStatusController_syncClusterStatus(t *testing.T) {
 				Duration: time.Duration(1000),
 			},
 			clusterConditionCache: clusterConditionStore{},
-			PredicateFunc:         helper.NewClusterPredicateOnAgent("test"),
+			PredicateFunc:         nil,
 			RateLimiterOptions: ratelimiterflag.Options{
 				RateLimiterBaseDelay:  time.Duration(1000),
 				RateLimiterMaxDelay:   time.Duration(1000),
@@ -301,7 +300,7 @@ func TestClusterStatusController_syncClusterStatus(t *testing.T) {
 				Duration: time.Duration(1000),
 			},
 			clusterConditionCache: clusterConditionStore{},
-			PredicateFunc:         helper.NewClusterPredicateOnAgent("test"),
+			PredicateFunc:         nil,
 			RateLimiterOptions: ratelimiterflag.Options{
 				RateLimiterBaseDelay:  time.Duration(1000),
 				RateLimiterMaxDelay:   time.Duration(1000),

--- a/pkg/util/helper/predicate.go
+++ b/pkg/util/helper/predicate.go
@@ -160,6 +160,26 @@ func NewClusterPredicateOnAgent(clusterName string) predicate.Funcs {
 	}
 }
 
+// NewClusterStatusControllerPredicateOnAgent generates an event filter function for ClusterStatusController running by karmada-agent.
+func NewClusterStatusControllerPredicateOnAgent(clusterName string) predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(createEvent event.CreateEvent) bool {
+			return createEvent.Object.GetName() == clusterName
+		},
+		UpdateFunc: func(event.UpdateEvent) bool {
+			// cluster-status-controller will reconcile cluster status periodically,
+			// so we don't need to handle update events
+			return false
+		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			return deleteEvent.Object.GetName() == clusterName
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
 // NewPredicateForServiceExportControllerOnAgent generates an event filter function for ServiceExport controller running by karmada-agent.
 func NewPredicateForServiceExportControllerOnAgent(curClusterName string) predicate.Funcs {
 	predFunc := func(eventType string, object client.Object) bool {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

The `cluster-status-controller` periodically processes the managed clusters (default interval: 10 seconds). Therefore, after a cluster is created or the `karmada-controller-manager` component is restarted, the controller will periodically collect the cluster status, and there is no need to pay attention to update events.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #6780 

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->



**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

