### PR TITLE
Add complete interpreter test coverage for BroadcastJob

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/customizations.yaml
@@ -156,6 +156,6 @@ spec:
       luaScript: >
         local kube = require("kube")
         function GetDependencies(desiredObj)
-          refs = kube.getPodDependencies(desiredObj.spec.template, desiredObj.metadata.namespace)
+          refs = kube.getPodDependencies(desiredObj.spec.template, desiredObj.metadata.namespace)   
           return refs
         end

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/aggregatestatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/aggregatestatus-test.yaml
@@ -1,6 +1,8 @@
 # test case for aggregating status of BroadcastJob
 # case1. BroadcastJob with two status items
-
+# case2. BroadcastJob completed in all clusters
+# case3. BroadcastJob with active and succeeded jobs
+# case4. BroadcastJob with no status items
 name: "BroadcastJob with two status items"
 description: "Test aggregating status of BroadcastJob with two status items"
 desiredObj:
@@ -79,3 +81,89 @@ statusItems:
       succeeded: 0
 operation: AggregateStatus
 output:
+  status:
+    active: 0
+    succeeded: 0
+    failed: 2
+    desired: 2
+    phase: failed
+    conditions:
+      - type: Failed
+        status: "True"
+        reason: JobFailed
+        message: "Job executed failed in member clusters: member1, member3"
+---
+name: "BroadcastJob completed in all clusters"
+description: "AggregateStatus when all jobs succeed"
+desiredObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: BroadcastJob
+  metadata:
+    name: sample
+    namespace: test-bcj
+statusItems:
+  - clusterName: member1
+    status:
+      succeeded: 1
+      desired: 1
+      conditions:
+        - type: Complete
+          status: "True"
+  - clusterName: member2
+    status:
+      succeeded: 1
+      desired: 1
+      conditions:
+        - type: Complete
+          status: "True"
+operation: AggregateStatus
+output:
+  status:
+    active: 0
+    succeeded: 2
+    failed: 0
+    desired: 2
+    phase: ""
+    conditions:
+      - type: Completed
+        status: "True"
+        reason: Completed
+        message: Job completed
+---
+name: "BroadcastJob with active and succeeded jobs"
+description: "AggregateStatus aggregates counters without terminal state"
+desiredObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: BroadcastJob
+  metadata:
+    name: sample
+    namespace: test-bcj
+statusItems:
+  - clusterName: member1
+    status:
+      active: 1
+      desired: 1
+  - clusterName: member2
+    status:
+      succeeded: 1
+      desired: 1
+operation: AggregateStatus
+output:
+  status:
+    active: 1
+    succeeded: 1
+    failed: 0
+    desired: 2
+    phase: ""
+    conditions: []
+---
+name: "BroadcastJob with no status items"
+description: "AggregateStatus when job is not propagated"
+desiredObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: BroadcastJob
+  metadata:
+    name: sample
+    namespace: test-bcj
+operation: AggregateStatus
+output: {}

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/interpretdependency-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/interpretdependency-test.yaml
@@ -1,5 +1,7 @@
 # test case for interpreting dependency of BroadcastJob
 # case1. BroadcastJob with configmap dependency
+# case2. BroadcastJob with secret dependency
+# case3. BroadcastJob with configmap and secret dependency
 
 name: "BroadcastJob with configmap dependency"
 description: "Test interpreting dependency of BroadcastJob with configmap dependency"
@@ -42,3 +44,67 @@ desiredObj:
       activeDeadlineSeconds: 10
 operation: InterpretDependency
 output:
+ configMaps:
+    - name: my-sample-config
+      namespace: test-bcj
+    - name: mysql-config
+      namespace: test-bcj
+---
+name: "BroadcastJob with secret dependency"
+description: "Test interpreting dependency of BroadcastJob with secret env reference"
+desiredObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: BroadcastJob
+  metadata:
+    name: sample
+    namespace: test-bcj
+  spec:
+    template:
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+            env:
+              - name: SECRET_VAL
+                valueFrom:
+                  secretKeyRef:
+                    name: my-secret
+                    key: password
+operation: InterpretDependency
+output:
+  secrets:
+    - name: my-secret
+      namespace: test-bcj
+---
+name: "BroadcastJob with configmap and secret dependency"
+description: "Test interpreting mixed dependencies"
+desiredObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: BroadcastJob
+  metadata:
+    name: sample
+    namespace: test-bcj
+  spec:
+    template:
+      spec:
+        volumes:
+          - name: cm
+            configMap:
+              name: app-config
+        containers:
+          - name: nginx
+            image: nginx:alpine
+            env:
+              - name: TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: api-secret
+                    key: token
+operation: InterpretDependency
+output:
+  configMaps:
+    - name: app-config
+      namespace: test-bcj
+  secrets:
+    - name: api-secret
+      namespace: test-bcj

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/interprethealth-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/interprethealth-test.yaml
@@ -1,6 +1,8 @@
 # test case for interpreting health of BroadcastJob
 # case1. BroadcastJob with failed phase should be Unhealthy
