### PR TITLE
feat: adjust the log position of interpreter

### DIFF
--- a/pkg/resourceinterpreter/customized/declarative/configurable.go
+++ b/pkg/resourceinterpreter/customized/declarative/configurable.go
@@ -84,8 +84,6 @@ func (c *ConfigurableInterpreter) HookEnabled(kind schema.GroupVersionKind, oper
 
 // GetReplicas returns the desired replicas of the object as well as the requirements of each replica.
 func (c *ConfigurableInterpreter) GetReplicas(object *unstructured.Unstructured) (replicas int32, requires *workv1alpha2.ReplicaRequirements, enabled bool, err error) {
-	klog.V(4).Infof("Get replicas for object: %v %s/%s with configurable interpreter.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
-
 	accessor, enabled := c.getCustomAccessor(object.GroupVersionKind())
 	if !enabled {
 		return
@@ -97,14 +95,14 @@ func (c *ConfigurableInterpreter) GetReplicas(object *unstructured.Unstructured)
 		return
 	}
 
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with configurable interpreter.",
+		configv1alpha1.InterpreterOperationInterpretReplica, object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	replicas, requires, err = c.luaVM.GetReplicas(object, script)
 	return
 }
 
 // GetComponents returns the desired components of the object.
 func (c *ConfigurableInterpreter) GetComponents(object *unstructured.Unstructured) (components []workv1alpha2.Component, enabled bool, err error) {
-	klog.V(4).Infof("Get components for object: %v %s/%s with configurable interpreter.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
-
 	accessor, enabled := c.getCustomAccessor(object.GroupVersionKind())
 	if !enabled {
 		return
@@ -116,14 +114,14 @@ func (c *ConfigurableInterpreter) GetComponents(object *unstructured.Unstructure
 		return
 	}
 
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with configurable interpreter.",
+		configv1alpha1.InterpreterOperationInterpretComponent, object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	components, err = c.luaVM.GetComponents(object, script)
 	return
 }
 
 // ReviseReplica revises the replica of the given object.
 func (c *ConfigurableInterpreter) ReviseReplica(object *unstructured.Unstructured, replica int64) (revised *unstructured.Unstructured, enabled bool, err error) {
-	klog.V(4).Infof("Revise replicas for object: %v %s/%s with configurable interpreter.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
-
 	accessor, enabled := c.getCustomAccessor(object.GroupVersionKind())
 	if !enabled {
 		return
@@ -135,14 +133,14 @@ func (c *ConfigurableInterpreter) ReviseReplica(object *unstructured.Unstructure
 		return
 	}
 
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with configurable interpreter.",
+		configv1alpha1.InterpreterOperationReviseReplica, object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	revised, err = c.luaVM.ReviseReplica(object, replica, script)
 	return
 }
 
 // Retain returns the objects that based on the "desired" object but with values retained from the "observed" object.
 func (c *ConfigurableInterpreter) Retain(desired *unstructured.Unstructured, observed *unstructured.Unstructured) (retained *unstructured.Unstructured, enabled bool, err error) {
-	klog.V(4).Infof("Retain object: %v %s/%s with configurable interpreter.", desired.GroupVersionKind(), desired.GetNamespace(), desired.GetName())
-
 	accessor, enabled := c.getCustomAccessor(desired.GroupVersionKind())
 	if !enabled {
 		return
@@ -154,13 +152,14 @@ func (c *ConfigurableInterpreter) Retain(desired *unstructured.Unstructured, obs
 		return
 	}
 
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with configurable interpreter.",
+		configv1alpha1.InterpreterOperationRetain, desired.GroupVersionKind(), desired.GetNamespace(), desired.GetName())
 	retained, err = c.luaVM.Retain(desired, observed, script)
 	return
 }
 
 // AggregateStatus returns the objects that based on the 'object' but with status aggregated.
 func (c *ConfigurableInterpreter) AggregateStatus(object *unstructured.Unstructured, aggregatedStatusItems []workv1alpha2.AggregatedStatusItem) (status *unstructured.Unstructured, enabled bool, err error) {
-	klog.V(4).Infof("Aggregate status of object: %v %s/%s with configurable interpreter.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	accessor, enabled := c.getCustomAccessor(object.GroupVersionKind())
 	if !enabled {
 		return
@@ -172,14 +171,14 @@ func (c *ConfigurableInterpreter) AggregateStatus(object *unstructured.Unstructu
 		return
 	}
 
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with configurable interpreter.",
+		configv1alpha1.InterpreterOperationAggregateStatus, object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	status, err = c.luaVM.AggregateStatus(object, aggregatedStatusItems, script)
 	return
 }
 
 // GetDependencies returns the dependent resources of the given object.
 func (c *ConfigurableInterpreter) GetDependencies(object *unstructured.Unstructured) (dependencies []configv1alpha1.DependentObjectReference, enabled bool, err error) {
-	klog.V(4).Infof("Get dependencies of object: %v %s/%s with configurable interpreter.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
-
 	accessor, enabled := c.getCustomAccessor(object.GroupVersionKind())
 	if !enabled {
 		return
@@ -191,6 +190,8 @@ func (c *ConfigurableInterpreter) GetDependencies(object *unstructured.Unstructu
 		return
 	}
 
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with configurable interpreter.",
+		configv1alpha1.InterpreterOperationInterpretDependency, object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	refs := sets.New[configv1alpha1.DependentObjectReference]()
 	for _, luaScript := range scripts {
 		var references []configv1alpha1.DependentObjectReference
@@ -226,8 +227,6 @@ func (c *ConfigurableInterpreter) GetDependencies(object *unstructured.Unstructu
 
 // ReflectStatus returns the status of the object.
 func (c *ConfigurableInterpreter) ReflectStatus(object *unstructured.Unstructured) (status *runtime.RawExtension, enabled bool, err error) {
-	klog.V(4).Infof("Reflect status of object: %v %s/%s with configurable interpreter.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
-
 	accessor, enabled := c.getCustomAccessor(object.GroupVersionKind())
 	if !enabled {
 		return
@@ -239,14 +238,14 @@ func (c *ConfigurableInterpreter) ReflectStatus(object *unstructured.Unstructure
 		return
 	}
 
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with configurable interpreter.",
+		configv1alpha1.InterpreterOperationInterpretStatus, object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	status, err = c.luaVM.ReflectStatus(object, script)
 	return
 }
 
 // InterpretHealth returns the health state of the object.
 func (c *ConfigurableInterpreter) InterpretHealth(object *unstructured.Unstructured) (health bool, enabled bool, err error) {
-	klog.V(4).Infof("Get health status of object: %v %s/%s with configurable interpreter.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
-
 	accessor, enabled := c.getCustomAccessor(object.GroupVersionKind())
 	if !enabled {
 		return
@@ -258,6 +257,8 @@ func (c *ConfigurableInterpreter) InterpretHealth(object *unstructured.Unstructu
 		return
 	}
 
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with configurable interpreter.",
+		configv1alpha1.InterpreterOperationInterpretHealth, object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	health, err = c.luaVM.InterpretHealth(object, script)
 	return
 }

--- a/pkg/resourceinterpreter/customized/webhook/customized.go
+++ b/pkg/resourceinterpreter/customized/webhook/customized.go
@@ -94,8 +94,6 @@ func (e *CustomizedInterpreter) HookEnabled(objGVK schema.GroupVersionKind, oper
 // GetReplicas returns the desired replicas of the object as well as the requirements of each replica.
 // It also returns a matched value to indicate whether there is a matching hook.
 func (e *CustomizedInterpreter) GetReplicas(ctx context.Context, attributes *request.Attributes) (replica int32, requires *workv1alpha2.ReplicaRequirements, matched bool, err error) {
-	klog.V(4).Infof("Get replicas for object: %v %s/%s with webhook interpreter.",
-		attributes.Object.GroupVersionKind(), attributes.Object.GetNamespace(), attributes.Object.GetName())
 	var response *request.ResponseAttributes
 	response, matched, err = e.interpret(ctx, attributes)
 	if err != nil {
@@ -105,14 +103,14 @@ func (e *CustomizedInterpreter) GetReplicas(ctx context.Context, attributes *req
 		return
 	}
 
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with webhook interpreter.",
+		attributes.Operation, attributes.Object.GroupVersionKind(), attributes.Object.GetNamespace(), attributes.Object.GetName())
 	return response.Replicas, response.ReplicaRequirements, matched, nil
 }
 
 // GetComponents returns the desired components of the object.
 // It also returns a matched value to indicate whether there is a matching hook.
 func (e *CustomizedInterpreter) GetComponents(ctx context.Context, attributes *request.Attributes) (components []workv1alpha2.Component, matched bool, err error) {
-	klog.V(4).Infof("Get components for object: %v %s/%s with webhook interpreter.",
-		attributes.Object.GroupVersionKind(), attributes.Object.GetNamespace(), attributes.Object.GetName())
 	var response *request.ResponseAttributes
 	response, matched, err = e.interpret(ctx, attributes)
 	if err != nil {
@@ -122,6 +120,8 @@ func (e *CustomizedInterpreter) GetComponents(ctx context.Context, attributes *r
 		return
 	}
 
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with webhook interpreter.",
+		attributes.Operation, attributes.Object.GroupVersionKind(), attributes.Object.GetNamespace(), attributes.Object.GetName())
 	return response.Components, matched, nil
 }
 
@@ -136,6 +136,8 @@ func (e *CustomizedInterpreter) Patch(ctx context.Context, attributes *request.A
 	if !matched {
 		return
 	}
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with webhook interpreter.",
+		attributes.Operation, attributes.Object.GroupVersionKind(), attributes.Object.GetNamespace(), attributes.Object.GetName())
 	obj, err = applyPatch(attributes.Object, response.Patch, response.PatchType)
 	if err != nil {
 		return
@@ -340,6 +342,8 @@ func (e *CustomizedInterpreter) GetDependencies(ctx context.Context, attributes 
 		return
 	}
 
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with webhook interpreter.",
+		attributes.Operation, attributes.Object.GroupVersionKind(), attributes.Object.GetNamespace(), attributes.Object.GetName())
 	return response.Dependencies, matched, nil
 }
 
@@ -355,6 +359,8 @@ func (e *CustomizedInterpreter) ReflectStatus(ctx context.Context, attributes *r
 		return
 	}
 
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with webhook interpreter.",
+		attributes.Operation, attributes.Object.GroupVersionKind(), attributes.Object.GetNamespace(), attributes.Object.GetName())
 	return &response.RawStatus, matched, nil
 }
 
@@ -370,6 +376,8 @@ func (e *CustomizedInterpreter) InterpretHealth(ctx context.Context, attributes 
 		return
 	}
 
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with webhook interpreter.",
+		attributes.Operation, attributes.Object.GroupVersionKind(), attributes.Object.GetNamespace(), attributes.Object.GetName())
 	return response.Healthy, matched, nil
 }
 

--- a/pkg/resourceinterpreter/default/native/default.go
+++ b/pkg/resourceinterpreter/default/native/default.go
@@ -93,21 +93,21 @@ func (e *DefaultInterpreter) HookEnabled(kind schema.GroupVersionKind, operation
 
 // GetReplicas returns the desired replicas of the object as well as the requirements of each replica.
 func (e *DefaultInterpreter) GetReplicas(object *unstructured.Unstructured) (int32, *workv1alpha2.ReplicaRequirements, error) {
-	klog.V(4).Infof("Get replicas for object: %v %s/%s with build-in interpreter.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	handler, exist := e.replicaHandlers[object.GroupVersionKind()]
 	if !exist {
 		return 0, &workv1alpha2.ReplicaRequirements{}, fmt.Errorf("default %s interpreter for %q not found", configv1alpha1.InterpreterOperationInterpretReplica, object.GroupVersionKind())
 	}
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with build-in interpreter.", configv1alpha1.InterpreterOperationInterpretReplica, object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	return handler(object)
 }
 
 // ReviseReplica revises the replica of the given object.
 func (e *DefaultInterpreter) ReviseReplica(object *unstructured.Unstructured, replica int64) (*unstructured.Unstructured, error) {
-	klog.V(4).Infof("Revise replicas for object: %v %s/%s with build-in interpreter.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	handler, exist := e.reviseReplicaHandlers[object.GroupVersionKind()]
 	if !exist {
 		return nil, fmt.Errorf("default %s interpreter for %q not found", configv1alpha1.InterpreterOperationReviseReplica, object.GroupVersionKind())
 	}
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with build-in interpreter.", configv1alpha1.InterpreterOperationReviseReplica, object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	return handler(object, replica)
 }
 
@@ -118,32 +118,32 @@ func (e *DefaultInterpreter) GetComponents(_ *unstructured.Unstructured) ([]work
 
 // Retain returns the objects that based on the "desired" object but with values retained from the "observed" object.
 func (e *DefaultInterpreter) Retain(desired *unstructured.Unstructured, observed *unstructured.Unstructured) (retained *unstructured.Unstructured, err error) {
-	klog.V(4).Infof("Retain object: %v %s/%s with build-in interpreter.", desired.GroupVersionKind(), desired.GetNamespace(), desired.GetName())
 	handler, exist := e.retentionHandlers[desired.GroupVersionKind()]
 	if !exist {
 		return nil, fmt.Errorf("default %s interpreter for %q not found", configv1alpha1.InterpreterOperationRetain, desired.GroupVersionKind())
 	}
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with build-in interpreter.", configv1alpha1.InterpreterOperationRetain, desired.GroupVersionKind(), desired.GetNamespace(), desired.GetName())
 	return handler(desired, observed)
 }
 
 // AggregateStatus returns the objects that based on the 'object' but with status aggregated.
 func (e *DefaultInterpreter) AggregateStatus(object *unstructured.Unstructured, aggregatedStatusItems []workv1alpha2.AggregatedStatusItem) (*unstructured.Unstructured, error) {
-	klog.V(4).Infof("Aggregate status of object: %v %s/%s with build-in interpreter.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	handler, exist := e.aggregateStatusHandlers[object.GroupVersionKind()]
 	if !exist {
 		return nil, fmt.Errorf("default %s interpreter for %q not found", configv1alpha1.InterpreterOperationAggregateStatus, object.GroupVersionKind())
 	}
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with build-in interpreter.", configv1alpha1.InterpreterOperationAggregateStatus, object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	return handler(object, aggregatedStatusItems)
 }
 
 // GetDependencies returns the dependent resources of the given object.
 func (e *DefaultInterpreter) GetDependencies(object *unstructured.Unstructured) (dependencies []configv1alpha1.DependentObjectReference, err error) {
-	klog.V(4).Infof("Get dependencies of object: %v %s/%s with build-in interpreter.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	handler, exist := e.dependenciesHandlers[object.GroupVersionKind()]
 	if !exist {
 		return dependencies, fmt.Errorf("default interpreter for operation %s not found", configv1alpha1.InterpreterOperationInterpretDependency)
 	}
 
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with build-in interpreter.", configv1alpha1.InterpreterOperationInterpretDependency, object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	dependencies, err = handler(object)
 	if err != nil {
 		return
@@ -153,7 +153,7 @@ func (e *DefaultInterpreter) GetDependencies(object *unstructured.Unstructured) 
 
 // ReflectStatus returns the status of the object.
 func (e *DefaultInterpreter) ReflectStatus(object *unstructured.Unstructured) (status *runtime.RawExtension, err error) {
-	klog.V(4).Infof("Reflect status of object: %v %s/%s with build-in interpreter.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with build-in interpreter.", configv1alpha1.InterpreterOperationInterpretStatus, object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	handler, exist := e.reflectStatusHandlers[object.GroupVersionKind()]
 	if exist {
 		return handler(object)
@@ -165,9 +165,9 @@ func (e *DefaultInterpreter) ReflectStatus(object *unstructured.Unstructured) (s
 
 // InterpretHealth returns the health state of the object.
 func (e *DefaultInterpreter) InterpretHealth(object *unstructured.Unstructured) (bool, error) {
-	klog.V(4).Infof("Get health status of object: %v %s/%s with build-in interpreter.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	handler, exist := e.healthHandlers[object.GroupVersionKind()]
 	if exist {
+		klog.V(4).Infof("Running operation %s for object: %v %s/%s with build-in interpreter.", configv1alpha1.InterpreterOperationInterpretHealth, object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 		return handler(object)
 	}
 

--- a/pkg/resourceinterpreter/default/thirdparty/thirdparty.go
+++ b/pkg/resourceinterpreter/default/thirdparty/thirdparty.go
@@ -70,13 +70,13 @@ func (p *ConfigurableInterpreter) HookEnabled(kind schema.GroupVersionKind, oper
 
 // GetReplicas returns the desired replicas of the object as well as the requirements of each replica.
 func (p *ConfigurableInterpreter) GetReplicas(object *unstructured.Unstructured) (replicas int32, requires *workv1alpha2.ReplicaRequirements, enabled bool, err error) {
-	klog.V(4).Infof("Get replicas for object: %v %s/%s with thirdparty configurable interpreter.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
-
 	customAccessor, enabled := p.getCustomAccessor(object.GroupVersionKind())
 	if !enabled {
 		return
 	}
 
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with thirdparty configurable interpreter.",
+		configv1alpha1.InterpreterOperationInterpretReplica, object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	script := customAccessor.GetReplicaResourceLuaScript()
 	if len(script) == 0 {
 		enabled = false
@@ -89,8 +89,6 @@ func (p *ConfigurableInterpreter) GetReplicas(object *unstructured.Unstructured)
 
 // GetComponents returns the desired components of the object.
 func (p *ConfigurableInterpreter) GetComponents(object *unstructured.Unstructured) (components []workv1alpha2.Component, enabled bool, err error) {
-	klog.V(4).Infof("Get components for object: %v %s/%s with thirdparty configurable interpreter.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
-
 	customAccessor, enabled := p.getCustomAccessor(object.GroupVersionKind())
 	if !enabled {
 		return
@@ -102,14 +100,14 @@ func (p *ConfigurableInterpreter) GetComponents(object *unstructured.Unstructure
 		return
 	}
 
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with thirdparty configurable interpreter.",
+		configv1alpha1.InterpreterOperationInterpretComponent, object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	components, err = p.luaVM.GetComponents(object, script)
 	return
 }
 
 // ReviseReplica revises the replica of the given object.
 func (p *ConfigurableInterpreter) ReviseReplica(object *unstructured.Unstructured, replica int64) (revised *unstructured.Unstructured, enabled bool, err error) {
-	klog.V(4).Infof("Revise replicas for object: %v %s/%s with thirdparty configurable interpreter.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
-
 	customAccessor, enabled := p.getCustomAccessor(object.GroupVersionKind())
 	if !enabled {
 		return
@@ -121,14 +119,14 @@ func (p *ConfigurableInterpreter) ReviseReplica(object *unstructured.Unstructure
 		return
 	}
 
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with thirdparty configurable interpreter.",
+		configv1alpha1.InterpreterOperationReviseReplica, object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	revised, err = p.luaVM.ReviseReplica(object, replica, script)
 	return
 }
 
 // Retain returns the objects that based on the "desired" object but with values retained from the "observed" object.
 func (p *ConfigurableInterpreter) Retain(desired *unstructured.Unstructured, observed *unstructured.Unstructured) (retained *unstructured.Unstructured, enabled bool, err error) {
-	klog.V(4).Infof("Retain object: %v %s/%s with thirdparty configurable interpreter.", desired.GroupVersionKind(), desired.GetNamespace(), desired.GetName())
-
 	customAccessor, enabled := p.getCustomAccessor(desired.GroupVersionKind())
 	if !enabled {
 		return
@@ -140,13 +138,14 @@ func (p *ConfigurableInterpreter) Retain(desired *unstructured.Unstructured, obs
 		return
 	}
 
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with thirdparty configurable interpreter.",
+		configv1alpha1.InterpreterOperationRetain, desired.GroupVersionKind(), desired.GetNamespace(), desired.GetName())
 	retained, err = p.luaVM.Retain(desired, observed, script)
 	return
 }
 
 // AggregateStatus returns the objects that based on the 'object' but with status aggregated.
 func (p *ConfigurableInterpreter) AggregateStatus(object *unstructured.Unstructured, aggregatedStatusItems []workv1alpha2.AggregatedStatusItem) (status *unstructured.Unstructured, enabled bool, err error) {
-	klog.V(4).Infof("Aggregate status of object: %v %s/%s with thirdparty configurable interpreter.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	customAccessor, enabled := p.getCustomAccessor(object.GroupVersionKind())
 	if !enabled {
 		return
@@ -158,14 +157,14 @@ func (p *ConfigurableInterpreter) AggregateStatus(object *unstructured.Unstructu
 		return
 	}
 
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with thirdparty configurable interpreter.",
+		configv1alpha1.InterpreterOperationAggregateStatus, object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	status, err = p.luaVM.AggregateStatus(object, aggregatedStatusItems, script)
 	return
 }
 
 // GetDependencies returns the dependent resources of the given object.
 func (p *ConfigurableInterpreter) GetDependencies(object *unstructured.Unstructured) (dependencies []configv1alpha1.DependentObjectReference, enabled bool, err error) {
-	klog.V(4).Infof("Get dependencies of object: %v %s/%s with thirdparty configurable interpreter.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
-
 	customAccessor, enabled := p.getCustomAccessor(object.GroupVersionKind())
 	if !enabled {
 		return
@@ -177,6 +176,8 @@ func (p *ConfigurableInterpreter) GetDependencies(object *unstructured.Unstructu
 		return
 	}
 
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with thirdparty configurable interpreter.",
+		configv1alpha1.InterpreterOperationInterpretDependency, object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	refs := sets.New[configv1alpha1.DependentObjectReference]()
 	for _, luaScript := range scripts {
 		var references []configv1alpha1.DependentObjectReference
@@ -212,8 +213,6 @@ func (p *ConfigurableInterpreter) GetDependencies(object *unstructured.Unstructu
 
 // ReflectStatus returns the status of the object.
 func (p *ConfigurableInterpreter) ReflectStatus(object *unstructured.Unstructured) (status *runtime.RawExtension, enabled bool, err error) {
-	klog.V(4).Infof("Reflect status of object: %v %s/%s with thirdparty configurable interpreter.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
-
 	customAccessor, enabled := p.getCustomAccessor(object.GroupVersionKind())
 	if !enabled {
 		return
@@ -225,14 +224,14 @@ func (p *ConfigurableInterpreter) ReflectStatus(object *unstructured.Unstructure
 		return
 	}
 
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with thirdparty configurable interpreter.",
+		configv1alpha1.InterpreterOperationInterpretStatus, object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	status, err = p.luaVM.ReflectStatus(object, script)
 	return
 }
 
 // InterpretHealth returns the health state of the object.
 func (p *ConfigurableInterpreter) InterpretHealth(object *unstructured.Unstructured) (health bool, enabled bool, err error) {
-	klog.V(4).Infof("Get health status of object: %v %s/%s with thirdparty configurable interpreter.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
-
 	customAccessor, enabled := p.getCustomAccessor(object.GroupVersionKind())
 	if !enabled {
 		return
@@ -244,6 +243,8 @@ func (p *ConfigurableInterpreter) InterpretHealth(object *unstructured.Unstructu
 		return
 	}
 
+	klog.V(4).Infof("Running operation %s for object: %v %s/%s with thirdparty configurable interpreter.",
+		configv1alpha1.InterpreterOperationInterpretHealth, object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	health, err = p.luaVM.InterpretHealth(object, script)
 	return
 }

--- a/pkg/resourceinterpreter/interpreter.go
+++ b/pkg/resourceinterpreter/interpreter.go
@@ -177,7 +177,6 @@ func (i *customResourceInterpreterImpl) ReviseReplica(object *unstructured.Unstr
 		return obj, nil
 	}
 
-	klog.V(4).Infof("Revise replicas for object: %v %s/%s with webhook interpreter.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	obj, hookEnabled, err = i.customizedInterpreter.Patch(context.TODO(), &request.Attributes{
 		Operation:   configv1alpha1.InterpreterOperationReviseReplica,
 		Object:      object,
@@ -250,7 +249,6 @@ func (i *customResourceInterpreterImpl) Retain(desired *unstructured.Unstructure
 		return obj, nil
 	}
 
-	klog.V(4).Infof("Retain object: %v %s/%s with webhook interpreter.", desired.GroupVersionKind(), desired.GetNamespace(), desired.GetName())
 	obj, hookEnabled, err = i.customizedInterpreter.Patch(context.TODO(), &request.Attributes{
 		Operation:   configv1alpha1.InterpreterOperationRetain,
 		Object:      desired,
@@ -283,7 +281,6 @@ func (i *customResourceInterpreterImpl) AggregateStatus(object *unstructured.Uns
 		return obj, nil
 	}
 
-	klog.V(4).Infof("Aggregate status of object: %v %s/%s with webhook interpreter.", object.GroupVersionKind(), object.GetNamespace(), object.GetName())
 	obj, hookEnabled, err = i.customizedInterpreter.Patch(context.TODO(), &request.Attributes{
 		Operation:        configv1alpha1.InterpreterOperationAggregateStatus,
 		Object:           object.DeepCopy(),


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
The current interpreter's log looks as follows:
```
xxxx] Aggregate status of object: kubeflow.org/v1, Kind=PyTorchJob default/pytorch with configurable interpreter.
xxxx] Aggregate status of object: kubeflow.org/v1, Kind=PyTorchJob default/pytorch with webhook interpreter.
xxxx] Aggregate status of object: kubeflow.org/v1, Kind=PyTorchJob default/pytorch with thirdparty configurable interpreter.
```

I think the only the interpreter that finally takes effects should output the logs.  Using ReviseReplicas as an example, this pr demonstrate the change.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

If reviewers think this is reasonable, I will modify all interface related log code.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note

```

