### PR TITLE
feat: improve deployment creation performance by using informer cache…

### DIFF
--- a/pkg/controllers/status/crb_status_controller.go
+++ b/pkg/controllers/status/crb_status_controller.go
@@ -116,7 +116,7 @@ func (c *CRBStatusController) syncBindingStatus(ctx context.Context, binding *wo
 		return err
 	}
 
-	err = updateResourceStatus(ctx, c.DynamicClient, c.RESTMapper, c.ResourceInterpreter, c.EventRecorder, binding.Spec.Resource, binding.Status)
+	err = updateResourceStatus(ctx, c.DynamicClient, c.InformerManager, c.RESTMapper, c.ResourceInterpreter, c.EventRecorder, binding.Spec.Resource, binding.Status)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/status/rb_status_controller.go
+++ b/pkg/controllers/status/rb_status_controller.go
@@ -118,7 +118,7 @@ func (c *RBStatusController) syncBindingStatus(ctx context.Context, binding *wor
 		return err
 	}
 
-	err = updateResourceStatus(ctx, c.DynamicClient, c.RESTMapper, c.ResourceInterpreter, c.EventRecorder, binding.Spec.Resource, binding.Status)
+	err = updateResourceStatus(ctx, c.DynamicClient, c.InformerManager, c.RESTMapper, c.ResourceInterpreter, c.EventRecorder, binding.Spec.Resource, binding.Status)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->
/kind feature

**What this PR does / why we need it**:
Performance improvement for create deployment.

Currently, `updateResourceStatus` in `pkg/controllers/status/common.go` performs a direct API `Get` and `Update` on the resource status for every Work status update. This bypasses the controller-runtime cache, leading to higher latency and increased load on the API server, especially when creating a large number of deployments concurrently.

This PR optimizes `updateResourceStatus` to attempt fetching the resource from the informer cache first.
1. It tries to get the object from the `InformerManager`.
2. If found, it calculates the new status and attempts to update the resource status via the API server.
3. If the update succeeds, it returns.
4. If the update fails with a conflict (optimistic locking failure) or if the object wasn't found in the cache, it falls back to the original behavior: fetching the latest object directly from the API server and retrying the update.

This "optimistic cache fetch" strategy significantly reduces the number of read operations against the API server during normal operation, improving performance for high-concurrency scenarios.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #4225

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->
Verified with `go test ./pkg/controllers/status/...`. The retry logic ensures data consistency even if the cache is stale.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE