### PR TITLE
Automated cherry pick of #7023: karmadactl: fix the messy auto-completion suggestions

### DIFF
--- a/pkg/karmadactl/util/completion/completion.go
+++ b/pkg/karmadactl/util/completion/completion.go
@@ -252,15 +252,15 @@ func compGetResourceList(restClientGetter genericclioptions.RESTClientGetter, cm
 	// TODO: Using karmadactlapiresources.CommandAPIResourcesOptions to adapt to the operation scope.
 	o := apiresources.NewAPIResourceOptions(streams)
 
-	if err := o.Complete(restClientGetter, cmd, nil); err != nil {
-		return nil
-	}
-
 	// Get the list of resources
 	o.PrintFlags.OutputFormat = ptr.To("name")
 	o.Cached = true
 	o.Verbs = []string{"get"}
 	// TODO:Should set --request-timeout=5s
+
+	if err := o.Complete(restClientGetter, cmd, nil); err != nil {
+		return nil
+	}
 
 	// Ignore errors as the output may still be valid
 	if err := o.RunAPIResources(); err != nil {


### PR DESCRIPTION
Cherry pick of #7023 on release-1.16.
#7023: karmadactl: fix the messy auto-completion suggestions
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmadactl`: Fixed the messy auto-completion suggestions for commands like 'get' and 'apply'.
```