### PR TITLE
Add `EstimateComponentsPlugins` support to estimator framework

### DIFF
--- a/pkg/estimator/server/framework/interface.go
+++ b/pkg/estimator/server/framework/interface.go
@@ -33,11 +33,18 @@ type Framework interface {
 	Handle
 	// RunEstimateReplicasPlugins runs the set of configured EstimateReplicasPlugins
 	// for estimating replicas based on the given replicaRequirements.
-	// It returns an integer and an Result.
+	// It returns an integer and a Result.
 	// The integer represents the minimum calculated value of estimated replicas from each EstimateReplicasPlugin.
-	// The Result contains code, reasons and error
-	// it is merged from all plugins returned result codes
+	// The Result contains code, reasons and error.
+	// It is merged from all plugins' returned result codes.
 	RunEstimateReplicasPlugins(ctx context.Context, snapshot *schedcache.Snapshot, replicaRequirements *pb.ReplicaRequirements) (int32, *Result)
+	// RunEstimateComponentsPlugins runs the set of configured EstimateComponentsPlugins
+	// for estimating the maximum number of complete component sets based on the given components.
+	// It returns an integer and a Result.
+	// The integer represents the minimum calculated value of estimated component sets from each EstimateComponentsPlugin.
+	// The Result contains code, reasons and error.
+	// It is merged from all plugins' returned result codes.
+	RunEstimateComponentsPlugins(ctx context.Context, snapshot *schedcache.Snapshot, components []pb.Component) (int32, *Result)
 	// TODO(wengyao04): we can add filter and score plugin extension points if needed in the future
 }
 
@@ -47,21 +54,34 @@ type Plugin interface {
 }
 
 // EstimateReplicasPlugin is an interface for replica estimation plugins.
-// These estimators are used to estimate the replicas for a given pb.ReplicaRequirements
+// These estimators are used to estimate the replicas for a given pb.ReplicaRequirements.
 type EstimateReplicasPlugin interface {
 	Plugin
 	// Estimate is called for each MaxAvailableReplicas request.
-	// It returns an integer and an error
-	// The integer representing the number of calculated replica for the given replicaRequirements
-	// The Result contains code, reasons and error
-	// it is merged from all plugins returned result codes
+	// It returns an integer and a Result.
+	// The integer represents the number of calculated replicas for the given replicaRequirements.
+	// The Result contains code, reasons and error.
+	// It is merged from all plugins' returned result codes.
 	Estimate(ctx context.Context, snapshot *schedcache.Snapshot, replicaRequirements *pb.ReplicaRequirements) (int32, *Result)
+}
+
+// EstimateComponentsPlugin is an interface for component set estimation plugins.
+// These estimators are used to estimate the maximum number of complete component sets
+// for a given set of components with different replica requirements.
+type EstimateComponentsPlugin interface {
+	Plugin
+	// EstimateComponents is called for each MaxAvailableComponentSets request.
+	// It returns an integer and a Result.
+	// The integer represents the estimated number of complete component sets that can be scheduled.
+	// The Result contains code, reasons and error.
+	// It is merged from all plugins' returned result codes.
+	EstimateComponents(ctx context.Context, snapshot *schedcache.Snapshot, components []pb.Component) (int32, *Result)
 }
 
 // Handle provides data and some tools that plugins can use. It is
 // passed to the plugin factories at the time of plugin initialization. Plugins
 // must store and use this handle to call framework functions.
-// We follow the design pattern as kubernetes scheduler framework
+// We follow the design pattern of the Kubernetes scheduler framework.
 type Handle interface {
 	ClientSet() clientset.Interface
 	SharedInformerFactory() informers.SharedInformerFactory
@@ -85,9 +105,9 @@ const (
 	// NOTE: A nil status is also considered as "Success".
 	Success Code = iota
 	// Unschedulable is used when a plugin finds the resource unschedulable.
-	// The accompanying status message should explain why the it is unschedulable.
+	// The accompanying status message should explain why it is unschedulable.
 	Unschedulable
-	// Nooperation is used when a plugin is disabled or the plugin list are empty
+	// Nooperation is used when a plugin is disabled or the plugin list is empty.
 	Noopperation
 	// Error is used for internal plugin errors, unexpected input, etc.
 	Error
@@ -115,8 +135,8 @@ func NewResult(code Code, reasons ...string) *Result {
 // PluginToResult maps plugin name to Result.
 type PluginToResult map[string]*Result
 
-// Merge merges the statuses in the map into one. The resulting status code have the following
-// precedence: Error, Unschedulable, Disabled.
+// Merge merges the statuses in the map into one. The resulting status code has the following
+// precedence: Error, Unschedulable, Nooperation.
 func (p PluginToResult) Merge() *Result {
 	if len(p) == 0 {
 		return NewResult(Noopperation, "plugin results are empty")
@@ -161,8 +181,8 @@ func (s *Result) IsUnschedulable() bool {
 	return s != nil && s.code == Unschedulable
 }
 
-// IsNoOperation returns true if "Result" is not nil and Code is "Nooperation"
-// ToDo (wengyao04): we can remove it once we include node resource estimation as the default plugin in the future
+// IsNoOperation returns true if "Result" is not nil and Code is "Nooperation".
+// TODO (wengyao04): we can remove it once we include node resource estimation as the default plugin in the future.
 func (s *Result) IsNoOperation() bool {
 	return s != nil && s.code == Noopperation
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
Add `EstimateComponentsPlugins` support to estimator framework to allow customizing scheduling logic for Components.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #6734

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-scheduler-estimator`: Allow adding plugins in estimator for component scheduling.
`karmada-scheduler-estimator`: Deprecated the `Estimator` label value for `estimating_plugin_extension_point` in the `estimating_plugin_execution_duration_seconds` and `estimating_plugin_extension_point_duration_seconds` metrics. Use `estimate_replicas` instead; `Estimator` will be removed in a future release. To avoid double counting during the deprecation period, update PromQL to filter on `estimating_plugin_extension_point="estimate_replicas"` (or exclude `Estimator`).
```

