### PR TITLE
Add the resource UID to the binding.spec.resource in the dependencies-distributor

### DIFF
--- a/pkg/dependenciesdistributor/dependencies_distributor.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor.go
@@ -767,6 +767,7 @@ func buildAttachedBinding(independentBinding *workv1alpha2.ResourceBinding, obje
 				Kind:            object.GetKind(),
 				Namespace:       object.GetNamespace(),
 				Name:            object.GetName(),
+				UID:             object.GetUID(),
 				ResourceVersion: object.GetResourceVersion(),
 			},
 			RequiredBy:                  result,

--- a/pkg/dependenciesdistributor/dependencies_distributor_test.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor_test.go
@@ -3144,6 +3144,7 @@ func Test_buildAttachedBinding(t *testing.T) {
 						Kind:            "Deployment",
 						Namespace:       "fake-ns",
 						Name:            "demo-app",
+						UID:             "db56a4a6-0dff-465a-b046-2c1dea42a42b",
 						ResourceVersion: "22222",
 					},
 					RequiredBy: []workv1alpha2.BindingSnapshot{


### PR DESCRIPTION


**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

In the dependencies-distributor scenario, we currently do not add the UID information of the resource to the `binding.spec.resource` field for the attached resources. However, the detector has [logic processing](https://github.com/karmada-io/karmada/blob/29536305bcc4c965a3538241bc60fb468d24d377/pkg/detector/detector.go#L811-L818) that could potentially cause repeated occurrences of this field, leading to unnecessary binding updates.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

