### PR TITLE
Enhances validation for dependency verification in resource interpreter

### DIFF
--- a/pkg/util/interpreter/validation/validation_test.go
+++ b/pkg/util/interpreter/validation/validation_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validation
 
 import (
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,15 +30,44 @@ func TestVerifyDependencies(t *testing.T) {
 		dependencies []configv1alpha1.DependentObjectReference
 	}
 	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
+		name            string
+		args            args
+		wantErr         bool
+		wantErrContains string
 	}{
 		{
-			name: "normal case",
+			name: "normal case with name only",
 			args: args{dependencies: []configv1alpha1.DependentObjectReference{
 				{APIVersion: "v1", Kind: "Foo", Name: "test"},
-				{APIVersion: "v2", Kind: "Hu", Namespace: "default", LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"bar": "foo"}}},
+			}},
+			wantErr: false,
+		},
+		{
+			name: "normal case with labelSelector only",
+			args: args{dependencies: []configv1alpha1.DependentObjectReference{
+				{APIVersion: "v1", Kind: "Foo", LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "nginx"}}},
+			}},
+			wantErr: false,
+		},
+		{
+			name: "normal case with both name and labelSelector",
+			args: args{dependencies: []configv1alpha1.DependentObjectReference{
+				{APIVersion: "v2", Kind: "Hu", Namespace: "default", Name: "test", LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"bar": "foo"}}},
+			}},
+			wantErr: false,
+		},
+		{
+			name: "normal case with matchExpressions",
+			args: args{dependencies: []configv1alpha1.DependentObjectReference{
+				{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+					LabelSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{Key: "env", Operator: metav1.LabelSelectorOpIn, Values: []string{"prod", "staging"}},
+						},
+					},
+				},
 			}},
 			wantErr: false,
 		},
@@ -46,27 +76,170 @@ func TestVerifyDependencies(t *testing.T) {
 			args: args{dependencies: []configv1alpha1.DependentObjectReference{
 				{Kind: "Foo", Name: "test"},
 			}},
-			wantErr: true,
+			wantErr:         true,
+			wantErrContains: "missing required apiVersion",
 		},
 		{
 			name: "empty kind",
 			args: args{dependencies: []configv1alpha1.DependentObjectReference{
 				{APIVersion: "v1", Name: "test"},
 			}},
-			wantErr: true,
+			wantErr:         true,
+			wantErrContains: "missing required kind",
 		},
 		{
 			name: "empty Name and LabelSelector at the same time",
 			args: args{dependencies: []configv1alpha1.DependentObjectReference{
 				{APIVersion: "v1", Kind: "Foo"},
 			}},
-			wantErr: true,
+			wantErr:         true,
+			wantErrContains: "dependency can not leave name and labelSelector all empty",
+		},
+		{
+			name: "invalid label key in matchLabels",
+			args: args{dependencies: []configv1alpha1.DependentObjectReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"-invalid-key": "value",
+						},
+					},
+				},
+			}},
+			wantErr:         true,
+			wantErrContains: "dependencies[0].labelSelector.matchLabels",
+		},
+		{
+			name: "invalid label value in matchLabels",
+			args: args{dependencies: []configv1alpha1.DependentObjectReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "invalid@value",
+						},
+					},
+				},
+			}},
+			wantErr:         true,
+			wantErrContains: "dependencies[0].labelSelector.matchLabels",
+		},
+		{
+			name: "invalid operator in matchExpressions",
+			args: args{dependencies: []configv1alpha1.DependentObjectReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					LabelSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{Key: "env", Operator: "InvalidOp", Values: []string{"prod"}},
+						},
+					},
+				},
+			}},
+			wantErr:         true,
+			wantErrContains: "not a valid selector operator",
+		},
+		{
+			name: "matchExpressions with In operator but no values",
+			args: args{dependencies: []configv1alpha1.DependentObjectReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					LabelSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{Key: "env", Operator: metav1.LabelSelectorOpIn, Values: []string{}},
+						},
+					},
+				},
+			}},
+			wantErr:         true,
+			wantErrContains: "must be specified when `operator` is 'In' or 'NotIn'",
+		},
+		{
+			name: "matchExpressions with Exists operator and values",
+			args: args{dependencies: []configv1alpha1.DependentObjectReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					LabelSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{Key: "env", Operator: metav1.LabelSelectorOpExists, Values: []string{"prod"}},
+						},
+					},
+				},
+			}},
+			wantErr:         true,
+			wantErrContains: "may not be specified when `operator` is 'Exists' or 'DoesNotExist'",
+		},
+		{
+			name: "invalid label key in matchExpressions",
+			args: args{dependencies: []configv1alpha1.DependentObjectReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					LabelSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{Key: "@invalid", Operator: metav1.LabelSelectorOpIn, Values: []string{"value"}},
+						},
+					},
+				},
+			}},
+			wantErr:         true,
+			wantErrContains: "dependencies[0].labelSelector.matchExpressions[0].key",
+		},
+		{
+			name: "multiple dependencies with mixed errors",
+			args: args{dependencies: []configv1alpha1.DependentObjectReference{
+				{APIVersion: "v1", Kind: "Foo", Name: "valid"},
+				{Kind: "Bar", Name: "missing-apiversion"},
+			}},
+			wantErr:         true,
+			wantErrContains: "dependencies[1].apiVersion",
+		},
+		{
+			name: "multiple errors in single dependency",
+			args: args{dependencies: []configv1alpha1.DependentObjectReference{
+				{
+					// Missing both apiVersion and kind
+					Name: "test",
+				},
+			}},
+			wantErr:         true,
+			wantErrContains: "missing required",
+		},
+		{
+			name: "label value too long",
+			args: args{dependencies: []configv1alpha1.DependentObjectReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "this-is-a-very-long-label-value-that-exceeds-the-maximum-allowed-length-of-63-characters-for-kubernetes-labels",
+						},
+					},
+				},
+			}},
+			wantErr:         true,
+			wantErrContains: "must be no more than 63 characters",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := VerifyDependencies(tt.args.dependencies); (err != nil) != tt.wantErr {
+			err := VerifyDependencies(tt.args.dependencies)
+			if (err != nil) != tt.wantErr {
 				t.Errorf("VerifyDependencies() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && tt.wantErrContains != "" {
+				if !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Errorf("VerifyDependencies() error = %v, want error containing %q", err, tt.wantErrContains)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

Prevents runtime errors: Invalid label selectors caught at validation time.

ref https://github.com/karmada-io/karmada/pull/6931#discussion_r2544138121

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

