### PR TITLE
Set bindingSpec.ReplicaRequirements.Namespace uniformly

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -1462,6 +1462,16 @@ func (d *ResourceDetector) applyReplicaInterpretation(object *unstructured.Unstr
 			klog.Errorf("Failed to customize replicas for %s(%s): %v", gvk, name, err)
 			return err
 		}
+
+		// Most interpreters (except webhook interpreter) cannot properly obtain the namespace because they extract
+		// information from PodTemplate, and advanced workloads' PodTemplates typically don't have a namespace set.
+		// Therefore, we uniformly check and set the namespace here.
+		// Note: The replicaRequirements.Namespace field is somewhat redundant and could be deprecated in the future,
+		// as the namespace can be obtained directly from ResourceBinding.
+		if features.FeatureGate.Enabled(features.ResourceQuotaEstimate) && replicaRequirements != nil && len(replicaRequirements.Namespace) == 0 {
+			replicaRequirements.Namespace = object.GetNamespace()
+		}
+
 		spec.Replicas = replicas
 		spec.ReplicaRequirements = replicaRequirements
 	}

--- a/pkg/util/helper/binding.go
+++ b/pkg/util/helper/binding.go
@@ -455,7 +455,6 @@ func GenerateReplicaRequirements(podTemplate *corev1.PodTemplateSpec) *workv1alp
 			ResourceRequest: resourceRequest,
 		}
 		if features.FeatureGate.Enabled(features.ResourceQuotaEstimate) {
-			replicaRequirements.Namespace = podTemplate.Namespace
 			// PriorityClassName is set from podTemplate
 			// If it is not set from podTemplate, it is default to an empty string
 			replicaRequirements.PriorityClassName = podTemplate.Spec.PriorityClassName

--- a/test/e2e/suites/base/estimator_test.go
+++ b/test/e2e/suites/base/estimator_test.go
@@ -135,6 +135,12 @@ var _ = ginkgo.Describe("Quota plugin Testing", func() {
 		ginkgo.By("first verifying resource binding scheduling", func() {
 			deployBindingName := names.GenerateBindingName(util.DeploymentKind, deployName)
 			framework.AssertBindingScheduledClusters(karmadaClient, deployNamespace, deployBindingName, [][]string{{targetCluster}})
+			framework.WaitResourceBindingFitWith(karmadaClient, deployNamespace, deployBindingName, func(binding *workv1alpha2.ResourceBinding) bool {
+				if binding.Spec.ReplicaRequirements == nil {
+					return false
+				}
+				return binding.Spec.ReplicaRequirements.Namespace == deployNamespace
+			})
 		})
 
 		ginkgo.By("Verifying deployment propagation to target cluster", func() {
@@ -158,6 +164,12 @@ var _ = ginkgo.Describe("Quota plugin Testing", func() {
 			framework.WaitResourceBindingFitWith(karmadaClient, deployNamespace, deployBindingName, func(binding *workv1alpha2.ResourceBinding) bool {
 				cond := meta.FindStatusCondition(binding.Status.Conditions, workv1alpha2.Scheduled)
 				return binding.Spec.Clusters == nil && cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == workv1alpha2.BindingReasonSchedulerError
+			})
+			framework.WaitResourceBindingFitWith(karmadaClient, deployNamespace, deployBindingName, func(binding *workv1alpha2.ResourceBinding) bool {
+				if binding.Spec.ReplicaRequirements == nil {
+					return false
+				}
+				return binding.Spec.ReplicaRequirements.Namespace == deployNamespace
 			})
 		})
 

--- a/test/e2e/suites/base/resourceinterpreter_test.go
+++ b/test/e2e/suites/base/resourceinterpreter_test.go
@@ -644,7 +644,9 @@ var _ = framework.SerialDescribe("Resource interpreter customization testing", f
 					expectedReplicaRequirements := &workv1alpha2.ReplicaRequirements{
 						ResourceRequest: map[corev1.ResourceName]resource.Quantity{
 							corev1.ResourceCPU: resource.MustParse("100m"),
-						}}
+						},
+						Namespace: deployment.Namespace,
+					}
 
 					gomega.Eventually(func(g gomega.Gomega) (bool, error) {
 						resourceBinding, err := karmadaClient.WorkV1alpha2().ResourceBindings(deployment.Namespace).Get(context.TODO(), resourceBindingName, metav1.GetOptions{})


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This PR fixes a bug in the scheduler estimator's resource quota plugin. The plugin was failing to correctly list resource quotas because the namespace information was missing from the gRPC request. This caused the plugin to list all ResourceQuota objects across all namespaces, instead of just the intended one.

The fix involves modifying `pkg/detector/detector.go` to ensure that `replicaRequirements.Namespace` is always set by using `object.GetNamespace()` when it's empty and the `ResourceQuotaEstimate` feature is enabled.

**Which issue(s) this PR fixes**:
Fixes #7112

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-scheduler-estimator`: Fixed the issue where the resource quota plugin failed to list resource quotas due to a missing namespace in the gRPC request.
```