### PR TITLE
stop populating ClusterResourceBinding with WorkloadAffinity fields

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -21360,7 +21360,7 @@
           "$ref": "#/definitions/github.com~1karmada-io~1karmada~1pkg~1apis~1work~1v1alpha2.Suspension"
         },
         "workloadAffinityGroups": {
-          "description": "WorkloadAffinityGroups represents instantiated grouping results from .spec.placement.workloadAffinity, used to keep workloads with the same affinity group co-located or those with the same anti-affinity group separated across clusters. Populated by controllers, the scheduler consumes it for decisions.",
+          "description": "WorkloadAffinityGroups represents instantiated grouping results from .spec.placement.workloadAffinity, used to keep workloads with the same affinity group co-located or those with the same anti-affinity group separated across clusters. Populated by controllers, the scheduler consumes it for decisions. Note: Since workloads are namespace-scoped resources, workload affinity only applies to ResourceBinding. Therefore, the WorkloadAffinityGroups field in ClusterResourceBinding will not be set and will not be consumed by the scheduler.",
           "$ref": "#/definitions/github.com~1karmada-io~1karmada~1pkg~1apis~1work~1v1alpha2.WorkloadAffinityGroups"
         }
       }

--- a/charts/karmada/_crds/bases/work/work.karmada.io_clusterresourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work/work.karmada.io_clusterresourcebindings.yaml
@@ -1660,6 +1660,9 @@ spec:
                   used to keep workloads with the same affinity group co-located or those with the same
                   anti-affinity group separated across clusters. Populated by controllers, the scheduler
                   consumes it for decisions.
+                  Note: Since workloads are namespace-scoped resources, workload affinity only applies to
+                  ResourceBinding. Therefore, the WorkloadAffinityGroups field in ClusterResourceBinding
+                  will not be set and will not be consumed by the scheduler.
                 properties:
                   affinityGroup:
                     description: AffinityGroup is the instantiated group name derived

--- a/charts/karmada/_crds/bases/work/work.karmada.io_resourcebindings.yaml
+++ b/charts/karmada/_crds/bases/work/work.karmada.io_resourcebindings.yaml
@@ -1660,6 +1660,9 @@ spec:
                   used to keep workloads with the same affinity group co-located or those with the same
                   anti-affinity group separated across clusters. Populated by controllers, the scheduler
                   consumes it for decisions.
+                  Note: Since workloads are namespace-scoped resources, workload affinity only applies to
+                  ResourceBinding. Therefore, the WorkloadAffinityGroups field in ClusterResourceBinding
+                  will not be set and will not be consumed by the scheduler.
                 properties:
                   affinityGroup:
                     description: AffinityGroup is the instantiated group name derived

--- a/pkg/apis/work/v1alpha2/binding_types.go
+++ b/pkg/apis/work/v1alpha2/binding_types.go
@@ -179,6 +179,9 @@ type ResourceBindingSpec struct {
 	// used to keep workloads with the same affinity group co-located or those with the same
 	// anti-affinity group separated across clusters. Populated by controllers, the scheduler
 	// consumes it for decisions.
+	// Note: Since workloads are namespace-scoped resources, workload affinity only applies to
+	// ResourceBinding. Therefore, the WorkloadAffinityGroups field in ClusterResourceBinding
+	// will not be set and will not be consumed by the scheduler.
 	// +optional
 	WorkloadAffinityGroups *WorkloadAffinityGroups `json:"workloadAffinityGroups,omitempty"`
 }

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -647,7 +647,6 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 				bindingCopy.Spec.ConflictResolution = binding.Spec.ConflictResolution
 				bindingCopy.Spec.PreserveResourcesOnDeletion = binding.Spec.PreserveResourcesOnDeletion
 				bindingCopy.Spec.Suspension = util.MergePolicySuspension(bindingCopy.Spec.Suspension, policy.Spec.Suspension)
-				bindingCopy.Spec.WorkloadAffinityGroups = binding.Spec.WorkloadAffinityGroups
 				return nil
 			})
 			return err
@@ -925,11 +924,6 @@ func (d *ResourceDetector) BuildClusterResourceBinding(object *unstructured.Unst
 			},
 		},
 	}
-
-	if features.FeatureGate.Enabled(features.WorkloadAffinity) {
-		binding.Spec.WorkloadAffinityGroups = getWorkloadAffinityGroups(object, policySpec, policyID)
-	}
-
 	if policySpec.Suspension != nil {
 		binding.Spec.Suspension = &workv1alpha2.Suspension{Suspension: *policySpec.Suspension}
 	}

