### PR TITLE
Disable image provenance to maintain compatibility

### DIFF
--- a/hack/docker.sh
+++ b/hack/docker.sh
@@ -74,8 +74,12 @@ function build_local_image() {
 
   echo "Building image for ${platform}: ${image_name}"
   set -x
+  # Disable provenance to maintain compatibility. Docker v29.1.5 changed default behavior from v28.0.4.
+  # GitHub Action runner upgraded Docker version which caused provenance to be enabled by default.
+  # Disable this feature temporarily until the image registry supports it.
   docker build --build-arg BINARY="${target}" \
           ${DOCKER_BUILD_ARGS} \
+          --provenance=false \
           --tag "${image_name}" \
           --file "${REPO_ROOT}/cluster/images/Dockerfile" \
           "${REPO_ROOT}/_output/bin/${platform}"


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

This PR tries to solve the failing workflow that pushes images to SWR:
- master: https://github.com/karmada-io/karmada/actions/runs/21970645668/job/63479611585

```
370e401744c7: Pushed
ed26b42e639b: Pushed
error from registry: Invalid image, fail to parse 'manifest.json'
make: *** [Makefile:130: upload-images] Error 1
Error: Process completed with exit code 2.
```

GitHub Action Runner Version change:
- Before: 
  - 20260201.24.1
  - Included Software: https://github.com/actions/runner-images/blob/ubuntu22/20260201.24/images/ubuntu/Ubuntu2204-Readme.md
  - Docker Client Version: `28.0.4`
- After:
  - 20260209.31.1
  - Included Software: https://github.com/actions/runner-images/blob/ubuntu22/20260209.31/images/ubuntu/Ubuntu2204-Readme.md
  - Docker Client Version: `29.1.5`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
We need to backport this to the release branches; otherwise image will be blocked from pushing when releasing. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

