### PR TITLE
fix: handle NotFound in cleanupPolicyClaimMetadata to unblock Work de…

### DIFF
--- a/pkg/controllers/execution/execution_controller.go
+++ b/pkg/controllers/execution/execution_controller.go
@@ -204,6 +204,9 @@ func (c *Controller) cleanupPolicyClaimMetadata(ctx context.Context, work *workv
 
 		clusterObj, err := helper.GetObjectFromCache(c.RESTMapper, c.InformerManager, fedKey)
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
 			klog.ErrorS(err, "Failed to get the resource from member cluster cache", "kind", workload.GetKind(), "namespace", workload.GetNamespace(), "name", workload.GetName(), "cluster", cluster.Name)
 			return err
 		}


### PR DESCRIPTION

When PreserveResourcesOnDeletion is true and the member-cluster resource is already gone, GetObjectFromCache returns NotFound. Without handling this case, the Work finalizer is never removed and the Work stays in Terminating state forever. This PR skips the manifest with continue, matching the behavior in ObjectWatcher.Delete.

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes a deletion deadlock in the execution controller.

When a Work with spec.preserveResourcesOnDeletion: true is being deleted, the controller attempts to clean up Karmada-managed metadata from the member-cluster resource.

If the resource has already been deleted on the member cluster (for example, manual deletion or external cleanup), GetObjectFromCache returns a NotFound error. Previously, this error was returned directly, which prevented the Work finalizer from being removed. As a result, the Work remained stuck in Terminating state permanently.

This change adds a NotFound guard and skips that manifest. Since the resource does not exist, there is nothing to clean up.

The behavior now matches ObjectWatcher.Delete, which already treats NotFound as a no-op.

---

Manual verification steps:

1. Create a PropagationPolicy with preserveResourcesOnDeletion: true
2. Deploy a resource through Karmada
3. Manually delete the resource on the member cluster
4. Delete the resource or policy from the control plane

---

Before this fix:
- Work stays in Terminating forever

After this fix:
- Work finalizer is removed correctly
- Work deletion completes successfully

All existing tests pass. No other behavior is changed.

---

```release-note
karmada-controller-manager: Fixed an issue where Work objects with PreserveResourcesOnDeletion enabled could remain stuck in Terminating state if the member-cluster resource was already deleted.
