### PR TITLE
Fix/spread constraint divide by zero

### DIFF
--- a/pkg/scheduler/core/spreadconstraint/group_clusters.go
+++ b/pkg/scheduler/core/spreadconstraint/group_clusters.go
@@ -213,6 +213,9 @@ func (info *GroupClustersInfo) calcGroupScoreForDuplicate(
 	// Group2's Score = 2 * 1000 + 0 = 2000
 
 	// the priority of validClusters is higher than sumValidScore.
+	if validClusters == 0 {
+		return 0
+	}
 	weightedValidClusters := validClusters * weightUnit
 	return weightedValidClusters + sumValidScore/validClusters
 }

--- a/pkg/scheduler/core/spreadconstraint/group_clusters_test.go
+++ b/pkg/scheduler/core/spreadconstraint/group_clusters_test.go
@@ -378,3 +378,38 @@ func Test_CalcGroupScore(t *testing.T) {
 		})
 	}
 }
+
+func Test_CalcGroupScoreForDuplicate(t *testing.T) {
+	tests := []struct {
+		name     string
+		clusters []ClusterDetailInfo
+		rbSpec   *workv1alpha2.ResourceBindingSpec
+		watScore int64
+	}{
+		{
+			name:     "get 0 score when clusters is empty",
+			clusters: []ClusterDetailInfo{},
+			rbSpec:   &workv1alpha2.ResourceBindingSpec{Replicas: 10},
+			watScore: 0,
+		},
+		{
+			name: "get 0 score when all clusters can not meet the replica requirements",
+			clusters: []ClusterDetailInfo{
+				{Name: "member1", Score: 50, AvailableReplicas: 5},
+				{Name: "member2", Score: 50, AvailableReplicas: 5},
+			},
+			rbSpec:   &workv1alpha2.ResourceBindingSpec{Replicas: 10},
+			watScore: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			groupClustersInfo := &GroupClustersInfo{}
+			score := groupClustersInfo.calcGroupScoreForDuplicate(tt.clusters, tt.rbSpec)
+			if score != tt.watScore {
+				t.Errorf("calcGroupScoreForDuplicate: want score %v, but got %v", tt.watScore, score)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Fixes a divide-by-zero panic in spread constraint group scoring when using
Duplicated ReplicaScheduling under resource pressure.

## Problem
If no cluster in a spread group can satisfy the requested replicas,
`calcGroupScoreForDuplicate` divides by zero, causing the scheduler to panic.
This can happen during normal scenarios like quota limits or node failures
and results in a full scheduler outage.

## Fix
When no cluster in a group has sufficient capacity, return a score of `0`
instead of panicking. This lets the scheduler continue evaluating other
groups or fail gracefully.

## Tests
Added `Test_CalcGroupScoreForDuplicate_NoValidClusters` to cover:
- No eligible clusters
- Empty cluster list
- All clusters exhausted

All scheduler tests pass.

```release-note
`karmada-scheduler`: Fixed a scheduler panic caused by a divide-by-zero error when calculating spread constraints with no valid clusters.
```
