### PR TITLE
Fix graceful eviction race condition causing premature Work deletion

### DIFF
--- a/pkg/controllers/gracefuleviction/crb_graceful_eviction_controller.go
+++ b/pkg/controllers/gracefuleviction/crb_graceful_eviction_controller.go
@@ -83,6 +83,7 @@ func (c *CRBGracefulEvictionController) syncBinding(ctx context.Context, binding
 		scheduleResult: binding.Spec.Clusters,
 		observedStatus: binding.Status.AggregatedStatus,
 		hasScheduled:   binding.Status.SchedulerObservedGeneration == binding.Generation,
+		statusUpToDate: isStatusUpToDate(binding.Spec.Clusters, binding.Status.AggregatedStatus),
 	})
 	if reflect.DeepEqual(binding.Spec.GracefulEvictionTasks, keptTask) {
 		return nextRetry(keptTask, c.GracefulEvictionTimeout, metav1.Now().Time), nil

--- a/pkg/controllers/gracefuleviction/rb_graceful_eviction_controller.go
+++ b/pkg/controllers/gracefuleviction/rb_graceful_eviction_controller.go
@@ -83,6 +83,7 @@ func (c *RBGracefulEvictionController) syncBinding(ctx context.Context, binding 
 		scheduleResult: binding.Spec.Clusters,
 		observedStatus: binding.Status.AggregatedStatus,
 		hasScheduled:   binding.Status.SchedulerObservedGeneration == binding.Generation,
+		statusUpToDate: isStatusUpToDate(binding.Spec.Clusters, binding.Status.AggregatedStatus),
 	})
 	if reflect.DeepEqual(binding.Spec.GracefulEvictionTasks, keptTask) {
 		return nextRetry(keptTask, c.GracefulEvictionTimeout, metav1.Now().Time), nil

--- a/pkg/controllers/status/common_test.go
+++ b/pkg/controllers/status/common_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2023 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"testing"
+
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+)
+
+func Test_targetClustersEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []workv1alpha2.TargetCluster
+		b    []workv1alpha2.TargetCluster
+		want bool
+	}{
+		{
+			name: "both empty",
+			a:    []workv1alpha2.TargetCluster{},
+			b:    []workv1alpha2.TargetCluster{},
+			want: true,
+		},
+		{
+			name: "both nil",
+			a:    nil,
+			b:    nil,
+			want: true,
+		},
+		{
+			name: "same clusters same order",
+			a: []workv1alpha2.TargetCluster{
+				{Name: "cluster-a", Replicas: 1},
+				{Name: "cluster-b", Replicas: 2},
+			},
+			b: []workv1alpha2.TargetCluster{
+				{Name: "cluster-a", Replicas: 1},
+				{Name: "cluster-b", Replicas: 2},
+			},
+			want: true,
+		},
+		{
+			name: "same clusters different order",
+			a: []workv1alpha2.TargetCluster{
+				{Name: "cluster-a", Replicas: 1},
+				{Name: "cluster-b", Replicas: 2},
+			},
+			b: []workv1alpha2.TargetCluster{
+				{Name: "cluster-b", Replicas: 2},
+				{Name: "cluster-a", Replicas: 1},
+			},
+			want: true,
+		},
+		{
+			name: "different lengths",
+			a: []workv1alpha2.TargetCluster{
+				{Name: "cluster-a", Replicas: 1},
+			},
+			b: []workv1alpha2.TargetCluster{
+				{Name: "cluster-a", Replicas: 1},
+				{Name: "cluster-b", Replicas: 2},
+			},
+			want: false,
+		},
+		{
+			name: "same names different replicas",
+			a: []workv1alpha2.TargetCluster{
+				{Name: "cluster-a", Replicas: 1},
+			},
+			b: []workv1alpha2.TargetCluster{
+				{Name: "cluster-a", Replicas: 2},
+			},
+			want: false,
+		},
+		{
+			name: "different cluster names",
+			a: []workv1alpha2.TargetCluster{
+				{Name: "cluster-a", Replicas: 1},
+			},
+			b: []workv1alpha2.TargetCluster{
+				{Name: "cluster-b", Replicas: 1},
+			},
+			want: false,
+		},
+		{
+			name: "one empty one not",
+			a:    []workv1alpha2.TargetCluster{},
+			b: []workv1alpha2.TargetCluster{
+				{Name: "cluster-a", Replicas: 1},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := targetClustersEqual(tt.a, tt.b); got != tt.want {
+				t.Errorf("targetClustersEqual() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Fix: Graceful Eviction Race Condition

This change fixes a race condition between the graceful eviction controller and the status controller that could cause **Work objects to be deleted too early during failover**.

Previously, graceful eviction relied on `AggregatedStatus` without ensuring it had been updated for the current binding generation. Under certain controller execution orders, this could result in eviction tasks being removed before the new target cluster was ready, causing temporary workload unavailability.

The fix ensures eviction decisions are only made when the status is confirmed fresh for the current scheduling decision, restoring safe and deterministic failover behavior.
