### PR TITLE
fix unrendered {{ ca_crt }} during upgrades

### DIFF
--- a/charts/karmada/templates/pre-upgrade-job.yaml
+++ b/charts/karmada/templates/pre-upgrade-job.yaml
@@ -85,8 +85,8 @@ spec:
           set -ex
           # Fetch certs from existing secret
           karmada_ca=$(kubectl get secret {{ $name }}-cert -n {{ $namespace }} -o jsonpath='{.data.server-ca\.crt}')
-          kubectl get configmap {{ $name }}-static-resources -n {{ $namespace }} -o yaml | sed -e "s/{{ print "{{ ca_crt }}" }}/${karmada_ca}/g" | kubectl apply -f -
-          kubectl get configmap {{ $name }}-crds-patches -n {{ $namespace }} -o yaml | sed -e "s/{{ print "{{ ca_crt }}" }}/${karmada_ca}/g" | kubectl apply -f -
+          kubectl get configmap {{ $name }}-static-resources -n {{ $namespace }} -o json | sed -e "s/{{ print "{{ ca_crt }}" }}/${karmada_ca}/g" | kubectl apply -f -
+          kubectl get configmap {{ $name }}-crds-patches -n {{ $namespace }} -o json | sed -e "s/{{ print "{{ ca_crt }}" }}/${karmada_ca}/g" | kubectl apply -f -
         resources:
           requests:
             cpu: 50m

--- a/examples/customresourceinterpreter/README.md
+++ b/examples/customresourceinterpreter/README.md
@@ -42,7 +42,7 @@ If all your clusters are `Push` type clusters, you can access the webhook servic
 Please run the following script to deploy `MetalLB`.
 
 ```bash
-kubectl --context="karmada-host" get configmap kube-proxy -n kube-system -o yaml | \
+kubectl --context="karmada-host" get configmap kube-proxy -n kube-system -o json | \
   sed -e "s/strictARP: false/strictARP: true/" | \
   kubectl --context="karmada-host" apply -n kube-system -f -
 

--- a/hack/post-run-e2e.sh
+++ b/hack/post-run-e2e.sh
@@ -36,7 +36,7 @@ kubectl --context="${HOST_CLUSTER_NAME}" delete -f "${REPO_ROOT}"/examples/custo
 # uninstall metallb
 kubectl --context="${HOST_CLUSTER_NAME}" --ignore-not-found=true delete -f https://raw.githubusercontent.com/metallb/metallb/v0.13.5/config/manifests/metallb-native.yaml
 
-kubectl --context="${HOST_CLUSTER_NAME}" get configmap kube-proxy -n kube-system -o yaml | \
+kubectl --context="${HOST_CLUSTER_NAME}" get configmap kube-proxy -n kube-system -o json | \
 sed -e "s/strictARP: true/strictARP: false/" | \
 kubectl --context="${HOST_CLUSTER_NAME}" apply -f - -n kube-system
 

--- a/hack/pre-run-e2e.sh
+++ b/hack/pre-run-e2e.sh
@@ -43,7 +43,7 @@ export KUBECONFIG="${MAIN_KUBECONFIG}"
 
 # Due to we are using kube-proxy in IPVS mode, we have to enable strict ARP mode.
 # refer to https://metallb.universe.tf/installation/#preparation
-kubectl --context="${HOST_CLUSTER_NAME}" get configmap kube-proxy -n kube-system -o yaml | \
+kubectl --context="${HOST_CLUSTER_NAME}" get configmap kube-proxy -n kube-system -o json | \
 sed -e "s/strictARP: false/strictARP: true/" | \
 kubectl --context="${HOST_CLUSTER_NAME}" apply -f - -n kube-system
 


### PR DESCRIPTION
To be honest, I didn't test the change, as I don't know if it's easy to rebuild the chart, so I am not completely sure if it will work. The sed result won't be a correct JSON, as the replaced string won't be quoted, but it will probably still be a correct YAML and will be accepted by kubectl --apply.
I am happy to write a test or something if you could tell me where.
Instead of using JSON, I could also just loosen the sed regexp to match any whitespace symbols.

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

after upgrade some of `{{ ca_crt }}` were unrendered in the static-resources configmap (`charts/karmada/templates/_karmada_apiservice.tpl`):

this is because `kubectl -o yaml` wraps long lines:
https://stackoverflow.com/questions/65996363/generating-yaml-output-using-kubectl-result-in-splits-line

using JSON instead of YAML looks safe for those `sed` calls.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-chart`: Fixed unrendered `{{ ca_crt }}` during upgrades.
```
