### PR TITLE
Remove the workaround for controller tests

### DIFF
--- a/pkg/controllers/execution/execution_controller.go
+++ b/pkg/controllers/execution/execution_controller.go
@@ -358,22 +358,7 @@ func (c *Controller) updateWorkDispatchingConditionIfNeeded(ctx context.Context,
 		return err
 	}
 
-	if work.GetObjectKind().GroupVersionKind().Empty() {
-		// In unit tests, we need to verify how many events are emitted. However, when using the fake client,
-		// the work object may not have TypeMeta (APIVersion/Kind) set, which prevents building a proper
-		// object reference and thus no event is actually emitted. This workaround ensures the GVK is set
-		// so event emission, and thereby event counting in unit tests, works as expected.
-		// Since controller-runtime v0.22.0, the group version kind is not set when using fake client.
-		// See https://github.com/kubernetes-sigs/controller-runtime/pull/3229 for more details.
-		work.SetGroupVersionKind(workv1alpha1.SchemeGroupVersion.WithKind("Work"))
-	}
-
-	obj, err := helper.ToUnstructured(work)
-	if err != nil {
-		return err
-	}
-
-	c.eventf(obj, corev1.EventTypeNormal, events.EventReasonWorkDispatching, newWorkDispatchingCondition.Message)
+	c.EventRecorder.Eventf(work, corev1.EventTypeNormal, events.EventReasonWorkDispatching, newWorkDispatchingCondition.Message)
 	return nil
 }
 

--- a/pkg/controllers/execution/execution_controller_test.go
+++ b/pkg/controllers/execution/execution_controller_test.go
@@ -26,6 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -36,6 +37,7 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
@@ -48,6 +50,27 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/objectwatcher"
 	testhelper "github.com/karmada-io/karmada/test/helper"
 )
+
+// withGVKInterceptor returns an interceptor that sets the GVK on objects after Get operations.
+// This simulates the behavior of real API server clients, which automatically set GVK.
+// The fake client doesn't do this by default (since controller-runtime v0.22.0).
+func withGVKInterceptor(scheme *runtime.Scheme) interceptor.Funcs {
+	return interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if err := c.Get(ctx, key, obj, opts...); err != nil {
+				return err
+			}
+			// Set GVK from scheme if it's empty (mimicking real client behavior)
+			if obj.GetObjectKind().GroupVersionKind().Empty() {
+				gvks, _, _ := scheme.ObjectKinds(obj)
+				if len(gvks) > 0 {
+					obj.GetObjectKind().SetGroupVersionKind(gvks[0])
+				}
+			}
+			return nil
+		},
+	}
+}
 
 type FakeResourceInterpreter struct {
 	*native.DefaultInterpreter
@@ -223,7 +246,14 @@ func newController(work *workv1alpha1.Work, recorder *record.FakeRecorder) Contr
 	pod.SetLabels(map[string]string{util.ManagedByKarmadaLabel: util.ManagedByKarmadaLabelValue})
 	restMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{corev1.SchemeGroupVersion})
 	restMapper.Add(corev1.SchemeGroupVersion.WithKind(pod.Kind), meta.RESTScopeNamespace)
-	fakeClient := fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithObjects(cluster, work).WithStatusSubresource(work).WithRESTMapper(restMapper).Build()
+	clientScheme := gclient.NewSchema()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(clientScheme).
+		WithObjects(cluster, work).
+		WithStatusSubresource(work).
+		WithRESTMapper(restMapper).
+		WithInterceptorFuncs(withGVKInterceptor(clientScheme)).
+		Build()
 	dynamicClientSet := dynamicfake.NewSimpleDynamicClient(scheme.Scheme, pod)
 	informerManager := genericmanager.GetInstance()
 	informerManager.ForCluster(cluster.Name, dynamicClientSet, 0).Lister(corev1.SchemeGroupVersion.WithResource("pods"))

--- a/pkg/controllers/namespace/namespace_sync_controller.go
+++ b/pkg/controllers/namespace/namespace_sync_controller.go
@@ -82,14 +82,6 @@ func (c *Controller) Reconcile(ctx context.Context, req controllerruntime.Reques
 
 		return controllerruntime.Result{}, err
 	}
-	if namespace.GetObjectKind().GroupVersionKind().Empty() {
-		// In unit tests, we need to verify that a work object is created for the corresponding namespace.
-		// However, the fake client does not set TypeMeta information, which results in an incorrect generated work object name.
-		// This ensures correct GVK is set so work name generation in tests works as expected.
-		// Since controller-runtime v0.22.0, the group version kind is not set when using fake client.
-		// See https://github.com/kubernetes-sigs/controller-runtime/pull/3229 for more details.
-		namespace.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Namespace"))
-	}
 
 	if !namespace.DeletionTimestamp.IsZero() {
 		// Do nothing, just return as we have added owner reference to Work.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR removes the ugly workarounds introduced when bumping controller-runtime in #6868 (See the removed comments for reference).

**Which issue(s) this PR fixes**:
Fixes #
Part of #6862

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

