### PR TITLE
Fix duplicate words and formatting

### DIFF
--- a/docs/proposals/hpa/cronfederatedhpa.md
+++ b/docs/proposals/hpa/cronfederatedhpa.md
@@ -27,7 +27,7 @@ A good summary is probably at least a paragraph in length.
 
 For some certain predictable load change scenarios, for example Black Friday sale and Singles' Day sale, there will be sharp load peaks. With standard K8s HPA, it needs time to scale up the replicas, which may not be fast enough to handle sharp load peaks, resulting in service unavailability.
 
-To solve this problem, there are already some approaches in single cluster, called `CronHPA`, which can scale up/down the workloads at specific time. Cluster administrators can scale up the workloads in advance with `CronHPA`, to meet the requirements of the sharp load peaks. So this proposal proposes `CronFederatedHPA` to meet the the same requirements in multi-cluster scenario.
+To solve this problem, there are already some approaches in single cluster, called `CronHPA`, which can scale up/down the workloads at specific time. Cluster administrators can scale up the workloads in advance with `CronHPA`, to meet the requirements of the sharp load peaks. So this proposal proposes `CronFederatedHPA` to meet the same requirements in multi-cluster scenario.
 
 ## Motivation
 

--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_job.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_job.go
@@ -78,7 +78,7 @@ func RunCronFederatedHPARule(c *ScalingJob) {
 		if apierrors.IsNotFound(err) {
 			klog.InfoS("CronFederatedHPA not found", "cronFederatedHPA", c.namespaceName)
 		} else {
-			// TODO: This may happen when the the network is down, we should do something here
+			// TODO: This may happen when the network is down, we should do something here
 			// But we are not sure what to do(retry not solve the problem)
 			klog.ErrorS(err, "Get CronFederatedHPA failed", "cronFederatedHPA", c.namespaceName)
 		}

--- a/pkg/karmadactl/unregister/unregister.go
+++ b/pkg/karmadactl/unregister/unregister.go
@@ -339,7 +339,7 @@ func (j *CommandUnregisterOption) RunUnregisterCluster() error {
 	j.Wait = j.Wait - time.Since(start)
 
 	// 2. delete the cluster object from the Karmada control plane
-	//TODO: add flag --force to implement force deletion.
+	// TODO: add flag --force to implement force deletion.
 	if err = cmdutil.DeleteClusterObject(j.ControlPlaneKubeClient, j.ControlPlaneClient, j.ClusterName, j.Wait, j.DryRun, false); err != nil {
 		klog.Errorf("Failed to delete cluster object. cluster name: %s, error: %v", j.ClusterName, err)
 		return err

--- a/pkg/karmadactl/util/completion/completion.go
+++ b/pkg/karmadactl/util/completion/completion.go
@@ -256,7 +256,7 @@ func compGetResourceList(restClientGetter genericclioptions.RESTClientGetter, cm
 	o.PrintFlags.OutputFormat = ptr.To("name")
 	o.Cached = true
 	o.Verbs = []string{"get"}
-	// TODO:Should set --request-timeout=5s
+	// TODO: Should set --request-timeout=5s
 
 	if err := o.Complete(restClientGetter, cmd, nil); err != nil {
 		return nil

--- a/pkg/modeling/modeling.go
+++ b/pkg/modeling/modeling.go
@@ -59,7 +59,7 @@ type resourceModels struct {
 
 // ClusterResourceNode represents the each raw resource entity without modeling.
 type ClusterResourceNode struct {
-	// quantity is the the number of this node
+	// quantity is the number of this node
 	// Only when the resourceLists are exactly the same can they be counted as the same node.
 	// +required
 	quantity int


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR performs cleanup across the codebase to improve readability and maintain consistency with Go comment conventions.

Changes include:

- fixes duplicate words in comments (e.g., "the the")
- improves TODO formatting (`//TODO:` → `// TODO:`)
- small comment wording improvements


**Which issue(s) this PR fixes**:

Fixes #7198 

**Special notes for your reviewer**:

- only comment and formatting updates are included.
- no logic changes were made.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

