### PR TITLE
Fix CronFederatedHPA scale-up from zero when replicas field is missing

### DIFF
--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_job.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_job.go
@@ -203,7 +203,7 @@ func (c *ScalingJob) ScaleWorkloads(cronFHPA *autoscalingv1alpha1.CronFederatedH
 	}
 
 	if scale.Spec.Replicas != *c.rule.TargetReplicas {
-		if err := helper.ApplyReplica(scaleObj, int64(*c.rule.TargetReplicas), util.ReplicasField); err != nil {
+		if err := helper.ApplyReplicaAlways(scaleObj, int64(*c.rule.TargetReplicas), util.ReplicasField); err != nil {
 			klog.ErrorS(err, "CronFederatedHPA applies Replicas failed", "cronFederatedHPA", c.namespaceName, "namespace", cronFHPA.Namespace, "name", cronFHPA.Spec.ScaleTargetRef.Name)
 			return err
 		}

--- a/pkg/util/helper/unstructured.go
+++ b/pkg/util/helper/unstructured.go
@@ -56,6 +56,17 @@ func ApplyReplica(workload *unstructured.Unstructured, desireReplica int64, fiel
 	return nil
 }
 
+// ApplyReplicaAlways unconditionally applies the Replica value for the specific field.
+// Unlike ApplyReplica, this function sets the field regardless of whether it exists or not.
+// This is useful for scenarios like scaling from zero where the replicas field may be missing.
+func ApplyReplicaAlways(workload *unstructured.Unstructured, desireReplica int64, field string) error {
+	_, _, err := unstructured.NestedInt64(workload.Object, util.SpecField, field)
+	if err != nil {
+		return err
+	}
+	return unstructured.SetNestedField(workload.Object, desireReplica, util.SpecField, field)
+}
+
 // ToUnstructured converts a typed object to an unstructured object.
 func ToUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
 	uncastObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)


### PR DESCRIPTION
Backport of #7183 to release-1.16.

When spec.replicas is 0, the Scale object's spec field is empty,
causing CronFederatedHPA to skip updating replicas using ApplyReplica.

This commit introduces ApplyReplicaAlways to unconditionally set the
replicas field, enabling CronFederatedHPA to scale workloads from zero.

Signed-off-by: zhengjr9 <zhengjr990121@gmail.com>

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-controller-manager`: Fixed CronFederatedHPA scale-up from zero failure when the replicas field is missing.
```