### PR TITLE
depercated: mark KarmadaInitConfig.spec.etcd.local.initImage deprecated

### DIFF
--- a/pkg/karmadactl/cmdinit/config/config_test.go
+++ b/pkg/karmadactl/cmdinit/config/config_test.go
@@ -47,9 +47,6 @@ spec:
      Repository: "registry.k8s.io/etcd"
      Tag: "latest"
      dataPath: "/var/lib/karmada-etcd"
-     initImage:
-       repository: "alpine"
-       tag: "3.19.1"
      nodeSelectorLabels:
        karmada.io/etcd: "true"
      pvcSize: "5Gi"
@@ -155,10 +152,6 @@ func TestLoadInitConfiguration(t *testing.T) {
 							Tag:        "latest",
 						},
 						Replicas: 3,
-					},
-					InitImage: Image{
-						Repository: "alpine",
-						Tag:        "3.19.1",
 					},
 					DataPath: "/var/lib/karmada-etcd",
 					PVCSize:  "5Gi",

--- a/pkg/karmadactl/cmdinit/config/types.go
+++ b/pkg/karmadactl/cmdinit/config/types.go
@@ -120,6 +120,7 @@ type LocalEtcd struct {
 	DataPath string `json:"dataPath,omitempty" yaml:"dataPath,omitempty"`
 
 	// InitImage is the image for the Etcd init container
+	// Deprecated: The etcd init container is no longer used, this field is therefore ineffective and will be removed in a future release.
 	// +optional
 	InitImage Image `json:"initImage,omitempty" yaml:"initImage,omitempty"`
 


### PR DESCRIPTION
**What type of PR is this?**
/kind deprecation
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
The etcd init container is no longer used; the field `InitImage` is therefore ineffective and should be marked as deprecated.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:


<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmadactl`: `Etcd.Local.InitImage` in `Karmada Init Configuration` is deprecated and will be removed in a future version.
```

