### PR TITLE
karmadactl: improve help text for token command

### DIFF
--- a/pkg/karmadactl/token/token.go
+++ b/pkg/karmadactl/token/token.go
@@ -77,7 +77,7 @@ func NewCmdToken(f util.Factory, parentCommand string, streams genericiooptions.
 
 	cmd := &cobra.Command{
 		Use:     "token",
-		Short:   "Manage bootstrap tokens",
+		Short:   "Manage bootstrap tokens for joining member clusters to Karmada",
 		Long:    tokenLong,
 		Example: fmt.Sprintf(tokenExamples, parentCommand),
 		Annotations: map[string]string{


### PR DESCRIPTION
This PR improves the help text of the `karmadactl token` command
to better explain its purpose when managing bootstrap tokens
for joining member clusters.

No functional changes are introduced.