### PR TITLE
skip cleanup rt and binding when the server could not find the requested resource

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -1014,6 +1014,7 @@ func (d *ResourceDetector) ReconcilePropagationPolicy(key util.QueueKey) error {
 		policyID := propagationObject.Labels[policyv1alpha1.PropagationPolicyPermanentIDLabel]
 		claimMetadata := labels.Set{policyv1alpha1.PropagationPolicyPermanentIDLabel: policyID}
 		if err = d.handlePolicyDeletion(claimMetadata, propagationObject.Spec.ResourceSelectors, CleanupPPClaimMetadata); err != nil {
+			klog.Errorf("Failed to handle policy deletion for PropagationPolicy(%s), err: %v", nkey.NamespaceKey(), err)
 			return err
 		}
 		if controllerutil.RemoveFinalizer(propagationObject, util.PropagationPolicyControllerFinalizer) {
@@ -1089,6 +1090,7 @@ func (d *ResourceDetector) ReconcileClusterPropagationPolicy(key util.QueueKey) 
 		policyID := propagationObject.Labels[policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel]
 		claimMetadata := labels.Set{policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel: policyID}
 		if err = d.handlePolicyDeletion(claimMetadata, propagationObject.Spec.ResourceSelectors, CleanupCPPClaimMetadata); err != nil {
+			klog.Errorf("Failed to handle policy deletion for ClusterPropagationPolicy(%s), err: %v", nkey.NamespaceKey(), err)
 			return err
 		}
 		if controllerutil.RemoveFinalizer(propagationObject, util.ClusterPropagationPolicyControllerFinalizer) {
@@ -1121,6 +1123,11 @@ func (d *ResourceDetector) handlePolicyDeletion(claimMetadata labels.Set, resour
 		rawObjects, err := helper.FetchResourceTemplatesByLabelSelector(d.DynamicClient, d.InformerManager, d.RESTMapper, objRef, labels.SelectorFromSet(claimMetadata))
 		if meta.IsNoMatchError(err) {
 			klog.Infof("Skip cleanup as API(%s, kind=%s) is not installed or has been removed", objRef.APIVersion, objRef.Kind)
+			continue
+		}
+		if apierrors.IsNotFound(err) {
+			// This error may occur because a namespace was incorrectly specified for a cluster-scoped resource.
+			klog.Infof("Skip cleanup as the server could not find the requested resource(%s, kind=%s, namespace=%s).", objRef.APIVersion, objRef.Kind, objRef.Namespace)
 			continue
 		}
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
When deleting a PropagationPolicy or ClusterPropagationPolicy, the cleanup logic attempts to find all resources matched by the policy's resource selectors. If a selector targets a resource that doesn't exist (for example, a cluster-scoped resource with a namespace specified), the API server returns a "Not Found" error. Previously, this error would be propagated up, potentially blocking the policy from being finalized and deleted.

This PR fixes this by specifically handling `apierrors.IsNotFound` errors during the cleanup process. Now, when a resource is not found, an informational message is logged, and the process continues to the next resource, ensuring that policy deletion is not blocked by selectors pointing to non-existent resources.

Additionally, error logging has been added to the policy deletion handlers to improve traceability when failures occur.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-controller-manager`: Fixed an issue where policy deletion could be blocked if a resource selector targeted a non-existent resource.
```

