### PR TITLE
Automated cherry pick of #7057: fix observedGeneration varible  in the statusAggregation

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/helm.toolkit.fluxcd.io/v2beta1/HelmRelease/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/helm.toolkit.fluxcd.io/v2beta1/HelmRelease/customizations.yaml
@@ -50,6 +50,7 @@ spec:
 
           local conditions = {}
           local generation = desiredObj.metadata.generation
+          local observedGeneration = desiredObj.status.observedGeneration
           local lastAttemptedRevision = desiredObj.status.lastAttemptedRevision
           local lastAppliedRevision = desiredObj.status.lastAppliedRevision
           local lastAttemptedValuesChecksum = desiredObj.status.lastAttemptedValuesChecksum


### PR DESCRIPTION
Cherry pick of #7057 on release-1.16.
#7057: fix observedGeneration varible  in the statusAggregation
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
karmada-controller-manager: Fix issue that HelmRelease doesn't define observedGeneration varible in the statusAggregation operation
```

https://github.com/karmada-io/karmada/issues/7058