### PR TITLE
Fix: potential NotFound error in dependenciesdistributor e2e test cleanup

### DIFF
--- a/test/e2e/framework/propagationpolicy.go
+++ b/test/e2e/framework/propagationpolicy.go
@@ -52,16 +52,10 @@ func RemovePropagationPolicy(client karmada.Interface, namespace, name string) {
 // RemovePropagationPolicyIfExist delete PropagationPolicy if it exists with karmada client.
 func RemovePropagationPolicyIfExist(client karmada.Interface, namespace, name string) {
 	ginkgo.By(fmt.Sprintf("Removing PropagationPolicy(%s/%s) if it exists", namespace, name), func() {
-		_, err := client.PolicyV1alpha1().PropagationPolicies(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return
-			}
+		err := client.PolicyV1alpha1().PropagationPolicies(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		}
-
-		err = client.PolicyV1alpha1().PropagationPolicies(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
-		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	})
 }
 

--- a/test/e2e/suites/base/dependenciesdistributor_test.go
+++ b/test/e2e/suites/base/dependenciesdistributor_test.go
@@ -426,8 +426,8 @@ var _ = ginkgo.Describe("[DependenciesDistributor] automatically propagate relev
 			framework.CreatePropagationPolicy(karmadaClient, policyA)
 			framework.CreatePropagationPolicy(karmadaClient, policyB)
 			ginkgo.DeferCleanup(func() {
-				framework.RemovePropagationPolicy(karmadaClient, policyA.Namespace, policyA.Name)
-				framework.RemovePropagationPolicy(karmadaClient, policyB.Namespace, policyB.Name)
+				framework.RemovePropagationPolicyIfExist(karmadaClient, policyA.Namespace, policyA.Name)
+				framework.RemovePropagationPolicyIfExist(karmadaClient, policyB.Namespace, policyB.Name)
 				// Delete deployments but ignore NotFound if already removed by the test
 				if err := kubeClient.AppsV1().Deployments(deploymentA.Namespace).Delete(context.TODO(), deploymentA.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
This PR fixes a potential test failure in the dependencies distributor e2e test. In the test case "conflict resolved after deleting policy B", policyB is explicitly deleted during the test execution. However, the DeferCleanup function was using `RemovePropagationPolicy` which doesn't handle NotFound errors, causing the cleanup to fail when policyB has already been deleted.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
None