### PR TITLE
updates the default Kubernetes and etcd versions in installation utils

### DIFF
--- a/charts/karmada/values.yaml
+++ b/charts/karmada/values.yaml
@@ -395,7 +395,7 @@ apiServer:
   image:
     registry: registry.k8s.io
     repository: kube-apiserver
-    tag: "v1.34.1"
+    tag: "v1.35.2"
     ## Specify a imagePullPolicy, defaults to 'IfNotPresent'
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -626,7 +626,7 @@ kubeControllerManager:
   image:
     registry: registry.k8s.io
     repository: kube-controller-manager
-    tag: "v1.34.1"
+    tag: "v1.35.2"
     ## Specify a imagePullPolicy, defaults to 'IfNotPresent'
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -724,7 +724,7 @@ etcd:
     image:
       registry: registry.k8s.io
       repository: etcd
-      tag: "3.6.0-0"
+      tag: "3.6.6-0"
       ## Specify a imagePullPolicy, defaults to 'IfNotPresent'
       pullPolicy: IfNotPresent
     ## @param etcd.internal.storageType storage type for etcd data

--- a/operator/config/samples/karmada-sample.yaml
+++ b/operator/config/samples/karmada-sample.yaml
@@ -13,7 +13,7 @@ spec:
     etcd:
       local:
         imageRepository: registry.k8s.io/etcd
-        imageTag: 3.6.0-0
+        imageTag: 3.6.6-0
         replicas: 1
         volumeData:
           # hostPath:
@@ -30,7 +30,7 @@ spec:
                   storage: 3Gi
     karmadaAPIServer:
       imageRepository: registry.k8s.io/kube-apiserver
-      imageTag: v1.34.1
+      imageTag: v1.35.2
       replicas: 1
       serviceType: NodePort
       serviceSubnet: 10.96.0.0/12
@@ -52,7 +52,7 @@ spec:
       replicas: 1
     kubeControllerManager:
       imageRepository: registry.k8s.io/kube-controller-manager
-      imageTag: v1.34.1
+      imageTag: v1.35.2
       replicas: 1
     karmadaMetricsAdapter:
       imageRepository: docker.io/karmada/karmada-metrics-adapter

--- a/operator/config/samples/karmada.yaml
+++ b/operator/config/samples/karmada.yaml
@@ -8,7 +8,7 @@ spec:
     etcd:
       local:
         imageRepository: registry.k8s.io/etcd
-        imageTag: 3.6.0-0
+        imageTag: 3.6.6-0
         replicas: 1
         volumeData:
           # hostPath:
@@ -25,7 +25,7 @@ spec:
                   storage: 3Gi
     karmadaAPIServer:
       imageRepository: registry.k8s.io/kube-apiserver
-      imageTag: v1.34.1
+      imageTag: v1.35.2
       replicas: 1
       serviceType: NodePort
       serviceSubnet: 10.96.0.0/12
@@ -47,7 +47,7 @@ spec:
       replicas: 1
     kubeControllerManager:
       imageRepository: registry.k8s.io/kube-controller-manager
-      imageTag: v1.34.1
+      imageTag: v1.35.2
       replicas: 1
     karmadaMetricsAdapter:
       imageRepository: docker.io/karmada/karmada-metrics-adapter

--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -29,9 +29,9 @@ const (
 	// KarmadaDefaultRepository defines the default of the karmada image repository
 	KarmadaDefaultRepository = "docker.io/karmada"
 	// EtcdDefaultVersion defines the default of the karmada etcd image tag
-	EtcdDefaultVersion = "3.6.0-0"
+	EtcdDefaultVersion = "3.6.6-0"
 	// KubeDefaultVersion defines the default of the karmada apiserver and kubeControllerManager image tag
-	KubeDefaultVersion = "v1.34.1"
+	KubeDefaultVersion = "v1.35.2"
 	// KarmadaDefaultServiceSubnet defines the default of the subnet used by k8s services.
 	KarmadaDefaultServiceSubnet = "10.96.0.0/12"
 	// KarmadaDefaultDNSDomain defines the default of the DNSDomain

--- a/pkg/karmadactl/cmdinit/cmdinit.go
+++ b/pkg/karmadactl/cmdinit/cmdinit.go
@@ -158,7 +158,7 @@ func NewCmdInit(parentCommand string) *cobra.Command {
 	// kube image registry
 	flags.StringVarP(&opts.KubeImageMirrorCountry, "kube-image-mirror-country", "", "", "Country code of the kube image registry to be used. For Chinese mainland users, set it to cn")
 	flags.StringVarP(&opts.KubeImageRegistry, "kube-image-registry", "", "", "Kube image registry. For Chinese mainland users, you may use local gcr.io mirrors such as registry.cn-hangzhou.aliyuncs.com/google_containers to override default kube image registry")
-	flags.StringVar(&opts.KubeImageTag, "kube-image-tag", "v1.34.1", "Choose a specific Kubernetes version for the control plane.")
+	flags.StringVar(&opts.KubeImageTag, "kube-image-tag", "v1.35.2", "Choose a specific Kubernetes version for the control plane.")
 	// cert
 	flags.StringVar(&opts.ExternalIP, "cert-external-ip", "", "the external IP of Karmada certificate (e.g 192.168.1.2,172.16.1.2)")
 	flags.StringVar(&opts.ExternalDNS, "cert-external-dns", "", "the external DNS of Karmada certificate (e.g localhost,localhost.com)")

--- a/pkg/karmadactl/cmdinit/kubernetes/deploy.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/deploy.go
@@ -99,7 +99,7 @@ var (
 
 	karmadaRelease string
 
-	defaultEtcdImage = "etcd:3.6.0-0"
+	defaultEtcdImage = "etcd:3.6.6-0"
 
 	// DefaultCrdURL Karmada crds resource
 	DefaultCrdURL string


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This pull request updates the default Kubernetes and etcd versions used in chart, operator, and CLI. The changes ensure that both the Helm chart and operator configurations, as well as code constants and CLI defaults, reference the updated versions for improved compatibility and security.

- Updated `kube-apiserver` and `kube-controller-manager` image tags from `v1.34.1` to `v1.35.2`
- Updated `etcd` image tag from `3.6.0-0` to `3.6.6-0`

**Which issue(s) this PR fixes**:
Fixes #
Part of #7140

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
`Helm Chart`: The default `kube-apiserver` and `kube-controller-manager` images have been updated from v1.34.1 to v1.35.2. And the default ETCD Image has been updated from 3.6.0-0 to 3.6.6-0.
`karmada-operator`: The default `kube-apiserver` and `kube-controller-manager` images have been updated from v1.34.1 to v1.35.2. And the default ETCD Image has been updated from 3.6.0-0 to 3.6.6-0.
`karmadactl`: The default `kube-apiserver` and `kube-controller-manager` images have been updated from v1.34.1 to v1.35.2. And the default ETCD Image has been updated from 3.6.0-0 to 3.6.6-0.
```

