### PR TITLE
Introduce WorkloadAffinity feature gate, default to false

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -127,6 +127,17 @@ const (
 	// owner: @zach593
 	// alpha: v1.15
 	ControllerPriorityQueue featuregate.Feature = "ControllerPriorityQueue"
+
+	// WorkloadAffinity enables the scheduler to group or separate workloads across clusters
+	// based on their defined workload affinity or anti-affinity groups, which are managed
+	// via the PropagationPolicy or ClusterPropagationPolicy.
+	// When enabled, the scheduler maintains a global in-memory index of affinity groups.
+	// Based on a workload's affinity group, the scheduler filters out candidate clusters
+	// that would violate the workload's affinity settings.
+	//
+	// owner: @mszacillo, @RainbowMango, @kevin-wangzefeng
+	// alpha: v1.17
+	WorkloadAffinity featuregate.Feature = "WorkloadAffinity"
 )
 
 var (
@@ -154,6 +165,7 @@ var (
 		ContextualLogging:                 {Default: true, PreRelease: featuregate.Beta},
 		MultiplePodTemplatesScheduling:    {Default: false, PreRelease: featuregate.Alpha},
 		ControllerPriorityQueue:           {Default: false, PreRelease: featuregate.Alpha},
+		WorkloadAffinity:                  {Default: false, PreRelease: featuregate.Alpha},
 	}
 )
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds feature gate for the new workload affinity feature described in #7064.

**Which issue(s) this PR fixes**:
Part of #7064

**Does this PR introduce a user-facing change?**:
```release-note
Introduce `WorkloadAffinity` feature gate, default to false. 
```