### PR TITLE
verify namespace consistency in resource selectors for policies

### DIFF
--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -34,6 +34,7 @@ import (
 func TestValidateOverrideSpec(t *testing.T) {
 	var tests = []struct {
 		name         string
+		namespace    string
 		overrideSpec policyv1alpha1.OverrideSpec
 		expectError  bool
 	}{
@@ -237,7 +238,7 @@ func TestValidateOverrideSpec(t *testing.T) {
 
 	for _, test := range tests {
 		tc := test
-		err := ValidateOverrideSpec(&tc.overrideSpec)
+		err := ValidateOverrideSpec(&tc.overrideSpec, tc.namespace)
 		if err != nil && tc.expectError != true {
 			t.Fatalf("expect no error but got: %v", err)
 		}
@@ -307,6 +308,7 @@ func TestEmptyOverrides(t *testing.T) {
 func TestValidatePropagationSpec(t *testing.T) {
 	tests := []struct {
 		name        string
+		namespace   string
 		spec        policyv1alpha1.PropagationSpec
 		expectedErr string
 	}{
@@ -628,7 +630,7 @@ func TestValidatePropagationSpec(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errs := ValidatePropagationSpec(tt.spec)
+			errs := ValidatePropagationSpec(tt.spec, tt.namespace)
 			err := errs.ToAggregate()
 			if err != nil {
 				errStr := err.Error()

--- a/pkg/webhook/clusteroverridepolicy/validating.go
+++ b/pkg/webhook/clusteroverridepolicy/validating.go
@@ -46,7 +46,7 @@ func (v *ValidatingAdmission) Handle(_ context.Context, req admission.Request) a
 	}
 	klog.V(2).Infof("Validating ClusterOverridePolicy(%s) for request: %s", policy.Name, req.Operation)
 
-	if errs := validation.ValidateOverrideSpec(&policy.Spec); len(errs) != 0 {
+	if errs := validation.ValidateOverrideSpec(&policy.Spec, req.Namespace); len(errs) != 0 {
 		klog.Error(errs)
 		return admission.Denied(errs.ToAggregate().Error())
 	}

--- a/pkg/webhook/clusterpropagationpolicy/validating.go
+++ b/pkg/webhook/clusterpropagationpolicy/validating.go
@@ -72,7 +72,7 @@ func (v *ValidatingAdmission) Handle(_ context.Context, req admission.Request) a
 			policyv1alpha1.ClusterPropagationPolicyPermanentIDLabel))
 	}
 
-	errs := validation.ValidatePropagationSpec(policy.Spec)
+	errs := validation.ValidatePropagationSpec(policy.Spec, req.Namespace)
 	if len(errs) != 0 {
 		klog.Error(errs)
 		return admission.Denied(errs.ToAggregate().Error())

--- a/pkg/webhook/overridepolicy/validating.go
+++ b/pkg/webhook/overridepolicy/validating.go
@@ -46,7 +46,7 @@ func (v *ValidatingAdmission) Handle(_ context.Context, req admission.Request) a
 	}
 	klog.V(2).Infof("Validating OverridePolicy(%s/%s) for request: %s", policy.Namespace, policy.Name, req.Operation)
 
-	if errs := validation.ValidateOverrideSpec(&policy.Spec); len(errs) != 0 {
+	if errs := validation.ValidateOverrideSpec(&policy.Spec, req.Namespace); len(errs) != 0 {
 		klog.Error(errs)
 		return admission.Denied(errs.ToAggregate().Error())
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
As namespace-scoped resources, PropagationPolicy and OverridePolicy should only target resources within the same namespace. 
Therefore, when deploying the following policies:
```yaml
apiVersion: policy.karmada.io/v1alpha1
kind: PropagationPolicy
metadata:
  name: nginx
  namespace: test
spec:
  resourceSelectors:
    - apiVersion: apps/v1
      kind: Deployment
      namespace: test1
      name: nginx
```
The validation webhook shall reject its creation request.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-webhook`: Added `namespace` validation for `spec.resourceSelectors` in `PropagationPolicy` and `OverridePolicy` to prevent unintended cross-namespace resource selection.
```

