### PR TITLE
unit operator CI and E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,62 +163,6 @@ jobs:
           name: karmada_kind_log_${{ matrix.k8s }}
           path: /tmp/karmada/
 
-  e2e-operator:
-    name: operator e2e test
-    needs: build
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        # Here support the latest three minor releases of Kubernetes, this can be considered to be roughly
-        # the same as the End of Life of the Kubernetes release: https://kubernetes.io/releases/
-        # Please remember to update the CI Schedule Workflow when we add a new version.
-        k8s: [ v1.31.0, v1.32.0, v1.33.0 ]
-    steps:
-      # Free up disk space on Ubuntu
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed, if set to "true" but frees about 6 GB
-          tool-cache: false
-          # all of these default to true, but feel free to set to "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: false
-          swap-storage: false
-      - name: checkout code
-        uses: actions/checkout@v5
-        with:
-          # Number of commits to fetch. 0 indicates all history for all branches and tags.
-          # We need to guess version via git tags.
-          fetch-depth: 0
-      - name: install Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-      - name: setup operator e2e test environment
-        run: |
-          export CLUSTER_VERSION=kindest/node:${{ matrix.k8s }}
-          hack/operator-e2e-environment.sh
-      - name: run e2e
-        run: |
-          export ARTIFACTS_PATH=${{ github.workspace }}/karmada-operator-e2e-logs/${{ matrix.k8s }}/
-          hack/run-e2e-operator.sh
-      - name: upload logs
-        if: always()
-        uses: actions/upload-artifact@v5
-        with:
-          name: karmada_operator_e2e_log_${{ matrix.k8s }}
-          path: ${{ github.workspace }}/karmada-operator-e2e-logs/${{ matrix.k8s }}/
-      - name: upload kind logs
-        if: always()
-        uses: actions/upload-artifact@v5
-        with:
-          name: karmada_operator_kind_log_${{ matrix.k8s }}
-          path: /tmp/karmada/
-
   e2e-init:
     name: init e2e test
     needs: build

--- a/.github/workflows/installation-operator.yaml
+++ b/.github/workflows/installation-operator.yaml
@@ -49,34 +49,23 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - name: setup operator test environment
+      - name: setup operator e2e test environment
         run: |
           export CLUSTER_VERSION=kindest/node:${{ matrix.k8s }}
-          hack/local-up-karmada-by-operator.sh
-      - name: run operator test
+          hack/operator-e2e-environment.sh
+      - name: run e2e
         run: |
-          # run a single e2e
-          export KUBECONFIG=${HOME}/.kube/karmada.config
-          kubectl config use-context karmada-apiserver
-          GO111MODULE=on go install github.com/onsi/ginkgo/v2/ginkgo
-          ginkgo -v --race --trace -p  --focus="[BasicPropagation] propagation testing deployment propagation testing"  ./test/e2e/suites/base
-      - name: export logs
-        if: always()
-        run: |
-          export ARTIFACTS_PATH=${{ github.workspace }}/karmada-operator-test-logs/${{ matrix.k8s }}/
-          mkdir -p $ARTIFACTS_PATH
-
-          mkdir -p $ARTIFACTS_PATH/karmada-host
-          kind export logs --name=karmada-host $ARTIFACTS_PATH/karmada-host
+          export ARTIFACTS_PATH=${{ github.workspace }}/karmada-operator-e2e-logs/${{ matrix.k8s }}/
+          hack/run-e2e-operator.sh
       - name: upload logs
         if: always()
         uses: actions/upload-artifact@v5
         with:
-          name: karmada_operator_test_logs_${{ matrix.k8s }}
-          path: ${{ github.workspace }}/karmada-operator-test-logs/${{ matrix.k8s }}/
+          name: karmada_operator_e2e_log_${{ matrix.k8s }}
+          path: ${{ github.workspace }}/karmada-operator-e2e-logs/${{ matrix.k8s }}/
       - name: upload kind logs
         if: always()
         uses: actions/upload-artifact@v5
         with:
