### PR TITLE
flake: Multi-Components: FederatedResourceQuota enforcement testing

### DIFF
--- a/test/e2e/suites/base/federatedresourcequota_test.go
+++ b/test/e2e/suites/base/federatedresourcequota_test.go
@@ -494,7 +494,8 @@ var _ = ginkgo.Describe("FederatedResourceQuota enforcement testing", func() {
 	})
 })
 
-var _ = ginkgo.Describe("Multi-Components: FederatedResourceQuota enforcement testing", func() {
+// This test case needs to create and clean up FlinkDeployment CRD, which may affect other test cases running in parallel. Therefore, it is set to run serially.
+var _ = framework.SerialDescribe("Multi-Components: FederatedResourceQuota enforcement testing", func() {
 	ginkgo.Context("The FederatedResourceQuota usage should be calculated correctly", func() {
 		var (
 			frqNamespace, frqName    string


### PR DESCRIPTION
**What type of PR is this?**
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
https://github.com/karmada-io/karmada/actions/runs/19536609426/job/55932805279
```bash
      customresourcedefinitions.apiextensions.k8s.io "flinkdeployments.flink.apache.org" already exists
      {
          ErrStatus: {
              TypeMeta: {Kind: "Status", APIVersion: "v1"},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "customresourcedefinitions.apiextensions.k8s.io \"flinkdeployments.flink.apache.org\" already exists",
              Reason: "AlreadyExists",
              Details: {
                  Name: "flinkdeployments.flink.apache.org",
                  Group: "apiextensions.k8s.io",
                  Kind: "customresourcedefinitions",
                  UID: "",
                  Causes: nil,
                  RetryAfterSeconds: 0,
              },
              Code: 409,
          },
      }
```
The test suite "[ScheduleMultiTemplate] schedule multi template resource" also creates and deletes the FlinkDeployment CRD, so running two suites in parallel will interfere with each other.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #6814

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #6814
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note

```

