### PR TITLE
Add complete interpreter test coverage for Policy

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kyverno.io/v1/Policy/testdata/aggregatestatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kyverno.io/v1/Policy/testdata/aggregatestatus-test.yaml
@@ -1,5 +1,8 @@
 # test case for aggregating status of Policy
 # case1. Policy with two status items
+# case2. Policy with different Ready reasons
+# case3. Policy with nil statusItems
+# case4. Policy with mixed empty and valid statusItems
 
 name: "Policy with two status items"
 description: "Test aggregating status of Policy with two status items"
@@ -145,3 +148,177 @@ statusItems:
         verifyimages: 0
 operation: AggregateStatus
 output:
+  aggregatedStatus:
+    apiVersion: kyverno.io/v1
+    kind: Policy
+    metadata:
+      name: sample
+      namespace: test-policy
+    spec:
+      validationFailureAction: Enforce
+      rules:
+        - name: require-pod-purpose-label
+          match:
+            any:
+              - resources:
+                  kinds:
+                    - Pod
+          validate:
+            message: "You must have label `purpose` with value `production` set on all new Pod in test-policy Namespace."
+            pattern:
+              metadata:
+                labels:
+                  purpose: production
+    status:
+      ready: true
+      autogen:
+        rules:
+          - match:
+              any:
+                - resources:
+                    kinds:
+                      - DaemonSet
+                      - Deployment
+                      - Job
+                      - StatefulSet
+                      - ReplicaSet
+                      - ReplicationController
+            name: autogen-require-pod-purpose-label
+            validate:
+              message: You must have label `purpose` with value `production` set on all new Pod in test-policy Namespace.
+              pattern:
+                spec:
+                  template:
+                    metadata:
+                      labels:
+                        purpose: production
+          - match:
+              any:
+                - resources:
+                    kinds:
+                      - CronJob
+            name: autogen-cronjob-require-pod-purpose-label
+            validate:
+              message: You must have label `purpose` with value `production` set on all new Pod in test-policy Namespace.
+              pattern:
+                spec:
+                  jobTemplate:
+                    spec:
+                      template:
+                        metadata:
+                          labels:
+                            purpose: production
+      rulecount:
+        generate: 0
+        mutate: 0
+        validate: 2
+        verifyimages: 0
+      conditions:
+        - type: Ready
+          status: "True"
+          reason: Succeeded
+          lastTransitionTime: "2023-05-07T09:19:06Z"
+          message: "member2=, member3="
+---
+name: "Policy with different Ready reasons"
+description: "Conditions with different reasons should not be merged"
+desiredObj:
+  apiVersion: kyverno.io/v1
+  kind: Policy
+  metadata:
+    name: mixed-reasons
+    namespace: test-policy
+statusItems:
+  - clusterName: member1
+    status:
+      conditions:
+        - type: Ready
+          status: "True"
+          reason: Succeeded
+          message: "ok"
+  - clusterName: member2
+    status:
+      conditions:
+        - type: Ready
+          status: "True"
+          reason: Failed
+          message: "error"
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: kyverno.io/v1
+    kind: Policy
+    metadata:
+      name: mixed-reasons
+      namespace: test-policy
+    status:
+      conditions:
+        - type: Ready
+          status: "True"
+          reason: Succeeded
+          message: "member1=ok"
+        - type: Ready
+          status: "True"
+          reason: Failed
+          message: "member2=error"
+      rulecount:
+        generate: 0
+        mutate: 0
+        validate: 0
+        verifyimages: 0
+---
+name: "Policy with nil statusItems"
+description: "AggregateStatus should return desiredObj unchanged when statusItems is nil"
+desiredObj:
+  apiVersion: kyverno.io/v1
+  kind: Policy
+  metadata:
+    name: no-status
+    namespace: test-policy
+statusItems: null
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: kyverno.io/v1
+    kind: Policy
+    metadata:
+      name: no-status
+      namespace: test-policy
+---
+name: "Policy with mixed empty and valid statusItems"
+description: "One statusItem has empty status and should be ignored"
+desiredObj:
+  apiVersion: kyverno.io/v1
+  kind: Policy
+  metadata:
+    name: mixed-empty
+    namespace: test-policy
+statusItems:
+  - clusterName: member1
+    status:
+      conditions:
+        - type: Ready
+          status: "True"
+          reason: Succeeded
+          message: "ok"
+  - clusterName: member2
+    status: {}
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: kyverno.io/v1
+    kind: Policy
+    metadata:
+      name: mixed-empty
+      namespace: test-policy
+    status:
+      conditions:
+        - type: Ready
+          status: "True"
+          reason: Succeeded
+          message: "member1=ok"
+      rulecount:
+        generate: 0
+        mutate: 0
+        validate: 0
+        verifyimages: 0

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kyverno.io/v1/Policy/testdata/interprethealth-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kyverno.io/v1/Policy/testdata/interprethealth-test.yaml
@@ -1,0 +1,115 @@
+# testcases for interprethealth of Policy
+# case1. Policy with status.ready = true
+# case2. Policy with status.ready false
+# case3. Policy with Ready=True and Succeeded condition
+# case4. Policy with Ready=True but non-succeeded reason
+# case5. Policy with empty status
+# case6. Policy without status
+# case7. Policy with conditions but no Ready condition
+
+name: "Policy with status.ready true"
+description: "InterpretHealth should return true when status.ready is true"
+observedObj:
+  apiVersion: kyverno.io/v1
+  kind: Policy
+  metadata:
+    name: sample
+    namespace: test-policy
+  status:
+    ready: true
+operation: InterpretHealth
+output:
+  healthy: true
+---
+name: "Policy with status.ready false"
+description: "InterpretHealth should return false when status.ready is false"
+observedObj:
+  apiVersion: kyverno.io/v1
+  kind: Policy
+  metadata:
+    name: sample
+    namespace: test-policy
+  status:
+    ready: false
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "Policy with Ready condition succeeded"
+description: "InterpretHealth should return true when Ready condition is True and Succeeded"
+observedObj:
+  apiVersion: kyverno.io/v1
+  kind: Policy
+  metadata:
+    name: sample
+    namespace: test-policy
+  status:
+    conditions:
+      - type: Ready
+        status: "True"
+        reason: Succeeded
+operation: InterpretHealth
+output:
+  healthy: true
+---
+name: "Policy with Ready condition but failed reason"
+description: "InterpretHealth should return false if Ready condition reason is not Succeeded"
+observedObj:
+  apiVersion: kyverno.io/v1
+  kind: Policy
+  metadata:
+    name: sample
+    namespace: test-policy
+  status:
+    conditions:
+      - type: Ready
+        status: "True"
+        reason: Failed
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "Policy with empty status"
+description: "InterpretHealth should return false when status has no ready or conditions"
+observedObj:
+  apiVersion: kyverno.io/v1
+  kind: Policy
+  metadata:
+    name: sample
+    namespace: test-policy
+  status: {}
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "Policy without status"
+description: "InterpretHealth should return false when status is nil"
+observedObj:
+  apiVersion: kyverno.io/v1
+  kind: Policy
+  metadata:
+    name: sample
+    namespace: test-policy
+operation: InterpretHealth
+output:
+  healthy: false
+---
+name: "Policy with conditions but no Ready condition"
+description: "InterpretHealth should return false when conditions exist but no Ready type is present"
+observedObj:
+  apiVersion: kyverno.io/v1
+  kind: Policy
+  metadata:
+    name: sample
+    namespace: test-policy
+  status:
+    conditions:
+      - type: Progressing
+        status: "True"
+        reason: InProgress
+      - type: Validating
+        status: "True"
+        reason: Ongoing
+operation: InterpretHealth
+output:
+  healthy: false

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kyverno.io/v1/Policy/testdata/interpretstatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/kyverno.io/v1/Policy/testdata/interpretstatus-test.yaml
@@ -1,5 +1,10 @@
 # test case for interpreting status of Policy
 # case1. Policy: interpret status test
