### PR TITLE
feat: informer should sync cache before other controllers start

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -194,6 +194,7 @@ func (d *ResourceDetector) discoverResources(ctx context.Context, period time.Du
 			d.InformerManager.ForResource(r, d.EventHandler)
 		}
 		d.InformerManager.Start()
+		d.InformerManager.WaitForCacheSync()
 	}, period, ctx.Done())
 }
 

--- a/pkg/detector/policy_test.go
+++ b/pkg/detector/policy_test.go
@@ -155,6 +155,9 @@ func Test_cleanPPUnmatchedRBs(t *testing.T) {
 			defer cancel()
 			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, tt.existingObject)
 			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0)
+			genMgr.Lister(appsv1.SchemeGroupVersion.WithResource("deployments"))
+			genMgr.Start()
+			genMgr.WaitForCacheSync()
 			resourceDetector := &ResourceDetector{
 				Client:          fakeClient,
 				DynamicClient:   fakeDynamicClient,
@@ -290,6 +293,9 @@ func Test_cleanUnmatchedRBs(t *testing.T) {
 			defer cancel()
 			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, tt.existingObject)
 			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0)
+			genMgr.Lister(appsv1.SchemeGroupVersion.WithResource("deployments"))
+			genMgr.Start()
+			genMgr.WaitForCacheSync()
 			resourceDetector := &ResourceDetector{
 				Client:          fakeClient,
 				DynamicClient:   fakeDynamicClient,
@@ -425,6 +431,9 @@ func Test_cleanUnmatchedCRBs(t *testing.T) {
 			defer cancel()
 			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, tt.existingObject)
 			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0)
+			genMgr.Lister(appsv1.SchemeGroupVersion.WithResource("deployments"))
+			genMgr.Start()
+			genMgr.WaitForCacheSync()
 			resourceDetector := &ResourceDetector{
 				Client:          fakeClient,
 				DynamicClient:   fakeDynamicClient,
@@ -659,6 +668,9 @@ func Test_removeRBsClaimMetadata(t *testing.T) {
 			defer cancel()
 			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, tt.existingObject)
 			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0)
+			genMgr.Lister(appsv1.SchemeGroupVersion.WithResource("deployments"))
+			genMgr.Start()
+			genMgr.WaitForCacheSync()
 			resourceDetector := &ResourceDetector{
 				Client:          fakeClient,
 				DynamicClient:   fakeDynamicClient,
@@ -884,6 +896,9 @@ func Test_removeCRBsClaimMetadata(t *testing.T) {
 			defer cancel()
 			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, tt.existingObject)
 			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0)
