### PR TITLE
Automated cherry pick of #7138: fix race condition in job startTime aggregation

### DIFF
--- a/pkg/util/helper/job.go
+++ b/pkg/util/helper/job.go
@@ -35,7 +35,7 @@ import (
 func ParsingJobStatus(obj *batchv1.Job, status []workv1alpha2.AggregatedStatusItem) (*batchv1.JobStatus, error) {
 	var jobFailed []string
 	var startTime, completionTime *metav1.Time
-	successfulJobs, completionJobs := 0, 0
+	successfulJobs, startJobs, completionJobs := 0, 0, 0
 	// Track how many member clusters already reported SuccessCriteriaMet=true
 	successCriteriaMetClusters := 0
 	newStatus := &batchv1.JobStatus{}
@@ -71,6 +71,9 @@ func ParsingJobStatus(obj *batchv1.Job, status []workv1alpha2.AggregatedStatusIt
 		}
 
 		// StartTime
+		if temp.StartTime != nil {
+			startJobs++
+		}
 		if startTime == nil || temp.StartTime.Before(startTime) {
 			startTime = temp.StartTime
 		}
@@ -119,7 +122,8 @@ func ParsingJobStatus(obj *batchv1.Job, status []workv1alpha2.AggregatedStatusIt
 		}
 	}
 
-	if startTime != nil {
+	newStatus.StartTime = obj.Status.StartTime
+	if obj.Status.StartTime == nil && startJobs == len(status) && startJobs > 0 {
 		newStatus.StartTime = startTime.DeepCopy()
 	}
 	if completionTime != nil && completionJobs == len(status) {


### PR DESCRIPTION
Cherry pick of #7138 on release-1.14.
#7138: fix race condition in job startTime aggregation
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
karmada-controller-manager: Fixed the issue where the job status aggregator could enter an error loop due to a race condition when setting the initial startTime.
```

part of : #7155 