### PR TITLE
[UT] Enhance third-party resource interpreter tests with output verification

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/AdvancedCronJob/customizations_tests.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/AdvancedCronJob/customizations_tests.yaml
@@ -2,5 +2,7 @@ tests:
   - desiredInputPath: testdata/desired-acj-nginx.yaml
     statusInputPath: testdata/status-file.yaml
     operation: AggregateStatus
+    expectedOutputPath: testdata/expected-aggregatestatus.yaml
   - desiredInputPath: testdata/desired-acj-nginx.yaml
     operation: InterpretDependency
+    expectedOutputPath: testdata/expected-dependencies.yaml

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/AdvancedCronJob/testdata/expected-aggregatestatus.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/AdvancedCronJob/testdata/expected-aggregatestatus.yaml
@@ -1,0 +1,55 @@
+aggregatedStatus:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: AdvancedCronJob
+  metadata:
+    labels:
+      app: sample
+    name: sample
+    namespace: test-acj
+  spec:
+    schedule: "*/2 * * * *"
+    template:
+      broadcastJobTemplate:
+        spec:
+          template:
+            metadata:
+              labels:
+                app: sample
+            spec:
+              restartPolicy: Never
+              volumes:
+                - name: configmap
+                  configMap:
+                    name: my-sample-config    
+              containers:
+                - name: nginx
+                  image: nginx:alpine
+                  env: 
+                  - name: logData
+                    valueFrom: 
+                      configMapKeyRef:
+                        name: mysql-config
+                        key: log
+                  - name: lowerData
+                    valueFrom:
+                      configMapKeyRef:
+                        name: mysql-config
+                        key: lower
+          completionPolicy:
+            type: Never
+  status:
+    active:
+    - apiVersion: apps.kruise.io/v1alpha1
+      kind: BroadcastJob
+      name: sample-1681378080
+      namespace: test-acj
+      resourceVersion: "3636404"
+      uid: f96013ef-2869-49d7-adf3-8f7231cc5e2a
+    - apiVersion: apps.kruise.io/v1alpha1
+      kind: BroadcastJob
+      name: sample-1681378080
+      namespace: test-acj
+      resourceVersion: "3635081"
+      uid: d1f3c194-d650-4cce-b23d-307a445bb92e
+    lastScheduleTime: "2023-04-13T09:30:00Z"
+    type: BroadcastJob

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/AdvancedCronJob/testdata/expected-dependencies.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/AdvancedCronJob/testdata/expected-dependencies.yaml
@@ -1,0 +1,9 @@
+dependencies:
+  - apiVersion: v1
+    kind: ConfigMap
+    name: my-sample-config
+    namespace: test-acj
+  - apiVersion: v1
+    kind: ConfigMap
+    name: mysql-config
+    namespace: test-acj


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

This PR enhances the testing framework for third-party resource interpreter customizations by adding support for verifying Lua script execution results against expected outputs.

**Key improvements:**
- Added `ExpectedOutput` structure to define expected results for all interpreter operations
- Implemented `verifyRuleResult` function to automatically verify actual outputs against expected values
- Flexible verification strategy: tests can optionally skip output verification, allowing gradual enhancement
- Added example expected output files for `AdvancedCronJob` tests

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

The framework includes TODO comments to guide migration to strict mode, where all outputs must have corresponding expected values. This will be enabled once all third-party resources have complete test coverage.

Next, I will gradually add the expected output files for other resources in the third-party resource interpreter.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