-
+# case2. BroadcastJob with desired zero should be Unhealthy
+# case3. BroadcastJob with no active and no succeeded should be Unhealthy
+# case4. BroadcastJob healthy when active or succeeded exists
 name: "BroadcastJob with failed phase should be Unhealthy"
 description: "Test interpreting health of BroadcastJob with failed phase"
 observedObj:
@@ -58,3 +60,54 @@ observedObj:
 operation: InterpretHealth
 output:
     health: false
+---
+name: "BroadcastJob with desired zero should be Unhealthy"
+description: "Health should be false when desired is zero"
+observedObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: BroadcastJob
+  metadata:
+    name: sample
+    namespace: test-bcj
+  status:
+    desired: 0
+    active: 0
+    succeeded: 0
+    failed: 0
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "BroadcastJob with no active and no succeeded should be Unhealthy"
+description: "Health should be false when both active and succeeded are zero"
+observedObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: BroadcastJob
+  metadata:
+    name: sample
+    namespace: test-bcj
+  status:
+    desired: 1
+    active: 0
+    succeeded: 0
+    failed: 0
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "BroadcastJob healthy when active or succeeded exists"
+description: "Health should be true when job is progressing or succeeded"
+observedObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: BroadcastJob
+  metadata:
+    name: sample
+    namespace: test-bcj
+  status:
+    desired: 1
+    active: 1
+    succeeded: 0
+    failed: 0
+operation: InterpretHealth
+output:
+  healthy: true

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/interpretreplica-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/interpretreplica-test.yaml
@@ -1,5 +1,7 @@
 # test case for interpreting replica of BroadcastJob
 # case1. BroadcastJob with parallelism set to 1
+# case2. BroadcastJob with parallelism set to 3
+# case3. BroadcastJob without parallelism
 
 name: "BroadcastJob with parallelism set to 1"
 description: "Test interpreting replica of BroadcastJob with parallelism set to 1"
@@ -41,3 +43,42 @@ desiredObj:
       type: Always
       activeDeadlineSeconds: 10
 operation: InterpretReplica
+output:
+  replica: 1
+---
+name: "BroadcastJob with parallelism set to 3"
+description: "Test interpreting replica of BroadcastJob with parallelism set to 3"
+desiredObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: BroadcastJob
+  metadata:
+    name: sample
+    namespace: test-bcj
+  spec:
+    parallelism: 3
+    template:
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+operation: InterpretReplica
+output:
+  replica: 3
+---
+name: "BroadcastJob without parallelism"
+description: "Test interpreting replica when parallelism is not specified"
+desiredObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: BroadcastJob
+  metadata:
+    name: sample
+    namespace: test-bcj
+  spec:
+    template:
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+operation: InterpretReplica
+output:
+  replica: 1

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/interpretstatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/interpretstatus-test.yaml
@@ -1,5 +1,7 @@
 # test case for interpreting status of BroadcastJob
 # case1. BroadcastJob: interpret status test
+# case2. BroadcastJob succeeded status
+# case3. BroadcastJob with empty status
 
 name: "BroadcastJob: interpret status test"
 description: "Test interpreting status for BroadcastJob"
@@ -57,3 +59,63 @@ observedObj:
     succeeded: 0
 operation: InterpretStatus
 output:
