### PR TITLE
feat: add support for etcd encryption to Karmada chart

### DIFF
--- a/charts/karmada/templates/karmada-apiserver.yaml
+++ b/charts/karmada/templates/karmada-apiserver.yaml
@@ -73,6 +73,9 @@ spec:
             - --max-requests-inflight={{ .Values.apiServer.maxRequestsInflight }}
             - --max-mutating-requests-inflight={{ .Values.apiServer.maxMutatingRequestsInflight }}
             - --tls-min-version=VersionTLS13
+            {{- if .Values.apiServer.encryptionAtRest.enabled }}
+            - --encryption-provider-config={{ .Values.apiServer.encryptionAtRest.configFile }}
+            {{- end }}
             {{- with .Values.apiServer.oidc }}
             {{- if .caFile }}
             - --oidc-ca-file={{ .caFile }}
@@ -137,6 +140,12 @@ spec:
             - name: etcd-cert
               mountPath: /etc/etcd/pki
               readOnly: true
+            {{- if .Values.apiServer.encryptionAtRest.enabled }}
+            - name: encryption-config
+              mountPath: {{ .Values.apiServer.encryptionAtRest.configFile }}
+              subPath: {{ .Values.apiServer.encryptionAtRest.existingSecret.key }}
+              readOnly: true
+            {{- end }}
       {{- if .Values.apiServer.hostNetwork }}
       dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
@@ -174,6 +183,14 @@ spec:
           {{- if eq .Values.etcd.mode "external" }}
             secretName: {{ $name }}-external-etcd-cert
           {{- end }}
+        {{- if .Values.apiServer.encryptionAtRest.enabled }}
+        - name: encryption-config
+          secret:
+            secretName: {{ .Values.apiServer.encryptionAtRest.existingSecret.name }}
+            items:
+              - key: {{ .Values.apiServer.encryptionAtRest.existingSecret.key }}
+                path: {{ .Values.apiServer.encryptionAtRest.existingSecret.key }}
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -469,6 +469,22 @@ apiServer:
     signingAlgs: ""
     usernameClaim: ""
     usernamePrefix: ""
+  ## @param apiServer.encryptionAtRest encryption at rest configuration
+  ## This feature enables Karmada API server encryption-at-rest by mounting a user-provided
+  ## Secret containing an EncryptionConfiguration file and passing --encryption-provider-config to karmada-apiserver.
+  ## SECURITY WARNING: Do NOT store encryption keys or config in Git or Helm values.
+  ## Use a secret management solution (Vault, External Secrets Operator, SealedSecrets, etc.) to provision the Secret.
+  encryptionAtRest:
+    ## @param apiServer.encryptionAtRest.enabled enable encryption at rest for karmada-apiserver
+    enabled: false
+    ## @param apiServer.encryptionAtRest.existingSecret reference to an existing Secret containing the encryption config
+    existingSecret:
+      ## @param apiServer.encryptionAtRest.existingSecret.name name of the existing Secret
+      name: ""
+      ## @param apiServer.encryptionAtRest.existingSecret.key key in the Secret that contains the EncryptionConfiguration YAML
+      key: "encryption-config.yaml"
+    ## @param apiServer.encryptionAtRest.configFile path where the encryption config file will be mounted in the container
+    configFile: "/etc/karmada/encryption/encryption-config.yaml"
 
 ## karmada aggregated apiserver config
 aggregatedApiServer:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**What this PR does / why we need it**: Configure `karmada-apiserver` to use Kubernetes API server encryption-at-rest. This feature enables encryption of sensitive resources (like Secrets) in etcd by mounting a user-provided Secret containing the encryption provider configuration.

**Which issue(s) this PR fixes**:

Fixes #7145


**Special notes for your reviewer**:

#### Verification plan (local)

1. Lint:

```shell
helm lint ./charts/karmada
==> Linting ./charts/karmada
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

2. Render default (ensure no change in output structure relevant to apiserver):

```shell
helm template karmada ./charts/karmada -n karmada-system > /tmp/out.yaml

# Verify nothing has been added:
rg -n "encryption" /tmp/out.yaml || echo "Nothing found"
Nothing found
```

3. Render with encryption enabled:

```shell
helm template karmada ./charts/karmada -n karmada-system \
  --set apiServer.encryptionAtRest.enabled=true \
  --set apiServer.encryptionAtRest.existingSecret.name=karmada-encryption-config \
  --set apiServer.encryptionAtRest.existingSecret.key=encryption-config.yaml \
  > /tmp/out-encryption.yaml
  

# Verify presence:
rg -n "encryption" /tmp/out-encryption.yaml
305:            - --encryption-provider-config=/etc/karmada/encryption/encryption-config.yaml
341:            - name: encryption-config
342:              mountPath: /etc/karmada/encryption/encryption-config.yaml
343:              subPath: encryption-config.yaml
369:        - name: encryption-config
371:            secretName: karmada-encryption-config
373:              - key: encryption-config.yaml
374:                path: encryption-config.yaml
```

**Does this PR introduce a user-facing change?**:
```
`HELM Chart`: Enhanced the security posture of Karmada by integrating encryption-at-rest capabilities for the karmada-apiserver. It allows users to encrypt sensitive data stored in etcd by providing a custom encryption configuration through a Kubernetes Secret, which the apiserver will then utilize.
```
