### PR TITLE
remark the workload for resourcebinding 

### DIFF
--- a/pkg/apis/work/v1alpha2/binding_types_helper.go
+++ b/pkg/apis/work/v1alpha2/binding_types_helper.go
@@ -213,3 +213,12 @@ func (s *ResourceBindingSpec) SchedulePriorityValue() int32 {
 	}
 	return s.SchedulePriority.Priority
 }
+
+// IsWorkload return true if the ResourceBinding represents workload which has replicas or replica requirements (e.g., Deployment, StatefulSet)
+// or multi-component workloads (e.g., FlinkDeployment), false otherwise.
+func (s *ResourceBindingSpec) IsWorkload() bool {
+	if s.Replicas > 0 || s.ReplicaRequirements != nil || len(s.Components) >= 1 {
+		return true
+	}
+	return false
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -420,7 +420,7 @@ func (s *Scheduler) doScheduleBinding(namespace, name string) (err error) {
 		metrics.BindingSchedule(string(ReconcileSchedule), utilmetrics.DurationInSeconds(start), err)
 		return err
 	}
-	if rb.Spec.Replicas == 0 ||
+	if !rb.Spec.IsWorkload() ||
 		rb.Spec.Placement.ReplicaSchedulingType() == policyv1alpha1.ReplicaSchedulingTypeDuplicated {
 		// Duplicated resources should always be scheduled. Note: non-workload is considered as duplicated
 		// even if scheduling type is divided.
@@ -496,7 +496,7 @@ func (s *Scheduler) doScheduleClusterBinding(name string) (err error) {
 		metrics.BindingSchedule(string(ReconcileSchedule), utilmetrics.DurationInSeconds(start), err)
 		return err
 	}
-	if crb.Spec.Replicas == 0 ||
+	if !crb.Spec.IsWorkload() ||
 		crb.Spec.Placement.ReplicaSchedulingType() == policyv1alpha1.ReplicaSchedulingTypeDuplicated {
 		// Duplicated resources should always be scheduled. Note: non-workload is considered as duplicated
 		// even if scheduling type is divided.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

This PR defines how to identify the resourcebinding  represents resource is a workload which has a pod template ; 
the function will be called by both the karmada-scheduler and the karmada controller.

Fixes #6156 

When the replicas of single pod template workload is zero, and `replicaSchedulingType` of their resource bindings is  not `Duplicated`,   karmada-scehduler should ignore to reschedule these resource bindings.

Fix relevant  code: 
https://github.com/karmada-io/karmada/blob/006cf70132c953a522f376cc26418802b74e792c/pkg/scheduler/scheduler.go#L393-L401
