### PR TITLE
Standardize Karmada metrics label for member clusters 

### DIFF
--- a/pkg/metrics/cluster.go
+++ b/pkg/metrics/cluster.go
@@ -41,68 +41,76 @@ const (
 	evictionKindTotalMetricsName         = "eviction_kind_total"
 	evictionProcessingLatencyMetricsName = "eviction_processing_latency_seconds"
 	evictionProcessingTotalMetricsName   = "eviction_processing_total"
+
+	// Canonical label for Karmada member clusters.
+	memberClusterLabel = "member_cluster"
+
+	// DEPRECATED: cluster_name (target removal: 1.18)
+	// Rationale: avoid collision with Prometheus external_labels like cluster and standardize on the metric label name used to denote a Karmada member cluster across all metrics.
+	// Migration: use member_cluster instead across all queries and dashboards.
+	clusterNameLabel = "cluster_name"
 )
 
 var (
 	// clusterReadyGauge reports if the cluster is ready.
 	clusterReadyGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: clusterReadyMetricsName,
-		Help: "State of the cluster(1 if ready, 0 otherwise).",
-	}, []string{"cluster_name"})
+		Help: "State of the cluster (1 if ready, 0 otherwise). [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
+	}, []string{memberClusterLabel, clusterNameLabel})
 
 	// clusterTotalNodeNumberGauge reports the number of nodes in the given cluster.
 	clusterTotalNodeNumberGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: clusterTotalNodeNumberMetricsName,
-		Help: "Number of nodes in the cluster.",
-	}, []string{"cluster_name"})
+		Help: "Number of nodes in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
+	}, []string{memberClusterLabel, clusterNameLabel})
 
 	// clusterReadyNodeNumberGauge reports the number of ready nodes in the given cluster.
 	clusterReadyNodeNumberGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: clusterReadyNodeNumberMetricsName,
-		Help: "Number of ready nodes in the cluster.",
-	}, []string{"cluster_name"})
+		Help: "Number of ready nodes in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
+	}, []string{memberClusterLabel, clusterNameLabel})
 
 	// clusterMemoryAllocatableGauge reports the allocatable memory in the given cluster.
 	clusterMemoryAllocatableGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: clusterMemoryAllocatableMetricsName,
-		Help: "Allocatable cluster memory resource in bytes.",
-	}, []string{"cluster_name"})
+		Help: "Allocatable cluster memory resource in bytes. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
+	}, []string{memberClusterLabel, clusterNameLabel})
 
 	// clusterCPUAllocatableGauge reports the allocatable CPU in the given cluster.
 	clusterCPUAllocatableGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: clusterCPUAllocatableMetricsName,
-		Help: "Number of allocatable CPU in the cluster.",
-	}, []string{"cluster_name"})
+		Help: "Number of allocatable CPU in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
+	}, []string{memberClusterLabel, clusterNameLabel})
 
 	// clusterPodAllocatableGauge reports the allocatable Pod number in the given cluster.
 	clusterPodAllocatableGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: clusterPodAllocatableMetricsName,
-		Help: "Number of allocatable pods in the cluster.",
-	}, []string{"cluster_name"})
+		Help: "Number of allocatable pods in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
+	}, []string{memberClusterLabel, clusterNameLabel})
 
 	// clusterMemoryAllocatedGauge reports the allocated memory in the given cluster.
 	clusterMemoryAllocatedGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: clusterMemoryAllocatedMetricsName,
-		Help: "Allocated cluster memory resource in bytes.",
-	}, []string{"cluster_name"})
+		Help: "Allocated cluster memory resource in bytes. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
+	}, []string{memberClusterLabel, clusterNameLabel})
 
 	// clusterCPUAllocatedGauge reports the allocated CPU in the given cluster.
 	clusterCPUAllocatedGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: clusterCPUAllocatedMetricsName,
