### PR TITLE
feat: default resource interpreter for kubernetes replicaset

### DIFF
--- a/pkg/resourceinterpreter/default/native/aggregatestatus_test.go
+++ b/pkg/resourceinterpreter/default/native/aggregatestatus_test.go
@@ -1294,6 +1294,7 @@ func Test_aggregateHorizontalPodAutoscalerStatus(t *testing.T) {
 func Test_getAllDefaultAggregateStatusInterpreter(t *testing.T) {
 	expectedKinds := []schema.GroupVersionKind{
 		{Group: "apps", Version: "v1", Kind: "Deployment"},
+		{Group: "apps", Version: "v1", Kind: "ReplicaSet"},
 		{Group: "apps", Version: "v1", Kind: "StatefulSet"},
 		{Group: "batch", Version: "v1", Kind: "Job"},
 		{Group: "", Version: "v1", Kind: "Pod"},

--- a/pkg/resourceinterpreter/default/native/replica.go
+++ b/pkg/resourceinterpreter/default/native/replica.go
@@ -36,6 +36,7 @@ type replicaInterpreter func(object *unstructured.Unstructured) (int32, *workv1a
 func getAllDefaultReplicaInterpreter() map[schema.GroupVersionKind]replicaInterpreter {
 	s := make(map[schema.GroupVersionKind]replicaInterpreter)
 	s[appsv1.SchemeGroupVersion.WithKind(util.DeploymentKind)] = deployReplica
+	s[appsv1.SchemeGroupVersion.WithKind(util.ReplicaSetKind)] = replicaSetReplica
 	s[appsv1.SchemeGroupVersion.WithKind(util.StatefulSetKind)] = statefulSetReplica
 	s[batchv1.SchemeGroupVersion.WithKind(util.JobKind)] = jobReplica
 	s[corev1.SchemeGroupVersion.WithKind(util.PodKind)] = podReplica
@@ -54,6 +55,22 @@ func deployReplica(object *unstructured.Unstructured) (int32, *workv1alpha2.Repl
 		replica = *deploy.Spec.Replicas
 	}
 	requirement := helper.GenerateReplicaRequirements(&deploy.Spec.Template)
+
+	return replica, requirement, nil
+}
+
+func replicaSetReplica(object *unstructured.Unstructured) (int32, *workv1alpha2.ReplicaRequirements, error) {
+	rs := &appsv1.ReplicaSet{}
+	if err := helper.ConvertToTypedObject(object, rs); err != nil {
+		klog.Errorf("Failed to convert object(%s), err %v", object.GroupVersionKind().String(), err)
+		return 0, nil, err
+	}
+
+	var replica int32
+	if rs.Spec.Replicas != nil {
+		replica = *rs.Spec.Replicas
+	}
+	requirement := helper.GenerateReplicaRequirements(&rs.Spec.Template)
 
 	return replica, requirement, nil
 }

--- a/pkg/resourceinterpreter/default/native/revisereplica.go
+++ b/pkg/resourceinterpreter/default/native/revisereplica.go
@@ -31,12 +31,20 @@ type reviseReplicaInterpreter func(object *unstructured.Unstructured, replica in
 func getAllDefaultReviseReplicaInterpreter() map[schema.GroupVersionKind]reviseReplicaInterpreter {
 	s := make(map[schema.GroupVersionKind]reviseReplicaInterpreter)
 	s[appsv1.SchemeGroupVersion.WithKind(util.DeploymentKind)] = reviseDeploymentReplica
+	s[appsv1.SchemeGroupVersion.WithKind(util.ReplicaSetKind)] = reviseReplicaSetReplica
 	s[appsv1.SchemeGroupVersion.WithKind(util.StatefulSetKind)] = reviseStatefulSetReplica
 	s[batchv1.SchemeGroupVersion.WithKind(util.JobKind)] = reviseJobReplica
 	return s
 }
 
 func reviseDeploymentReplica(object *unstructured.Unstructured, replica int64) (*unstructured.Unstructured, error) {
+	if err := helper.ApplyReplica(object, replica, util.ReplicasField); err != nil {
+		return nil, err
+	}
+	return object, nil
+}
+
+func reviseReplicaSetReplica(object *unstructured.Unstructured, replica int64) (*unstructured.Unstructured, error) {
 	if err := helper.ApplyReplica(object, replica, util.ReplicasField); err != nil {
 		return nil, err
 	}

--- a/pkg/resourceinterpreter/default/native/status_type.go
+++ b/pkg/resourceinterpreter/default/native/status_type.go
@@ -40,6 +40,12 @@ type WrappedDaemonSetStatus struct {
 	appsv1.DaemonSetStatus `json:",inline"`
 }
 
+// WrappedReplicaSetStatus is a wrapper for appsv1.ReplicaSetStatus.
+type WrappedReplicaSetStatus struct {
+	FederatedGeneration     `json:",inline"`
+	appsv1.ReplicaSetStatus `json:",inline"`
+}
+
 // WrappedStatefulSetStatus is a wrapper for appsv1.StatefulSetStatus.
 type WrappedStatefulSetStatus struct {
 	FederatedGeneration      `json:",inline"`


### PR DESCRIPTION
**What type of PR is this?**
feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
extend the default interpreter for native kubernetes workloads

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes https://github.com/karmada-io/karmada/issues/6794

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-controller-manager`: Introduced built-in resource interpreter for Kubernetes ReplicaSet workloads.
```

