### PR TITLE
Add complete interpreter tests covarage for Bucket

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/Bucket/testdata/aggregatestatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/Bucket/testdata/aggregatestatus-test.yaml
@@ -1,5 +1,10 @@
 # test case for aggregating status of Bucket
 # case1. Bucket with two status items
+# case2. Bucket with no status items
+# case3. Bucket with stale member
+# case4. Bucket condition merging with different reasons
+# case5. Bucket ignores empty url
+# case6. Bucket with different artifacts picks last one
 
 name: "Bucket with two status items"
 description: "Test aggregating status of Bucket with two status items"
@@ -78,3 +83,203 @@ statusItems:
       resourceTemplateGeneration: 1
 operation: AggregateStatus
 output:
+  aggregatedStatus:
+    apiVersion: source.toolkit.fluxcd.io/v1beta2
+    kind: Bucket
+    metadata:
+      name: sample
+      namespace: test-bucket
+      generation: 1
+    spec:
+      provider: generic
+      interval: 5m0s
+      bucketName: podinfo
+      endpoint: minio.minio.svc.cluster.local:9000
+      timeout: 60s
+      insecure: true
+      secretRef:
+        name: fake-minio-credentials
+    status:
+      conditions:
+        - type: Reconciling
+          status: "True"
+          reason: ProgressingWithRetry
+          message: "member1=building artifact, member3=building artifact"
+          observedGeneration: 1
+          lastTransitionTime: "2023-04-29T14:02:31Z"
+        - type: Ready
+          status: "False"
+          reason: AuthenticationFailed
+          message: "member1=invalid 'fake-secret' secret data: required fields 'accesskey' and 'secretkey', member3=invalid 'fake-secret' secret data: required fields 'accesskey' and 'secretkey'"
+          observedGeneration: 1
+          lastTransitionTime: "2023-04-29T14:02:31Z"
+        - type: FetchFailed
+          status: "True"
+          reason: AuthenticationFailed
+          message: "member1=invalid 'fake-secret' secret data: required fields 'accesskey' and 'secretkey', member3=invalid 'fake-secret' secret data: required fields 'accesskey' and 'secretkey'"
+          observedGeneration: 1
+          lastTransitionTime: "2023-04-29T14:01:44Z"
+      observedGeneration: 0
+      url: ""
+---
+name: "Bucket with no status items"
+description: "AggregateStatus initializes empty status when no members exist"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  metadata:
+    name: sample
+    namespace: test-bucket
+    generation: 3
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: source.toolkit.fluxcd.io/v1beta2
+    kind: Bucket
+    metadata:
+      name: sample
+      namespace: test-bucket
+      generation: 3
+    status:
+      url: ""
+      observedGeneration: 3
+---
+name: "Bucket with stale member"
+description: "observedGeneration should not advance if any member is stale"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  metadata:
+    name: sample
+    namespace: test-bucket
+    generation: 5
+  status:
+    observedGeneration: 4
+statusItems:
+  - status:
+      generation: 5
+      observedGeneration: 5
+      resourceTemplateGeneration: 5
+  - status:
+      generation: 5
+      observedGeneration: 4
+      resourceTemplateGeneration: 5
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: source.toolkit.fluxcd.io/v1beta2
+    kind: Bucket
+    metadata:
+      name: sample
+      namespace: test-bucket
+      generation: 5
+    status:
+      observedGeneration: 4
+      url: ""
+---
+name: "Bucket condition merging with different reasons"
+description: "Conditions with same type but different reasons are not merged"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  metadata:
+    name: sample
+    namespace: test-bucket
+statusItems:
+  - clusterName: member1
+    status:
+      conditions:
+        - type: Ready
+          status: "True"
+          reason: Succeeded
+          message: ok
+  - clusterName: member2
+    status:
+      conditions:
+        - type: Ready
+          status: "False"
+          reason: Failed
+          message: error
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: source.toolkit.fluxcd.io/v1beta2
+    kind: Bucket
+    metadata:
+      name: sample
+      namespace: test-bucket
+      generation: 0
+    status:
+      conditions:
+        - type: Ready
+          status: "True"
+          reason: Succeeded
+          message: member1=ok
+        - type: Ready
+          status: "False"
+          reason: Failed
+          message: member2=error
+      observedGeneration: 0
+      url: ""
+---
+name: "Bucket ignores empty url"
+description: "Empty url fields are ignored during aggregation"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  metadata:
+    name: sample
+    namespace: test-bucket
+statusItems:
+  - status:
+      url: ""
+  - status:
+      url: http://bucket/valid
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: source.toolkit.fluxcd.io/v1beta2
+    kind: Bucket
+    metadata:
+      name: sample
+      namespace: test-bucket
+      generation: 0
+    status:
+      observedGeneration: 0
+      url: http://bucket/valid
+---
+name: "Bucket with different artifacts picks last one"
+description: "AggregateStatus should pick the last artifact when members report different artifacts"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  metadata:
+    name: sample
+    namespace: test-bucket
+    generation: 1
+statusItems:
+  - clusterName: member1
+    status:
+      artifact:
+        path: artifact-a.tar.gz
+        revision: rev-a
+  - clusterName: member2
+    status:
+      artifact:
+        path: artifact-b.tar.gz
+        revision: rev-b
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: source.toolkit.fluxcd.io/v1beta2
+    kind: Bucket
+    metadata:
+      name: sample
+      namespace: test-bucket
+      generation: 1
+    status:
+      artifact:
+        path: artifact-b.tar.gz
+        revision: rev-b
+      observedGeneration: 0
+      url: ""

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/Bucket/testdata/interpretdependency-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/Bucket/testdata/interpretdependency-test.yaml
@@ -1,0 +1,47 @@
+# test case for interpreting dependencies of Bucket
+# case1. Bucket with secretRef dependency
+# case2. Bucket without secretRef
+# case3. Bucket with empty secretRef name
+
+name: "Bucket with secretRef dependency"
+description: "InterpretDependency returns Secret reference"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  metadata:
+    namespace: default
+  spec:
+    secretRef:
+      name: bucket-secret
+operation: InterpretDependency
+output:
+  dependencies:
+    - apiVersion: v1
+      kind: Secret
+      name: bucket-secret
+      namespace: default
+---
+name: "Bucket without secretRef"
+description: "No dependencies when secretRef missing"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  spec: {}
+operation: InterpretDependency
+output:
+  dependencies: []
+---
+name: "Bucket with empty secretRef name"
+description: "Empty secretRef name should be ignored"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  metadata:
+    name: sample
+    namespace: test-bucket
+  spec:
+    secretRef:
+      name: ""
+operation: InterpretDependency
+output:
+  dependencies: []

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/Bucket/testdata/interprethealth-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/Bucket/testdata/interprethealth-test.yaml
@@ -1,0 +1,93 @@
+# test case for interpreting health of Bucket
+# case1. Bucket Ready=True Succeeded should be healthy
+# case2. Bucket Ready=True but wrong reason should be unhealthy
+# case3. Bucket Ready=False should be unhealthy
+# case4. Bucket without Ready condition should be unhealthy
+# case5. Bucket with empty conditions should be unhealthy
+# case6. Bucket unhealthy when status is nil
+# case7. Bucket unhealthy when status.conditions is nil
+
+name: "Bucket healthy when Ready=True and reason=Succeeded"
+description: "Health should be true when Ready condition is True and reason is Succeeded"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  status:
+    conditions:
+      - type: Ready
+        status: "True"
+        reason: Succeeded
+operation: InterpretHealth
+output:
+  healthy: true
+---
+name: "Bucket unhealthy when Ready=True but wrong reason"
+description: "Health should be false when Ready is True but reason is not Succeeded"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  status:
+    conditions:
+      - type: Ready
+        status: "True"
+        reason: Progressing
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "Bucket unhealthy when Ready=False"
+description: "Health should be false when Ready condition is False"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  status:
+    conditions:
+      - type: Ready
+        status: "False"
+        reason: Failed
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "Bucket unhealthy without Ready condition"
+description: "Health should be false when Ready condition is missing"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  status:
+    conditions:
+      - type: Reconciling
+        status: "True"
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "Bucket unhealthy with empty conditions"
+description: "Health should be false when status.conditions is empty"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  status:
+    conditions: []
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "Bucket unhealthy when status is nil"
+description: "Health should be false when status is nil"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "Bucket unhealthy when status.conditions is nil"
+description: "Health should be false when status.conditions is nil"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  status: {}
+operation: InterpretHealth
+output:
+  healthy: false

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/Bucket/testdata/interpretstatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/Bucket/testdata/interpretstatus-test.yaml
@@ -1,5 +1,10 @@
 # test case for interpreting status of Bucket
 # case1. Bucket: interpret status test
