### PR TITLE
Add GitRepository resource interpreter test coverage

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1/GitRepository/testdata/aggregatestatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1/GitRepository/testdata/aggregatestatus-test.yaml
@@ -1,5 +1,9 @@
 # test case for aggregating status of GitRepository
 # case1. GitRepository with two status items
+# case2. GitRepository with stale member
+# case3. GitRepository with no status items
+# case4. GitRepository with different artifacts picks last one
+# case5. GitRepository condition merging with different reasons
 
 name: "GitRepository with two status items"
 description: "Test aggregating status of GitRepository with two status items"
@@ -72,3 +76,169 @@ statusItems:
       resourceTemplateGeneration: 1
 operation: AggregateStatus
 output:
+  aggregatedStatus:
+    apiVersion: source.toolkit.fluxcd.io/v1
+    kind: GitRepository
+    metadata:
+      generation: 1
+      name: sample
+      namespace: test-gitrepository
+    spec:
+      interval: 30s
+      ref:
+        branch: master
+      url: https://github.com/stefanprodan/podinfo
+    status:
+      artifact:
+        digest: sha256:a375b2ca68275734e3850d3c80e0bc20c1d7a4daa1a9717056d5c0c563ea0719
+        lastUpdateTime: "2023-05-01T10:17:08Z"
+        path: gitrepository/test-gitrepository/sample/0647aea75b85755411b007a290b9321668370be5.tar.gz
+        revision: master@sha1:0647aea75b85755411b007a290b9321668370be5
+        size: 83516
+        url: http://source-controller.flux-system.svc.cluster.local./gitrepository/test-gitrepository/sample/0647aea75b85755411b007a290b9321668370be5.tar.gz
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: Succeeded
+        lastTransitionTime: "2023-05-01T10:17:09Z"
+        message: member1=stored artifact for revision 'master@sha1:0647aea75b85755411b007a290b9321668370be5', member3=stored artifact for revision 'master@sha1:0647aea75b85755411b007a290b9321668370be5'
+        observedGeneration: 1
+      - type: ArtifactInStorage
+        status: "True"
+        reason: Succeeded
+        lastTransitionTime: "2023-05-01T10:17:09Z"
+        message: member1=stored artifact for revision 'master@sha1:0647aea75b85755411b007a290b9321668370be5', member3=stored artifact for revision 'master@sha1:0647aea75b85755411b007a290b9321668370be5'
+        observedGeneration: 1
+      observedGeneration: 1
+---
+name: "GitRepository with stale member"
+description: "observedGeneration should not advance if any member is stale"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    generation: 2
+    name: sample
+    namespace: test-gitrepository
+  status:
+    observedGeneration: 1
+statusItems:
+  - status:
+      generation: 2
+      observedGeneration: 2
+      resourceTemplateGeneration: 2
+  - status:
+      generation: 2
+      observedGeneration: 1
+      resourceTemplateGeneration: 2
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: source.toolkit.fluxcd.io/v1
+    kind: GitRepository
+    metadata:
+      generation: 2
+      name: sample
+      namespace: test-gitrepository
+    status:
+      observedGeneration: 1
+---
+name: "GitRepository with no status items"
+description: "AggregateStatus should initialize empty status"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    generation: 3
+    name: sample
+    namespace: test-gitrepository
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: source.toolkit.fluxcd.io/v1
+    kind: GitRepository
+    metadata:
+      generation: 3
+      name: sample
+      namespace: test-gitrepository
+    status:
+      observedGeneration: 3
+---
+name: "GitRepository with different artifacts picks last one"
+description: "AggregateStatus should pick the last artifact when members report different revisions"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    generation: 1
+    name: sample
+    namespace: test-gitrepository
+statusItems:
+  - clusterName: member1
+    status:
+      artifact:
+        revision: master@sha1:aaaa1111
+        path: artifact-a.tar.gz
+  - clusterName: member2
+    status:
+      artifact:
+        revision: master@sha1:bbbb2222
+        path: artifact-b.tar.gz
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: source.toolkit.fluxcd.io/v1
+    kind: GitRepository
+    metadata:
+      generation: 1
+      name: sample
+      namespace: test-gitrepository
+    status:
+      artifact:
+        revision: master@sha1:bbbb2222
+        path: artifact-b.tar.gz
+      observedGeneration: 0
+---
+name: "GitRepository condition merging with different reasons"
+description: "Conditions with same type but different reasons should not be merged"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+statusItems:
+  - clusterName: member1
+    status:
+      conditions:
+        - type: Ready
+          status: "True"
+          reason: Succeeded
+          message: ok
+  - clusterName: member2
+    status:
+      conditions:
+        - type: Ready
+          status: "False"
+          reason: Failed
+          message: error
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: source.toolkit.fluxcd.io/v1
+    kind: GitRepository
+    metadata:
+      generation: 0
+      name: sample
+      namespace: test-gitrepository
+    status:
+      conditions:
+        - type: Ready
+          status: "True"
+          reason: Succeeded
+          message: member1=ok
+        - type: Ready
+          status: "False"
+          reason: Failed
+          message: member2=error
+      observedGeneration: 0

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1/GitRepository/testdata/interpretdependency-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1/GitRepository/testdata/interpretdependency-test.yaml
@@ -1,0 +1,150 @@
+# test cases for interpreting dependency of GitRepository
+# case1: GitRepository with secretRef dependency
+# case2: GitRepository with certSecretRef only (not supported)
+# case3: GitRepository with both secretRef and certSecretRef
+# case4: GitRepository with verify.secretRef dependency
+# case5. GitRepository with empty secretRef names
+# case6. GitRepository with secretRef and verify.secretRef different names
+# case7. GitRepository with secretRef and verify.secretRef same name
+
+name: "GitRepository with secretRef dependency"
+description: "Should return Secret dependency from spec.secretRef"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+  spec:
+    secretRef:
+      name: git-secret
+operation: InterpretDependency
+output:
+  dependencies:
+    - apiVersion: v1
+      kind: Secret
+      name: git-secret
+      namespace: test-gitrepository
+---
+name: "GitRepository with certSecretRef only"
+description: "certSecretRef is not interpreted by current logic"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+  spec:
+    certSecretRef:
+      name: cert-secret
+operation: InterpretDependency
+output:
+  dependencies: []
+---
+name: "GitRepository with secretRef and certSecretRef"
+description: "Only secretRef should be returned"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+  spec:
+    secretRef:
+      name: git-secret
+    certSecretRef:
+      name: cert-secret
+operation: InterpretDependency
+output:
+  dependencies:
+    - apiVersion: v1
+      kind: Secret
+      name: git-secret
+      namespace: test-gitrepository
+---
+name: "GitRepository with verify.secretRef dependency"
+description: "Should return Secret dependency from spec.verify.secretRef"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+  spec:
+    verify:
+      secretRef:
+        name: verify-secret
+operation: InterpretDependency
+output:
+  dependencies:
+    - apiVersion: v1
+      kind: Secret
+      name: verify-secret
+      namespace: test-gitrepository
+---
+name: "GitRepository with empty secretRef names"
+description: "Empty secretRef and verify.secretRef names should be ignored"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+  spec:
+    secretRef:
+      name: ""
+    verify:
+      secretRef:
+        name: ""
+operation: InterpretDependency
+output:
+  dependencies: []
+---
+name: "GitRepository with secretRef and verify.secretRef different names"
+description: "Two different secret names should return two dependencies"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+  spec:
+    secretRef:
+      name: repo-secret
+    verify:
+      secretRef:
+        name: verify-secret
+operation: InterpretDependency
+output:
+  dependencies:
+    - apiVersion: v1
+      kind: Secret
+      name: repo-secret
+      namespace: test-gitrepository
+    - apiVersion: v1
+      kind: Secret
+      name: verify-secret
+      namespace: test-gitrepository
+---
+name: "GitRepository with secretRef and verify.secretRef same name"
+description: "Same secret name should be deduplicated"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+  spec:
+    secretRef:
+      name: shared-secret
+    verify:
+      secretRef:
+        name: shared-secret
+operation: InterpretDependency
+output:
+  dependencies:
+    - apiVersion: v1
+      kind: Secret
+      name: shared-secret
+      namespace: test-gitrepository
+

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1/GitRepository/testdata/interprethealth-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1/GitRepository/testdata/interprethealth-test.yaml
@@ -1,0 +1,115 @@
+# test cases for interpreting health of GitRepository
+# case1: GitRepository Ready=True Succeeded should be Healthy
+# case2: GitRepository Ready=True but wrong reason
+# case3: GitRepository Ready=False
+# case4: GitRepository without Ready condition
+# case5: GitRepository with empty conditions
+# case6: GitRepository unhealthy when status is nil
+# case7: GitRepository unhealthy when status.conditions is nil
+
+name: "GitRepository Ready=True Succeeded should be Healthy"
+description: "Ready condition True with reason Succeeded"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+  status:
+    conditions:
+      - type: Ready
+        status: "True"
+        reason: Succeeded
+operation: InterpretHealth
+output:
+  healthy: true
+---
+name: "GitRepository Ready=True but wrong reason"
+description: "Ready True but reason is not Succeeded"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+  status:
+    conditions:
+      - type: Ready
+        status: "True"
+        reason: Progressing
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "GitRepository Ready=False"
+description: "Ready condition False should be Unhealthy"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+  status:
+    conditions:
+      - type: Ready
+        status: "False"
+        reason: Succeeded
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "GitRepository without Ready condition"
+description: "No Ready condition present"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+  status:
+    conditions:
+      - type: ArtifactInStorage
+        status: "True"
+        reason: Succeeded
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "GitRepository with empty conditions"
+description: "Empty conditions list"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+  status:
+    conditions: []
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "GitRepository unhealthy when status is nil"
+description: "Health should be false when status is nil"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "GitRepository unhealthy when conditions is nil"
+description: "Health should be false when status.conditions is nil"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+  status: {}
+operation: InterpretHealth
+output:
+  healthy: false

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1/GitRepository/testdata/interpretstatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1/GitRepository/testdata/interpretstatus-test.yaml
@@ -1,5 +1,11 @@
 # test case for interpreting status of GitRepository
 # case1. GitRepository: interpret status test
