### PR TITLE
Add RayService Interpreter and Tests

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/ray.io/v1/RayService/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/ray.io/v1/RayService/customizations.yaml
@@ -1,0 +1,493 @@
+apiVersion: config.karmada.io/v1alpha1
+kind: ResourceInterpreterCustomization
+metadata:
+  name: declarative-configuration-rayservice
+spec:
+  target:
+    apiVersion: ray.io/v1
+    kind: RayService
+  customizations:
+    replicaResource:
+      luaScript: |
+        local kube = require("kube")
+
+        function GetReplicas(desiredObj)
+          -- RayService replica calculation:
+          -- - Total replicas = 1 (head) + sum of all worker group replicas
+          -- - Resource requirements = MAX of CPU and memory across head and all worker groups
+          -- - NodeClaim (nodeSelector, tolerations) from head pod template
+          --
+          -- Note: HeadGroupSpec and HeadGroupSpec.Template are required fields per kuberay API.
+          -- A valid RayService always has a head pod template.
+
+          if desiredObj.spec == nil or desiredObj.spec.rayClusterConfig == nil then
+            return 0, nil
+          end
+
+          local clusterConfig = desiredObj.spec.rayClusterConfig
+
+          -- HeadGroupSpec is required per kuberay API
+          if clusterConfig.headGroupSpec == nil or clusterConfig.headGroupSpec.template == nil then
+            return 0, nil
+          end
+
+          -- Head group always has 1 replica
+          local totalReplicas = 1
+          local requires = kube.accuratePodRequirements(clusterConfig.headGroupSpec.template)
+
+          -- Track max resources (value for comparison, string for output)
+          local maxCpuVal = 0
+          local maxMemVal = 0
+          local maxCpuStr = nil
+          local maxMemStr = nil
+
+          if requires ~= nil and requires.resourceRequest ~= nil then
+            if requires.resourceRequest.cpu ~= nil then
+              maxCpuVal = kube.getResourceQuantity(requires.resourceRequest.cpu)
+              maxCpuStr = requires.resourceRequest.cpu
+            end
+            if requires.resourceRequest.memory ~= nil then
+              maxMemVal = kube.getResourceQuantity(requires.resourceRequest.memory)
+              maxMemStr = requires.resourceRequest.memory
+            end
+          end
+
+          -- Add replicas from worker groups and find max resources
+          if clusterConfig.workerGroupSpecs ~= nil then
+            for _, workerGroup in ipairs(clusterConfig.workerGroupSpecs) do
+              totalReplicas = totalReplicas + (workerGroup.replicas or 0)
+
+              if workerGroup.template ~= nil then
+                local workerReqs = kube.accuratePodRequirements(workerGroup.template)
+                if workerReqs ~= nil and workerReqs.resourceRequest ~= nil then
+                  if workerReqs.resourceRequest.cpu ~= nil then
+                    local cpuVal = kube.getResourceQuantity(workerReqs.resourceRequest.cpu)
+                    if cpuVal > maxCpuVal then
+                      maxCpuVal = cpuVal
+                      maxCpuStr = workerReqs.resourceRequest.cpu
+                    end
+                  end
+                  if workerReqs.resourceRequest.memory ~= nil then
+                    local memVal = kube.getResourceQuantity(workerReqs.resourceRequest.memory)
+                    if memVal > maxMemVal then
+                      maxMemVal = memVal
+                      maxMemStr = workerReqs.resourceRequest.memory
+                    end
+                  end
+                end
+              end
+            end
+          end
+
+          -- Apply max resources to the requires object
+          if requires ~= nil and (maxCpuStr ~= nil or maxMemStr ~= nil) then
+            if requires.resourceRequest == nil then
+              requires.resourceRequest = {}
+            end
+            if maxCpuStr ~= nil then
+              requires.resourceRequest.cpu = maxCpuStr
+            end
+            if maxMemStr ~= nil then
+              requires.resourceRequest.memory = maxMemStr
+            end
+          end
+
+          return totalReplicas, requires
+        end
+    replicaRevision:
+      luaScript: |
+        function ReviseReplica(desiredObj, desiredReplica)
+          -- RayService replica revision:
+          -- - Head group always has 1 replica (not scalable)
+          -- - Worker replicas = desiredReplica - 1
+          -- - Distribution: single group gets all, multiple groups distributed proportionally
+
+          if desiredObj.spec == nil or desiredObj.spec.rayClusterConfig == nil then
+            return desiredObj
+          end
+
+          local clusterConfig = desiredObj.spec.rayClusterConfig
+          local workerReplicas = math.max(0, desiredReplica - 1)
+
+          if clusterConfig.workerGroupSpecs == nil or #clusterConfig.workerGroupSpecs == 0 then
+            return desiredObj
+          end
+
+          local workerGroups = clusterConfig.workerGroupSpecs
+          local numGroups = #workerGroups
+
+          -- Single worker group: assign all worker replicas directly
+          if numGroups == 1 then
+            workerGroups[1].replicas = workerReplicas
+            return desiredObj
+          end
+
+          -- Calculate current total for proportional distribution
+          local currentTotal = 0
+          for _, wg in ipairs(workerGroups) do
+            currentTotal = currentTotal + (wg.replicas or 0)
+          end
+
+          -- Handle zero workers case
+          if workerReplicas == 0 then
+            for _, wg in ipairs(workerGroups) do
+              wg.replicas = 0
+            end
+            return desiredObj
+          end
+
+          -- Multiple groups: distribute proportionally or equally if starting from 0
+          local distributed = 0
+          for i, wg in ipairs(workerGroups) do
+            if i == numGroups then
+              -- Last group gets remainder to ensure exact total
+              wg.replicas = workerReplicas - distributed
+            elseif currentTotal == 0 then
+              -- Equal distribution when starting from 0
+              wg.replicas = math.floor(workerReplicas / numGroups)
+              if i <= (workerReplicas % numGroups) then
+                wg.replicas = wg.replicas + 1
+              end
+              distributed = distributed + wg.replicas
+            else
+              -- Proportional distribution based on current ratio
+              local proportion = (wg.replicas or 0) / currentTotal
+              wg.replicas = math.floor(workerReplicas * proportion + 0.5)
+              distributed = distributed + wg.replicas
+            end
+          end
+
+          return desiredObj
+        end
+    healthInterpretation:
+      luaScript: >
+        function InterpretHealth(observedObj)
+          if observedObj.status == nil or observedObj.status.conditions == nil then
+            return false
+          end
+
+          for _, condition in ipairs(observedObj.status.conditions) do
+            if condition.type == 'Ready' and condition.status == 'True' then
+              return true
+            end
+          end
+
+          return false
+        end
+    statusAggregation:
+      luaScript: >
+        function AggregateStatus(desiredObj, statusItems)
+          if statusItems == nil then
+            return desiredObj
+          end
+          if desiredObj.status == nil then
+            desiredObj.status = {}
+          end
+
+          desiredObj.spec = nil
+
+          -- If only one item, use it directly
+          if #statusItems == 1 then
+            desiredObj.status = statusItems[1].status
+            return desiredObj
+          end
+
+          -- Priority for application status (higher = worse, worst wins)
+          local appStatusPriority = {
+            ["RUNNING"] = 0,
+            ["NOT_STARTED"] = 1,
+            ["DEPLOYING"] = 2,
+            ["DELETING"] = 3,
+            ["UNHEALTHY"] = 4,
+            ["DEPLOY_FAILED"] = 5,
+          }
+
+          -- Aggregate values
+          local conditions = {}
+          local numServeEndpoints = 0
+          local lastUpdateTime = nil
+          local observedGeneration = 0
+          local worstServiceStatus = "Running"
+          local activeServiceStatus = nil
+          local pendingServiceStatus = nil
+          local aggregatedApps = {}
+
+          for i = 1, #statusItems do
+            local currentStatus = statusItems[i].status
+            if currentStatus ~= nil then
+              -- Collect all conditions from all clusters
+              if currentStatus.conditions ~= nil then
+                for _, condition in ipairs(currentStatus.conditions) do
+                  table.insert(conditions, condition)
+                end
+              end
+
+              -- Sum serve endpoints across clusters
+              if currentStatus.numServeEndpoints ~= nil then
+                numServeEndpoints = numServeEndpoints + currentStatus.numServeEndpoints
+              end
+
+              -- Take most recent lastUpdateTime
+              if currentStatus.lastUpdateTime ~= nil then
+                if lastUpdateTime == nil or currentStatus.lastUpdateTime > lastUpdateTime then
+                  lastUpdateTime = currentStatus.lastUpdateTime
+                end
+              end
+
+              -- Take highest observed generation
+              if currentStatus.observedGeneration ~= nil and currentStatus.observedGeneration > observedGeneration then
+                observedGeneration = currentStatus.observedGeneration
+              end
+
+              -- Take worst serviceStatus (empty = not running = worse)
+              if currentStatus.serviceStatus ~= nil and currentStatus.serviceStatus == "" then
+                worstServiceStatus = ""
+              end
+
+              -- Take first activeServiceStatus as base, merge applicationStatuses
+              if currentStatus.activeServiceStatus ~= nil then
+                if activeServiceStatus == nil then
+                  activeServiceStatus = currentStatus.activeServiceStatus
+                end
+                -- Merge application statuses with worst-status-wins logic
+                if currentStatus.activeServiceStatus.applicationStatuses ~= nil then
+                  for appName, appStatus in pairs(currentStatus.activeServiceStatus.applicationStatuses) do
+                    local currentPriority = appStatusPriority[appStatus.status] or 0
+                    local existingPriority = -1
+                    if aggregatedApps[appName] ~= nil then
+                      existingPriority = appStatusPriority[aggregatedApps[appName].status] or 0
+                    end
+                    if currentPriority > existingPriority then
+                      aggregatedApps[appName] = appStatus
+                    end
+                  end
+                end
+              end
+
+              -- Take first pendingServiceStatus
+              if currentStatus.pendingServiceStatus ~= nil and pendingServiceStatus == nil then
+                pendingServiceStatus = currentStatus.pendingServiceStatus
+              end
+            end
+          end
+
+          -- Set aggregated status
+          desiredObj.status.conditions = conditions
+          desiredObj.status.numServeEndpoints = numServeEndpoints
+          desiredObj.status.lastUpdateTime = lastUpdateTime
+          desiredObj.status.observedGeneration = observedGeneration
+          desiredObj.status.serviceStatus = worstServiceStatus
+
+          if activeServiceStatus ~= nil then
+            activeServiceStatus.applicationStatuses = aggregatedApps
+            desiredObj.status.activeServiceStatus = activeServiceStatus
+          end
+
+          if pendingServiceStatus ~= nil then
+            desiredObj.status.pendingServiceStatus = pendingServiceStatus
+          end
+
+          return desiredObj
+        end
+    dependencyInterpretation:
+      luaScript: >
+        function GetDependencies(desiredObj)
+          dependentConfigMaps = {}
+          dependentSecrets = {}
+          dependentSas = {}
+          dependentPVCs = {}
+          refs = {}
+
+          -- Helper function to extract dependencies from a pod template spec
+          local function extractDependenciesFromPodSpec(podSpec)
+            if podSpec == nil then
+              return
+            end
+
+            -- Service account
+            if podSpec.serviceAccountName ~= nil and podSpec.serviceAccountName ~= '' and podSpec.serviceAccountName ~= 'default' then
+              dependentSas[podSpec.serviceAccountName] = true
+            end
+
+            -- Image pull secrets
+            if podSpec.imagePullSecrets ~= nil then
+              for _, secretRef in pairs(podSpec.imagePullSecrets) do
+                if secretRef.name ~= nil and secretRef.name ~= '' then
+                  dependentSecrets[secretRef.name] = true
+                end
+              end
+            end
+
+            -- Volumes
+            if podSpec.volumes ~= nil then
+              for _, volume in pairs(podSpec.volumes) do
+                -- ConfigMap volumes
+                if volume.configMap ~= nil and volume.configMap.name ~= nil and volume.configMap.name ~= '' then
+                  dependentConfigMaps[volume.configMap.name] = true
+                end
+                -- Secret volumes
+                if volume.secret ~= nil and volume.secret.secretName ~= nil and volume.secret.secretName ~= '' then
+                  dependentSecrets[volume.secret.secretName] = true
+                end
+                -- Projected volumes
+                if volume.projected ~= nil and volume.projected.sources ~= nil then
+                  for _, source in pairs(volume.projected.sources) do
+                    if source.configMap ~= nil and source.configMap.name ~= nil and source.configMap.name ~= '' then
+                      dependentConfigMaps[source.configMap.name] = true
+                    end
+                    if source.secret ~= nil and source.secret.name ~= nil and source.secret.name ~= '' then
+                      dependentSecrets[source.secret.name] = true
+                    end
+                    if source.serviceAccountToken ~= nil then
+                      -- ServiceAccount tokens don't need explicit dependency tracking
+                    end
+                  end
+                end
+                -- PVC volumes
+                if volume.persistentVolumeClaim ~= nil and volume.persistentVolumeClaim.claimName ~= nil and volume.persistentVolumeClaim.claimName ~= '' then
+                  dependentPVCs[volume.persistentVolumeClaim.claimName] = true
+                end
+                -- Other secret references in volumes
+                if volume.azureFile ~= nil and volume.azureFile.secretName ~= nil and volume.azureFile.secretName ~= '' then
+                  dependentSecrets[volume.azureFile.secretName] = true
+                end
+                if volume.cephfs ~= nil and volume.cephfs.secretRef ~= nil and volume.cephfs.secretRef.name ~= nil and volume.cephfs.secretRef.name ~= '' then
+                  dependentSecrets[volume.cephfs.secretRef.name] = true
+                end
+                if volume.cinder ~= nil and volume.cinder.secretRef ~= nil and volume.cinder.secretRef.name ~= nil and volume.cinder.secretRef.name ~= '' then
+                  dependentSecrets[volume.cinder.secretRef.name] = true
+                end
+                if volume.flexVolume ~= nil and volume.flexVolume.secretRef ~= nil and volume.flexVolume.secretRef.name ~= nil and volume.flexVolume.secretRef.name ~= '' then
+                  dependentSecrets[volume.flexVolume.secretRef.name] = true
+                end
+                if volume.rbd ~= nil and volume.rbd.secretRef ~= nil and volume.rbd.secretRef.name ~= nil and volume.rbd.secretRef.name ~= '' then
+                  dependentSecrets[volume.rbd.secretRef.name] = true
+                end
+                if volume.scaleIO ~= nil and volume.scaleIO.secretRef ~= nil and volume.scaleIO.secretRef.name ~= nil and volume.scaleIO.secretRef.name ~= '' then
+                  dependentSecrets[volume.scaleIO.secretRef.name] = true
+                end
+                if volume.iscsi ~= nil and volume.iscsi.secretRef ~= nil and volume.iscsi.secretRef.name ~= nil and volume.iscsi.secretRef.name ~= '' then
+                  dependentSecrets[volume.iscsi.secretRef.name] = true
+                end
+                if volume.storageos ~= nil and volume.storageos.secretRef ~= nil and volume.storageos.secretRef.name ~= nil and volume.storageos.secretRef.name ~= '' then
+                  dependentSecrets[volume.storageos.secretRef.name] = true
+                end
+                if volume.csi ~= nil and volume.csi.nodePublishSecretRef ~= nil and volume.csi.nodePublishSecretRef.name ~= nil and volume.csi.nodePublishSecretRef.name ~= '' then
+                  dependentSecrets[volume.csi.nodePublishSecretRef.name] = true
+                end
+              end
+            end
+
+            -- Container envFrom references
+            if podSpec.containers ~= nil then
+              for _, container in pairs(podSpec.containers) do
+                if container.envFrom ~= nil then
+                  for _, envFromSource in pairs(container.envFrom) do
+                    if envFromSource.configMapRef ~= nil and envFromSource.configMapRef.name ~= nil and envFromSource.configMapRef.name ~= '' then
+                      dependentConfigMaps[envFromSource.configMapRef.name] = true
+                    end
+                    if envFromSource.secretRef ~= nil and envFromSource.secretRef.name ~= nil and envFromSource.secretRef.name ~= '' then
+                      dependentSecrets[envFromSource.secretRef.name] = true
+                    end
+                  end
+                end
+                -- Container env valueFrom references
+                if container.env ~= nil then
+                  for _, envVar in pairs(container.env) do
+                    if envVar.valueFrom ~= nil then
+                      if envVar.valueFrom.configMapKeyRef ~= nil and envVar.valueFrom.configMapKeyRef.name ~= nil and envVar.valueFrom.configMapKeyRef.name ~= '' then
+                        dependentConfigMaps[envVar.valueFrom.configMapKeyRef.name] = true
+                      end
+                      if envVar.valueFrom.secretKeyRef ~= nil and envVar.valueFrom.secretKeyRef.name ~= nil and envVar.valueFrom.secretKeyRef.name ~= '' then
+                        dependentSecrets[envVar.valueFrom.secretKeyRef.name] = true
+                      end
+                    end
+                  end
+                end
+              end
+            end
+
+            -- Init containers
+            if podSpec.initContainers ~= nil then
+              for _, container in pairs(podSpec.initContainers) do
+                if container.envFrom ~= nil then
+                  for _, envFromSource in pairs(container.envFrom) do
+                    if envFromSource.configMapRef ~= nil and envFromSource.configMapRef.name ~= nil and envFromSource.configMapRef.name ~= '' then
+                      dependentConfigMaps[envFromSource.configMapRef.name] = true
+                    end
+                    if envFromSource.secretRef ~= nil and envFromSource.secretRef.name ~= nil and envFromSource.secretRef.name ~= '' then
+                      dependentSecrets[envFromSource.secretRef.name] = true
+                    end
+                  end
+                end
+                if container.env ~= nil then
+                  for _, envVar in pairs(container.env) do
+                    if envVar.valueFrom ~= nil then
+                      if envVar.valueFrom.configMapKeyRef ~= nil and envVar.valueFrom.configMapKeyRef.name ~= nil and envVar.valueFrom.configMapKeyRef.name ~= '' then
+                        dependentConfigMaps[envVar.valueFrom.configMapKeyRef.name] = true
+                      end
+                      if envVar.valueFrom.secretKeyRef ~= nil and envVar.valueFrom.secretKeyRef.name ~= nil and envVar.valueFrom.secretKeyRef.name ~= '' then
+                        dependentSecrets[envVar.valueFrom.secretKeyRef.name] = true
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+
+          -- Extract dependencies from rayClusterConfig
+          if desiredObj.spec ~= nil and desiredObj.spec.rayClusterConfig ~= nil then
+            local clusterSpec = desiredObj.spec.rayClusterConfig
+
+            -- Head group
+            if clusterSpec.headGroupSpec ~= nil and clusterSpec.headGroupSpec.template ~= nil and clusterSpec.headGroupSpec.template.spec ~= nil then
+              extractDependenciesFromPodSpec(clusterSpec.headGroupSpec.template.spec)
+            end
+
+            -- Worker groups
+            if clusterSpec.workerGroupSpecs ~= nil then
+              for _, workerGroup in pairs(clusterSpec.workerGroupSpecs) do
+                if workerGroup.template ~= nil and workerGroup.template.spec ~= nil then
+                  extractDependenciesFromPodSpec(workerGroup.template.spec)
+                end
+              end
+            end
+          end
+
+          -- Build dependency references array
+          for key, _ in pairs(dependentConfigMaps) do
+            table.insert(refs, {
+              apiVersion = 'v1',
+              kind = 'ConfigMap',
+              name = key,
+              namespace = desiredObj.metadata.namespace
+            })
+          end
+          for key, _ in pairs(dependentSecrets) do
+            table.insert(refs, {
+              apiVersion = 'v1',
+              kind = 'Secret',
+              name = key,
+              namespace = desiredObj.metadata.namespace
+            })
+          end
+          for key, _ in pairs(dependentSas) do
+            table.insert(refs, {
+              apiVersion = 'v1',
+              kind = 'ServiceAccount',
+              name = key,
+              namespace = desiredObj.metadata.namespace
+            })
+          end
+          for key, _ in pairs(dependentPVCs) do
+            table.insert(refs, {
+              apiVersion = 'v1',
+              kind = 'PersistentVolumeClaim',
+              name = key,
+              namespace = desiredObj.metadata.namespace
+            })
+          end
+
+          return refs
+        end

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/ray.io/v1/RayService/testdata/aggregatestatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/ray.io/v1/RayService/testdata/aggregatestatus-test.yaml
@@ -1,0 +1,273 @@
+# test case for aggregating status of RayService
+# case1. Single status item (passthrough)
+# case2. Multi-cluster with mixed app statuses (tests endpoint summing, worst-status logic)
+# case3. Upgrade in progress with pending cluster
+
+name: "RayService with single status item"
+description: "Single cluster passthrough - status should be returned unchanged"
+desiredObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-single
+    namespace: default
+  spec:
+    serveConfigV2: |
+      applications:
+        - name: simple-app
+          route_prefix: /
+          import_path: simple:app
+    rayClusterConfig:
+      rayVersion: "2.9.0"
+      headGroupSpec:
+        template:
+          spec:
+            containers:
+            - name: ray-head
+              image: rayproject/ray:2.9.0
+statusItems:
+  - applied: true
+    clusterName: member1
+    status:
+      conditions:
+      - type: Ready
+        status: "False"
+        reason: ZeroServeEndpoints
+        message: "No serve endpoints available"
+        lastTransitionTime: "2024-01-15T11:00:00Z"
+      serviceStatus: ""
+      numServeEndpoints: 0
+      lastUpdateTime: "2024-01-15T11:00:00Z"
+      observedGeneration: 2
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: ray.io/v1
+    kind: RayService
+    metadata:
+      name: rayservice-single
+      namespace: default
+    status:
+      conditions:
+      - type: Ready
+        status: "False"
+        reason: ZeroServeEndpoints
+        message: "No serve endpoints available"
+        lastTransitionTime: "2024-01-15T11:00:00Z"
+      serviceStatus: ""
+      numServeEndpoints: 0
+      lastUpdateTime: "2024-01-15T11:00:00Z"
+      observedGeneration: 2
+
+---
+name: "RayService multi-cluster with mixed app statuses"
+description: "Tests endpoint summing, condition collection, lastUpdateTime selection, and worst-status app aggregation"
+desiredObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-multi
+    namespace: production
+  spec:
+    serveConfigV2: |
+      applications:
+        - name: model-serving
+          route_prefix: /predict
+          import_path: model:app
+        - name: data-processing
+          route_prefix: /process
+          import_path: processor:app
+    rayClusterConfig:
+      rayVersion: "2.9.0"
+      headGroupSpec:
+        template:
+          spec:
+            containers:
+            - name: ray-head
+              image: rayproject/ray:2.9.0
+statusItems:
+  - applied: true
+    clusterName: member1
+    status:
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: NonZeroServeEndpoints
+        message: "Service is ready"
+        lastTransitionTime: "2024-01-15T12:00:00Z"
+      serviceStatus: Running
+      numServeEndpoints: 4
+      lastUpdateTime: "2024-01-15T12:00:00Z"
+      observedGeneration: 3
+      activeServiceStatus:
+        rayClusterName: "rayservice-multi-cluster1"
+        applicationStatuses:
+          model-serving:
+            status: RUNNING
+            message: "Model serving is running"
+          data-processing:
+            status: DEPLOYING
+            message: "Data processing is deploying"
+  - applied: true
+    clusterName: member2
+    status:
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: NonZeroServeEndpoints
+        message: "Service is ready on member2"
+        lastTransitionTime: "2024-01-15T12:01:00Z"
+      serviceStatus: Running
+      numServeEndpoints: 6
+      lastUpdateTime: "2024-01-15T12:01:00Z"
+      observedGeneration: 2
+      activeServiceStatus:
+        rayClusterName: "rayservice-multi-cluster2"
+        applicationStatuses:
+          model-serving:
+            status: RUNNING
+            message: "Model serving is running"
+          data-processing:
+            status: UNHEALTHY
+            message: "Data processing is unhealthy"
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: ray.io/v1
+    kind: RayService
+    metadata:
+      name: rayservice-multi
+      namespace: production
+    status:
+      # Conditions collected from all clusters
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: NonZeroServeEndpoints
+        message: "Service is ready"
+        lastTransitionTime: "2024-01-15T12:00:00Z"
+      - type: Ready
+        status: "True"
+        reason: NonZeroServeEndpoints
+        message: "Service is ready on member2"
+        lastTransitionTime: "2024-01-15T12:01:00Z"
+      serviceStatus: Running
+      # Endpoints summed: 4 + 6 = 10
+      numServeEndpoints: 10
+      # Takes most recent lastUpdateTime
+      lastUpdateTime: "2024-01-15T12:01:00Z"
+      # Takes highest observedGeneration
+      observedGeneration: 3
+      # Takes first cluster's base, merges apps with worst-status logic
+      activeServiceStatus:
+        rayClusterName: "rayservice-multi-cluster1"
+        applicationStatuses:
+          # RUNNING from both clusters = RUNNING
+          model-serving:
+            status: RUNNING
+            message: "Model serving is running"
+          # DEPLOYING vs UNHEALTHY = UNHEALTHY (priority 4 > 2)
+          data-processing:
+            status: UNHEALTHY
+            message: "Data processing is unhealthy"
+
+---
+name: "RayService upgrade in progress"
+description: "Tests activeServiceStatus and pendingServiceStatus during NewCluster upgrade"
+desiredObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-upgrading
+    namespace: default
+  spec:
+    serveConfigV2: |
+      applications:
+        - name: api-service
+          route_prefix: /api
+          import_path: api:service
+    upgradeStrategy:
+      type: NewCluster
+    rayClusterConfig:
+      rayVersion: "2.9.0"
+      headGroupSpec:
+        template:
+          spec:
+            containers:
+            - name: ray-head
+              image: rayproject/ray:2.9.0
+statusItems:
+  - applied: true
+    clusterName: member1
+    status:
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: NonZeroServeEndpoints
+        message: "Service is ready"
+        lastTransitionTime: "2024-01-15T13:00:00Z"
+      - type: UpgradeInProgress
+        status: "True"
+        reason: BothActivePendingClustersExist
+        message: "Upgrading to new cluster"
+        lastTransitionTime: "2024-01-15T13:10:00Z"
+      serviceStatus: Running
+      numServeEndpoints: 5
+      lastUpdateTime: "2024-01-15T13:10:00Z"
+      observedGeneration: 3
+      activeServiceStatus:
+        rayClusterName: "rayservice-upgrading-old"
+        targetCapacity: 100
+        trafficRoutedPercent: 70
+        applicationStatuses:
+          api-service:
+            status: RUNNING
+            message: "API service is running"
+      pendingServiceStatus:
+        rayClusterName: "rayservice-upgrading-new"
+        targetCapacity: 100
+        trafficRoutedPercent: 30
+        applicationStatuses:
+          api-service:
+            status: DEPLOYING
+            message: "API service is deploying on new cluster"
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: ray.io/v1
+    kind: RayService
+    metadata:
+      name: rayservice-upgrading
+      namespace: default
+    status:
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: NonZeroServeEndpoints
+        message: "Service is ready"
+        lastTransitionTime: "2024-01-15T13:00:00Z"
+      - type: UpgradeInProgress
+        status: "True"
+        reason: BothActivePendingClustersExist
+        message: "Upgrading to new cluster"
+        lastTransitionTime: "2024-01-15T13:10:00Z"
+      serviceStatus: Running
+      numServeEndpoints: 5
+      lastUpdateTime: "2024-01-15T13:10:00Z"
+      observedGeneration: 3
+      activeServiceStatus:
+        rayClusterName: "rayservice-upgrading-old"
+        targetCapacity: 100
+        trafficRoutedPercent: 70
+        applicationStatuses:
+          api-service:
+            status: RUNNING
+            message: "API service is running"
+      pendingServiceStatus:
+        rayClusterName: "rayservice-upgrading-new"
+        targetCapacity: 100
+        trafficRoutedPercent: 30
+        applicationStatuses:
+          api-service:
+            status: DEPLOYING
+            message: "API service is deploying on new cluster"

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/ray.io/v1/RayService/testdata/interpretdependency-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/ray.io/v1/RayService/testdata/interpretdependency-test.yaml
@@ -1,0 +1,298 @@
+# Test cases for interpreting dependencies of RayService
+#
+# RayService dependencies are extracted from:
+# - spec.rayClusterConfig.headGroupSpec.template.spec (head pod)
+# - spec.rayClusterConfig.workerGroupSpecs[].template.spec (worker pods)
+#
+# Dependency types:
+# - ConfigMap: volumes, envFrom, env valueFrom
+# - Secret: volumes, envFrom, env valueFrom, imagePullSecrets
+# - ServiceAccount: non-default serviceAccountName
+# - PersistentVolumeClaim: PVC volumes
+#
+# Test cases:
+# 1. No dependencies
+# 2. Head group with ConfigMap and Secret dependencies
+# 3. Worker group dependencies
+# 4. Mixed dependencies from head and workers (deduplication)
+
+name: "RayService with no dependencies"
+description: "Simple RayService with no ConfigMaps, Secrets, or PVCs"
+desiredObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: simple-rayservice
+    namespace: default
+  spec:
+    serveConfigV2: |
+      applications:
+        - name: simple-app
+          route_prefix: /
+          import_path: app:deployment
+    rayClusterConfig:
+      rayVersion: "2.9.0"
+      headGroupSpec:
+        template:
+          spec:
+            containers:
+            - name: ray-head
+              image: rayproject/ray:2.9.0
+              resources:
+                requests:
+                  cpu: "1"
+                  memory: "2Gi"
+      workerGroupSpecs:
+      - groupName: small-workers
+        replicas: 2
+        template:
+          spec:
+            containers:
+            - name: ray-worker
+              image: rayproject/ray:2.9.0
+operation: InterpretDependency
+output:
+  dependencies: []
+
+---
+name: "RayService with head group dependencies"
+description: "Head pod with ConfigMap volume, Secret env, ServiceAccount, and imagePullSecrets"
+desiredObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-head-deps
+    namespace: production
+  spec:
+    serveConfigV2: |
+      applications:
+        - name: model-app
+          route_prefix: /predict
+          import_path: model:deployment
+    rayClusterConfig:
+      rayVersion: "2.9.0"
+      headGroupSpec:
+        template:
+          spec:
+            serviceAccountName: ray-head-sa
+            imagePullSecrets:
+            - name: docker-registry-secret
+            volumes:
+            - name: serve-config
+              configMap:
+                name: serve-config-cm
+            - name: model-weights
+              persistentVolumeClaim:
+                claimName: model-pvc
+            containers:
+            - name: ray-head
+              image: private-registry.io/ray:2.9.0
+              volumeMounts:
+              - name: serve-config
+                mountPath: /config
+              - name: model-weights
+                mountPath: /models
+              env:
+              - name: API_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: api-secrets
+                    key: api-key
+              envFrom:
+              - configMapRef:
+                  name: env-config-cm
+              - secretRef:
+                  name: env-secrets
+operation: InterpretDependency
+output:
+  dependencies:
+    - apiVersion: v1
+      kind: ConfigMap
+      name: serve-config-cm
+      namespace: production
+    - apiVersion: v1
+      kind: ConfigMap
+      name: env-config-cm
+      namespace: production
+    - apiVersion: v1
+      kind: Secret
+      name: docker-registry-secret
+      namespace: production
+    - apiVersion: v1
+      kind: Secret
+      name: api-secrets
+      namespace: production
+    - apiVersion: v1
+      kind: Secret
+      name: env-secrets
+      namespace: production
+    - apiVersion: v1
+      kind: ServiceAccount
+      name: ray-head-sa
+      namespace: production
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: model-pvc
+      namespace: production
+
+---
+name: "RayService with worker group dependencies"
+description: "Worker groups with their own ConfigMaps and Secrets"
+desiredObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-worker-deps
+    namespace: default
+  spec:
+    serveConfigV2: |
+      applications:
+        - name: data-app
+          route_prefix: /process
+          import_path: processor:deployment
+    rayClusterConfig:
+      rayVersion: "2.9.0"
+      headGroupSpec:
+        template:
+          spec:
+            containers:
+            - name: ray-head
+              image: rayproject/ray:2.9.0
+      workerGroupSpecs:
+      - groupName: gpu-workers
+        replicas: 2
+        template:
+          spec:
+            serviceAccountName: gpu-worker-sa
+            volumes:
+            - name: worker-config
+              configMap:
+                name: gpu-worker-config
+            containers:
+            - name: ray-worker
+              image: rayproject/ray:2.9.0
+              env:
+              - name: GPU_LICENSE
+                valueFrom:
+                  secretKeyRef:
+                    name: gpu-license-secret
+                    key: license
+      - groupName: cpu-workers
+        replicas: 4
+        template:
+          spec:
+            volumes:
+            - name: data-volume
+              persistentVolumeClaim:
+                claimName: shared-data-pvc
+            containers:
+            - name: ray-worker
+              image: rayproject/ray:2.9.0
+operation: InterpretDependency
+output:
+  dependencies:
+    - apiVersion: v1
+      kind: ConfigMap
+      name: gpu-worker-config
+      namespace: default
+    - apiVersion: v1
+      kind: Secret
+      name: gpu-license-secret
+      namespace: default
+    - apiVersion: v1
+      kind: ServiceAccount
+      name: gpu-worker-sa
+      namespace: default
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: shared-data-pvc
+      namespace: default
+
+---
+name: "RayService with mixed dependencies and deduplication"
+description: "Same ConfigMap/Secret used in head and workers should appear only once"
+desiredObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-dedup
+    namespace: ml-team
+  spec:
+    serveConfigV2: |
+      applications:
+        - name: ml-app
+          route_prefix: /ml
+          import_path: ml:deployment
+    rayClusterConfig:
+      rayVersion: "2.9.0"
+      headGroupSpec:
+        template:
+          spec:
+            volumes:
+            - name: shared-config
+              configMap:
+                name: shared-config-cm
+            initContainers:
+            - name: init-container
+              image: busybox
+              envFrom:
+              - secretRef:
+                  name: init-secrets
+            containers:
+            - name: ray-head
+              image: rayproject/ray:2.9.0
+              env:
+              - name: SHARED_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: shared-secrets
+                    key: value
+      workerGroupSpecs:
+      - groupName: workers
+        replicas: 3
+        template:
+          spec:
+            volumes:
+            # Same ConfigMap as head - should be deduplicated
+            - name: shared-config
+              configMap:
+                name: shared-config-cm
+            containers:
+            - name: ray-worker
+              image: rayproject/ray:2.9.0
+              env:
+              # Same Secret as head - should be deduplicated
+              - name: SHARED_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: shared-secrets
+                    key: value
+              # Worker-specific secret
+              - name: WORKER_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: worker-tokens
+                    key: token
+operation: InterpretDependency
+output:
+  dependencies:
+    # shared-config-cm appears once even though used in head and workers
+    - apiVersion: v1
+      kind: ConfigMap
+      name: shared-config-cm
+      namespace: ml-team
+    # init-secrets from init container
+    - apiVersion: v1
+      kind: Secret
+      name: init-secrets
+      namespace: ml-team
+    # shared-secrets appears once even though used in head and workers
+    - apiVersion: v1
+      kind: Secret
+      name: shared-secrets
+      namespace: ml-team
+    # worker-tokens is worker-specific
+    - apiVersion: v1
+      kind: Secret
+      name: worker-tokens
+      namespace: ml-team

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/ray.io/v1/RayService/testdata/interprethealth-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/ray.io/v1/RayService/testdata/interprethealth-test.yaml
@@ -1,0 +1,131 @@
+# Test cases for interpreting health of RayService
+#
+# RayService health interpretation:
+# - Healthy: Ready condition is True
+# - Unhealthy: Ready condition is False, missing, or status/conditions is nil
+# - During upgrades, RayService remains healthy as long as Ready=True
+#
+# Test cases:
+# 1. Ready=True (healthy, includes upgrade scenario)
+# 2. Ready=False (unhealthy)
+# 3. No status or conditions (unhealthy edge cases)
+# 4. Ready not at first position (tests iteration)
+
+name: "RayService with Ready=True is healthy"
+description: "Test that RayService is healthy when Ready=True, including during upgrades"
+observedObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-ready
+    namespace: default
+  spec:
+    rayClusterConfig:
+      headGroupSpec:
+        template:
+          spec:
+            containers:
+              - name: ray-head
+                image: rayproject/ray:2.9.0
+  status:
+    conditions:
+      - type: Ready
+        status: "True"
+        reason: NonZeroServeEndpoints
+        message: "Service is ready"
+      - type: UpgradeInProgress
+        status: "True"
+        reason: BothActivePendingClustersExist
+        message: "Upgrading to new cluster"
+    serviceStatus: Running
+    numServeEndpoints: 3
+operation: InterpretHealth
+output:
+  healthy: true
+
+---
+name: "RayService with Ready=False is unhealthy"
+description: "Test that RayService is unhealthy when Ready=False, even with other conditions present"
+observedObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-not-ready
+    namespace: default
+  spec:
+    rayClusterConfig:
+      headGroupSpec:
+        template:
+          spec:
+            containers:
+              - name: ray-head
+                image: rayproject/ray:2.9.0
+  status:
+    conditions:
+      - type: UpgradeInProgress
+        status: "False"
+        reason: NoPendingCluster
+      - type: Ready
+        status: "False"
+        reason: ZeroServeEndpoints
+        message: "No serve endpoints available"
+    serviceStatus: ""
+    numServeEndpoints: 0
+operation: InterpretHealth
+output:
+  healthy: false
+
+---
+name: "RayService with no status or conditions is unhealthy"
+description: "Test that RayService is unhealthy when status or conditions is nil"
+observedObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-no-status
+    namespace: default
+  spec:
+    rayClusterConfig:
+      headGroupSpec:
+        template:
+          spec:
+            containers:
+              - name: ray-head
+                image: rayproject/ray:2.9.0
+operation: InterpretHealth
+output:
+  healthy: false
+
+---
+name: "RayService with Ready condition at non-first position"
+description: "Test that Ready=True is found even when not the first condition"
+observedObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-ready-later
+    namespace: default
+  spec:
+    rayClusterConfig:
+      headGroupSpec:
+        template:
+          spec:
+            containers:
+              - name: ray-head
+                image: rayproject/ray:2.9.0
+  status:
+    conditions:
+      - type: UpgradeInProgress
+        status: "False"
+        reason: NoPendingCluster
+      - type: RayClusterReady
+        status: "True"
+        reason: RayClusterRunning
+      - type: Ready
+        status: "True"
+        reason: NonZeroServeEndpoints
+    serviceStatus: Running
+    numServeEndpoints: 5
+operation: InterpretHealth
+output:
+  healthy: true

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/ray.io/v1/RayService/testdata/interpretreplica-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/ray.io/v1/RayService/testdata/interpretreplica-test.yaml
@@ -1,0 +1,346 @@
+# Test cases for interpreting replica of RayService
+#
+# RayService replica calculation:
+# - Total replicas = 1 (head) + sum of all worker group replicas
+# - Resource requirements = MAX of CPU and memory across head and all worker groups
+# - NodeClaim (nodeSelector, tolerations) from head pod template
+#
+# Test cases:
+# 1. Basic RayService with head and one worker group
+# 2. Multiple worker groups with max resources from workers
+# 3. Head only (no worker groups)
+# 4. Head with higher resources and worker group with 0 replicas
+# 5. NodeSelector and tolerations on head
+# 6. Multiple containers (tests resource aggregation)
+# 7. Mixed CPU/memory max (different pods win each resource type)
+
+name: "Basic RayService with head and one worker group"
+description: "Test basic replica counting: 1 head + 3 workers = 4 total"
+desiredObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-basic
+    namespace: default
+  spec:
+    rayClusterConfig:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+              - name: ray-head
+                image: rayproject/ray:2.9.0
+                resources:
+                  requests:
+                    cpu: "2"
+                    memory: "4Gi"
+      workerGroupSpecs:
+        - groupName: workers
+          replicas: 3
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-worker
+                  image: rayproject/ray:2.9.0
+                  resources:
+                    requests:
+                      cpu: "2"
+                      memory: "4Gi"
+operation: InterpretReplica
+output:
+  replica: 4
+  requires:
+    resourceRequest:
+      cpu: "2"
+      memory: "4Gi"
+
+---
+name: "Multiple worker groups with max resources from workers"
+description: "Test multiple worker groups (1 head + 2 + 4 = 7 total) and max resources taken from gpu-group"
+desiredObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-multi-worker
+    namespace: default
+  spec:
+    rayClusterConfig:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+              - name: ray-head
+                image: rayproject/ray:2.9.0
+                resources:
+                  requests:
+                    cpu: "1"
+                    memory: "2Gi"
+      workerGroupSpecs:
+        - groupName: cpu-group
+          replicas: 2
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-worker
+                  image: rayproject/ray:2.9.0
+                  resources:
+                    requests:
+                      cpu: "2"
+                      memory: "4Gi"
+        - groupName: gpu-group
+          replicas: 4
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-worker
+                  image: rayproject/ray:2.9.0
+                  resources:
+                    requests:
+                      cpu: "8"
+                      memory: "32Gi"
+operation: InterpretReplica
+output:
+  replica: 7
+  requires:
+    resourceRequest:
+      cpu: "8"
+      memory: "32Gi"
+
+---
+name: "Head only with no worker groups"
+description: "Test RayService with only head group (1 replica total)"
+desiredObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-head-only
+    namespace: default
+  spec:
+    rayClusterConfig:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+              - name: ray-head
+                image: rayproject/ray:2.9.0
+                resources:
+                  requests:
+                    cpu: "2"
+                    memory: "4Gi"
+operation: InterpretReplica
+output:
+  replica: 1
+  requires:
+    resourceRequest:
+      cpu: "2"
+      memory: "4Gi"
+
+---
+name: "Head with higher resources and worker group with 0 replicas"
+description: "Test that head resources are used as max when workers have lower resources, and 0 replica workers don't affect count"
+desiredObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-head-heavy
+    namespace: default
+  spec:
+    rayClusterConfig:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+              - name: ray-head
+                image: rayproject/ray:2.9.0
+                resources:
+                  requests:
+                    cpu: "4"
+                    memory: "16Gi"
+      workerGroupSpecs:
+        - groupName: dormant-group
+          replicas: 0
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-worker
+                  image: rayproject/ray:2.9.0
+                  resources:
+                    requests:
+                      cpu: "1"
+                      memory: "2Gi"
+        - groupName: active-group
+          replicas: 3
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-worker
+                  image: rayproject/ray:2.9.0
+                  resources:
+                    requests:
+                      cpu: "2"
+                      memory: "4Gi"
+operation: InterpretReplica
+output:
+  replica: 4
+  requires:
+    resourceRequest:
+      cpu: "4"
+      memory: "16Gi"
+
+---
+name: "NodeSelector and tolerations on head"
+description: "Test that nodeSelector and tolerations are extracted from head template"
+desiredObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-scheduling
+    namespace: default
+  spec:
+    rayClusterConfig:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            nodeSelector:
+              accelerator: nvidia-a100
+              zone: us-west-2a
+            tolerations:
+              - key: "nvidia.com/gpu"
+                operator: "Exists"
+                effect: "NoSchedule"
+            containers:
+              - name: ray-head
+                image: rayproject/ray:2.9.0
+                resources:
+                  requests:
+                    cpu: "2"
+                    memory: "8Gi"
+      workerGroupSpecs:
+        - groupName: workers
+          replicas: 2
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-worker
+                  image: rayproject/ray:2.9.0
+                  resources:
+                    requests:
+                      cpu: "2"
+                      memory: "8Gi"
+operation: InterpretReplica
+output:
+  replica: 3
+  requires:
+    resourceRequest:
+      cpu: "2"
+      memory: "8Gi"
+    nodeClaim:
+      nodeSelector:
+        accelerator: nvidia-a100
+        zone: us-west-2a
+      tolerations:
+        - key: "nvidia.com/gpu"
+          operator: "Exists"
+          effect: "NoSchedule"
+
+---
+name: "Multiple containers in pod template"
+description: "Test that resources from multiple containers (ray-head + sidecar) are aggregated"
+desiredObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-sidecar
+    namespace: default
+  spec:
+    rayClusterConfig:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+              - name: ray-head
+                image: rayproject/ray:2.9.0
+                resources:
+                  requests:
+                    cpu: "2"
+                    memory: "4Gi"
+              - name: sidecar
+                image: busybox:latest
+                resources:
+                  requests:
+                    cpu: "500m"
+                    memory: "512Mi"
+      workerGroupSpecs:
+        - groupName: workers
+          replicas: 2
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-worker
+                  image: rayproject/ray:2.9.0
+                  resources:
+                    requests:
+                      cpu: "1"
+                      memory: "2Gi"
+operation: InterpretReplica
+output:
+  replica: 3
+  requires:
+    resourceRequest:
+      cpu: "2500m"
+      memory: "4608Mi"
+---
+name: "Mixed CPU and memory max from different pods"
+description: "Test when head has higher memory (16Gi) but worker has higher CPU (8) - both max values are taken"
+desiredObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-mixed
+    namespace: default
+  spec:
+    rayClusterConfig:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+              - name: ray-head
+                image: rayproject/ray:2.9.0
+                resources:
+                  requests:
+                    cpu: "1"
+                    memory: "16Gi"
+      workerGroupSpecs:
+        - groupName: cpu-workers
+          replicas: 3
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-worker
+                  image: rayproject/ray:2.9.0
+                  resources:
+                    requests:
+                      cpu: "8"
+                      memory: "4Gi"
+operation: InterpretReplica
+output:
+  replica: 4
+  requires:
+    resourceRequest:
+      cpu: "8"
+      memory: "16Gi"

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/ray.io/v1/RayService/testdata/revisereplica-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/ray.io/v1/RayService/testdata/revisereplica-test.yaml
@@ -1,0 +1,391 @@
+# Test cases for revising replica of RayService
+#
+# RayService replica revision:
+# - Head group always has 1 replica (not scalable)
+# - Worker replicas = desiredReplica - 1
+# - Single worker group: gets all worker replicas
+# - Multiple groups with 0 total: distribute equally
+# - Multiple groups with existing workers: distribute proportionally
+#
+# Test cases:
+# 1. Single worker group scaling
+# 2. Multiple worker groups with proportional distribution
+# 3. Scale from 0 workers (equal distribution)
+# 4. Scale to 0 or 1 (workers become 0)
+# 5. Head only (no worker groups)
+# 6. Partial zero group (one group has 0 replicas, preserve ratio)
+
+name: "Single worker group scaling"
+description: "Test scaling a single worker group from 3 to 6 workers (7 total with head)"
+desiredObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-single
+    namespace: default
+  spec:
+    rayClusterConfig:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+              - name: ray-head
+                image: rayproject/ray:2.9.0
+      workerGroupSpecs:
+        - groupName: workers
+          replicas: 3
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-worker
+                  image: rayproject/ray:2.9.0
+inputReplicas: 7
+operation: ReviseReplica
+output:
+  revised:
+    apiVersion: ray.io/v1
+    kind: RayService
+    metadata:
+      name: rayservice-single
+      namespace: default
+    spec:
+      rayClusterConfig:
+        headGroupSpec:
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-head
+                  image: rayproject/ray:2.9.0
+        workerGroupSpecs:
+          - groupName: workers
+            replicas: 6
+            rayStartParams: {}
+            template:
+              spec:
+                containers:
+                  - name: ray-worker
+                    image: rayproject/ray:2.9.0
+
+---
+name: "Multiple worker groups with proportional distribution"
+description: "Test scaling 3 groups with 1:2:3 ratio from 7 to 13 total (workers 2:4:6)"
+desiredObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-multi
+    namespace: default
+  spec:
+    rayClusterConfig:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+              - name: ray-head
+                image: rayproject/ray:2.9.0
+      workerGroupSpecs:
+        - groupName: group-small
+          replicas: 1
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-worker
+                  image: rayproject/ray:2.9.0
+        - groupName: group-medium
+          replicas: 2
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-worker
+                  image: rayproject/ray:2.9.0
+        - groupName: group-large
+          replicas: 3
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-worker
+                  image: rayproject/ray:2.9.0
+inputReplicas: 13
+operation: ReviseReplica
+output:
+  revised:
+    apiVersion: ray.io/v1
+    kind: RayService
+    metadata:
+      name: rayservice-multi
+      namespace: default
+    spec:
+      rayClusterConfig:
+        headGroupSpec:
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-head
+                  image: rayproject/ray:2.9.0
+        workerGroupSpecs:
+          - groupName: group-small
+            replicas: 2
+            rayStartParams: {}
+            template:
+              spec:
+                containers:
+                  - name: ray-worker
+                    image: rayproject/ray:2.9.0
+          - groupName: group-medium
+            replicas: 4
+            rayStartParams: {}
+            template:
+              spec:
+                containers:
+                  - name: ray-worker
+                    image: rayproject/ray:2.9.0
+          - groupName: group-large
+            replicas: 6
+            rayStartParams: {}
+            template:
+              spec:
+                containers:
+                  - name: ray-worker
+                    image: rayproject/ray:2.9.0
+
+---
+name: "Scale from 0 workers with equal distribution"
+description: "Test scaling from 0 workers to 7 total with 2 groups (3+3 workers)"
+desiredObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-from-zero
+    namespace: default
+  spec:
+    rayClusterConfig:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+              - name: ray-head
+                image: rayproject/ray:2.9.0
+      workerGroupSpecs:
+        - groupName: group-a
+          replicas: 0
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-worker
+                  image: rayproject/ray:2.9.0
+        - groupName: group-b
+          replicas: 0
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-worker
+                  image: rayproject/ray:2.9.0
+inputReplicas: 7
+operation: ReviseReplica
+output:
+  revised:
+    apiVersion: ray.io/v1
+    kind: RayService
+    metadata:
+      name: rayservice-from-zero
+      namespace: default
+    spec:
+      rayClusterConfig:
+        headGroupSpec:
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-head
+                  image: rayproject/ray:2.9.0
+        workerGroupSpecs:
+          - groupName: group-a
+            replicas: 3
+            rayStartParams: {}
+            template:
+              spec:
+                containers:
+                  - name: ray-worker
+                    image: rayproject/ray:2.9.0
+          - groupName: group-b
+            replicas: 3
+            rayStartParams: {}
+            template:
+              spec:
+                containers:
+                  - name: ray-worker
+                    image: rayproject/ray:2.9.0
+
+---
+name: "Scale to 0 sets worker replicas to 0"
+description: "Test that scaling to 0 total sets all workers to 0 (head remains 1)"
+desiredObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-to-zero
+    namespace: default
+  spec:
+    rayClusterConfig:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+              - name: ray-head
+                image: rayproject/ray:2.9.0
+      workerGroupSpecs:
+        - groupName: workers
+          replicas: 5
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-worker
+                  image: rayproject/ray:2.9.0
+inputReplicas: 0
+operation: ReviseReplica
+output:
+  revised:
+    apiVersion: ray.io/v1
+    kind: RayService
+    metadata:
+      name: rayservice-to-zero
+      namespace: default
+    spec:
+      rayClusterConfig:
+        headGroupSpec:
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-head
+                  image: rayproject/ray:2.9.0
+        workerGroupSpecs:
+          - groupName: workers
+            replicas: 0
+            rayStartParams: {}
+            template:
+              spec:
+                containers:
+                  - name: ray-worker
+                    image: rayproject/ray:2.9.0
+
+---
+name: "Head only with no worker groups"
+description: "Test that RayService with no worker groups remains unchanged"
+desiredObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-head-only
+    namespace: default
+  spec:
+    rayClusterConfig:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+              - name: ray-head
+                image: rayproject/ray:2.9.0
+inputReplicas: 5
+operation: ReviseReplica
+output:
+  revised:
+    apiVersion: ray.io/v1
+    kind: RayService
+    metadata:
+      name: rayservice-head-only
+      namespace: default
+    spec:
+      rayClusterConfig:
+        headGroupSpec:
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-head
+                  image: rayproject/ray:2.9.0
+
+---
+name: "Partial zero group preserves ratio"
+description: "Test that a group with 0 replicas stays at 0 while active group scales proportionally"
+desiredObj:
+  apiVersion: ray.io/v1
+  kind: RayService
+  metadata:
+    name: rayservice-partial-zero
+    namespace: default
+  spec:
+    rayClusterConfig:
+      headGroupSpec:
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+              - name: ray-head
+                image: rayproject/ray:2.9.0
+      workerGroupSpecs:
+        - groupName: active-group
+          replicas: 4
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-worker
+                  image: rayproject/ray:2.9.0
+        - groupName: dormant-group
+          replicas: 0
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-worker
+                  image: rayproject/ray:2.9.0
+inputReplicas: 9
+operation: ReviseReplica
+output:
+  revised:
+    apiVersion: ray.io/v1
+    kind: RayService
+    metadata:
+      name: rayservice-partial-zero
+      namespace: default
+    spec:
+      rayClusterConfig:
+        headGroupSpec:
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-head
+                  image: rayproject/ray:2.9.0
+        workerGroupSpecs:
+          - groupName: active-group
+            replicas: 8
+            rayStartParams: {}
+            template:
+              spec:
+                containers:
+                  - name: ray-worker
+                    image: rayproject/ray:2.9.0
+          - groupName: dormant-group
+            replicas: 0
+            rayStartParams: {}
+            template:
+              spec:
+                containers:
+                  - name: ray-worker
+                    image: rayproject/ray:2.9.0


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
[RayService](https://docs.ray.io/en/latest/cluster/kubernetes/getting-started/rayservice-quick-start.html) is a popular CRD for AI Inference Workload.
Add a RayService interpreter customization to allow Karmada to manage RayService CRD of KubeRay.
Additionally, users can use this as a reference if they would like to use Karmada to manage the RayService.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
See the design in https://github.com/karmada-io/karmada/pull/7102#issuecomment-3752860254 for more details.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-resource-interpreter`: Added RayService interpreter support
```

