### PR TITLE
fix: persist failover toleration timestamps across controller restarts

### DIFF
--- a/pkg/controllers/applicationfailover/crb_application_failover_controller.go
+++ b/pkg/controllers/applicationfailover/crb_application_failover_controller.go
@@ -148,7 +148,8 @@ func (c *CRBApplicationFailoverController) syncBinding(ctx context.Context, bind
 	c.workloadUnhealthyMap.deleteIrrelevantClusters(key, allClusters, others)
 
 	if err := persistUnhealthyTimestamps(ctx, c.Client, c.workloadUnhealthyMap, key, binding); err != nil {
-		klog.V(4).InfoS("Failed to persist unhealthy timestamps", "binding", klog.KObj(binding), "err", err)
+		klog.ErrorS(err, "Failed to persist unhealthy timestamps", "binding", klog.KObj(binding))
+		return 0, err
 	}
 
 	return time.Duration(duration) * time.Second, nil

--- a/pkg/controllers/applicationfailover/rb_application_failover_controller.go
+++ b/pkg/controllers/applicationfailover/rb_application_failover_controller.go
@@ -148,7 +148,8 @@ func (c *RBApplicationFailoverController) syncBinding(ctx context.Context, bindi
 	c.workloadUnhealthyMap.deleteIrrelevantClusters(key, allClusters, others)
 
 	if err := persistUnhealthyTimestamps(ctx, c.Client, c.workloadUnhealthyMap, key, binding); err != nil {
-		klog.V(4).InfoS("Failed to persist unhealthy timestamps", "binding", klog.KObj(binding), "err", err)
+		klog.ErrorS(err, "Failed to persist unhealthy timestamps", "binding", klog.KObj(binding))
+		return 0, err
 	}
 
 	return time.Duration(duration) * time.Second, nil


### PR DESCRIPTION
### Summary

Fix application failover toleration timer being reset on controller restart.

The failover controllers relied on an in-memory map to track when a workload was first observed as unhealthy. On controller restarts (leader election switch, pod restart, rolling upgrade), this state was lost and the toleration timer restarted from zero, leading to unexpected failover delays in HA environments.

---

### Problem

The application failover controllers record unhealthy detection timestamps only in memory. When the controller restarts, this state is reinitialized and the original unhealthy start time cannot be recovered.

This causes the toleration timer to restart even if the workload has already been unhealthy for most of the configured toleration period. With frequent restarts, failover may be delayed indefinitely without any visible error.

---

### Fix

Persist the first unhealthy detection timestamp per cluster as an annotation on the binding.

During reconciliation:
- Restore timestamps from the annotation when in-memory state is empty (e.g. after restart)
- Use the restored timestamps for failover detection instead of starting from `now`
- Persist updated timestamps back to the annotation only when changes occur

The in-memory map remains the hot path for normal reconciliation, while the annotation is used only to recover state across restarts.

---

### Impact

- Prevents silent reset of the failover toleration timer
- Ensures failover triggers within the configured toleration window
- Improves reliability in HA and production deployments
- No API or CRD changes
- Backward compatible with existing bindings

---

### Tests

- Manually tested application failover with controller-manager restart
- Verified toleration timer continues from the original unhealthy timestamp
- Verified backward compatibility when annotation is not present

