### PR TITLE
Bump kind cluster to defaults to Kubernetes v1.35

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,8 +55,8 @@ require (
 	layeh.com/gopher-json v0.0.0-20201124131017-552bb3c4c3bf
 	sigs.k8s.io/cluster-api v1.7.1
 	sigs.k8s.io/controller-runtime v0.23.1
-	sigs.k8s.io/custom-metrics-apiserver v1.34.1-0.20260127041547-647100cc1b83
-	sigs.k8s.io/kind v0.30.0
+	sigs.k8s.io/custom-metrics-apiserver v1.35.0
+	sigs.k8s.io/kind v0.31.0
 	sigs.k8s.io/mcs-api v0.1.0
 	sigs.k8s.io/metrics-server v0.8.1-0.20260129002750-4bf067be02ad
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482

--- a/go.sum
+++ b/go.sum
@@ -961,13 +961,13 @@ sigs.k8s.io/controller-runtime v0.6.1/go.mod h1:XRYBPdbf5XJu9kpS84VJiZ7h/u1hF3gE
 sigs.k8s.io/controller-runtime v0.23.1 h1:TjJSM80Nf43Mg21+RCy3J70aj/W6KyvDtOlpKf+PupE=
 sigs.k8s.io/controller-runtime v0.23.1/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
-sigs.k8s.io/custom-metrics-apiserver v1.34.1-0.20260127041547-647100cc1b83 h1:2Q5cTbq1BiREpwdsAJ2HyYO/UAyzKYEm/GArq4H8o6c=
-sigs.k8s.io/custom-metrics-apiserver v1.34.1-0.20260127041547-647100cc1b83/go.mod h1:v4zAqlNkVdOuSM5h3ixlCYVPQIwlUewNGDL9YpLLL1o=
+sigs.k8s.io/custom-metrics-apiserver v1.35.0 h1:KAzi/4kvqdHQdfhXBcDhYEPN2+ekav5u5A4Bg0jj68g=
+sigs.k8s.io/custom-metrics-apiserver v1.35.0/go.mod h1:v4zAqlNkVdOuSM5h3ixlCYVPQIwlUewNGDL9YpLLL1o=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/kind v0.8.1/go.mod h1:oNKTxUVPYkV9lWzY6CVMNluVq8cBsyq+UgPJdvA3uu4=
-sigs.k8s.io/kind v0.30.0 h1:2Xi1KFEfSMm0XDcvKnUt15ZfgRPCT0OnCBbpgh8DztY=
-sigs.k8s.io/kind v0.30.0/go.mod h1:FSqriGaoTPruiXWfRnUXNykF8r2t+fHtK0P0m1AbGF8=
+sigs.k8s.io/kind v0.31.0 h1:UcT4nzm+YM7YEbqiAKECk+b6dsvc/HRZZu9U0FolL1g=
+sigs.k8s.io/kind v0.31.0/go.mod h1:FSqriGaoTPruiXWfRnUXNykF8r2t+fHtK0P0m1AbGF8=
 sigs.k8s.io/kustomize/api v0.20.1 h1:iWP1Ydh3/lmldBnH/S5RXgT98vWYMaTUL1ADcr+Sv7I=
 sigs.k8s.io/kustomize/api v0.20.1/go.mod h1:t6hUFxO+Ph0VxIk1sKp1WS0dOjbPCtLJ4p8aADLwqjM=
 sigs.k8s.io/kustomize/kyaml v0.20.1 h1:PCMnA2mrVbRP3NIB6v9kYCAc38uvFLVs8j/CD567A78=

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -40,7 +40,7 @@ KARMADA_GO_PACKAGE="github.com/karmada-io/karmada"
 
 MIN_GO_VERSION="go$(go list -m -f {{.GoVersion}})"
 
-DEFAULT_CLUSTER_VERSION="kindest/node:v1.34.0"
+DEFAULT_CLUSTER_VERSION="kindest/node:v1.35.0"
 
 # KIND_VERSION defines the version of Kind (Kubernetes IN Docker) tool to be used
 # across all scripts in the project. This version is referenced by:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1903,7 +1903,7 @@ sigs.k8s.io/controller-runtime/pkg/webhook/admission/metrics
 sigs.k8s.io/controller-runtime/pkg/webhook/conversion
 sigs.k8s.io/controller-runtime/pkg/webhook/conversion/metrics
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
-# sigs.k8s.io/custom-metrics-apiserver v1.34.1-0.20260127041547-647100cc1b83
+# sigs.k8s.io/custom-metrics-apiserver v1.35.0
 ## explicit; go 1.25.0
 sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver
 sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver/endpoints/handlers
@@ -1923,7 +1923,7 @@ sigs.k8s.io/custom-metrics-apiserver/pkg/registry/external_metrics
 ## explicit; go 1.23
 sigs.k8s.io/json
 sigs.k8s.io/json/internal/golang/encoding/json
-# sigs.k8s.io/kind v0.30.0
+# sigs.k8s.io/kind v0.31.0
 ## explicit; go 1.17
 sigs.k8s.io/kind/pkg/apis/config/defaults
 sigs.k8s.io/kind/pkg/apis/config/v1alpha4

--- a/vendor/sigs.k8s.io/kind/pkg/apis/config/defaults/image.go
+++ b/vendor/sigs.k8s.io/kind/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a"
+const Image = "kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f"

--- a/vendor/sigs.k8s.io/kind/pkg/cluster/internal/loadbalancer/const.go
+++ b/vendor/sigs.k8s.io/kind/pkg/cluster/internal/loadbalancer/const.go
@@ -17,7 +17,7 @@ limitations under the License.
 package loadbalancer
 
 // Image defines the loadbalancer image:tag
-const Image = "docker.io/kindest/haproxy:v20230606-42a2262b"
+const Image = "docker.io/kindest/haproxy:v20251211-v0.29.0-alpha-100-g82a92c5d"
 
 // ConfigPath defines the path to the config file in the image
 const ConfigPath = "/usr/local/etc/haproxy/haproxy.cfg"

--- a/vendor/sigs.k8s.io/kind/pkg/cluster/internal/providers/docker/network.go
+++ b/vendor/sigs.k8s.io/kind/pkg/cluster/internal/providers/docker/network.go
@@ -271,7 +271,10 @@ func isIPv6UnavailableError(err error) bool {
 	// even on hosts that lack ip6tables setup.
 	// Preferably users would either have ip6tables setup properly or else disable ipv6 in docker
 	const dockerIPV6TablesError = "Error response from daemon: Failed to Setup IP tables: Unable to enable NAT rule:  (iptables failed: ip6tables"
-	return strings.HasPrefix(errorMessage, dockerIPV6DisabledError) || strings.HasPrefix(errorMessage, dockerIPV6TablesError)
+	// we get this error when ipv6 is missing in kernel
+	const dockerIPV6PolicyError = "Error response from daemon: setting default policy to DROP in FORWARD chain failed:  (iptables failed: ip6tables"
+
+	return strings.HasPrefix(errorMessage, dockerIPV6DisabledError) || strings.HasPrefix(errorMessage, dockerIPV6TablesError) || strings.HasPrefix(errorMessage, dockerIPV6PolicyError)
 }
 
 func isPoolOverlapError(err error) bool {

--- a/vendor/sigs.k8s.io/kind/pkg/cluster/internal/providers/docker/node.go
+++ b/vendor/sigs.k8s.io/kind/pkg/cluster/internal/providers/docker/node.go
@@ -9,7 +9,7 @@ You may obtain a copy of the License at
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or impliep.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/vendor/sigs.k8s.io/kind/pkg/cmd/kind/version/version.go
+++ b/vendor/sigs.k8s.io/kind/pkg/cmd/kind/version/version.go
@@ -58,7 +58,7 @@ func DisplayVersion() string {
 }
 
 // versionCore is the core portion of the kind CLI version per Semantic Versioning 2.0.0
-const versionCore = "0.30.0"
+const versionCore = "0.31.0"
 
 // versionPreRelease is the base pre-release portion of the kind CLI version per
 // Semantic Versioning 2.0.0


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This pull request updates the Kind tool's dependencies to a newer version, ensuring compatibility and access to the latest features and fixes.

Dependency updates:
* Updated `sigs.k8s.io/kind` from version `v0.30.0` to `v0.31.0` in `go.mod`.
* Updated `sigs.k8s.io/custom-metrics-apiserver` from version `v1.34.1-0.20260127041547-647100cc1b83` to `v1.35.0` in `go.mod`.

**Which issue(s) this PR fixes**:

Fixes #
Part of #7140

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

