### PR TITLE
Automated cherry pick of #6866: fix: use user-provided bootstrap server endpoint rather than

### DIFF
--- a/pkg/karmadactl/register/register.go
+++ b/pkg/karmadactl/register/register.go
@@ -476,6 +476,17 @@ func (o *CommandRegisterOption) preflight() []error {
 	return errlist
 }
 
+func (o *CommandRegisterOption) getAPIServerEndpoint(clusterInfo *clientcmdapi.Cluster) string {
+	// if the command has specified a bootstrap API server endpoint, use that instead of the one from the clusterinfo
+	// since the one from the cluster-info is often local and unreachable from the pull cluster
+	karmadaServer := clusterInfo.Server
+	if o.BootstrapToken.APIServerEndpoint != "" {
+		karmadaServer = fmt.Sprintf("https://%s", o.BootstrapToken.APIServerEndpoint)
+	}
+
+	return karmadaServer
+}
+
 // discoveryBootstrapConfigAndClusterInfo get bootstrap-config and cluster-info from control plane
 func (o *CommandRegisterOption) discoveryBootstrapConfigAndClusterInfo(parentCommand string) (*kubeclient.Clientset, *clientcmdapi.Cluster, error) {
 	config, err := retrieveValidatedConfigInfo(nil, o.BootstrapToken, o.Timeout, DiscoveryRetryInterval, parentCommand)
@@ -485,8 +496,9 @@ func (o *CommandRegisterOption) discoveryBootstrapConfigAndClusterInfo(parentCom
 
 	klog.V(1).Info("[discovery] Using provided TLSBootstrapToken as authentication credentials for the join process")
 	clusterinfo := tokenutil.GetClusterFromKubeConfig(config, "")
+
 	tlsBootstrapCfg := CreateWithToken(
-		clusterinfo.Server,
+		o.getAPIServerEndpoint(clusterinfo),
 		DefaultClusterName,
 		TokenUserName,
 		clusterinfo.CertificateAuthorityData,
@@ -867,15 +879,8 @@ func (o *CommandRegisterOption) constructKubeConfig(bootstrapClient *kubeclient.
 		return nil, err
 	}
 
-	// Using o.BootstrapToken.APIServerEndpoint instead of the endpoint in discovered cluster-info
-	// because discivered endpoint can often be unreachable from member cluster
-	karmadaServer := karmadaClusterInfo.Server
-	if o.BootstrapToken.APIServerEndpoint != "" {
-		karmadaServer = fmt.Sprintf("https://%s", o.BootstrapToken.APIServerEndpoint)
-	}
-
 	return CreateWithCert(
-		karmadaServer,
+		o.getAPIServerEndpoint(karmadaClusterInfo),
 		DefaultClusterName,
 		o.ClusterName,
 		karmadaClusterInfo.CertificateAuthorityData,


### PR DESCRIPTION
Cherry pick of #6866 on release-1.14.
#6866: fix: use user-provided bootstrap server endpoint rather than
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmadactl`: Fixed the issue that the `register` command still uses the cluster-info endpoint when registering a pull-mode cluster, even if the user provides the API server endpoint.
```