### PR TITLE
Deprecate unused cluster lease flags in karmada-controller-manager

### DIFF
--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -187,8 +187,10 @@ func (o *Options) AddFlags(flags *pflag.FlagSet, allControllers, disabledByDefau
 		"of a leadership. This is only applicable if leader election is enabled.")
 	flags.DurationVar(&o.ClusterLeaseDuration.Duration, "cluster-lease-duration", 40*time.Second,
 		"Specifies the expiration period of a cluster lease.")
+	_ = flags.MarkDeprecated("cluster-lease-duration", "The flag --cluster-lease-duration has been marked deprecated because it has never been used, and will be removed in a future release.")
 	flags.Float64Var(&o.ClusterLeaseRenewIntervalFraction, "cluster-lease-renew-interval-fraction", 0.25,
 		"Specifies the cluster lease renew interval fraction.")
+	_ = flags.MarkDeprecated("cluster-lease-renew-interval-fraction", "The flag --cluster-lease-renew-interval-fraction has been marked deprecated because it has never been used, and will be removed in a future release.")
 	flags.DurationVar(&o.ClusterSuccessThreshold.Duration, "cluster-success-threshold", 30*time.Second, "The duration of successes for the cluster to be considered healthy after recovery.")
 	flags.DurationVar(&o.ClusterFailureThreshold.Duration, "cluster-failure-threshold", 30*time.Second, "The duration of failure for the cluster to be considered unhealthy.")
 	flags.DurationVar(&o.ClusterMonitorPeriod.Duration, "cluster-monitor-period", 5*time.Second,


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes https://github.com/karmada-io/karmada/issues/7125

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-controller-manager`: The flags `--cluster-lease-duration` and `cluster-lease-renew-interval-fraction` have been marked deprecated and will be removed in the future release.
```

