### PR TITLE
add valition for binding resourcebinding.karmada.io/dependencies annotation

### DIFF
--- a/pkg/dependenciesdistributor/dependencies_distributor.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor.go
@@ -78,13 +78,6 @@ const (
 	dependedByLabelKeyPrefix = "resourcebinding.karmada.io/depended-by-"
 )
 
-// well-know annotations
-const (
-	// dependenciesAnnotationKey is added to the independent binding,
-	// it describes the names of dependencies (json serialized).
-	dependenciesAnnotationKey = "resourcebinding.karmada.io/dependencies"
-)
-
 // LabelsKey is the object key which is a unique identifier under a cluster, across all resources.
 type LabelsKey struct {
 	keys.ClusterWideKey
@@ -211,7 +204,7 @@ func (d *DependenciesDistributor) reconcileResourceTemplate(key util.QueueKey) e
 // matchesWithBindingDependencies tells if the given object(resource template) is matched
 // with the dependencies of independent resourceBinding.
 func matchesWithBindingDependencies(resourceTemplateKey *LabelsKey, independentBinding *workv1alpha2.ResourceBinding) bool {
-	dependencies, exist := independentBinding.Annotations[dependenciesAnnotationKey]
+	dependencies, exist := independentBinding.Annotations[util.DependenciesAnnotationKey]
 	if !exist {
 		return false
 	}
@@ -439,10 +432,10 @@ func (d *DependenciesDistributor) recordDependencies(ctx context.Context, indepe
 	}
 
 	// dependencies are not updated, no need to update annotation.
-	if oldDependencies, exist := objectAnnotation[dependenciesAnnotationKey]; exist && oldDependencies == dependenciesStr {
+	if oldDependencies, exist := objectAnnotation[util.DependenciesAnnotationKey]; exist && oldDependencies == dependenciesStr {
 		return nil
 	}
-	objectAnnotation[dependenciesAnnotationKey] = dependenciesStr
+	objectAnnotation[util.DependenciesAnnotationKey] = dependenciesStr
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() (err error) {
 		independentBinding.SetAnnotations(objectAnnotation)

--- a/pkg/dependenciesdistributor/dependencies_distributor_test.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor_test.go
@@ -329,7 +329,7 @@ func Test_reconcileResourceTemplate(t *testing.T) {
 								"app": "test",
 							},
 							Annotations: map[string]string{
-								dependenciesAnnotationKey: "[{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"namespace\":\"test\",\"name\":\"demo-app\"}]",
+								util.DependenciesAnnotationKey: "[{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"namespace\":\"test\",\"name\":\"demo-app\"}]",
 							},
 						},
 						Spec: workv1alpha2.ResourceBindingSpec{
@@ -394,7 +394,7 @@ func Test_dependentObjectReferenceMatches(t *testing.T) {
 				},
 				referenceBinding: &workv1alpha2.ResourceBinding{
 					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-						dependenciesAnnotationKey: "[{\"apiVersion\":\"example-stgzr.karmada.io/v1alpha1\",\"kind\":\"Foot5zmh\",\"namespace\":\"karmadatest-vpvll\",\"name\":\"cr-fxzq6\"}]",
+						util.DependenciesAnnotationKey: "[{\"apiVersion\":\"example-stgzr.karmada.io/v1alpha1\",\"kind\":\"Foot5zmh\",\"namespace\":\"karmadatest-vpvll\",\"name\":\"cr-fxzq6\"}]",
 					}},
 				},
 			},
@@ -415,7 +415,7 @@ func Test_dependentObjectReferenceMatches(t *testing.T) {
 				},
 				referenceBinding: &workv1alpha2.ResourceBinding{
 					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-						dependenciesAnnotationKey: "[{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"namespace\":\"karmadatest-h46wh\",\"name\":\"configmap-8w426\"}]",
+						util.DependenciesAnnotationKey: "[{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"namespace\":\"karmadatest-h46wh\",\"name\":\"configmap-8w426\"}]",
 					}},
 				},
 			},