+			genMgr.Lister(appsv1.SchemeGroupVersion.WithResource("deployments"))
+			genMgr.Start()
+			genMgr.WaitForCacheSync()
 			resourceDetector := &ResourceDetector{
 				Client:          fakeClient,
 				DynamicClient:   fakeDynamicClient,
@@ -1107,6 +1122,9 @@ func Test_removeResourceClaimMetadataIfNotMatched(t *testing.T) {
 			defer cancel()
 			fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, tt.existingObject)
 			genMgr := genericmanager.NewSingleClusterInformerManager(ctx, fakeDynamicClient, 0)
+			genMgr.Lister(appsv1.SchemeGroupVersion.WithResource("deployments"))
+			genMgr.Start()
+			genMgr.WaitForCacheSync()
 			resourceDetector := &ResourceDetector{
 				Client:          fakeClient,
 				DynamicClient:   fakeDynamicClient,

--- a/pkg/registry/search/storage/cache.go
+++ b/pkg/registry/search/storage/cache.go
@@ -122,6 +122,11 @@ func (r *SearchREST) getObjectItemsFromClusters(
 		}
 
 		var err error
+		// Skip resources whose informer has not been started
+		if !singleClusterManger.IsInformerStarted(objGVR) {
+			klog.V(4).Infof("Informer for %s in cluster %s not started, skipping", objGVR, cluster.Name)
+			continue
+		}
 		objLister := singleClusterManger.Lister(objGVR)
 		if len(name) > 0 {
 			var resourceObject runtime.Object

--- a/pkg/util/fedinformer/lister/synced_lister.go
+++ b/pkg/util/fedinformer/lister/synced_lister.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lister
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+// SyncWaitFunc is a function that blocks until the cache is synced.
+// This allows the syncedLister to be decoupled from specific manager implementations.
+type SyncWaitFunc func() error
+
+// NewSyncedLister wraps a cache.GenericLister with sync waiting capability.
+// The waitForSync function will be called before each List/Get operation
+// to ensure the cache is synced before returning data.
+//
+// This design avoids blocking on Lister() call which could cause deadlock
+// if called before informer is started, while still ensuring data consistency
+// by waiting for sync before actual data access.
+func NewSyncedLister(lister cache.GenericLister, waitForSync SyncWaitFunc) cache.GenericLister {
+	return &syncedLister{
+		lister:      lister,
+		waitForSync: waitForSync,
+	}
+}
+
+// syncedLister wraps a cache.GenericLister and ensures the cache is synced
+// before actually performing List/Get operations.
+type syncedLister struct {
+	lister      cache.GenericLister
+	waitForSync SyncWaitFunc
+}
+
+// List returns all objects matching the selector after ensuring cache is synced.
+func (l *syncedLister) List(selector labels.Selector) ([]runtime.Object, error) {
+	if err := l.waitForSync(); err != nil {
+		return nil, err
+	}
+	return l.lister.List(selector)
+}
+
+// Get returns the object with the given name after ensuring cache is synced.
+func (l *syncedLister) Get(name string) (runtime.Object, error) {
+	if err := l.waitForSync(); err != nil {
+		return nil, err
+	}
+	return l.lister.Get(name)
+}
+
+// ByNamespace returns a GenericNamespaceLister that lists/gets objects in the given namespace.
+func (l *syncedLister) ByNamespace(namespace string) cache.GenericNamespaceLister {
+	return &syncedNamespaceLister{
+		namespaceLister: l.lister.ByNamespace(namespace),
+		waitForSync:     l.waitForSync,
+	}
+}
+
+// syncedNamespaceLister wraps a cache.GenericNamespaceLister and ensures the cache
+// is synced before actually performing List/Get operations.
+type syncedNamespaceLister struct {
+	namespaceLister cache.GenericNamespaceLister
+	waitForSync     SyncWaitFunc
+}
+
+// List returns all objects in the namespace matching the selector after ensuring cache is synced.
+func (l *syncedNamespaceLister) List(selector labels.Selector) ([]runtime.Object, error) {
+	if err := l.waitForSync(); err != nil {
+		return nil, err
+	}
+	return l.namespaceLister.List(selector)
+}
+
+// Get returns the object with the given name in the namespace after ensuring cache is synced.
+func (l *syncedNamespaceLister) Get(name string) (runtime.Object, error) {
+	if err := l.waitForSync(); err != nil {
+		return nil, err
+	}
+	return l.namespaceLister.Get(name)
+}

--- a/pkg/util/helper/binding_test.go
+++ b/pkg/util/helper/binding_test.go
@@ -1015,58 +1015,6 @@ func TestFetchWorkload(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "not found",
-			args: args{
-				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme),
-				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0)
-				},
-				restMapper: func() meta.RESTMapper {
-					m := meta.NewDefaultRESTMapper([]schema.GroupVersion{corev1.SchemeGroupVersion})
-					m.Add(corev1.SchemeGroupVersion.WithKind("Pod"), meta.RESTScopeNamespace)
-					return m
-				}(),
-				resource: workv1alpha2.ObjectReference{
-					APIVersion: "v1",
-					Kind:       "Pod",
-					Namespace:  "default",
-					Name:       "pod",
-				},
-			},
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			name: "namespace scope: get from client",
-			args: args{
-				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
-					&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"}}),
-				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0)
-				},
-				restMapper: func() meta.RESTMapper {
-					m := meta.NewDefaultRESTMapper([]schema.GroupVersion{corev1.SchemeGroupVersion})
-					m.Add(corev1.SchemeGroupVersion.WithKind("Pod"), meta.RESTScopeNamespace)
-					return m
-				}(),
-				resource: workv1alpha2.ObjectReference{
-					APIVersion: "v1",
-					Kind:       "Pod",
-					Namespace:  "default",
-					Name:       "pod",
-				},
-			},
-			want: &unstructured.Unstructured{Object: map[string]interface{}{
-				"apiVersion": "v1",
-				"kind":       "Pod",
-				"metadata": map[string]interface{}{
-					"name":      "pod",
-					"namespace": "default",
-				},
-			}},
-			wantErr: false,
-		},
-		{
 			name: "namespace scope: get from cache",
 			args: args{
 				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme),
@@ -1097,34 +1045,6 @@ func TestFetchWorkload(t *testing.T) {
 				"metadata": map[string]interface{}{
 					"name":      "pod",
 					"namespace": "default",
-				},
-			}},
-			wantErr: false,
-		},
-		{
-			name: "cluster scope: get from client",
-			args: args{
-				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
-					&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node"}}),
-				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0)
-				},
-				restMapper: func() meta.RESTMapper {
-					m := meta.NewDefaultRESTMapper([]schema.GroupVersion{corev1.SchemeGroupVersion})
-					m.Add(corev1.SchemeGroupVersion.WithKind("Node"), meta.RESTScopeRoot)
-					return m
-				}(),
-				resource: workv1alpha2.ObjectReference{
-					APIVersion: "v1",
-					Kind:       "Node",
-					Name:       "node",
-				},
-			},
-			want: &unstructured.Unstructured{Object: map[string]interface{}{
-				"apiVersion": "v1",
-				"kind":       "Node",
-				"metadata": map[string]interface{}{
-					"name": "node",
 				},
 			}},
 			wantErr: false,
