### PR TITLE
operator docs: revise the name of karmada config

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -113,7 +113,7 @@ karmada-demo-webhook-6f5944f5d8-bpkqz                   1/1     Running   0     
 ### Generate kubeconfig for karmada
 
 ```shell
-kubectl get secret -n test karmada-demo-admin-config -o jsonpath={.data.kubeconfig} | base64 -d > ~/.kube/karmada-apiserver.config
+kubectl get secret -n test karmada-demo-admin-config -o jsonpath='{.data.karmada\.config}' | base64 -d > ~/.kube/karmada-apiserver.config
 export KUBECONFIG=~/.kube/karmada-apiserver.config
 ```
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
#6082 changed the `secretKey` of `kubeconfigSecret` from `kubeconfig` to `karmada.config`. Therefore, the command in the documentation for retrieving the kubeconfig file from `kubeconfigSecret` also needs to be updated.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note

```