-		Help: "Number of allocated CPU in the cluster.",
-	}, []string{"cluster_name"})
+		Help: "Number of allocated CPU in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
+	}, []string{memberClusterLabel, clusterNameLabel})
 
 	// clusterPodAllocatedGauge reports the allocated Pod number in the given cluster.
 	clusterPodAllocatedGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: clusterPodAllocatedMetricsName,
-		Help: "Number of allocated pods in the cluster.",
-	}, []string{"cluster_name"})
+		Help: "Number of allocated pods in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
+	}, []string{memberClusterLabel, clusterNameLabel})
 
 	// clusterSyncStatusDuration reports the duration of the given cluster syncing status.
 	clusterSyncStatusDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name: clusterSyncStatusDurationMetricsName,
-		Help: "Duration in seconds for syncing the status of the cluster once.",
-	}, []string{"cluster_name"})
+		Help: "Duration in seconds for syncing the status of the cluster once. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
+	}, []string{memberClusterLabel, clusterNameLabel})
 
 	evictionQueueMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: evictionQueueDepthMetricsName,
@@ -111,8 +119,8 @@ var (
 
 	evictionKindTotalMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: evictionKindTotalMetricsName,
-		Help: "Number of resources in the eviction queue by resource kind",
-	}, []string{"member_cluster", "resource_kind"})
+		Help: "Number of resources in the eviction queue by resource kind [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
+	}, []string{memberClusterLabel, clusterNameLabel, "resource_kind"})
 
 	evictionProcessingLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    evictionProcessingLatencyMetricsName,
