### PR TITLE
Add interpreter test coverage for StatefulSet

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/aggregatestatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/aggregatestatus-test.yaml
@@ -1,5 +1,9 @@
 # test case for aggregating status of StatefulSet
 # case1. StatefulSet with two status items
+# case2. StatefulSet with partially ready replicas
+# case3. StatefulSet with mixed observed generations
+# case4. StatefulSet with no status items
+# case5. StatefulSet with stale resourceTemplateGeneration
 
 name: "StatefulSet with two status items"
 description: "Test aggregating status of StatefulSet with two status items"
@@ -86,3 +90,233 @@ statusItems:
       updatedReplicas: 2
 operation: AggregateStatus
 output:
+  aggregatedStatus:
+    apiVersion: apps.kruise.io/v1beta1
+    kind: StatefulSet
+    metadata:
+      name: sample
+      namespace: test-statefulset
+      generation: 1
+    spec:
+      replicas: 2
+      serviceName: sample-statefulset-headless-service
+      podManagementPolicy: Parallel
+      selector:
+        matchLabels:
+          app: sample
+      template:
+        metadata:
+          labels:
+            app: sample
+        spec:
+          volumes:
+            - name: configmap
+              configMap:
+                name: my-sample-config
+          readinessGates:
+            - conditionType: InPlaceUpdateReady
+          containers:
+            - name: nginx
+              image: nginx:alpine
+              ports:
+                - containerPort: 80
+                  name: web
+              env:
+                - name: logData
+                  valueFrom:
+                    configMapKeyRef:
+                      name: mysql-config
+                      key: log
+                - name: lowerData
+                  valueFrom:
+                    configMapKeyRef:
+                      name: mysql-config
+                      key: lower
+      updateStrategy:
+        type: RollingUpdate
+        rollingUpdate:
+          podUpdatePolicy: InPlaceIfPossible
+          maxUnavailable: 2
+    status:
+      replicas: 4
+      readyReplicas: 4
+      currentReplicas: 4
+      updatedReplicas: 4
+      availableReplicas: 4
+      updatedReadyReplicas: 4
+      updateRevision: sample-5675547df7
+      currentRevision: sample-5675547df7
+      observedGeneration: 1
+---
+name: "StatefulSet with partially ready replicas"
+description: "AggregateStatus when some replicas are not ready"
+desiredObj:
+  apiVersion: apps.kruise.io/v1beta1
+  kind: StatefulSet
+  metadata:
+    name: sample
+    namespace: test-statefulset
+    generation: 2
+statusItems:
+  - clusterName: member1
+    status:
+      replicas: 2
+      readyReplicas: 1
+      availableReplicas: 1
+      updatedReplicas: 2
+      updatedReadyReplicas: 1
+      currentReplicas: 2
+      generation: 2
+      observedGeneration: 2
+      resourceTemplateGeneration: 2
+  - clusterName: member2
+    status:
+      replicas: 2
+      readyReplicas: 2
+      availableReplicas: 2
+      updatedReplicas: 2
+      updatedReadyReplicas: 2
+      currentReplicas: 2
+      generation: 2
+      observedGeneration: 2
+      resourceTemplateGeneration: 2
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: apps.kruise.io/v1beta1
+    kind: StatefulSet
+    metadata:
+      name: sample
+      namespace: test-statefulset
+      generation: 2
+    status:
+      replicas: 4
+      readyReplicas: 3
+      currentReplicas: 4
+      updatedReplicas: 4
+      availableReplicas: 3
+      updatedReadyReplicas: 3
+      currentRevision: ""
+      updateRevision: ""
+      observedGeneration: 2
+---
+name: "StatefulSet with mixed observed generations"
+description: "ObservedGeneration should not advance if any member is stale"
+desiredObj:
+  apiVersion: apps.kruise.io/v1beta1
+  kind: StatefulSet
+  metadata:
+    name: sample
+    namespace: test-statefulset
+    generation: 3
+  status:
+    observedGeneration: 2
+statusItems:
+  - clusterName: member1
+    status:
+      replicas: 2
+      readyReplicas: 2
+      generation: 3
+      observedGeneration: 3
+      resourceTemplateGeneration: 3
+  - clusterName: member2
+    status:
+      replicas: 2
+      readyReplicas: 2
+      generation: 3
+      observedGeneration: 2
+      resourceTemplateGeneration: 3
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: apps.kruise.io/v1beta1
+    kind: StatefulSet
+    metadata:
+      name: sample
+      namespace: test-statefulset
+      generation: 3
+    status:
+      replicas: 4
+      readyReplicas: 4
+      currentReplicas: 0
+      updatedReplicas: 0
+      availableReplicas: 0
+      updatedReadyReplicas: 0
+      currentRevision: ""
+      updateRevision: ""
+      observedGeneration: 2
+---
+name: "StatefulSet with no status items"
+description: "AggregateStatus when StatefulSet is not propagated"
+desiredObj:
+  apiVersion: apps.kruise.io/v1beta1
+  kind: StatefulSet
+  metadata:
+    name: sample
+    namespace: test-statefulset
+    generation: 1
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: apps.kruise.io/v1beta1
+    kind: StatefulSet
+    metadata:
+      name: sample
+      namespace: test-statefulset
+      generation: 1
+    status:
+      replicas: 0
+      readyReplicas: 0
+      currentReplicas: 0
+      updatedReplicas: 0
+      availableReplicas: 0
+      updatedReadyReplicas: 0
+      updateRevision: ""
+      currentRevision: ""
+      observedGeneration: 1
+---
+name: "StatefulSet with stale resourceTemplateGeneration"
+description: "observedGeneration should not advance when any member has stale resourceTemplateGeneration"
+desiredObj:
+  apiVersion: apps.kruise.io/v1beta1
+  kind: StatefulSet
+  metadata:
+    name: sample
+    namespace: test-statefulset
+    generation: 3
+  status:
+    observedGeneration: 2
+statusItems:
+  - clusterName: member1
+    status:
+      replicas: 2
+      readyReplicas: 2
+      generation: 3
+      observedGeneration: 3
+      resourceTemplateGeneration: 3
+  - clusterName: member2
+    status:
+      replicas: 2
+      readyReplicas: 2
+      generation: 3
+      observedGeneration: 3
+      resourceTemplateGeneration: 2   
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: apps.kruise.io/v1beta1
+    kind: StatefulSet
+    metadata:
+      name: sample
+      namespace: test-statefulset
+      generation: 3
+    status:
+      replicas: 4
+      readyReplicas: 4
+      observedGeneration: 2
+      availableReplicas: 0
+      currentReplicas: 0
+      updatedReplicas: 0
+      updatedReadyReplicas: 0
+      updateRevision: ""
+      currentRevision: ""

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/interpretdependency-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/interpretdependency-test.yaml
@@ -1,0 +1,42 @@
+# test case for interpreting dependency of StatefulSet
+# case1. StatefulSet with configmap and secret dependency
+
+name: "StatefulSet with configmap and secret dependency"
+description: "InterpretDependency should return configmap and secret references"
+desiredObj:
+  apiVersion: apps.kruise.io/v1beta1
+  kind: StatefulSet
+  metadata:
+    name: sample
+    namespace: test-ns
+  spec:
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: sample
+      spec:
+        volumes:
+          - name: config-vol
+            configMap:
+              name: my-config
+        containers:
+          - name: nginx
+            image: nginx:alpine
+            env:
+              - name: SECRET_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: my-secret
+                    key: password
+operation: InterpretDependency
+output:
+  dependencies:
+    - apiVersion: v1
+      kind: ConfigMap
+      name: my-config
+      namespace: test-ns
+    - apiVersion: v1
+      kind: Secret
+      name: my-secret
+      namespace: test-ns

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/interprethealth-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/interprethealth-test.yaml
@@ -1,0 +1,81 @@
+# test case for interpreting health of StatefulSet
+# case1. StatefulSet unhealthy when observedGeneration mismatches
+# case2. StatefulSet unhealthy when rollout is not complete
+# case3. StatefulSet unhealthy when availableReplicas < updatedReplicas
+# case4. StatefulSet healthy when rollout and availability are complete
+
+name: "StatefulSet unhealthy when observedGeneration mismatches"
+description: "Health should be false if observedGeneration != metadata.generation"
+observedObj:
+  apiVersion: apps.kruise.io/v1beta1
+  kind: StatefulSet
+  metadata:
+    name: sample
+    namespace: default
+    generation: 2
+  spec:
+    replicas: 3
+  status:
+    observedGeneration: 1
+    updatedReplicas: 3
+    availableReplicas: 3
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "StatefulSet unhealthy when rollout is not complete"
+description: "Health should be false if updatedReplicas < spec.replicas"
+observedObj:
+  apiVersion: apps.kruise.io/v1beta1
+  kind: StatefulSet
+  metadata:
+    name: sample
+    namespace: default
+    generation: 1
+  spec:
+    replicas: 3
+  status:
+    observedGeneration: 1
+    updatedReplicas: 2
+    availableReplicas: 2
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "StatefulSet unhealthy when availableReplicas < updatedReplicas"
+description: "Health should be false if availability lags rollout"
+observedObj:
+  apiVersion: apps.kruise.io/v1beta1
+  kind: StatefulSet
+  metadata:
+    name: sample
+    namespace: default
+    generation: 1
+  spec:
+    replicas: 3
+  status:
+    observedGeneration: 1
+    updatedReplicas: 3
+    availableReplicas: 2
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "StatefulSet healthy when rollout and availability are complete"
+description: "Health should be true when all conditions are satisfied"
+observedObj:
+  apiVersion: apps.kruise.io/v1beta1
+  kind: StatefulSet
+  metadata:
+    name: sample
+    namespace: default
+    generation: 1
+  spec:
+    replicas: 3
+  status:
+    observedGeneration: 1
+    updatedReplicas: 3
+    availableReplicas: 3
+operation: InterpretHealth
+output:
+  healthy: true

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/interpretreplica-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/interpretreplica-test.yaml
@@ -1,0 +1,47 @@
+# test case for interpreting replica of StatefulSet
+# case1. StatefulSet with replicas set
+# case2. StatefulSet with zero replicas
+
+name: "StatefulSet with replicas set to 3"
+description: "InterpretReplica should return replicas from spec.replicas"
+desiredObj:
+  apiVersion: apps.kruise.io/v1beta1
+  kind: StatefulSet
+  metadata:
+    name: sample
+    namespace: default
+  spec:
+    replicas: 3
+    template:
+      metadata:
+        labels:
+          app: sample
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+operation: InterpretReplica
+output:
+  replica: 3
+---
+name: "StatefulSet with zero replicas"
+description: "InterpretReplica should return zero replicas"
+desiredObj:
+  apiVersion: apps.kruise.io/v1beta1
+  kind: StatefulSet
+  metadata:
+    name: sample
+    namespace: default
+  spec:
+    replicas: 0
+    template:
+      metadata:
+        labels:
+          app: sample
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+operation: InterpretReplica
+output:
+  replica: 0

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/interpretstatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/interpretstatus-test.yaml
@@ -1,5 +1,6 @@
 # test case for interpreting status of StatefulSet
 # case1. StatefulSet: interpret status test
