### PR TITLE
fix dynamicScaleDown uses stale clusters for scale-down operations

### DIFF
--- a/pkg/scheduler/core/assignment.go
+++ b/pkg/scheduler/core/assignment.go
@@ -67,6 +67,7 @@ const (
 
 // assignState is a wrapper of the input for assigning function.
 type assignState struct {
+	// candidates are the clusters selected for assignment by the selectClusters function.
 	candidates []spreadconstraint.ClusterDetailInfo
 	strategy   *policyv1alpha1.ReplicaSchedulingStrategy
 	spec       *workv1alpha2.ResourceBindingSpec
@@ -77,9 +78,14 @@ type assignState struct {
 	// assignmentMode represents the mode how to assign replicas
 	assignmentMode assignmentMode
 
+	// scheduledClusters is the list of clusters from `candidates` that were assigned replicas in the previous scheduling.
 	scheduledClusters []workv1alpha2.TargetCluster
-	assignedReplicas  int32
+	// assignedReplicas is the total number of replicas assigned to `candidates` in the previous scheduling. It is calculated from scheduledClusters.
+	assignedReplicas int32
+	// availableClusters is the list of available clusters for the current scheduling, where the Replicas field indicates
+	// the number of assignable replicas and is generally used as dynamic weight.
 	availableClusters []workv1alpha2.TargetCluster
+	// availableReplicas is the number of replicas that can be assigned in this round. It is calculated from availableClusters.
 	availableReplicas int32
 
 	// targetReplicas is the replicas that we need to schedule in this round

--- a/pkg/scheduler/core/division_algorithm.go
+++ b/pkg/scheduler/core/division_algorithm.go
@@ -105,16 +105,16 @@ func dynamicScaleDown(state *assignState) ([]workv1alpha2.TargetCluster, error) 
 	// In other words, we scale down the replicas proportionally by their scheduled replicas.
 	// Now:
 	// 1. targetReplicas is set to desired replicas.
-	// 2. availableClusters is set to the former schedule result.
+	// 2. availableClusters is set to the filtered scheduled clusters (only clusters still in candidates).
 	// 3. scheduledClusters and assignedReplicas are not set, which implicates we consider this action as a first schedule.
 	state.targetReplicas = state.spec.Replicas
-	state.scheduledClusters = nil
-	state.buildAvailableClusters(func(_ []spreadconstraint.ClusterDetailInfo, spec *workv1alpha2.ResourceBindingSpec) []workv1alpha2.TargetCluster {
-		availableClusters := make(TargetClustersList, len(spec.Clusters))
-		copy(availableClusters, spec.Clusters)
+	state.buildAvailableClusters(func(_ []spreadconstraint.ClusterDetailInfo, _ *workv1alpha2.ResourceBindingSpec) []workv1alpha2.TargetCluster {
+		availableClusters := make(TargetClustersList, len(state.scheduledClusters))
+		copy(availableClusters, state.scheduledClusters)
 		sort.Sort(availableClusters)
 		return availableClusters
 	})
+	state.scheduledClusters = nil
 	return dynamicDivideReplicas(state)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
In the dynamic divided scheduling mode, the dynamicScaleDown function incorrectly uses clusters from the previous scheduling result without verifying they are still available in the current candidate list. This can lead to incorrect replica distribution during scale-down operations.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #7109

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-scheduler`: Fixed the issue that `dynamicScaleDown` used stale clusters for scale-down operations
```