+  status:
+    active: 0
+    succeeded: 0
+    failed: 1
+    desired: 1
+    phase: failed
+    startTime: "2023-04-06T15:01:37Z"
+    completionTime: "2023-04-06T15:01:47Z"
+    conditions:
+      - lastProbeTime: "2023-04-06T15:01:47Z"
+        lastTransitionTime: "2023-04-06T15:01:47Z"
+        message: Job test-bcj/sample was active longer than specified deadline
+        reason: Failed
+        status: "True"
+        type: Failed
+---
+name: "BroadcastJob succeeded status"
+description: "InterpretStatus when BroadcastJob completes successfully"
+observedObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: BroadcastJob
+  metadata:
+    name: sample
+    namespace: test-bcj
+  status:
+    active: 0
+    succeeded: 1
+    failed: 0
+    desired: 1
+    phase: completed
+    startTime: "2023-04-06T15:01:10Z"
+    completionTime: "2023-04-06T15:01:20Z"
+    conditions:
+      - type: Complete
+        status: "True"
+operation: InterpretStatus
+output:
+  status:
+    active: 0
+    succeeded: 1
+    failed: 0
+    desired: 1
+    phase: completed
+    startTime: "2023-04-06T15:01:10Z"
+    completionTime: "2023-04-06T15:01:20Z"
+    conditions:
+      - type: Complete
+        status: "True"
+---
+name: "BroadcastJob with empty status"
+description: "InterpretStatus should return empty status when status is nil"
+observedObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: BroadcastJob
+  metadata:
+    name: sample
+    namespace: test-bcj
+operation: InterpretStatus
+output:
+  status: {}

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/retain-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/retain-test.yaml
@@ -1,5 +1,6 @@
 # test case for retaining BroadcastJob
 # case1. BroadcastJob: retain test
+# case2. BroadcastJob retain should preserve observed labels
 
 name: "BroadcastJob: retain test"
 description: "Test retaining BroadcastJob"
@@ -94,3 +95,76 @@ observedObj:
     succeeded: 0
 operation: Retain
 output:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: BroadcastJob
+  metadata:
+    labels:
+      app: sample
+    name: sample
+    namespace: test-bcj
+  spec:
+    parallelism: 1
+    template:
+      metadata:
+        labels:
+          app: sample
+      spec:
+        restartPolicy: Never
+        volumes:
+          - name: configmap
+            configMap:
+              name: my-sample-config
+        containers:
+          - name: nginx
+            image: nginx:alpine
+            env:
+              - name: logData
+                valueFrom:
+                  configMapKeyRef:
+                    name: mysql-config
+                    key: log
+              - name: lowerData
+                valueFrom:
+                  configMapKeyRef:
+                    name: mysql-config
+                    key: lower
+    completionPolicy:
+      type: Always
+      activeDeadlineSeconds: 10
+---
+name: "BroadcastJob retain should preserve observed labels"
+description: "Retain should copy pod template labels from observedObj"
+desiredObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: BroadcastJob
+  metadata:
+    name: sample
+    namespace: test-bcj
+  spec:
+    template:
+      metadata:
+        labels:
+          app: old-label
+observedObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: BroadcastJob
+  metadata:
+    name: sample
+    namespace: test-bcj
+  spec:
+    template:
+      metadata:
+        labels:
+          app: new-label
+operation: Retain
+output:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: BroadcastJob
+  metadata:
+    name: sample
+    namespace: test-bcj
+  spec:
+    template:
+      metadata:
+        labels:
+          app: new-label

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/revisereplica-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/revisereplica-test.yaml
@@ -1,45 +1,23 @@
 # test case for revise replica
-# case1. BroadcastJob: revise replica test
+# case1. BroadcastJob revise replica should update parallelism
 
-name: "BroadcastJob: revise replica test"
-description: "Test revising replica of BroadcastJob"
+name: "BroadcastJob revise replica should update parallelism"
+description: "ReviseReplica updates spec.parallelism"
 desiredObj:
   apiVersion: apps.kruise.io/v1alpha1
   kind: BroadcastJob
   metadata:
-    labels:
-      app: sample
     name: sample
     namespace: test-bcj
   spec:
     parallelism: 1
-    template:
-      metadata:
-        labels:
-          app: sample
-      spec:
-        restartPolicy: Never
-        volumes:
-          - name: configmap
-            configMap:
-              name: my-sample-config
-        containers:
-          - name: nginx
-            image: nginx:alpine
-            env:
-              - name: logData
-                valueFrom:
-                  configMapKeyRef:
-                    name: mysql-config
-                    key: log
-              - name: lowerData
-                valueFrom:
-                  configMapKeyRef:
-                    name: mysql-config
-                    key: lower
-    completionPolicy:
-      type: Always
-      activeDeadlineSeconds: 10
-inputReplicas: 1
+inputReplicas: 3
 operation: ReviseReplica
 output:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: BroadcastJob
+  metadata:
+    name: sample
+    namespace: test-bcj
+  spec:
+    parallelism: 3


### PR DESCRIPTION
### What this PR does
Adds comprehensive interpreter test coverage for BroadcastJob.

### Details
- Covers AggregateStatus, InterpretHealth, InterpretDependency
- Adds tests for InterpretReplica, InterpretStatus, Retain, and ReviseReplica
- All tests are passing locally

### Why we need it
Improves correctness and reliability of BroadcastJob interpreter behavior.