### PR TITLE
Add a global index based on the affinity groups defined in resourcebindings

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -17,12 +17,17 @@ limitations under the License.
 package cache
 
 import (
+	"sync"
+
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/features"
 	clusterlister "github.com/karmada-io/karmada/pkg/generated/listers/cluster/v1alpha1"
-	"github.com/karmada-io/karmada/pkg/scheduler/framework"
 )
 
 // Cache is an interface for scheduler internal cache.
@@ -30,35 +35,70 @@ type Cache interface {
 	AddCluster(cluster *clusterv1alpha1.Cluster)
 	UpdateCluster(cluster *clusterv1alpha1.Cluster)
 	DeleteCluster(cluster *clusterv1alpha1.Cluster)
-	// Snapshot returns a snapshot of the current clusters info
 	Snapshot() Snapshot
+
+	// Cache should be updated in response to RB/CRB changes
+	OnResourceBindingAdd(obj interface{})
+	OnResourceBindingUpdate(old, cur interface{})
+	OnResourceBindingDelete(obj interface{})
+}
+
+// GroupType is a string defining the type of affinity used by a ResourceBinding or ClusterResourceBinding
+type GroupType string
+
+const (
+	// GroupTypeAffinity declares the group type for affinity
+	GroupTypeAffinity GroupType = "Affinity"
+	// GroupTypeAntiAffinity declares the group type for anti-affinity
+	GroupTypeAntiAffinity GroupType = "AntiAffinity"
+)
+
+// WorkloadGroupKey scopes an affinity group lookup.
+// Namespace is used for namespaced ResourceBindings; for ClusterResourceBindings it is "".
+// GroupType ensures Affinity and AntiAffinity never collide even if group strings match.
+type WorkloadGroupKey struct {
+	Namespace string
+	Type      GroupType
+	Group     string
+}
+
+func makeWorkloadGroupKey(namespace string, t GroupType, group string) WorkloadGroupKey {
+	return WorkloadGroupKey{Namespace: namespace, Type: t, Group: group}
 }
 
 type schedulerCache struct {
 	clusterLister clusterlister.ClusterLister
+	mu            sync.RWMutex
+
+	// bindingGroups maps bindingID -> set(WorkloadGroupKey), used as reverse index for updates / deletes
+	bindingGroups map[string]sets.Set[WorkloadGroupKey]
+	// clustersByBinding maps bindingID -> set(clusterName) for scheduled bindings
+	clustersByBinding map[string]sets.Set[string]
+	// groupPeers maps (ns, type, group) -> []bindingID
+	groupMembers map[WorkloadGroupKey]sets.Set[string]
 }
 
 // NewCache instantiates a cache used only by scheduler.
 func NewCache(clusterLister clusterlister.ClusterLister) Cache {
 	return &schedulerCache{
-		clusterLister: clusterLister,
+		clusterLister:     clusterLister,
+		groupMembers:      make(map[WorkloadGroupKey]sets.Set[string]),
+		bindingGroups:     make(map[string]sets.Set[WorkloadGroupKey]),
+		clustersByBinding: make(map[string]sets.Set[string]),
 	}
 }
 
 // AddCluster does nothing since clusterLister would synchronize automatically
-func (c *schedulerCache) AddCluster(_ *clusterv1alpha1.Cluster) {
-}
+func (c *schedulerCache) AddCluster(_ *clusterv1alpha1.Cluster) {}
 
 // UpdateCluster does nothing since clusterLister would synchronize automatically
-func (c *schedulerCache) UpdateCluster(_ *clusterv1alpha1.Cluster) {
-}
+func (c *schedulerCache) UpdateCluster(_ *clusterv1alpha1.Cluster) {}
 
 // DeleteCluster does nothing since clusterLister would synchronize automatically
-func (c *schedulerCache) DeleteCluster(_ *clusterv1alpha1.Cluster) {
-}
+func (c *schedulerCache) DeleteCluster(_ *clusterv1alpha1.Cluster) {}
 
 // Snapshot returns clusters' snapshot.