+# case2. StatefulSet interpret status without resourceTemplateGeneration annotation
 
 name: "StatefulSet: interpret status test"
 description: "Test interpreting status for StatefulSet"
@@ -66,3 +67,44 @@ observedObj:
     updatedReplicas: 2
 operation: InterpretStatus
 output:
+  status:
+    replicas: 2
+    readyReplicas: 2
+    currentReplicas: 2
+    updatedReplicas: 2
+    availableReplicas: 2
+    updatedReadyReplicas: 2
+    updateRevision: sample-5675547df7
+    currentRevision: sample-5675547df7
+    observedGeneration: 1
+    generation: 1
+    resourceTemplateGeneration: 1
+---
+name: "StatefulSet interpret status without resourceTemplateGeneration annotation"
+description: "InterpretStatus without resourcetemplate annotation"
+observedObj:
+  apiVersion: apps.kruise.io/v1beta1
+  kind: StatefulSet
+  metadata:
+    name: sample
+    namespace: test-statefulset
+    generation: 2
+  status:
+    replicas: 3
+    readyReplicas: 2
+    currentReplicas: 3
+    updatedReplicas: 3
+    availableReplicas: 2
+    updatedReadyReplicas: 2
+    observedGeneration: 2
+operation: InterpretStatus
+output:
+  status:
+    replicas: 3
+    readyReplicas: 2
+    currentReplicas: 3
+    updatedReplicas: 3
+    availableReplicas: 2
+    updatedReadyReplicas: 2
+    observedGeneration: 2
+    generation: 2

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/revisereplica-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1beta1/StatefulSet/testdata/revisereplica-test.yaml
@@ -1,0 +1,40 @@
+# test case for revising replica of StatefulSet
+# case1. StatefulSet revise replica from 1 to 3
+
+name: "StatefulSet revise replica from 1 to 3"
+description: "ReviseReplica should update spec.replicas to desired value"
+desiredObj:
+  apiVersion: apps.kruise.io/v1beta1
+  kind: StatefulSet
+  metadata:
+    name: sample
+    namespace: default
+  spec:
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: sample
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+inputReplicas: 3
+operation: ReviseReplica
+output:
+  revised:
+    apiVersion: apps.kruise.io/v1beta1
+    kind: StatefulSet
+    metadata:
+      name: sample
+      namespace: default
+    spec:
+      replicas: 3
+      template:
+        metadata:
+          labels:
+            app: sample
+        spec:
+          containers:
+            - name: nginx
+              image: nginx:alpine


### PR DESCRIPTION
### What this PR does
Adds  interpreter test coverage for Kruise StatefulSet, including:
- InterpretHealth
- InterpretReplica
- ReviseReplica
- InterpretDependency
- InterpretStatus
- AggregateStatus

### Notes
- Tests follow existing third-party interpreter patterns
- No functional logic changes, tests only