### PR TITLE
Automated cherry pick of #7038: skip cleanup rt and binding when the server could not find

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -1014,6 +1014,7 @@ func (d *ResourceDetector) ReconcilePropagationPolicy(key util.QueueKey) error {
 		policyID := propagationObject.Labels[policyv1alpha1.PropagationPolicyPermanentIDLabel]
 		claimMetadata := labels.Set{policyv1alpha1.PropagationPolicyPermanentIDLabel: policyID}
 		if err = d.handlePolicyDeletion(claimMetadata, propagationObject.Spec.ResourceSelectors, CleanupPPClaimMetadata); err != nil {
+			klog.Errorf("Failed to handle policy deletion for PropagationPolicy(%s), err: %v", nkey.NamespaceKey(), err)
 			return err
 		}
 		if controllerutil.RemoveFinalizer(propagationObject, util.PropagationPolicyControllerFinalizer) {
@@ -1089,6 +1090,7 @@ func (d *ResourceDetector) ReconcileClusterPropagationPolicy(key util.QueueKey) 
 		policyID := propagationObject.Labels[policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel]
 		claimMetadata := labels.Set{policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel: policyID}
 		if err = d.handlePolicyDeletion(claimMetadata, propagationObject.Spec.ResourceSelectors, CleanupCPPClaimMetadata); err != nil {
+			klog.Errorf("Failed to handle policy deletion for ClusterPropagationPolicy(%s), err: %v", nkey.NamespaceKey(), err)
 			return err
 		}
 		if controllerutil.RemoveFinalizer(propagationObject, util.ClusterPropagationPolicyControllerFinalizer) {
@@ -1121,6 +1123,11 @@ func (d *ResourceDetector) handlePolicyDeletion(claimMetadata labels.Set, resour
 		rawObjects, err := helper.FetchResourceTemplatesByLabelSelector(d.DynamicClient, d.InformerManager, d.RESTMapper, objRef, labels.SelectorFromSet(claimMetadata))
 		if meta.IsNoMatchError(err) {
 			klog.Infof("Skip cleanup as API(%s, kind=%s) is not installed or has been removed", objRef.APIVersion, objRef.Kind)
+			continue
+		}
+		if apierrors.IsNotFound(err) {
+			// This error may occur because a namespace was incorrectly specified for a cluster-scoped resource.
+			klog.Infof("Skip cleanup as the server could not find the requested resource(%s, kind=%s, namespace=%s).", objRef.APIVersion, objRef.Kind, objRef.Namespace)
 			continue
 		}
 		if err != nil {


### PR DESCRIPTION
Cherry pick of #7038 on release-1.16.
#7038: skip cleanup rt and binding when the server could not find
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-controller-manager`: Fixed an issue where policy deletion could be blocked if a resource selector targeted a non-existent resource.
```

Part of https://github.com/karmada-io/karmada/issues/7075