@@ -1212,29 +1132,6 @@ func TestFetchWorkloadByLabelSelector(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "namespace scope: get from client",
-			args: args{
-				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
-					&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", Labels: map[string]string{"foo": "foo"}}}),
-				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0)
-				},
-				restMapper: func() meta.RESTMapper {
-					m := meta.NewDefaultRESTMapper([]schema.GroupVersion{corev1.SchemeGroupVersion})
-					m.Add(corev1.SchemeGroupVersion.WithKind("Pod"), meta.RESTScopeNamespace)
-					return m
-				}(),
-				resource: workv1alpha2.ObjectReference{
-					APIVersion: "v1",
-					Kind:       "Pod",
-					Namespace:  "default",
-				},
-				selector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "foo"}},
-			},
-			want:    1,
-			wantErr: false,
-		},
-		{
 			name: "namespace scope: get from cache",
 			args: args{
 				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme),
@@ -1259,29 +1156,6 @@ func TestFetchWorkloadByLabelSelector(t *testing.T) {
 					Name:       "pod",
 				},
 				selector: &metav1.LabelSelector{MatchLabels: map[string]string{"bar": "foo"}},
-			},
-			want:    1,
-			wantErr: false,
-		},
-		{
-			name: "cluster scope: get from client",
-			args: args{
-				dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme,
-					&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node", Labels: map[string]string{"bar": "bar"}}}),
-				informerManager: func(ctx context.Context) genericmanager.SingleClusterInformerManager {
-					return genericmanager.NewSingleClusterInformerManager(ctx, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), 0)
-				},
-				restMapper: func() meta.RESTMapper {
-					m := meta.NewDefaultRESTMapper([]schema.GroupVersion{corev1.SchemeGroupVersion})
-					m.Add(corev1.SchemeGroupVersion.WithKind("Node"), meta.RESTScopeRoot)
-					return m
-				}(),
-				resource: workv1alpha2.ObjectReference{
-					APIVersion: "v1",
-					Kind:       "Node",
-					Name:       "node",
-				},
-				selector: &metav1.LabelSelector{MatchLabels: map[string]string{"bar": "bar"}},
 			},
 			want:    1,
 			wantErr: false,

--- a/pkg/util/helper/cache.go
+++ b/pkg/util/helper/cache.go
@@ -55,7 +55,7 @@ func GetObjectFromCache(
 		return nil, fmt.Errorf("the informer of cluster(%s) has not been initialized", fedKey.Cluster)
 	}
 
-	if !singleClusterManager.IsInformerSynced(gvr) {
+	if !singleClusterManager.IsInformerStarted(gvr) {
 		// fall back to call api server in case the cache has not been synchronized yet
 		return getObjectFromSingleCluster(gvr, &fedKey.ClusterWideKey, singleClusterManager.GetClient())
 	}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind feature

**What this PR does / why we need it**:

The cluster informer manager should sync the cache first to avoid directly fetching from the apiserver. This means detectors and other controllers have dependencies, so detectors should be placed in the controller-runtime cache case.

Avoid starting detectors and other controllers in a parallel way that causes the cache to be unavailable and other controllers directly query the apiserver.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

