### PR TITLE
Remove unnecessary update and delete events in cert-rotation-controller

### DIFF
--- a/pkg/util/helper/predicate.go
+++ b/pkg/util/helper/predicate.go
@@ -148,10 +148,10 @@ func NewClusterPredicateOnAgent(clusterName string) predicate.Funcs {
 		CreateFunc: func(createEvent event.CreateEvent) bool {
 			return createEvent.Object.GetName() == clusterName
 		},
-		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
+		UpdateFunc: func(_ event.UpdateEvent) bool {
 			return false
 		},
-		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+		DeleteFunc: func(_ event.DeleteEvent) bool {
 			return false
 		},
 		GenericFunc: func(event.GenericEvent) bool {

--- a/pkg/util/helper/predicate.go
+++ b/pkg/util/helper/predicate.go
@@ -149,10 +149,10 @@ func NewClusterPredicateOnAgent(clusterName string) predicate.Funcs {
 			return createEvent.Object.GetName() == clusterName
 		},
 		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
-			return updateEvent.ObjectOld.GetName() == clusterName
+			return false
 		},
 		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
-			return deleteEvent.Object.GetName() == clusterName
+			return false
 		},
 		GenericFunc: func(event.GenericEvent) bool {
 			return false

--- a/pkg/util/helper/predicate_test.go
+++ b/pkg/util/helper/predicate_test.go
@@ -56,8 +56,8 @@ func TestNewClusterPredicateOnAgent(t *testing.T) {
 			obj:  &clusterv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "test"}},
 			want: want{
 				create:  true,
-				update:  true,
-				delete:  true,
+				update:  false,
+				delete:  false,
 				generic: false,
 			},
 		},


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:


The cert-rotation-controller only need to watch the creation event of the cluster object, as the cluster object will be processed periodically, so there is no need to watch the update or deletion events of the cluster.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #6780

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