@@ -128,7 +136,9 @@ var (
 
 // RecordClusterStatus records the status of the given cluster.
 func RecordClusterStatus(cluster *v1alpha1.Cluster) {
-	clusterReadyGauge.WithLabelValues(cluster.Name).Set(func() float64 {
+	labels := []string{cluster.Name, cluster.Name} // member_cluster, cluster_name
+
+	clusterReadyGauge.WithLabelValues(labels...).Set(func() float64 {
 		if util.IsClusterReady(&cluster.Status) {
 			return 1
 		}
@@ -136,42 +146,45 @@ func RecordClusterStatus(cluster *v1alpha1.Cluster) {
 	}())
 
 	if cluster.Status.NodeSummary != nil {
-		clusterTotalNodeNumberGauge.WithLabelValues(cluster.Name).Set(float64(cluster.Status.NodeSummary.TotalNum))
-		clusterReadyNodeNumberGauge.WithLabelValues(cluster.Name).Set(float64(cluster.Status.NodeSummary.ReadyNum))
+		clusterTotalNodeNumberGauge.WithLabelValues(labels...).Set(float64(cluster.Status.NodeSummary.TotalNum))
+		clusterReadyNodeNumberGauge.WithLabelValues(labels...).Set(float64(cluster.Status.NodeSummary.ReadyNum))
 	}
 
 	if cluster.Status.ResourceSummary != nil {
 		if cluster.Status.ResourceSummary.Allocatable != nil {
-			clusterMemoryAllocatableGauge.WithLabelValues(cluster.Name).Set(cluster.Status.ResourceSummary.Allocatable.Memory().AsApproximateFloat64())
-			clusterCPUAllocatableGauge.WithLabelValues(cluster.Name).Set(cluster.Status.ResourceSummary.Allocatable.Cpu().AsApproximateFloat64())
-			clusterPodAllocatableGauge.WithLabelValues(cluster.Name).Set(cluster.Status.ResourceSummary.Allocatable.Pods().AsApproximateFloat64())
+			clusterMemoryAllocatableGauge.WithLabelValues(labels...).Set(cluster.Status.ResourceSummary.Allocatable.Memory().AsApproximateFloat64())
+			clusterCPUAllocatableGauge.WithLabelValues(labels...).Set(cluster.Status.ResourceSummary.Allocatable.Cpu().AsApproximateFloat64())
+			clusterPodAllocatableGauge.WithLabelValues(labels...).Set(cluster.Status.ResourceSummary.Allocatable.Pods().AsApproximateFloat64())
 		}
 
 		if cluster.Status.ResourceSummary.Allocated != nil {
-			clusterMemoryAllocatedGauge.WithLabelValues(cluster.Name).Set(cluster.Status.ResourceSummary.Allocated.Memory().AsApproximateFloat64())
-			clusterCPUAllocatedGauge.WithLabelValues(cluster.Name).Set(cluster.Status.ResourceSummary.Allocated.Cpu().AsApproximateFloat64())
-			clusterPodAllocatedGauge.WithLabelValues(cluster.Name).Set(cluster.Status.ResourceSummary.Allocated.Pods().AsApproximateFloat64())
+			clusterMemoryAllocatedGauge.WithLabelValues(labels...).Set(cluster.Status.ResourceSummary.Allocated.Memory().AsApproximateFloat64())
+			clusterCPUAllocatedGauge.WithLabelValues(labels...).Set(cluster.Status.ResourceSummary.Allocated.Cpu().AsApproximateFloat64())
+			clusterPodAllocatedGauge.WithLabelValues(labels...).Set(cluster.Status.ResourceSummary.Allocated.Pods().AsApproximateFloat64())
 		}
 	}
 }
 
 // RecordClusterSyncStatusDuration records the duration of the given cluster syncing status
 func RecordClusterSyncStatusDuration(cluster *v1alpha1.Cluster, startTime time.Time) {
-	clusterSyncStatusDuration.WithLabelValues(cluster.Name).Observe(utilmetrics.DurationInSeconds(startTime))
+	labels := []string{cluster.Name, cluster.Name}
+	clusterSyncStatusDuration.WithLabelValues(labels...).Observe(utilmetrics.DurationInSeconds(startTime))
 }
 
 // CleanupMetricsForCluster removes the cluster status metrics after the cluster is deleted.
 func CleanupMetricsForCluster(clusterName string) {
-	clusterReadyGauge.DeleteLabelValues(clusterName)
-	clusterTotalNodeNumberGauge.DeleteLabelValues(clusterName)
-	clusterReadyNodeNumberGauge.DeleteLabelValues(clusterName)
-	clusterMemoryAllocatableGauge.DeleteLabelValues(clusterName)
-	clusterCPUAllocatableGauge.DeleteLabelValues(clusterName)
-	clusterPodAllocatableGauge.DeleteLabelValues(clusterName)
-	clusterMemoryAllocatedGauge.DeleteLabelValues(clusterName)
-	clusterCPUAllocatedGauge.DeleteLabelValues(clusterName)
-	clusterPodAllocatedGauge.DeleteLabelValues(clusterName)
-	clusterSyncStatusDuration.DeleteLabelValues(clusterName)
+	labels := []string{clusterName, clusterName}
+
+	clusterReadyGauge.DeleteLabelValues(labels...)
+	clusterTotalNodeNumberGauge.DeleteLabelValues(labels...)
+	clusterReadyNodeNumberGauge.DeleteLabelValues(labels...)
+	clusterMemoryAllocatableGauge.DeleteLabelValues(labels...)
+	clusterCPUAllocatableGauge.DeleteLabelValues(labels...)
+	clusterPodAllocatableGauge.DeleteLabelValues(labels...)
+	clusterMemoryAllocatedGauge.DeleteLabelValues(labels...)
+	clusterCPUAllocatedGauge.DeleteLabelValues(labels...)
+	clusterPodAllocatedGauge.DeleteLabelValues(labels...)
+	clusterSyncStatusDuration.DeleteLabelValues(labels...)
 }
 
 // RecordEvictionQueueMetrics record the depth Of the EvictionQueue
@@ -186,10 +199,11 @@ func RecordEvictionKindMetrics(clusterName, resourceKind string, increase bool) 
 		return
 	}
 
+	labels := []string{clusterName, clusterName, resourceKind}
 	if increase {
-		evictionKindTotalMetrics.WithLabelValues(clusterName, resourceKind).Inc()
+		evictionKindTotalMetrics.WithLabelValues(labels...).Inc()
 	} else {
-		evictionKindTotalMetrics.WithLabelValues(clusterName, resourceKind).Dec()
+		evictionKindTotalMetrics.WithLabelValues(labels...).Dec()
 	}
 }
 

--- a/pkg/metrics/cluster_test.go
+++ b/pkg/metrics/cluster_test.go
@@ -53,9 +53,9 @@ func TestClusterReadyMetrics(t *testing.T) {
 				},
 			},
 			want: `
-# HELP cluster_ready_state State of the cluster(1 if ready, 0 otherwise).
+# HELP cluster_ready_state State of the cluster (1 if ready, 0 otherwise). [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]
 # TYPE cluster_ready_state gauge
-cluster_ready_state{cluster_name="foo"} 1
+cluster_ready_state{cluster_name="foo",member_cluster="foo"} 1
 `,
 		},
 		{
@@ -74,9 +74,9 @@ cluster_ready_state{cluster_name="foo"} 1
 				},
 			},
 			want: `
-# HELP cluster_ready_state State of the cluster(1 if ready, 0 otherwise).
+# HELP cluster_ready_state State of the cluster (1 if ready, 0 otherwise). [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]
 # TYPE cluster_ready_state gauge
-cluster_ready_state{cluster_name="foo"} 0
+cluster_ready_state{cluster_name="foo",member_cluster="foo"} 0
 `,
 		},
 	}
