### PR TITLE
Group Cluster Failover flags into a single command flagSet

### DIFF
--- a/cmd/controller-manager/app/options/cluster_failover.go
+++ b/cmd/controller-manager/app/options/cluster_failover.go
@@ -19,10 +19,12 @@ package options
 import (
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 )
 
-// FailoverOptions holds the Failover configurations.
-type FailoverOptions struct {
+// ClusterFailoverOptions holds the Cluster Failover configurations.
+type ClusterFailoverOptions struct {
 	// EnableNoExecuteTaintEviction enables controller response to NoExecute taints on clusters,
 	// which triggers eviction of workloads without explicit tolerations.
 	EnableNoExecuteTaintEviction bool
@@ -39,25 +41,25 @@ type FailoverOptions struct {
 	ResourceEvictionRate float32
 }
 
-// AddFlags adds flags related to FailoverOptions for controller manager to the specified FlagSet.
-func (o *FailoverOptions) AddFlags(flags *pflag.FlagSet) {
+// AddFlags adds flags related to ClusterFailoverOptions for controller manager to the specified FlagSet.
+func (o *ClusterFailoverOptions) AddFlags(flags *pflag.FlagSet) {
 	if o == nil {
 		return
 	}
 
 	flags.BoolVar(&o.EnableNoExecuteTaintEviction, "enable-no-execute-taint-eviction", false, "Enables controller response to NoExecute taints on clusters, which triggers eviction of workloads without explicit tolerations. Given the impact of eviction caused by NoExecute Taint, this parameter is designed to remain disabled by default and requires careful evaluation by administrators before being enabled.\n")
-	flags.StringVar(&o.NoExecuteTaintEvictionPurgeMode, "no-execute-taint-eviction-purge-mode", "Gracefully", "Controls resource cleanup behavior for NoExecute-triggered evictions (only active when --enable-no-execute-taint-eviction=true). Supported values are \"Directly\", and \"Gracefully\". \"Directly\" mode directly evicts workloads first (risking temporary service interruption) and then triggers rescheduling to other clusters, while \"Gracefully\" mode first schedules workloads to new clusters and then cleans up original workloads after successful startup elsewhere to ensure service continuity.")
+	flags.StringVar(&o.NoExecuteTaintEvictionPurgeMode, "no-execute-taint-eviction-purge-mode", string(policyv1alpha1.PurgeModeGracefully), "Controls resource cleanup behavior for NoExecute-triggered evictions (only active when --enable-no-execute-taint-eviction=true). Supported values are \"Directly\", and \"Gracefully\". \"Directly\" mode directly evicts workloads first (risking temporary service interruption) and then triggers rescheduling to other clusters, while \"Gracefully\" mode first schedules workloads to new clusters and then cleans up original workloads after successful startup elsewhere to ensure service continuity.")
 	flags.Float32Var(&o.ResourceEvictionRate, "resource-eviction-rate", 0.5, "This is the number of resources to be evicted per second in a cluster failover scenario.")
 }
 
-// Validate checks FailoverOptions and return a slice of found errs.
-func (o *FailoverOptions) Validate() field.ErrorList {
+// Validate checks ClusterFailoverOptions and return a slice of found errs.
+func (o *ClusterFailoverOptions) Validate() field.ErrorList {
 	errs := field.ErrorList{}
-	rootPath := field.NewPath("FailoverOptions")
+	rootPath := field.NewPath("ClusterFailoverOptions")
 
 	if o.EnableNoExecuteTaintEviction &&
-		o.NoExecuteTaintEvictionPurgeMode != "Gracefully" &&
-		o.NoExecuteTaintEvictionPurgeMode != "Directly" {
+		o.NoExecuteTaintEvictionPurgeMode != string(policyv1alpha1.PurgeModeGracefully) &&
+		o.NoExecuteTaintEvictionPurgeMode != string(policyv1alpha1.PurgeModeDirectly) {
 		errs = append(errs, field.Invalid(rootPath.Child("NoExecuteTaintEvictionPurgeMode"),
 			o.NoExecuteTaintEvictionPurgeMode, "Invalid mode"))
 	}

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -146,8 +146,8 @@ type Options struct {
 	EnableClusterResourceModeling bool
 	// FederatedResourceQuotaOptions holds configurations for FederatedResourceQuota reconciliation.
 	FederatedResourceQuotaOptions FederatedResourceQuotaOptions
-	// FailoverOptions holds the Failover configurations.
-	FailoverOptions FailoverOptions
+	// ClusterFailoverOptions holds the cluster failover configurations.
+	ClusterFailoverOptions ClusterFailoverOptions
 }
 
 // NewOptions builds an empty options.
@@ -233,7 +233,6 @@ func (o *Options) AddFlags(flags *pflag.FlagSet, allControllers, disabledByDefau
 	o.ProfileOpts.AddFlags(flags)
 	o.HPAControllerConfiguration.AddFlags(flags)
 	o.FederatedResourceQuotaOptions.AddFlags(flags)
-	o.FailoverOptions.AddFlags(flags)
 	features.FeatureGate.AddFlag(flags)
 }
 

--- a/cmd/controller-manager/app/options/validation.go
+++ b/cmd/controller-manager/app/options/validation.go
@@ -56,7 +56,7 @@ func (o *Options) Validate() field.ErrorList {
 	}
 
 	errs = append(errs, o.FederatedResourceQuotaOptions.Validate()...)
-	errs = append(errs, o.FailoverOptions.Validate()...)
+	errs = append(errs, o.ClusterFailoverOptions.Validate()...)
 
 	return errs
 }

--- a/cmd/controller-manager/app/options/validation_test.go
+++ b/cmd/controller-manager/app/options/validation_test.go
@@ -101,13 +101,13 @@ func TestValidateControllerManagerConfiguration(t *testing.T) {
 			}),
 			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("ClusterStartupGracePeriod"), metav1.Duration{Duration: 0 * time.Second}, "must be greater than 0")},
 		},
-		"invalid FailoverOptions": {
+		"invalid ClusterFailoverOptions": {
 			opt: New(func(options *Options) {
-				options.FailoverOptions.EnableNoExecuteTaintEviction = true
-				options.FailoverOptions.NoExecuteTaintEvictionPurgeMode = ""
+				options.ClusterFailoverOptions.EnableNoExecuteTaintEviction = true
+				options.ClusterFailoverOptions.NoExecuteTaintEvictionPurgeMode = ""
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("FailoverOptions").Child("NoExecuteTaintEvictionPurgeMode"), "", "Invalid mode"),
+				field.Invalid(field.NewPath("ClusterFailoverOptions").Child("NoExecuteTaintEvictionPurgeMode"), "", "Invalid mode"),
 			},
 		},
 	}

--- a/pkg/controllers/context/context.go
+++ b/pkg/controllers/context/context.go
@@ -98,8 +98,8 @@ type Options struct {
 	HPAControllerConfiguration federatehpaconfig.HPAControllerConfiguration
 	// FederatedResourceQuotaOptions holds configurations for FederatedResourceQuota reconciliation.
 	FederatedResourceQuotaOptions options.FederatedResourceQuotaOptions
-	// FailoverConfiguration is the config of failover function.
-	FailoverConfiguration options.FailoverOptions
+	// ClusterFailoverConfiguration is the config of cluster failover function.
+	ClusterFailoverConfiguration options.ClusterFailoverOptions
 }
 
 // Context defines the context object for controller.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

Currently, there are an increasing number of parameters in the generic component of karmada-controller-manager. It might be a good idea to group these parameters according to the functions or controllers they handle.

Let's first take Cluster Failover as an example to create a template, and then we will gradually group and process other parameters in the following sections.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

<img width="1603" height="219" alt="image" src="https://github.com/user-attachments/assets/27c213a5-7a9b-4121-a9c7-c9975964486c" />

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

