### PR TITLE
feat: add complete interpreter test coverage for DaemonSet

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/customizations.yaml
@@ -161,6 +161,5 @@ spec:
       luaScript: >
         local kube = require("kube")
         function GetDependencies(desiredObj)
-          refs = kube.getPodDependencies(desiredObj.spec.template, desiredObj.metadata.namespace)
-          return refs
+          return kube.getPodDependencies(desiredObj.spec.template, desiredObj.metadata.namespace) or {}
         end

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/testdata/aggregatestatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/testdata/aggregatestatus-test.yaml
@@ -1,5 +1,10 @@
 # test case for aggregating status of DaemonSet
-# case1. DaemonSet with two status items
+# case 1: DaemonSet with two status items
+# case 2: DaemonSet with no member status
+# case 3: DaemonSet with all members updated to latest generation
+# case 4: DaemonSet with mixed observed generations
+# case 5: DaemonSet with stale resourceTemplateGeneration
+# case 6: DaemonSet with mixed nil status fields
 
 name: "DaemonSet with two status items"
 description: "Test aggregating status of DaemonSet with two status items"
@@ -70,3 +75,437 @@ statusItems:
       resourceTemplateGeneration: 1
 operation: AggregateStatus
 output:
+  aggregatedStatus:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: DaemonSet
+    metadata:
+      labels:
+        app: sample-daemonset
+      name: sample
+      namespace: test-kruise-daemonset
+      generation: 1
+    spec:
+      selector:
+        matchLabels:
+          app: sample-daemonset
+      template:
+        metadata:
+          labels:
+            app: sample-daemonset
+        spec:
+          volumes:
+            - name: configmap
+              configMap:
+                name: my-sample-config
+          containers:
+            - name: nginx
+              image: nginx:alpine
+              env:
+                - name: logData
+                  valueFrom:
+                    configMapKeyRef:
+                      name: mysql-config
+                      key: log
+                - name: lowerData
+                  valueFrom:
+                    configMapKeyRef:
+                      name: mysql-config
+                      key: lower
+    status:
+      observedGeneration: 1
+      currentNumberScheduled: 2
+      numberMisscheduled: 0
+      desiredNumberScheduled: 2
+      numberReady: 2
+      updatedNumberScheduled: 2
+      numberAvailable: 2
+      numberUnavailable: 0
+      daemonSetHash: 7dd59cf749
+
+---
+name: "DaemonSet: aggregate status with no members"
+description: "Test AggregateStatus initializes status when statusItems is nil"
+desiredObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: DaemonSet
+  metadata:
+    name: sample-nil
+    namespace: test-kruise-daemonset
+    generation: 3
+  spec:
+    selector:
+      matchLabels:
+        app: sample-daemonset
+    template:
+      metadata:
+        labels:
+          app: sample-daemonset
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: DaemonSet
+    metadata:
+      name: sample-nil
+      namespace: test-kruise-daemonset
+      generation: 3
+    spec:
+      selector:
+        matchLabels:
+          app: sample-daemonset
+      template:
+        metadata:
+          labels:
+            app: sample-daemonset
+        spec:
+          containers:
+            - name: nginx
+              image: nginx:alpine
+    status:
+      observedGeneration: 3
+      currentNumberScheduled: 0
+      numberMisscheduled: 0
+      desiredNumberScheduled: 0
+      numberReady: 0
+      updatedNumberScheduled: 0
+      numberAvailable: 0
+      numberUnavailable: 0
+      daemonSetHash: 0
+
+---
+name: "DaemonSet with all members updated to latest generation"
+description: "Check if the member's status is updated to the latest generation and observedGeneration should advance"
+desiredObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: DaemonSet
+  metadata:
+    name: sample-updated
+    namespace: test-kruise-daemonset
+    generation: 3
+  status:
+    observedGeneration: 2
+  spec:
+    selector:
+      matchLabels:
+        app: sample-daemonset
+    template:
+      metadata:
+        labels:
+          app: sample-daemonset
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+statusItems:
+  - applied: true
+    clusterName: member1
+    health: Healthy
+    status:
+      currentNumberScheduled: 1
+      daemonSetHash: abc123
+      desiredNumberScheduled: 1
+      numberAvailable: 1
+      numberMisscheduled: 0
+      numberReady: 1
+      observedGeneration: 3
+      updatedNumberScheduled: 1
+      generation: 3
+      resourceTemplateGeneration: 3
+  - applied: true
+    clusterName: member2
+    health: Healthy
+    status:
+      currentNumberScheduled: 1
+      daemonSetHash: abc123
+      desiredNumberScheduled: 1
+      numberAvailable: 1
+      numberMisscheduled: 0
+      numberReady: 1
+      observedGeneration: 3
+      updatedNumberScheduled: 1
+      generation: 3
+      resourceTemplateGeneration: 3
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: DaemonSet
+    metadata:
+      name: sample-updated
+      namespace: test-kruise-daemonset
+      generation: 3
+    spec:
+      selector:
+        matchLabels:
+          app: sample-daemonset
+      template:
+        metadata:
+          labels:
+            app: sample-daemonset
+        spec:
+          containers:
+            - name: nginx
+              image: nginx:alpine
+    status:
+      observedGeneration: 3
+      currentNumberScheduled: 2
+      numberMisscheduled: 0
+      desiredNumberScheduled: 2
+      numberReady: 2
+      updatedNumberScheduled: 2
+      numberAvailable: 2
+      numberUnavailable: 0
+      daemonSetHash: abc123
+
+---
+name: "DaemonSet with mixed observed generations"
+description: "Update the observed generation based on the observedResourceTemplateGenerationCount - should not advance if any member is stale"
+desiredObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: DaemonSet
+  metadata:
+    name: sample-mixed
+    namespace: test-kruise-daemonset
+    generation: 3
+  status:
+    observedGeneration: 2
+  spec:
+    selector:
+      matchLabels:
+        app: sample-daemonset
+    template:
+      metadata:
+        labels:
+          app: sample-daemonset
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+statusItems:
+  - applied: true
+    clusterName: member1
+    health: Healthy
+    status:
+      currentNumberScheduled: 1
+      daemonSetHash: def456
+      desiredNumberScheduled: 1
+      numberAvailable: 1
+      numberMisscheduled: 0
+      numberReady: 1
+      observedGeneration: 3
+      updatedNumberScheduled: 1
+      generation: 3
+      resourceTemplateGeneration: 3
+  - applied: true
+    clusterName: member2
+    health: Healthy
+    status:
+      currentNumberScheduled: 1
+      daemonSetHash: def456
+      desiredNumberScheduled: 1
+      numberAvailable: 1
+      numberMisscheduled: 0
+      numberReady: 1
+      observedGeneration: 2
+      updatedNumberScheduled: 1
+      generation: 3
+      resourceTemplateGeneration: 3
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: DaemonSet
+    metadata:
+      name: sample-mixed
+      namespace: test-kruise-daemonset
+      generation: 3
+    spec:
+      selector:
+        matchLabels:
+          app: sample-daemonset
+      template:
+        metadata:
+          labels:
+            app: sample-daemonset
+        spec:
+          containers:
+            - name: nginx
+              image: nginx:alpine
+    status:
+      observedGeneration: 2
+      currentNumberScheduled: 2
+      numberMisscheduled: 0
+      desiredNumberScheduled: 2
+      numberReady: 2
+      updatedNumberScheduled: 2
+      numberAvailable: 2
+      numberUnavailable: 0
+      daemonSetHash: def456
+
+---
+name: "DaemonSet with stale resourceTemplateGeneration"
+description: "observedGeneration should not advance when any member has stale resourceTemplateGeneration"
+desiredObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: DaemonSet
+  metadata:
+    name: sample-stale-template
+    namespace: test-kruise-daemonset
+    generation: 3
+  status:
+    observedGeneration: 2
+  spec:
+    selector:
+      matchLabels:
+        app: sample-daemonset
+    template:
+      metadata:
+        labels:
+          app: sample-daemonset
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+statusItems:
+  - applied: true
+    clusterName: member1
+    health: Healthy
+    status:
+      currentNumberScheduled: 1
+      daemonSetHash: ghi789
+      desiredNumberScheduled: 1
+      numberAvailable: 1
+      numberMisscheduled: 0
+      numberReady: 1
+      observedGeneration: 3
+      updatedNumberScheduled: 1
+      generation: 3
+      resourceTemplateGeneration: 3
+  - applied: true
+    clusterName: member2
+    health: Healthy
+    status:
+      currentNumberScheduled: 1
+      daemonSetHash: ghi789
+      desiredNumberScheduled: 1
+      numberAvailable: 1
+      numberMisscheduled: 0
+      numberReady: 1
+      observedGeneration: 3
+      updatedNumberScheduled: 1
+      generation: 3
+      resourceTemplateGeneration: 2
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: DaemonSet
+    metadata:
+      name: sample-stale-template
+      namespace: test-kruise-daemonset
+      generation: 3
+    spec:
+      selector:
+        matchLabels:
+          app: sample-daemonset
+      template:
+        metadata:
+          labels:
+            app: sample-daemonset
+        spec:
+          containers:
+            - name: nginx
+              image: nginx:alpine
+    status:
+      observedGeneration: 2
+      currentNumberScheduled: 2
+      numberMisscheduled: 0
+      desiredNumberScheduled: 2
+      numberReady: 2
+      updatedNumberScheduled: 2
+      numberAvailable: 2
+      numberUnavailable: 0
+      daemonSetHash: ghi789
+
+---
+name: "DaemonSet with mixed nil status fields"
+description: "If some fields in the status of certain members are nil, the accumulation should be skipped"
+desiredObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: DaemonSet
+  metadata:
+    name: sample-nil-fields
+    namespace: test-kruise-daemonset
+    generation: 2
+  spec:
+    selector:
+      matchLabels:
+        app: sample-daemonset
+    template:
+      metadata:
+        labels:
+          app: sample-daemonset
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+statusItems:
+  - applied: true
+    clusterName: member1
+    health: Healthy
+    status:
+      currentNumberScheduled: 2
+      daemonSetHash: jkl012
+      desiredNumberScheduled: 2
+      numberAvailable: 2
+      numberMisscheduled: 0
+      numberReady: 2
+      observedGeneration: 2
+      updatedNumberScheduled: 2
+      generation: 2
+      resourceTemplateGeneration: 2
+  - applied: true
+    clusterName: member2
+    health: Healthy
+    status:
+      currentNumberScheduled: 1
+      numberMisscheduled: 0
+      numberReady: 1
+      observedGeneration: 2
+      generation: 2
+      resourceTemplateGeneration: 2
+operation: AggregateStatus
+output:
+  aggregatedStatus:
+    apiVersion: apps.kruise.io/v1alpha1
+    kind: DaemonSet
+    metadata:
+      name: sample-nil-fields
+      namespace: test-kruise-daemonset
+      generation: 2
+    spec:
+      selector:
+        matchLabels:
+          app: sample-daemonset
+      template:
+        metadata:
+          labels:
+            app: sample-daemonset
+        spec:
+          containers:
+            - name: nginx
+              image: nginx:alpine
+    status:
+      observedGeneration: 2
+      currentNumberScheduled: 3
+      numberMisscheduled: 0
+      desiredNumberScheduled: 2
+      numberReady: 3
+      updatedNumberScheduled: 2
+      numberAvailable: 2
+      numberUnavailable: 0
+      daemonSetHash: jkl012

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/testdata/interpretdependency-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/testdata/interpretdependency-test.yaml
@@ -1,5 +1,8 @@
 # test case for interpreting dependency of DaemonSet
 # case1. DaemonSet with configmap dependency
