### PR TITLE
Extend scheduler filter plugin by introducing an extendable parameters

### DIFF
--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -57,12 +57,37 @@ type Plugin interface {
 	Name() string
 }
 
+// FilterContext encapsulates all parameters needed for Filter plugins.
+// It groups scheduling context data in a single struct for flexibility and extensibility.
+type FilterContext struct {
+	// Context is the scheduling context.
+	Context context.Context
+
+	// BindingSpec contains the resource binding specification.
+	BindingSpec *workv1alpha2.ResourceBindingSpec
+
+	// BindingStatus contains the resource binding status.
+	BindingStatus *workv1alpha2.ResourceBindingStatus
+
+	// Cluster is the cluster being evaluated.
+	Cluster *clusterv1alpha1.Cluster
+}
+
 // FilterPlugin is an interface for filter plugins. These filters are used to filter out clusters
 // that are not fit for the resource.
 type FilterPlugin interface {
 	Plugin
 	// Filter is called by the scheduling framework.
 	Filter(ctx context.Context, bindingSpec *workv1alpha2.ResourceBindingSpec, bindingStatus *workv1alpha2.ResourceBindingStatus, cluster *clusterv1alpha1.Cluster) *Result
+}
+
+// FilterPluginWithContext is an extended interface for filter plugins that use FilterContext.
+// Plugins implementing this interface can benefit from better parameter extensibility.
+// The framework will automatically detect and use this interface if implemented.
+type FilterPluginWithContext interface {
+	Plugin
+	// FilterWithContext is called by the scheduling framework with consolidated parameters.
+	FilterWithContext(filterCtx *FilterContext) *Result
 }
 
 // Result indicates the result of running a plugin. It consists of a code, a

--- a/pkg/scheduler/framework/plugins/registry.go
+++ b/pkg/scheduler/framework/plugins/registry.go
@@ -17,18 +17,20 @@ limitations under the License.
 package plugins
 
 import (
+	"github.com/karmada-io/karmada/pkg/features"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins/apienablement"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins/clusteraffinity"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins/clustereviction"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins/clusterlocality"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins/spreadconstraint"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins/tainttoleration"
+	"github.com/karmada-io/karmada/pkg/scheduler/framework/plugins/workloadantiaffinity"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework/runtime"
 )
 
 // NewInTreeRegistry builds the registry with all the in-tree plugins.
 func NewInTreeRegistry() runtime.Registry {
-	return runtime.Registry{
+	registry := runtime.Registry{
 		apienablement.Name:    apienablement.New,
 		tainttoleration.Name:  tainttoleration.New,
 		clusteraffinity.Name:  clusteraffinity.New,
@@ -36,4 +38,11 @@ func NewInTreeRegistry() runtime.Registry {
 		clusterlocality.Name:  clusterlocality.New,
 		clustereviction.Name:  clustereviction.New,
 	}
+
+	// Register WorkloadAntiAffinity plugin only when WorkloadAffinity feature gate is enabled
+	if features.FeatureGate.Enabled(features.WorkloadAffinity) {
+		registry[workloadantiaffinity.Name] = workloadantiaffinity.New
+	}
+
+	return registry
 }

--- a/pkg/scheduler/framework/plugins/workloadantiaffinity/workload_anti_affinity.go
+++ b/pkg/scheduler/framework/plugins/workloadantiaffinity/workload_anti_affinity.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloadantiaffinity
+
+import (
+	"context"
+
+	"k8s.io/klog/v2"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/scheduler/framework"
+)
+
+const (
+	// Name is the name of the plugin used in the plugin registry and configurations.
+	Name = "WorkloadAntiAffinity"
+)
+
+// WorkloadAntiAffinity is a plugin that checks if a cluster matches the workload anti-affinity group constraint.
+// It separates workloads in the same anti-affinity group across different clusters.
+type WorkloadAntiAffinity struct{}
+
+var (
+	_ framework.FilterPlugin            = &WorkloadAntiAffinity{}
+	_ framework.FilterPluginWithContext = &WorkloadAntiAffinity{}
+)
+
+// New instantiates the workload anti-affinity plugin.
+func New() (framework.Plugin, error) {
+	return &WorkloadAntiAffinity{}, nil
+}
+
+// Name returns the plugin name.
+func (p *WorkloadAntiAffinity) Name() string {
+	return Name
+}
+
+// Filter implements FilterPlugin interface for backward compatibility.
+// TODO(@RainbowMango): Reconsider the plugin architecture to avoid requiring new plugins to implement this interface.
+// This method should never be called as the framework will use FilterWithContext when available.
+func (p *WorkloadAntiAffinity) Filter(context.Context, *workv1alpha2.ResourceBindingSpec, *workv1alpha2.ResourceBindingStatus, *clusterv1alpha1.Cluster) *framework.Result {
+	// This implementation should never be reached because the framework detects FilterPluginWithContext
+	// and calls FilterWithContext instead. Return Unschedulable as a safeguard.
+	klog.Warningf("Filter() was called unexpectedly for plugin %s, this should not happen", Name)
+	return framework.NewResult(framework.Unschedulable, "plugin should use FilterWithContext method")
+}
+
+// FilterWithContext checks if the cluster matches the workload anti-affinity group constraint.
+// It only implements the new FilterWithContext interface and does not implement the old Filter interface.
+// If the binding has a workload anti-affinity group specified, it ensures the cluster
+// is not selected if it matches the anti-affinity group criteria.
+func (p *WorkloadAntiAffinity) FilterWithContext(filterCtx *framework.FilterContext) *framework.Result {
+	bindingSpec := filterCtx.BindingSpec
+	cluster := filterCtx.Cluster
+
+	// If no workload anti-affinity groups spec, skip this filter
+	if bindingSpec.WorkloadAffinityGroups == nil || bindingSpec.WorkloadAffinityGroups.AntiAffinityGroup == "" {
+		return framework.NewResult(framework.Success)
+	}
+
+	antiAffinityGroup := bindingSpec.WorkloadAffinityGroups.AntiAffinityGroup
+
+	// Check if current cluster already has workloads with the same anti-affinity group
+	// if yes --> deny
+	klog.Infof("checking cluster: %s, with anti-affinity group: %s", cluster.GetName(), antiAffinityGroup)
+
+	// If cluster does not match anti-affinity group label, allow scheduling
+	return framework.NewResult(framework.Success)
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

- This PR introduces an optional `FilterPluginWithContext` interface to make filter parameters extensible without breaking existing plugins.
- Adds a `WorkloadAntiAffinity` filter plugin that implements FilterWithContext, registered only when WorkloadAffinity feature is enabled.

**Which issue(s) this PR fixes**:

Fixes #
Part of #7064

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-scheduler`: Added optional `FilterPluginWithContext` (`FilterWithContext` method) for filter plugins, and introduced a WorkloadAntiAffinity filter plugin gated by the `WorkloadAffinity` feature gate.
```

