### PR TITLE
Bypass replicas assignment for workloads with multiple components.

### DIFF
--- a/pkg/scheduler/core/assignment.go
+++ b/pkg/scheduler/core/assignment.go
@@ -86,8 +86,7 @@ type assignState struct {
 	targetReplicas int32
 }
 
-func newAssignState(candidates []spreadconstraint.ClusterDetailInfo, spec *workv1alpha2.ResourceBindingSpec,
-	status *workv1alpha2.ResourceBindingStatus) *assignState {
+func newAssignState(candidates []spreadconstraint.ClusterDetailInfo, spec *workv1alpha2.ResourceBindingSpec, status *workv1alpha2.ResourceBindingStatus) *assignState {
 	var strategyType string
 
 	switch spec.Placement.ReplicaSchedulingType() {

--- a/pkg/scheduler/core/common.go
+++ b/pkg/scheduler/core/common.go
@@ -28,8 +28,7 @@ import (
 )
 
 // SelectClusters selects clusters based on the placement and resource binding spec.
-func SelectClusters(clustersScore framework.ClusterScoreList,
-	placement *policyv1alpha1.Placement, spec *workv1alpha2.ResourceBindingSpec) ([]spreadconstraint.ClusterDetailInfo, error) {
+func SelectClusters(clustersScore framework.ClusterScoreList, placement *policyv1alpha1.Placement, spec *workv1alpha2.ResourceBindingSpec) ([]spreadconstraint.ClusterDetailInfo, error) {
 	startTime := time.Now()
 	defer metrics.ScheduleStep(metrics.ScheduleStepSelect, startTime)
 
@@ -38,11 +37,7 @@ func SelectClusters(clustersScore framework.ClusterScoreList,
 }
 
 // AssignReplicas assigns replicas to clusters based on the placement and resource binding spec.
-func AssignReplicas(
-	clusters []spreadconstraint.ClusterDetailInfo,
-	spec *workv1alpha2.ResourceBindingSpec,
-	status *workv1alpha2.ResourceBindingStatus,
-) ([]workv1alpha2.TargetCluster, error) {
+func AssignReplicas(clusters []spreadconstraint.ClusterDetailInfo, spec *workv1alpha2.ResourceBindingSpec, status *workv1alpha2.ResourceBindingStatus) ([]workv1alpha2.TargetCluster, error) {
 	startTime := time.Now()
 	defer metrics.ScheduleStep(metrics.ScheduleStepAssignReplicas, startTime)
 
@@ -50,7 +45,16 @@ func AssignReplicas(
 		return nil, fmt.Errorf("no clusters available to schedule")
 	}
 
-	if spec.Replicas > 0 {
+	// Only workloads should participate in replica assignments.
+	// Workloads with multiple components should be excluded from replica assignment because:
+	//   1) They don't support replica division.
+	//   2) They usually don't implement the ReviseReplica interpreter; even if replicas are assigned, the result cannot be applied by the controller.
+	// For single pod template workloads (like Deployment), if the replica is 0 and no resource requirements are specified,
+	// assignment is bypassed, causing the workload to be propagated to all candidate clusters. This is a known issue, and
+	// a suggested fix is: when parsing replicas and requirements, set them to components. This should be addressed along with
+	// the deprecation of binding.spec.replicas and binding.spec.ReplicaRequirements. After that, the check should be changed to
+	// len(spec.Components) == 1.
+	if (spec.Replicas > 0 || spec.ReplicaRequirements != nil) && len(spec.Components) <= 1 {
 		state := newAssignState(clusters, spec, status)
 		assignFunc, ok := assignFuncMap[state.strategyType]
 		if !ok {
@@ -65,7 +69,7 @@ func AssignReplicas(
 		return removeZeroReplicasCluster(assignResults), nil
 	}
 
-	// If not workload, assign all clusters without considering replicas.
+	// For non-workloads (e.g., Service, Config) and multi-component workloads (e.g., FlinkDeployment), propagate to all candidate clusters.
 	targetClusters := make([]workv1alpha2.TargetCluster, len(clusters))
 	for i, cluster := range clusters {
 		targetClusters[i] = workv1alpha2.TargetCluster{Name: cluster.Cluster.Name}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR bypasses the replica assignment for workloads with multiple components, as those workloads do not support division yet.

**Which issue(s) this PR fixes**:
Fixes #
Part of #6734

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

