### PR TITLE
Fix timeout leakage across graceful eviction tasks

### DIFF
--- a/pkg/controllers/gracefuleviction/evictiontask.go
+++ b/pkg/controllers/gracefuleviction/evictiontask.go
@@ -39,6 +39,7 @@ func assessEvictionTasks(tasks []workv1alpha2.GracefulEvictionTask, now metav1.T
 	var keptTasks []workv1alpha2.GracefulEvictionTask
 	var evictedClusters []string
 
+	defaultTimeout := opt.timeout
 	for _, task := range tasks {
 		// set creation timestamp for new task
 		if task.CreationTimestamp.IsZero() {
@@ -47,6 +48,7 @@ func assessEvictionTasks(tasks []workv1alpha2.GracefulEvictionTask, now metav1.T
 			continue
 		}
 
+		opt.timeout = defaultTimeout
 		if task.GracePeriodSeconds != nil {
 			opt.timeout = time.Duration(*task.GracePeriodSeconds) * time.Second
 		}


### PR DESCRIPTION
**This PR backports the fix from #7184 to the release-1.15 branch.**

The change fixes an issue in assessEvictionTasks where a per-task GracePeriodSeconds value could leak into subsequent eviction tasks. When tasks with and without a custom grace period were processed together, later tasks could incorrectly inherit the previous task’s timeout, leading to premature or delayed evictions.

The fix resets the eviction timeout to the global default at the start of each loop iteration and applies the per-task override only when explicitly specified. A regression test is included to ensure mixed tasks behave correctly and to prevent future regressions.

**Fixes part of** #7186.

```release note
karmada-controller-manager: Fixed an issue where a per-task GracePeriodSeconds value could leak to subsequent graceful eviction tasks, causing premature or delayed evictions.
```