-          name: karmada_kind_log_${{ matrix.k8s }}
+          name: karmada_operator_kind_log_${{ matrix.k8s }}
           path: /tmp/karmada/

--- a/hack/run-e2e-operator.sh
+++ b/hack/run-e2e-operator.sh
@@ -42,6 +42,8 @@ GO111MODULE=on go install github.com/onsi/ginkgo/v2/ginkgo
 
 # Run e2e
 export KUBECONFIG=${HOST_KUBECONFIG}
+export PUSH_MODE_CLUSTER_NAME=${MEMBER_CLUSTER_1_NAME:-"member1"}
+export PUSH_MODE_KUBECONFIG_PATH=${PUSH_MODE_KUBECONFIG_PATH:-"$KUBECONFIG_PATH/members.config"}
 
 set +e
 ginkgo -v --race --trace --fail-fast -p --randomize-all ./test/e2e/suites/operator

--- a/test/e2e/suites/operator/api_sidecar_test.go
+++ b/test/e2e/suites/operator/api_sidecar_test.go
@@ -66,7 +66,7 @@ var _ = ginkgo.Describe("API server sidecar configuration testing", func() {
 			})
 
 			ginkgo.By("Check if API server sidecar configuration works", func() {
-				apiserver, err = kubeClient.AppsV1().Deployments(testNamespace).Get(context.TODO(), karmadaName+"-apiserver", metav1.GetOptions{})
+				apiserver, err = hostClient.AppsV1().Deployments(testNamespace).Get(context.TODO(), karmadaName+"-apiserver", metav1.GetOptions{})
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				containers := apiserver.Spec.Template.Spec.Containers
 				gomega.Expect(len(containers)).Should(gomega.Equal(2))

--- a/test/e2e/suites/operator/base_test.go
+++ b/test/e2e/suites/operator/base_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1alpha1 "github.com/karmada-io/karmada/operator/pkg/apis/operator/v1alpha1"
+	"github.com/karmada-io/karmada/operator/pkg/constants"
+	operatorutil "github.com/karmada-io/karmada/operator/pkg/util"
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	karmada "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
+	"github.com/karmada-io/karmada/pkg/util/gclient"
+	"github.com/karmada-io/karmada/test/e2e/framework"
+	testhelper "github.com/karmada-io/karmada/test/helper"
+)
+
+const karmadactlTimeout = time.Second * 60
+
+var karmadaContext = fmt.Sprintf("%s@%s", constants.UserName, constants.ClusterName)
+
+var _ = ginkgo.Describe("Base E2E: deploy a karmada instance and do a propagation testing", func() {
+	var karmadaName string
+	var controlPlaneConfig client.Client
+	var kubeClient kubernetes.Interface
+	var karmadaClient karmada.Interface
+	var karmadaConfigFilePath string
+
+	var pushModeClusterName string
+	var pushModeKubeConfigPath string
+	var pushModeClusterClient kubernetes.Interface
+	var targetClusters []string
+
+	var deploymentNamespace string
+	var deploymentName string
+	var policyName string
+
+	ginkgo.Context("Karmada Operator base testing", func() {
+		ginkgo.BeforeEach(func() {
+			karmadaName = KarmadaInstanceNamePrefix + rand.String(RandomStrLength)
+			InitializeKarmadaInstance(operatorClient, testNamespace, karmadaName, func(karmada *operatorv1alpha1.Karmada) {
+				karmada.Spec.Components.KarmadaAPIServer.ServiceType = corev1.ServiceTypeNodePort
+			})
+		})
+
+		ginkgo.BeforeEach(func() {
+			homeDir := os.Getenv("HOME")
+			karmadaConfigFilePath = fmt.Sprintf("%s/.kube/karmada-%s.config", homeDir, karmadaName)
+			secret, err := hostClient.CoreV1().Secrets(testNamespace).Get(context.Background(), operatorutil.AdminKarmadaConfigSecretName(karmadaName), metav1.GetOptions{})
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			karmadaConfigBytes := secret.Data["karmada.config"]
+			err = writeKubeConfigToFile(karmadaConfigBytes, karmadaConfigFilePath)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			karmadaRestConfig, err := framework.LoadRESTClientConfig(karmadaConfigFilePath, karmadaContext)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			controlPlaneConfig = gclient.NewForConfigOrDie(karmadaRestConfig)
+			kubeClient = kubernetes.NewForConfigOrDie(karmadaRestConfig)
+			karmadaClient = karmada.NewForConfigOrDie(karmadaRestConfig)
+
+			pushModeClusterName = os.Getenv("PUSH_MODE_CLUSTER_NAME")
+			pushModeKubeConfigPath = os.Getenv("PUSH_MODE_KUBECONFIG_PATH")
+			pushModeClusterRestConfig, err := framework.LoadRESTClientConfig(pushModeKubeConfigPath, pushModeClusterName)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			pushModeClusterClient = kubernetes.NewForConfigOrDie(pushModeClusterRestConfig)
+
+			targetClusters = []string{pushModeClusterName}
+		})
+
+		ginkgo.AfterEach(func() {
+			// Clean up resources
+			framework.RemoveDeployment(kubeClient, deploymentNamespace, deploymentName)
+			framework.RemovePropagationPolicy(karmadaClient, deploymentNamespace, policyName)
+			framework.RemoveNamespace(kubeClient, deploymentNamespace)
+
+			// Unjoin the push mode cluster
+			cmd := framework.NewKarmadactlCommand(karmadaConfigFilePath, karmadaContext, karmadactlPath, "", karmadactlTimeout,
+				"unjoin", "--cluster-kubeconfig", pushModeKubeConfigPath, "--cluster-context", pushModeClusterName, "--cluster-namespace", "karmada-cluster",
+				"--v", "4", pushModeClusterName)
+			_, err := cmd.ExecOrDie()
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			// Delete the karmada instance
+			err = operatorClient.OperatorV1alpha1().Karmadas(testNamespace).Delete(context.Background(), karmadaName, metav1.DeleteOptions{})
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			os.Remove(karmadaConfigFilePath)
+		})
+
+		ginkgo.It("Deploy a karmada instance and do a propagation testing", func() {
+			ginkgo.By("join a push mode cluster", func() {
+				cmd := framework.NewKarmadactlCommand(karmadaConfigFilePath, karmadaContext, karmadactlPath, "", karmadactlTimeout, "join",
+					"--cluster-kubeconfig", pushModeKubeConfigPath, "--cluster-context", pushModeClusterName, "--cluster-namespace", "karmada-cluster",
+					"--v", "4", pushModeClusterName)
+				_, err := cmd.ExecOrDie()
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+
+			ginkgo.By("Wait for the new cluster to be ready", func() {
+				framework.WaitClusterFitWith(controlPlaneConfig, pushModeClusterName, func(cluster *clusterv1alpha1.Cluster) bool {
+					return meta.IsStatusConditionPresentAndEqual(cluster.Status.Conditions, clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)
+				})
+			})
+
+			ginkgo.By("Do a simple propagation testing", func() {
+				deploymentNamespace = "deployment-" + rand.String(RandomStrLength)
+				framework.CreateNamespace(kubeClient, testhelper.NewNamespace(deploymentNamespace))
+
+				policyName = "deployment" + rand.String(RandomStrLength)
+				deploymentName = policyName
+
+				deployment := testhelper.NewDeployment(deploymentNamespace, deploymentName)
+				policy := testhelper.NewPropagationPolicy(deploymentNamespace, policyName, []policyv1alpha1.ResourceSelector{
+					{
+						APIVersion: deployment.APIVersion,
+						Kind:       deployment.Kind,
+						Name:       deployment.Name,
+					},
+				}, policyv1alpha1.Placement{
+					ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+						ClusterNames: targetClusters,
+					},
+				})
+
+				framework.CreateDeployment(kubeClient, deployment)
+				framework.CreatePropagationPolicy(karmadaClient, policy)
+				framework.WaitDeploymentFitWith(pushModeClusterClient, deployment.Namespace, deployment.Name,
+					func(*appsv1.Deployment) bool {
+						return true
+					})
+			})
+		})
+	})
+})
+
+func writeKubeConfigToFile(config []byte, filePath string) error {
+	// Write the config to the specified file path
+	err := os.WriteFile(filePath, config, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to write kubeconfig to file: %v", err)
+	}
+	return nil
+}

--- a/test/e2e/suites/operator/priorityclass_test.go
+++ b/test/e2e/suites/operator/priorityclass_test.go
@@ -47,12 +47,12 @@ var _ = ginkgo.Describe("PriorityClass configuration testing", func() {
 		ginkgo.It("Custom priorityClass configuration", func() {
 			ginkgo.By("Check if default value is system-node-critical", func() {
 				// take etcd as a representative of StatefulSet.
-				etcd, err := kubeClient.AppsV1().StatefulSets(testNamespace).Get(context.TODO(), karmadaName+"-etcd", metav1.GetOptions{})
+				etcd, err := hostClient.AppsV1().StatefulSets(testNamespace).Get(context.Background(), karmadaName+"-etcd", metav1.GetOptions{})
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				gomega.Expect(etcd.Spec.Template.Spec.PriorityClassName).Should(gomega.Equal("system-node-critical"))
 
 				// take karmada-apiserver as a representative of Deployment.
-				karmadaApiserver, err := kubeClient.AppsV1().Deployments(testNamespace).Get(context.TODO(), karmadaName+"-apiserver", metav1.GetOptions{})
+				karmadaApiserver, err := hostClient.AppsV1().Deployments(testNamespace).Get(context.TODO(), karmadaName+"-apiserver", metav1.GetOptions{})
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				gomega.Expect(karmadaApiserver.Spec.Template.Spec.PriorityClassName).Should(gomega.Equal("system-node-critical"))
 			})
@@ -68,12 +68,12 @@ var _ = ginkgo.Describe("PriorityClass configuration testing", func() {
 
 			ginkgo.By("Check if the PriorityClass is applied correctly", func() {
 				// take etcd as a representative of StatefulSet.
-				etcd, err := kubeClient.AppsV1().StatefulSets(testNamespace).Get(context.TODO(), karmadaName+"-etcd", metav1.GetOptions{ResourceVersion: "0"})
+				etcd, err := hostClient.AppsV1().StatefulSets(testNamespace).Get(context.TODO(), karmadaName+"-etcd", metav1.GetOptions{ResourceVersion: "0"})
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				gomega.Expect(etcd.Spec.Template.Spec.PriorityClassName).Should(gomega.Equal("system-cluster-critical"))
 
 				// take karmada-apiserver as a representative of Deployment.
-				karmadaApiserver, err := kubeClient.AppsV1().Deployments(testNamespace).Get(context.TODO(), karmadaName+"-apiserver", metav1.GetOptions{ResourceVersion: "0"})
+				karmadaApiserver, err := hostClient.AppsV1().Deployments(testNamespace).Get(context.TODO(), karmadaName+"-apiserver", metav1.GetOptions{ResourceVersion: "0"})
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				gomega.Expect(karmadaApiserver.Spec.Template.Spec.PriorityClassName).Should(gomega.Equal("system-cluster-critical"))
 			})

--- a/test/e2e/suites/operator/status_test.go
+++ b/test/e2e/suites/operator/status_test.go
@@ -70,7 +70,7 @@ var _ = ginkgo.Describe("Status testing", func() {
 				gomega.Expect(secretRef).ShouldNot(gomega.BeNil())
 				gomega.Expect(secretRef.Namespace).Should(gomega.Equal(karmadaObject.GetNamespace()))
 				gomega.Expect(secretRef.Name).Should(gomega.Equal(operatorutil.AdminKarmadaConfigSecretName(karmadaObject.GetName())))
-				_, err := kubeClient.CoreV1().Secrets(secretRef.Namespace).Get(context.TODO(), secretRef.Name, metav1.GetOptions{})
+				_, err := hostClient.CoreV1().Secrets(secretRef.Namespace).Get(context.Background(), secretRef.Name, metav1.GetOptions{})
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 
@@ -78,7 +78,7 @@ var _ = ginkgo.Describe("Status testing", func() {
 				apiServerService := karmadaObject.Status.APIServerService
 				gomega.Expect(apiServerService).ShouldNot(gomega.BeNil())
 				gomega.Expect(apiServerService.Name).Should(gomega.Equal(operatorutil.KarmadaAPIServerName(karmadaObject.GetName())))
-				_, err := kubeClient.CoreV1().Services(karmadaObject.GetNamespace()).Get(context.TODO(), apiServerService.Name, metav1.GetOptions{})
+				_, err := hostClient.CoreV1().Services(karmadaObject.GetNamespace()).Get(context.TODO(), apiServerService.Name, metav1.GetOptions{})
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 		})

--- a/test/e2e/suites/operator/suite_test.go
+++ b/test/e2e/suites/operator/suite_test.go
@@ -58,7 +58,7 @@ var (
 	kubeconfig     string
 	karmadactlPath string
 	restConfig     *rest.Config
-	kubeClient     kubernetes.Interface
+	hostClient     kubernetes.Interface
 	testNamespace  string
 	operatorClient operator.Interface
 )
@@ -93,11 +93,11 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	restConfig, err = framework.LoadRESTClientConfig(kubeconfig, hostContext)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-	kubeClient, err = kubernetes.NewForConfig(restConfig)
+	hostClient, err = kubernetes.NewForConfig(restConfig)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	testNamespace = fmt.Sprintf("operatortest-%s", rand.String(RandomStrLength))
-	err = setupTestNamespace(testNamespace, kubeClient)
+	err = setupTestNamespace(testNamespace, hostClient)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	operatorClient, err = operator.NewForConfig(restConfig)
@@ -107,7 +107,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 var _ = ginkgo.SynchronizedAfterSuite(func() {
 	// cleanup all namespaces we created both in control plane and member clusters.
 	// It will not return error even if there is no such namespace in there that may happen in case setup failed.
-	err := cleanupTestNamespace(testNamespace, kubeClient)
+	err := cleanupTestNamespace(testNamespace, hostClient)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 }, func() {})
 

--- a/test/helper/karmada.go
+++ b/test/helper/karmada.go
@@ -35,7 +35,8 @@ func NewKarmada(namespace string, name string) *operatorv1alpha1.Karmada {
 				HTTPSource: &operatorv1alpha1.HTTPSource{URL: "http://local"},
 			},
 			Components: &operatorv1alpha1.KarmadaComponents{
-				Etcd: &operatorv1alpha1.Etcd{},
+				Etcd:             &operatorv1alpha1.Etcd{},
+				KarmadaAPIServer: &operatorv1alpha1.KarmadaAPIServer{},
 				KarmadaAggregatedAPIServer: &operatorv1alpha1.KarmadaAggregatedAPIServer{
 					CommonSettings: operatorv1alpha1.CommonSettings{
 						Image: operatorv1alpha1.Image{


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**: 
Currently, the operator-related tests are scattered across two CI files: [ci.yml](https://github.com/karmada-io/karmada/blob/master/.github/workflows/ci.yml) and [installation-operator.yaml](https://github.com/karmada-io/karmada/blob/master/.github/workflows/installation-operator.yaml). 
This PR aims to unify the operator's CI by using e2e tests for the operator. It introduces a base e2e test in the operator e2e suite to cover the full process from installing Karmada, joining member clusters, to a simple propagation test.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #6887

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note

```

