### PR TITLE
Automated cherry pick of #7086: fix: use QuotaExceeded reason when FederatedResourceQuota is

### DIFF
--- a/test/e2e/suites/base/federatedresourcequota_test.go
+++ b/test/e2e/suites/base/federatedresourcequota_test.go
@@ -443,7 +443,11 @@ var _ = ginkgo.Describe("FederatedResourceQuota enforcement testing", func() {
 					if err != nil {
 						return false
 					}
-					return rb != nil && meta.IsStatusConditionPresentAndEqual(rb.Status.Conditions, workv1alpha2.Scheduled, metav1.ConditionFalse)
+					if rb == nil {
+						return false
+					}
+					cond := meta.FindStatusCondition(rb.Status.Conditions, workv1alpha2.Scheduled)
+					return cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == workv1alpha2.BindingReasonQuotaExceeded
 				}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 				framework.WaitResourceBindingFitWith(karmadaClient, newDeploymentNamespace, newRB, func(resourceBinding *workv1alpha2.ResourceBinding) bool {
 					return resourceBinding.Spec.Clusters == nil
@@ -474,7 +478,11 @@ var _ = ginkgo.Describe("FederatedResourceQuota enforcement testing", func() {
 					if err != nil {
 						return false
 					}
-					return rb != nil && meta.IsStatusConditionPresentAndEqual(rb.Status.Conditions, workv1alpha2.Scheduled, metav1.ConditionFalse)
+					if rb == nil {
+						return false
+					}
+					cond := meta.FindStatusCondition(rb.Status.Conditions, workv1alpha2.Scheduled)
+					return cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == workv1alpha2.BindingReasonQuotaExceeded
 				}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 			})
 


### PR DESCRIPTION
Related Issue: #7097 

Cherry pick of #7086 on release-1.16.
#7086: fix: use QuotaExceeded reason when FederatedResourceQuota is
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-webhook`: Fixed an issue where the `condition.reason` was not set to `QuotaExceeded` when FederatedResourceQuota is exceeded.
```