+# case2. Bucket with nil status
+# case3. Bucket without resourceTemplateGeneration annotation
+# case4. Bucket with non-numeric resourceTemplateGeneration
+# case5. Bucket copies observedIgnore and url
+# case6. Bucket with numeric resourceTemplateGeneration annotation
 
 name: "Bucket: interpret status test"
 description: "Test interpreting status for Bucket"
@@ -47,3 +52,113 @@ observedObj:
     observedGeneration: -1
 operation: InterpretStatus
 output:
+  status:
+    conditions:
+      - lastTransitionTime: "2023-04-29T14:03:19Z"
+        message: building artifact
+        observedGeneration: 1
+        reason: ProgressingWithRetry
+        status: "True"
+        type: Reconciling
+      - lastTransitionTime: "2023-04-29T14:03:19Z"
+        message: "invalid 'fake-secret' secret data: required fields 'accesskey' and 'secretkey'"
+        observedGeneration: 1
+        reason: AuthenticationFailed
+        status: "False"
+        type: Ready
+      - lastTransitionTime: "2023-04-29T14:01:44Z"
+        message: "invalid 'fake-secret' secret data: required fields 'accesskey' and 'secretkey'"
+        observedGeneration: 1
+        reason: AuthenticationFailed
+        status: "True"
+        type: FetchFailed
+    observedGeneration: -1
+    generation: 1
+    resourceTemplateGeneration: 1
+---
+name: "Bucket with nil status"
+description: "InterpretStatus should return empty status when observed status is nil"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  metadata:
+    name: sample
+    namespace: test-bucket
+operation: InterpretStatus
+output:
+  status: {}
+---
+name: "Bucket without resourceTemplateGeneration annotation"
+description: "resourceTemplateGeneration should not be set when annotation is missing"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  metadata:
+    name: sample
+    namespace: test-bucket
+    generation: 2
+  status:
+    observedGeneration: 2
+operation: InterpretStatus
+output:
+  status:
+    observedGeneration: 2
+    generation: 2
+---
+name: "Bucket with non-numeric resourceTemplateGeneration"
+description: "Non-numeric resourceTemplateGeneration annotation should be ignored"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  metadata:
+    name: sample
+    namespace: test-bucket
+    generation: 3
+    annotations:
+      resourcetemplate.karmada.io/generation: not-a-number
+  status:
+    observedGeneration: 3
+operation: InterpretStatus
+output:
+  status:
+    observedGeneration: 3
+    generation: 3
+---
+name: "Bucket copies observedIgnore and url"
+description: "InterpretStatus should copy observedIgnore and url fields"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  metadata:
+    name: sample
+    namespace: test-bucket
+    generation: 4
+  status:
+    observedIgnore: true
+    url: http://bucket/example
+operation: InterpretStatus
+output:
+  status:
+    observedIgnore: true
+    url: http://bucket/example
+    generation: 4
+---
+name: "Bucket with numeric resourceTemplateGeneration annotation"
+description: "InterpretStatus should set resourceTemplateGeneration when annotation is numeric"
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  metadata:
+    name: sample
+    namespace: test-bucket
+    generation: 6
+    annotations:
+      resourcetemplate.karmada.io/generation: "123"
+  status:
+    observedGeneration: 6
+operation: InterpretStatus
+output:
+  status:
+    observedGeneration: 6
+    generation: 6
+    resourceTemplateGeneration: 123

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/Bucket/testdata/retention-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/source.toolkit.fluxcd.io/v1beta2/Bucket/testdata/retention-test.yaml
@@ -1,0 +1,59 @@
+# test case for retaining suspend field of Bucket
+# case1. Bucket: retain suspend=true
+# case2. Bucket: retain suspend=false
+# case3. Bucket: retain without suspend
+
+name: "Bucket retain suspend=true"
+description: "Retain should copy suspend=true from observed object"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  spec: {}
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  spec:
+    suspend: true
+operation: Retain
+output:
+  retained:
+    apiVersion: source.toolkit.fluxcd.io/v1beta2
+    kind: Bucket
+    spec:
+      suspend: true
+---
+name: "Bucket retain suspend=false"
+description: "Retain should copy suspend=false from observed object"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  spec: {}
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  spec:
+    suspend: false
+operation: Retain
+output:
+  retained:
+    apiVersion: source.toolkit.fluxcd.io/v1beta2
+    kind: Bucket
+    spec:
+      suspend: false
+---
+name: "Bucket retain without suspend"
+description: "Retain should not add suspend if observed object does not have it"
+desiredObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  spec: {}
+observedObj:
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: Bucket
+  spec: {}
+operation: Retain
+output:
+  retained:
+    apiVersion: source.toolkit.fluxcd.io/v1beta2
+    kind: Bucket
+    spec: {}


### PR DESCRIPTION
Adds test coverage for Bucket resource interpreter including aggregation,
status reflection, retention,health interpretation and dependency interpretation.


Fixes- a subtask of #6952 

All tests pass locally, no logic has been changed.
Thanks to @FAUST-BENCHOU for reviews and feedback.