@@ -110,9 +110,9 @@ func TestClusterTotalNodeNumberMetrics(t *testing.T) {
 		},
 	}
 	want := `
-# HELP cluster_node_number Number of nodes in the cluster.
+# HELP cluster_node_number Number of nodes in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]
 # TYPE cluster_node_number gauge
-cluster_node_number{cluster_name="foo"} 100
+cluster_node_number{cluster_name="foo",member_cluster="foo"} 100
 `
 	clusterTotalNodeNumberGauge.Reset()
 	RecordClusterStatus(testCluster)
@@ -143,9 +143,9 @@ func TestClusterReadyNodeNumberMetrics(t *testing.T) {
 		},
 	}
 	want := `
-# HELP cluster_ready_node_number Number of ready nodes in the cluster.
+# HELP cluster_ready_node_number Number of ready nodes in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]
 # TYPE cluster_ready_node_number gauge
-cluster_ready_node_number{cluster_name="foo"} 10
+cluster_ready_node_number{cluster_name="foo",member_cluster="foo"} 10
 `
 	clusterReadyNodeNumberGauge.Reset()
 	RecordClusterStatus(testCluster)
@@ -177,9 +177,9 @@ func TestClusterMemoryAllocatableMetrics(t *testing.T) {
 		},
 	}
 	want := `
-# HELP cluster_memory_allocatable_bytes Allocatable cluster memory resource in bytes.
+# HELP cluster_memory_allocatable_bytes Allocatable cluster memory resource in bytes. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]
 # TYPE cluster_memory_allocatable_bytes gauge
-cluster_memory_allocatable_bytes{cluster_name="foo"} 200
+cluster_memory_allocatable_bytes{cluster_name="foo",member_cluster="foo"} 200
 `
 	clusterMemoryAllocatableGauge.Reset()
 	RecordClusterStatus(testCluster)
@@ -211,9 +211,9 @@ func TestClusterCPUAllocatableMetrics(t *testing.T) {
 		},
 	}
 	want := `
-# HELP cluster_cpu_allocatable_number Number of allocatable CPU in the cluster.
+# HELP cluster_cpu_allocatable_number Number of allocatable CPU in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]
 # TYPE cluster_cpu_allocatable_number gauge
-cluster_cpu_allocatable_number{cluster_name="foo"} 0.2
+cluster_cpu_allocatable_number{cluster_name="foo",member_cluster="foo"} 0.2
 `
 	clusterCPUAllocatableGauge.Reset()
 	RecordClusterStatus(testCluster)
