### PR TITLE
fix: update pytorchjob status when it's created or running

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kubeflow.org/v1/PyTorchJob/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kubeflow.org/v1/PyTorchJob/customizations.yaml
@@ -106,7 +106,7 @@ spec:
           end
         
           -- If no member cluster status, initialize default status
-          if statusItems == nil then
+          if statusItems == nil or #statusItems == 0 then
             desiredObj.status.startTime = nil
             desiredObj.status.completionTime = nil
             desiredObj.status.replicaStatuses = {}
@@ -121,6 +121,10 @@ spec:
           local aggregatedConditions = {}
           local successfulClustersNum = 0
           local failedClusters = {}
+          local hasRunningCondition = false
+          local createdClustersNum = 0
+          local runningLastUpdateTime = nil
+          local runningLastTransitionTime = nil
         
           -- Initialize Master and Worker status
           replicaStatuses.Master = { active = 0, failed = 0, succeeded = 0 }
@@ -162,55 +166,103 @@ spec:
                 end
               end
             
-              -- Aggregate condition status (merge conditions from all member clusters)
-              local isFinished = false
-              local finishedType = ""
+              -- Aggregate condition status from member clusters
+              local hasFailed = false
+              local hasSucceeded = false
+              local hasCreated = false
+              
               if statusItems[i].status.conditions ~= nil then
                 for _, c in ipairs(statusItems[i].status.conditions) do
-                  -- Like kubernetes native Job, we do not merge conditions from member clusters, 
-                  -- but generate a new condition by PytorchJob finish state.
-                  -- table.insert(aggregatedConditions, c)
-                  if (c.type == "Succeeded" or c.type == "Failed") and c.status == "True" then
-                    isFinished = true
-                    finishedType = c.type
+                  if c.type == "Failed" and c.status == "True" then
+                    hasFailed = true
+                  elseif c.type == "Succeeded" and c.status == "True" then
+                    hasSucceeded = true
+                  end
+                  
+                  if c.type == "Running" then
+                    hasRunningCondition = true
+                    -- TODO: If users have specific requirements, refine the logic for selecting lastUpdateTime and lastTransitionTime
+                    -- Currently, we just pick a value from statusItems
+                    runningLastUpdateTime = c.lastUpdateTime
+                    runningLastTransitionTime = c.lastTransitionTime
+                  end
+                  
+                  if c.type == "Created" and c.status == "True" then
+                    hasCreated = true
                   end
                 end
               end
 
-              if isFinished then
-                if finishedType == "Succeeded" then
-                  successfulClustersNum = successfulClustersNum + 1
-                elseif finishedType == "Failed" then
-                  table.insert(failedClusters, statusItems[i].clusterName)
-                end
+              -- Count clusters by status
+              if hasFailed then
+                table.insert(failedClusters, statusItems[i].clusterName)
+              elseif hasSucceeded then
+                successfulClustersNum = successfulClustersNum + 1
+              end
+
+              if hasCreated then
+                createdClustersNum = createdClustersNum + 1
               end
 
             end
           end
             