+# case2. Policy with nil status
+# case3. Policy with only ready field
+# case4. Policy without conditions
+# case5. Policy with only conditions
+# case6. Policy with only autogen
 
 name: "Policy: interpret status test"
 description: "Test interpreting status for Policy"
@@ -92,3 +97,163 @@ observedObj:
       verifyimages: 0
 operation: InterpretStatus
 output:
+  status:
+    autogen:
+      rules:
+        - exclude: {}
+          generate: {}
+          match:
+            any:
+              - resources:
+                  kinds:
+                    - DaemonSet
+                    - Deployment
+                    - Job
+                    - StatefulSet
+                    - ReplicaSet
+                    - ReplicationController
+          name: autogen-require-pod-purpose-label
+          validate:
+            message: You must have label `purpose` with value `production` set on all new Pod in test-policy Namespace.
+            pattern:
+              spec:
+                template:
+                  metadata:
+                    labels:
+                      purpose: production
+        - exclude: {}
+          generate: {}
+          match:
+            any:
+              - resources:
+                  kinds:
+                    - CronJob
+          name: autogen-cronjob-require-pod-purpose-label
+          validate:
+            message: You must have label `purpose` with value `production` set on all new Pod in test-policy Namespace.
+            pattern:
+              spec:
+                jobTemplate:
+                  spec:
+                    template:
+                      metadata:
+                        labels:
+                          purpose: production
+    conditions:
+      - lastTransitionTime: "2023-05-07T09:19:06Z"
+        message: ""
+        reason: Succeeded
+        status: "True"
+        type: Ready
+    ready: true
+    rulecount:
+      generate: 0
+      mutate: 0
+      validate: 1
+      verifyimages: 0
+---
+name: "Policy with nil status"
+description: "InterpretStatus should return empty status when status is nil"
+observedObj:
+  apiVersion: kyverno.io/v1
+  kind: Policy
+  metadata:
+    name: sample
+    namespace: test-policy
+operation: InterpretStatus
+output:
+  status: {}
+---
+name: "Policy with only ready"
+description: "InterpretStatus should copy ready when other fields are missing"
+observedObj:
+  apiVersion: kyverno.io/v1
+  kind: Policy
+  metadata:
+    name: sample
+    namespace: test-policy
+  status:
+    ready: false
+operation: InterpretStatus
+output:
+  status:
+    ready: false
+---
+name: "Policy without conditions"
+description: "InterpretStatus should work when conditions are absent"
+observedObj:
+  apiVersion: kyverno.io/v1
+  kind: Policy
+  metadata:
+    name: sample
+    namespace: test-policy
+  status:
+    rulecount:
+      generate: 0
+      mutate: 1
+      validate: 0
+      verifyimages: 0
+operation: InterpretStatus
+output:
+  status:
+    rulecount:
+      generate: 0
+      mutate: 1
+      validate: 0
+      verifyimages: 0
+---
+name: "Policy with only conditions"
+description: "InterpretStatus should copy conditions when other fields are missing"
+observedObj:
+  apiVersion: kyverno.io/v1
+  kind: Policy
+  metadata:
+    name: only-conditions
+    namespace: test-policy
+  status:
+    conditions:
+      - type: Ready
+        status: "True"
+        reason: Succeeded
+        message: "ok"
+operation: InterpretStatus
+output:
+  status:
+    conditions:
+      - type: Ready
+        status: "True"
+        reason: Succeeded
+        message: "ok"
+---
+name: "Policy with only autogen"
+description: "InterpretStatus should reflect autogen when only autogen exists"
+observedObj:
+  apiVersion: kyverno.io/v1
+  kind: Policy
+  metadata:
+    name: autogen-only
+    namespace: test-policy
+  status:
+    autogen:
+      rules:
+        - match:
+            any:
+              - resources:
+                  kinds:
+                    - Deployment
+          name: autogen-only
+          validate:
+            message: test
+operation: InterpretStatus
+output:
+  status:
+    autogen:
+      rules:
+        - match:
+            any:
+              - resources:
+                  kinds:
+                    - Deployment
+          name: autogen-only
+          validate:
+            message: test


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
This PR adds comprehensive test coverage for the Policy resource interpreter customization.

Specifically, it:
	•	Adds unit tests for AggregateStatus, InterpretStatus, and InterpretHealth
	•	Aligns test expectations with the actual aggregation behavior 
	
These tests improve confidence in Kyverno Policy status handling across clusters and prevent future regressions.

**Which issue(s) this PR fixes**:
Fixes part of #6952


**Special notes for your reviewer**:
	•	Tests are written to strictly follow the existing Lua aggregation logic
	•	All cases are verified using:
                 `go test ./pkg/resourceinterpreter/default/thirdparty`

**Does this PR introduce a user-facing change?**:
None
  