+# case2. DaemonSet with secret dependency
+# case3. DaemonSet with multiple containers sharing dependency
+# case4. DaemonSet with no dependencies
 
 name: "DaemonSet with configmap dependency"
 description: "Test interpreting dependency of DaemonSet with configmap dependency"
@@ -41,3 +44,120 @@ desiredObj:
                     key: lower
 operation: InterpretDependency
 output:
+  dependencies:
+    - apiVersion: v1
+      kind: ConfigMap
+      name: my-sample-config
+      namespace: test-kruise-daemonset
+    - apiVersion: v1
+      kind: ConfigMap
+      name: mysql-config
+      namespace: test-kruise-daemonset
+
+---
+name: "DaemonSet with secret dependency"
+description: "Test interpreting dependency of DaemonSet with secret dependency"
+desiredObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: DaemonSet
+  metadata:
+    name: sample-secret
+    namespace: test-kruise-daemonset
+  spec:
+    selector:
+      matchLabels:
+        app: sample-daemonset
+    template:
+      metadata:
+        labels:
+          app: sample-daemonset
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+            env:
+              - name: SECRET_VAL
+                valueFrom:
+                  secretKeyRef:
+                    name: my-secret
+                    key: password
+operation: InterpretDependency
+output:
+  dependencies:
+    - apiVersion: v1
+      kind: Secret
+      name: my-secret
+      namespace: test-kruise-daemonset
+
+---
+name: "DaemonSet with multiple containers sharing configmap"
+description: "Test interpreting dependency with multiple containers using same ConfigMap"
+desiredObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: DaemonSet
+  metadata:
+    name: sample-multicontainer
+    namespace: test-kruise-daemonset
+  spec:
+    selector:
+      matchLabels:
+        app: sample-daemonset
+    template:
+      metadata:
+        labels:
+          app: sample-daemonset
+      spec:
+        containers:
+          - name: app1
+            image: nginx:alpine
+            env:
+              - name: CFG
+                valueFrom:
+                  configMapKeyRef:
+                    name: shared-config
+                    key: abc
+          - name: app2
+            image: busybox
+            env:
+              - name: CFG
+                valueFrom:
+                  configMapKeyRef:
+                    name: shared-config
+                    key: cba
+operation: InterpretDependency
+output:
+  dependencies:
+    - apiVersion: v1
+      kind: ConfigMap
+      name: shared-config
+      namespace: test-kruise-daemonset
+
+---
+name: "DaemonSet with no dependencies"
+description: "Test interpreting dependency when DaemonSet has no ConfigMap or Secret dependencies"
+desiredObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: DaemonSet
+  metadata:
+    name: sample-no-deps
+    namespace: test-kruise-daemonset
+  spec:
+    selector:
+      matchLabels:
+        app: sample-daemonset
+    template:
+      metadata:
+        labels:
+          app: sample-daemonset
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+            env:
+              - name: STATIC_VALUE
+                value: "hello-world"
+              - name: ANOTHER_VAL
+                value: "67"
+operation: InterpretDependency
+output:
+  dependencies: []

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/testdata/interprethealth-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/testdata/interprethealth-test.yaml
@@ -1,5 +1,9 @@
 # test case for interpreting health of DaemonSet
 # case1. DaemonSet interpreting health test
