### PR TITLE
refactor: unify maxAvailableComponentsSets calculation

### DIFF
--- a/pkg/estimator/client/general.go
+++ b/pkg/estimator/client/general.go
@@ -19,7 +19,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"maps"
 	"math"
 	"sort"
 
@@ -29,8 +28,17 @@ import (
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/estimator"
+	"github.com/karmada-io/karmada/pkg/estimator/pb"
 	"github.com/karmada-io/karmada/pkg/features"
+	"github.com/karmada-io/karmada/pkg/util"
+	schedulerframework "github.com/karmada-io/karmada/pkg/util/lifted/scheduler/framework"
 )
+
+// maxPodsCountPerNode defines the maximum pods count per node.
+// This is the default and recommended value set by Kubernetes for nodes.
+// More details can be found at: https://kubernetes.io/docs/setup/best-practices/cluster-large/
+const maxPodsCountPerNode = 110
 
 // GeneralEstimator is the default replica estimator.
 func init() {
@@ -127,9 +135,9 @@ func (ge *GeneralEstimator) maxAvailableComponentSets(cluster *clusterv1alpha1.C
 		return int32(allowedPods) // #nosec G115: integer overflow conversion int64 -> int32
 	}
 
-	podBound := allowedPods / podsPerSet
+	podBound := int32(allowedPods / podsPerSet) // #nosec G115: integer overflow conversion int64 -> int32
 	if len(perSet) == 0 || allZero(perSet) {
-		return int32(podBound) // #nosec G115: integer overflow conversion int64 -> int32
+		return podBound
 	}
 
 	// Find limiting resource requirement, which will bound maxSet calculation
@@ -144,116 +152,48 @@ func (ge *GeneralEstimator) maxAvailableComponentSets(cluster *clusterv1alpha1.C
 			return 0 // no capacity for this resource
 		}
 
-		resBound := resAvail / req
+		resBound := int32(resAvail / req) // #nosec G115: integer overflow conversion int64 -> int32
 		if resBound < maxSets {
 			maxSets = resBound
 		}
 	}
 
 	if features.FeatureGate.Enabled(features.CustomizedClusterResourceModeling) && len(cluster.Status.ResourceSummary.AllocatableModelings) > 0 {
-		if num, err := getMaximumSetsBasedOnResourceModels(cluster, components, podBound); err != nil {
+		if num, err := getMaximumSetsBasedOnResourceModels(cluster, components, maxSets); err != nil {
 			klog.Warningf("Failed to get maximum sets based on resource models, skipping: %v", err)
 		} else if num < maxSets {
 			maxSets = num
 		}
 	}
 
-	return int32(maxSets) // #nosec G115: integer overflow conversion int64 -> int32
+	return maxSets
 }
 
 // getMaximumSetsBasedOnResourceModels computes the maximum number of full sets that can be
 // placed on a cluster using the cluster's ResourceModels. It expands one set into
 // replica kinds (demand + count) and performs a first-fit-decreasing placement onto model-grade nodes.
 // `upperBound` caps the search. We can set this using the podBound (allowedPods / podsPerSet)
