### PR TITLE
fix: use user-provided bootstrap server endpoint rather than cluster-info endpoint when registering pull-mode clusters

### DIFF
--- a/pkg/karmadactl/register/register.go
+++ b/pkg/karmadactl/register/register.go
@@ -476,6 +476,17 @@ func (o *CommandRegisterOption) preflight() []error {
 	return errlist
 }
 
+func (o *CommandRegisterOption) getAPIServerEndpoint(clusterInfo *clientcmdapi.Cluster) string {
+	// if the command has specified a bootstrap API server endpoint, use that instead of the one from the clusterinfo
+	// since the one from the cluster-info is often local and unreachable from the pull cluster
+	karmadaServer := clusterInfo.Server
+	if o.BootstrapToken.APIServerEndpoint != "" {
+		karmadaServer = fmt.Sprintf("https://%s", o.BootstrapToken.APIServerEndpoint)
+	}
+
+	return karmadaServer
+}
+
 // discoveryBootstrapConfigAndClusterInfo get bootstrap-config and cluster-info from control plane
 func (o *CommandRegisterOption) discoveryBootstrapConfigAndClusterInfo(parentCommand string) (*kubeclient.Clientset, *clientcmdapi.Cluster, error) {
 	config, err := retrieveValidatedConfigInfo(nil, o.BootstrapToken, o.Timeout, DiscoveryRetryInterval, parentCommand)
@@ -485,8 +496,9 @@ func (o *CommandRegisterOption) discoveryBootstrapConfigAndClusterInfo(parentCom
 
 	klog.V(1).Info("[discovery] Using provided TLSBootstrapToken as authentication credentials for the join process")
 	clusterinfo := tokenutil.GetClusterFromKubeConfig(config, "")
+
 	tlsBootstrapCfg := CreateWithToken(
-		clusterinfo.Server,
+		o.getAPIServerEndpoint(clusterinfo),
 		DefaultClusterName,
 		TokenUserName,
 		clusterinfo.CertificateAuthorityData,
@@ -867,15 +879,8 @@ func (o *CommandRegisterOption) constructKubeConfig(bootstrapClient *kubeclient.
 		return nil, err
 	}
 
-	// Using o.BootstrapToken.APIServerEndpoint instead of the endpoint in discovered cluster-info
-	// because discivered endpoint can often be unreachable from member cluster
-	karmadaServer := karmadaClusterInfo.Server
-	if o.BootstrapToken.APIServerEndpoint != "" {
-		karmadaServer = fmt.Sprintf("https://%s", o.BootstrapToken.APIServerEndpoint)
-	}
-
 	return CreateWithCert(
-		karmadaServer,
+		o.getAPIServerEndpoint(karmadaClusterInfo),
 		DefaultClusterName,
 		o.ClusterName,
 		karmadaClusterInfo.CertificateAuthorityData,


### PR DESCRIPTION
**What type of PR is this?**
Fix for https://github.com/karmada-io/karmada/issues/6865

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
anyone attempting to register a pull-mode cluster that is unable to resolve the DNS hostname of the karmada API server that is defined in the cluster-info

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #6865

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmadactl`: Fixed the issue that the `register` command still uses the cluster-info endpoint when registering a pull-mode cluster, even if the user provides the API server endpoint.
```

