### PR TITLE
[Flake] use ClusterIP Service to replace NodePort Service

### DIFF
--- a/test/e2e/suites/base/migration_and_rollback_test.go
+++ b/test/e2e/suites/base/migration_and_rollback_test.go
@@ -215,7 +215,7 @@ var _ = ginkgo.Describe("Seamless migration and rollback testing", func() {
 		})
 	})
 
-	ginkgo.Context("Test migrate namespaced resource: Service (NodePort)", func() {
+	ginkgo.Context("Test migrate namespaced resource: Service (ClusterIP)", func() {
 		var serviceName string
 		var service *corev1.Service
 		var pp *policyv1alpha1.PropagationPolicy
@@ -223,7 +223,7 @@ var _ = ginkgo.Describe("Seamless migration and rollback testing", func() {
 
 		ginkgo.BeforeEach(func() {
 			serviceName = serviceNamePrefix + rand.String(RandomStrLength)
-			service = helper.NewService(testNamespace, serviceName, corev1.ServiceTypeNodePort)
+			service = helper.NewService(testNamespace, serviceName, corev1.ServiceTypeClusterIP)
 			pp = helper.NewPropagationPolicy(testNamespace, service.Name, []policyv1alpha1.ResourceSelector{
 				{
 					APIVersion: service.APIVersion,


### PR DESCRIPTION
**What type of PR is this?**

/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

ref #6872 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #6872

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

In fact, from the perspective of testing objectives, it is not necessarily required to use a NodePort type Service; a ClusterIP type Service can also achieve the same goal. Therefore, to avoid occasional conflicts caused by random NodePort allocation, we have switched to using a ClusterIP type Service.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

