### PR TITLE
Add ResourceInterpreter tests for UnitedDeployment

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/aggregatestatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/aggregatestatus-test.yaml
@@ -1,5 +1,7 @@
 # test case for aggregating status of UnitedDeployment
 # case1. UnitedDeployment with two status items
+# case2. UnitedDeployment with mixed observed generations
+# case3. UnitedDeployment with no status items
 
 name: "UnitedDeployment with two status items"
 description: "Test aggregating status of UnitedDeployment with two status items"
@@ -58,6 +60,8 @@ statusItems:
       availableReplicas: 2
       collisionCount: 0
       observedGeneration: 1
+      generation: 1
+      resourceTemplateGeneration: 1
   - apiVersion: apps.kruise.io/v1alpha1
     kind: UnitedDeployment
     metadata:
@@ -71,5 +75,126 @@ statusItems:
       availableReplicas: 1
       collisionCount: 0
       observedGeneration: 1
+      generation: 1
+      resourceTemplateGeneration: 1
 operation: AggregateStatus
 output:
+  aggregatedStatus:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: UnitedDeployment
+    metadata:
+      name: sample-uniteddeployment
+      namespace: test-namespace
+      generation: 1
+    spec:
+      replicas: 3
+      selector:
+        matchLabels:
+          app: sample
+      template:
+        metadata:
+          labels:
+            app: sample
+        spec:
+          containers:
+            - name: nginx
+              image: nginx:latest
+              env:
+                - name: CONFIG_DATA
+                  valueFrom:
+                    configMapKeyRef:
+                      name: app-config
+                      key: config
+                - name: SECRET_DATA
+                  valueFrom:
+                    secretKeyRef:
+                      name: app-secret
+                      key: token
+              volumeMounts:
+                - name: config-volume
+                  mountPath: /etc/config
+          volumes:
+            - name: config-volume
+              configMap:
+                name: app-config
+      topologySpread:
+        - topologyKey: kubernetes.io/hostname
+          maxSkew: 1
+    status:
+      replicas: 3
+      readyReplicas: 3
+      updatedReplicas: 3
+      availableReplicas: 3
+      unavailableReplicas: 0
+      observedGeneration: 1
+---
+name: "UnitedDeployment with mixed observed generations"
+description: "observedGeneration should not advance if any member is stale"
+desiredObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: UnitedDeployment
+  metadata:
+    name: sample-uniteddeployment
+    namespace: test-namespace
+    generation: 2
+  status:
+    observedGeneration: 1
+statusItems:
+  - status:
+      replicas: 2
+      readyReplicas: 2
+      updatedReplicas: 2
+      availableReplicas: 2
+      generation: 2
+      observedGeneration: 2
+      resourceTemplateGeneration: 2
+  - status:
+      replicas: 1
+      readyReplicas: 1
+      updatedReplicas: 1
+      availableReplicas: 1
+      generation: 2
+      observedGeneration: 1
+      resourceTemplateGeneration: 2
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: UnitedDeployment
+    metadata:
+      name: sample-uniteddeployment
+      namespace: test-namespace
+      generation: 2
+    status:
+      replicas: 3
+      readyReplicas: 3
+      updatedReplicas: 3
+      availableReplicas: 3
+      unavailableReplicas: 0
+      observedGeneration: 1
+---
+name: "UnitedDeployment with no status items"
+description: "AggregateStatus should initialize empty status"
+desiredObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: UnitedDeployment
+  metadata:
+    name: sample-uniteddeployment
+    namespace: test-namespace
+    generation: 1
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: UnitedDeployment
+    metadata:
+      name: sample-uniteddeployment
+      namespace: test-namespace
+      generation: 1
+    status:
+      replicas: 0
+      readyReplicas: 0
+      updatedReplicas: 0
+      availableReplicas: 0
+      unavailableReplicas: 0
+      observedGeneration: 1

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/interpretdependency-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/interpretdependency-test.yaml
@@ -46,3 +46,12 @@ desiredObj:
         maxSkew: 1
 operation: InterpretDependency
 output:
+  dependencies:
+    - apiVersion: v1
+      kind: ConfigMap
+      name: app-config
+      namespace: test-namespace
+    - apiVersion: v1
+      kind: Secret
+      name: app-secret
+      namespace: test-namespace

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/interprethealth-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/interprethealth-test.yaml
@@ -1,5 +1,7 @@
 # test case for interpreting health of UnitedDeployment
 # case1. UnitedDeployment interpreting health test
