### PR TITLE
Fix issue that HelmRelease doesn't define observedGeneration varible in the statusAggregation operation

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/helm.toolkit.fluxcd.io/v2beta1/HelmRelease/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/helm.toolkit.fluxcd.io/v2beta1/HelmRelease/customizations.yaml
@@ -50,6 +50,7 @@ spec:
 
           local conditions = {}
           local generation = desiredObj.metadata.generation
+          local observedGeneration = desiredObj.status.observedGeneration
           local lastAttemptedRevision = desiredObj.status.lastAttemptedRevision
           local lastAppliedRevision = desiredObj.status.lastAppliedRevision
           local lastAttemptedValuesChecksum = desiredObj.status.lastAttemptedValuesChecksum


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes https://github.com/karmada-io/karmada/issues/7056

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
karmada-controller-manager: Fix issue that HelmRelease doesn't define observedGeneration varible in the statusAggregation operation
```

