### PR TITLE
introduces assigning binding list to avoid cache delay

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -17,13 +17,20 @@ limitations under the License.
 package cache
 
 import (
+	"maps"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	clusterlister "github.com/karmada-io/karmada/pkg/generated/listers/cluster/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/scheduler/framework"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 // Cache is an interface for scheduler internal cache.
@@ -36,18 +43,33 @@ type Cache interface {
 
 	// ResourceBindingIndexer returns the indexer for ResourceBindings, used for advanced scheduling logic.
 	ResourceBindingIndexer() cache.Indexer
+
+	// AssigningResourceBindings returns a cache for ResourceBindings that are in the "assigning" state.
+	// After the control plane generates scheduling results and commits them to the API server,
+	// there is a period before these results are fully propagated to and reflected in the member clusters.
+	// This cache stores these "assigning" bindings to provide the scheduler with a more accurate and
+	// immediate view of the intended state, enabling more precise decision-making during subsequent scheduling cycles.
+	AssigningResourceBindings() *AssigningResourceBindingCache
 }
 
 type schedulerCache struct {
 	clusterLister          clusterlister.ClusterLister
 	resourceBindingIndexer cache.Indexer
+
+	assigningResourceBindings *AssigningResourceBindingCache
 }
+
+// Check if our schedulerCache implements necessary interface
+var _ Cache = &schedulerCache{}
 
 // NewCache instantiates a cache used only by scheduler.
 func NewCache(clusterLister clusterlister.ClusterLister, resourceBindingIndexer cache.Indexer) Cache {
 	return &schedulerCache{
 		clusterLister:          clusterLister,
 		resourceBindingIndexer: resourceBindingIndexer,
+		assigningResourceBindings: &AssigningResourceBindingCache{
+			items: make(map[string]*workv1alpha2.ResourceBinding),
+		},
 	}
 }
 
@@ -82,6 +104,79 @@ func (c *schedulerCache) Snapshot() Snapshot {
 	return out
 }
 
+// ResourceBindingIndexer returns the indexer for ResourceBindings.
 func (c *schedulerCache) ResourceBindingIndexer() cache.Indexer {
 	return c.resourceBindingIndexer
+}
+
+// AssigningResourceBindings returns the cache of ResourceBindings that are in the "assigning" state.
+func (c *schedulerCache) AssigningResourceBindings() *AssigningResourceBindingCache {
+	return c.assigningResourceBindings
+}
+
+// AssigningResourceBindingCache acts as a temporary buffer for ResourceBindings that have new scheduling
+// decisions ("assigning" state) but are not yet fully reflected in the local Informer cache or member clusters.
+type AssigningResourceBindingCache struct {
+	sync.RWMutex
+	items map[string]*workv1alpha2.ResourceBinding
+}
+
+// OnBindingUpdate is called when an update event for a ResourceBinding is received from the Informer.
+// It removes the binding from this temporary cache if the Informer's version has caught up
+// to or surpassed the version we recorded, indicating that the scheduling decision is now
+// reflected in the Informer's state. This means the binding is no longer in the "assigning" state
+// from the cache's perspective.
+func (b *AssigningResourceBindingCache) OnBindingUpdate(binding *workv1alpha2.ResourceBinding) {
+	b.Lock()
+	defer b.Unlock()
+
+	ca, ok := b.items[names.NamespacedKey(binding.Namespace, binding.Name)]
+	if !ok {
+		return
+	}
+
+	compare, err := resourceversion.CompareResourceVersion(ca.GetResourceVersion(), binding.GetResourceVersion())
+	if err != nil {
+		// should not happen since Kubernetes generates the resource versions, but log just in case
+		klog.Errorf("Failed to compare resource versions for ResourceBinding %s/%s: %v", binding.Namespace, binding.Name, err)
+		return
+	}
+
+	if compare == 1 {
+		return
+	}
+
+	if meta.IsStatusConditionTrue(binding.Status.Conditions, workv1alpha2.FullyApplied) {
+		delete(b.items, names.NamespacedKey(binding.Namespace, binding.Name))
+		return
+	}
+
+	b.items[names.NamespacedKey(binding.Namespace, binding.Name)] = binding
+}
+
+// OnBindingDelete is called when a delete event for a ResourceBinding is received from the Informer.
+func (b *AssigningResourceBindingCache) OnBindingDelete(binding *workv1alpha2.ResourceBinding) {
+	b.Lock()
+	defer b.Unlock()
+
+	delete(b.items, names.NamespacedKey(binding.Namespace, binding.Name))
+}
+
+// Add records a ResourceBinding that has a new scheduling decision committed to the API server.
+// This binding is considered to be in an "assigning" state and will be served by the scheduler
+// as the intended state until its full reflection in the Informer cache and member clusters.
+func (b *AssigningResourceBindingCache) Add(binding *workv1alpha2.ResourceBinding) {
+	b.Lock()
+	defer b.Unlock()
+
+	b.items[names.NamespacedKey(binding.Namespace, binding.Name)] = binding
+}
+
+// GetBindings returns all currently cached ResourceBindings that are in the "assigning" state,
+// providing the scheduler with the most up-to-date view of pending assignments.
+func (b *AssigningResourceBindingCache) GetBindings() map[string]*workv1alpha2.ResourceBinding {
+	b.RLock()
+	defer b.RUnlock()
+
+	return maps.Clone(b.items)
 }

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -148,6 +148,7 @@ func (g *genericScheduler) findClustersThatFit(
 			BindingStatus:          bindingStatus,
 			Cluster:                c.Cluster(),
 			ResourceBindingIndexer: resourceBindingIndexer,
+			AssigningBindings:      g.schedulerCache.AssigningResourceBindings().GetBindings(),
 		}
 
 		if result := g.scheduleFramework.RunFilterPlugins(filterCtx); !result.IsSuccess() {

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -75,6 +75,9 @@ type FilterContext struct {
 
 	// ResourceBindingIndexer provides access to ResourceBindings for advanced scheduling logic.
 	ResourceBindingIndexer cache.Indexer
+
+	// AssigningBindings stores the ResourceBindings that are in the "assigning" state.
+	AssigningBindings map[string]*workv1alpha2.ResourceBinding
 }
 
 // FilterPlugin is an interface for filter plugins. These filters are used to filter out clusters

--- a/vendor/k8s.io/apimachinery/pkg/util/resourceversion/resourceversion.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/resourceversion/resourceversion.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceversion
+
+import (
+	"fmt"
+	"strings"
+)
+
+type InvalidResourceVersion struct {
+	rv string
+}
+
+func (i InvalidResourceVersion) Error() string {
+	return fmt.Sprintf("resource version is not well formed: %s", i.rv)
+}
+
+// CompareResourceVersion runs a comparison between two ResourceVersions. This
+// only has semantic meaning when the comparison is done on two objects of the
+// same resource. The return values are:
+//
+//	-1: If RV a < RV b
+//	 0: If RV a == RV b
+//	+1: If RV a > RV b
+//
+// The function will return an error if the resource version is not a properly
+// formatted positive integer, but has no restriction on length. A properly
+// formatted integer will not contain leading zeros or non integer characters.
+// Zero is also considered an invalid value as it is used as a special value in
+// list/watch events and will never be a live resource version.
+func CompareResourceVersion(a, b string) (int, error) {
+	if !isWellFormed(a) {
+		return 0, InvalidResourceVersion{rv: a}
+	}
+	if !isWellFormed(b) {
+		return 0, InvalidResourceVersion{rv: b}
+	}
+	// both are well-formed integer strings with no leading zeros
+	aLen := len(a)
+	bLen := len(b)
+	switch {
+	case aLen < bLen:
+		// shorter is less
+		return -1, nil
+	case aLen > bLen:
+		// longer is greater
+		return 1, nil
+	default:
+		// equal-length compares lexically
+		return strings.Compare(a, b), nil
+	}
+}
+
+func isWellFormed(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	if s[0] == '0' {
+		return false
+	}
+	for i := range s {
+		if !isDigit(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isDigit(b byte) bool {
+	return b >= '0' && b <= '9'
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1048,6 +1048,7 @@ k8s.io/apimachinery/pkg/util/portforward
 k8s.io/apimachinery/pkg/util/proxy
 k8s.io/apimachinery/pkg/util/rand
 k8s.io/apimachinery/pkg/util/remotecommand
+k8s.io/apimachinery/pkg/util/resourceversion
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/util/sort


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
This PR introduces a `BindingCache` within the `karmada-scheduler` to address a potential race condition and state inconsistency between successful API writes and Informer synchronization.

There is a non-negligible delay between when a ResourceBinding is successfully updated via the scheduler and when that update is reflected in the local Informer cache. If the scheduler processes subsequent ResourceBindings that depend on the state of the previously updated one during this synchronization window, it might make conflicting or incorrect decisions based on stale data.

The `BindingCache` acts as a temporary "source of truth" for committed but not yet synced ResourceBindings. It bridges this gap by providing the scheduler with immediate access to the most recently committed state, ensuring high consistency during rapid scheduling cycles.

**Which issue(s) this PR fixes**:
Part of #7064

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
`karmada-scheduler`: Improved scheduling consistency for workload affinity groups during rapid scheduling cycles by introducing a dedicated cache for recently committed ResourceBindings.
```