+# case2. UnitedDeployment unhealthy when observedGeneration mismatches
+# case3. UnitedDeployment unhealthy when rollout not complete
 
 name: "UnitedDeployment interpreting health test"
 description: "Test interpreting health of UnitedDeployment"
@@ -67,3 +69,41 @@ observedObj:
 operation: InterpretHealth
 output:
   healthy: true
+---
+name: "UnitedDeployment unhealthy when observedGeneration mismatches"
+description: "Health should be false when observedGeneration != metadata.generation"
+observedObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: UnitedDeployment
+  metadata:
+    name: sample-uniteddeployment
+    namespace: test-namespace
+    generation: 2
+  spec:
+    replicas: 3
+  status:
+    observedGeneration: 1
+    updatedReplicas: 3
+    availableReplicas: 3
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "UnitedDeployment unhealthy when rollout not complete"
+description: "Health should be false when updatedReplicas < spec.replicas"
+observedObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: UnitedDeployment
+  metadata:
+    name: sample-uniteddeployment
+    namespace: test-namespace
+    generation: 1
+  spec:
+    replicas: 3
+  status:
+    observedGeneration: 1
+    updatedReplicas: 2
+    availableReplicas: 2
+operation: InterpretHealth
+output:
+  healthy: false

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/interpretreplica-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/interpretreplica-test.yaml
@@ -45,3 +45,5 @@ desiredObj:
       - topologyKey: kubernetes.io/hostname
         maxSkew: 1
 operation: InterpretReplica
+output:
+  replica: 3

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/interpretstatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/interpretstatus-test.yaml
@@ -1,5 +1,6 @@
 # test case for interpreting status of UnitedDeployment
 # case1. UnitedDeployment: interpret status test
+# case2. UnitedDeployment: interpret status with resourceTemplateGeneration
 
 name: "UnitedDeployment: interpret status test"
 description: "Test interpreting status for UnitedDeployment"
@@ -66,3 +67,49 @@ observedObj:
         message: ReplicaSet has successfully progressed.
 operation: InterpretStatus
 output:
+  status:
+    replicas: 3
+    updatedReplicas: 3
+    readyReplicas: 3
+    availableReplicas: 3
+    observedGeneration: 1
+    conditions:
+      - type: Available
+        status: "True"
+        lastTransitionTime: "2023-01-01T00:00:00Z"
+        reason: MinimumReplicasAvailable
+        message: Deployment has minimum availability.
+      - type: Progressing
+        status: "True"
+        lastTransitionTime: "2023-01-01T00:00:00Z"
+        reason: NewReplicaSetAvailable
+        message: ReplicaSet has successfully progressed.
+    generation: 1
+---
+name: "UnitedDeployment interpret status with resourceTemplateGeneration"
+description: "InterpretStatus should reflect resourceTemplateGeneration from annotation"
+observedObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: UnitedDeployment
+  metadata:
+    name: sample-uniteddeployment
+    namespace: test-namespace
+    generation: 1
+    annotations:
+      resourcetemplate.karmada.io/generation: "5"
+  status:
+    replicas: 3
+    updatedReplicas: 3
+    readyReplicas: 3
+    availableReplicas: 3
+    observedGeneration: 1
+operation: InterpretStatus
+output:
+  status:
+    replicas: 3
+    updatedReplicas: 3
+    readyReplicas: 3
+    availableReplicas: 3
+    observedGeneration: 1
+    resourceTemplateGeneration: 5
+    generation: 1

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/revisereplica-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/UnitedDeployment/testdata/revisereplica-test.yaml
@@ -47,3 +47,44 @@ desiredObj:
 inputReplicas: 1
 operation: ReviseReplica
 output:
+  revised:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: UnitedDeployment
+    metadata:
+      name: sample-uniteddeployment
+      namespace: test-namespace
+      generation: 1
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: sample
+      template:
+        metadata:
+          labels:
+            app: sample
+        spec:
+          containers:
+            - name: nginx
+              image: nginx:latest
+              env:
+                - name: CONFIG_DATA
+                  valueFrom:
+                    configMapKeyRef:
+                      name: app-config
+                      key: config
+                - name: SECRET_DATA
+                  valueFrom:
+                    secretKeyRef:
+                      name: app-secret
+                      key: token
+              volumeMounts:
+                - name: config-volume
+                  mountPath: /etc/config
+          volumes:
+            - name: config-volume
+              configMap:
+                name: app-config
+      topologySpread:
+        - topologyKey: kubernetes.io/hostname
+          maxSkew: 1


### PR DESCRIPTION
This PR adds ResourceInterpreter test coverage for UnitedDeployment using declarative configuration test cases.

No logic has been changed.