### PR TITLE
added deprecation mark flag

### DIFF
--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -176,6 +176,7 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 		fmt.Sprintf("etcd data storage mode(%s). value is PVC, specify --storage-classes-name", strings.Join(kubernetes.SupportedStorageMode(), ",")))
 	flags.StringVarP(&opts.EtcdImage, "etcd-image", "", "", "etcd image")
 	flags.StringVarP(&opts.EtcdInitImage, "etcd-init-image", "", kubernetes.DefaultInitImage, "etcd init container image")
+	_ = flags.MarkDeprecated("etcd-init-image", "The etcd init container is no longer used; this flag is therefore ineffective and will be removed in a future release.")
 	flags.Int32VarP(&opts.EtcdReplicas, "etcd-replicas", "", 1, "etcd replica set, cluster 3,5...singular")
 	flags.StringVarP(&opts.EtcdHostDataPath, "etcd-data", "", "/var/lib/karmada-etcd", "etcd data path,valid in hostPath mode.")
 	flags.StringVarP(&opts.EtcdNodeSelectorLabels, "etcd-node-selector-labels", "", "", "the labels used for etcd pod to select nodes, valid in hostPath mode, and with each label separated by a comma. ( e.g. --etcd-node-selector-labels karmada.io/etcd=true,kubernetes.io/os=linux)")


### PR DESCRIPTION
**What type of PR is this?**
Added a deprecation warning for the `--etcd-init-image` flag

<!--
Add one of the following kinds:
/kind documentation

Optionally add one or more of the following kinds if applicable:
/kind deprecation


-->

**What this PR does / why we need it**: Tells about deprecation of a flag which helps developers to know that not using the flag in future is a good practise

**Which issue(s) this PR fixes**: https://github.com/karmada-io/karmada/issues/6942
Fixes #6942

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
`karmadactl`: The flag `--etcd-init-image` of command `init` has been marked deprecated because it is no longer used, and will be removed in the future release. 
```


