### PR TITLE
refactors the scheduler framework to improve extensibility

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -142,7 +142,15 @@ func (g *genericScheduler) findClustersThatFit(
 			continue
 		}
 
-		if result := g.scheduleFramework.RunFilterPlugins(ctx, bindingSpec, bindingStatus, c.Cluster(), resourceBindingIndexer); !result.IsSuccess() {
+		filterCtx := &framework.FilterContext{
+			Context:                ctx,
+			BindingSpec:            bindingSpec,
+			BindingStatus:          bindingStatus,
+			Cluster:                c.Cluster(),
+			ResourceBindingIndexer: resourceBindingIndexer,
+		}
+
+		if result := g.scheduleFramework.RunFilterPlugins(filterCtx); !result.IsSuccess() {
 			klog.V(4).Infof("Cluster %q is not fit, reason: %v", c.Cluster().Name, result.AsError())
 			diagnosis.ClusterToResultMap[c.Cluster().Name] = result
 		} else {

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -47,8 +47,7 @@ const (
 type Framework interface {
 
 	// RunFilterPlugins runs the set of configured Filter plugins for resources on the given cluster.
-	// TODO(@RainbowMango): refactor parameters to a struct for easier extension
-	RunFilterPlugins(ctx context.Context, bindingSpec *workv1alpha2.ResourceBindingSpec, bindingStatus *workv1alpha2.ResourceBindingStatus, cluster *clusterv1alpha1.Cluster, resourceBindingIndexer cache.Indexer) *Result
+	RunFilterPlugins(filterCtx *FilterContext) *Result
 
 	// RunScorePlugins runs the set of configured Score plugins, it returns a map of plugin names to scores
 	RunScorePlugins(ctx context.Context, spec *workv1alpha2.ResourceBindingSpec, clusters []*clusterv1alpha1.Cluster) (PluginToClusterScores, *Result)

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -88,7 +88,7 @@ func Test_frameworkImpl_RunFilterPlugins(t *testing.T) {
 				t.Errorf("create frame work error:%v", err)
 			}
 
-			result := frameWork.RunFilterPlugins(ctx, nil, nil, nil, nil)
+			result := frameWork.RunFilterPlugins(&framework.FilterContext{Context: ctx})
 			if result.IsSuccess() != tt.isSuccess {
 				t.Errorf("want %v, but get:%v", tt.isSuccess, result.IsSuccess())
 			}

--- a/pkg/scheduler/framework/testing/mock_interface.go
+++ b/pkg/scheduler/framework/testing/mock_interface.go
@@ -14,7 +14,6 @@ import (
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
-	cache "k8s.io/client-go/tools/cache"
 
 	v1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	v1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
@@ -45,17 +44,17 @@ func (m *MockFramework) EXPECT() *MockFrameworkMockRecorder {
 }
 
 // RunFilterPlugins mocks base method.
-func (m *MockFramework) RunFilterPlugins(ctx context.Context, bindingSpec *v1alpha2.ResourceBindingSpec, bindingStatus *v1alpha2.ResourceBindingStatus, cluster *v1alpha1.Cluster, resourceBindingIndexer cache.Indexer) *framework.Result {
+func (m *MockFramework) RunFilterPlugins(filterCtx *framework.FilterContext) *framework.Result {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunFilterPlugins", ctx, bindingSpec, bindingStatus, cluster, resourceBindingIndexer)
+	ret := m.ctrl.Call(m, "RunFilterPlugins", filterCtx)
 	ret0, _ := ret[0].(*framework.Result)
 	return ret0
 }
 
 // RunFilterPlugins indicates an expected call of RunFilterPlugins.
-func (mr *MockFrameworkMockRecorder) RunFilterPlugins(ctx, bindingSpec, bindingStatus, cluster, resourceBindingIndexer any) *gomock.Call {
+func (mr *MockFrameworkMockRecorder) RunFilterPlugins(filterCtx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunFilterPlugins", reflect.TypeOf((*MockFramework)(nil).RunFilterPlugins), ctx, bindingSpec, bindingStatus, cluster, resourceBindingIndexer)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunFilterPlugins", reflect.TypeOf((*MockFramework)(nil).RunFilterPlugins), filterCtx)
 }
 
 // RunScorePlugins mocks base method.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This pull request refactors the scheduler framework to improve extensibility and code clarity. The main change is replacing multiple parameters in the `RunFilterPlugins` method with a single `FilterContext` struct, simplifying function signatures and making future extensions easier.

**Which issue(s) this PR fixes**:
Part of #7064

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