+# case2: Generation mismatch
+# case3: Not all updated pods are available
+# case4: Not all pods updated
+# case5: Zero desired pods
 
 name: "DaemonSet interpreting health test"
 description: "Test interpreting health of DaemonSet"
@@ -52,3 +56,130 @@ observedObj:
     updatedNumberScheduled: 1
 operation: InterpretHealth
 output:
+  healthy: true
+
+---
+name: "DaemonSet unhealthy - generation mismatch"
+description: "Test InterpretHealth returns false when observedGeneration doesn't match generation"
+observedObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: DaemonSet
+  metadata:
+    name: sample
+    namespace: test-kruise-daemonset
+    generation: 5
+  spec:
+    selector:
+      matchLabels:
+        app: sample-daemonset
+    template:
+      metadata:
+        labels:
+          app: sample-daemonset
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+  status:
+    observedGeneration: 3
+    desiredNumberScheduled: 3
+    updatedNumberScheduled: 3
+    numberAvailable: 3
+operation: InterpretHealth
+output:
+  healthy: false
+
+---
+name: "DaemonSet unhealthy - not all updated pods available"
+description: "Test InterpretHealth returns false when numberAvailable < updatedNumberScheduled"
+observedObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: DaemonSet
+  metadata:
+    name: sample
+    namespace: test-kruise-daemonset
+    generation: 2
+  spec:
+    selector:
+      matchLabels:
+        app: sample-daemonset
+    template:
+      metadata:
+        labels:
+          app: sample-daemonset
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+  status:
+    observedGeneration: 2
+    desiredNumberScheduled: 5
+    updatedNumberScheduled: 5
+    numberAvailable: 3
+operation: InterpretHealth
+output:
+  healthy: false
+
+---
+name: "DaemonSet unhealthy - not all pods updated"
+description: "Test InterpretHealth returns false when updatedNumberScheduled < desiredNumberScheduled"
+observedObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: DaemonSet
+  metadata:
+    name: sample
+    namespace: test-kruise-daemonset
+    generation: 2
+  spec:
+    selector:
+      matchLabels:
+        app: sample-daemonset
+    template:
+      metadata:
+        labels:
+          app: sample-daemonset
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+  status:
+    observedGeneration: 2
+    desiredNumberScheduled: 5
+    updatedNumberScheduled: 3
+    numberAvailable: 3
+operation: InterpretHealth
+output:
+  healthy: false
+
+---
+name: "DaemonSet healthy - zero desired pods"
+description: "Test InterpretHealth returns true when desiredNumberScheduled is 0"
+observedObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: DaemonSet
+  metadata:
+    name: sample
+    namespace: test-kruise-daemonset
+    generation: 1
+  spec:
+    selector:
+      matchLabels:
+        app: sample-daemonset
+    template:
+      metadata:
+        labels:
+          app: sample-daemonset
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+  status:
+    observedGeneration: 1
+    desiredNumberScheduled: 0
+    updatedNumberScheduled: 0
+    numberAvailable: 0
+    currentNumberScheduled: 0
+    numberReady: 0
+operation: InterpretHealth
+output:
+  healthy: true

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/testdata/interpretstatus-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/apps.kruise.io/v1alpha1/DaemonSet/testdata/interpretstatus-test.yaml
@@ -1,5 +1,11 @@
 # test case for interpreting status of DaemonSet
 # case1. DaemonSet: interpret status test
