### PR TITLE
chore(operator):Update default k8s version

### DIFF
--- a/operator/config/samples/karmada.yaml
+++ b/operator/config/samples/karmada.yaml
@@ -11,7 +11,7 @@ spec:
     etcd:
       local:
         imageRepository: registry.k8s.io/etcd
-        imageTag: 3.5.16-0
+        imageTag: 3.6.0-0
         replicas: 1
         volumeData:
           # hostPath:
@@ -28,7 +28,7 @@ spec:
                   storage: 3Gi
     karmadaAPIServer:
       imageRepository: registry.k8s.io/kube-apiserver
-      imageTag: v1.31.3
+      imageTag: v1.34.1
       replicas: 1
       serviceType: NodePort
       serviceSubnet: 10.96.0.0/12
@@ -50,7 +50,7 @@ spec:
       replicas: 1
     kubeControllerManager:
       imageRepository: registry.k8s.io/kube-controller-manager
-      imageTag: v1.31.3
+      imageTag: v1.34.1
       replicas: 1
     karmadaMetricsAdapter:
       imageRepository: docker.io/karmada/karmada-metrics-adapter

--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -29,9 +29,9 @@ const (
 	// KarmadaDefaultRepository defines the default of the karmada image repository
 	KarmadaDefaultRepository = "docker.io/karmada"
 	// EtcdDefaultVersion defines the default of the karmada etcd image tag
-	EtcdDefaultVersion = "3.5.16-0"
+	EtcdDefaultVersion = "3.6.0-0"
 	// KubeDefaultVersion defines the default of the karmada apiserver and kubeControllerManager image tag
-	KubeDefaultVersion = "v1.31.3"
+	KubeDefaultVersion = "v1.34.1"
 	// KarmadaDefaultServiceSubnet defines the default of the subnet used by k8s services.
 	KarmadaDefaultServiceSubnet = "10.96.0.0/12"
 	// KarmadaDefaultDNSDomain defines the default of the DNSDomain


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
This PR bumps `karmada-operator`, https://github.com/karmada-io/karmada/issues/6862 tracks the rest of the tasks
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of https://github.com/karmada-io/karmada/issues/6862

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-operator`: Update default kube-apiserver, kube-controller-manager to v1.34.1 and etcd to v3.6.0-0
```

