### PR TITLE
nominate chart owners Wei-Cheng Lai and Zhuang Zhang

### DIFF
--- a/charts/OWNERS
+++ b/charts/OWNERS
@@ -5,9 +5,12 @@ reviewers:
 - jrkeen
 - pidb
 - Poor12
+- seanlaii
 - zhzhuang-zju
 approvers:
 - a7i
 - chaosi-zju
 - pidb
 - Poor12
+- seanlaii
+- zhzhuang-zju


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR nominates @seanlaii and @zhzhuang-zju as the owners of charts, including both Karmada charts and Karmada Operator charts.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Both @seanlaii and @zhzhuang-zju have been helping review PRs related to charts over an extended period. I have full confidence that they will continue to provide strong technical leadership and guide the charts in the right direction. 

cc current owners here
@a7i @chaosi-zju @pidb @Poor12
**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

