### PR TITLE
Adopt Kuberentes PR133571: deprecated SchemeGroupVersion

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
@@ -222,8 +223,8 @@ func run(ctx context.Context, opts *options.Options) error {
 		},
 		Controller: config.Controller{
 			GroupKindConcurrency: map[string]int{
-				workv1alpha1.SchemeGroupVersion.WithKind("Work").GroupKind().String():       opts.ConcurrentWorkSyncs,
-				clusterv1alpha1.SchemeGroupVersion.WithKind("Cluster").GroupKind().String(): opts.ConcurrentClusterSyncs,
+				schema.GroupKind{Group: workv1alpha1.GroupName, Kind: "Work"}.String():       opts.ConcurrentWorkSyncs,
+				schema.GroupKind{Group: clusterv1alpha1.GroupName, Kind: "Cluster"}.String(): opts.ConcurrentClusterSyncs,
 			},
 			CacheSyncTimeout: opts.ClusterCacheSyncTimeout.Duration,
 			UsePriorityQueue: ptr.To(features.FeatureGate.Enabled(features.ControllerPriorityQueue)),

--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -191,11 +191,11 @@ func Run(ctx context.Context, opts *options.Options) error {
 		},
 		Controller: config.Controller{
 			GroupKindConcurrency: map[string]int{
-				workv1alpha1.SchemeGroupVersion.WithKind("Work").GroupKind().String():                     opts.ConcurrentWorkSyncs,
-				workv1alpha2.SchemeGroupVersion.WithKind("ResourceBinding").GroupKind().String():          opts.ConcurrentResourceBindingSyncs,
-				workv1alpha2.SchemeGroupVersion.WithKind("ClusterResourceBinding").GroupKind().String():   opts.ConcurrentClusterResourceBindingSyncs,
-				clusterv1alpha1.SchemeGroupVersion.WithKind("Cluster").GroupKind().String():               opts.ConcurrentClusterSyncs,
-				schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}.GroupKind().String(): opts.ConcurrentNamespaceSyncs,
+				schema.GroupKind{Group: workv1alpha1.GroupName, Kind: "Work"}.String():                   opts.ConcurrentWorkSyncs,
+				schema.GroupKind{Group: workv1alpha2.GroupName, Kind: "ResourceBinding"}.String():        opts.ConcurrentResourceBindingSyncs,
+				schema.GroupKind{Group: workv1alpha2.GroupName, Kind: "ClusterResourceBinding"}.String(): opts.ConcurrentClusterResourceBindingSyncs,
+				schema.GroupKind{Group: clusterv1alpha1.GroupName, Kind: "Cluster"}.String():             opts.ConcurrentClusterSyncs,
+				schema.GroupKind{Group: "", Kind: "Namespace"}.String():                                  opts.ConcurrentNamespaceSyncs,
 			},
 			CacheSyncTimeout: opts.ClusterCacheSyncTimeout.Duration,
 			UsePriorityQueue: ptr.To(features.FeatureGate.Enabled(features.ControllerPriorityQueue)),

--- a/hack/tools/swagger/generateswagger.go
+++ b/hack/tools/swagger/generateswagger.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/klog/v2"
 	"k8s.io/kube-openapi/pkg/common"
@@ -45,83 +46,100 @@ func main() {
 
 	mapper := meta.NewDefaultRESTMapper(nil)
 
-	mapper.AddSpecific(clusterv1alpha1.SchemeGroupVersion.WithKind(clusterv1alpha1.ResourceKindCluster),
-		clusterv1alpha1.SchemeGroupVersion.WithResource(clusterv1alpha1.ResourcePluralCluster),
-		clusterv1alpha1.SchemeGroupVersion.WithResource(clusterv1alpha1.ResourceSingularCluster), meta.RESTScopeRoot)
+	mapper.AddSpecific(schema.GroupVersion{Group: clusterv1alpha1.GroupVersion.Group, Version: clusterv1alpha1.GroupVersion.Version}.WithKind(clusterv1alpha1.ResourceKindCluster),
+		schema.GroupVersion{Group: clusterv1alpha1.GroupVersion.Group, Version: clusterv1alpha1.GroupVersion.Version}.WithResource(clusterv1alpha1.ResourcePluralCluster),
+		schema.GroupVersion{Group: clusterv1alpha1.GroupVersion.Group, Version: clusterv1alpha1.GroupVersion.Version}.WithResource(clusterv1alpha1.ResourceSingularCluster),
+		meta.RESTScopeRoot)
 
-	mapper.AddSpecific(configv1alpha1.SchemeGroupVersion.WithKind(configv1alpha1.ResourceKindResourceInterpreterWebhookConfiguration),
-		configv1alpha1.SchemeGroupVersion.WithResource(configv1alpha1.ResourcePluralResourceInterpreterWebhookConfiguration),
-		configv1alpha1.SchemeGroupVersion.WithResource(configv1alpha1.ResourceSingularResourceInterpreterWebhookConfiguration), meta.RESTScopeRoot)
+	mapper.AddSpecific(schema.GroupVersion{Group: configv1alpha1.GroupVersion.Group, Version: configv1alpha1.GroupVersion.Version}.WithKind(configv1alpha1.ResourceKindResourceInterpreterWebhookConfiguration),
+		schema.GroupVersion{Group: configv1alpha1.GroupVersion.Group, Version: configv1alpha1.GroupVersion.Version}.WithResource(configv1alpha1.ResourcePluralResourceInterpreterWebhookConfiguration),
+		schema.GroupVersion{Group: configv1alpha1.GroupVersion.Group, Version: configv1alpha1.GroupVersion.Version}.WithResource(configv1alpha1.ResourceSingularResourceInterpreterWebhookConfiguration),
+		meta.RESTScopeRoot)
 
-	mapper.AddSpecific(configv1alpha1.SchemeGroupVersion.WithKind(configv1alpha1.ResourceKindResourceInterpreterCustomization),
-		configv1alpha1.SchemeGroupVersion.WithResource(configv1alpha1.ResourcePluralResourceInterpreterCustomization),
-		configv1alpha1.SchemeGroupVersion.WithResource(configv1alpha1.ResourceSingularResourceInterpreterCustomization), meta.RESTScopeRoot)
+	mapper.AddSpecific(schema.GroupVersion{Group: configv1alpha1.GroupVersion.Group, Version: configv1alpha1.GroupVersion.Version}.WithKind(configv1alpha1.ResourceKindResourceInterpreterCustomization),
+		schema.GroupVersion{Group: configv1alpha1.GroupVersion.Group, Version: configv1alpha1.GroupVersion.Version}.WithResource(configv1alpha1.ResourcePluralResourceInterpreterCustomization),
+		schema.GroupVersion{Group: configv1alpha1.GroupVersion.Group, Version: configv1alpha1.GroupVersion.Version}.WithResource(configv1alpha1.ResourceSingularResourceInterpreterCustomization),
+		meta.RESTScopeRoot)
 
-	mapper.AddSpecific(networkingv1alpha1.SchemeGroupVersion.WithKind(networkingv1alpha1.ResourceKindMultiClusterIngress),
-		networkingv1alpha1.SchemeGroupVersion.WithResource(networkingv1alpha1.ResourcePluralMultiClusterIngress),
-		networkingv1alpha1.SchemeGroupVersion.WithResource(networkingv1alpha1.ResourceSingularMultiClusterIngress), meta.RESTScopeRoot)
+	mapper.AddSpecific(schema.GroupVersion{Group: networkingv1alpha1.GroupVersion.Group, Version: networkingv1alpha1.GroupVersion.Version}.WithKind(networkingv1alpha1.ResourceKindMultiClusterIngress),
+		schema.GroupVersion{Group: networkingv1alpha1.GroupVersion.Group, Version: networkingv1alpha1.GroupVersion.Version}.WithResource(networkingv1alpha1.ResourcePluralMultiClusterIngress),
+		schema.GroupVersion{Group: networkingv1alpha1.GroupVersion.Group, Version: networkingv1alpha1.GroupVersion.Version}.WithResource(networkingv1alpha1.ResourceSingularMultiClusterIngress),
+		meta.RESTScopeRoot)
 
-	mapper.AddSpecific(networkingv1alpha1.SchemeGroupVersion.WithKind(networkingv1alpha1.ResourceKindMultiClusterService),
-		networkingv1alpha1.SchemeGroupVersion.WithResource(networkingv1alpha1.ResourcePluralMultiClusterService),
-		networkingv1alpha1.SchemeGroupVersion.WithResource(networkingv1alpha1.ResourceSingularMultiClusterService), meta.RESTScopeRoot)
+	mapper.AddSpecific(schema.GroupVersion{Group: networkingv1alpha1.GroupVersion.Group, Version: networkingv1alpha1.GroupVersion.Version}.WithKind(networkingv1alpha1.ResourceKindMultiClusterService),
+		schema.GroupVersion{Group: networkingv1alpha1.GroupVersion.Group, Version: networkingv1alpha1.GroupVersion.Version}.WithResource(networkingv1alpha1.ResourcePluralMultiClusterService),
+		schema.GroupVersion{Group: networkingv1alpha1.GroupVersion.Group, Version: networkingv1alpha1.GroupVersion.Version}.WithResource(networkingv1alpha1.ResourceSingularMultiClusterService), meta.RESTScopeRoot)
 
-	mapper.AddSpecific(policyv1alpha1.SchemeGroupVersion.WithKind(policyv1alpha1.ResourceKindPropagationPolicy),
-		policyv1alpha1.SchemeGroupVersion.WithResource(policyv1alpha1.ResourcePluralPropagationPolicy),
-		policyv1alpha1.SchemeGroupVersion.WithResource(policyv1alpha1.ResourceSingularPropagationPolicy), meta.RESTScopeRoot)
+	mapper.AddSpecific(schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithKind(policyv1alpha1.ResourceKindPropagationPolicy),
+		schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithResource(policyv1alpha1.ResourcePluralPropagationPolicy),
+		schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithResource(policyv1alpha1.ResourceSingularPropagationPolicy),
+		meta.RESTScopeRoot)
 
-	mapper.AddSpecific(policyv1alpha1.SchemeGroupVersion.WithKind(policyv1alpha1.ResourceKindClusterPropagationPolicy),
-		policyv1alpha1.SchemeGroupVersion.WithResource(policyv1alpha1.ResourcePluralClusterPropagationPolicy),
-		policyv1alpha1.SchemeGroupVersion.WithResource(policyv1alpha1.ResourceSingularClusterPropagationPolicy), meta.RESTScopeRoot)
+	mapper.AddSpecific(schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithKind(policyv1alpha1.ResourceKindClusterPropagationPolicy),
+		schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithResource(policyv1alpha1.ResourcePluralClusterPropagationPolicy),
+		schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithResource(policyv1alpha1.ResourceSingularClusterPropagationPolicy), meta.RESTScopeRoot)
 
-	mapper.AddSpecific(policyv1alpha1.SchemeGroupVersion.WithKind(policyv1alpha1.ResourceKindOverridePolicy),
-		policyv1alpha1.SchemeGroupVersion.WithResource(policyv1alpha1.ResourcePluralOverridePolicy),
-		policyv1alpha1.SchemeGroupVersion.WithResource(policyv1alpha1.ResourceSingularOverridePolicy), meta.RESTScopeRoot)
+	mapper.AddSpecific(schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithKind(policyv1alpha1.ResourceKindOverridePolicy),
+		schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithResource(policyv1alpha1.ResourcePluralOverridePolicy),
+		schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithResource(policyv1alpha1.ResourceSingularOverridePolicy),
+		meta.RESTScopeRoot)
 
-	mapper.AddSpecific(policyv1alpha1.SchemeGroupVersion.WithKind(policyv1alpha1.ResourceKindClusterOverridePolicy),
-		policyv1alpha1.SchemeGroupVersion.WithResource(policyv1alpha1.ResourcePluralClusterOverridePolicy),
-		policyv1alpha1.SchemeGroupVersion.WithResource(policyv1alpha1.ResourceSingularClusterOverridePolicy), meta.RESTScopeRoot)
+	mapper.AddSpecific(schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithKind(policyv1alpha1.ResourceKindClusterOverridePolicy),
+		schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithResource(policyv1alpha1.ResourcePluralClusterOverridePolicy),
+		schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithResource(policyv1alpha1.ResourceSingularClusterOverridePolicy),
+		meta.RESTScopeRoot)
 
-	mapper.AddSpecific(policyv1alpha1.SchemeGroupVersion.WithKind(policyv1alpha1.ResourceKindFederatedResourceQuota),
-		policyv1alpha1.SchemeGroupVersion.WithResource(policyv1alpha1.ResourcePluralFederatedResourceQuota),
-		policyv1alpha1.SchemeGroupVersion.WithResource(policyv1alpha1.ResourceSingularFederatedResourceQuota), meta.RESTScopeRoot)
+	mapper.AddSpecific(schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithKind(policyv1alpha1.ResourceKindFederatedResourceQuota),
+		schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithResource(policyv1alpha1.ResourcePluralFederatedResourceQuota),
+		schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithResource(policyv1alpha1.ResourceSingularFederatedResourceQuota),
+		meta.RESTScopeRoot)
 
-	mapper.AddSpecific(policyv1alpha1.SchemeGroupVersion.WithKind(policyv1alpha1.ResourceKindClusterTaintPolicy),
-		policyv1alpha1.SchemeGroupVersion.WithResource(policyv1alpha1.ResourcePluralClusterTaintPolicy),
-		policyv1alpha1.SchemeGroupVersion.WithResource(policyv1alpha1.ResourceSingularClusterTaintPolicy), meta.RESTScopeRoot)
+	mapper.AddSpecific(schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithKind(policyv1alpha1.ResourceKindClusterTaintPolicy),
+		schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithResource(policyv1alpha1.ResourcePluralClusterTaintPolicy),
+		schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithResource(policyv1alpha1.ResourceSingularClusterTaintPolicy),
+		meta.RESTScopeRoot)
 
-	mapper.AddSpecific(workv1alpha1.SchemeGroupVersion.WithKind(workv1alpha1.ResourceKindWork),
-		workv1alpha1.SchemeGroupVersion.WithResource(workv1alpha1.ResourcePluralWork),
-		workv1alpha1.SchemeGroupVersion.WithResource(workv1alpha1.ResourceSingularWork), meta.RESTScopeRoot)
+	mapper.AddSpecific(schema.GroupVersion{Group: workv1alpha1.GroupVersion.Group, Version: workv1alpha1.GroupVersion.Version}.WithKind(workv1alpha1.ResourceKindWork),
+		schema.GroupVersion{Group: workv1alpha1.GroupVersion.Group, Version: workv1alpha1.GroupVersion.Version}.WithResource(workv1alpha1.ResourcePluralWork),
+		schema.GroupVersion{Group: workv1alpha1.GroupVersion.Group, Version: workv1alpha1.GroupVersion.Version}.WithResource(workv1alpha1.ResourceSingularWork),
+		meta.RESTScopeRoot)
 
-	mapper.AddSpecific(workv1alpha2.SchemeGroupVersion.WithKind(workv1alpha2.ResourceKindResourceBinding),
-		workv1alpha2.SchemeGroupVersion.WithResource(workv1alpha2.ResourcePluralResourceBinding),
-		workv1alpha2.SchemeGroupVersion.WithResource(workv1alpha2.ResourceSingularResourceBinding), meta.RESTScopeRoot)
+	mapper.AddSpecific(schema.GroupVersion{Group: workv1alpha2.GroupVersion.Group, Version: workv1alpha2.GroupVersion.Version}.WithKind(workv1alpha2.ResourceKindResourceBinding),
+		schema.GroupVersion{Group: workv1alpha2.GroupVersion.Group, Version: workv1alpha2.GroupVersion.Version}.WithResource(workv1alpha2.ResourcePluralResourceBinding),
+		schema.GroupVersion{Group: workv1alpha2.GroupVersion.Group, Version: workv1alpha2.GroupVersion.Version}.WithResource(workv1alpha2.ResourceSingularResourceBinding),
+		meta.RESTScopeRoot)
 
-	mapper.AddSpecific(workv1alpha2.SchemeGroupVersion.WithKind(workv1alpha2.ResourceKindClusterResourceBinding),
-		workv1alpha2.SchemeGroupVersion.WithResource(workv1alpha2.ResourcePluralClusterResourceBinding),
-		workv1alpha2.SchemeGroupVersion.WithResource(workv1alpha2.ResourceSingularClusterResourceBinding), meta.RESTScopeRoot)
+	mapper.AddSpecific(schema.GroupVersion{Group: workv1alpha2.GroupVersion.Group, Version: workv1alpha2.GroupVersion.Version}.WithKind(workv1alpha2.ResourceKindClusterResourceBinding),
+		schema.GroupVersion{Group: workv1alpha2.GroupVersion.Group, Version: workv1alpha2.GroupVersion.Version}.WithResource(workv1alpha2.ResourcePluralClusterResourceBinding),
+		schema.GroupVersion{Group: workv1alpha2.GroupVersion.Group, Version: workv1alpha2.GroupVersion.Version}.WithResource(workv1alpha2.ResourceSingularClusterResourceBinding),
+		meta.RESTScopeRoot)
 
-	mapper.AddSpecific(searchv1alpha1.SchemeGroupVersion.WithKind(searchv1alpha1.ResourceKindResourceRegistry),
-		searchv1alpha1.SchemeGroupVersion.WithResource(searchv1alpha1.ResourcePluralResourceRegistry),
-		searchv1alpha1.SchemeGroupVersion.WithResource(searchv1alpha1.ResourceSingularResourceRegistry), meta.RESTScopeRoot)
+	mapper.AddSpecific(schema.GroupVersion{Group: searchv1alpha1.GroupVersion.Group, Version: searchv1alpha1.GroupVersion.Version}.WithKind(searchv1alpha1.ResourceKindResourceRegistry),
+		schema.GroupVersion{Group: searchv1alpha1.GroupVersion.Group, Version: searchv1alpha1.GroupVersion.Version}.WithResource(searchv1alpha1.ResourcePluralResourceRegistry),
+		schema.GroupVersion{Group: searchv1alpha1.GroupVersion.Group, Version: searchv1alpha1.GroupVersion.Version}.WithResource(searchv1alpha1.ResourceSingularResourceRegistry),
+		meta.RESTScopeRoot)
 
-	mapper.AddSpecific(autoscalingv1alpha1.SchemeGroupVersion.WithKind(autoscalingv1alpha1.FederatedHPAKind),
-		autoscalingv1alpha1.SchemeGroupVersion.WithResource(autoscalingv1alpha1.ResourcePluralFederatedHPA),
-		autoscalingv1alpha1.SchemeGroupVersion.WithResource(autoscalingv1alpha1.ResourceSingularFederatedHPA), meta.RESTScopeRoot)
+	mapper.AddSpecific(schema.GroupVersion{Group: autoscalingv1alpha1.GroupVersion.Group, Version: autoscalingv1alpha1.GroupVersion.Version}.WithKind(autoscalingv1alpha1.FederatedHPAKind),
+		schema.GroupVersion{Group: autoscalingv1alpha1.GroupVersion.Group, Version: autoscalingv1alpha1.GroupVersion.Version}.WithResource(autoscalingv1alpha1.ResourcePluralFederatedHPA),
+		schema.GroupVersion{Group: autoscalingv1alpha1.GroupVersion.Group, Version: autoscalingv1alpha1.GroupVersion.Version}.WithResource(autoscalingv1alpha1.ResourceSingularFederatedHPA),
+		meta.RESTScopeRoot)
 
-	mapper.AddSpecific(autoscalingv1alpha1.SchemeGroupVersion.WithKind(autoscalingv1alpha1.ResourceKindCronFederatedHPA),
-		autoscalingv1alpha1.SchemeGroupVersion.WithResource(autoscalingv1alpha1.ResourcePluralCronFederatedHPA),
-		autoscalingv1alpha1.SchemeGroupVersion.WithResource(autoscalingv1alpha1.ResourceSingularCronFederatedHPA), meta.RESTScopeRoot)
+	mapper.AddSpecific(schema.GroupVersion{Group: autoscalingv1alpha1.GroupVersion.Group, Version: autoscalingv1alpha1.GroupVersion.Version}.WithKind(autoscalingv1alpha1.ResourceKindCronFederatedHPA),
+		schema.GroupVersion{Group: autoscalingv1alpha1.GroupVersion.Group, Version: autoscalingv1alpha1.GroupVersion.Version}.WithResource(autoscalingv1alpha1.ResourcePluralCronFederatedHPA),
+		schema.GroupVersion{Group: autoscalingv1alpha1.GroupVersion.Group, Version: autoscalingv1alpha1.GroupVersion.Version}.WithResource(autoscalingv1alpha1.ResourceSingularCronFederatedHPA),
+		meta.RESTScopeRoot)
 
-	mapper.AddSpecific(remedyv1alpha1.SchemeGroupVersion.WithKind(remedyv1alpha1.ResourceKindRemedy),
-		remedyv1alpha1.SchemeGroupVersion.WithResource(remedyv1alpha1.ResourcePluralRemedy),
-		remedyv1alpha1.SchemeGroupVersion.WithResource(remedyv1alpha1.ResourceSingularRemedy), meta.RESTScopeRoot)
+	mapper.AddSpecific(schema.GroupVersion{Group: remedyv1alpha1.GroupVersion.Group, Version: remedyv1alpha1.GroupVersion.Version}.WithKind(remedyv1alpha1.ResourceKindRemedy),
+		schema.GroupVersion{Group: remedyv1alpha1.GroupVersion.Group, Version: remedyv1alpha1.GroupVersion.Version}.WithResource(remedyv1alpha1.ResourcePluralRemedy),
+		schema.GroupVersion{Group: remedyv1alpha1.GroupVersion.Group, Version: remedyv1alpha1.GroupVersion.Version}.WithResource(remedyv1alpha1.ResourceSingularRemedy),
+		meta.RESTScopeRoot)
 
-	mapper.AddSpecific(appsv1alpha1.SchemeGroupVersion.WithKind(appsv1alpha1.ResourceKindWorkloadRebalancer),
-		appsv1alpha1.SchemeGroupVersion.WithResource(appsv1alpha1.ResourcePluralWorkloadRebalancer),
-		appsv1alpha1.SchemeGroupVersion.WithResource(appsv1alpha1.ResourceSingularWorkloadRebalancer), meta.RESTScopeRoot)
+	mapper.AddSpecific(schema.GroupVersion{Group: appsv1alpha1.GroupVersion.Group, Version: appsv1alpha1.GroupVersion.Version}.WithKind(appsv1alpha1.ResourceKindWorkloadRebalancer),
+		schema.GroupVersion{Group: appsv1alpha1.GroupVersion.Group, Version: appsv1alpha1.GroupVersion.Version}.WithResource(appsv1alpha1.ResourcePluralWorkloadRebalancer),
+		schema.GroupVersion{Group: appsv1alpha1.GroupVersion.Group, Version: appsv1alpha1.GroupVersion.Version}.WithResource(appsv1alpha1.ResourceSingularWorkloadRebalancer),
+		meta.RESTScopeRoot)
 
-	spec, err := lib.RenderOpenAPISpec(lib.Config{
+	openAPISpec, err := lib.RenderOpenAPISpec(lib.Config{
 		Info: spec.InfoProps{
 			Title:       "Karmada OpenAPI",
 			Version:     "unversioned",
@@ -137,30 +155,30 @@ func main() {
 			generatedopenapi.GetOpenAPIDefinitions,
 		},
 		Resources: []lib.ResourceWithNamespaceScoped{
-			{GVR: clusterv1alpha1.SchemeGroupVersion.WithResource(clusterv1alpha1.ResourcePluralCluster), NamespaceScoped: clusterv1alpha1.ResourceNamespaceScopedCluster},
-			{GVR: configv1alpha1.SchemeGroupVersion.WithResource(configv1alpha1.ResourcePluralResourceInterpreterWebhookConfiguration), NamespaceScoped: configv1alpha1.ResourceNamespaceScopedResourceInterpreterWebhookConfiguration},
-			{GVR: configv1alpha1.SchemeGroupVersion.WithResource(configv1alpha1.ResourcePluralResourceInterpreterCustomization), NamespaceScoped: configv1alpha1.ResourceNamespaceScopedResourceInterpreterCustomization},
-			{GVR: networkingv1alpha1.SchemeGroupVersion.WithResource(networkingv1alpha1.ResourcePluralMultiClusterIngress), NamespaceScoped: networkingv1alpha1.ResourceNamespaceScopedMultiClusterIngress},
-			{GVR: networkingv1alpha1.SchemeGroupVersion.WithResource(networkingv1alpha1.ResourcePluralMultiClusterService), NamespaceScoped: networkingv1alpha1.ResourceNamespaceScopedMultiClusterService},
-			{GVR: policyv1alpha1.SchemeGroupVersion.WithResource(policyv1alpha1.ResourcePluralPropagationPolicy), NamespaceScoped: policyv1alpha1.ResourceNamespaceScopedPropagationPolicy},
-			{GVR: policyv1alpha1.SchemeGroupVersion.WithResource(policyv1alpha1.ResourcePluralClusterPropagationPolicy), NamespaceScoped: policyv1alpha1.ResourceNamespaceScopedClusterPropagationPolicy},
-			{GVR: policyv1alpha1.SchemeGroupVersion.WithResource(policyv1alpha1.ResourcePluralOverridePolicy), NamespaceScoped: policyv1alpha1.ResourceNamespaceScopedOverridePolicy},
-			{GVR: policyv1alpha1.SchemeGroupVersion.WithResource(policyv1alpha1.ResourcePluralClusterOverridePolicy), NamespaceScoped: policyv1alpha1.ResourceNamespaceScopedClusterOverridePolicy},
-			{GVR: policyv1alpha1.SchemeGroupVersion.WithResource(policyv1alpha1.ResourcePluralFederatedResourceQuota), NamespaceScoped: policyv1alpha1.ResourceNamespaceScopedFederatedResourceQuota},
-			{GVR: policyv1alpha1.SchemeGroupVersion.WithResource(policyv1alpha1.ResourcePluralClusterTaintPolicy), NamespaceScoped: policyv1alpha1.ResourceNamespaceScopedClusterTaintPolicy},
-			{GVR: workv1alpha1.SchemeGroupVersion.WithResource(workv1alpha1.ResourcePluralWork), NamespaceScoped: workv1alpha1.ResourceNamespaceScopedWork},
-			{GVR: workv1alpha2.SchemeGroupVersion.WithResource(workv1alpha2.ResourcePluralResourceBinding), NamespaceScoped: workv1alpha2.ResourceNamespaceScopedResourceBinding},
-			{GVR: workv1alpha2.SchemeGroupVersion.WithResource(workv1alpha2.ResourcePluralClusterResourceBinding), NamespaceScoped: workv1alpha2.ResourceNamespaceScopedClusterResourceBinding},
-			{GVR: searchv1alpha1.SchemeGroupVersion.WithResource(searchv1alpha1.ResourcePluralResourceRegistry), NamespaceScoped: searchv1alpha1.ResourceNamespaceScopedResourceRegistry},
-			{GVR: autoscalingv1alpha1.SchemeGroupVersion.WithResource(autoscalingv1alpha1.ResourcePluralFederatedHPA), NamespaceScoped: autoscalingv1alpha1.ResourceNamespaceScopedFederatedHPA},
-			{GVR: autoscalingv1alpha1.SchemeGroupVersion.WithResource(autoscalingv1alpha1.ResourcePluralCronFederatedHPA), NamespaceScoped: autoscalingv1alpha1.ResourceNamespaceScopedCronFederatedHPA},
-			{GVR: remedyv1alpha1.SchemeGroupVersion.WithResource(remedyv1alpha1.ResourcePluralRemedy), NamespaceScoped: remedyv1alpha1.ResourceNamespaceScopedRemedy},
-			{GVR: appsv1alpha1.SchemeGroupVersion.WithResource(appsv1alpha1.ResourcePluralWorkloadRebalancer), NamespaceScoped: appsv1alpha1.ResourceNamespaceScopedWorkloadRebalancer},
+			{GVR: schema.GroupVersion{Group: clusterv1alpha1.GroupVersion.Group, Version: clusterv1alpha1.GroupVersion.Version}.WithResource(clusterv1alpha1.ResourcePluralCluster), NamespaceScoped: clusterv1alpha1.ResourceNamespaceScopedCluster},
+			{GVR: schema.GroupVersion{Group: configv1alpha1.GroupVersion.Group, Version: configv1alpha1.GroupVersion.Version}.WithResource(configv1alpha1.ResourcePluralResourceInterpreterWebhookConfiguration), NamespaceScoped: configv1alpha1.ResourceNamespaceScopedResourceInterpreterWebhookConfiguration},
+			{GVR: schema.GroupVersion{Group: configv1alpha1.GroupVersion.Group, Version: configv1alpha1.GroupVersion.Version}.WithResource(configv1alpha1.ResourcePluralResourceInterpreterCustomization), NamespaceScoped: configv1alpha1.ResourceNamespaceScopedResourceInterpreterCustomization},
+			{GVR: schema.GroupVersion{Group: networkingv1alpha1.GroupVersion.Group, Version: networkingv1alpha1.GroupVersion.Version}.WithResource(networkingv1alpha1.ResourcePluralMultiClusterIngress), NamespaceScoped: networkingv1alpha1.ResourceNamespaceScopedMultiClusterIngress},
+			{GVR: schema.GroupVersion{Group: networkingv1alpha1.GroupVersion.Group, Version: networkingv1alpha1.GroupVersion.Version}.WithResource(networkingv1alpha1.ResourcePluralMultiClusterService), NamespaceScoped: networkingv1alpha1.ResourceNamespaceScopedMultiClusterService},
+			{GVR: schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithResource(policyv1alpha1.ResourcePluralPropagationPolicy), NamespaceScoped: policyv1alpha1.ResourceNamespaceScopedPropagationPolicy},
+			{GVR: schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithResource(policyv1alpha1.ResourcePluralClusterPropagationPolicy), NamespaceScoped: policyv1alpha1.ResourceNamespaceScopedClusterPropagationPolicy},
+			{GVR: schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithResource(policyv1alpha1.ResourcePluralOverridePolicy), NamespaceScoped: policyv1alpha1.ResourceNamespaceScopedOverridePolicy},
+			{GVR: schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithResource(policyv1alpha1.ResourcePluralClusterOverridePolicy), NamespaceScoped: policyv1alpha1.ResourceNamespaceScopedClusterOverridePolicy},
+			{GVR: schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithResource(policyv1alpha1.ResourcePluralFederatedResourceQuota), NamespaceScoped: policyv1alpha1.ResourceNamespaceScopedFederatedResourceQuota},
+			{GVR: schema.GroupVersion{Group: policyv1alpha1.GroupVersion.Group, Version: policyv1alpha1.GroupVersion.Version}.WithResource(policyv1alpha1.ResourcePluralClusterTaintPolicy), NamespaceScoped: policyv1alpha1.ResourceNamespaceScopedClusterTaintPolicy},
+			{GVR: schema.GroupVersion{Group: workv1alpha1.GroupVersion.Group, Version: workv1alpha1.GroupVersion.Version}.WithResource(workv1alpha1.ResourcePluralWork), NamespaceScoped: workv1alpha1.ResourceNamespaceScopedWork},
+			{GVR: schema.GroupVersion{Group: workv1alpha2.GroupVersion.Group, Version: workv1alpha2.GroupVersion.Version}.WithResource(workv1alpha2.ResourcePluralResourceBinding), NamespaceScoped: workv1alpha2.ResourceNamespaceScopedResourceBinding},
+			{GVR: schema.GroupVersion{Group: workv1alpha2.GroupVersion.Group, Version: workv1alpha2.GroupVersion.Version}.WithResource(workv1alpha2.ResourcePluralClusterResourceBinding), NamespaceScoped: workv1alpha2.ResourceNamespaceScopedClusterResourceBinding},
+			{GVR: schema.GroupVersion{Group: searchv1alpha1.GroupVersion.Group, Version: searchv1alpha1.GroupVersion.Version}.WithResource(searchv1alpha1.ResourcePluralResourceRegistry), NamespaceScoped: searchv1alpha1.ResourceNamespaceScopedResourceRegistry},
+			{GVR: schema.GroupVersion{Group: autoscalingv1alpha1.GroupVersion.Group, Version: autoscalingv1alpha1.GroupVersion.Version}.WithResource(autoscalingv1alpha1.ResourcePluralFederatedHPA), NamespaceScoped: autoscalingv1alpha1.ResourceNamespaceScopedFederatedHPA},
+			{GVR: schema.GroupVersion{Group: autoscalingv1alpha1.GroupVersion.Group, Version: autoscalingv1alpha1.GroupVersion.Version}.WithResource(autoscalingv1alpha1.ResourcePluralCronFederatedHPA), NamespaceScoped: autoscalingv1alpha1.ResourceNamespaceScopedCronFederatedHPA},
+			{GVR: schema.GroupVersion{Group: remedyv1alpha1.GroupVersion.Group, Version: remedyv1alpha1.GroupVersion.Version}.WithResource(remedyv1alpha1.ResourcePluralRemedy), NamespaceScoped: remedyv1alpha1.ResourceNamespaceScopedRemedy},
+			{GVR: schema.GroupVersion{Group: appsv1alpha1.GroupVersion.Group, Version: appsv1alpha1.GroupVersion.Version}.WithResource(appsv1alpha1.ResourcePluralWorkloadRebalancer), NamespaceScoped: appsv1alpha1.ResourceNamespaceScopedWorkloadRebalancer},
 		},
 		Mapper: mapper,
 	})
 	if err != nil {
 		klog.Fatal(err.Error())
 	}
-	fmt.Println(spec)
+	fmt.Println(openAPISpec)
 }

--- a/pkg/controllers/multiclusterservice/endpointslice_collect_controller.go
+++ b/pkg/controllers/multiclusterservice/endpointslice_collect_controller.go
@@ -78,7 +78,7 @@ type EndpointSliceCollectController struct {
 
 var (
 	endpointSliceGVR       = discoveryv1.SchemeGroupVersion.WithResource("endpointslices")
-	multiClusterServiceGVK = networkingv1alpha1.SchemeGroupVersion.WithKind("MultiClusterService")
+	multiClusterServiceGVK = schema.GroupVersion{Group: networkingv1alpha1.GroupVersion.Group, Version: networkingv1alpha1.GroupVersion.Version}.WithKind("MultiClusterService")
 )
 
 // EndpointSliceCollectControllerName is the controller name that will be used when reporting events and metrics.

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -710,7 +710,7 @@ func (d *ResourceDetector) fetchResourceBinding(ctx context.Context, rbNamespace
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// If not found with client, try using dynamic client
-			gvr := workv1alpha2.SchemeGroupVersion.WithResource(workv1alpha2.ResourcePluralResourceBinding)
+			gvr := schema.GroupVersion{Group: workv1alpha2.GroupVersion.Group, Version: workv1alpha2.GroupVersion.Version}.WithResource(workv1alpha2.ResourcePluralResourceBinding)
 			unstructuredRB, dynamicErr := d.DynamicClient.Resource(gvr).Namespace(rbNamespace).Get(ctx, rbName, metav1.GetOptions{})
 			if dynamicErr != nil {
 				return nil, dynamicErr
@@ -739,7 +739,7 @@ func (d *ResourceDetector) fetchClusterResourceBinding(ctx context.Context, crbN
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// If not found with client, try using dynamic client
-			gvr := workv1alpha2.SchemeGroupVersion.WithResource(workv1alpha2.ResourcePluralClusterResourceBinding)
+			gvr := schema.GroupVersion{Group: workv1alpha2.GroupVersion.Group, Version: workv1alpha2.GroupVersion.Version}.WithResource(workv1alpha2.ResourcePluralClusterResourceBinding)
 			unstructuredRB, dynamicErr := d.DynamicClient.Resource(gvr).Get(ctx, crbName, metav1.GetOptions{})
 			if dynamicErr != nil {
 				return nil, dynamicErr
@@ -1371,7 +1371,7 @@ func (d *ResourceDetector) CleanupResourceBindingClaimMetadata(rbNamespace, rbNa
 
 		if apierrors.IsConflict(updateErr) {
 			updated := &workv1alpha2.ResourceBinding{}
-			gvr := workv1alpha2.SchemeGroupVersion.WithResource(workv1alpha2.ResourcePluralResourceBinding)
+			gvr := schema.GroupVersion{Group: workv1alpha2.GroupVersion.Group, Version: workv1alpha2.GroupVersion.Version}.WithResource(workv1alpha2.ResourcePluralResourceBinding)
 			if unstructuredRB, dynamicErr := d.DynamicClient.Resource(gvr).Namespace(rbNamespace).Get(context.TODO(), rbName, metav1.GetOptions{}); dynamicErr == nil {
 				// Convert unstructured to ResourceBinding
 				if convertErr := helper.ConvertToTypedObject(unstructuredRB, updated); convertErr != nil {
@@ -1418,7 +1418,7 @@ func (d *ResourceDetector) CleanupClusterResourceBindingClaimMetadata(crbName st
 
 		if apierrors.IsConflict(updateErr) {
 			updated := &workv1alpha2.ClusterResourceBinding{}
-			gvr := workv1alpha2.SchemeGroupVersion.WithResource(workv1alpha2.ResourcePluralClusterResourceBinding)
+			gvr := schema.GroupVersion{Group: workv1alpha2.GroupVersion.Group, Version: workv1alpha2.GroupVersion.Version}.WithResource(workv1alpha2.ResourcePluralClusterResourceBinding)
 			if unstructuredRB, dynamicErr := d.DynamicClient.Resource(gvr).Get(context.TODO(), crbName, metav1.GetOptions{}); dynamicErr == nil {
 				// Convert unstructured to ClusterResourceBinding
 				if convertErr := helper.ConvertToTypedObject(unstructuredRB, updated); convertErr != nil {

--- a/pkg/search/proxy/testing/constant.go
+++ b/pkg/search/proxy/testing/constant.go
@@ -33,7 +33,7 @@ var (
 	PodGVR     = corev1.SchemeGroupVersion.WithResource("pods")
 	NodeGVR    = corev1.SchemeGroupVersion.WithResource("nodes")
 	SecretGVR  = corev1.SchemeGroupVersion.WithResource("secret")
-	ClusterGVR = clusterv1alpha1.SchemeGroupVersion.WithResource("cluster")
+	ClusterGVR = schema.GroupVersion{Group: clusterv1alpha1.GroupVersion.Group, Version: clusterv1alpha1.GroupVersion.Version}.WithResource("cluster")
 
 	PodSelector = searchv1alpha1.ResourceSelector{APIVersion: PodGVK.GroupVersion().String(), Kind: PodGVK.Kind}
 

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -21,6 +21,7 @@ import (
 
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	configv1alpha1 "github.com/karmada-io/karmada/pkg/apis/config/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
@@ -252,10 +253,10 @@ var (
 // Define resource group version resource.
 var (
 	// ResourceInterpreterCustomizationsGVR is the GroupVersionResource of ResourceInterpreterCustomizations.
-	ResourceInterpreterCustomizationsGVR = configv1alpha1.SchemeGroupVersion.WithResource("resourceinterpretercustomizations")
+	ResourceInterpreterCustomizationsGVR = schema.GroupVersion{Group: configv1alpha1.GroupVersion.Group, Version: configv1alpha1.GroupVersion.Version}.WithResource("resourceinterpretercustomizations")
 
 	// ResourceInterpreterWebhookConfigurationsGVR is the GroupVersionResource of ResourceInterpreterWebhookConfigurations.
-	ResourceInterpreterWebhookConfigurationsGVR = configv1alpha1.SchemeGroupVersion.WithResource("resourceinterpreterwebhookconfigurations")
+	ResourceInterpreterWebhookConfigurationsGVR = schema.GroupVersion{Group: configv1alpha1.GroupVersion.Group, Version: configv1alpha1.GroupVersion.Version}.WithResource("resourceinterpreterwebhookconfigurations")
 )
 
 const (

--- a/pkg/util/credential.go
+++ b/pkg/util/credential.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	kubeclient "k8s.io/client-go/kubernetes"
 
@@ -30,7 +31,7 @@ import (
 )
 
 var (
-	clusterResourceKind = clusterv1alpha1.SchemeGroupVersion.WithKind("Cluster")
+	clusterResourceKind = schema.GroupVersion{Group: clusterv1alpha1.GroupVersion.Group, Version: clusterv1alpha1.GroupVersion.Version}.WithKind("Cluster")
 
 	// Policy rules allowing full access to resources in the cluster or namespace.
 	namespacedPolicyRules = []rbacv1.PolicyRule{

--- a/pkg/webhook/resourcebinding/validating_test.go
+++ b/pkg/webhook/resourcebinding/validating_test.go
@@ -135,7 +135,7 @@ func makeTestRB(namespace, name string, opts ...RBOption) *workv1alpha2.Resource
 		APIVersion: "v1", Kind: "Pod", Name: "test-pod-" + name, Namespace: namespace,
 	}
 	rb := &workv1alpha2.ResourceBinding{
-		TypeMeta: metav1.TypeMeta{APIVersion: workv1alpha2.SchemeGroupVersion.String(), Kind: "ResourceBinding"},
+		TypeMeta: metav1.TypeMeta{APIVersion: workv1alpha2.GroupVersion.String(), Kind: "ResourceBinding"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -170,7 +170,7 @@ func WithOverallUsed(used corev1.ResourceList) FRQOption {
 
 func makeTestFRQ(namespace, name string, opts ...FRQOption) *policyv1alpha1.FederatedResourceQuota {
 	frq := &policyv1alpha1.FederatedResourceQuota{
-		TypeMeta: metav1.TypeMeta{APIVersion: policyv1alpha1.SchemeGroupVersion.String(), Kind: "FederatedResourceQuota"},
+		TypeMeta: metav1.TypeMeta{APIVersion: policyv1alpha1.GroupVersion.String(), Kind: "FederatedResourceQuota"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,

--- a/test/e2e/framework/workload.go
+++ b/test/e2e/framework/workload.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
 
@@ -33,7 +34,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/helper"
 )
 
-var workloadGVR = workloadv1alpha1.SchemeGroupVersion.WithResource("workloads")
+var workloadGVR = schema.GroupVersionResource{Group: workloadv1alpha1.GroupVersion.Group, Version: workloadv1alpha1.GroupVersion.Version, Resource: "workloads"}
 
 // CreateWorkload creates Workload with dynamic client
 func CreateWorkload(client dynamic.Interface, workload *workloadv1alpha1.Workload) {

--- a/test/e2e/suites/base/clustertaintpolicy_test.go
+++ b/test/e2e/suites/base/clustertaintpolicy_test.go
@@ -50,7 +50,7 @@ var _ = framework.SerialDescribe("Taint cluster with ClusterTaintPolicy", func()
 		policyName = clusterTaintPolicyNamePrefix + rand.String(RandomStrLength)
 		clusterTaintPolicy = &policyv1alpha1.ClusterTaintPolicy{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: policyv1alpha1.SchemeGroupVersion.String(),
+				APIVersion: policyv1alpha1.GroupVersion.String(),
 				Kind:       "ClusterTaintPolicy",
 			},
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/suites/base/resourceinterpreter_test.go
+++ b/test/e2e/suites/base/resourceinterpreter_test.go
@@ -123,7 +123,7 @@ var _ = ginkgo.Describe("Resource interpreter webhook testing", func() {
 					newUnstructuredObj, err := helper.ToUnstructured(curWorkload)
 					g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-					workloadGVR := workloadv1alpha1.SchemeGroupVersion.WithResource("workloads")
+					workloadGVR := schema.GroupVersion{Group: workloadv1alpha1.GroupVersion.Group, Version: workloadv1alpha1.GroupVersion.Version}.WithResource("workloads")
 					_, err = dynamicClient.Resource(workloadGVR).Namespace(curWorkload.Namespace).Update(context.TODO(), newUnstructuredObj, metav1.UpdateOptions{})
 					return err
 				}, pollTimeout, pollInterval).ShouldNot(gomega.HaveOccurred())


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR cleans up the usage of the deprecated `SchemeGroupVersion` variables.

**Which issue(s) this PR fixes**:
Fixes #
Part of #7140

**Special notes for your reviewer**:
1. The lint checker will rise warning after Kubernetes v1.35, which fixed the incorrect deprecations in https://github.com/kubernetes/kubernetes/pull/133571

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

