### PR TITLE
Implements maxAvailableComponentSets for accurate estimator

### DIFF
--- a/pkg/estimator/server/metrics/metrics.go
+++ b/pkg/estimator/server/metrics/metrics.go
@@ -33,6 +33,8 @@ const (
 	EstimatingTypeMaxAvailableReplicas = "MaxAvailableReplicas"
 	// EstimatingTypeGetUnschedulableReplicas - label of estimating type
 	EstimatingTypeGetUnschedulableReplicas = "GetUnschedulableReplicas"
+	// EstimatingTypeMaxAvailableComponentSets - label of estimating type
+	EstimatingTypeMaxAvailableComponentSets = "MaxAvailableComponentSets"
 )
 
 const (


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Implements maxAvailableComponentSets for the accurate estimator. I have a follow-up commented as a TODO in the implementation for the conversion of the node resource estimation into a plugin.

**Which issue(s) this PR fixes**:
Part of #6734

**Special notes for your reviewer**:
Tested E2E using code from #6857. At the moment the estimator returns 0 for the component set estimation, but this is expected since I have not linked this together with the resourcequota plugin (which is under review). 

```
I1027 02:35:43.329736       1 server.go:240] Begin calculating available component sets of resource(kind=FlinkDeployment, name=s-spaaseng/a-5-ticker-demo), request: pb.MaxAvailableComponentSetsRequest{
    Cluster:    "spaas-kaas-tt-dev",
    Components: {
        {
            Name:                "jobmanager",
            ReplicaRequirements: pb.ReplicaRequirements{
                NodeClaim: &pb.NodeClaim{
                    NodeAffinity: (*v1.NodeSelector)(nil),
                    NodeSelector: {},
                    Tolerations:  {
                        {
                            Key:               "node.kubernetes.io/unreachable",
                            Operator:          "Exists",
                            Value:             "",
                            Effect:            "NoExecute",
                            TolerationSeconds: &int64(5),
                        },
                        {
                            Key:               "node.kubernetes.io/not-ready",
                            Operator:          "Exists",
                            Value:             "",
                            Effect:            "NoExecute",
                            TolerationSeconds: &int64(5),
                        },
                    },
                },
                ResourceRequest: {
                    "cpu": {
                        i:      resource.int64Amount{value:500, scale:-3},
                        d:      resource.infDecAmount{},
                        s:      "500m",
                        Format: "DecimalSI",
                    },
                    "memory": {
                        i:      resource.int64Amount{value:2048, scale:-3},
                        d:      resource.infDecAmount{},
                        s:      "2.048",
                        Format: "DecimalSI",
                    },
                },
                Namespace:         "s-spaaseng",
                PriorityClassName: "",
            },
            Replicas: 1,
        },
        {
            Name:                "taskmanager",
            ReplicaRequirements: pb.ReplicaRequirements{
                NodeClaim: &pb.NodeClaim{
                    NodeAffinity: (*v1.NodeSelector)(nil),
                    NodeSelector: {},
                    Tolerations:  {
                        {
                            Key:               "node.kubernetes.io/unreachable",
                            Operator:          "Exists",
                            Value:             "",
                            Effect:            "NoExecute",
                            TolerationSeconds: &int64(5),
                        },
                        {
                            Key:               "node.kubernetes.io/not-ready",
                            Operator:          "Exists",
                            Value:             "",
                            Effect:            "NoExecute",
                            TolerationSeconds: &int64(5),
                        },
                    },
                },
                ResourceRequest: {
                    "cpu": {
                        i:      resource.int64Amount{value:500, scale:-3},
                        d:      resource.infDecAmount{},
                        s:      "500m",
                        Format: "DecimalSI",
                    },
                    "memory": {
                        i:      resource.int64Amount{value:2048, scale:-3},
                        d:      resource.infDecAmount{},
                        s:      "2.048",
                        Format: "DecimalSI",
                    },
                },
                Namespace:         "s-spaaseng",
                PriorityClassName: "",
            },
            Replicas: 1,
        },
    },
}
I1027 02:35:43.330091       1 server.go:247] Finish calculating cluster available component sets of resource(kind=FlinkDeployment, name=s-spaaseng/a-5-ticker-demo), max component sets: 0, time elapsed: 1.688997ms
```

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-scheduler`/`karmada-scheduler-estimator`: Implemented maxAvailableComponentSets for the accurate estimator.
```