### PR TITLE
use etcdctl endpoint health to replace get all /registry prefix keys

### DIFF
--- a/artifacts/deploy/karmada-etcd.yaml
+++ b/artifacts/deploy/karmada-etcd.yaml
@@ -43,7 +43,7 @@ spec:
               command:
                 - /bin/sh
                 - -ec
-                - 'etcdctl get /registry --prefix --keys-only  --endpoints https://127.0.0.1:2379  --cacert /etc/karmada/pki/etcd-client/ca.crt --cert /etc/karmada/pki/etcd-client/tls.crt --key /etc/karmada/pki/etcd-client/tls.key'
+                - 'etcdctl endpoint health --endpoints https://127.0.0.1:2379  --cacert /etc/karmada/pki/etcd-client/ca.crt --cert /etc/karmada/pki/etcd-client/tls.crt --key /etc/karmada/pki/etcd-client/tls.key'
             failureThreshold: 3
             initialDelaySeconds: 600
             periodSeconds: 60

--- a/charts/karmada/templates/etcd.yaml
+++ b/charts/karmada/templates/etcd.yaml
@@ -52,7 +52,7 @@ spec:
               command:
                 - /bin/sh
                 - -ec
-                - 'etcdctl get /registry --prefix --keys-only  --endpoints https://127.0.0.1:2379  --cacert /etc/kubernetes/pki/etcd/server-ca.crt --cert /etc/kubernetes/pki/etcd/karmada.crt --key /etc/kubernetes/pki/etcd/karmada.key'
+                - 'etcdctl endpoint health --endpoints https://127.0.0.1:2379  --cacert /etc/kubernetes/pki/etcd/server-ca.crt --cert /etc/kubernetes/pki/etcd/karmada.crt --key /etc/kubernetes/pki/etcd/karmada.key'
             failureThreshold: 3
             initialDelaySeconds: 600
             periodSeconds: 60

--- a/operator/pkg/controlplane/etcd/manifests.go
+++ b/operator/pkg/controlplane/etcd/manifests.go
@@ -74,7 +74,7 @@ spec:
             command:
             - /bin/sh
             - -ec
-            - etcdctl get /registry --prefix --keys-only --endpoints https://127.0.0.1:{{ .EtcdListenClientPort }} --cacert=/etc/karmada/pki/etcd/etcd-ca.crt --cert=/etc/karmada/pki/etcd/etcd-server.crt --key=/etc/karmada/pki/etcd/etcd-server.key
+            - etcdctl endpoint health --endpoints https://127.0.0.1:{{ .EtcdListenClientPort }} --cacert=/etc/karmada/pki/etcd/etcd-ca.crt --cert=/etc/karmada/pki/etcd/etcd-server.crt --key=/etc/karmada/pki/etcd/etcd-server.key
           failureThreshold: 3
           initialDelaySeconds: 600
           periodSeconds: 60

--- a/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/statefulset.go
@@ -148,7 +148,7 @@ func (i *CommandInitOption) makeETCDStatefulSet() *appsv1.StatefulSet {
 				Command: []string{
 					"/bin/sh",
 					"-ec",
-					fmt.Sprintf("etcdctl get /registry --prefix --keys-only  --endpoints http://127.0.0.1:%v", etcdContainerClientPort),
+					fmt.Sprintf("etcdctl endpoint health --endpoints http://127.0.0.1:%v", etcdContainerClientPort),
 				},
 			},
 		},


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

## PR Description

The current livenessProbe configuration for karmada-etcd uses the `etcdctl get /registry --prefix --keys-only` command for health checks. This approach has the following issues:

**Drawbacks of the current health check method:**

1. **Heavy-weight operation**: Using `etcdctl get` performs actual database read operations by scanning all keys under the `/registry` prefix. This is a relatively expensive operation that may unnecessarily impact etcd performance.

2. **Higher resource consumption**: Each health check requires executing actual database queries, including network communication and data serialization, consuming more CPU and memory resources.

3. **Mismatched purpose**: The purpose of livenessProbe is to check if the container is alive, not to verify database read/write functionality. Using `etcdctl get` for health checks is overly strict and unnecessary.

Replace the health check command from `etcdctl get /registry --prefix --keys-only` to the lighter-weight `etcdctl endpoint health` command.

**Benefits**

1. **More lightweight**: `etcdctl endpoint health` only checks the health status of the etcd service without performing actual database query operations, significantly reducing resource consumption.

2. **More efficient**: Avoids the overhead of scanning all keys under the `/registry` prefix, reducing the burden of network communication and data serialization.

3. **Better aligned with purpose**: The health command is specifically designed to check if the etcd service is healthy, which better matches the design intent of livenessProbe.

4. **Faster response**: Health check response time is shorter, enabling faster detection of abnormal etcd service states.

5. **Less interference**: Avoids frequent database queries that could affect normal etcd service operations, especially in high-load scenarios.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

