### PR TITLE
Fix Job status failed to aggregate due to missing `JobSuccessCriteriaMet` condition

### DIFF
--- a/pkg/util/helper/job_test.go
+++ b/pkg/util/helper/job_test.go
@@ -88,7 +88,7 @@ func TestParsingJobStatus(t *testing.T) {
 		"startTime":      testV1time,
 		"completionTime": testV1time,
 		"failed":         0,
-		"conditions":     []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}},
+		"conditions":     []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}, {Type: batchv1.JobSuccessCriteriaMet, Status: corev1.ConditionTrue}},
 	}
 	raw, _ := BuildStatusRawExtension(statusMap)
 	statusMapWithJobfailed := map[string]interface{}{
@@ -128,6 +128,14 @@ func TestParsingJobStatus(t *testing.T) {
 						LastTransitionTime: testV1time,
 						Reason:             "Completed",
 						Message:            "Job completed",
+					},
+					{
+						Type:               batchv1.JobSuccessCriteriaMet,
+						Status:             corev1.ConditionTrue,
+						LastProbeTime:      testV1time,
+						LastTransitionTime: testV1time,
+						Reason:             "CompletionsReached",
+						Message:            "All member clusters have met success criteria",
 					},
 				},
 			},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
When adding `JobSuccessCriteriaMet` condition to the aggregated JobStatus in ParsingJobStatus, when a job is considered completed across all member clusters.

**Which issue(s) this PR fixes**:
Fixes #6414

**Special notes for your reviewer**:
This patch was tested in PR #6960, which tries to bump kube-apiserver to v1.34. 
Fixing this issue in a separate PR, as this should be backported to release branches. 

This patch might fail the compatibility tests when using karmada-apiserver@v1.30.0, but it manages clusters with higher Kubernetes versions, like v1.32+. This case is worth exploring further.

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-controller-manager`: Fixed the Job status can not be aggregated issue due to the missing `JobSuccessCriteriaMet` condition when using kube-apiserver v1.32+ as Karmada API server.
```

