### PR TITLE
fix: recompute FullyApplied condition inside RetryOnConflict to avoid stale spec evaluation

### DIFF
--- a/pkg/util/helper/workstatus.go
+++ b/pkg/util/helper/workstatus.go
@@ -65,20 +65,17 @@ func AggregateResourceBindingWorkStatus(
 	if err != nil {
 		return err
 	}
-
 	aggregatedStatuses, err := assembleWorkStatus(workList.Items, binding.Spec.Resource)
 	if err != nil {
 		return err
 	}
-
-	fullyAppliedCondition := generateFullyAppliedCondition(binding.Spec, aggregatedStatuses)
 
 	var operationResult controllerutil.OperationResult
 	if err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		operationResult, err = UpdateStatus(ctx, c, binding, func() error {
 			binding.Status.AggregatedStatus = aggregatedStatuses
 			// set binding status with the newest condition
-			meta.SetStatusCondition(&binding.Status.Conditions, fullyAppliedCondition)
+			meta.SetStatusCondition(&binding.Status.Conditions, generateFullyAppliedCondition(binding.Spec, aggregatedStatuses))
 			return nil
 		})
 		return err
@@ -108,20 +105,17 @@ func AggregateClusterResourceBindingWorkStatus(
 	if err != nil {
 		return err
 	}
-
 	aggregatedStatuses, err := assembleWorkStatus(workList.Items, binding.Spec.Resource)
 	if err != nil {
 		return err
 	}
-
-	fullyAppliedCondition := generateFullyAppliedCondition(binding.Spec, aggregatedStatuses)
 
 	var operationResult controllerutil.OperationResult
 	if err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		operationResult, err = UpdateStatus(ctx, c, binding, func() error {
 			binding.Status.AggregatedStatus = aggregatedStatuses
 			// set binding status with the newest condition
-			meta.SetStatusCondition(&binding.Status.Conditions, fullyAppliedCondition)
+			meta.SetStatusCondition(&binding.Status.Conditions, generateFullyAppliedCondition(binding.Spec, aggregatedStatuses))
 			return nil
 		})
 		return err


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

This PR fixes an issue where the `FullyApplied` condition of a `ResourceBinding` (and `ClusterResourceBinding`) could be computed using a stale snapshot of `binding.Spec.Clusters`.

Previously, `generateFullyAppliedCondition()` was executed before entering the `RetryOnConflict` loop. However, `UpdateStatus()` re-fetches the binding from the API server on each retry. If the scheduler updates `Spec.Clusters` between the initial read and a retry (for example when a new cluster is added by a PropagationPolicy update), the retry would write a condition that was evaluated against the old cluster set.

This could temporarily report `FullyApplied=True` even though a newly added cluster had not yet received or applied its `Work`.

To avoid this inconsistency, the condition is now recomputed inside the mutation closure so it is always evaluated against the latest `binding.Spec` fetched during the retry.

---

**Special notes for your reviewer**:

The change is intentionally minimal. The only modification is moving the call to `generateFullyAppliedCondition()` inside the retry mutation closure in:

- `AggregateResourceBindingWorkStatus`
- `AggregateClusterResourceBindingWorkStatus`

This ensures the condition is evaluated against the latest `Spec.Clusters` after each retry fetch.

---

**Fixes issue : #7227** 

---

```release-note
karmada-controller-manager: Fixed an issue where the FullyApplied condition of ResourceBinding could be incorrectly reported during RetryOnConflict retries when the cluster set changed.