### PR TITLE
Remove deprecated external etcd fields

### DIFF
--- a/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
+++ b/charts/karmada-operator/crds/operator.karmada.io_karmadas.yaml
@@ -61,32 +61,11 @@ spec:
                           External describes how to connect to an external etcd cluster
                           Local and External are mutually exclusive
                         properties:
-                          caData:
-                            description: |-
-                              CAData is an SSL Certificate Authority file used to secure etcd communication.
-                              Required if using a TLS connection.
-                              Deprecated: This field is deprecated and will be removed in a future version. Use SecretRef for providing client connection credentials.
-                            format: byte
-                            type: string
-                          certData:
-                            description: |-
-                              CertData is an SSL certification file used to secure etcd communication.
-                              Required if using a TLS connection.
-                              Deprecated: This field is deprecated and will be removed in a future version. Use SecretRef for providing client connection credentials.
-                            format: byte
-                            type: string
                           endpoints:
                             description: Endpoints of etcd members. Required for ExternalEtcd.
                             items:
                               type: string
                             type: array
-                          keyData:
-                            description: |-
-                              KeyData is an SSL key file used to secure etcd communication.
-                              Required if using a TLS connection.
-                              Deprecated: This field is deprecated and will be removed in a future version. Use SecretRef for providing client connection credentials.
-                            format: byte
-                            type: string
                           secretRef:
                             description: |-
                               SecretRef references a Kubernetes secret containing the etcd connection credentials.

--- a/operator/config/crds/operator.karmada.io_karmadas.yaml
+++ b/operator/config/crds/operator.karmada.io_karmadas.yaml
@@ -61,32 +61,11 @@ spec:
                           External describes how to connect to an external etcd cluster
                           Local and External are mutually exclusive
                         properties:
-                          caData:
-                            description: |-
-                              CAData is an SSL Certificate Authority file used to secure etcd communication.
-                              Required if using a TLS connection.
-                              Deprecated: This field is deprecated and will be removed in a future version. Use SecretRef for providing client connection credentials.
-                            format: byte
-                            type: string
-                          certData:
-                            description: |-
-                              CertData is an SSL certification file used to secure etcd communication.
-                              Required if using a TLS connection.
-                              Deprecated: This field is deprecated and will be removed in a future version. Use SecretRef for providing client connection credentials.
-                            format: byte
-                            type: string
                           endpoints:
                             description: Endpoints of etcd members. Required for ExternalEtcd.
                             items:
                               type: string
                             type: array
-                          keyData:
-                            description: |-
-                              KeyData is an SSL key file used to secure etcd communication.
-                              Required if using a TLS connection.
-                              Deprecated: This field is deprecated and will be removed in a future version. Use SecretRef for providing client connection credentials.
-                            format: byte
-                            type: string
                           secretRef:
                             description: |-
                               SecretRef references a Kubernetes secret containing the etcd connection credentials.

--- a/operator/pkg/apis/operator/v1alpha1/type.go
+++ b/operator/pkg/apis/operator/v1alpha1/type.go
@@ -291,21 +291,6 @@ type ExternalEtcd struct {
 	// +required
 	Endpoints []string `json:"endpoints"`
 
-	// CAData is an SSL Certificate Authority file used to secure etcd communication.
-	// Required if using a TLS connection.
-	// Deprecated: This field is deprecated and will be removed in a future version. Use SecretRef for providing client connection credentials.
-	CAData []byte `json:"caData,omitempty"`
-
-	// CertData is an SSL certification file used to secure etcd communication.
-	// Required if using a TLS connection.
-	// Deprecated: This field is deprecated and will be removed in a future version. Use SecretRef for providing client connection credentials.
-	CertData []byte `json:"certData,omitempty"`
-
-	// KeyData is an SSL key file used to secure etcd communication.
-	// Required if using a TLS connection.
-	// Deprecated: This field is deprecated and will be removed in a future version. Use SecretRef for providing client connection credentials.
-	KeyData []byte `json:"keyData,omitempty"`
-
 	// SecretRef references a Kubernetes secret containing the etcd connection credentials.
 	// The secret must contain the following data keys:
 	// ca.crt: The Certificate Authority (CA) certificate data.

--- a/operator/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -166,21 +166,6 @@ func (in *ExternalEtcd) DeepCopyInto(out *ExternalEtcd) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.CAData != nil {
-		in, out := &in.CAData, &out.CAData
-		*out = make([]byte, len(*in))
-		copy(*out, *in)
-	}
-	if in.CertData != nil {
-		in, out := &in.CertData, &out.CertData
-		*out = make([]byte, len(*in))
-		copy(*out, *in)
-	}
-	if in.KeyData != nil {
-		in, out := &in.KeyData, &out.KeyData
-		*out = make([]byte, len(*in))
-		copy(*out, *in)
-	}
 	out.SecretRef = in.SecretRef
 	return
 }


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind cleanup

**What this PR does / why we need it**:
Remove deprecated external etcd fields that have been deprecated.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-operator`: Deprecated external etcd fields `CAData`, `CertData`,  and `KeyData` have been removed.
```

