### PR TITLE
Automated cherry pick of #7086: fix: use QuotaExceeded reason when FederatedResourceQuota is

### DIFF
--- a/pkg/webhook/resourcebinding/validating.go
+++ b/pkg/webhook/resourcebinding/validating.go
@@ -26,6 +26,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
@@ -56,6 +57,14 @@ type frqProcessOutcome struct {
 	ProcessError       error // Error for RetryOnConflict (e.g., conflict error or nil for success/final decision)
 }
 
+type quotaExceededError struct {
+	errMsg string
+}
+
+func (q *quotaExceededError) Error() string {
+	return q.errMsg
+}
+
 // Handle implements admission.Handler interface.
 func (v *ValidatingAdmission) Handle(ctx context.Context, req admission.Request) admission.Response {
 	rb, oldRB, err := v.decodeRBs(req)
@@ -70,7 +79,7 @@ func (v *ValidatingAdmission) Handle(ctx context.Context, req admission.Request)
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
 		klog.Errorf("Admission denied for ResourceBinding %s/%s: %v", rb.Namespace, rb.Name, err)
-		return admission.Denied(err.Error())
+		return buildDenyResponse(err)
 	}
 
 	if features.FeatureGate.Enabled(features.MultiplePodTemplatesScheduling) {
@@ -278,6 +287,23 @@ func (v *ValidatingAdmission) decodeRBs(req admission.Request) (
 	return decodedRB, decodedOldRB, nil
 }
 
+func buildDenyResponse(err error) admission.Response {
+	var quotaErr *quotaExceededError
+	if errors.As(err, &quotaErr) {
+		return admission.Response{
+			AdmissionResponse: admissionv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Message: quotaErr.Error(),
+					Reason:  util.QuotaExceededReason,
+					Code:    int32(http.StatusForbidden),
+				},
+			},
+		}
+	}
+	return admission.Denied(err.Error())
+}
+
 func (v *ValidatingAdmission) calculateRBUsages(rb, oldRB *workv1alpha2.ResourceBinding) (corev1.ResourceList, corev1.ResourceList, error) {
 	newRbTotalUsage := helper.CalculateResourceUsage(rb)
 	klog.V(4).Infof("Calculated total usage for incoming RB %s/%s: %v", rb.Namespace, rb.Name, newRbTotalUsage)
@@ -322,7 +348,7 @@ func (v *ValidatingAdmission) processSingleFRQ(frqItem *policyv1alpha1.Federated
 	if !isAllowed {
 		klog.Warningf("Quota exceeded for FederatedResourceQuota %s/%s. ResourceBinding %s/%s will be denied. %s",
 			frqItem.Namespace, frqItem.Name, rbNamespace, rbName, errMsg)
-		return nil, "", errors.New(errMsg)
+		return nil, "", &quotaExceededError{errMsg: errMsg}
 	}
 
 	msg := fmt.Sprintf("Quota check passed for FRQ %s/%s.", frqItem.Namespace, frqItem.Name)

--- a/pkg/webhook/resourcebinding/validating_test.go
+++ b/pkg/webhook/resourcebinding/validating_test.go
@@ -40,6 +40,7 @@ import (
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/features"
+	"github.com/karmada-io/karmada/pkg/util"
 )
 
 // testScheme is the scheme used for fake client in tests.
@@ -174,6 +175,20 @@ func makeTestFRQ(namespace, name string, opts ...FRQOption) *policyv1alpha1.Fede
 
 // boolPtr returns a pointer to a boolean value.
 func boolPtr(b bool) *bool { return &b }
+
+// quotaExceededResponse creates an admission response for quota exceeded errors.
+func quotaExceededResponse(message string) admission.Response {
+	return admission.Response{
+		AdmissionResponse: admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: message,
+				Reason:  util.QuotaExceededReason,
+				Code:    int32(http.StatusForbidden),
+			},
+		},
+	}
+}
 
 // --- Admission Request Builder ---
 type admissionRequestBuilder struct {
@@ -474,7 +489,7 @@ func TestValidatingAdmission_Handle(t *testing.T) {
 			decoder:       &fakeDecoder{decodeObj: rbCreateExceeds},
 			clientObjects: []client.Object{frqForCreateExceeds},
 			enableFederatedQuotaEnforcementFeatureGate: true,
-			wantResponse: admission.Denied("FederatedResourceQuota(quota-ns/frq-create-exceeds) exceeded for resource cpu: requested sum 200m, limit 150m."),
+			wantResponse: quotaExceededResponse("FederatedResourceQuota(quota-ns/frq-create-exceeds) exceeded for resource cpu: requested sum 200m, limit 150m."),
 		},
 		{
 			name: "update passes quota (allowed response, non-dryrun)",
@@ -509,7 +524,7 @@ func TestValidatingAdmission_Handle(t *testing.T) {
 			decoder:       &fakeDecoder{decodeObj: rbUpdateFailNew, rawDecodedObj: rbUpdateFailOld},
 			clientObjects: []client.Object{frqForUpdateFail},
 			enableFederatedQuotaEnforcementFeatureGate: true,
-			wantResponse: admission.Denied("FederatedResourceQuota(quota-ns/frq-update-fail) exceeded for resource cpu: requested sum 110m, limit 100m."),
+			wantResponse: quotaExceededResponse("FederatedResourceQuota(quota-ns/frq-update-fail) exceeded for resource cpu: requested sum 110m, limit 100m."),
 		},
 		{
 			name: "validateComponents: zero components (should allow)",
@@ -603,7 +618,7 @@ func TestValidatingAdmission_Handle(t *testing.T) {
 			decoder:       &fakeDecoder{decodeObj: rbWithComponents},
 			clientObjects: []client.Object{frqForComponentsExceeded},
 			enableFederatedQuotaEnforcementFeatureGate: true,
-			wantResponse: admission.Denied("FederatedResourceQuota(quota-ns/frq-components-exceeded) exceeded for resource cpu: requested sum 160m, limit 150m."),
+			wantResponse: quotaExceededResponse("FederatedResourceQuota(quota-ns/frq-components-exceeded) exceeded for resource cpu: requested sum 160m, limit 150m."),
 		},
 		{
 			name: "update components passes quota (allowed response)",
@@ -625,7 +640,7 @@ func TestValidatingAdmission_Handle(t *testing.T) {
 			decoder:       &fakeDecoder{decodeObj: rbComponentsFailNew, rawDecodedObj: rbComponentsFailOld},
 			clientObjects: []client.Object{frqForComponentsFail},
 			enableFederatedQuotaEnforcementFeatureGate: true,
-			wantResponse: admission.Denied("FederatedResourceQuota(quota-ns/frq-components-fail) exceeded for resource cpu: requested sum 110m, limit 100m."),
+			wantResponse: quotaExceededResponse("FederatedResourceQuota(quota-ns/frq-components-fail) exceeded for resource cpu: requested sum 110m, limit 100m."),
 		},
 	}
 
@@ -668,6 +683,9 @@ func TestValidatingAdmission_Handle(t *testing.T) {
 				}
 				if got.Result.Code != tt.wantResponse.Result.Code {
 					t.Errorf("Handle() got.Result.Code = %d, want %d", got.Result.Code, tt.wantResponse.Result.Code)
+				}
+				if got.Result.Reason != tt.wantResponse.Result.Reason {
+					t.Errorf("Handle() got.Result.Reason = %q, want %q", got.Result.Reason, tt.wantResponse.Result.Reason)
 				}
 			}
 

--- a/test/e2e/suites/base/federatedresourcequota_test.go
+++ b/test/e2e/suites/base/federatedresourcequota_test.go
@@ -430,7 +430,11 @@ var _ = ginkgo.Describe("FederatedResourceQuota enforcement testing", func() {
 					if err != nil {
 						return false
 					}
-					return rb != nil && meta.IsStatusConditionPresentAndEqual(rb.Status.Conditions, workv1alpha2.Scheduled, metav1.ConditionFalse)
+					if rb == nil {
+						return false
+					}
+					cond := meta.FindStatusCondition(rb.Status.Conditions, workv1alpha2.Scheduled)
+					return cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == workv1alpha2.BindingReasonQuotaExceeded
 				}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 				framework.WaitResourceBindingFitWith(karmadaClient, newDeploymentNamespace, newRB, func(resourceBinding *workv1alpha2.ResourceBinding) bool {
 					return resourceBinding.Spec.Clusters == nil
@@ -461,7 +465,11 @@ var _ = ginkgo.Describe("FederatedResourceQuota enforcement testing", func() {
 					if err != nil {
 						return false
 					}
-					return rb != nil && meta.IsStatusConditionPresentAndEqual(rb.Status.Conditions, workv1alpha2.Scheduled, metav1.ConditionFalse)
+					if rb == nil {
+						return false
+					}
+					cond := meta.FindStatusCondition(rb.Status.Conditions, workv1alpha2.Scheduled)
+					return cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == workv1alpha2.BindingReasonQuotaExceeded
 				}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 			})
 


### PR DESCRIPTION
Related Issue: #7097 

Cherry pick of #7086 on release-1.15.
#7086: fix: use QuotaExceeded reason when FederatedResourceQuota is
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-webhook`: Fixed an issue where the `condition.reason` was not set to `QuotaExceeded` when FederatedResourceQuota is exceeded.
```