-func getMaximumSetsBasedOnResourceModels(
-	cluster *clusterv1alpha1.Cluster,
-	components []workv1alpha2.Component,
-	upperBound int64,
-) (int64, error) {
-	if upperBound <= 0 {
-		return 0, nil
-	}
-
-	// Compressed one-set: per-kind (identical replicas grouped)
-	oneSetKinds := expandKindsOneSet(components)
-	if len(oneSetKinds) == 0 {
-		// If there are no pods to schedule, just return upperBound
-		return upperBound, nil
-	}
-
-	// Use cluster "available" totals (allocatable - allocated - allocating) for normalized scoring
-	// This reflects what the cluster can actually accept now
-	totals := availableResourceMap(cluster.Status.ResourceSummary)
-
-	for i := range oneSetKinds {
-		oneSetKinds[i].score = demandScoreNormalized(oneSetKinds[i].dem, totals)
-	}
-	sort.Slice(oneSetKinds, func(i, j int) bool {
-		if oneSetKinds[i].score == oneSetKinds[j].score {
-			return demandSum(oneSetKinds[i].dem) > demandSum(oneSetKinds[j].dem)
-		}
-		return oneSetKinds[i].score > oneSetKinds[j].score
-	})
-
-	//Build model nodes from Spec.ResourceModels and Status.AllocatableModelings
+func getMaximumSetsBasedOnResourceModels(cluster *clusterv1alpha1.Cluster, components []workv1alpha2.Component, upperBound int32) (int32, error) {
 	nodes, err := buildModelNodes(cluster)
 	if err != nil {
 		return -1, err
 	}
-	if len(nodes) == 0 {
-		return 0, nil
+
+	pbComponents := make([]pb.Component, 0, len(components))
+	for _, comp := range components {
+		pbComponents = append(pbComponents, pb.Component{
+			Name:                comp.Name,
+			Replicas:            comp.Replicas,
+			ReplicaRequirements: toPBReplicaRequirements(comp.ReplicaRequirements),
+		})
 	}
 
-	var sets int64
-	for sets < upperBound {
-		if !placeOneSet(oneSetKinds, nodes) {
-			break
-		}
-		sets++
-	}
-	return sets, nil
-}
-
-// placeOneSet attempts to place exactly ONE full set (all kinds with their per-set replica counts)
-// onto the provided working node capacities (in-place)
-// Returns true if successful
-func placeOneSet(orderedKinds []replicaKind, work []modelNode) bool {
-	for _, k := range orderedKinds {
-		remaining := k.count
-		if remaining <= 0 {
-			continue
-		}
-		// first-fit across nodes
-		for n := range work {
-			if remaining <= 0 {
-				break
-			}
-			fit := maxFit(work[n].cap, k.dem)
-			if fit <= 0 {
-				continue
-			}
-			place := fit
-			if place > remaining {
-				place = remaining
-			}
-			consumeMul(work[n].cap, k.dem, place)
-			remaining -= place
-		}
-		if remaining > 0 {
-			return false
-		}
-	}
-	return true
-}
-
-// modelNode holds remaining capacity for a given node across all resource types
-type modelNode struct {
-	cap map[corev1.ResourceName]int64
+	return estimator.NewSchedulingSimulator(nodes).SimulateScheduling(pbComponents, upperBound), nil
 }
 
 // buildModelNodes constructs identical nodes for each model grade using its Min vector,
 // repeated AllocatableModelings[grade].Count times. Grades are indexed directly.
-func buildModelNodes(cluster *clusterv1alpha1.Cluster) ([]modelNode, error) {
+func buildModelNodes(cluster *clusterv1alpha1.Cluster) ([]*schedulerframework.NodeInfo, error) {
 	if cluster == nil {
 		return nil, fmt.Errorf("nil cluster")
 	}
@@ -267,12 +207,22 @@ func buildModelNodes(cluster *clusterv1alpha1.Cluster) ([]modelNode, error) {
 	}
 
 	// Build capacity template per grade
-	capsByGrade := make(map[uint]map[corev1.ResourceName]int64, len(spec))
+	capsByGrade := make(map[uint]corev1.ResourceList, len(spec))
 	for _, m := range spec {
-		tmpl := make(map[corev1.ResourceName]int64, len(m.Ranges))
+		tmpl := make(corev1.ResourceList, len(m.Ranges))
 		for _, r := range m.Ranges {
-			tmpl[r.Name] = quantityAsInt64(r.Min)
+			tmpl[r.Name] = r.Min
 		}
+
+		// The number of pods a node can accommodate is a critical metric in scheduling simulation. Each node must have
+		// a pod capacity limit; otherwise, the scheduler cannot determine if a node can accommodate any pod. Kubernetes
+		// sets a default pod limit of 110 per node, which we adopt here for consistency.
+		//
+		// Note: This virtual node uses a fixed pod capacity of 110 for each simulation. The actual pod count already
+		// running on this virtual node is not considered in the calculation. This means the estimation may be inaccurate
+		// and could potentially exceed 110 pods in practice. This is an inherent limitation of the ResourceModel mechanism,
+		// as the estimation is approximate rather than precise.
+		tmpl[corev1.ResourcePods] = *resource.NewQuantity(maxPodsCountPerNode, resource.DecimalSI)
 		capsByGrade[m.Grade] = tmpl
 	}
 
@@ -293,122 +243,21 @@ func buildModelNodes(cluster *clusterv1alpha1.Cluster) ([]modelNode, error) {
 	sort.Ints(grades)
 
 	// Emit nodes for grades present in both spec & status.
-	var nodes []modelNode
+	var nodes []*schedulerframework.NodeInfo
 	for _, grade := range grades {
 		tmpl, cnt := capsByGrade[uint(grade)], countByGrade[uint(grade)] // #nosec G115: integer overflow conversion int -> uint
 		if tmpl == nil || cnt == 0 {
 			continue
 		}
-		for range cnt {
-			capCopy := maps.Clone(tmpl)
-			nodes = append(nodes, modelNode{cap: capCopy})
+
+		for i := 0; i < cnt; i++ {
+			node := &schedulerframework.NodeInfo{
+				Allocatable: util.NewResource(tmpl),
+			}
+			nodes = append(nodes, node)
 		}
 	}
 	return nodes, nil
-}
-
-// replicaKind represents a single type of component, including replica demand and count
-type replicaKind struct {
-	dem   map[corev1.ResourceName]int64 // per-replica demand
-	count int64                         // how many replicas
-	score float64                       // ordering heuristic (higher first)
-}
-
-// expandKindsOneSet flattens components into a slice of unique replica kinds.
-// Each entry holds the per-replica demand and how many replicas of that kind a set needs.
-func expandKindsOneSet(components []workv1alpha2.Component) []replicaKind {
-	kinds := make([]replicaKind, 0, len(components))
-	for _, c := range components {
-		if c.ReplicaRequirements == nil || c.ReplicaRequirements.ResourceRequest == nil {
-			continue
-		}
-		// normalize per-replica demand
-		base := make(map[corev1.ResourceName]int64, len(c.ReplicaRequirements.ResourceRequest))
-		for name, qty := range c.ReplicaRequirements.ResourceRequest {
-			base[name] = quantityAsInt64(qty)
-		}
-		// skip zero-demand or non-positive replica count
-		if allZero(base) || c.Replicas <= 0 {
-			continue
-		}
-
-		k := replicaKind{
-			dem:   base,
-			count: int64(c.Replicas),
-			// score is filled later once we know cluster-wide totals
-		}
-		kinds = append(kinds, k)
-	}
-	return kinds
-}
-
-// demandScoreNormalized returns the "max utilization ratio" of a demand vector against total capacities
-// If a resource is missing/zero in total, treat it as maximally constrained
-func demandScoreNormalized(
-	demand map[corev1.ResourceName]int64,
-	total map[corev1.ResourceName]int64,
-) float64 {
-	var maxRatio float64
-	for res, req := range demand {
-		if req <= 0 {
-			continue
-		}
-		totalCap := float64(total[res])
-		if totalCap <= 0 {
-			return math.MaxFloat64
-		}
-		ratio := float64(req) / totalCap
-		if ratio > maxRatio {
-			maxRatio = ratio
-		}
-	}
-	return maxRatio
-}
-
-// demandSum is used as a tie-breaker when initial scores are equal
-func demandSum(m map[corev1.ResourceName]int64) int64 {
-	var s int64
-	for _, v := range m {
-		if v > 0 {
-			s += v
-		}
-	}
-	return s
-}
-
-// maxFit returns how many copies of `dem` fit in `cap` simultaneously
-func maxFit(capacity map[corev1.ResourceName]int64, dem map[corev1.ResourceName]int64) int64 {
-	var limit int64 = math.MaxInt64
-	for k, req := range dem {
-		if req <= 0 {
-			continue
-		}
-		avail := capacity[k]
-		if avail <= 0 {
-			return 0
-		}
-		bound := avail / req
-		if bound < limit {
-			limit = bound
-		}
-	}
-	if limit == math.MaxInt64 {
-		return 0
-	}
-	return limit
-}
-
-// consumeMul subtracts mult * dem from cap
-func consumeMul(capacity map[corev1.ResourceName]int64, dem map[corev1.ResourceName]int64, mult int64) {
-	if mult <= 0 {
-		return
-	}
-	for k, req := range dem {
-		if req <= 0 {
-			continue
-		}
-		capacity[k] -= req * mult
-	}
 }
 
 // podsInSet computes the total number of pods in the CRD

--- a/pkg/estimator/client/general_test.go
+++ b/pkg/estimator/client/general_test.go
@@ -244,16 +244,16 @@ func comp(name string, replicas int32, rl corev1.ResourceList) workv1alpha2.Comp
 func TestGetMaximumSetsBasedOnResourceModels(t *testing.T) {
 	const (
 		GPU  corev1.ResourceName = "nvidia.com/gpu"
-		BIGU int64               = 100 // define a large upper bound so we can test model decision algo
+		BIGU int32               = 100 // define a large upper bound so we can test model decision algo
 	)
 
 	tests := []struct {
 		name         string
 		cluster      clusterv1alpha1.Cluster
 		components   []workv1alpha2.Component
-		upperBound   int64
+		upperBound   int32
 		expectError  bool
-		expectedSets int64
+		expectedSets int32
 	}{
 		{
 			name: "No grades defined → error",

--- a/pkg/estimator/scheduling_simulator_components.go
+++ b/pkg/estimator/scheduling_simulator_components.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package estimator
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/karmada-io/karmada/pkg/estimator/pb"
+	nodeutil "github.com/karmada-io/karmada/pkg/estimator/server/nodes"
+	"github.com/karmada-io/karmada/pkg/util"
+	schedulerframework "github.com/karmada-io/karmada/pkg/util/lifted/scheduler/framework"
+)
+
+// SchedulingSimulator simulates a scheduling process to estimate workload capacity.
+// It uses the First Fit(FF) algorithm to pack components into available nodes efficiently.
+// During the simulation, it will consume node resources as components are scheduled, so make
+// sure the nodes passed in are cloned copies or not used elsewhere.
+type SchedulingSimulator struct {
+	// nodes represent the available cluster nodes with their resource capacity
+	nodes []*schedulerframework.NodeInfo
+}
+
+// NewSchedulingSimulator creates a new scheduling simulator instance.
+func NewSchedulingSimulator(nodes []*schedulerframework.NodeInfo) *SchedulingSimulator {
+	return &SchedulingSimulator{
+		nodes: nodes,
+	}
+}
+
+// SimulateScheduling implements the First Fit(FF) algorithm to estimate
+// the maximum number of complete component sets that can be scheduled on the cluster.
+//
+// FF Algorithm Steps:
+// 1. For each complete set, try to schedule all components using first-fit strategy
+// 2. Continue until no more complete sets can be scheduled or upper limit is reached
+func (s *SchedulingSimulator) SimulateScheduling(components []pb.Component, upperBound int32) int32 {
+	var completeSets int32
+	// Try to schedule complete component sets until we can no longer do so or reach the upper limit.
+	for {
+		if completeSets < upperBound && s.scheduleComponentSet(components) {
+			completeSets++
+		} else {
+			break
+		}
+	}
+
+	return completeSets
+}
+
+// scheduleComponentSet attempts to schedule one complete set of all components.
+func (s *SchedulingSimulator) scheduleComponentSet(components []pb.Component) bool {
+	for _, component := range components {
+		if !s.scheduleComponent(component) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (s *SchedulingSimulator) scheduleComponent(component pb.Component) bool {
+	requiredPerReplica := util.NewResource(component.ReplicaRequirements.ResourceRequest)
+	requiredPerReplica.AllowedPodNumber = 1
+	remaining := component.Replicas
+	nodeClaim := component.ReplicaRequirements.NodeClaim
+
+	for _, node := range s.nodes {
+		if !matchNode(nodeClaim, node) {
+			continue
+		}
+
+		allocatable := node.Allocatable.MaxDivided(requiredPerReplica.ResourceList())
+		if allocatable == 0 {
+			continue
+		}
+
+		if int64(remaining) < allocatable {
+			allocatable = int64(remaining)
+		}
+
+		node.Allocatable.SubResource(requiredPerReplica.Clone().Multiply(allocatable))
+		remaining -= int32(allocatable) // #nosec G115: integer overflow conversion int64 -> int32
+		if remaining == 0 {
+			return true
+		}
+	}
+
+	return remaining == 0
+}
+
+// matchNode checks whether the node matches the scheduling constraints defined in the replica requirements.
+func matchNode(nodeClaim *pb.NodeClaim, node *schedulerframework.NodeInfo) bool {
+	if node.Node() == nil {
+		// Always match since we lack node affinity/toleration info, so we skip these checks.
+		return true
+	}
+
+	affinity := nodeutil.GetRequiredNodeAffinity(pb.ReplicaRequirements{NodeClaim: nodeClaim})
+	var tolerations []corev1.Toleration
+
+	if nodeClaim != nil {
+		tolerations = nodeClaim.Tolerations
+	}
+
+	return nodeutil.IsNodeAffinityMatched(node.Node(), affinity) && nodeutil.IsTolerationMatched(node.Node(), tolerations)
+}

--- a/pkg/estimator/scheduling_simulator_components_test.go
+++ b/pkg/estimator/scheduling_simulator_components_test.go
@@ -1,0 +1,404 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package estimator
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/karmada-io/karmada/pkg/estimator/pb"
+	"github.com/karmada-io/karmada/pkg/util"
+	schedulerframework "github.com/karmada-io/karmada/pkg/util/lifted/scheduler/framework"
+)
+
+func TestMatchNode(t *testing.T) {
+	tests := []struct {
+		name                string
+		replicaRequirements pb.ReplicaRequirements
+		node                *schedulerframework.NodeInfo
+		expected            bool
+	}{
+		{
+			name: "no enough information to perform the match operation - should match",
+			replicaRequirements: pb.ReplicaRequirements{
+				ResourceRequest: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+				NodeClaim: &pb.NodeClaim{
+					NodeAffinity: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "zone",
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{"us-west"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			node: func() *schedulerframework.NodeInfo {
+				return schedulerframework.NewNodeInfo()
+			}(),
+			expected: true,
+		},
+		{
+			name: "no constraints - should match",
+			replicaRequirements: pb.ReplicaRequirements{
+				ResourceRequest: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+			},
+			node: func() *schedulerframework.NodeInfo {
+				nodeInfo := schedulerframework.NewNodeInfo()
+				nodeInfo.SetNode(makeNode("node1", map[string]string{}, corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				}))
+				return nodeInfo
+			}(),
+			expected: true,
+		},
+		{
+			name: "node affinity matches",
+			replicaRequirements: pb.ReplicaRequirements{
+				ResourceRequest: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+				NodeClaim: &pb.NodeClaim{
+					NodeAffinity: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "zone",
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{"us-west"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			node: func() *schedulerframework.NodeInfo {
+				nodeInfo := schedulerframework.NewNodeInfo()
+				nodeInfo.SetNode(makeNode("node1", map[string]string{"zone": "us-west"}, corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				}))
+				return nodeInfo
+			}(),
+			expected: true,
+		},
+		{
+			name: "node affinity does not match",
+			replicaRequirements: pb.ReplicaRequirements{
+				ResourceRequest: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+				NodeClaim: &pb.NodeClaim{
+					NodeAffinity: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "zone",
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{"us-west"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			node: func() *schedulerframework.NodeInfo {
+				nodeInfo := schedulerframework.NewNodeInfo()
+				nodeInfo.SetNode(makeNode("node1", map[string]string{"zone": "us-east"}, corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				}))
+				return nodeInfo
+			}(),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := matchNode(tt.replicaRequirements.NodeClaim, tt.node)
+			if result != tt.expected {
+				t.Errorf("matchNode() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSchedulingSimulator_SimulateSchedulingFF(t *testing.T) {
+	tests := []struct {
+		name         string
+		nodes        []*schedulerframework.NodeInfo
+		components   []pb.Component
+		upperBound   int32
+		expectedSets int32
+	}{
+		{
+			name: "single component fits perfectly",
+			nodes: []*schedulerframework.NodeInfo{
+				createNodeInfo("node1", corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+					corev1.ResourcePods:   resource.MustParse("10"),
+				}),
+			},
+			components: []pb.Component{
+				{
+					Name:     "web",
+					Replicas: 2,
+					ReplicaRequirements: pb.ComponentReplicaRequirements{
+						ResourceRequest: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+					},
+				},
+			},
+			upperBound:   10,
+			expectedSets: 2, // 4 CPU / 1 CPU per replica = 4 replicas, 4 / 2 replicas per set = 2 sets
+		},
+		{
+			name: "multiple components with resource constraints",
+			nodes: []*schedulerframework.NodeInfo{
+				createNodeInfo("node1", corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("8"),
+					corev1.ResourceMemory: resource.MustParse("16Gi"),
+					corev1.ResourcePods:   resource.MustParse("10"),
+				}),
+			},
+			components: []pb.Component{
+				{
+					Name:     "web",
+					Replicas: 2,
+					ReplicaRequirements: pb.ComponentReplicaRequirements{
+						ResourceRequest: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+					},
+				},
+				{
+					Name:     "db",
+					Replicas: 1,
+					ReplicaRequirements: pb.ComponentReplicaRequirements{
+						ResourceRequest: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("2"),
+							corev1.ResourceMemory: resource.MustParse("4Gi"),
+						},
+					},
+				},
+			},
+			upperBound:   10,
+			expectedSets: 2, // Each set needs 4 CPU (2*1 + 1*2) and 8Gi memory (2*2 + 1*4), so 2 sets fit
+		},
+		{
+			name: "no resources available",
+			nodes: []*schedulerframework.NodeInfo{
+				createNodeInfo("node1", corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("0"),
+					corev1.ResourceMemory: resource.MustParse("0"),
+					corev1.ResourcePods:   resource.MustParse("10"),
+				}),
+			},
+			components: []pb.Component{
+				{
+					Name:     "web",
+					Replicas: 1,
+					ReplicaRequirements: pb.ComponentReplicaRequirements{
+						ResourceRequest: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						},
+					},
+				},
+			},
+			upperBound:   10,
+			expectedSets: 0,
+		},
+		{
+			name: "upper bound limits scheduling",
+			nodes: []*schedulerframework.NodeInfo{
+				createNodeInfo("node1", corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse("100"),
+					corev1.ResourcePods: resource.MustParse("10"),
+				}),
+			},
+			components: []pb.Component{
+				{
+					Name:     "web",
+					Replicas: 1,
+					ReplicaRequirements: pb.ComponentReplicaRequirements{
+						ResourceRequest: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						},
+					},
+				},
+			},
+			upperBound:   3,
+			expectedSets: 3, // Limited by upper bound, not resources
+		},
+		{
+			name: "multiple nodes distribution",
+			nodes: []*schedulerframework.NodeInfo{
+				createNodeInfo("node1", corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse("2"),
+					corev1.ResourcePods: resource.MustParse("10"),
+				}),
+				createNodeInfo("node2", corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse("2"),
+					corev1.ResourcePods: resource.MustParse("10"),
+				}),
+			},
+			components: []pb.Component{
+				{
+					Name:     "web",
+					Replicas: 3,
+					ReplicaRequirements: pb.ComponentReplicaRequirements{
+						ResourceRequest: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						},
+					},
+				},
+			},
+			upperBound:   10,
+			expectedSets: 1, // Total 4 CPU, need 3 CPU per set, so 1 set fits
+		},
+		{
+			name: "nodes with different capacities",
+			nodes: []*schedulerframework.NodeInfo{
+				createNodeInfo("small-node", corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+					corev1.ResourcePods:   resource.MustParse("10"),
+				}),
+				createNodeInfo("medium-node", corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+					corev1.ResourcePods:   resource.MustParse("20"),
+				}),
+				createNodeInfo("large-node", corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("8"),
+					corev1.ResourceMemory: resource.MustParse("16Gi"),
+					corev1.ResourcePods:   resource.MustParse("30"),
+				}),
+			},
+			components: []pb.Component{
+				{
+					Name:     "frontend",
+					Replicas: 2,
+					ReplicaRequirements: pb.ComponentReplicaRequirements{
+						ResourceRequest: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("500m"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+					},
+				},
+				{
+					Name:     "backend",
+					Replicas: 1,
+					ReplicaRequirements: pb.ComponentReplicaRequirements{
+						ResourceRequest: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("2"),
+							corev1.ResourceMemory: resource.MustParse("4Gi"),
+						},
+					},
+				},
+			},
+			upperBound:   10,
+			expectedSets: 4,
+		},
+		{
+			name: "many small nodes",
+			nodes: []*schedulerframework.NodeInfo{
+				createNodeInfo("node1", corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse("1"),
+					corev1.ResourcePods: resource.MustParse("5"),
+				}),
+				createNodeInfo("node2", corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse("1"),
+					corev1.ResourcePods: resource.MustParse("5"),
+				}),
+				createNodeInfo("node3", corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse("1"),
+					corev1.ResourcePods: resource.MustParse("5"),
+				}),
+				createNodeInfo("node4", corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse("1"),
+					corev1.ResourcePods: resource.MustParse("5"),
+				}),
+			},
+			components: []pb.Component{
+				{
+					Name:     "microservice",
+					Replicas: 1,
+					ReplicaRequirements: pb.ComponentReplicaRequirements{
+						ResourceRequest: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2"),
+						},
+					},
+				},
+			},
+			upperBound:   10,
+			expectedSets: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			simulator := NewSchedulingSimulator(tt.nodes)
+			result := simulator.SimulateScheduling(tt.components, tt.upperBound)
+			if result != tt.expectedSets {
+				t.Errorf("SimulateScheduling() = %d, expected %d", result, tt.expectedSets)
+			}
+		})
+	}
+}
+
+// Helper functions
+
+func createNodeInfo(name string, allocatable corev1.ResourceList) *schedulerframework.NodeInfo {
+	nodeInfo := schedulerframework.NewNodeInfo()
+	nodeInfo.SetNode(makeNode(name, map[string]string{}, allocatable))
+	// Set the Allocatable field using util.NewResource
+	nodeInfo.Allocatable = util.NewResource(allocatable)
+	return nodeInfo
+}
+
+func makeNode(name string, labels map[string]string, allocatable corev1.ResourceList) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: allocatable,
+			Capacity:    allocatable,
+		},
+	}
+}

--- a/pkg/util/resource.go
+++ b/pkg/util/resource.go
@@ -72,6 +72,25 @@ func (r *Resource) Add(rl corev1.ResourceList) {
 	}
 }
 
+// Multiply is used to multiply a resource by a factor.
+func (r *Resource) Multiply(factor int64) *Resource {
+	if r == nil {
+		return r
+	}
+
+	r.MilliCPU = r.MilliCPU * factor
+	r.Memory = r.Memory * factor
+	r.EphemeralStorage = r.EphemeralStorage * factor
+	r.AllowedPodNumber = r.AllowedPodNumber * factor
+
+	for rName, rScalar := range r.ScalarResources {
+		if lifted.IsScalarResourceName(rName) {
+			r.ScalarResources[rName] = rScalar * factor
+		}
+	}
+	return r
+}
+
 // SubResource is used to subtract two resources, if r < rr, set r to zero.
 func (r *Resource) SubResource(rr *Resource) *Resource {
 	if r == nil || rr == nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
Ref to https://github.com/karmada-io/karmada/pull/6912#issuecomment-3531756545
Given the high similarity in both algorithm and objective between the `noderesource` plugin and the resource model when computing `maxAvailableComponentsSets`, we can unify their computation logic.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note

```

