### PR TITLE
feat: expose lua vm pool size as flag

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -272,7 +272,7 @@ func setupControllers(ctx context.Context, mgr controllerruntime.Manager, opts *
 	sharedFactory.Start(ctx.Done())
 	sharedFactory.WaitForCacheSync(ctx.Done())
 
-	resourceInterpreter := resourceinterpreter.NewResourceInterpreter(controlPlaneInformerManager, serviceLister)
+	resourceInterpreter := resourceinterpreter.NewResourceInterpreter(controlPlaneInformerManager, serviceLister, opts.ConfigurableInterpreterLuaVMPoolSize, opts.ThirdPartyInterpreterLuaVMPoolSize)
 	if err := resourceInterpreter.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start resource interpreter: %w", err)
 	}

--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -78,6 +78,11 @@ type Options struct {
 	// KubeAPIBurst is the burst to allow while talking with karmada-apiserver.
 	KubeAPIBurst int
 
+	// ConfigurableInterpreterLuaVMPoolSize is the size of the pool for the configurable interpreter lua vm.
+	ConfigurableInterpreterLuaVMPoolSize int
+	// ThirdPartyInterpreterLuaVMPoolSize is the size of the pool for the third party interpreter lua vm.
+	ThirdPartyInterpreterLuaVMPoolSize int
+
 	ClusterCacheSyncTimeout metav1.Duration
 	// ResyncPeriod is the base frequency the informers are resynced.
 	// Defaults to 0, which means the created informer will never do resyncs.
@@ -211,6 +216,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, allControllers []string) {
 	fs.DurationVar(&o.CertRotationCheckingInterval, "cert-rotation-checking-interval", 5*time.Minute, "The interval of checking if the certificate need to be rotated. This is only applicable if cert rotation is enabled")
 	fs.Float64Var(&o.CertRotationRemainingTimeThreshold, "cert-rotation-remaining-time-threshold", 0.2, "The threshold of remaining time of the valid certificate. This is only applicable if cert rotation is enabled.")
 	fs.StringVar(&o.KarmadaKubeconfigNamespace, "karmada-kubeconfig-namespace", "karmada-system", "Namespace of the secret containing karmada-agent certificate. This is only applicable if cert rotation is enabled.")
+	fs.IntVar(&o.ConfigurableInterpreterLuaVMPoolSize, "configurable-interpreter-lua-vm-pool-size", 10, "The size of the pool for the configurable interpreter lua vm.")
+	fs.IntVar(&o.ThirdPartyInterpreterLuaVMPoolSize, "third-party-interpreter-lua-vm-pool-size", 10, "The size of the pool for the third party interpreter lua vm.")
 	o.RateLimiterOpts.AddFlags(fs)
 	features.FeatureGate.AddFlag(fs)
 	o.ProfileOpts.AddFlags(fs)

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -860,7 +860,7 @@ func setupControllers(ctx context.Context, mgr controllerruntime.Manager, opts *
 	sharedFactory.Start(ctx.Done())
 	sharedFactory.WaitForCacheSync(ctx.Done())
 
-	resourceInterpreter := resourceinterpreter.NewResourceInterpreter(controlPlaneInformerManager, serviceLister)
+	resourceInterpreter := resourceinterpreter.NewResourceInterpreter(controlPlaneInformerManager, serviceLister, opts.ConfigurableInterpreterLuaVMPoolSize, opts.ThirdPartyInterpreterLuaVMPoolSize)
 	if err := resourceInterpreter.Start(ctx); err != nil {
 		klog.Fatalf("Failed to start resource interpreter: %v", err)
 	}

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -135,6 +135,10 @@ type Options struct {
 	// GracefulEvictionTimeout is the timeout period waiting for the grace-eviction-controller performs the final
 	// removal since the workload(resource) has been moved to the graceful eviction tasks.
 	GracefulEvictionTimeout metav1.Duration
+	// ConfigurableInterpreterLuaVMPoolSize is the size of the pool for the configurable interpreter lua vm.
+	ConfigurableInterpreterLuaVMPoolSize int
+	// ThirdPartyInterpreterLuaVMPoolSize is the size of the pool for the third party interpreter lua vm.
+	ThirdPartyInterpreterLuaVMPoolSize int
 
 	RateLimiterOpts            ratelimiterflag.Options
 	ProfileOpts                profileflag.Options
@@ -228,7 +232,8 @@ func (o *Options) AddFlags(flags *pflag.FlagSet, allControllers, disabledByDefau
 	flags.BoolVar(&o.EnableClusterResourceModeling, "enable-cluster-resource-modeling", true, "Enable means controller would build resource modeling for each cluster by syncing Nodes and Pods resources.\n"+
 		"The resource modeling might be used by the scheduler to make scheduling decisions in scenario of dynamic replica assignment based on cluster free resources.\n"+
 		"Disable if it does not fit your cases for better performance.")
-
+	flags.IntVar(&o.ConfigurableInterpreterLuaVMPoolSize, "configurable-interpreter-lua-vm-pool-size", 10, "The size of the pool for the configurable interpreter lua vm.")
+	flags.IntVar(&o.ThirdPartyInterpreterLuaVMPoolSize, "third-party-interpreter-lua-vm-pool-size", 10, "The size of the pool for the third party interpreter lua vm.")
 	o.RateLimiterOpts.AddFlags(flags)
 	o.ProfileOpts.AddFlags(flags)
 	o.HPAControllerConfiguration.AddFlags(flags)

--- a/pkg/karmadactl/interpret/execute.go
+++ b/pkg/karmadactl/interpret/execute.go
@@ -96,7 +96,7 @@ func (o *Options) runExecute() error {
 		Replica:  int64(o.DesiredReplica),
 	}
 
-	configurableInterpreter := declarative.NewConfigurableInterpreter(nil)
+	configurableInterpreter := declarative.NewConfigurableInterpreter(nil, 10)
 	configurableInterpreter.LoadConfig(customizations)
 
 	r := o.Rules.GetByOperation(o.Operation)

--- a/pkg/karmadactl/promote/promote.go
+++ b/pkg/karmadactl/promote/promote.go
@@ -464,8 +464,8 @@ func (o *CommandPromoteOption) promoteDeps(memberClusterFactory cmdutil.Factory,
 	sharedFactory.WaitForCacheSync(ctx.Done())
 
 	defaultInterpreter := native.NewDefaultInterpreter()
-	thirdpartyInterpreter := thirdparty.NewConfigurableInterpreter()
-	configurableInterpreter := declarative.NewConfigurableInterpreter(controlPlaneInformerManager)
+	thirdpartyInterpreter := thirdparty.NewConfigurableInterpreter(10)
+	configurableInterpreter := declarative.NewConfigurableInterpreter(controlPlaneInformerManager, 10)
 	customizedInterpreter, err := webhook.NewCustomizedInterpreter(controlPlaneInformerManager, serviceLister)
 	if err != nil {
 		return fmt.Errorf("failed to create customized interpreter: %v", err)

--- a/pkg/resourceinterpreter/customized/declarative/configurable.go
+++ b/pkg/resourceinterpreter/customized/declarative/configurable.go
@@ -42,11 +42,11 @@ type ConfigurableInterpreter struct {
 
 // NewConfigurableInterpreter builds a new interpreter by registering the
 // event handler to the provided informer instance.
-func NewConfigurableInterpreter(informer genericmanager.SingleClusterInformerManager) *ConfigurableInterpreter {
+func NewConfigurableInterpreter(informer genericmanager.SingleClusterInformerManager, pool int) *ConfigurableInterpreter {
 	return &ConfigurableInterpreter{
 		configManager: configmanager.NewInterpreterConfigManager(informer),
 		// TODO: set an appropriate pool size.
-		luaVM: luavm.New(false, 10),
+		luaVM: luavm.New(false, pool),
 	}
 }
 

--- a/pkg/resourceinterpreter/default/thirdparty/thirdparty.go
+++ b/pkg/resourceinterpreter/default/thirdparty/thirdparty.go
@@ -254,9 +254,9 @@ func (p *ConfigurableInterpreter) getCustomAccessor(kind schema.GroupVersionKind
 }
 
 // NewConfigurableInterpreter return a new ConfigurableInterpreter.
-func NewConfigurableInterpreter() *ConfigurableInterpreter {
+func NewConfigurableInterpreter(pool int) *ConfigurableInterpreter {
 	return &ConfigurableInterpreter{
 		configManager: NewThirdPartyConfigManager(),
-		luaVM:         luavm.New(false, 10),
+		luaVM:         luavm.New(false, pool),
 	}
 }

--- a/pkg/resourceinterpreter/default/thirdparty/thirdparty_test.go
+++ b/pkg/resourceinterpreter/default/thirdparty/thirdparty_test.go
@@ -76,7 +76,7 @@ type IndividualTest struct {
 }
 
 func checkInterpretationRule(t *testing.T, path string, configs []*configv1alpha1.ResourceInterpreterCustomization) {
-	ipt := declarative.NewConfigurableInterpreter(nil)
+	ipt := declarative.NewConfigurableInterpreter(nil, 10)
 	ipt.LoadConfig(configs)
 
 	dir := filepath.Dir(path)

--- a/pkg/resourceinterpreter/interpreter.go
+++ b/pkg/resourceinterpreter/interpreter.go
@@ -81,10 +81,12 @@ type ResourceInterpreter interface {
 }
 
 // NewResourceInterpreter builds a new ResourceInterpreter object.
-func NewResourceInterpreter(informer genericmanager.SingleClusterInformerManager, serviceLister corev1.ServiceLister) ResourceInterpreter {
+func NewResourceInterpreter(informer genericmanager.SingleClusterInformerManager, serviceLister corev1.ServiceLister, configurablePool, thirdpartyPool int) ResourceInterpreter {
 	return &customResourceInterpreterImpl{
-		informer:      informer,
-		serviceLister: serviceLister,
+		informer:         informer,
+		serviceLister:    serviceLister,
+		configurablePool: configurablePool,
+		thirdpartyPool:   thirdpartyPool,
 	}
 }
 
@@ -96,6 +98,9 @@ type customResourceInterpreterImpl struct {
 	customizedInterpreter   *webhook.CustomizedInterpreter
 	thirdpartyInterpreter   *thirdparty.ConfigurableInterpreter
 	defaultInterpreter      *native.DefaultInterpreter
+
+	configurablePool int
+	thirdpartyPool   int
 }
 
 // Start initializes all interpreters and load all ResourceInterpreterCustomization and
@@ -109,9 +114,9 @@ func (i *customResourceInterpreterImpl) Start(_ context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	i.configurableInterpreter = declarative.NewConfigurableInterpreter(i.informer)
+	i.configurableInterpreter = declarative.NewConfigurableInterpreter(i.informer, i.configurablePool)
 
-	i.thirdpartyInterpreter = thirdparty.NewConfigurableInterpreter()
+	i.thirdpartyInterpreter = thirdparty.NewConfigurableInterpreter(i.thirdpartyPool)
 	i.defaultInterpreter = native.NewDefaultInterpreter()
 
 	i.informer.Start()


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind feature

**What this PR does / why we need it**:

We should consider to expose lua vm pool size to flags. So it can be adjusted. When `ConcurrentXXXXSyncs` is much more than 10, 10 lua vm might not be enough.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
1. `karmada-controller-manager`: Add new flags(--configurable-interpreter-lua-vm-pool-size and --third-party-interpreter-lua-vm-pool-size)
2. `karmada-agent`: Add new flags(--configurable-interpreter-lua-vm-pool-size and --third-party-interpreter-lua-vm-pool-size)
```

