### PR TITLE
Collect container logs for restarted components in E2E tests

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -122,6 +122,16 @@ check_component_restart() {
     if [ "$restart_count" -gt 0 ]; then
       echo "ERROR: ${component_name} pod $pod_name has restarted $restart_count times."
       echo "This indicates OOM or panic occurred and needs to be investigated."
+      
+      # Collect logs from the previous container instance
+      echo "Collecting logs from previous container instance for ${component_name} pod $pod_name..."
+      local log_file="$ARTIFACTS_PATH/${component_name}-${pod_name}-previous-logs.log"
+      if kubectl --context="${KARMADA_HOST_CLUSTER_NAME}" logs -p "$pod_name" -n karmada-system > "$log_file" 2>&1; then
+        echo "Previous container logs saved to: $log_file"
+      else
+        echo "Warning: Failed to collect previous container logs for pod $pod_name. See details in $log_file"
+      fi
+      
       return 1  # Return failure to stop checking
     else
       echo "${component_name} pod $pod_name: no restarts"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

- Added log collection functionality to check_component_restart function
- Automatically collect logs from previous container instances using kubectl logs -p when Karmada components are detected to have restarted
- Save collected logs to `$ARTIFACTS_PATH` directory with filename format: `${component_name}-${pod_name}-previous-logs.log`

**What this PR does / why we need it**:

- Facilitate troubleshooting of component restart causes (OOM, panic, etc.)
- Provide more detailed debugging information to improve issue identification efficiency
- Collect logs alongside other E2E test artifacts for comprehensive test reporting

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

- Log collection only occurs when component restarts are detected, no impact on normal test flow
- Added error handling to ensure log collection failures don't interrupt test execution

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

