### PR TITLE
update cherry-pick issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/cherry-pick.md
+++ b/.github/ISSUE_TEMPLATE/cherry-pick.md
@@ -1,6 +1,7 @@
 ---
 name: CherryPick Track
 about: Track tasks when release branches need cherry-pick.
+title: 'Backport #<PR_ID>'
 labels: help wanted
 ---
 
@@ -15,17 +16,16 @@ PR #
 Karmada now maintains 3 latest releases.
 If a branch doesn't need this cherry-pick, please explain the reason.
 -->
-- [ ] release-1.x 
+- [ ] release-1.x
 - [ ] release-1.y
 - [ ] release-1.z
 
 **How to cherry-pick PRs:**
 
 The `hack/cherry_pick_pull.sh` script can help you initiate a cherry-pick
-automatically, please follow the instructions at [this guideline](https://karmada.io/docs/contributor/cherry-picks). 
+automatically, please follow the instructions at [this guideline](https://karmada.io/docs/contributor/cherry-picks).
 
-The script will send the PR for you, please remember `copy the release notes` from
-the original PR by to the new PR description part.
+The script will send the PR for you and automatically include the release notes from the original PR in the new PR description.
 
 **How to join or take the task**:
 


### PR DESCRIPTION
**What type of PR is this?**
/cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
The current cherry-pick process is already well-established, and the format of its issue title has largely stabilized; therefore, we can fix this format in the issue template. 

Additionally, the script `hack/cherry_pick_pull.sh` has been enhanced to automatically copy the release note to the new PR. After testing across multiple PRs, this feature has proven stable, so the manual copying instructions can be removed from the issue template.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

