### PR TITLE
bump kubeapi and etcd to new version 

### DIFF
--- a/charts/karmada/Chart.lock
+++ b/charts/karmada/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.19.1
-digest: sha256:0a730717cb8d4d2c481be801923c643b0b9c5087b48bb2f4bc6f5d35ea90c849
-generated: "2024-04-12T20:38:01.015548+08:00"
+  version: 2.31.4
+digest: sha256:812f9bf703b331dab00cc69ac348f6b1c021e479cbf1bdc0b788da8763c02062
+generated: "2025-11-24T02:53:16.517896+05:30"

--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -395,7 +395,7 @@ apiServer:
   image:
     registry: registry.k8s.io
     repository: kube-apiserver
-    tag: "v1.31.3"
+    tag: "v1.34.1"
     ## Specify a imagePullPolicy, defaults to 'IfNotPresent'
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -610,7 +610,7 @@ kubeControllerManager:
   image:
     registry: registry.k8s.io
     repository: kube-controller-manager
-    tag: "v1.31.3"
+    tag: "v1.34.1"
     ## Specify a imagePullPolicy, defaults to 'IfNotPresent'
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -708,7 +708,7 @@ etcd:
     image:
       registry: registry.k8s.io
       repository: etcd
-      tag: "3.5.16-0"
+      tag: "3.6.0-0"
       ## Specify a imagePullPolicy, defaults to 'IfNotPresent'
       pullPolicy: IfNotPresent
     ## @param etcd.internal.storageType storage type for etcd data


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
This PR bumps helm charts, #6862  tracks the rest of the tasks
**Which issue(s) this PR fixes**:
Part of  #6862 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
`Helm Chart`: The default `kube-apiserver` and `kube-controller-manager` image have been updated from v1.31.3 to v1.34.1. And the default ETCD Image has been updated from 3.5.16-0 to 3.6.0-0.
```

