### PR TITLE
Add Complete interpreter test coverage for ClusterPolicy

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kyverno.io/v1/ClusterPolicy/testdata/aggregatestatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kyverno.io/v1/ClusterPolicy/testdata/aggregatestatus-test.yaml
@@ -1,5 +1,7 @@
 # test case for aggregating status of ClusterPolicy
 # case1. ClusterPolicy with two status items
+# case2. ClusterPolicy with different Ready reasons
+# case3. ClusterPolicy with nil statusItems
 
 name: "ClusterPolicy with two status items"
 description: "Test aggregating status of ClusterPolicy with two status items"
@@ -58,3 +60,95 @@ statusItems:
         verifyimages: 0
 operation: AggregateStatus
 output:
+  aggregatedStatus:
+    apiVersion: kyverno.io/v1
+    kind: ClusterPolicy
+    metadata:
+      name: sample
+    spec:
+      validationFailureAction: Enforce
+      rules:
+        - name: require-ns-purpose-label
+          match:
+            any:
+              - resources:
+                  kinds:
+                    - Namespace
+          validate:
+            message: "You must have label `purpose` with value `production` set on all new namespaces."
+            pattern:
+              metadata:
+                labels:
+                  purpose: production
+    status:
+      conditions:
+        - type: Ready
+          status: "True"
+          reason: Succeeded
+          lastTransitionTime: "2023-05-07T12:28:58Z"
+          message: "member2=, member3="
+      ready: true
+      rulecount:
+        generate: 0
+        mutate: 0
+        validate: 2
+        verifyimages: 0
+---
+name: "ClusterPolicy with different Ready reasons"
+desiredObj:
+  apiVersion: kyverno.io/v1
+  kind: ClusterPolicy
+  metadata:
+    name: mixed-reasons
+statusItems:
+  - clusterName: member1
+    status:
+      conditions:
+        - type: Ready
+          status: "True"
+          reason: Succeeded
+          message: "ok"
+  - clusterName: member2
+    status:
+      conditions:
+        - type: Ready
+          status: "True"
+          reason: Failed
+          message: "error"
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: kyverno.io/v1
+    kind: ClusterPolicy
+    metadata:
+      name: mixed-reasons
+    status:
+      conditions:
+        - type: Ready
+          status: "True"
+          reason: Succeeded
+          message: "member1=ok"
+        - type: Ready
+          status: "True"
+          reason: Failed
+          message: "member2=error"
+      rulecount:
+        generate: 0
+        mutate: 0
+        validate: 0
+        verifyimages: 0
+---
+name: "ClusterPolicy with nil statusItems"
+desiredObj:
+  apiVersion: kyverno.io/v1
+  kind: ClusterPolicy
+  metadata:
+    name: no-status
+statusItems: null
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: kyverno.io/v1
+    kind: ClusterPolicy
+    metadata:
+      name: no-status

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kyverno.io/v1/ClusterPolicy/testdata/interprethealth-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kyverno.io/v1/ClusterPolicy/testdata/interprethealth-test.yaml
@@ -1,0 +1,93 @@
+# test cases for interprethealth of ClusterPolicy
+# case1. ClusterPolicy healthy when status.ready is true
+# case2. ClusterPolicy unhealthy when ready=false
+# case3. ClusterPolicy healthy via Ready condition
+# case4. ClusterPolicy unhealthy when Ready=True but reason is not Succeeded
+# case5. ClusterPolicy unhealthy when Ready condition is missing
+# case6. ClusterPolicy unhealthy when conditions are empty
+
+name: "ClusterPolicy healthy when ready=true"
+description: "Health should be true when status.ready is true"
+observedObj:
+  apiVersion: kyverno.io/v1
+  kind: ClusterPolicy
+  status:
+    ready: true
+operation: InterpretHealth
+output:
+  healthy: true
+---
+name: "ClusterPolicy unhealthy when ready=false"
+description: "Health should be false when status.ready is false"
+observedObj:
+  apiVersion: kyverno.io/v1
+  kind: ClusterPolicy
+  status:
+    ready: false
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "ClusterPolicy healthy when Ready=True and reason=Succeeded"
+description: "Health should be true when Ready condition is True and reason is Succeeded"
+observedObj:
+  apiVersion: kyverno.io/v1
+  kind: ClusterPolicy
+  status:
+    conditions:
+      - type: Ready
+        status: "True"
+        reason: Succeeded
+operation: InterpretHealth
+output:
+  healthy: true
+---
+name: "ClusterPolicy unhealthy when Ready=True but reason is not Succeeded"
+description: "Health should be false when Ready condition reason is not Succeeded"
+observedObj:
+  apiVersion: kyverno.io/v1
+  kind: ClusterPolicy
+  status:
+    conditions:
+      - type: Ready
+        status: "True"
+        reason: Progressing
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "ClusterPolicy unhealthy when Ready condition is missing"
+description: "Health should be false when no Ready condition exists"
+observedObj:
+  apiVersion: kyverno.io/v1
+  kind: ClusterPolicy
+  status:
+    conditions:
+      - type: SomethingElse
+        status: "True"
+        reason: Succeeded
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "ClusterPolicy unhealthy when conditions are empty"
+description: "Health should be false when status.conditions is empty"
+observedObj:
+  apiVersion: kyverno.io/v1
+  kind: ClusterPolicy
+  status:
+    conditions: []
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "ClusterPolicy unhealthy without status"
+description: "InterpretHealth should return false when status is missing"
+observedObj:
+  apiVersion: kyverno.io/v1
+  kind: ClusterPolicy
+  metadata:
+    name: no-status
+operation: InterpretHealth
+output:
+  healthy: false

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kyverno.io/v1/ClusterPolicy/testdata/interpretstatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kyverno.io/v1/ClusterPolicy/testdata/interpretstatus-test.yaml
@@ -1,5 +1,8 @@
 # test case for interpreting status of ClusterPolicy
 # case1. ClusterPolicy: interpret status test
