### PR TITLE
Add complete interpreter test coverage for CloneSet

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/aggregatestatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/aggregatestatus-test.yaml
@@ -1,5 +1,8 @@
-# test case for aggregating status of CloneSet
+# test cases for aggregating status of CloneSet
 # case1. CloneSet with two status items
+# case2. CloneSet with partially ready replicas
+# case3. CloneSet with mixed observed generations
+# case4. CloneSet with no status items
 
 name: "CloneSet with two status items"
 description: "Test aggregating status of CloneSet with two status items"
@@ -77,3 +80,115 @@ statusItems:
       resourceTemplateGeneration: 1
 operation: AggregateStatus
 output:
+  status:
+    replicas: 4
+    readyReplicas: 4
+    availableReplicas: 4
+    updatedReplicas: 4
+    updatedReadyReplicas: 4
+    expectedUpdatedReplicas: 4
+    observedGeneration: 1
+---
+name: "CloneSet with partially ready replicas"
+description: "AggregateStatus when some replicas are not ready"
+desiredObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: CloneSet
+  metadata:
+    name: sample
+    namespace: test-cloneset
+    generation: 2
+  spec:
+    replicas: 4
+statusItems:
+  - applied: true
+    clusterName: member1
+    status:
+      replicas: 2
+      readyReplicas: 1
+      availableReplicas: 1
+      updatedReplicas: 2
+      updatedReadyReplicas: 1
+      expectedUpdatedReplicas: 2
+      generation: 2
+      observedGeneration: 2
+      resourceTemplateGeneration: 2
+  - applied: true
+    clusterName: member2
+    status:
+      replicas: 2
+      readyReplicas: 2
+      availableReplicas: 2
+      updatedReplicas: 2
+      updatedReadyReplicas: 2
+      expectedUpdatedReplicas: 2
+      generation: 2
+      observedGeneration: 2
+      resourceTemplateGeneration: 2
+operation: AggregateStatus
+output:
+  status:
+    replicas: 4
+    readyReplicas: 3
+    availableReplicas: 3
+    updatedReplicas: 4
+    updatedReadyReplicas: 3
+    expectedUpdatedReplicas: 4
+    observedGeneration: 2
+---
+name: "CloneSet with mixed observed generations"
+description: "AggregateStatus should not update observedGeneration if any member is stale"
+desiredObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: CloneSet
+  metadata:
+    name: sample
+    namespace: test-cloneset
+    generation: 3
+  status:
+    observedGeneration: 2
+statusItems:
+  - applied: true
+    clusterName: member1
+    status:
+      replicas: 2
+      readyReplicas: 2
+      generation: 3
+      observedGeneration: 3
+      resourceTemplateGeneration: 3
+  - applied: true
+    clusterName: member2
+    status:
+      replicas: 2
+      readyReplicas: 2
+      generation: 3
+      observedGeneration: 2   
+      resourceTemplateGeneration: 3
+operation: AggregateStatus
+output:
+  status:
+    replicas: 4
+    readyReplicas: 4
+    observedGeneration: 2
+---
+name: "CloneSet with no status items"
+description: "AggregateStatus when CloneSet is not propagated"
+desiredObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: CloneSet
+  metadata:
+    name: sample
+    namespace: test-cloneset
+    generation: 1
+operation: AggregateStatus
+output:
+  status:
+    replicas: 0
+    readyReplicas: 0
+    availableReplicas: 0
+    updatedReplicas: 0
+    updatedReadyReplicas: 0
+    expectedUpdatedReplicas: 0
+    observedGeneration: 1
+
+

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/interpretdependency-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/interpretdependency-test.yaml
@@ -44,3 +44,12 @@ desiredObj:
                     key: lower
 operation: InterpretDependency
 output:
+  dependencies:
+    - apiVersion: v1
+      kind: ConfigMap
+      namespace: test-cloneset
+      name: my-sample-config
+    - apiVersion: v1
+      kind: ConfigMap
+      namespace: test-cloneset
+      name: mysql-config

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/interprethealth-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/interprethealth-test.yaml
@@ -1,5 +1,8 @@
 # test case for interpreting health of CloneSet
 # case1. CloneSet interpreting health test
