### PR TITLE
cleanup: remove unused etcd-init-container related code

### DIFF
--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -175,8 +175,6 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 	flags.StringVarP(&opts.EtcdStorageMode, "etcd-storage-mode", "", "hostPath",
 		fmt.Sprintf("etcd data storage mode(%s). value is PVC, specify --storage-classes-name", strings.Join(kubernetes.SupportedStorageMode(), ",")))
 	flags.StringVarP(&opts.EtcdImage, "etcd-image", "", "", "etcd image")
-	flags.StringVarP(&opts.EtcdInitImage, "etcd-init-image", "", kubernetes.DefaultInitImage, "etcd init container image")
-	_ = flags.MarkDeprecated("etcd-init-image", "The etcd init container is no longer used; this flag is therefore ineffective and will be removed in a future release.")
 	flags.Int32VarP(&opts.EtcdReplicas, "etcd-replicas", "", 1, "etcd replica set, cluster 3,5...singular")
 	flags.StringVarP(&opts.EtcdHostDataPath, "etcd-data", "", "/var/lib/karmada-etcd", "etcd data path,valid in hostPath mode.")
 	flags.StringVarP(&opts.EtcdNodeSelectorLabels, "etcd-node-selector-labels", "", "", "the labels used for etcd pod to select nodes, valid in hostPath mode, and with each label separated by a comma. ( e.g. --etcd-node-selector-labels karmada.io/etcd=true,kubernetes.io/os=linux)")

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -102,8 +102,6 @@ var (
 
 	// DefaultCrdURL Karmada crds resource
 	DefaultCrdURL string
-	// DefaultInitImage etcd init container image
-	DefaultInitImage string
 	// DefaultKarmadaSchedulerImage Karmada scheduler image
 	DefaultKarmadaSchedulerImage string
 	// DefaultKarmadaControllerManagerImage Karmada controller manager image
@@ -129,7 +127,6 @@ func init() {
 	karmadaRelease = releaseVer.ReleaseVersion()
 
 	DefaultCrdURL = fmt.Sprintf("https://github.com/karmada-io/karmada/releases/download/%s/crds.tar.gz", releaseVer.ReleaseVersion())
-	DefaultInitImage = "docker.io/alpine:3.21.3"
 	DefaultKarmadaSchedulerImage = fmt.Sprintf("docker.io/karmada/karmada-scheduler:%s", releaseVer.ReleaseVersion())
 	DefaultKarmadaControllerManagerImage = fmt.Sprintf("docker.io/karmada/karmada-controller-manager:%s", releaseVer.ReleaseVersion())
 	DefaultKarmadaWebhookImage = fmt.Sprintf("docker.io/karmada/karmada-webhook:%s", releaseVer.ReleaseVersion())
@@ -147,7 +144,6 @@ type CommandInitOption struct {
 	// internal etcd
 	EtcdImage                 string
 	EtcdReplicas              int32
-	EtcdInitImage             string
 	EtcdStorageMode           string
 	EtcdHostDataPath          string
 	EtcdNodeSelectorLabels    string
@@ -801,14 +797,6 @@ func (i *CommandInitOption) kubeControllerManagerImage() string {
 	return i.kubeRegistry() + "/kube-controller-manager:" + i.KubeImageTag
 }
 
-// get etcd-init image
-func (i *CommandInitOption) etcdInitImage() string {
-	if i.ImageRegistry != "" && i.EtcdInitImage == DefaultInitImage {
-		return i.ImageRegistry + "/alpine:3.21.3"
-	}
-	return i.EtcdInitImage
-}
-
 // get etcd image
 func (i *CommandInitOption) etcdImage() string {
 	if i.EtcdImage != "" {
@@ -990,7 +978,6 @@ func (i *CommandInitOption) parseEtcdConfig(etcd initConfig.Etcd) error {
 // data path, PVC size, and node selector labels.
 func (i *CommandInitOption) parseLocalEtcdConfig(localEtcd *initConfig.LocalEtcd) error {
 	setIfNotEmpty(&i.EtcdImage, localEtcd.CommonSettings.Image.GetImage())
-	setIfNotEmpty(&i.EtcdInitImage, localEtcd.InitImage.GetImage())
 	setIfNotEmpty(&i.EtcdHostDataPath, localEtcd.DataPath)
 	setIfNotEmpty(&i.EtcdPersistentVolumeSize, localEtcd.PVCSize)
 

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy_test.go
@@ -389,46 +389,6 @@ func TestKubeControllerManagerImage(t *testing.T) {
 	}
 }
 
-func TestEtcdInitImage(t *testing.T) {
-	tests := []struct {
-		name     string
-		opt      *CommandInitOption
-		expected string
-	}{
-		{
-			name: "ImageRegistry is set and EtcdInitImage is set to default value",
-			opt: &CommandInitOption{
-				ImageRegistry: "my-registry",
-				EtcdInitImage: DefaultInitImage,
-			},
-			expected: "my-registry/alpine:3.21.3",
-		},
-		{
-			name: "EtcdInitImage is set to a non-default value",
-			opt: &CommandInitOption{
-				EtcdInitImage: "my-etcd-init-image",
-			},
-			expected: "my-etcd-init-image",
-		},
-		{
-			name: "ImageRegistry is not set and EtcdInitImage is set to default value",
-			opt: &CommandInitOption{
-				EtcdInitImage: DefaultInitImage,
-			},
-			expected: DefaultInitImage,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := tt.opt.etcdInitImage()
-			if result != tt.expected {
-				t.Errorf("Unexpected result: %s, expected: %s", result, tt.expected)
-			}
-		})
-	}
-}
-
 func TestEtcdImage(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -576,10 +536,6 @@ func TestParseInitConfig(t *testing.T) {
 						},
 						Replicas: 3,
 					},
-					InitImage: config.Image{
-						Repository: "init-image",
-						Tag:        "latest",
-					},
 					DataPath: "/data/dir",
 					PVCSize:  "5Gi",
 					NodeSelectorLabels: map[string]string{
@@ -686,7 +642,6 @@ func TestParseInitConfig(t *testing.T) {
 	assert.Equal(t, "1.2.3.4,5.6.7.8", opt.ExternalIP)
 	assert.Equal(t, parseDuration("8760h"), opt.CertValidity)
 	assert.Equal(t, "etcd-image:latest", opt.EtcdImage)
-	assert.Equal(t, "init-image:latest", opt.EtcdInitImage)
 	assert.Equal(t, "/data/dir", opt.EtcdHostDataPath)
 	assert.Equal(t, "5Gi", opt.EtcdPersistentVolumeSize)
 	assert.Equal(t, "key=value", opt.EtcdNodeSelectorLabels)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR removes unused code related to the `etcd-init-container` which was previously deprecated. Specifically:
- Removed `etcdInitImage` function in `pkg/karmadactl/cmdinit/kubernetes/deploy.go`.
- Removed `TestEtcdInitImage` and related assertions in `pkg/karmadactl/cmdinit/kubernetes/deploy_test.go`.

**Which issue(s) this PR fixes**:
Fixes #6972

**Special notes for your reviewer**:
I have verified that the relevant tests pass locally:
`go test ./pkg/karmadactl/cmdinit/kubernetes/...`

**Does this PR introduce a user-facing change?**:
```release-note
`karmadactl`: The deprecated flag `--etcd-init-image` of `init` command has now been removed.
```