### PR TITLE
federatedresourcequota add the support to multi-components scheduling

### DIFF
--- a/pkg/webhook/resourcebinding/validating.go
+++ b/pkg/webhook/resourcebinding/validating.go
@@ -356,6 +356,9 @@ func isQuotaRelevantFieldChanged(oldRB, newRB *workv1alpha2.ResourceBinding) boo
 	if isScheduledReplicasChanged(oldRB, newRB) {
 		return true
 	}
+	if (len(oldRB.Spec.Components) != 0 || len(newRB.Spec.Components) != 0) && isScheduledClusterChanged(oldRB, newRB) {
+		return true
+	}
 	return isComponentsChanged(oldRB, newRB)
 }
 
@@ -381,6 +384,22 @@ func isScheduledReplicasChanged(oldRB, newRB *workv1alpha2.ResourceBinding) bool
 		newScheduledReplicas += c.Replicas
 	}
 	return oldScheduledReplicas != newScheduledReplicas
+}
+
+func isScheduledClusterChanged(oldRB, newRB *workv1alpha2.ResourceBinding) bool {
+	if len(oldRB.Spec.Clusters) != len(newRB.Spec.Clusters) {
+		return true
+	}
+	oldClusterMap := make(map[string]struct{})
+	for _, c := range oldRB.Spec.Clusters {
+		oldClusterMap[c.Name] = struct{}{}
+	}
+	for _, c := range newRB.Spec.Clusters {
+		if _, exists := oldClusterMap[c.Name]; !exists {
+			return true
+		}
+	}
+	return false
 }
 
 func isComponentsChanged(oldRB, newRB *workv1alpha2.ResourceBinding) bool {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
We introduced support for resource quota calculation for multi-components in https://github.com/karmada-io/karmada/pull/6701. However, further adaptation is needed for multi-components scheduling. For example, the current scheduling result for multi-components does not include `replicas`, so the existing logic skips quota calculation entirely—this needs to be updated.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-webhook`: Enabled federated resource quota calculation for multi-component scheduling.
```