+# case2. GitRepository with nil status
+# case3. GitRepository without resourceTemplateGeneration annotation
+# case4. GitRepository interpret status with observedIgnore
+# case5. GitRepository interpret status with observedRecurseSubmodules
+# case6. GitRepository interpret status with non-numeric resourceTemplateGeneration
+# case7. GitRepository with numeric resourceTemplateGeneration annotation
 
 name: "GitRepository: interpret status test"
 description: "Test interpreting status for GitRepository"
@@ -45,3 +51,121 @@ observedObj:
     observedGeneration: 1
 operation: InterpretStatus
 output:
+  status:
+    artifact:
+      digest: sha256:a375b2ca68275734e3850d3c80e0bc20c1d7a4daa1a9717056d5c0c563ea0719
+      lastUpdateTime: "2023-05-01T10:17:09Z"
+      path: gitrepository/test-gitrepository/sample/0647aea75b85755411b007a290b9321668370be5.tar.gz
+      revision: master@sha1:0647aea75b85755411b007a290b9321668370be5
+      size: 83516
+      url: http://source-controller.flux-system.svc.cluster.local./gitrepository/test-gitrepository/sample/0647aea75b85755411b007a290b9321668370be5.tar.gz
+    conditions:
+    - lastTransitionTime: "2023-05-01T10:17:09Z"
+      message: stored artifact for revision 'master@sha1:0647aea75b85755411b007a290b9321668370be5'
+      observedGeneration: 1
+      reason: Succeeded
+      status: "True"
+      type: Ready
+    - lastTransitionTime: "2023-05-01T10:17:09Z"
+      message: stored artifact for revision 'master@sha1:0647aea75b85755411b007a290b9321668370be5'
+      observedGeneration: 1
+      reason: Succeeded
+      status: "True"
+      type: ArtifactInStorage
+    observedGeneration: 1
+    generation: 1
+    resourceTemplateGeneration: 1
+---
+name: "GitRepository with nil status"
+description: "InterpretStatus should return empty status when status is nil"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+operation: InterpretStatus
+output:
+  status: {}
+---
+name: "GitRepository without resourceTemplateGeneration annotation"
+description: "resourceTemplateGeneration should be absent if annotation is missing"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    generation: 2
+    name: sample
+    namespace: test-gitrepository
+  status:
+    observedGeneration: 2
+operation: InterpretStatus
+output:
+  status:
+    observedGeneration: 2
+    generation: 2
+---
+name: "GitRepository interpret status with observedIgnore"
+description: "InterpretStatus should copy observedIgnore field"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+  status:
+    observedIgnore: true
+operation: InterpretStatus
+output:
+  status:
+    observedIgnore: true
+---
+name: "GitRepository interpret status with observedRecurseSubmodules"
+description: "InterpretStatus should copy observedRecurseSubmodules field"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+  status:
+    observedRecurseSubmodules: true
+operation: InterpretStatus
+output:
+  status:
+    observedRecurseSubmodules: true
+---
+name: "GitRepository interpret status with non-numeric resourceTemplateGeneration"
+description: "Non-numeric resourceTemplateGeneration annotation should be ignored"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+    annotations:
+      resourcetemplate.karmada.io/generation: not-a-number
+  status: {}
+operation: InterpretStatus
+output:
+  status: {}
+---
+name: "GitRepository with numeric resourceTemplateGeneration annotation"
+description: "Numeric resourceTemplateGeneration annotation should be parsed correctly"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+    generation: 3
+    annotations:
+      resourcetemplate.karmada.io/generation: 123
+  status:
+    observedGeneration: 3
+operation: InterpretStatus
+output:
+  status:
+    generation: 3
+    observedGeneration: 3
+    resourceTemplateGeneration: 123

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1/GitRepository/testdata/retention-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1/GitRepository/testdata/retention-test.yaml
@@ -1,0 +1,97 @@
+# test case for retaining suspend field of GitRepository
+# case1. GitRepository: retain suspend=true
+# case2. GitRepository: retain suspend=false
+# case3. GitRepository: retain without suspend
+
+name: "GitRepository retain suspend=true"
+description: "Retain should copy suspend=true from observed to desired"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+  spec:
+    interval: 30s
+    url: https://github.com/example/repo
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+  spec:
+    suspend: true
+operation: Retain
+output:
+  retained:
+    apiVersion: source.toolkit.fluxcd.io/v1
+    kind: GitRepository
+    metadata:
+      name: sample
+      namespace: test-gitrepository
+    spec:
+      interval: 30s
+      url: https://github.com/example/repo
+      suspend: true
+---
+name: "GitRepository retain suspend=false"
+description: "Retain should copy suspend=false from observed to desired"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+  spec:
+    interval: 30s
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+  spec:
+    suspend: false
+operation: Retain
+output:
+  retained:
+    apiVersion: source.toolkit.fluxcd.io/v1
+    kind: GitRepository
+    metadata:
+      name: sample
+      namespace: test-gitrepository
+    spec:
+      interval: 30s
+      suspend: false
+---
+name: "GitRepository retain without suspend"
+description: "Retain should not change suspend if observed has none"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+  spec:
+    interval: 30s
+    suspend: true
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    name: sample
+    namespace: test-gitrepository
+  spec:
+    interval: 30s
+operation: Retain
+output:
+  retained:
+    apiVersion: source.toolkit.fluxcd.io/v1
+    kind: GitRepository
+    metadata:
+      name: sample
+      namespace: test-gitrepository
+    spec:
+      interval: 30s
+      suspend: true


### PR DESCRIPTION
This PR adds missing test coverage for the GitRepository resource interpreter.
It covers status interpretation, health interpretation, dependency detection, retention behavior, and status reflection.

No production logic changes are included.

Thanks to @FAUST-BENCHOU for the valuable reviews and feedback throughout this PR.