--- a/pkg/detector/detector_test.go
+++ b/pkg/detector/detector_test.go
@@ -1187,7 +1187,6 @@ func TestApplyClusterPolicy(t *testing.T) {
 					}, binding)
 					assert.NoError(t, err)
 					assert.Equal(t, tt.object.GetName(), binding.Spec.Resource.Name)
-					verifyWorkloadAffinity(t, tt.object, &tt.policy.Spec, &binding.Spec)
 				}
 			}
 		})

--- a/pkg/generated/applyconfigurations/work/v1alpha2/resourcebindingspec.go
+++ b/pkg/generated/applyconfigurations/work/v1alpha2/resourcebindingspec.go
@@ -104,6 +104,9 @@ type ResourceBindingSpecApplyConfiguration struct {
 	// used to keep workloads with the same affinity group co-located or those with the same
 	// anti-affinity group separated across clusters. Populated by controllers, the scheduler
 	// consumes it for decisions.
+	// Note: Since workloads are namespace-scoped resources, workload affinity only applies to
+	// ResourceBinding. Therefore, the WorkloadAffinityGroups field in ClusterResourceBinding
+	// will not be set and will not be consumed by the scheduler.
 	WorkloadAffinityGroups *WorkloadAffinityGroupsApplyConfiguration `json:"workloadAffinityGroups,omitempty"`
 }
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -7955,7 +7955,7 @@ func schema_pkg_apis_work_v1alpha2_ResourceBindingSpec(ref common.ReferenceCallb
 					},
 					"workloadAffinityGroups": {
 						SchemaProps: spec.SchemaProps{
-							Description: "WorkloadAffinityGroups represents instantiated grouping results from .spec.placement.workloadAffinity, used to keep workloads with the same affinity group co-located or those with the same anti-affinity group separated across clusters. Populated by controllers, the scheduler consumes it for decisions.",
+							Description: "WorkloadAffinityGroups represents instantiated grouping results from .spec.placement.workloadAffinity, used to keep workloads with the same affinity group co-located or those with the same anti-affinity group separated across clusters. Populated by controllers, the scheduler consumes it for decisions. Note: Since workloads are namespace-scoped resources, workload affinity only applies to ResourceBinding. Therefore, the WorkloadAffinityGroups field in ClusterResourceBinding will not be set and will not be consumed by the scheduler.",
 							Ref:         ref("github.com/karmada-io/karmada/pkg/apis/work/v1alpha2.WorkloadAffinityGroups"),
 						},
 					},

--- a/pkg/scheduler/framework/testing/mock_interface.go
+++ b/pkg/scheduler/framework/testing/mock_interface.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
+	cache "k8s.io/client-go/tools/cache"
 
 	v1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	v1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
@@ -44,17 +45,17 @@ func (m *MockFramework) EXPECT() *MockFrameworkMockRecorder {
 }
 
 // RunFilterPlugins mocks base method.
-func (m *MockFramework) RunFilterPlugins(ctx context.Context, bindingSpec *v1alpha2.ResourceBindingSpec, bindingStatus *v1alpha2.ResourceBindingStatus, cluster *v1alpha1.Cluster) *framework.Result {
+func (m *MockFramework) RunFilterPlugins(ctx context.Context, bindingSpec *v1alpha2.ResourceBindingSpec, bindingStatus *v1alpha2.ResourceBindingStatus, cluster *v1alpha1.Cluster, resourceBindingIndexer cache.Indexer) *framework.Result {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunFilterPlugins", ctx, bindingSpec, bindingStatus, cluster)
+	ret := m.ctrl.Call(m, "RunFilterPlugins", ctx, bindingSpec, bindingStatus, cluster, resourceBindingIndexer)
 	ret0, _ := ret[0].(*framework.Result)
 	return ret0
 }
 
 // RunFilterPlugins indicates an expected call of RunFilterPlugins.
-func (mr *MockFrameworkMockRecorder) RunFilterPlugins(ctx, bindingSpec, bindingStatus, cluster any) *gomock.Call {
+func (mr *MockFrameworkMockRecorder) RunFilterPlugins(ctx, bindingSpec, bindingStatus, cluster, resourceBindingIndexer any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunFilterPlugins", reflect.TypeOf((*MockFramework)(nil).RunFilterPlugins), ctx, bindingSpec, bindingStatus, cluster)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunFilterPlugins", reflect.TypeOf((*MockFramework)(nil).RunFilterPlugins), ctx, bindingSpec, bindingStatus, cluster, resourceBindingIndexer)
 }
 
 // RunScorePlugins mocks base method.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
stop populating ClusterResourceBinding with WorkloadAffinity fields

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note

```

