### PR TITLE
[Fix] Log message for selected clusters in karmada-scheduler is unreadable

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"time"
+	"strings"
 
 	"k8s.io/klog/v2"
 
@@ -99,8 +100,14 @@ func (g *genericScheduler) Schedule(
 	if err != nil {
 		return result, fmt.Errorf("failed to select clusters: %w", err)
 	}
-	klog.V(4).Infof("Selected clusters: %v", selectedClusters)
-
+	if klog.V(4).Enabled() {
+		var clusterSummaries []string
+		for _, c := range selectedClusters {
+			clusterSummaries = append(clusterSummaries,
+				fmt.Sprintf("%s(Score: %d, AvailableReplicas: %d)", c.Cluster.Name, c.Score, c.AvailableReplicas))
+		}
+		klog.Infof("Selected clusters: [%s]", strings.Join(clusterSummaries, ", "))
+	}
 	clustersWithReplicas, err := g.assignReplicas(selectedClusters, spec, status)
 	if err != nil {
 		return result, fmt.Errorf("failed to assign replicas: %w", err)

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"time"
-	"strings"
 
 	"k8s.io/klog/v2"
 
@@ -100,14 +99,8 @@ func (g *genericScheduler) Schedule(
 	if err != nil {
 		return result, fmt.Errorf("failed to select clusters: %w", err)
 	}
-	if klog.V(4).Enabled() {
-		var clusterSummaries []string
-		for _, c := range selectedClusters {
-			clusterSummaries = append(clusterSummaries,
-				fmt.Sprintf("%s(Score: %d, AvailableReplicas: %d)", c.Cluster.Name, c.Score, c.AvailableReplicas))
-		}
-		klog.Infof("Selected clusters: [%s]", strings.Join(clusterSummaries, ", "))
-	}
+	klog.V(4).Infof("Selected clusters: %+v", selectedClusters)
+
 	clustersWithReplicas, err := g.assignReplicas(selectedClusters, spec, status)
 	if err != nil {
 		return result, fmt.Errorf("failed to assign replicas: %w", err)


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

**What this PR does / why we need it**:
This PR enhances the logging for selected clusters in the generic scheduler. It introduces detailed cluster summaries in the log output when the verbosity level is high, improving the traceability and debuggability of scheduling operations.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #6880 

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
- Added more comprehensive log messages for selected clusters.
- Helps developers trace scheduling behavior during high verbosity debugging sessions.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
Enhance logging for selected clusters in the generic scheduler, adding detailed cluster summaries when verbosity level is high.
```

