### PR TITLE
retry on conflict when syncing work for binding controllers

### DIFF
--- a/pkg/controllers/binding/binding_controller.go
+++ b/pkg/controllers/binding/binding_controller.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -136,7 +137,9 @@ func (c *ResourceBindingController) syncBinding(ctx context.Context, binding *wo
 		return controllerruntime.Result{}, err
 	}
 	start := time.Now()
-	err = ensureWork(ctx, c.Client, c.ResourceInterpreter, workload, c.OverrideManager, binding, apiextensionsv1.NamespaceScoped)
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		return ensureWork(ctx, c.Client, c.ResourceInterpreter, workload, c.OverrideManager, binding, apiextensionsv1.NamespaceScoped)
+	})
 	metrics.ObserveSyncWorkLatency(err, start)
 	if err != nil {
 		klog.ErrorS(err, "Failed to transform ResourceBinding to works", "namespace", binding.GetNamespace(), "binding", binding.GetName())


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR mitigates the issue where the `binding_sync_work_duration_seconds` metric records Kubernetes conflict errors (HTTP 409) as failures, causing false SLO violations and misleading availability metrics.

**Problem:**
- Conflict errors are expected, retriable errors from Kubernetes optimistic concurrency control
- Currently, every conflict error is recorded as `result="error"` in the metric
- This causes false alerts and misleading dashboards (e.g., showing 85% availability when actual is >99%)

**Solution:**
By wrapping `ensureWork()` with `retry.RetryOnConflict()`, conflict errors are automatically retried and only the **final outcome** is recorded in the metric:
- If retries succeed → `result="success"`
- If retries exhaust with non-retriable error → `result="error"` 

This is the same approach used in PR #7106 for the `execution-controller` (`work_sync_workload_duration_seconds` metric).

**Files changed:**
| File | Change |
|------|--------|
| `pkg/controllers/binding/binding_controller.go` | Wrap `ensureWork` with `retry.RetryOnConflict` |
| `pkg/controllers/binding/cluster_resource_binding_controller.go` | Wrap `ensureWork` with `retry.RetryOnConflict` |

**Which issue(s) this PR fixes**:

Part of #7111

**Special notes for your reviewer**:

This is a follow-up to #7106 which implemented the same pattern for the `execution-controller`. As requested by @jabellard in the [issue discussion](https://github.com/karmada-io/karmada/issues/7111#issuecomment-3764226190), the same fix is needed for the binding controllers.

The pattern follows exactly what was suggested:
```go
start := time.Now()
err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
    return ensureWork(ctx, c.Client, c.ResourceInterpreter, workload, c.OverrideManager, binding, apiextensionsv1.NamespaceScoped)
})
metrics.ObserveSyncWorkLatency(err, start)
```

cc @jabellard @RainbowMango

**Does this PR introduce a user-facing change?**:

```release-note
`Instrumentation`: The metric `binding_sync_work_duration_seconds` no longer counts retriable Kubernetes 409 conflicts as errors, improving availability accuracy and reducing false alerts.