### PR TITLE
Add validation to ensure output keys match actual results in thirdpart resource interpreter UT

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/README.md
+++ b/pkg/resourceinterpreter/default/thirdparty/README.md
@@ -76,6 +76,18 @@ type IndividualTest struct {
 Where:
 - `Output` The output are key-value mapping where the key is the field name of the expected result and the value is the expected result. The keys in output for different operations correspond to the Name field of the results returned by the corresponding resource interpreter operation `RuleResult.Results`.
 
+**Important:** All keys defined in the `output` field must exist in the actual test results. If any defined key is missing from the results, the test will fail. This ensures test accuracy and prevents silent failures due to typos or incorrect key names.
+
+**Supported output keys by operation:**
+- `Retention`: `retained` - The object after retention rules applied
+- `InterpretReplica`: `replica` - The replica count, `requires` - Resource requirements
+- `InterpretComponent`: `components` - List of component objects
+- `ReviseReplica`: `revised` - The object with revised replica count
+- `InterpretStatus`: `status` - The reflected status object
+- `AggregateStatus`: `aggregatedStatus` - The object with aggregated status
+- `InterpretHealth`: `healthy` - Boolean indicating health status
+- `InterpretDependency`: `dependencies` - List of dependent resources
+
 For example:
 ```go
 func (h *healthInterpretationRule) Run(interpreter *declarative.ConfigurableInterpreter, args RuleArgs) *RuleResult {

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/aggregatestatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/aggregatestatus-test.yaml
@@ -3,6 +3,8 @@
 # case2. BroadcastJob completed in all clusters
 # case3. BroadcastJob with active and succeeded jobs
 # case4. BroadcastJob with no status items
+
+# Case 1:
 name: "BroadcastJob with two status items"
 description: "Test aggregating status of BroadcastJob with two status items"
 desiredObj:
@@ -13,35 +15,6 @@ desiredObj:
       app: sample
     name: sample
     namespace: test-bcj
-  spec:
-    parallelism: 1
-    template:
-      metadata:
-        labels:
-          app: sample
-      spec:
-        restartPolicy: Never
-        volumes:
-          - name: configmap
-            configMap:
-              name: my-sample-config
-        containers:
-          - name: nginx
-            image: nginx:alpine
-            env:
-              - name: logData
-                valueFrom:
-                  configMapKeyRef:
-                    name: mysql-config
-                    key: log
-              - name: lowerData
-                valueFrom:
-                  configMapKeyRef:
-                    name: mysql-config
-                    key: lower
-    completionPolicy:
-      type: Always
-      activeDeadlineSeconds: 10
 statusItems:
   - applied: true
     clusterName: member1
@@ -81,18 +54,27 @@ statusItems:
       succeeded: 0
 operation: AggregateStatus
 output:
-  status:
-    active: 0
-    succeeded: 0
-    failed: 2
-    desired: 2
-    phase: failed
-    conditions:
-      - type: Failed
-        status: "True"
-        reason: JobFailed
-        message: "Job executed failed in member clusters: member1, member3"
+  aggregatedStatus:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: BroadcastJob
+    metadata:
+      labels:
+        app: sample
+      name: sample
+      namespace: test-bcj
+    status:
+      active: 0
+      conditions:
+        - type: Failed
+          status: "True"
+          reason: JobFailed
+          message: 'Job executed failed in member clusters: member1, member3'
+      desired: 2
+      failed: 2
+      phase: failed
+      succeeded: 0
 ---
+# Case 2:
 name: "BroadcastJob completed in all clusters"
 description: "AggregateStatus when all jobs succeed"
 desiredObj:
@@ -118,18 +100,25 @@ statusItems:
           status: "True"
 operation: AggregateStatus
 output:
-  status:
-    active: 0
-    succeeded: 2
-    failed: 0
-    desired: 2
-    phase: ""
-    conditions:
-      - type: Completed
-        status: "True"
-        reason: Completed
-        message: Job completed
+  aggregatedStatus:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: BroadcastJob
+    metadata:
+      name: sample
+      namespace: test-bcj
+    status:
+      active: 0
+      conditions:
+        - type: Completed
+          status: "True"
+          reason: Completed
+          message: 'Job completed'
+      desired: 2
+      failed: 0
+      phase: ""
+      succeeded: 2
 ---
+# Case 3:
 name: "BroadcastJob with active and succeeded jobs"
 description: "AggregateStatus aggregates counters without terminal state"
 desiredObj:
@@ -149,14 +138,20 @@ statusItems:
       desired: 1
 operation: AggregateStatus
 output:
-  status:
-    active: 1
-    succeeded: 1
-    failed: 0
-    desired: 2
-    phase: ""
-    conditions: []
+  aggregatedStatus:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: BroadcastJob
+    metadata:
+      name: sample
+      namespace: test-bcj
+    status:
+      active: 1
+      desired: 2
+      phase: ""
+      failed: 0
+      succeeded: 1
 ---
+# Case 4:
 name: "BroadcastJob with no status items"
 description: "AggregateStatus when job is not propagated"
 desiredObj:

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/interpretdependency-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/interpretdependency-test.yaml
@@ -3,6 +3,7 @@
 # case2. BroadcastJob with secret dependency
 # case3. BroadcastJob with configmap and secret dependency
 
+# Case 1:
 name: "BroadcastJob with configmap dependency"
 description: "Test interpreting dependency of BroadcastJob with configmap dependency"
 desiredObj:
@@ -44,12 +45,17 @@ desiredObj:
       activeDeadlineSeconds: 10
 operation: InterpretDependency
 output:
- configMaps:
-    - name: my-sample-config
+  dependencies:
+    - apiVersion: v1
+      kind: ConfigMap
+      name: my-sample-config
       namespace: test-bcj
-    - name: mysql-config
+    - apiVersion: v1
+      kind: ConfigMap
+      name: mysql-config
       namespace: test-bcj
 ---
+# Case 2:
 name: "BroadcastJob with secret dependency"
 description: "Test interpreting dependency of BroadcastJob with secret env reference"
 desiredObj:
@@ -72,10 +78,13 @@ desiredObj:
                     key: password
 operation: InterpretDependency
 output:
-  secrets:
-    - name: my-secret
+  dependencies:
+    - apiVersion: v1
+      kind: Secret
+      name: my-secret
       namespace: test-bcj
 ---
+# Case 3:
 name: "BroadcastJob with configmap and secret dependency"
 description: "Test interpreting mixed dependencies"
 desiredObj:
@@ -102,9 +111,12 @@ desiredObj:
                     key: token
 operation: InterpretDependency
 output:
-  configMaps:
-    - name: app-config
+  dependencies:
+    - apiVersion: v1
+      kind: ConfigMap
+      name: app-config
       namespace: test-bcj
-  secrets:
-    - name: api-secret
+    - apiVersion: v1
+      kind: Secret
+      name: api-secret
       namespace: test-bcj

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/interprethealth-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/interprethealth-test.yaml
@@ -3,6 +3,8 @@
 # case2. BroadcastJob with desired zero should be Unhealthy
 # case3. BroadcastJob with no active and no succeeded should be Unhealthy
 # case4. BroadcastJob healthy when active or succeeded exists
+
+# Case 1:
 name: "BroadcastJob with failed phase should be Unhealthy"
 description: "Test interpreting health of BroadcastJob with failed phase"
 observedObj:
@@ -59,8 +61,9 @@ observedObj:
     succeeded: 0
 operation: InterpretHealth
 output:
-    health: false
+  healthy: false
 ---
+# Case 2:
 name: "BroadcastJob with desired zero should be Unhealthy"
 description: "Health should be false when desired is zero"
 observedObj:
@@ -78,6 +81,7 @@ operation: InterpretHealth
 output:
   healthy: false
 ---
+# Case 3:
 name: "BroadcastJob with no active and no succeeded should be Unhealthy"
 description: "Health should be false when both active and succeeded are zero"
 observedObj:
@@ -95,6 +99,7 @@ operation: InterpretHealth
 output:
   healthy: false
 ---
+# Case 4:
 name: "BroadcastJob healthy when active or succeeded exists"
 description: "Health should be true when job is progressing or succeeded"
 observedObj:

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/interpretreplica-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/interpretreplica-test.yaml
@@ -1,51 +1,8 @@
 # test case for interpreting replica of BroadcastJob
-# case1. BroadcastJob with parallelism set to 1
-# case2. BroadcastJob with parallelism set to 3
-# case3. BroadcastJob without parallelism
+# case1. BroadcastJob with parallelism set to 3
+# case2. BroadcastJob without parallelism
 
-name: "BroadcastJob with parallelism set to 1"
-description: "Test interpreting replica of BroadcastJob with parallelism set to 1"
-desiredObj:
-  apiVersion: apps.kruise.io/v1alpha1
-  kind: BroadcastJob
-  metadata:
-    labels:
-      app: sample
-    name: sample
-    namespace: test-bcj
-  spec:
-    parallelism: 1
-    template:
-      metadata:
-        labels:
-          app: sample
-      spec:
-        restartPolicy: Never
-        volumes:
-          - name: configmap
-            configMap:
-              name: my-sample-config
-        containers:
-          - name: nginx
-            image: nginx:alpine
-            env:
-              - name: logData
-                valueFrom:
-                  configMapKeyRef:
-                    name: mysql-config
-                    key: log
-              - name: lowerData
-                valueFrom:
-                  configMapKeyRef:
-                    name: mysql-config
-                    key: lower
-    completionPolicy:
-      type: Always
-      activeDeadlineSeconds: 10
-operation: InterpretReplica
-output:
-  replica: 1
----
+# Case 1:
 name: "BroadcastJob with parallelism set to 3"
 description: "Test interpreting replica of BroadcastJob with parallelism set to 3"
 desiredObj:
@@ -65,6 +22,7 @@ operation: InterpretReplica
 output:
   replica: 3
 ---
+# Case 2:
 name: "BroadcastJob without parallelism"
 description: "Test interpreting replica when parallelism is not specified"
 desiredObj:

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/interpretstatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/interpretstatus-test.yaml
@@ -1,10 +1,11 @@
 # test case for interpreting status of BroadcastJob
-# case1. BroadcastJob: interpret status test
-# case2. BroadcastJob succeeded status
-# case3. BroadcastJob with empty status
+# case1. Test interpreting status of BroadcastJob with failed phase
+# case2. Test interpreting status of BroadcastJob with completed phase
+# case3. Test interpreting status of BroadcastJob with empty status
 
-name: "BroadcastJob: interpret status test"
-description: "Test interpreting status for BroadcastJob"
+# Case 1:
+name: "BroadcastJob with failed phase status"
+description: "Test interpreting status of BroadcastJob with failed phase"
 observedObj:
   apiVersion: apps.kruise.io/v1alpha1
   kind: BroadcastJob
@@ -75,8 +76,9 @@ output:
         status: "True"
         type: Failed
 ---
-name: "BroadcastJob succeeded status"
-description: "InterpretStatus when BroadcastJob completes successfully"
+# Case 2:
+name: "BroadcastJob with completed phase status"
+description: "Test interpreting status of BroadcastJob with completed phase"
 observedObj:
   apiVersion: apps.kruise.io/v1alpha1
   kind: BroadcastJob
@@ -108,8 +110,9 @@ output:
       - type: Complete
         status: "True"
 ---
+# Case 3:
 name: "BroadcastJob with empty status"
-description: "InterpretStatus should return empty status when status is nil"
+description: "Test interpreting status of BroadcastJob with empty status"
 observedObj:
   apiVersion: apps.kruise.io/v1alpha1
   kind: BroadcastJob

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/retain-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/retain-test.yaml
@@ -1,137 +1,6 @@
 # test case for retaining BroadcastJob
-# case1. BroadcastJob: retain test
-# case2. BroadcastJob retain should preserve observed labels
+# case1. BroadcastJob retain should preserve observed labels
 
-name: "BroadcastJob: retain test"
-description: "Test retaining BroadcastJob"
-desiredObj:
-  apiVersion: apps.kruise.io/v1alpha1
-  kind: BroadcastJob
-  metadata:
-    labels:
-      app: sample
-    name: sample
-    namespace: test-bcj
-  spec:
-    parallelism: 1
-    template:
-      metadata:
-        labels:
-          app: sample
-      spec:
-        restartPolicy: Never
-        volumes:
-          - name: configmap
-            configMap:
-              name: my-sample-config
-        containers:
-          - name: nginx
-            image: nginx:alpine
-            env:
-              - name: logData
-                valueFrom:
-                  configMapKeyRef:
-                    name: mysql-config
-                    key: log
-              - name: lowerData
-                valueFrom:
-                  configMapKeyRef:
-                    name: mysql-config
-                    key: lower
-    completionPolicy:
-      type: Always
-      activeDeadlineSeconds: 10
-observedObj:
-  apiVersion: apps.kruise.io/v1alpha1
-  kind: BroadcastJob
-  metadata:
-    labels:
-      app: sample
-    name: sample
-    namespace: test-bcj
-  spec:
-    parallelism: 1
-    template:
-      metadata:
-        labels:
-          app: sample
-      spec:
-        restartPolicy: Never
-        volumes:
-          - name: configmap
-            configMap:
-              name: my-sample-config
-        containers:
-          - name: nginx
-            image: nginx:alpine
-            env:
-              - name: logData
-                valueFrom:
-                  configMapKeyRef:
-                    name: mysql-config
-                    key: log
-              - name: lowerData
-                valueFrom:
-                  configMapKeyRef:
-                    name: mysql-config
-                    key: lower
-    completionPolicy:
-      type: Always
-      activeDeadlineSeconds: 10
-  status:
-    active: 0
-    completionTime: "2023-04-06T15:01:47Z"
-    conditions:
-      - lastProbeTime: "2023-04-06T15:01:47Z"
-        lastTransitionTime: "2023-04-06T15:01:47Z"
-        message: Job test-bcj/sample was active longer than specified deadline
-        reason: Failed
-        status: "True"
-        type: Failed
-    desired: 1
-    failed: 1
-    phase: failed
-    startTime: "2023-04-06T15:01:37Z"
-    succeeded: 0
-operation: Retain
-output:
-  apiVersion: apps.kruise.io/v1alpha1
-  kind: BroadcastJob
-  metadata:
-    labels:
-      app: sample
-    name: sample
-    namespace: test-bcj
-  spec:
-    parallelism: 1
-    template:
-      metadata:
-        labels:
-          app: sample
-      spec:
-        restartPolicy: Never
-        volumes:
-          - name: configmap
-            configMap:
-              name: my-sample-config
-        containers:
-          - name: nginx
-            image: nginx:alpine
-            env:
-              - name: logData
-                valueFrom:
-                  configMapKeyRef:
-                    name: mysql-config
-                    key: log
-              - name: lowerData
-                valueFrom:
-                  configMapKeyRef:
-                    name: mysql-config
-                    key: lower
-    completionPolicy:
-      type: Always
-      activeDeadlineSeconds: 10
----
 name: "BroadcastJob retain should preserve observed labels"
 description: "Retain should copy pod template labels from observedObj"
 desiredObj:
@@ -158,13 +27,14 @@ observedObj:
           app: new-label
 operation: Retain
 output:
-  apiVersion: apps.kruise.io/v1alpha1
-  kind: BroadcastJob
-  metadata:
-    name: sample
-    namespace: test-bcj
-  spec:
-    template:
-      metadata:
-        labels:
-          app: new-label
+  retained:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: BroadcastJob
+    metadata:
+      name: sample
+      namespace: test-bcj
+    spec:
+      template:
+        metadata:
+          labels:
+            app: new-label

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/revisereplica-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/BroadcastJob/testdata/revisereplica-test.yaml
@@ -14,10 +14,11 @@ desiredObj:
 inputReplicas: 3
 operation: ReviseReplica
 output:
-  apiVersion: apps.kruise.io/v1alpha1
-  kind: BroadcastJob
-  metadata:
-    name: sample
-    namespace: test-bcj
-  spec:
-    parallelism: 3
+  revised:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: BroadcastJob
+    metadata:
+      name: sample
+      namespace: test-bcj
+    spec:
+      parallelism: 3

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/aggregatestatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/aggregatestatus-test.yaml
@@ -4,6 +4,7 @@
 # case3. CloneSet with mixed observed generations
 # case4. CloneSet with no status items
 
+# Case 1:
 name: "CloneSet with two status items"
 description: "Test aggregating status of CloneSet with two status items"
 desiredObj:
@@ -15,36 +16,6 @@ desiredObj:
     name: sample
     namespace: test-cloneset
     generation: 1
-  spec:
-    replicas: 4
-    selector:
-      matchLabels:
-        app: sample
-        test: cloneset
-    template:
-      metadata:
-        labels:
-          app: sample
-          test: cloneset
-      spec:
-        volumes:
-          - name: configmap
-            configMap:
-              name: my-sample-config
-        containers:
-          - name: nginx
-            image: nginx:alpine
-            env:
-              - name: logData
-                valueFrom:
-                  configMapKeyRef:
-                    name: mysql-config
-                    key: log
-              - name: lowerData
-                valueFrom:
-                  configMapKeyRef:
-                    name: mysql-config
-                    key: lower
 statusItems:
   - applied: true
     clusterName: member1
@@ -80,15 +51,28 @@ statusItems:
       resourceTemplateGeneration: 1
 operation: AggregateStatus
 output:
-  status:
-    replicas: 4
-    readyReplicas: 4
-    availableReplicas: 4
-    updatedReplicas: 4
-    updatedReadyReplicas: 4
-    expectedUpdatedReplicas: 4
-    observedGeneration: 1
+  aggregatedStatus:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: CloneSet
+    metadata:
+      labels:
+        app: sample
+      name: sample
+      namespace: test-cloneset
+      generation: 1
+    status:
+      replicas: 4
+      readyReplicas: 4
+      availableReplicas: 4
+      updatedReplicas: 4
+      updatedReadyReplicas: 4
+      expectedUpdatedReplicas: 4
+      observedGeneration: 1
+      currentRevision: sample-59df6bd888
+      updateRevision: sample-59df6bd888
+      labelSelector: app=sample,test=cloneset
 ---
+# Case 2:
 name: "CloneSet with partially ready replicas"
 description: "AggregateStatus when some replicas are not ready"
 desiredObj:
@@ -127,15 +111,28 @@ statusItems:
       resourceTemplateGeneration: 2
 operation: AggregateStatus
 output:
-  status:
-    replicas: 4
-    readyReplicas: 3
-    availableReplicas: 3
-    updatedReplicas: 4
-    updatedReadyReplicas: 3
-    expectedUpdatedReplicas: 4
-    observedGeneration: 2
+  aggregatedStatus:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: CloneSet
+    metadata:
+      name: sample
+      namespace: test-cloneset
+      generation: 2
+    spec:
+      replicas: 4
+    status:
+      replicas: 4
+      readyReplicas: 3
+      availableReplicas: 3
+      updatedReplicas: 4
+      updatedReadyReplicas: 3
+      expectedUpdatedReplicas: 4
+      observedGeneration: 2
+      currentRevision: ''
+      updateRevision: ''
+      labelSelector: ''
 ---
+# Case 3:
 name: "CloneSet with mixed observed generations"
 description: "AggregateStatus should not update observedGeneration if any member is stale"
 desiredObj:
@@ -166,11 +163,26 @@ statusItems:
       resourceTemplateGeneration: 3
 operation: AggregateStatus
 output:
-  status:
-    replicas: 4
-    readyReplicas: 4
-    observedGeneration: 2
+  aggregatedStatus:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: CloneSet
+    metadata:
+      name: sample
+      namespace: test-cloneset
+      generation: 3
+    status:
+      replicas: 4
+      readyReplicas: 4
+      availableReplicas: 0
+      updatedReplicas: 0
+      updatedReadyReplicas: 0
+      expectedUpdatedReplicas: 0
+      observedGeneration: 2
+      currentRevision: ''
+      updateRevision: ''
+      labelSelector: ''
 ---
+# Case 4:
 name: "CloneSet with no status items"
 description: "AggregateStatus when CloneSet is not propagated"
 desiredObj:
@@ -182,13 +194,18 @@ desiredObj:
     generation: 1
 operation: AggregateStatus
 output:
-  status:
-    replicas: 0
-    readyReplicas: 0
-    availableReplicas: 0
-    updatedReplicas: 0
-    updatedReadyReplicas: 0
-    expectedUpdatedReplicas: 0
-    observedGeneration: 1
-
-
+  aggregatedStatus:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: CloneSet
+    metadata:
+      name: sample
+      namespace: test-cloneset
+      generation: 1
+    status:
+      replicas: 0
+      readyReplicas: 0
+      availableReplicas: 0
+      updatedReplicas: 0
+      updatedReadyReplicas: 0
+      expectedUpdatedReplicas: 0
+      observedGeneration: 1

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/interprethealth-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/interprethealth-test.yaml
@@ -4,6 +4,7 @@
 # case3. CloneSet health when updatedReplicas less than desired replicas
 # case4. CloneSet health when availableReplicas less than updatedReplicas
 
+# Case 1:
 name: "CloneSet interpreting health test"
 description: "Test interpreting health of CloneSet"
 observedObj:
@@ -63,6 +64,7 @@ operation: InterpretHealth
 output:
   healthy: true
 ---
+# Case 2:
 name: "CloneSet health when observedGeneration mismatches generation"
 description: "Health should be false when observedGeneration != generation"
 observedObj:
@@ -89,6 +91,7 @@ operation: InterpretHealth
 output:
   healthy: false
 ---
+# Case 3:
 name: "CloneSet health when updatedReplicas less than desired replicas"
 description: "Health should be false when updatedReplicas < spec.replicas"
 observedObj:
@@ -115,6 +118,7 @@ operation: InterpretHealth
 output:
   healthy: false
 ---
+# Case 4:
 name: "CloneSet health when availableReplicas less than updatedReplicas"
 description: "Health should be false when availableReplicas < updatedReplicas"
 observedObj:

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/revisereplica-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/CloneSet/testdata/revisereplica-test.yaml
@@ -23,27 +23,26 @@ desiredObj:
         labels:
           app: sample
           test: cloneset
-      spec:
-        volumes:
-          - name: configmap
-            configMap:
-              name: my-sample-config
-        containers:
-          - name: nginx
-            image: nginx:alpine
-            env:
-              - name: logData
-                valueFrom:
-                  configMapKeyRef:
-                    name: mysql-config
-                    key: log
-              - name: lowerData
-                valueFrom:
-                  configMapKeyRef:
-                    name: mysql-config
-                    key: lower
 inputReplicas: 1
 operation: ReviseReplica
 output:
-  spec:
-    replicas: 1
+  revised:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: CloneSet
+    metadata:
+      labels:
+        app: sample
+      name: sample
+      namespace: test-cloneset
+      generation: 1
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: sample
+          test: cloneset
+      template:
+        metadata:
+          labels:
+            app: sample
+            test: cloneset

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/interprethealth-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/interprethealth-test.yaml
@@ -66,4 +66,4 @@ observedObj:
         message: ReplicaSet has successfully progressed.
 operation: InterpretHealth
 output:
-    health: false
+  healthy: true


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

This PR enhances test validation to ensure all keys defined in test case outputs are present in actual results, preventing silent test failures due to typos or incorrect key names.

**Changes:**
- Added validation logic to track and verify all output keys exist in results
- Fixed incorrect output key names (`status` → `aggregatedStatus`)
- Corrected expected outputs to include complete object structures
- Fixed YAML syntax errors (quote formatting)
- Updated ReviseReplica test with correct replica values

Previously, if output keys were misspelled, the test would skip validation without failing. Now it fails immediately when expected keys are missing.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