+# case2. ClusterPolicy with nil status
+# case3. ClusterPolicy without conditions
+# case4. ClusterPolicy with only ready field
 
 name: "ClusterPolicy: interpret status test"
 description: "Test interpreting status for ClusterPolicy"
@@ -41,3 +44,65 @@ observedObj:
       verifyimages: 0
 operation: InterpretStatus
 output:
+  status:
+    ready: true
+    conditions:
+      - lastTransitionTime: "2023-05-07T12:28:58Z"
+        message: ""
+        reason: Succeeded
+        status: "True"
+        type: Ready
+    rulecount:
+      generate: 0
+      mutate: 0
+      validate: 1
+      verifyimages: 0
+---
+name: "ClusterPolicy with nil status"
+description: "InterpretStatus should return empty status when status is nil"
+observedObj:
+  apiVersion: kyverno.io/v1
+  kind: ClusterPolicy
+  metadata:
+    name: sample
+operation: InterpretStatus
+output:
+  status: {}
+---
+name: "ClusterPolicy without conditions"
+description: "InterpretStatus should work when conditions are missing"
+observedObj:
+  apiVersion: kyverno.io/v1
+  kind: ClusterPolicy
+  metadata:
+    name: sample
+  status:
+    ready: false
+    rulecount:
+      generate: 0
+      mutate: 1
+      validate: 0
+      verifyimages: 0
+operation: InterpretStatus
+output:
+  status:
+    ready: false
+    rulecount:
+      generate: 0
+      mutate: 1
+      validate: 0
+      verifyimages: 0
+---
+name: "ClusterPolicy with only ready"
+description: "InterpretStatus should copy ready when other fields are absent"
+observedObj:
+  apiVersion: kyverno.io/v1
+  kind: ClusterPolicy
+  metadata:
+    name: sample
+  status:
+    ready: true
+operation: InterpretStatus
+output:
+  status:
+    ready: true


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
This PR adds comprehensive test coverage for the ClusterPolicy resource interpreter customization.

Specifically, it:
	•	Adds unit tests for AggregateStatus, InterpretStatus, and InterpretHealth
	•	Aligns test expectations with the actual aggregation behavior (e.g. preserving spec while aggregating status)
	•	Covers multi-member aggregation, mixed condition reasons, and edge cases such as nil or missing fields

These tests improve confidence in Kyverno ClusterPolicy status handling across clusters and prevent future regressions.

**Which issue(s) this PR fixes**:
Fixes #6952


**Special notes for your reviewer**:
	•	Tests are written to strictly follow the existing Lua aggregation logic
	•	spec is intentionally preserved in aggregated results, as AggregateStatus only mutates status
	•	All cases are verified using:
                 `go test ./pkg/resourceinterpreter/default/thirdparty`

**Does this PR introduce a user-facing change?**:
None
  
Thanks to @FAUST-BENCHOU for review and feedbacks.