+          -- Set conditions in order: Created -> Running -> Succeeded/Failed (mutually exclusive)
+          -- kubectl get shows the last condition, so order matters
+          
+          -- 1. Created condition (earliest state, can coexist with others)
+          if createdClustersNum > 0 then
+            table.insert(aggregatedConditions, {
+              type = "Created",
+              status = "True",
+              lastUpdateTime = startTime,
+              lastTransitionTime = startTime,
+              reason = "PyTorchJobCreated",
+              message = "PyTorchJob is created."
+            })
+          end
+          
+          -- 2. Running condition (intermediate state, can coexist with Created)
+          if hasRunningCondition then
+            local hasFinalState = (#failedClusters > 0) or (successfulClustersNum == #statusItems)
+            local runningStatus = "True"
+            if hasFinalState then
+              runningStatus = "False"
+            end
+            -- TODO: If users have specific requirements, refine the logic for selecting lastUpdateTime and lastTransitionTime
+            -- Currently, we just pick the first value from statusItems
+            table.insert(aggregatedConditions, {
+              type = "Running",
+              status = runningStatus,
+              lastUpdateTime = runningLastUpdateTime,
+              lastTransitionTime = runningLastTransitionTime,
+              reason = "PyTorchJobRunning",
+              message = "PyTorchJob is running."
+            })
+          end
+          
+          -- 3. Final states: Succeeded and Failed are mutually exclusive (last condition shown by kubectl get)
           if #failedClusters > 0 then
             table.insert(aggregatedConditions, {
               type = "Failed",
               status = "True",
-              lastProbeTime = os.date("!%Y-%m-%dT%H:%M:%SZ"),
-              lastTransitionTime = os.date("!%Y-%m-%dT%H:%M:%SZ"),
+              lastUpdateTime = completionTime,
+              lastTransitionTime = completionTime,
               reason = "PyTorchJobFailed",
               message = "PyTorchJob executed failed in member clusters: " .. table.concat(failedClusters, ", ")
             })
-          end
-
-          if successfulClustersNum == #statusItems and successfulClustersNum > 0 then
+          elseif successfulClustersNum == #statusItems and successfulClustersNum > 0 then
             table.insert(aggregatedConditions, {
               type = "Succeeded",
               status = "True",
-              lastProbeTime = os.date("!%Y-%m-%dT%H:%M:%SZ"),
-              lastTransitionTime = os.date("!%Y-%m-%dT%H:%M:%SZ"),
-              reason = "Completed",
-              message = "PyTorchJob completed successfully"
+              lastUpdateTime = completionTime,
+              lastTransitionTime = completionTime,
+              reason = "PyTorchJobSucceeded",
+              message = "PyTorchJob is successfully completed."
             })
             desiredObj.status.completionTime = completionTime
           end
-        
+          
           -- Set aggregated status
           desiredObj.status.startTime = startTime
           desiredObj.status.lastReconcileTime = lastReconcileTime

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kubeflow.org/v1/PyTorchJob/testdata/aggregatestatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kubeflow.org/v1/PyTorchJob/testdata/aggregatestatus-test.yaml
@@ -120,3 +120,80 @@ statusItems:
       startTime: "2025-10-13T11:46:42Z"
 operation: AggregateStatus
 output:
+  aggregatedStatus:
+    apiVersion: kubeflow.org/v1
+    kind: PyTorchJob
+    metadata:
+      name: pytorch-simple
+      namespace: kubeflow
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 2
+          restartPolicy: OnFailure
+          template:
+            spec:
+              containers:
+                - name: pytorch
+                  image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
+                  imagePullPolicy: Always
+                  command:
+                    - "python3"
+                    - "/opt/pytorch-mnist/mnist.py"
+                    - "--epochs=1"
+                  resources:
+                    limits:
+                      cpu: 1
+                      memory: 512Mi
+        Worker:
+          replicas: 2
+          restartPolicy: OnFailure
+          template:
+            spec:
+              serviceAccountName: pytorch-service-account
+              containers:
+                - name: pytorch
+                  image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
+                  imagePullPolicy: Always
+                  volumeMounts:
+                    - mountPath: "/train"
+                      name: "training"
+                  command:
+                    - "python3"
+                    - "/opt/pytorch-mnist/mnist.py"
+                    - "--epochs=1"
+                  resources:
+                    limits:
+                      cpu: 1
+                      memory: 512Mi
+              volumes:
+                - name: "training"
+                  persistentVolumeClaim:
+                    claimName: "training-data"
+    status:
+      completionTime: "2025-10-13T11:48:12Z"
+      conditions:
+        - lastTransitionTime: "2025-10-13T11:46:42Z"
+          lastUpdateTime: "2025-10-13T11:46:42Z"
+          message: PyTorchJob is created.
+          reason: PyTorchJobCreated
+          status: "True"
+          type: Created
+        - lastTransitionTime: "2025-10-13T11:47:40Z"
+          lastUpdateTime: "2025-10-13T11:47:40Z"
+          message: PyTorchJob is running.
+          reason: PyTorchJobRunning
+          status: "False"
+          type: Running
+        - lastTransitionTime: "2025-10-13T11:48:12Z"
+          lastUpdateTime: "2025-10-13T11:48:12Z"
+          message: PyTorchJob is successfully completed.
+          reason: PyTorchJobSucceeded
+          status: "True"
+          type: Succeeded
+      replicaStatuses:
+        Master:
+          succeeded: 2
+        Worker:
+          succeeded: 2
+      startTime: "2025-10-13T11:46:42Z"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

https://github.com/karmada-io/karmada/pull/6826 add resource interpreter for pytorchjob. When I tested it, I found some problems.

1. It only focuses on succeed and failed condition, no running and created condition. I think running and created condition should be aggregated too.
2. According to API of `PytorchJob`, it should be `lastUpdateTime` instead of `lastProbeTime`.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
3. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
5. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

