### PR TITLE
Fix application failover timer reset on controller restart

### DIFF
--- a/pkg/apis/work/v1alpha2/binding_types.go
+++ b/pkg/apis/work/v1alpha2/binding_types.go
@@ -443,6 +443,12 @@ type ResourceBindingStatus struct {
 	// AggregatedStatus represents status list of the resource running in each member cluster.
 	// +optional
 	AggregatedStatus []AggregatedStatusItem `json:"aggregatedStatus,omitempty"`
+
+	// FailoverHistory records the timestamp when each cluster's workload first became
+	// unhealthy. Used by the application failover controller to track toleration periods
+	// across controller restarts.
+	// +optional
+	FailoverHistory map[string]metav1.Time `json:"failoverHistory,omitempty"`
 }
 
 // AggregatedStatusItem represents status of the resource running in a member cluster.

--- a/pkg/controllers/applicationfailover/crb_application_failover_controller.go
+++ b/pkg/controllers/applicationfailover/crb_application_failover_controller.go
@@ -19,6 +19,7 @@ package applicationfailover
 import (
 	"context"
 	"math"
+	"reflect"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -26,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -122,6 +124,8 @@ func (c *CRBApplicationFailoverController) syncBinding(ctx context.Context, bind
 	key := types.NamespacedName{Name: binding.Name, Namespace: binding.Namespace}
 	tolerationSeconds := binding.Spec.Failover.Application.DecisionConditions.TolerationSeconds
 
+	c.workloadUnhealthyMap.loadFromStatus(key, binding.Status.FailoverHistory)
+
 	allClusters := sets.New[string]()
 	for _, cluster := range binding.Spec.Clusters {
 		allClusters.Insert(cluster.Name)
@@ -142,8 +146,11 @@ func (c *CRBApplicationFailoverController) syncBinding(ctx context.Context, bind
 		}
 	}
 
-	// Cleanup clusters on which the application status is not unhealthy and clusters that have been evicted or removed in the workloadUnhealthyMap.
 	c.workloadUnhealthyMap.deleteIrrelevantClusters(key, allClusters, others)
+
+	if err = c.persistFailoverHistory(ctx, binding, key); err != nil {
+		klog.ErrorS(err, "Failed to persist failover history", "name", binding.Name)
+	}
 
 	return time.Duration(duration) * time.Second, nil
 }
@@ -176,6 +183,22 @@ func (c *CRBApplicationFailoverController) updateBinding(ctx context.Context, bi
 	}
 
 	return nil
+}
+
+func (c *CRBApplicationFailoverController) persistFailoverHistory(ctx context.Context, binding *workv1alpha2.ClusterResourceBinding, key types.NamespacedName) error {
+	timestamps := c.workloadUnhealthyMap.getAll(key)
+	if reflect.DeepEqual(binding.Status.FailoverHistory, timestamps) {
+		return nil
+	}
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &workv1alpha2.ClusterResourceBinding{}
+		if err := c.Client.Get(ctx, client.ObjectKeyFromObject(binding), latest); err != nil {
+			return err
+		}
+		latest.Status.FailoverHistory = timestamps
+		return c.Client.Status().Update(ctx, latest)
+	})
 }
 
 // SetupWithManager creates a controller and register to controller manager.


### PR DESCRIPTION
Persist unhealthy detection timestamps to binding status to prevent the failover toleration timer from resetting when the controller restarts.

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
The application failover controller previously tracked unhealthy detection timestamps only in memory. When the controller restarted, this state was lost, causing the failover toleration timer to reset and delaying failover by the full toleration period again.

This PR persists the first unhealthy detection timestamp in the binding status and restores it on reconciliation. As a result, the toleration timer continues correctly across controller restarts, ensuring failover happens within the expected time window.

This aligns failover behavior with real-world production conditions where controller restarts are common.


**Special notes for your reviewer**:
Tested locally with make verify and make test.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

