### PR TITLE
Backport: fix GracePeriodSeconds leakage in assessEvictionTasks

### DIFF
--- a/pkg/controllers/gracefuleviction/evictiontask.go
+++ b/pkg/controllers/gracefuleviction/evictiontask.go
@@ -39,6 +39,7 @@ func assessEvictionTasks(tasks []workv1alpha2.GracefulEvictionTask, now metav1.T
 	var keptTasks []workv1alpha2.GracefulEvictionTask
 	var evictedClusters []string
 
+	defaultTimeout := opt.timeout
 	for _, task := range tasks {
 		// set creation timestamp for new task
 		if task.CreationTimestamp.IsZero() {
@@ -47,6 +48,7 @@ func assessEvictionTasks(tasks []workv1alpha2.GracefulEvictionTask, now metav1.T
 			continue
 		}
 
+		opt.timeout = defaultTimeout
 		if task.GracePeriodSeconds != nil {
 			opt.timeout = time.Duration(*task.GracePeriodSeconds) * time.Second
 		}


### PR DESCRIPTION
**This is a backport of #7184 to the release-1.16 branch.**

The change fixes a bug where a per-task GracePeriodSeconds value could
leak into subsequent eviction tasks, causing premature or delayed evictions.

The fix resets the timeout to the global default at each iteration and
adds a regression test to prevent future regressions.

**Fixes part of** #7186

```release note
karmada-controller-manager: Fixed an issue where a per-task GracePeriodSeconds value could leak to subsequent graceful eviction tasks, causing premature or delayed evictions.
```