+# case2. DaemonSet: empty observed status
+# case3. DaemonSet: missing metadata
+# case4. DaemonSet: missing annotations
+# case5. DaemonSet: missing annotation
+# case6. DaemonSet: invalid resourceTemplateGeneration value
+# case7. DaemonSet: high generation numbers
 
 name: "DaemonSet: interpret status test"
 description: "Test interpreting status for DaemonSet"
@@ -50,5 +56,279 @@ observedObj:
     numberReady: 1
     observedGeneration: 1
     updatedNumberScheduled: 1
+    numberUnavailable: 0 
 operation: InterpretStatus
 output:
+  status:
+    observedGeneration: 1
+    currentNumberScheduled: 1
+    numberMisscheduled: 0
+    desiredNumberScheduled: 1
+    numberReady: 1
+    updatedNumberScheduled: 1
+    numberAvailable: 1
+    numberUnavailable: 0
+    daemonSetHash: 7dd59cf749
+    generation: 1
+    resourceTemplateGeneration: 1
+
+---
+name: "DaemonSet: interpret status with empty status"
+description: "Test InterpretStatus returns empty result when observedObj.status is nil"
+observedObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: DaemonSet
+  metadata:
+    name: sample-nil
+    namespace: test-kruise-daemonset
+    generation: 1
+    annotations:
+      resourcetemplate.karmada.io/generation: "1"
+  spec:
+    selector:
+      matchLabels:
+        app: sample-daemonset
+    template:
+      metadata:
+        labels:
+          app: sample-daemonset
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+operation: InterpretStatus
+output:
+  status: {}
+
+---
+name: "DaemonSet: interpret status with missing metadata"
+description: "Test InterpretStatus returns status fields without generation when metadata is nil"
+observedObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: DaemonSet
+  spec:
+    selector:
+      matchLabels:
+        app: sample-daemonset
+    template:
+      metadata:
+        labels:
+          app: sample-daemonset
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+  status:
+    currentNumberScheduled: 3
+    daemonSetHash: abc123
+    desiredNumberScheduled: 3
+    numberAvailable: 2
+    numberMisscheduled: 0
+    numberReady: 3
+    observedGeneration: 5
+    updatedNumberScheduled: 3
+    numberUnavailable: 1
+operation: InterpretStatus
+output:
+  status:
+    observedGeneration: 5
+    currentNumberScheduled: 3
+    numberMisscheduled: 0
+    desiredNumberScheduled: 3
+    numberReady: 3
+    updatedNumberScheduled: 3
+    numberAvailable: 2
+    numberUnavailable: 1
+    daemonSetHash: abc123
+
+---
+name: "DaemonSet: interpret status with missing annotations"
+description: "Test InterpretStatus returns status with generation without resourceTemplateGeneration when annotations is nil"
+observedObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: DaemonSet
+  metadata:
+    name: sample
+    namespace: test-kruise-daemonset
+    generation: 7
+  spec:
+    selector:
+      matchLabels:
+        app: sample-daemonset
+    template:
+      metadata:
+        labels:
+          app: sample-daemonset
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+  status:
+    currentNumberScheduled: 5
+    daemonSetHash: xyz789
+    desiredNumberScheduled: 5
+    numberAvailable: 5
+    numberMisscheduled: 0
+    numberReady: 5
+    observedGeneration: 7
+    updatedNumberScheduled: 5
+    numberUnavailable: 0
+operation: InterpretStatus
+output:
+  status:
+    observedGeneration: 7
+    currentNumberScheduled: 5
+    numberMisscheduled: 0
+    desiredNumberScheduled: 5
+    numberReady: 5
+    updatedNumberScheduled: 5
+    numberAvailable: 5
+    numberUnavailable: 0
+    daemonSetHash: xyz789
+    generation: 7
+
+---
+name: "DaemonSet: interpret status with missing resourcetemplate annotation"
+description: "Test InterpretStatus when resourcetemplate.karmada.io/generation annotation is missing"
+observedObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: DaemonSet
+  metadata:
+    name: sample
+    namespace: test-kruise-daemonset
+    generation: 3
+    annotations:
+      some-other-annotation: "value"
+  spec:
+    selector:
+      matchLabels:
+        app: sample-daemonset
+    template:
+      metadata:
+        labels:
+          app: sample-daemonset
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+  status:
+    currentNumberScheduled: 2
+    daemonSetHash: def456
+    desiredNumberScheduled: 2
+    numberAvailable: 2
+    numberMisscheduled: 0
+    numberReady: 2
+    observedGeneration: 3
+    updatedNumberScheduled: 2
+    numberUnavailable: 0
+operation: InterpretStatus
+output:
+  status:
+    observedGeneration: 3
+    currentNumberScheduled: 2
+    numberMisscheduled: 0
+    desiredNumberScheduled: 2
+    numberReady: 2
+    updatedNumberScheduled: 2
+    numberAvailable: 2
+    numberUnavailable: 0
+    daemonSetHash: def456
+    generation: 3
+
+---
+name: "DaemonSet: interpret status with invalid resourceTemplateGeneration"
+description: "Test InterpretStatus when resourcetemplate.karmada.io/generation is not a valid number"
+observedObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: DaemonSet
+  metadata:
+    name: sample
+    namespace: test-kruise-daemonset
+    generation: 4
+    annotations:
+      resourcetemplate.karmada.io/generation: "not-a-number"
+  spec:
+    selector:
+      matchLabels:
+        app: sample-daemonset
+    template:
+      metadata:
+        labels:
+          app: sample-daemonset
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+  status:
+    currentNumberScheduled: 4
+    daemonSetHash: ghi789
+    desiredNumberScheduled: 4
+    numberAvailable: 4
+    numberMisscheduled: 0
+    numberReady: 4
+    observedGeneration: 4
+    updatedNumberScheduled: 4
+    numberUnavailable: 0
+operation: InterpretStatus
+output:
+  status:
+    observedGeneration: 4
+    currentNumberScheduled: 4
+    numberMisscheduled: 0
+    desiredNumberScheduled: 4
+    numberReady: 4
+    updatedNumberScheduled: 4
+    numberAvailable: 4
+    numberUnavailable: 0
+    daemonSetHash: ghi789
+    generation: 4
+
+---
+name: "DaemonSet: interpret status with high generation numbers"
+description: "Test InterpretStatus with large generation values"
+observedObj:
+  apiVersion: apps.kruise.io/v1alpha1
+  kind: DaemonSet
+  metadata:
+    name: sample
+    namespace: test-kruise-daemonset
+    generation: 999
+    annotations:
+      resourcetemplate.karmada.io/generation: "888"
+  spec:
+    selector:
+      matchLabels:
+        app: sample-daemonset
+    template:
+      metadata:
+        labels:
+          app: sample-daemonset
+      spec:
+        containers:
+          - name: nginx
+            image: nginx:alpine
+  status:
+    currentNumberScheduled: 10
+    daemonSetHash: jkl012
+    desiredNumberScheduled: 10
+    numberAvailable: 8
+    numberMisscheduled: 1
+    numberReady: 9
+    observedGeneration: 998
+    updatedNumberScheduled: 10
+    numberUnavailable: 2
+operation: InterpretStatus
+output:
+  status:
+    observedGeneration: 998
+    currentNumberScheduled: 10
+    numberMisscheduled: 1
+    desiredNumberScheduled: 10
+    numberReady: 9
+    updatedNumberScheduled: 10
+    numberAvailable: 8
+    numberUnavailable: 2
+    daemonSetHash: jkl012
+    generation: 999
+    resourceTemplateGeneration: 888
+


### PR DESCRIPTION
**What type of PR is this?**
Adds test cases for DaemonSet under third-party resource customizations, covering
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #6952 

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note

```

