### PR TITLE
Log warning logs only when needed

### DIFF
--- a/test/e2e/suites/base/search_test.go
+++ b/test/e2e/suites/base/search_test.go
@@ -548,7 +548,9 @@ var _ = ginkgo.Describe("[karmada-search] karmada search testing", ginkgo.Ordere
 					deleteAnnotationAfterTest = func(c kubernetes.Interface, name string, anno string) {
 						data := []byte(`{"metadata": {"annotations": {"` + anno + `":null}}}`)
 						_, err := c.CoreV1().Nodes().Patch(context.TODO(), name, types.StrategicMergePatchType, data, metav1.PatchOptions{})
-						klog.Warningf("Clean node %v's annotation %v failed: %v", name, anno, err)
+						if err != nil {
+							klog.Warningf("Failed to clean annotation for node: %s, left annoation: %v, error: %v", name, anno, err)
+						}
 					}
 				)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Fix/remove an unnecessary log in E2E testing. 

**Which issue(s) this PR fixes**:
Part of #6868

**Special notes for your reviewer**:
This PR was used to adopt the changes when bumping Kubernetes dependencies to v1.34 in #6868. The fixes have been cherry-picked to #6868 to make CI happy. So this PR only addresses some small findings during the process. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

