### PR TITLE
cleanup unused sort.Interface implementation

### DIFF
--- a/pkg/util/helper/binding_test.go
+++ b/pkg/util/helper/binding_test.go
@@ -19,7 +19,6 @@ package helper
 import (
 	"context"
 	"reflect"
-	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -564,66 +563,6 @@ func TestObtainBindingSpecExistingClusters(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := ObtainBindingSpecExistingClusters(tt.bindingSpec); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ObtainBindingSpecExistingClusters() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-// sortClusterByWeight sort clusters by the weight
-func sortClusterByWeight(m map[string]int64) ClusterWeightInfoList {
-	p := make(ClusterWeightInfoList, len(m))
-	i := 0
-	for k, v := range m {
-		p[i] = ClusterWeightInfo{ClusterName: k, Weight: v}
-		i++
-	}
-	sort.Sort(p)
-	return p
-}
-
-func TestSortClusterByWeight(t *testing.T) {
-	type args struct {
-		m map[string]int64
-	}
-	tests := []struct {
-		name string
-		args args
-		want ClusterWeightInfoList
-	}{
-		{
-			name: "nil",
-			args: args{
-				m: nil,
-			},
-			want: []ClusterWeightInfo{},
-		},
-		{
-			name: "empty",
-			args: args{
-				m: map[string]int64{},
-			},
-			want: []ClusterWeightInfo{},
-		},
-		{
-			name: "sort",
-			args: args{
-				m: map[string]int64{
-					"cluster11": 1,
-					"cluster12": 2,
-					"cluster13": 3,
-				},
-			},
-			want: []ClusterWeightInfo{
-				{ClusterName: "cluster13", Weight: 3},
-				{ClusterName: "cluster12", Weight: 2},
-				{ClusterName: "cluster11", Weight: 1},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := sortClusterByWeight(tt.args.m); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("SortClusterByWeight() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
After introducing the Webster method, the ClusterWeightInfoList no longer needs to be sorted, so this PR will clean up the sort.Interface implementation.



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #6739

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note

```

