### PR TITLE
fix: should use nodesgvr when querying node metrics

### DIFF
--- a/pkg/metricsadapter/provider/resourcemetrics.go
+++ b/pkg/metricsadapter/provider/resourcemetrics.go
@@ -259,7 +259,7 @@ func (r *ResourceMetricsProvider) queryPodMetricsBySelector(selector, namespace 
 // queryNodeMetricsByName queries metrics by node name from target clusters
 func (r *ResourceMetricsProvider) queryNodeMetricsByName(name string) ([]metrics.NodeMetrics, error) {
 	resourceQueryFunc := func(sci typedmanager.SingleClusterInformerManager, _ string) error {
-		nodeInterface, err := sci.Lister(PodsGVR)
+		nodeInterface, err := sci.Lister(NodesGVR)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind bug

**What this PR does / why we need it**:

When run `kubectl get --raw "/apis/metrics.k8s.io/v1beta1/nodes/xxx`, there will be panic in karmada metrics adapter. And I found this is because the lister use the wrong gvr.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-metrics-adapter`: Fixed a panic when querying node metrics by name. This was caused by using the wrong GroupVersionResource (PodsGVR instead of NodesGVR) when creating a lister, which led to a type assertion failure.
```