@@ -245,9 +245,9 @@ func TestClusterPodAllocatableMetrics(t *testing.T) {
 		},
 	}
 	want := `
-# HELP cluster_pod_allocatable_number Number of allocatable pods in the cluster.
+# HELP cluster_pod_allocatable_number Number of allocatable pods in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]
 # TYPE cluster_pod_allocatable_number gauge
-cluster_pod_allocatable_number{cluster_name="foo"} 110
+cluster_pod_allocatable_number{cluster_name="foo",member_cluster="foo"} 110
 `
 	clusterPodAllocatableGauge.Reset()
 	RecordClusterStatus(testCluster)
@@ -279,9 +279,9 @@ func TestClusterMemoryAllocatedMetrics(t *testing.T) {
 		},
 	}
 	want := `
-# HELP cluster_memory_allocated_bytes Allocated cluster memory resource in bytes.
+# HELP cluster_memory_allocated_bytes Allocated cluster memory resource in bytes. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]
 # TYPE cluster_memory_allocated_bytes gauge
-cluster_memory_allocated_bytes{cluster_name="foo"} 200
+cluster_memory_allocated_bytes{cluster_name="foo",member_cluster="foo"} 200
 `
 	clusterMemoryAllocatedGauge.Reset()
 	RecordClusterStatus(testCluster)
@@ -313,9 +313,9 @@ func TestClusterCPUAllocatedMetrics(t *testing.T) {
 		},
 	}
 	want := `
-# HELP cluster_cpu_allocated_number Number of allocated CPU in the cluster.
+# HELP cluster_cpu_allocated_number Number of allocated CPU in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]
 # TYPE cluster_cpu_allocated_number gauge
-cluster_cpu_allocated_number{cluster_name="foo"} 0.2
+cluster_cpu_allocated_number{cluster_name="foo",member_cluster="foo"} 0.2
 `
 	clusterCPUAllocatedGauge.Reset()
 	RecordClusterStatus(testCluster)
@@ -347,9 +347,9 @@ func TestClusterPodAllocatedMetrics(t *testing.T) {
 		},
 	}
 	want := `
-# HELP cluster_pod_allocated_number Number of allocated pods in the cluster.
+# HELP cluster_pod_allocated_number Number of allocated pods in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]
 # TYPE cluster_pod_allocated_number gauge
-cluster_pod_allocated_number{cluster_name="foo"} 110
+cluster_pod_allocated_number{cluster_name="foo",member_cluster="foo"} 110
 `
 	clusterPodAllocatedGauge.Reset()
 	RecordClusterStatus(testCluster)

