### PR TITLE
Automated cherry pick of #6838: fix: should use nodesgvr when querying node metrics

### DIFF
--- a/pkg/metricsadapter/provider/resourcemetrics.go
+++ b/pkg/metricsadapter/provider/resourcemetrics.go
@@ -259,7 +259,7 @@ func (r *ResourceMetricsProvider) queryPodMetricsBySelector(selector, namespace 
 // queryNodeMetricsByName queries metrics by node name from target clusters
 func (r *ResourceMetricsProvider) queryNodeMetricsByName(name string) ([]metrics.NodeMetrics, error) {
 	resourceQueryFunc := func(sci typedmanager.SingleClusterInformerManager, _ string) error {
-		nodeInterface, err := sci.Lister(PodsGVR)
+		nodeInterface, err := sci.Lister(NodesGVR)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Cherry pick of #6838 on release-1.14.
#6838: fix: should use nodesgvr when querying node metrics
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-metrics-adapter`: Fixed a panic when querying node metrics by name. This was caused by using the wrong GroupVersionResource (PodsGVR instead of NodesGVR) when creating a lister, which led to a type assertion failure.
```