### PR TITLE
Implement default resource interpreter in third-party resourcecustomizations for MPIJob

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kubeflow.org/v2beta1/MPIJob/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kubeflow.org/v2beta1/MPIJob/customizations.yaml
@@ -1,0 +1,221 @@
+apiVersion: config.karmada.io/v1alpha1
+kind: ResourceInterpreterCustomization
+metadata:
+  name: declarative-configuration-mpijob
+spec:
+  target:
+    apiVersion: kubeflow.org/v2beta1
+    kind: MPIJob
+  customizations:
+    healthInterpretation:
+      luaScript: >
+        function InterpretHealth(observedObj)
+          if observedObj.status == nil or observedObj.status.conditions == nil or #observedObj.status.conditions == 0 then
+            return false
+          end
+
+          local conditions = observedObj.status.conditions
+          for i = 1, #conditions do
+            local c = conditions[i]
+            if c.type == "Failed" and c.status == "True" then
+              return false
+            end
+          end
+          
+          return true
+        end
+    componentResource:
+      luaScript: |
+        local kube = require("kube")
+        local function get(obj, path)
+          local cur = obj
+          for i = 1, #path do
+            if cur == nil then return nil end
+            cur = cur[path[i]]
+          end
+          return cur
+        end
+
+        local function to_num(v, default)
+          if v == nil or v == '' then
+            return default
+          end
+          local n = tonumber(v)
+          if n ~= nil then return n end
+          return default
+        end
+
+        function GetComponents(observedObj)
+          local components = {}
+
+          local replicaSpecs = get(observedObj, {"spec", "mpiReplicaSpecs"})
+          if replicaSpecs == nil then
+            return components
+          end
+
+          for taskName, spec in pairs(replicaSpecs) do
+            if spec ~= nil and spec.template ~= nil then
+              local default_replicas = 1
+              if string.lower(taskName) == "worker" then
+                default_replicas = 0
+              end
+              local replicas = to_num(spec.replicas, default_replicas)
+              local requires = kube.accuratePodRequirements(spec.template)
+              table.insert(components, {
+                name = taskName,
+                replicas = replicas,
+                replicaRequirements = requires
+              })
+            end
+          end
+
+          return components
+        end
+    statusAggregation:
+      luaScript: >
+        local function get(obj, path)
+          local cur = obj
+          for i = 1, #path do
+            if cur == nil then return nil end
+            cur = cur[path[i]]
+          end
+          return cur
+        end
+
+        local function omitEmpty(t)
+          if t == nil then return nil end
+          local out = {}
+          for k, v in pairs(t) do
+            if type(v) == "table" then
+              local inner = omitEmpty(v)
+              if inner ~= nil and next(inner) ~= nil then
+                out[k] = inner
+              end
+            elseif v ~= nil then
+              out[k] = v
+            end
+          end
+          if next(out) ~= nil then
+            return out
+          else
+            return nil
+          end
+        end
+
+        function AggregateStatus(desiredObj, statusItems)
+          if statusItems == nil or #statusItems == 0 then return desiredObj end
+          if desiredObj.status == nil then desiredObj.status = {} end
+          
+          if #statusItems == 1 then
+            desiredObj.status = statusItems[1].status
+            return desiredObj
+          end
+          
+          local latestTransition = {}
+
+          local status = {
+            replicaStatuses = {},
+            conditions = {},
+            startTime = nil,
+            completionTime = nil,
+            lastReconcileTime = nil,
+          }
+
+          for i = 1, #statusItems do
+            local s = statusItems[i].status
+            if s ~= nil then
+              if s.replicaStatuses ~= nil then
+                for replicaType, repStatus in pairs(s.replicaStatuses) do
+                  if status.replicaStatuses[replicaType] == nil then
+                    status.replicaStatuses[replicaType] = {
+                      active = 0,
+                      succeeded = 0,
+                      failed = 0
+                    }
+                  end
+                  
+                  status.replicaStatuses[replicaType].active = status.replicaStatuses[replicaType].active + (repStatus.active or 0)
+                  status.replicaStatuses[replicaType].succeeded = status.replicaStatuses[replicaType].succeeded + (repStatus.succeeded or 0)
+                  status.replicaStatuses[replicaType].failed = status.replicaStatuses[replicaType].failed + (repStatus.failed or 0)
+                end
+              end
+
+              if s.startTime ~= nil and s.startTime ~= "" then
+                if status.startTime == nil or s.startTime < status.startTime then
+                  status.startTime = s.startTime
+                end
+              end
+
+              if s.completionTime ~= nil and s.completionTime ~= "" then
+                if status.completionTime == nil or s.completionTime > status.completionTime then
+                  status.completionTime = s.completionTime
+                end
+              end
+
+              if s.lastReconcileTime ~= nil and s.lastReconcileTime ~= "" then
+                if status.lastReconcileTime == nil or s.lastReconcileTime > status.lastReconcileTime then
+                  status.lastReconcileTime = s.lastReconcileTime
+                end
+              end
+
+              if s.conditions then
+                for _, c in ipairs(s.conditions) do
+                  local exist = latestTransition[c.type]
+                  local newTime = c.lastUpdateTime or c.lastTransitionTime
+
+                  if newTime ~= nil and newTime ~= "" then
+                    if exist == nil or newTime > (exist.lastUpdateTime or exist.lastTransitionTime) then
+                      latestTransition[c.type] = c
+                    end
+                  end
+                end
+              end
+              
+            end
+          end
+
+          for _, v in pairs(latestTransition) do
+            table.insert(status.conditions, v)
+          end
+
+          desiredObj.status = omitEmpty(status) or {}
+          return desiredObj
+        end
+    statusReflection:
+      luaScript: >
+        function ReflectStatus(observedObj)
+          local status = {}
+
+          if observedObj == nil or observedObj.status == nil then
+            return status
+          end
+
+          local s = observedObj.status
+
+          status.replicaStatuses = {}
+          if s.replicaStatuses ~= nil then
+            for k, v in pairs(s.replicaStatuses) do
+              if v ~= nil then
+                status.replicaStatuses[k] = {
+                  active = v.active,
+                  succeeded = v.succeeded,
+                  failed = v.failed,
+                  selector = v.selector
+                }
+              end
+            end
+          end
+
+          status.conditions = {}
+          if type(s.conditions) == "table" then
+            for _, cond in ipairs(s.conditions) do
+              table.insert(status.conditions, cond)
+            end
+          end
+
+          status.startTime = s.startTime
+          status.completionTime = s.completionTime
+          status.lastReconcileTime = s.lastReconcileTime
+
+          return status
+        end

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kubeflow.org/v2beta1/MPIJob/customizations_tests.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kubeflow.org/v2beta1/MPIJob/customizations_tests.yaml
@@ -1,0 +1,8 @@
+tests:
+  - desiredInputPath: testdata/desired-mpijob.yaml
+    statusInputPath: testdata/status-file.yaml
+    operation: AggregateStatus
+  - observedInputPath: testdata/observed-mpijob.yaml
+    operation: InterpretHealth
+  - observedInputPath: testdata/observed-mpijob.yaml
+    operation: InterpretStatus

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kubeflow.org/v2beta1/MPIJob/testdata/desired-mpijob.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kubeflow.org/v2beta1/MPIJob/testdata/desired-mpijob.yaml
@@ -1,0 +1,52 @@
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: tensorflow-benchmarks
+spec:
+  slotsPerWorker: 1
+  runPolicy:
+    cleanPodPolicy: Running
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+           containers:
+           - image: mpioperator/tensorflow-benchmarks:latest
+             name: tensorflow-benchmarks
+             command:
+             - mpirun
+             - --allow-run-as-root
+             - -np
+             - "2"
+             - -bind-to
+             - none
+             - -map-by
+             - slot
+             - -x
+             - NCCL_DEBUG=INFO
+             - -x
+             - LD_LIBRARY_PATH
+             - -x
+             - PATH
+             - -mca
+             - pml
+             - ob1
+             - -mca
+             - btl
+             - ^openib
+             - python
+             - scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py
+             - --model=resnet101
+             - --batch_size=64
+             - --variable_update=horovod
+    Worker:
+      replicas: 2
+      template:
+        spec:
+          containers:
+          - image: mpioperator/tensorflow-benchmarks:latest
+            name: tensorflow-benchmarks
+            resources:
+              limits:
+                nvidia.com/gpu: 1

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kubeflow.org/v2beta1/MPIJob/testdata/observed-mpijob.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kubeflow.org/v2beta1/MPIJob/testdata/observed-mpijob.yaml
@@ -1,0 +1,84 @@
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  creationTimestamp: "2019-07-09T22:15:51Z"
+  generation: 1
+  name: tensorflow-benchmarks
+  namespace: default
+  resourceVersion: "5645868"
+  selfLink: /apis/kubeflow.org/v2beta1/namespaces/default/mpijobs/tensorflow-benchmarks
+  uid: 1c5b470f-a297-11e9-964d-88d7f67c6e6d
+spec:
+  runPolicy:
+    cleanPodPolicy: Running
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+          - command:
+            - mpirun
+            - --allow-run-as-root
+            - -np
+            - "2"
+            - -bind-to
+            - none
+            - -map-by
+            - slot
+            - -x
+            - NCCL_DEBUG=INFO
+            - -x
+            - LD_LIBRARY_PATH
+            - -x
+            - PATH
+            - -mca
+            - pml
+            - ob1
+            - -mca
+            - btl
+            - ^openib
+            - python
+            - scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py
+            - --model=resnet101
+            - --batch_size=64
+            - --variable_update=horovod
+            image: mpioperator/tensorflow-benchmarks:latest
+            name: tensorflow-benchmarks
+    Worker:
+      replicas: 1
+      template:
+        spec:
+          containers:
+          - image: mpioperator/tensorflow-benchmarks:latest
+            name: tensorflow-benchmarks
+            resources:
+              limits:
+                nvidia.com/gpu: 2
+  slotsPerWorker: 2
+status:
+  completionTime: "2019-07-09T22:17:06Z"
+  conditions:
+  - lastTransitionTime: "2019-07-09T22:15:51Z"
+    lastUpdateTime: "2019-07-09T22:15:51Z"
+    message: MPIJob default/tensorflow-benchmarks is created.
+    reason: MPIJobCreated
+    status: "True"
+    type: Created
+  - lastTransitionTime: "2019-07-09T22:15:54Z"
+    lastUpdateTime: "2019-07-09T22:15:54Z"
+    message: MPIJob default/tensorflow-benchmarks is running.
+    reason: MPIJobRunning
+    status: "False"
+    type: Running
+  - lastTransitionTime: "2019-07-09T22:17:06Z"
+    lastUpdateTime: "2019-07-09T22:17:06Z"
+    message: MPIJob default/tensorflow-benchmarks successfully completed.
+    reason: MPIJobSucceeded
+    status: "True"
+    type: Succeeded
+  replicaStatuses:
+    Launcher:
+      succeeded: 1
+    Worker: {}
+  startTime: "2019-07-09T22:15:51Z"

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kubeflow.org/v2beta1/MPIJob/testdata/status-file.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kubeflow.org/v2beta1/MPIJob/testdata/status-file.yaml
@@ -1,0 +1,73 @@
+applied: true
+clusterName: member1
+health: Healthy
+status:
+  startTime: "2019-07-10T10:00:00Z"
+  conditions:
+  - lastTransitionTime: "2019-07-10T10:00:00Z"
+    lastUpdateTime: "2019-07-10T10:00:00Z"
+    message: MPIJob default/tensorflow-benchmarks is created.
+    reason: MPIJobCreated
+    status: "True"
+    type: Created
+  - lastTransitionTime: "2019-07-10T10:01:00Z"
+    lastUpdateTime: "2019-07-10T10:01:00Z"
+    message: MPIJob default/tensorflow-benchmarks is running.
+    reason: MPIJobRunning
+    status: "True"
+    type: Running
+  replicaStatuses:
+    Launcher:
+      active: 1
+    Worker:
+      active: 2
+---
+applied: true
+clusterName: member2
+health: Unhealthy
+status:
+  completionTime: "2019-07-11T12:00:00Z"
+  startTime: "2019-07-11T11:30:00Z"
+  conditions:
+  - lastTransitionTime: "2019-07-11T11:30:00Z"
+    lastUpdateTime: "2019-07-11T11:30:00Z"
+    message: MPIJob default/tensorflow-benchmarks is created.
+    reason: MPIJobCreated
+    status: "True"
+    type: Created
+  - lastTransitionTime: "2019-07-11T11:45:00Z"
+    lastUpdateTime: "2019-07-11T11:45:00Z"
+    message: MPIJob default/tensorflow-benchmarks failed during execution.
+    reason: MPIJobFailed
+    status: "True"
+    type: Failed
+  replicaStatuses:
+    Launcher:
+      failed: 1
+    Worker:
+      failed: 2
+---
+applied: true
+clusterName: member3
+health: Healthy
+status:
+  startTime: "2019-07-12T08:00:00Z"
+  conditions:
+  - lastTransitionTime: "2019-07-12T08:00:00Z"
+    lastUpdateTime: "2019-07-12T08:00:00Z"
+    message: MPIJob default/tensorflow-benchmarks is created.
+    reason: MPIJobCreated
+    status: "True"
+    type: Created
+  - lastTransitionTime: "2019-07-12T08:05:00Z"
+    lastUpdateTime: "2019-07-12T08:05:00Z"
+    message: MPIJob default/tensorflow-benchmarks running with partial successes.
+    reason: MPIJobRunning
+    status: "True"
+    type: Running
+  replicaStatuses:
+    Launcher:
+      active: 1
+    Worker:
+      active: 1
+      succeeded: 1


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of #[6587](https://github.com/karmada-io/karmada/issues/6587)

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-controller-manager`: Introduced built-in interpreter for MPIJob.
```

