### PR TITLE
introduce node resource estimation as the default estimator plugin

### DIFF
--- a/pkg/estimator/server/estimate.go
+++ b/pkg/estimator/server/estimate.go
@@ -19,17 +19,12 @@ package server
 import (
 	"context"
 	"fmt"
-	"sync/atomic"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	utiltrace "k8s.io/utils/trace"
 
 	"github.com/karmada-io/karmada/pkg/estimator/pb"
-	nodeutil "github.com/karmada-io/karmada/pkg/estimator/server/nodes"
-	"github.com/karmada-io/karmada/pkg/util"
 	schedcache "github.com/karmada-io/karmada/pkg/util/lifted/scheduler/cache"
-	"github.com/karmada-io/karmada/pkg/util/lifted/scheduler/framework"
 )
 
 // EstimateReplicas returns max available replicas in terms of request and cluster status.
@@ -56,25 +51,7 @@ func (es *AccurateSchedulerEstimatorServer) EstimateReplicas(ctx context.Context
 	return maxAvailableReplicas, nil
 }
 
-func (es *AccurateSchedulerEstimatorServer) estimateReplicas(
-	ctx context.Context,
-	snapshot *schedcache.Snapshot,
-	requirements pb.ReplicaRequirements,
-) (int32, error) {
-	allNodes, err := snapshot.NodeInfos().List()
-	if err != nil {
-		return 0, err
-	}
-	var (
-		affinity    = nodeutil.GetRequiredNodeAffinity(requirements)
-		tolerations []corev1.Toleration
-	)
-
-	if requirements.NodeClaim != nil {
-		tolerations = requirements.NodeClaim.Tolerations
-	}
-
-	var res int32
+func (es *AccurateSchedulerEstimatorServer) estimateReplicas(ctx context.Context, snapshot *schedcache.Snapshot, requirements pb.ReplicaRequirements) (int32, error) {
 	replicas, ret := es.estimateFramework.RunEstimateReplicasPlugins(ctx, snapshot, &requirements)
 
 	// No replicas can be scheduled on the cluster, skip further checks and return 0
@@ -82,23 +59,11 @@ func (es *AccurateSchedulerEstimatorServer) estimateReplicas(
 		return 0, nil
 	}
 
-	if !ret.IsSuccess() && !ret.IsNoOperation() {
-		return replicas, fmt.Errorf("estimate replica plugins fails with %s", ret.Reasons())
+	if ret.IsFailed() {
+		return 0, fmt.Errorf("estimate replica plugins fails with %s", ret.Reasons())
 	}
-	processNode := func(i int) {
-		node := allNodes[i]
-		if !nodeutil.IsNodeAffinityMatched(node.Node(), affinity) || !nodeutil.IsTolerationMatched(node.Node(), tolerations) {
-			return
-		}
-		maxReplica := es.nodeMaxAvailableReplica(node, requirements.ResourceRequest)
-		atomic.AddInt32(&res, maxReplica)
-	}
-	es.parallelizer.Until(ctx, len(allNodes), processNode)
 
-	if ret.IsSuccess() && replicas < res {
-		res = replicas
-	}
-	return res, nil
+	return replicas, nil
 }
 
 // EstimateComponents returns max available component sets in terms of request and cluster status.
@@ -148,14 +113,4 @@ func (es *AccurateSchedulerEstimatorServer) estimateComponents(
 		return maxSets, nil
 	}
 	return 0, nil
-}
-
-func (es *AccurateSchedulerEstimatorServer) nodeMaxAvailableReplica(node *framework.NodeInfo, rl corev1.ResourceList) int32 {
-	rest := node.Allocatable.Clone().SubResource(node.Requested)
-	// The number of pods in a node is a kind of resource in node allocatable resources.
-	// However, total requested resources of all pods on this node, i.e. `node.Requested`,
-	// do not contain pod resources. So after subtraction, we should cope with allowed pod
-	// number manually which is the upper bound of this node available replicas.
-	rest.AllowedPodNumber = util.MaxInt64(rest.AllowedPodNumber-int64(len(node.Pods)), 0)
-	return int32(rest.MaxDivided(rl)) // #nosec G115: integer overflow conversion int64 -> int32
 }

--- a/pkg/estimator/server/framework/interface.go
+++ b/pkg/estimator/server/framework/interface.go
@@ -85,6 +85,7 @@ type EstimateComponentsPlugin interface {
 type Handle interface {
 	ClientSet() clientset.Interface
 	SharedInformerFactory() informers.SharedInformerFactory
+	Parallelism() int
 }
 
 // Code is the Status code/type which is returned from plugins.
@@ -174,6 +175,11 @@ func (p PluginToResult) Merge() *Result {
 // IsSuccess returns true if and only if "Result" is nil or Code is "Success".
 func (s *Result) IsSuccess() bool {
 	return s == nil || s.code == Success
+}
+
+// IsFailed returns true if "Result" is not nil and Code is "Error".
+func (s *Result) IsFailed() bool {
+	return s != nil && s.code == Error
 }
 
 // IsUnschedulable returns true if "Result" is not nil and Code is "Unschedulable".

--- a/pkg/estimator/server/framework/plugins/noderesource/noderesource.go
+++ b/pkg/estimator/server/framework/plugins/noderesource/noderesource.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package noderesource
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sync/atomic"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/karmada-io/karmada/pkg/estimator/pb"
+	"github.com/karmada-io/karmada/pkg/estimator/server/framework"
+	nodeutil "github.com/karmada-io/karmada/pkg/estimator/server/nodes"
+	"github.com/karmada-io/karmada/pkg/util"
+	schedcache "github.com/karmada-io/karmada/pkg/util/lifted/scheduler/cache"
+	schedulerframework "github.com/karmada-io/karmada/pkg/util/lifted/scheduler/framework"
+	"github.com/karmada-io/karmada/pkg/util/lifted/scheduler/framework/parallelize"
+)
+
+const (
+	// Name is the name of the plugin used in Registry and configurations.
+	Name = "NodeResourceEstimator"
+	// nodeResourceEstimator is enabled by default.
+	enabled = true
+)
+
+// nodeResourceEstimator is to estimate how many replicas/sets allowed by the node resources for a given pb.ReplicaRequirements.
+type nodeResourceEstimator struct {
+	enabled      bool
+	parallelizer parallelize.Parallelizer
+}
+
+var _ framework.EstimateReplicasPlugin = &nodeResourceEstimator{}
+
+// New initializes a new plugin and returns it.
+func New(fh framework.Handle) (framework.Plugin, error) {
+	return &nodeResourceEstimator{
+		enabled:      enabled,
+		parallelizer: parallelize.NewParallelizer(fh.Parallelism()),
+	}, nil
+}
+
+// Name returns name of the plugin. It is used in logs, etc.
+func (pl *nodeResourceEstimator) Name() string {
+	return Name
+}
+
+// Estimate the replica allowed by the node resources for a given pb.ReplicaRequirements.
+func (pl *nodeResourceEstimator) Estimate(ctx context.Context, snapshot *schedcache.Snapshot, requirements *pb.ReplicaRequirements) (int32, *framework.Result) {
+	if !pl.enabled {
+		klog.V(5).Info("Estimator Plugin", "name", Name, "enabled", pl.enabled)
+		return math.MaxInt32, framework.NewResult(framework.Noopperation, fmt.Sprintf("%s is disabled", pl.Name()))
+	}
+
+	allNodes, err := snapshot.NodeInfos().List()
+	if err != nil {
+		return 0, framework.AsResult(err)
+	}
+	var (
+		affinity    = nodeutil.GetRequiredNodeAffinity(*requirements)
+		tolerations []corev1.Toleration
+	)
+
+	if requirements.NodeClaim != nil {
+		tolerations = requirements.NodeClaim.Tolerations
+	}
+
+	var res int32
+	processNode := func(i int) {
+		node := allNodes[i]
+		if !nodeutil.IsNodeAffinityMatched(node.Node(), affinity) || !nodeutil.IsTolerationMatched(node.Node(), tolerations) {
+			return
+		}
+		maxReplica := pl.nodeMaxAvailableReplica(node, requirements.ResourceRequest)
+		atomic.AddInt32(&res, maxReplica)
+	}
+	pl.parallelizer.Until(ctx, len(allNodes), processNode)
+
+	return res, framework.NewResult(framework.Success)
+}
+
+func (pl *nodeResourceEstimator) nodeMaxAvailableReplica(node *schedulerframework.NodeInfo, rl corev1.ResourceList) int32 {
+	rest := node.Allocatable.Clone().SubResource(node.Requested)
+	// The number of pods in a node is a kind of resource in node allocatable resources.
+	// However, total requested resources of all pods on this node, i.e. `node.Requested`,
+	// do not contain pod resources. So after subtraction, we should cope with allowed pod
+	// number manually which is the upper bound of this node available replicas.
+	rest.AllowedPodNumber = util.MaxInt64(rest.AllowedPodNumber-int64(len(node.Pods)), 0)
+	return int32(rest.MaxDivided(rl)) // #nosec G115: integer overflow conversion int64 -> int32
+}

--- a/pkg/estimator/server/framework/plugins/registry.go
+++ b/pkg/estimator/server/framework/plugins/registry.go
@@ -17,6 +17,7 @@ limitations under the License.
 package plugins
 
 import (
+	"github.com/karmada-io/karmada/pkg/estimator/server/framework/plugins/noderesource"
 	"github.com/karmada-io/karmada/pkg/estimator/server/framework/plugins/resourcequota"
 	"github.com/karmada-io/karmada/pkg/estimator/server/framework/runtime"
 )
@@ -24,6 +25,7 @@ import (
 // NewInTreeRegistry builds the registry with all the in-tree plugins.
 func NewInTreeRegistry() runtime.Registry {
 	registry := runtime.Registry{
+		noderesource.Name:  noderesource.New,
 		resourcequota.Name: resourcequota.New,
 	}
 	return registry

--- a/pkg/estimator/server/framework/runtime/framework_test.go
+++ b/pkg/estimator/server/framework/runtime/framework_test.go
@@ -100,7 +100,7 @@ func Test_frameworkImpl_RunEstimateReplicasPlugins(t *testing.T) {
 				},
 			},
 			expected: estimateReplicaResult{
-				replica: 1,
+				replica: 0,
 				ret:     framework.AsResult(fmt.Errorf("plugin 2 failed")),
 			},
 		},

--- a/pkg/estimator/server/server.go
+++ b/pkg/estimator/server/server.go
@@ -135,6 +135,7 @@ func NewEstimatorServer(
 	estimateFramework, err := frameworkruntime.NewFramework(registry,
 		frameworkruntime.WithClientSet(kubeClient),
 		frameworkruntime.WithInformerFactory(informerFactory),
+		frameworkruntime.WithParallelism(opts.Parallelism),
 	)
 	if err != nil {
 		return es, err


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
The current estimator framework provides a plugin mechanism to calculate the available replicas/sets of a workload. However, the calculation based on node resources is not implemented as a plugin. Instead, it is performed separately after the plugin returns its result, and then compared with the plugin’s output.
I propose making node resource–based calculation a default plugin for the following reasons:
- It unifies the logic: the result returned by the plugins would be the final result.
- This capability was already considered when the estimator framework was initially designed, but it was never implemented. I believe it’s essential to deliver this enhancement now while introducing the new `EstimateComponentsPlugin`, to avoid increasing the cost and complexity of future modifications.
https://github.com/karmada-io/karmada/blob/a892fef437356429d7aa257efb22b8e3840b54eb/pkg/estimator/server/framework/interface.go#L184-L188
- It enables consistent monitoring through the plugin metrics

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #6734

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-scheduler-estimator`: Refactored the replica estimation logic by moving the node resource-based calculation into a dedicated, default plugin. 
```

