### PR TITLE
Update ReplicaEstimator interface signature, remove unncessary pointer type

### DIFF
--- a/pkg/estimator/client/accurate.go
+++ b/pkg/estimator/client/accurate.go
@@ -68,9 +68,7 @@ func (se *SchedulerEstimator) MaxAvailableReplicas(
 }
 
 // MaxAvailableComponentSets returns the maximum number of complete multi-component sets (in terms of replicas) that each cluster can host.
-func (se *SchedulerEstimator) MaxAvailableComponentSets(
-	_ context.Context,
-	_ *ComponentSetEstimationRequest) ([]ComponentSetEstimationResponse, error) {
+func (se *SchedulerEstimator) MaxAvailableComponentSets(_ context.Context, _ ComponentSetEstimationRequest) ([]ComponentSetEstimationResponse, error) {
 	// Dummy implementation: return nothing for now
 	// TODO: Implement as part of #6734
 	return nil, nil

--- a/pkg/estimator/client/general.go
+++ b/pkg/estimator/client/general.go
@@ -94,7 +94,7 @@ func (ge *GeneralEstimator) maxAvailableReplicas(cluster *clusterv1alpha1.Cluste
 }
 
 // MaxAvailableComponentSets (generic estimator) – resourceSummary only.
-func (ge *GeneralEstimator) MaxAvailableComponentSets(_ context.Context, req *ComponentSetEstimationRequest) ([]ComponentSetEstimationResponse, error) {
+func (ge *GeneralEstimator) MaxAvailableComponentSets(_ context.Context, req ComponentSetEstimationRequest) ([]ComponentSetEstimationResponse, error) {
 	responses := make([]ComponentSetEstimationResponse, len(req.Clusters))
 	for i, cluster := range req.Clusters {
 		maxComponentSets := ge.maxAvailableComponentSets(cluster, req.Components)
@@ -103,7 +103,7 @@ func (ge *GeneralEstimator) MaxAvailableComponentSets(_ context.Context, req *Co
 	return responses, nil
 }
 
-func (ge *GeneralEstimator) maxAvailableComponentSets(cluster *clusterv1alpha1.Cluster, components []*workv1alpha2.Component) int32 {
+func (ge *GeneralEstimator) maxAvailableComponentSets(cluster *clusterv1alpha1.Cluster, components []workv1alpha2.Component) int32 {
 	resourceSummary := cluster.Status.ResourceSummary.DeepCopy()
 	if resourceSummary == nil {
 		return 0
@@ -163,14 +163,14 @@ func (ge *GeneralEstimator) maxAvailableComponentSets(cluster *clusterv1alpha1.C
 // getMaximumSetsBasedOnResourceModels is a placeholder for future implementation.
 // It should refine the maximum sets based on cluster resource models, similar
 // to getMaximumReplicasBasedOnResourceModels but adapted to full component sets.
-func getMaximumSetsBasedOnResourceModels(_ *clusterv1alpha1.Cluster, _ []*workv1alpha2.Component) (int64, error) {
+func getMaximumSetsBasedOnResourceModels(_ *clusterv1alpha1.Cluster, _ []workv1alpha2.Component) (int64, error) {
 	// TODO: implement logic based on cluster.Spec.ResourceModels
 	// For now, just return MaxInt64 so it never reduces the upper bound.
 	return math.MaxInt64, nil
 }
 
 // podsInSet computes the total number of pods in the CRD
-func podsInSet(components []*workv1alpha2.Component) int64 {
+func podsInSet(components []workv1alpha2.Component) int64 {
 	var sum int64
 	for _, c := range components {
 		sum += int64(c.Replicas)
@@ -179,7 +179,7 @@ func podsInSet(components []*workv1alpha2.Component) int64 {
 }
 
 // perSetRequirement computes the aggregate resource(such as CPU, Memory, GPU, etc) demand of one set of components.
-func perSetRequirement(components []*workv1alpha2.Component) map[corev1.ResourceName]int64 {
+func perSetRequirement(components []workv1alpha2.Component) map[corev1.ResourceName]int64 {
 	resourceRequirements := map[corev1.ResourceName]int64{}
 	for _, c := range components {
 		if c.ReplicaRequirements == nil || c.ReplicaRequirements.ResourceRequest == nil {

--- a/pkg/estimator/client/general_test.go
+++ b/pkg/estimator/client/general_test.go
@@ -805,7 +805,7 @@ func TestGetMaxAvailableComponentSetsGeneral(t *testing.T) {
 	tests := []struct {
 		name       string
 		cluster    *clusterv1alpha1.Cluster
-		components []*workv1alpha2.Component
+		components []workv1alpha2.Component
 		expected   int32
 	}{
 		{
@@ -862,7 +862,7 @@ func TestGetMaxAvailableComponentSetsGeneral(t *testing.T) {
 					},
 				},
 			},
-			components: []*workv1alpha2.Component{
+			components: []workv1alpha2.Component{
 				{
 					Name:     "jobmanager",
 					Replicas: 1,
@@ -902,7 +902,7 @@ func TestGetMaxAvailableComponentSetsGeneral(t *testing.T) {
 					},
 				},
 			},
-			components: []*workv1alpha2.Component{
+			components: []workv1alpha2.Component{
 				{
 					Name:     "jobmanager",
 					Replicas: 1,
@@ -943,7 +943,7 @@ func TestGetMaxAvailableComponentSetsGeneral(t *testing.T) {
 					},
 				},
 			},
-			components: []*workv1alpha2.Component{
+			components: []workv1alpha2.Component{
 				{
 					Name:     "small-component",
 					Replicas: 3,
@@ -977,7 +977,7 @@ func TestGetMaxAvailableComponentSetsGeneral(t *testing.T) {
 					},
 				},
 			},
-			components: []*workv1alpha2.Component{
+			components: []workv1alpha2.Component{
 				{
 					Name:     "gpu-worker",
 					Replicas: 2,

--- a/pkg/estimator/client/interface.go
+++ b/pkg/estimator/client/interface.go
@@ -40,7 +40,7 @@ type ReplicaEstimator interface {
 	// MaxAvailableReplicas returns the maximum number of replicas of a single-component workload that each cluster can host.
 	MaxAvailableReplicas(ctx context.Context, clusters []*clusterv1alpha1.Cluster, replicaRequirements *workv1alpha2.ReplicaRequirements) ([]workv1alpha2.TargetCluster, error)
 	// MaxAvailableComponentSets returns the maximum number of complete multi-component sets (in terms of replicas) that each cluster can host.
-	MaxAvailableComponentSets(ctx context.Context, req *ComponentSetEstimationRequest) ([]ComponentSetEstimationResponse, error)
+	MaxAvailableComponentSets(ctx context.Context, req ComponentSetEstimationRequest) ([]ComponentSetEstimationResponse, error)
 }
 
 // ComponentSetEstimationRequest carries input parameters for estimating multi-component set availability per cluster.
@@ -49,7 +49,7 @@ type ComponentSetEstimationRequest struct {
 	// Clusters represents a list of feasible clusters to estimate against.
 	Clusters []*clusterv1alpha1.Cluster
 	// Components are the components that form a multi-component workload.
-	Components []*workv1alpha2.Component
+	Components []workv1alpha2.Component
 	// Namespace is the namespace of the workload being estimated.
 	// It is used by the accurate estimator to check the quota configurations
 	// in the target member cluster. This field is required for quota-aware estimation.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This pull request refines the ReplicaEstimator interface and its associated implementations by removing unnecessary pointer types for the `ComponentSetEstimationRequest` and its `Components` field. This change aims to simplify the API and internal logic, making the code cleaner and potentially more efficient by avoiding pointer indirection where not strictly required for value types.

**Which issue(s) this PR fixes**:
Part of #6734

**Special notes for your reviewer**:
My bad for suggesting using the pointer type at https://github.com/karmada-io/karmada/pull/6765#discussion_r2371458705. 
I don't see any benefit from using a pointer type. :) See the inconvenience in #6857.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