@@ -437,7 +437,7 @@ func Test_dependentObjectReferenceMatches(t *testing.T) {
 				},
 				referenceBinding: &workv1alpha2.ResourceBinding{
 					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-						dependenciesAnnotationKey: "[{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"namespace\":\"test\",\"labelSelector\":{\"matchExpressions\":[{\"key\":\"app\",\"operator\":\"In\",\"values\":[\"test\"]}]}}]",
+						util.DependenciesAnnotationKey: "[{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"namespace\":\"test\",\"labelSelector\":{\"matchExpressions\":[{\"key\":\"app\",\"operator\":\"In\",\"values\":[\"test\"]}]}}]",
 					}},
 				},
 			},
@@ -1324,7 +1324,7 @@ func Test_recordDependencies(t *testing.T) {
 					Namespace:       "test",
 					ResourceVersion: "1001",
 					Annotations: map[string]string{
-						dependenciesAnnotationKey: "[{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"namespace\":\"default\",\"name\":\"pod\"}]",
+						util.DependenciesAnnotationKey: "[{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"namespace\":\"default\",\"name\":\"pod\"}]",
 					},
 				},
 				Spec: workv1alpha2.ResourceBindingSpec{
@@ -1352,7 +1352,7 @@ func Test_recordDependencies(t *testing.T) {
 							Namespace:       "test",
 							ResourceVersion: "1000",
 							Annotations: map[string]string{
-								dependenciesAnnotationKey: "[{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"namespace\":\"default\",\"name\":\"pod\"}]",
+								util.DependenciesAnnotationKey: "[{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"namespace\":\"default\",\"name\":\"pod\"}]",
 							},
 						},
 						Spec: workv1alpha2.ResourceBindingSpec{
@@ -1375,7 +1375,7 @@ func Test_recordDependencies(t *testing.T) {
 						Namespace:       "test",
 						ResourceVersion: "1000",
 						Annotations: map[string]string{
-							dependenciesAnnotationKey: "[{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"namespace\":\"default\",\"name\":\"pod\"}]",
+							util.DependenciesAnnotationKey: "[{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"namespace\":\"default\",\"name\":\"pod\"}]",
 						},
 					},
 					Spec: workv1alpha2.ResourceBindingSpec{
@@ -1403,7 +1403,7 @@ func Test_recordDependencies(t *testing.T) {
 					Namespace:       "test",
 					ResourceVersion: "1000",
 					Annotations: map[string]string{
-						dependenciesAnnotationKey: "[{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"namespace\":\"default\",\"name\":\"pod\"}]",
+						util.DependenciesAnnotationKey: "[{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"namespace\":\"default\",\"name\":\"pod\"}]",
 					},
 				},
 				Spec: workv1alpha2.ResourceBindingSpec{
@@ -1431,7 +1431,7 @@ func Test_recordDependencies(t *testing.T) {
 							Namespace:       "test",
 							ResourceVersion: "1000",
 							Annotations: map[string]string{
-								dependenciesAnnotationKey: "[{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"namespace\":\"default\",\"name\":\"pod\"}]",
+								util.DependenciesAnnotationKey: "[{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"namespace\":\"default\",\"name\":\"pod\"}]",
 							},
 						},
 						Spec: workv1alpha2.ResourceBindingSpec{
@@ -1479,7 +1479,7 @@ func Test_recordDependencies(t *testing.T) {
 					Namespace:       "test",
 					ResourceVersion: "1001",
 					Annotations: map[string]string{
-						dependenciesAnnotationKey: "[{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"namespace\":\"default\",\"name\":\"pod\"}]",
+						util.DependenciesAnnotationKey: "[{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"namespace\":\"default\",\"name\":\"pod\"}]",
 					},
 				},
 				Spec: workv1alpha2.ResourceBindingSpec{

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -105,6 +105,10 @@ const (
 
 	// EndpointSliceProvisionClusterAnnotation is added to work of the dispatch EndpointSlice in consumption clusters' namespace.
 	EndpointSliceProvisionClusterAnnotation = "endpointslice.karmada.io/provision-cluster"
+
+	// DependenciesAnnotationKey is added to the independent binding,
+	// it describes the names of dependencies (json serialized).
+	DependenciesAnnotationKey = "resourcebinding.karmada.io/dependencies"
 )
 
 // Define finalizers used by karmada system.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

Foolproofing: To prevent user misoperation, the `resourcebinding.karmada.io/dependencies` annotation in the ResourceBinding object has been modified.

ref https://github.com/karmada-io/karmada/pull/6931#discussion_r2544138121

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