--- a/pkg/metrics/resource_test.go
+++ b/pkg/metrics/resource_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	k8stestutil "k8s.io/component-base/metrics/testutil"
+)
+
+func TestCountCreateResourceToCluster(t *testing.T) {
+	createResourceWhenSyncWork.Reset()
+
+	cluster := "member-1"
+	apiVersion := "v1"
+	kind := "Pod"
+
+	CountCreateResourceToCluster(nil, apiVersion, kind, cluster, true)
+	CountCreateResourceToCluster(fmt.Errorf("boom"), apiVersion, kind, cluster, false)
+
+	want := `
+# HELP create_resource_to_cluster Number of creation operations against a target member cluster. The 'result' label indicates outcome ('success' or 'error'), 'recreate' indicates whether the operation is recreated (true/false). Labels 'apiversion', 'kind', and 'cluster' specify the resource type, API version, and target cluster respectively. [Label deprecation: cluster deprecated in 1.16; use member_cluster. Removal planned 1.18.]
+# TYPE create_resource_to_cluster counter
+create_resource_to_cluster{apiversion="v1",cluster="member-1",kind="Pod",member_cluster="member-1",recreate="false",result="error"} 1
+create_resource_to_cluster{apiversion="v1",cluster="member-1",kind="Pod",member_cluster="member-1",recreate="true",result="success"} 1
+`
+	if err := promtestutil.CollectAndCompare(createResourceWhenSyncWork, strings.NewReader(want), createResourceToCluster); err != nil {
+		t.Fatalf("unexpected collecting result:\n%s", err)
+	}
+}
+
+func TestCountUpdateResourceToCluster(t *testing.T) {
+	updateResourceWhenSyncWork.Reset()
+
+	cluster := "member-2"
+	apiVersion := "apps/v1"
+	kind := "Deployment"
+
+	CountUpdateResourceToCluster(nil, apiVersion, kind, cluster, "updated")
+
+	want := `
+# HELP update_resource_to_cluster Number of updating operation of the resource to a target member cluster. By the result, 'error' means a resource updated failed. Otherwise 'success'. Cluster means the target member cluster. operationResult means the result of the update operation. [Label deprecation: cluster deprecated in 1.16; use member_cluster. Removal planned 1.18.]
+# TYPE update_resource_to_cluster counter
+update_resource_to_cluster{apiversion="apps/v1",cluster="member-2",kind="Deployment",member_cluster="member-2",operationResult="updated",result="success"} 1
+`
+	if err := promtestutil.CollectAndCompare(updateResourceWhenSyncWork, strings.NewReader(want), updateResourceToCluster); err != nil {
+		t.Fatalf("unexpected collecting result:\n%s", err)
+	}
+}
+
+func TestCountDeleteResourceFromCluster(t *testing.T) {
+	deleteResourceWhenSyncWork.Reset()
+
+	cluster := "member-3"
+	apiVersion := "batch/v1"
+	kind := "Job"
+
+	// Record an error deletion
+	CountDeleteResourceFromCluster(fmt.Errorf("nope"), apiVersion, kind, cluster)
+
+	want := `
+# HELP delete_resource_from_cluster Number of deletion operations against a target member cluster. The 'result' label indicates outcome ('success' or 'error'). Labels 'apiversion', 'kind', and 'cluster' specify the resource's API version, type, and source cluster respectively. [Label deprecation: cluster deprecated in 1.16; use member_cluster. Removal planned 1.18.]
+# TYPE delete_resource_from_cluster counter
+delete_resource_from_cluster{apiversion="batch/v1",cluster="member-3",kind="Job",member_cluster="member-3",result="error"} 1
+`
+	if err := promtestutil.CollectAndCompare(deleteResourceWhenSyncWork, strings.NewReader(want), deleteResourceFromCluster); err != nil {
+		t.Fatalf("unexpected collecting result:\n%s", err)
+	}
+}
+
+func TestCountPolicyPreemption(t *testing.T) {
+	policyPreemptionCounter.Reset()
+
+	// One success, one error
+	CountPolicyPreemption(nil)
+	CountPolicyPreemption(fmt.Errorf("preempt failed"))
+
+	want := `
+# HELP policy_preemption_total Number of preemption for the resource template. By the result, 'error' means a resource template failed to be preempted by other propagation policies. Otherwise 'success'.
+# TYPE policy_preemption_total counter
+policy_preemption_total{result="error"} 1
+policy_preemption_total{result="success"} 1
+`
+	if err := k8stestutil.CollectAndCompare(policyPreemptionCounter, strings.NewReader(want), policyPreemptionMetricsName); err != nil {
+		t.Fatalf("unexpected collecting result:\n%s", err)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind deprecation

**What this PR does / why we need it**:
Please see this this issue for more details:  https://github.com/karmada-io/karmada/issues/6781

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #6781
-->

Part of #6781

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`Instrumentation`: The `cluster` and `cluster_name` Prometheus metric labels previously used to denote a Karmada member cluster have been deprecated and will be removed in the `1.18` release. The newly introduced `member_cluster` metric label name will now be used for that purpose moving forward.
```

