### PR TITLE
Add validation for ClusterLeaseRenewIntervalFraction flag

### DIFF
--- a/cmd/agent/app/options/validation.go
+++ b/cmd/agent/app/options/validation.go
@@ -41,8 +41,8 @@ func (o *Options) Validate() field.ErrorList {
 		errs = append(errs, field.Invalid(newPath.Child("ClusterLeaseDuration"), o.ClusterLeaseDuration, "must be greater than or equal to 0"))
 	}
 
-	if o.ClusterLeaseRenewIntervalFraction <= 0 {
-		errs = append(errs, field.Invalid(newPath.Child("ClusterLeaseRenewIntervalFraction"), o.ClusterLeaseRenewIntervalFraction, "must be greater than 0"))
+	if o.ClusterLeaseRenewIntervalFraction <= 0 || o.ClusterLeaseRenewIntervalFraction >= 1 {
+		errs = append(errs, field.Invalid(newPath.Child("ClusterLeaseRenewIntervalFraction"), o.ClusterLeaseRenewIntervalFraction, "must be greater than 0 and less than 1"))
 	}
 
 	return errs

--- a/cmd/agent/app/options/validation_test.go
+++ b/cmd/agent/app/options/validation_test.go
@@ -85,9 +85,15 @@ func TestValidateKarmadaAgentConfiguration(t *testing.T) {
 		},
 		"invalid ClusterLeaseRenewIntervalFraction": {
 			opt: New(func(options *Options) {
-				options.ClusterLeaseRenewIntervalFraction = 0
+				options.ClusterLeaseRenewIntervalFraction = 1.2
 			}),
-			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("ClusterLeaseRenewIntervalFraction"), 0, "must be greater than 0")},
+			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("ClusterLeaseRenewIntervalFraction"), float64(1.2), "must be greater than 0 and less than 1")},
+		},
+		"invalid ClusterLeaseRenewIntervalFraction (negative)": {
+			opt: New(func(options *Options) {
+				options.ClusterLeaseRenewIntervalFraction = -0.1
+			}),
+			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("ClusterLeaseRenewIntervalFraction"), float64(-0.1), "must be greater than 0 and less than 1")},
 		},
 	}
 

--- a/cmd/controller-manager/app/options/validation.go
+++ b/cmd/controller-manager/app/options/validation.go
@@ -40,6 +40,9 @@ func (o *Options) Validate() field.ErrorList {
 	if o.ClusterLeaseDuration.Duration <= 0 {
 		errs = append(errs, field.Invalid(newPath.Child("ClusterLeaseDuration"), o.ClusterLeaseDuration, "must be greater than 0"))
 	}
+	if o.ClusterLeaseRenewIntervalFraction <= 0 || o.ClusterLeaseRenewIntervalFraction >= 1 {
+		errs = append(errs, field.Invalid(newPath.Child("ClusterLeaseRenewIntervalFraction"), o.ClusterLeaseRenewIntervalFraction, "must be greater than 0 and less than 1"))
+	}
 	if o.ClusterMonitorPeriod.Duration <= 0 {
 		errs = append(errs, field.Invalid(newPath.Child("ClusterMonitorPeriod"), o.ClusterMonitorPeriod, "must be greater than 0"))
 	}

--- a/cmd/controller-manager/app/options/validation_test.go
+++ b/cmd/controller-manager/app/options/validation_test.go
@@ -30,12 +30,13 @@ type ModifyOptions func(option *Options)
 // New an Options with default parameters
 func New(modifyOptions ModifyOptions) Options {
 	option := Options{
-		SkippedPropagatingAPIs:       "cluster.karmada.io;policy.karmada.io;work.karmada.io",
-		ClusterStatusUpdateFrequency: metav1.Duration{Duration: 10 * time.Second},
-		ClusterLeaseDuration:         metav1.Duration{Duration: 10 * time.Second},
-		ClusterMonitorPeriod:         metav1.Duration{Duration: 10 * time.Second},
-		ClusterMonitorGracePeriod:    metav1.Duration{Duration: 10 * time.Second},
-		ClusterStartupGracePeriod:    metav1.Duration{Duration: 10 * time.Second},
+		SkippedPropagatingAPIs:            "cluster.karmada.io;policy.karmada.io;work.karmada.io",
+		ClusterStatusUpdateFrequency:      metav1.Duration{Duration: 10 * time.Second},
+		ClusterLeaseDuration:              metav1.Duration{Duration: 10 * time.Second},
+		ClusterMonitorPeriod:              metav1.Duration{Duration: 10 * time.Second},
+		ClusterMonitorGracePeriod:         metav1.Duration{Duration: 10 * time.Second},
+		ClusterStartupGracePeriod:         metav1.Duration{Duration: 10 * time.Second},
+		ClusterLeaseRenewIntervalFraction: 0.25,
 		FederatedResourceQuotaOptions: FederatedResourceQuotaOptions{
 			ResourceQuotaSyncPeriod: metav1.Duration{
 				Duration: 10 * time.Second,
@@ -82,6 +83,18 @@ func TestValidateControllerManagerConfiguration(t *testing.T) {
 				options.ClusterLeaseDuration.Duration = -40 * time.Second
 			}),
 			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("ClusterLeaseDuration"), metav1.Duration{Duration: -40 * time.Second}, "must be greater than 0")},
+		},
+		"invalid ClusterLeaseRenewIntervalFraction": {
+			opt: New(func(options *Options) {
+				options.ClusterLeaseRenewIntervalFraction = 1.2
+			}),
+			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("ClusterLeaseRenewIntervalFraction"), float64(1.2), "must be greater than 0 and less than 1")},
+		},
+		"invalid ClusterLeaseRenewIntervalFraction (negative)": {
+			opt: New(func(options *Options) {
+				options.ClusterLeaseRenewIntervalFraction = -0.1
+			}),
+			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("ClusterLeaseRenewIntervalFraction"), float64(-0.1), "must be greater than 0 and less than 1")},
 		},
 		"invalid ClusterMonitorPeriod": {
 			opt: New(func(options *Options) {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

---

**What this PR does / why we need it**:

This PR adds validation for the `ClusterLeaseRenewIntervalFraction` flag in
`karmada-controller-manager and karmada-agent`.

Although the flag is defined with a default value (`0.25`), it previously
accepted invalid values (≤ 0 or >= 1) without error. Such values can lead to
unexpected lease renewal behavior and unstable cluster health reporting.

The new validation ensures the value stays within a safe and meaningful range,
preventing misconfiguration and improving controller reliability.

---

**Which issue(s) this PR fixes**:

Fixes #7122 

---

**Special notes for your reviewer**:

- Added validation to ensure `0 < ClusterLeaseRenewIntervalFraction < 1`
- Added unit tests covering invalid and valid configurations
- Behavior aligns with how lease renewal intervals are calculated internally

---

**Does this PR introduce a user-facing change?**:

`karmada-controller-manager/karmada-agent`: The flag `--cluster-lease-renew-interval-fraction` is now constrained to be greater than 0 and less than 1.