### PR TITLE
Set allocatable replicas for unhealthy cluster to zero when scale up.

### DIFF
--- a/pkg/apis/cluster/v1alpha1/cluster_helper.go
+++ b/pkg/apis/cluster/v1alpha1/cluster_helper.go
@@ -65,3 +65,7 @@ func (c *Cluster) APIEnablement(gvk schema.GroupVersionKind) APIEnablementStatus
 
 	return APIUnknown
 }
+
+func (c *Cluster) IsClusterReady() bool {
+	return meta.IsStatusConditionPresentAndEqual(c.Status.Conditions, ClusterConditionReady, metav1.ConditionTrue)
+}

--- a/pkg/apis/cluster/v1alpha1/cluster_helper.go
+++ b/pkg/apis/cluster/v1alpha1/cluster_helper.go
@@ -66,6 +66,7 @@ func (c *Cluster) APIEnablement(gvk schema.GroupVersionKind) APIEnablementStatus
 	return APIUnknown
 }
 
+// IsClusterReady checks if the Cluster is ready.
 func (c *Cluster) IsClusterReady() bool {
 	return meta.IsStatusConditionPresentAndEqual(c.Status.Conditions, ClusterConditionReady, metav1.ConditionTrue)
 }

--- a/pkg/scheduler/core/division_algorithm.go
+++ b/pkg/scheduler/core/division_algorithm.go
@@ -18,8 +18,9 @@ package core
 
 import (
 	"fmt"
-	"k8s.io/klog/v2"
 	"sort"
+
+	"k8s.io/klog/v2"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"

--- a/test/helper/resource.go
+++ b/test/helper/resource.go
@@ -679,6 +679,17 @@ func MakeNodeWithTaints(node string, milliCPU, memory, pods, ephemeralStorage in
 func NewCluster(name string) *clusterv1alpha1.Cluster {
 	return &clusterv1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: clusterv1alpha1.ClusterStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               clusterv1alpha1.ClusterConditionReady,
+					Status:             metav1.ConditionTrue,
+					Reason:             "ClusterReady",
+					Message:            "cluster is healthy and ready to accept workloads",
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+		},
 	}
 }
 
@@ -691,6 +702,38 @@ func NewClusterWithResource(name string, allocatable, allocating, allocated core
 				Allocatable: allocatable,
 				Allocating:  allocating,
 				Allocated:   allocated,
+			},
+			Conditions: []metav1.Condition{
+				{
+					Type:               clusterv1alpha1.ClusterConditionReady,
+					Status:             metav1.ConditionTrue,
+					Reason:             "ClusterReady",
+					Message:            "cluster is healthy and ready to accept workloads",
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+		},
+	}
+}
+
+// NewClusterWithUnhealthyStatus will build a Cluster with resource.
+func NewClusterWithUnhealthyStatus(name string, allocatable, allocating, allocated corev1.ResourceList) *clusterv1alpha1.Cluster {
+	return &clusterv1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: clusterv1alpha1.ClusterStatus{
+			ResourceSummary: &clusterv1alpha1.ResourceSummary{
+				Allocatable: allocatable,
+				Allocating:  allocating,
+				Allocated:   allocated,
+			},
+			Conditions: []metav1.Condition{
+				{
+					Type:               clusterv1alpha1.ClusterConditionReady,
+					Status:             metav1.ConditionFalse,
+					Reason:             "ClusterNotReachable",
+					Message:            "cluster is not reachable",
+					LastTransitionTime: metav1.Now(),
+				},
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:


**Which issue(s) this PR fixes**:

Fixes #6861 

**Does this PR introduce a user-facing change?**:

```release-note

karmada-scheduler ignore unhealthy member cluster when scale up workload.

```

