### PR TITLE
fix: recompute FullyApplied condition inside retry loop to prevent st…

### DIFF
--- a/pkg/util/helper/workstatus.go
+++ b/pkg/util/helper/workstatus.go
@@ -71,13 +71,13 @@ func AggregateResourceBindingWorkStatus(
 		return err
 	}
 
-	fullyAppliedCondition := generateFullyAppliedCondition(binding.Spec, aggregatedStatuses)
-
 	var operationResult controllerutil.OperationResult
 	if err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		operationResult, err = UpdateStatus(ctx, c, binding, func() error {
 			binding.Status.AggregatedStatus = aggregatedStatuses
-			// set binding status with the newest condition
+			// set binding status with the newest condition, recompute using the
+			// refreshed binding.Spec to reflect any concurrent spec.clusters changes
+			fullyAppliedCondition := generateFullyAppliedCondition(binding.Spec, aggregatedStatuses)
 			meta.SetStatusCondition(&binding.Status.Conditions, fullyAppliedCondition)
 			return nil
 		})
@@ -114,13 +114,13 @@ func AggregateClusterResourceBindingWorkStatus(
 		return err
 	}
 
-	fullyAppliedCondition := generateFullyAppliedCondition(binding.Spec, aggregatedStatuses)
-
 	var operationResult controllerutil.OperationResult
 	if err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		operationResult, err = UpdateStatus(ctx, c, binding, func() error {
 			binding.Status.AggregatedStatus = aggregatedStatuses
-			// set binding status with the newest condition
+			// set binding status with the newest condition, recompute using the
+			// refreshed binding.Spec to reflect any concurrent spec.clusters changes
+			fullyAppliedCondition := generateFullyAppliedCondition(binding.Spec, aggregatedStatuses)
 			meta.SetStatusCondition(&binding.Status.Conditions, fullyAppliedCondition)
 			return nil
 		})


### PR DESCRIPTION
Fix stale FullyApplied condition during concurrent rescheduling

**What type of PR is this?**

/kind bug

---

**What this PR does / why we need it**:

This PR fixes a status inconsistency where the `FullyApplied` condition could be incorrectly set to `True` during concurrent rescheduling.

In `AggregateResourceBindingWorkStatus` and `AggregateClusterResourceBindingWorkStatus`, the
`generateFullyAppliedCondition()` result was previously computed *outside* the
`retry.RetryOnConflict` → `UpdateStatus()` mutation closure.

Since `UpdateStatus()` internally re-fetches the latest binding before applying the mutation,
a concurrent scheduler update to `spec.clusters` could cause the condition to be evaluated
using a stale cluster list, while the status update was applied to a newer binding.

This could result in `FullyApplied=True` being written even though newly scheduled clusters
had not finished applying.

The fix moves the condition generation **inside** the mutation closure so it always evaluates
against the freshly re-fetched `binding.Spec`, ensuring correctness under concurrent updates.

---

**Special notes for your reviewer**:

- The change is minimal and localized to status update logic
- No behavior change outside concurrent rescheduling scenarios
- Existing tests pass; no unrelated files are touched


**Release-note**:
```NONE```