-// TODO: need optimization, only clone when necessary
+// TODO: optimize cloning
 func (c *schedulerCache) Snapshot() Snapshot {
 	out := NewEmptySnapshot()
 	clusters, err := c.clusterLister.List(labels.Everything())
@@ -67,11 +107,324 @@ func (c *schedulerCache) Snapshot() Snapshot {
 		return out
 	}
 
-	out.clusterInfoList = make([]*framework.ClusterInfo, 0, len(clusters))
+	out.clusters = make([]*clusterv1alpha1.Cluster, 0, len(clusters))
 	for _, cluster := range clusters {
-		cloned := cluster.DeepCopy()
-		out.clusterInfoList = append(out.clusterInfoList, framework.NewClusterInfo(cloned))
+		out.clusters = append(out.clusters, cluster.DeepCopy())
 	}
 
+	if features.FeatureGate.Enabled(features.WorkloadAffinity) {
+		c.mu.RLock()
+		defer c.mu.RUnlock()
+
+		out.groupMembers = cloneMapOfSets(c.groupMembers)
+		out.bindingGroups = cloneMapOfSets(c.bindingGroups)
+		out.clustersByBinding = cloneMapOfSets(c.clustersByBinding)
+	}
+
+	return out
+}
+
+// OnResourceBindingAdd indexes a newly observed ResourceBinding or ClusterResourceBinding.
+// Binding will only be indexed if work has been scheduled to clusters and the binding has relevant affinity groups.
+// Operation is atomic (single lock).
+func (c *schedulerCache) OnResourceBindingAdd(obj interface{}) {
+	info := getBindingInfoFromObj(obj)
+	if info == nil {
+		return
+	}
+
+	// If binding is not scheduled anywhere, or does not have any affinity groups, do not update cache.
+	if info.clusters == nil || info.clusters.Len() == 0 || (info.affinityGroup == "" && info.antiAffinityGroup == "") {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// For each non-empty group, index the binding. indexBindingLocked will also set clustersByBinding.
+	if info.affinityGroup != "" {
+		k := makeWorkloadGroupKey(info.namespace, GroupTypeAffinity, info.affinityGroup)
+		c.indexBindingLocked(k, info.id, info.clusters)
+	}
+	if info.antiAffinityGroup != "" {
+		k := makeWorkloadGroupKey(info.namespace, GroupTypeAntiAffinity, info.antiAffinityGroup)
+		c.indexBindingLocked(k, info.id, info.clusters)
+	}
+}
+
+// OnResourceBindingUpdate updates cache indexes only when relevant fields changed:
+// - If clusters has changed
+// - If affinity/anti-affinity group strings have changed
+// The update is atomic (single lock)
+func (c *schedulerCache) OnResourceBindingUpdate(oldObj, newObj interface{}) {
+	oldInfo := getBindingInfoFromObj(oldObj)
+	newInfo := getBindingInfoFromObj(newObj)
+	if oldInfo == nil || newInfo == nil {
+		return
+	}
+
+	// If clusters and affinity groups have not checked, skip cache update
+	if setsEqualString(oldInfo.clusters, newInfo.clusters) &&
+		oldInfo.affinityGroup == newInfo.affinityGroup &&
+		oldInfo.antiAffinityGroup == newInfo.antiAffinityGroup &&
+		oldInfo.id == newInfo.id {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// If the binding id unexpectedly changed, remove everything associated with the old id first.
+	if oldInfo.id != newInfo.id {
+		c.deleteByIDLocked(oldInfo.id)
+	}
+
+	// Remove old memberships
+	if oldInfo.affinityGroup != "" {
+		oldK := makeWorkloadGroupKey(oldInfo.namespace, GroupTypeAffinity, oldInfo.affinityGroup)
+		c.unindexBindingLocked(oldK, oldInfo.id)
+	}
+	if oldInfo.antiAffinityGroup != "" {
+		oldK := makeWorkloadGroupKey(oldInfo.namespace, GroupTypeAntiAffinity, oldInfo.antiAffinityGroup)
+		c.unindexBindingLocked(oldK, oldInfo.id)
+	}
+
+	// Add new memberships only if newInfo is scheduled somewhere and has groups.
+	if newInfo.clusters != nil && newInfo.clusters.Len() > 0 {
+		if newInfo.affinityGroup != "" {
+			newK := makeWorkloadGroupKey(newInfo.namespace, GroupTypeAffinity, newInfo.affinityGroup)
+			c.indexBindingLocked(newK, newInfo.id, newInfo.clusters)
+		}
+		if newInfo.antiAffinityGroup != "" {
+			newK := makeWorkloadGroupKey(newInfo.namespace, GroupTypeAntiAffinity, newInfo.antiAffinityGroup)
+			c.indexBindingLocked(newK, newInfo.id, newInfo.clusters)
+		}
+	} else {
+		// If new binding has no clusters, ensure clustersByBinding is removed for the new ID
+		// (in case it was previously present)
+		delete(c.clustersByBinding, newInfo.id)
+	}
+}
+
+// OnResourceBindingDelete removes the binding's clusters mapping and group membership.
+// It attempts a targeted removal using affinity fields on the tombstone; to be robust
+// against tombstones that may lack group info, it falls back to a full reverse-index
+// cleanup if necessary.
+func (c *schedulerCache) OnResourceBindingDelete(obj interface{}) {
+	info := getBindingInfoFromObj(obj)
+	if info == nil {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Remove group memberships if group info present on the tombstone.
+	removedAny := false
+	if info.affinityGroup != "" {
+		k := makeWorkloadGroupKey(info.namespace, GroupTypeAffinity, info.affinityGroup)
+		c.unindexBindingLocked(k, info.id)
+		removedAny = true
+	}
+	if info.antiAffinityGroup != "" {
+		k := makeWorkloadGroupKey(info.namespace, GroupTypeAntiAffinity, info.antiAffinityGroup)
+		c.unindexBindingLocked(k, info.id)
+		removedAny = true
+	}
+
+	// If tombstone lacked group info, or we suspect there may still be a membership,
+	// use the reverse-index cleanup.
+	if !removedAny || c.isPossiblyStillMemberLocked(info.id) {
+		c.deleteByIDLocked(info.id)
+	}
+}
+
+// indexBindingLocked adds bindingID to the specified group key and ensures the reverse index
+// and cluster mapping are updated. Caller MUST hold c.mu.
+func (c *schedulerCache) indexBindingLocked(k WorkloadGroupKey, bindingID string, clusters sets.Set[string]) {
+	// add to groupMembers
+	members := c.groupMembers[k]
+	if members == nil {
+		members = sets.New[string]()
+		c.groupMembers[k] = members
+	}
+	members.Insert(bindingID)
+
+	// add to bindingGroups (reverse index)
+	bg := c.bindingGroups[bindingID]
+	if bg == nil {
+		bg = sets.New[WorkloadGroupKey]()
+		c.bindingGroups[bindingID] = bg
+	}
+	bg.Insert(k)
+
+	// ensure clusters mapping exists if clusters provided
+	if clusters != nil && clusters.Len() > 0 {
+		c.clustersByBinding[bindingID] = clusters
+	}
+}
+
+// unindexBindingLocked removes bindingID from the specified group key and updates the
+// reverse index. If that was the last group for this binding, it also removes the
+// clustersByBinding entry. Caller MUST hold c.mu.
+func (c *schedulerCache) unindexBindingLocked(k WorkloadGroupKey, bindingID string) {
+	// remove from groupMembers
+	if members := c.groupMembers[k]; members != nil {
+		members.Delete(bindingID)
+		if members.Len() == 0 {
+			delete(c.groupMembers, k)
+		}
+	}
+
+	// remove from bindingGroups, and if no groups left for this binding, remove clusters mapping
+	if bg := c.bindingGroups[bindingID]; bg != nil {
+		bg.Delete(k)
+		if bg.Len() == 0 {
+			// no more groups reference this binding
+			delete(c.bindingGroups, bindingID)
+			delete(c.clustersByBinding, bindingID)
+		} else {
+			// keep updated set (not strictly necessary because bg is the same object)
+			c.bindingGroups[bindingID] = bg
+		}
+	}
+}
+
+// deleteByIDLocked removes all traces of bindingID using the reverse index.
+// Caller must hold c.mu.
+func (c *schedulerCache) deleteByIDLocked(bindingID string) {
+	// Remove cluster mapping
+	delete(c.clustersByBinding, bindingID)
+
+	// Use bindingGroups to remove bindingID from all groups efficiently
+	if bg := c.bindingGroups[bindingID]; bg != nil {
+		for g := range bg {
+			if members := c.groupMembers[g]; members != nil {
+				members.Delete(bindingID)
+				if members.Len() == 0 {
+					delete(c.groupMembers, g)
+				}
+			}
+		}
+		delete(c.bindingGroups, bindingID)
+	}
+}
+
+// Helpers
+
+// bindingInfo contains metadata on te ResourceBinding being indexed or unindexed by this cache
+type bindingInfo struct {
+	id                string
+	namespace         string // "" for CRB
+	clusters          sets.Set[string]
+	affinityGroup     string
+	antiAffinityGroup string
+}
+
+func getBindingInfoFromObj(obj interface{}) *bindingInfo {
+	switch t := obj.(type) {
+	case *workv1alpha2.ResourceBinding:
+		return bindingInfoFromRB(t)
+	case *workv1alpha2.ClusterResourceBinding:
+		return bindingInfoFromCRB(t)
+	case cache.DeletedFinalStateUnknown:
+		return getBindingInfoFromObj(t.Obj)
+	default:
+		return nil
+	}
+}
+
+func bindingInfoFromRB(rb *workv1alpha2.ResourceBinding) *bindingInfo {
+	id := "rb:" + rb.Namespace + "/" + rb.Name
+
+	clusters := sets.New[string]()
+	for _, target := range rb.Spec.Clusters {
+		clusters.Insert(target.Name)
+	}
+
+	var aff, anti string
+	if rb.Spec.WorkloadAffinityGroups != nil {
+		aff = rb.Spec.WorkloadAffinityGroups.AffinityGroup
+		anti = rb.Spec.WorkloadAffinityGroups.AntiAffinityGroup
+	}
+
+	return &bindingInfo{
+		id:                id,
+		namespace:         rb.Namespace,
+		clusters:          clusters,
+		affinityGroup:     aff,
+		antiAffinityGroup: anti,
+	}
+}
+
+func bindingInfoFromCRB(crb *workv1alpha2.ClusterResourceBinding) *bindingInfo {
+	id := "crb:" + crb.Name
+
+	clusters := sets.New[string]()
+	for _, target := range crb.Spec.Clusters {
+		clusters.Insert(target.Name)
+	}
+
+	var aff, anti string
+	if crb.Spec.WorkloadAffinityGroups != nil {
+		aff = crb.Spec.WorkloadAffinityGroups.AffinityGroup
+		anti = crb.Spec.WorkloadAffinityGroups.AntiAffinityGroup
+	}
+
+	return &bindingInfo{
+		id:                id,
+		namespace:         "", // cluster-scoped
+		clusters:          clusters,
+		affinityGroup:     aff,
+		antiAffinityGroup: anti,
+	}
+}
+
+// isPossiblyStillMemberLocked returns true if bindingID still appears in any group.
+// Caller must hold c.mu.
+func (c *schedulerCache) isPossiblyStillMemberLocked(bindingID string) bool {
+	for _, m := range c.groupMembers {
+		if m.Has(bindingID) {
+			return true
+		}
+	}
+	return false
+}
+
+// setsEqualString checks if sets a, b are equal
+func setsEqualString(a, b sets.Set[string]) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	return a.Equal(b)
+}
+
+// cloneSet returns a deep copy of s (nil-safe).
+func cloneSet[T comparable](s sets.Set[T]) sets.Set[T] {
+	if s == nil {
+		return nil
+	}
+	cp := sets.New[T]()
+	for v := range s {
+		cp.Insert(v)
+	}
+	return cp
+}
+
+// cloneMapOfSets returns a deep copy of a map whose values are sets (nil-safe values are skipped).
+func cloneMapOfSets[K comparable, V comparable](in map[K]sets.Set[V]) map[K]sets.Set[V] {
+	if in == nil {
+		return nil
+	}
+	out := make(map[K]sets.Set[V], len(in))
+	for k, s := range in {
+		if s == nil {
+			continue
+		}
+		out[k] = cloneSet[V](s)
+	}
 	return out
 }

--- a/pkg/scheduler/cache/cache_test.go
+++ b/pkg/scheduler/cache/cache_test.go
@@ -18,14 +18,18 @@ package cache
 
 import (
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	clusterlister "github.com/karmada-io/karmada/pkg/generated/listers/cluster/v1alpha1"
 )
 
@@ -148,7 +152,7 @@ func TestSnapshot(t *testing.T) {
 			for _, cluster := range tt.clusters {
 				gotCluster := snapshot.GetCluster(cluster.Name)
 				assert.NotNil(t, gotCluster, "GetCluster(%s) returned nil", cluster.Name)
-				assert.Equal(t, cluster, gotCluster.Cluster(), "GetCluster(%s) returned incorrect cluster", cluster.Name)
+				assert.Equal(t, cluster, gotCluster, "GetCluster(%s) returned incorrect cluster", cluster.Name)
 			}
 
 			// Test GetCluster for non-existent cluster
@@ -156,7 +160,7 @@ func TestSnapshot(t *testing.T) {
 
 			// Verify that the snapshot is a deep copy
 			for i, cluster := range tt.clusters {
-				snapshotCluster := snapshot.GetClusters()[i].Cluster()
+				snapshotCluster := snapshot.GetClusters()[i]
 				assert.Equal(t, cluster, snapshotCluster, "Snapshot cluster should be equal to original")
 			}
 		})
@@ -232,8 +236,362 @@ func TestSnapshotError(t *testing.T) {
 	assert.Empty(t, snapshot.GetClusters(), "Snapshot should have no clusters when there's an error")
 }
 
-// Mock Implementations
+func TestOnResourceBindingAdd_IndexesAffinityAndAntiAffinity(t *testing.T) {
+	c := NewCache(&mockClusterLister{}).(*schedulerCache)
 
+	rb := rbWithGroups("default", "rb1", []string{"c1", "c2"}, "gA", "gB")
+	c.OnResourceBindingAdd(rb)
+
+	// internal keys should be present
+	affKey := makeWorkloadGroupKey("default", GroupTypeAffinity, "gA")
+	antiKey := makeWorkloadGroupKey("default", GroupTypeAntiAffinity, "gB")
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	gotAff := c.groupMembers[affKey]
+	assert.NotNil(t, gotAff)
+	assert.True(t, gotAff.Equal(sets.New[string]("rb:default/rb1")))
+
+	gotAnti := c.groupMembers[antiKey]
+	assert.NotNil(t, gotAnti)
+	assert.True(t, gotAnti.Equal(sets.New[string]("rb:default/rb1")))
+
+	clusters := c.clustersByBinding["rb:default/rb1"]
+	assert.NotNil(t, clusters)
+	assert.True(t, clusters.Has("c1"))
+	assert.True(t, clusters.Has("c2"))
+}
+
+func TestOnResourceBindingAdd_SkipsWhenNoClusters(t *testing.T) {
+	c := NewCache(&mockClusterLister{}).(*schedulerCache)
+
+	// Has groups, but no scheduled clusters -> should not be indexed.
+	rb := rbWithGroups("default", "rb1", nil, "gA", "gB")
+	c.OnResourceBindingAdd(rb)
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	assert.Empty(t, c.groupMembers)
+	assert.Empty(t, c.clustersByBinding)
+}
+
+func TestOnResourceBindingAdd_SkipsWhenNoGroups(t *testing.T) {
+	c := NewCache(&mockClusterLister{}).(*schedulerCache)
+
+	// Has clusters, but no WorkloadAffinityGroups -> should not be indexed.
+	rb := rbWithGroups("default", "rb1", []string{"c1"}, "", "")
+	c.OnResourceBindingAdd(rb)
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	assert.Empty(t, c.groupMembers)
+	assert.Empty(t, c.clustersByBinding)
+}
+
+func TestOnResourceBindingAddThenUpdate_IndexesWhenClustersArrive(t *testing.T) {
+	c := NewCache(&mockClusterLister{}).(*schedulerCache)
+
+	// 1) ResourceBinding added with anti-affinity but NO clusters -> should be skipped.
+	oldRB := rbWithGroups("default", "rb1", nil, "", "gAntiOnly")
+	c.OnResourceBindingAdd(oldRB)
+
+	c.mu.RLock()
+	assert.Empty(t, c.groupMembers, "groupMembers must be empty after Add with no clusters")
+	assert.Empty(t, c.clustersByBinding, "clustersByBinding must be empty after Add with no clusters")
+	c.mu.RUnlock()
+
+	// 2) ResourceBinding updated to include a cluster -> cache should be indexed.
+	newRB := rbWithGroups("default", "rb1", []string{"c1"}, "", "gAntiOnly")
+	c.OnResourceBindingUpdate(oldRB, newRB)
+
+	antiKey := makeWorkloadGroupKey("default", GroupTypeAntiAffinity, "gAntiOnly")
+	bindingID := "rb:default/rb1"
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	// clustersByBinding should now contain the cluster set
+	gotClusters, ok := c.clustersByBinding[bindingID]
+	assert.True(t, ok, "clustersByBinding should contain the binding after Update")
+	assert.True(t, gotClusters.Equal(sets.New[string]("c1")), "clustersByBinding should equal {c1}")
+
+	// groupMembers should now include the binding under the anti-affinity key
+	gotMembers, ok := c.groupMembers[antiKey]
+	assert.True(t, ok, "groupMembers should contain the anti-affinity key after Update")
+	assert.True(t, gotMembers.Equal(sets.New[string](bindingID)), "groupMembers for anti-key should contain the binding ID")
+}
+
+func TestOnResourceBindingAddThenUpdate_StillSkipsWhenNoClusters(t *testing.T) {
+	c := NewCache(&mockClusterLister{}).(*schedulerCache)
+
+	// 1) Add RB with anti-affinity but NO clusters -> should be skipped.
+	oldRB := rbWithGroups("default", "rb1", nil, "", "gAntiOnly")
+	c.OnResourceBindingAdd(oldRB)
+
+	c.mu.RLock()
+	assert.Empty(t, c.groupMembers, "groupMembers must be empty after Add with no clusters")
+	assert.Empty(t, c.clustersByBinding, "clustersByBinding must be empty after Add with no clusters")
+	c.mu.RUnlock()
+
+	// 2) Update RB but still NO clusters -> cache should remain skipped.
+	// For example, change some other field that is irrelevant to indexing (simulate a no-cluster update).
+	updatedRB := rbWithGroups("default", "rb1", nil, "", "gAntiOnly")
+	// (optionally mutate a non-indexed field)
+	// updatedRB.Annotations = map[string]string{"note": "updated but still unscheduled"}
+
+	c.OnResourceBindingUpdate(oldRB, updatedRB)
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	// still nothing indexed
+	assert.Empty(t, c.groupMembers, "groupMembers must remain empty after Update with no clusters")
+	assert.Empty(t, c.clustersByBinding, "clustersByBinding must remain empty after Update with no clusters")
+}
+
+func TestOnResourceBindingUpdate_ReindexesGroupAndClusters(t *testing.T) {
+	c := NewCache(&mockClusterLister{}).(*schedulerCache)
+
+	oldRB := rbWithGroups("default", "rb1", []string{"c1"}, "gOld", "gAntiOld")
+	newRB := rbWithGroups("default", "rb1", []string{"c2", "c3"}, "gNew", "gAntiNew")
+
+	c.OnResourceBindingAdd(oldRB)
+	c.OnResourceBindingUpdate(oldRB, newRB)
+
+	oldAffKey := makeWorkloadGroupKey("default", GroupTypeAffinity, "gOld")
+	oldAntiKey := makeWorkloadGroupKey("default", GroupTypeAntiAffinity, "gAntiOld")
+	newAffKey := makeWorkloadGroupKey("default", GroupTypeAffinity, "gNew")
+	newAntiKey := makeWorkloadGroupKey("default", GroupTypeAntiAffinity, "gAntiNew")
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	// old keys removed
+	_, ok := c.groupMembers[oldAffKey]
+	assert.False(t, ok)
+	_, ok = c.groupMembers[oldAntiKey]
+	assert.False(t, ok)
+
+	// new keys present
+	gotNewAff := c.groupMembers[newAffKey]
+	assert.NotNil(t, gotNewAff)
+	assert.True(t, gotNewAff.Equal(sets.New[string]("rb:default/rb1")))
+
+	gotNewAnti := c.groupMembers[newAntiKey]
+	assert.NotNil(t, gotNewAnti)
+	assert.True(t, gotNewAnti.Equal(sets.New[string]("rb:default/rb1")))
+
+	// clusters updated
+	got := c.clustersByBinding["rb:default/rb1"]
+	assert.True(t, got.Equal(sets.New[string]("c2", "c3")))
+}
+
+func TestOnResourceBindingDelete_UnindexesAndCleansUp(t *testing.T) {
+	c := NewCache(&mockClusterLister{}).(*schedulerCache)
+
+	rb := rbWithGroups("default", "rb1", []string{"c1"}, "gA", "gB")
+	c.OnResourceBindingAdd(rb)
+
+	// delete via tombstone to cover that path too
+	tombstone := cache.DeletedFinalStateUnknown{Obj: rb}
+	c.OnResourceBindingDelete(tombstone)
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	assert.Empty(t, c.groupMembers)
+	assert.Empty(t, c.clustersByBinding)
+}
+
+func TestAffinityAndAntiAffinity_SameGroupString_DoNotCollide(t *testing.T) {
+	c := NewCache(&mockClusterLister{}).(*schedulerCache)
+
+	// Same string in both fields
+	rb := rbWithGroups("default", "rb1", []string{"c1"}, "same", "same")
+	c.OnResourceBindingAdd(rb)
+
+	affKey := makeWorkloadGroupKey("default", GroupTypeAffinity, "same")
+	antiKey := makeWorkloadGroupKey("default", GroupTypeAntiAffinity, "same")
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	// both exist independently
+	gotAff := c.groupMembers[affKey]
+	assert.NotNil(t, gotAff)
+	assert.True(t, gotAff.Equal(sets.New[string]("rb:default/rb1")))
+
+	gotAnti := c.groupMembers[antiKey]
+	assert.NotNil(t, gotAnti)
+	assert.True(t, gotAnti.Equal(sets.New[string]("rb:default/rb1")))
+
+	assert.NotEqual(t, affKey, antiKey)
+}
+
+func TestClusterResourceBinding_IsIndexedAndNamespacedSeparately(t *testing.T) {
+	c := NewCache(&mockClusterLister{}).(*schedulerCache)
+
+	crb := crbWithGroups("crb1", []string{"c9"}, "gA", "gB")
+	c.OnResourceBindingAdd(crb)
+
+	affKey := makeWorkloadGroupKey("", GroupTypeAffinity, "gA")
+	antiKey := makeWorkloadGroupKey("", GroupTypeAntiAffinity, "gB")
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	gotAff := c.groupMembers[affKey]
+	assert.NotNil(t, gotAff)
+	assert.True(t, gotAff.Equal(sets.New[string]("crb:crb1")))
+
+	gotAnti := c.groupMembers[antiKey]
+	assert.NotNil(t, gotAnti)
+	assert.True(t, gotAnti.Equal(sets.New[string]("crb:crb1")))
+
+	got := c.clustersByBinding["crb:crb1"]
+	assert.True(t, got.Equal(sets.New[string]("c9")))
+}
+
+func TestResourceBindingAndClusterResourceBinding_SameName_NoCollision(t *testing.T) {
+	c := NewCache(&mockClusterLister{}).(*schedulerCache)
+
+	// RB name "x" and CRB name "x" must not collide
+	rb := rbWithGroups("default", "x", []string{"c1"}, "g1", "")
+	crb := crbWithGroups("x", []string{"c2"}, "g1", "")
+
+	c.OnResourceBindingAdd(rb)
+	c.OnResourceBindingAdd(crb)
+
+	rbID := "rb:default/x"
+	crbID := "crb:x"
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	assert.NotEqual(t, rbID, crbID)
+	assert.True(t, c.clustersByBinding[rbID].Equal(sets.New[string]("c1")))
+	assert.True(t, c.clustersByBinding[crbID].Equal(sets.New[string]("c2")))
+
+	// groupMembers should contain both, under different namespaces ("default" vs "")
+	rbKey := makeWorkloadGroupKey("default", GroupTypeAffinity, "g1")
+	crbKey := makeWorkloadGroupKey("", GroupTypeAffinity, "g1")
+
+	gotRB := c.groupMembers[rbKey]
+	assert.NotNil(t, gotRB)
+	assert.True(t, gotRB.Equal(sets.New[string](rbID)))
+
+	gotCRB := c.groupMembers[crbKey]
+	assert.NotNil(t, gotCRB)
+	assert.True(t, gotCRB.Equal(sets.New[string](crbID)))
+}
+
+// Concurrency unit tests
+
+func TestSchedulerCache_ConcurrentUpdates_SameBinding(t *testing.T) {
+	c := NewCache(&mockClusterLister{}).(*schedulerCache)
+
+	initial := rbWithGroups("default", "rb1", []string{"c1"}, "gA", "gB")
+	c.OnResourceBindingAdd(initial)
+
+	const workers = 32
+	const iters = 200
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	for w := 0; w < workers; w++ {
+		go func(worker int) {
+			defer wg.Done()
+
+			prev := initial
+			for i := 0; i < iters; i++ {
+				var cur *workv1alpha2.ResourceBinding
+				switch (worker + i) % 4 {
+				case 0:
+					cur = rbWithGroups("default", "rb1", []string{"c1", "c2"}, "gA", "gB")
+				case 1:
+					cur = rbWithGroups("default", "rb1", []string{"c1"}, "gX", "gB")
+				case 2:
+					cur = rbWithGroups("default", "rb1", []string{"c1"}, "gA", "gY")
+				default:
+					cur = rbWithGroups("default", "rb1", nil, "gA", "gB")
+				}
+				c.OnResourceBindingUpdate(prev, cur)
+				prev = cur
+			}
+		}(w)
+	}
+
+	wg.Wait()
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	assertCacheInvariants(t, c)
+}
+
+func TestSchedulerCache_ConcurrentMixedOperations_ManyBindings(t *testing.T) {
+	c := NewCache(&mockClusterLister{}).(*schedulerCache)
+
+	const workers = 24
+	const bindings = 50
+	const iters = 200
+
+	// Pre-create a set of binding names to operate on.
+	names := make([]string, 0, bindings)
+	for i := 0; i < bindings; i++ {
+		names = append(names, fmt.Sprintf("rb-%d", i))
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	for w := 0; w < workers; w++ {
+		go func(worker int) {
+			defer wg.Done()
+
+			for i := 0; i < iters; i++ {
+				name := names[(worker+i)%len(names)]
+
+				switch (worker + i) % 5 {
+				case 0:
+					// Add indexed
+					rb := rbWithGroups("default", name, []string{"c1"}, "gA", "gB")
+					c.OnResourceBindingAdd(rb)
+				case 1:
+					// Add unindexable (should skip)
+					rb := rbWithGroups("default", name, nil, "gA", "gB")
+					c.OnResourceBindingAdd(rb)
+				case 2:
+					// Update to indexed
+					old := rbWithGroups("default", name, nil, "gA", "gB")
+					newRB := rbWithGroups("default", name, []string{"c2"}, "gA", "gB")
+					c.OnResourceBindingUpdate(old, newRB)
+				case 3:
+					// Update group change
+					old := rbWithGroups("default", name, []string{"c1"}, "gA", "gB")
+					newRB := rbWithGroups("default", name, []string{"c1"}, "gX", "gY")
+					c.OnResourceBindingUpdate(old, newRB)
+				default:
+					// Delete via tombstone
+					rb := rbWithGroups("default", name, []string{"c1"}, "gA", "gB")
+					tombstone := cache.DeletedFinalStateUnknown{Obj: rb}
+					c.OnResourceBindingDelete(tombstone)
+				}
+			}
+		}(w)
+	}
+
+	wg.Wait()
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	assertCacheInvariants(t, c)
+}
+
+// Mock Implementations
 type mockClusterLister struct {
 	clusters []*clusterv1alpha1.Cluster
 	err      error
@@ -253,4 +611,87 @@ func (m *mockClusterLister) Get(name string) (*clusterv1alpha1.Cluster, error) {
 		}
 	}
 	return nil, nil
+}
+
+// Helper methods
+
+// assertCacheInvariants verifies that the data structures managed by the cache are being maintained correctly during concurrent operations
+// This method checks:
+// 1. groupMembers is populated correctly: if bindingID exists, then it should also be in bindingGroups + clustersByBinding
+// 2. bindingGroups is populated correctly: if groupKey exists, then it should also be in groupMembers
+// 3. clustersByBinding is populated correctly and does not contain orphan entries
+func assertCacheInvariants(t *testing.T, c *schedulerCache) {
+	t.Helper()
+
+	// 1) groupMembers -> bindingGroups and clustersByBinding
+	for gk, members := range c.groupMembers {
+		assert.NotNil(t, members, "groupMembers[%v] is nil", gk)
+		assert.Greater(t, members.Len(), 0, "groupMembers[%v] is empty but present in map", gk)
+
+		for id := range members {
+			bg := c.bindingGroups[id]
+			assert.NotNil(t, bg, "bindingGroups[%s] missing but referenced by groupMembers[%v]", id, gk)
+			assert.True(t, bg.Has(gk), "bindingGroups[%s] missing key %v", id, gk)
+
+			cl := c.clustersByBinding[id]
+			assert.NotNil(t, cl, "clustersByBinding[%s] missing but binding is indexed in groupMembers", id)
+			assert.Greater(t, cl.Len(), 0, "clustersByBinding[%s] is empty but binding is indexed", id)
+		}
+	}
+
+	// 2) bindingGroups -> groupMembers
+	for id, groups := range c.bindingGroups {
+		assert.NotNil(t, groups, "bindingGroups[%s] is nil", id)
+		assert.Greater(t, groups.Len(), 0, "bindingGroups[%s] is empty but present in map", id)
+
+		for gk := range groups {
+			members := c.groupMembers[gk]
+			assert.NotNil(t, members, "groupMembers[%v] missing but referenced by bindingGroups[%s]", gk, id)
+			assert.True(t, members.Has(id), "groupMembers[%v] missing binding %s", gk, id)
+		}
+	}
+
+	// 3) clustersByBinding should not contain entries for bindings that have no groups
+	// clusters map exists iff at least one group is indexed
+	for id, cl := range c.clustersByBinding {
+		assert.NotNil(t, cl, "clustersByBinding[%s] is nil", id)
+		assert.Greater(t, cl.Len(), 0, "clustersByBinding[%s] is empty but present in map", id)
+
+		bg := c.bindingGroups[id]
+		assert.NotNil(t, bg, "clustersByBinding[%s] exists but bindingGroups missing", id)
+		assert.Greater(t, bg.Len(), 0, "clustersByBinding[%s] exists but bindingGroups empty", id)
+	}
+}
+
+func rbWithGroups(ns, name string, clusters []string, affinityGroup, antiGroup string) *workv1alpha2.ResourceBinding {
+	rb := &workv1alpha2.ResourceBinding{}
+	rb.Namespace = ns
+	rb.Name = name
+
+	for _, c := range clusters {
+		rb.Spec.Clusters = append(rb.Spec.Clusters, workv1alpha2.TargetCluster{Name: c})
+	}
+	if affinityGroup != "" || antiGroup != "" {
+		rb.Spec.WorkloadAffinityGroups = &workv1alpha2.WorkloadAffinityGroups{
+			AffinityGroup:     affinityGroup,
+			AntiAffinityGroup: antiGroup,
+		}
+	}
+	return rb
+}
+
+func crbWithGroups(name string, clusters []string, affinityGroup, antiGroup string) *workv1alpha2.ClusterResourceBinding {
+	crb := &workv1alpha2.ClusterResourceBinding{}
+	crb.Name = name
+
+	for _, c := range clusters {
+		crb.Spec.Clusters = append(crb.Spec.Clusters, workv1alpha2.TargetCluster{Name: c})
+	}
+	if affinityGroup != "" || antiGroup != "" {
+		crb.Spec.WorkloadAffinityGroups = &workv1alpha2.WorkloadAffinityGroups{
+			AffinityGroup:     affinityGroup,
+			AntiAffinityGroup: antiGroup,
+		}
+	}
+	return crb
 }

--- a/pkg/scheduler/event_handler.go
+++ b/pkg/scheduler/event_handler.go
@@ -50,6 +50,7 @@ func (s *Scheduler) addAllEventHandlers() {
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    s.onResourceBindingAdd,
 			UpdateFunc: s.onResourceBindingUpdate,
+			DeleteFunc: s.onResourceBindingDelete,
 		},
 	})
 	if err != nil {
@@ -62,6 +63,7 @@ func (s *Scheduler) addAllEventHandlers() {
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    s.onResourceBindingAdd,
 			UpdateFunc: s.onResourceBindingUpdate,
+			DeleteFunc: s.onResourceBindingDelete,
 		},
 	})
 	if err != nil {
@@ -137,6 +139,11 @@ func newQueuedBindingInfo(obj interface{}) *internalqueue.QueuedBindingInfo {
 }
 
 func (s *Scheduler) onResourceBindingAdd(obj interface{}) {
+	// If WorkloadAffinity is enabled, we need to update the scheduler cache to reindex RBs
+	if features.FeatureGate.Enabled(features.WorkloadAffinity) {
+		s.schedulerCache.OnResourceBindingAdd(obj)
+	}
+
 	if features.FeatureGate.Enabled(features.PriorityBasedScheduling) {
 		bindingInfo := newQueuedBindingInfo(obj)
 		if bindingInfo == nil {
@@ -179,6 +186,11 @@ func (s *Scheduler) onResourceBindingUpdate(old, cur interface{}) {
 		return
 	}
 
+	// If WorkloadAffinity is enabled, we need to update the scheduler cache to reindex RBs
+	if features.FeatureGate.Enabled(features.WorkloadAffinity) {
+		s.schedulerCache.OnResourceBindingUpdate(old, cur)
+	}
+
 	if features.FeatureGate.Enabled(features.PriorityBasedScheduling) {
 		bindingInfo := newQueuedBindingInfo(cur)
 		if bindingInfo == nil {
@@ -198,6 +210,13 @@ func (s *Scheduler) onResourceBindingUpdate(old, cur interface{}) {
 		s.queue.Add(key)
 	}
 	metrics.CountSchedulerBindings(metrics.BindingUpdate)
+}
+
+func (s *Scheduler) onResourceBindingDelete(obj interface{}) {
+	// If WorkloadAffinity is enabled, we need to update the scheduler cache to reindex RBs
+	if features.FeatureGate.Enabled(features.WorkloadAffinity) {
+		s.schedulerCache.OnResourceBindingDelete(obj)
+	}
 }
 
 func (s *Scheduler) onResourceBindingRequeue(binding *workv1alpha2.ResourceBinding, event string) {

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -30,6 +30,7 @@ import (
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/scheduler/cache"
 )
 
 const (
@@ -46,7 +47,7 @@ type Framework interface {
 
 	// RunFilterPlugins runs the set of configured Filter plugins for resources on
 	// the given cluster.
-	RunFilterPlugins(ctx context.Context, bindingSpec *workv1alpha2.ResourceBindingSpec, bindingStatus *workv1alpha2.ResourceBindingStatus, cluster *clusterv1alpha1.Cluster) *Result
+	RunFilterPlugins(ctx context.Context, bindingSpec *workv1alpha2.ResourceBindingSpec, bindingStatus *workv1alpha2.ResourceBindingStatus, cluster *clusterv1alpha1.Cluster, snapshot *cache.Snapshot) *Result
 
 	// RunScorePlugins runs the set of configured Score plugins, it returns a map of plugin names to scores
 	RunScorePlugins(ctx context.Context, spec *workv1alpha2.ResourceBindingSpec, clusters []*clusterv1alpha1.Cluster) (PluginToClusterScores, *Result)
@@ -71,6 +72,9 @@ type FilterContext struct {
 
 	// Cluster is the cluster being evaluated.
 	Cluster *clusterv1alpha1.Cluster
+
+	// Snapshot of the scheduler cache
+	Snapshot *cache.Snapshot
 }
 
 // FilterPlugin is an interface for filter plugins. These filters are used to filter out clusters
@@ -78,7 +82,12 @@ type FilterContext struct {
 type FilterPlugin interface {
 	Plugin
 	// Filter is called by the scheduling framework.
-	Filter(ctx context.Context, bindingSpec *workv1alpha2.ResourceBindingSpec, bindingStatus *workv1alpha2.ResourceBindingStatus, cluster *clusterv1alpha1.Cluster) *Result
+	Filter(
+		ctx context.Context,
+		bindingSpec *workv1alpha2.ResourceBindingSpec,
+		bindingStatus *workv1alpha2.ResourceBindingStatus,
+		cluster *clusterv1alpha1.Cluster,
+	) *Result
 }
 
 // FilterPluginWithContext is an extended interface for filter plugins that use FilterContext.

--- a/pkg/scheduler/framework/plugins/clustereviction/cluster_eviction.go
+++ b/pkg/scheduler/framework/plugins/clustereviction/cluster_eviction.go
@@ -47,7 +47,12 @@ func (p *ClusterEviction) Name() string {
 }
 
 // Filter checks if the target cluster is in the GracefulEvictionTasks which means it is in the process of eviction.
-func (p *ClusterEviction) Filter(_ context.Context, bindingSpec *workv1alpha2.ResourceBindingSpec, _ *workv1alpha2.ResourceBindingStatus, cluster *clusterv1alpha1.Cluster) *framework.Result {
+func (p *ClusterEviction) Filter(
+	_ context.Context,
+	bindingSpec *workv1alpha2.ResourceBindingSpec,
+	_ *workv1alpha2.ResourceBindingStatus,
+	cluster *clusterv1alpha1.Cluster,
+) *framework.Result {
 	if bindingSpec.ClusterInGracefulEvictionTasks(cluster.Name) {
 		klog.V(2).Infof("Cluster(%s) is in the process of eviction.", cluster.Name)
 		return framework.NewResult(framework.Unschedulable, "cluster(s) is in the process of eviction")

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -24,6 +24,7 @@ import (
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/scheduler/cache"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework"
 	"github.com/karmada-io/karmada/pkg/scheduler/metrics"
 	utilmetrics "github.com/karmada-io/karmada/pkg/util/metrics"
@@ -95,6 +96,7 @@ func (frw *frameworkImpl) RunFilterPlugins(
 	bindingSpec *workv1alpha2.ResourceBindingSpec,
 	bindingStatus *workv1alpha2.ResourceBindingStatus,
 	cluster *clusterv1alpha1.Cluster,
+	snapshot *cache.Snapshot,
 ) (result *framework.Result) {
 	startTime := time.Now()
 	defer func() {
@@ -106,6 +108,7 @@ func (frw *frameworkImpl) RunFilterPlugins(
 		BindingSpec:   bindingSpec,
 		BindingStatus: bindingStatus,
 		Cluster:       cluster,
+		Snapshot:      snapshot,
 	}
 
 	for _, p := range frw.filterPlugins {

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -88,7 +88,7 @@ func Test_frameworkImpl_RunFilterPlugins(t *testing.T) {
 				t.Errorf("create frame work error:%v", err)
 			}
 
-			result := frameWork.RunFilterPlugins(ctx, nil, nil, nil)
+			result := frameWork.RunFilterPlugins(ctx, nil, nil, nil, nil)
 			if result.IsSuccess() != tt.isSuccess {
 				t.Errorf("want %v, but get:%v", tt.isSuccess, result.IsSuccess())
 			}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -683,6 +683,12 @@ func (s *Scheduler) patchScheduleResultForResourceBinding(oldBinding *workv1alph
 		return err
 	}
 
+	// Update cache to make sure next scheduling cycle has latest RB information
+	if features.FeatureGate.Enabled(features.WorkloadAffinity) {
+		klog.V(4).Infof("Updating cache snapshot for ResourceBinding(%s/%s).", oldBinding.Namespace, oldBinding.Name)
+		s.schedulerCache.OnResourceBindingUpdate(oldBinding, newBinding)
+	}
+
 	klog.V(4).Infof("Patch schedule to ResourceBinding(%s/%s) succeed", oldBinding.Namespace, oldBinding.Name)
 	return nil
 }
@@ -819,6 +825,12 @@ func (s *Scheduler) patchScheduleResultForClusterResourceBinding(oldBinding *wor
 	if err != nil {
 		klog.Errorf("Failed to patch schedule to ClusterResourceBinding(%s): %v", oldBinding.Name, err)
 		return err
+	}
+
+	// Update cache to make sure next scheduling cycle has latest RB information
+	if features.FeatureGate.Enabled(features.WorkloadAffinity) {
+		klog.V(4).Infof("Updating cache snapshot for ClusterResourceBinding(%s).", oldBinding.Name)
+		s.schedulerCache.OnResourceBindingUpdate(oldBinding, newBinding)
 	}
 
 	klog.V(4).Infof("Patch schedule to ClusterResourceBinding(%s) succeed", oldBinding.Name)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR includes several changes required to add a global index based on affinity groups declared in resourcebindings and clusterresourcebindings:
-  cache.go / snapshot.go have been augmented to include `groupPeers` and `clustersByBinding`, which are new data structures that group resourcebindings based on affinity groups and also track clusters to which the resourcebindings have been scheduled.
- cache.go has been linked with event_handler, to respond to changes in resourcebinding objects
- snapshot.go has been refactored to no longer use ClusterInfo and instead just have a list of clusters
- `RunFilterPlugins` method has been refactored to include a snapshot parameter
- unit tests have been added to test cache and snapshot changes

**Which issue(s) this PR fixes**:
Part of #7064

**Special notes for your reviewer**:
I am still doing e2e tests on this branch, so please keep that in mind. However I wanted to publish the PR so we could start to review the implementation.

**Does this PR introduce a user-facing change?**:
```release-note
Add a global index based on the affinity groups defined in resourcebindings
```

