### PR TITLE
fix: ensure status updates are not skipped due to stale cache

### DIFF
--- a/pkg/controllers/multiclusterservice/endpointslice_dispatch_controller_test.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_dispatch_controller_test.go
@@ -77,13 +77,8 @@ func TestUpdateEndpointSliceDispatched(t *testing.T) {
 
 			// Expectations Setup
 			mockClient.On("Status").Return(mockStatusWriter)
-			mockClient.On("Get", mock.Anything, mock.AnythingOfType("types.NamespacedName"), mock.AnythingOfType("*v1alpha1.MultiClusterService"), mock.Anything).
-				Run(func(args mock.Arguments) {
-					arg := args.Get(2).(*networkingv1alpha1.MultiClusterService)
-					*arg = *tt.mcs // Copy the input MCS to the output
-				}).Return(nil)
 
-			mockStatusWriter.On("Update", mock.Anything, mock.AnythingOfType("*v1alpha1.MultiClusterService"), mock.Anything).
+			mockStatusWriter.On("Patch", mock.Anything, mock.AnythingOfType("*v1alpha1.MultiClusterService"), mock.Anything, mock.Anything).
 				Run(func(args mock.Arguments) {
 					mcs := args.Get(1).(*networkingv1alpha1.MultiClusterService)
 					mcs.Status.Conditions = []metav1.Condition{tt.expectedCondition}

--- a/pkg/controllers/remediation/remedy_controller_test.go
+++ b/pkg/controllers/remediation/remedy_controller_test.go
@@ -192,7 +192,11 @@ func setupScheme() *runtime.Scheme {
 
 // Helper function to create a fake client
 func createFakeClient(scheme *runtime.Scheme, objs ...runtime.Object) client.Client {
-	return fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(objs...).
+		WithStatusSubresource(&clusterv1alpha1.Cluster{}).
+		Build()
 }
 
 // Helper function to set up the manager


### PR DESCRIPTION
Fixes #6858
fix: ensure status updates are not skipped due to stale cache

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #6858

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-controller-manager`: Fixed the issue that AggregatedStatus in rb status may be skipped update due to stale cache
```