+# case2. CloneSet health when observedGeneration mismatches generation
+# case3. CloneSet health when updatedReplicas less than desired replicas
+# case4. CloneSet health when availableReplicas less than updatedReplicas
 
 name: "CloneSet interpreting health test"
 description: "Test interpreting health of CloneSet"
@@ -58,3 +61,82 @@ observedObj:
     updatedReplicas: 2
 operation: InterpretHealth
 output:
+  healthy: true
+---
+name: "CloneSet health when observedGeneration mismatches generation"
+description: "Health should be false when observedGeneration != generation"
+observedObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: CloneSet
+  metadata:
+    annotations:
+      resourcetemplate.karmada.io/generation: "1"
+    name: sample
+    namespace: test-cloneset
+    generation: 2
+  spec:
+    replicas: 2
+    template:
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+  status:
+    observedGeneration: 1
+    updatedReplicas: 2
+    availableReplicas: 2
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "CloneSet health when updatedReplicas less than desired replicas"
+description: "Health should be false when updatedReplicas < spec.replicas"
+observedObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: CloneSet
+  metadata:
+    annotations:
+      resourcetemplate.karmada.io/generation: "1"
+    name: sample
+    namespace: test-cloneset
+    generation: 1
+  spec:
+    replicas: 3
+    template:
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+  status:
+    observedGeneration: 1
+    updatedReplicas: 2
+    availableReplicas: 2
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "CloneSet health when availableReplicas less than updatedReplicas"
+description: "Health should be false when availableReplicas < updatedReplicas"
+observedObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: CloneSet
+  metadata:
+    annotations:
+      resourcetemplate.karmada.io/generation: "1"
+    name: sample
+    namespace: test-cloneset
+    generation: 1
+  spec:
+    replicas: 2
+    template:
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+  status:
+    observedGeneration: 1
+    updatedReplicas: 2
+    availableReplicas: 1
+operation: InterpretHealth
+output:
+  healthy: false  

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/interpretreplica-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/interpretreplica-test.yaml
@@ -43,3 +43,5 @@ desiredObj:
                     name: mysql-config
                     key: lower
 operation: InterpretReplica
+output:
+  replica: 4

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/interpretstatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/interpretstatus-test.yaml
@@ -58,3 +58,16 @@ observedObj:
     updatedReplicas: 2
 operation: InterpretStatus
 output:
+  status:
+    availableReplicas: 2
+    currentRevision: sample-59df6bd888
+    expectedUpdatedReplicas: 2
+    generation: 1
+    labelSelector: app=sample,test=cloneset
+    observedGeneration: 1
+    readyReplicas: 2
+    replicas: 2
+    resourceTemplateGeneration: 1
+    updateRevision: sample-59df6bd888
+    updatedReadyReplicas: 2
+    updatedReplicas: 2

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/revisereplica-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/revisereplica-test.yaml
@@ -45,3 +45,5 @@ desiredObj:
 inputReplicas: 1
 operation: ReviseReplica
 output:
+  spec:
+    replicas: 1


### PR DESCRIPTION
### What this PR does
Adds output-verification test cases for CloneSet under third-party resource customizations, covering:
	•	InterpretReplica
	•	InterpretHealth
	•	InterpretDependency
	•	InterpretStatus
	•	AggregateStatus
	•	ReviseReplica

### Why we need it
	•	Improves test coverage for Kruise CloneSet interpreter logic
	•	Ensures different logical paths are properly validated
	•	Keeps CloneSet tests consistent with existing third-party resources
### Notes
	Test cases are added based on logic complexity:
	•	Single test for straight-through logic (e.g. InterpretReplica)
	•	Multiple tests for operations with branching logic (e.g. InterpretHealth, AggregateStatus)
	•	No behavior change; test-only PR