### PR TITLE
Automated cherry pick of #6964: Adopt Kubernetes KEP: 4368-support-managed-by-for-batch-jobs.

### DIFF
--- a/pkg/util/helper/job_test.go
+++ b/pkg/util/helper/job_test.go
@@ -88,7 +88,7 @@ func TestParsingJobStatus(t *testing.T) {
 		"startTime":      testV1time,
 		"completionTime": testV1time,
 		"failed":         0,
-		"conditions":     []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}},
+		"conditions":     []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}, {Type: batchv1.JobSuccessCriteriaMet, Status: corev1.ConditionTrue}},
 	}
 	raw, _ := BuildStatusRawExtension(statusMap)
 	statusMapWithJobfailed := map[string]interface{}{
@@ -128,6 +128,14 @@ func TestParsingJobStatus(t *testing.T) {
 						LastTransitionTime: testV1time,
 						Reason:             "Completed",
 						Message:            "Job completed",
+					},
+					{
+						Type:               batchv1.JobSuccessCriteriaMet,
+						Status:             corev1.ConditionTrue,
+						LastProbeTime:      testV1time,
+						LastTransitionTime: testV1time,
+						Reason:             "CompletionsReached",
+						Message:            "All member clusters have met success criteria",
 					},
 				},
 			},


### PR DESCRIPTION
Cherry pick of #6964 on release-1.14.
#6964: Adopt Kubernetes KEP: 4368-support-managed-by-for-batch-jobs.
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`: Fixed the Job status can not be aggregated issue due to the missing `JobSuccessCriteriaMet` condition when using kube-apiserver v1.32+ as Karmada API server.
```