### PR TITLE
fix race condition in job startTime aggregation

### DIFF
--- a/pkg/util/helper/job.go
+++ b/pkg/util/helper/job.go
@@ -35,7 +35,7 @@ import (
 func ParsingJobStatus(obj *batchv1.Job, status []workv1alpha2.AggregatedStatusItem) (*batchv1.JobStatus, error) {
 	var jobFailed []string
 	var startTime, completionTime *metav1.Time
-	successfulJobs, completionJobs := 0, 0
+	successfulJobs, startJobs, completionJobs := 0, 0, 0
 	// Track how many member clusters already reported SuccessCriteriaMet=true
 	successCriteriaMetClusters := 0
 	newStatus := &batchv1.JobStatus{}
@@ -71,6 +71,9 @@ func ParsingJobStatus(obj *batchv1.Job, status []workv1alpha2.AggregatedStatusIt
 		}
 
 		// StartTime
+		if temp.StartTime != nil {
+			startJobs++
+		}
 		if startTime == nil || temp.StartTime.Before(startTime) {
 			startTime = temp.StartTime
 		}
@@ -119,7 +122,8 @@ func ParsingJobStatus(obj *batchv1.Job, status []workv1alpha2.AggregatedStatusIt
 		}
 	}
 
-	if startTime != nil {
+	newStatus.StartTime = obj.Status.StartTime
+	if obj.Status.StartTime == nil && startJobs == len(status) && startJobs > 0 {
 		newStatus.StartTime = startTime.DeepCopy()
 	}
 	if completionTime != nil && completionJobs == len(status) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

When aggregating job status from multiple member clusters, a race condition could occur. The `job-aggregator` might set the `startTime` on the control plane Job based on the status of the first-reporting member cluster. If another member cluster, which started earlier, reports its status later, the aggregator would attempt to update the control plane's `startTime` to this earlier timestamp.

This update fails Kubernetes API validation, as `startTime` is an immutable field for a running (non-suspended) Job. This caused the `karmada-controller-manager` to enter a persistent error loop, continuously failing to update the job's status and blocking further reconciliations.

This PR fixes the issue by making the `startTime` aggregation logic in `ParsingJobStatus` more robust. It now only sets the `startTime` if the `startTime` on the control plane Job is currently `nil`. In all other cases, it preserves the existing `startTime`, thus avoiding the invalid update attempt and resolving the error loop.

**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/karmada/issues/7135

**Special notes for your reviewer**:

This PR focuses on fixing the critical race condition that occurs during the initial aggregation of a Job's status.

The full lifecycle support for Job suspension/resumption, which requires aggregating the `JobSuspended` condition and handling `startTime` removal/reset upon resume, is **out of the scope** of this PR. This has been explicitly marked with a `TODO` in the code for a future enhancement.

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-controller-manager`: Fixed the issue where the job status aggregator could enter an error loop due to a race condition when setting the initial `startTime`.
```

