### PR TITLE
karmadactl: fix the messy auto-completion suggestions

### DIFF
--- a/pkg/karmadactl/util/completion/completion.go
+++ b/pkg/karmadactl/util/completion/completion.go
@@ -252,15 +252,15 @@ func compGetResourceList(restClientGetter genericclioptions.RESTClientGetter, cm
 	// TODO: Using karmadactlapiresources.CommandAPIResourcesOptions to adapt to the operation scope.
 	o := apiresources.NewAPIResourceOptions(streams)
 
-	if err := o.Complete(restClientGetter, cmd, nil); err != nil {
-		return nil
-	}
-
 	// Get the list of resources
 	o.PrintFlags.OutputFormat = ptr.To("name")
 	o.Cached = true
 	o.Verbs = []string{"get"}
 	// TODO:Should set --request-timeout=5s
+
+	if err := o.Complete(restClientGetter, cmd, nil); err != nil {
+		return nil
+	}
 
 	// Ignore errors as the output may still be valid
 	if err := o.RunAPIResources(); err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
Recently, while using the auto-completion feature of `karmadactl get`, I noticed that the completion output is messy and unusable. For example, when typing `karmadactl get dep` and pressing Tab, the result appears as:

```bash
$ karmadactl get deployments\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ deploy\ \ \ \ apps/v1\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ true\ \ \ \ Deployment
```

The root cause lies in the `compGetResourceList` function, which calls `o.RunAPIResources()` to fetch the list of supported API resources from the environment. Normally, only the `name` column should be returned. This behavior is supposed to be controlled by the `o.PrintFlags.OutputFormat` setting within the `o.Complete` method. However, in `compGetResourceList`, the assignment to `o.PrintFlags.OutputFormat` occurs *after* `o.Complete`. As a result, the `OutputFormat` setting takes no effect, causing all columns—not just the `name`—to be returned during completion.

https://github.com/karmada-io/karmada/blob/ed620ac77196106ae497ed4ff211f5e3096dbec8/pkg/karmadactl/util/completion/completion.go#L255-L267


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
This issue affects not only `karmadactl get` but also other commands that rely on API resource completion, such as `karmadactl apply`.  
A backport to the `release-1.16` branch is required.

<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmadactl`: Fixed the messy auto-completion suggestions for commands like 'get' and 'apply'.
```

