### PR TITLE
Automated cherry pick of #7154: Fix divide-by-zero panic in spread constraint group scoring

### DIFF
--- a/pkg/scheduler/core/spreadconstraint/group_clusters.go
+++ b/pkg/scheduler/core/spreadconstraint/group_clusters.go
@@ -210,6 +210,9 @@ func (info *GroupClustersInfo) calcGroupScoreForDuplicate(
 	// Group2's Score = 2 * 1000 + 0 = 2000
 
 	// the priority of validClusters is higher than sumValidScore.
+	if validClusters == 0 {
+		return 0
+	}
 	weightedValidClusters := validClusters * weightUnit
 	return weightedValidClusters + sumValidScore/validClusters
 }

--- a/pkg/scheduler/core/spreadconstraint/group_clusters_test.go
+++ b/pkg/scheduler/core/spreadconstraint/group_clusters_test.go
@@ -378,3 +378,38 @@ func Test_CalcGroupScore(t *testing.T) {
 		})
 	}
 }
+
+func Test_CalcGroupScoreForDuplicate(t *testing.T) {
+	tests := []struct {
+		name     string
+		clusters []ClusterDetailInfo
+		rbSpec   *workv1alpha2.ResourceBindingSpec
+		watScore int64
+	}{
+		{
+			name:     "get 0 score when clusters is empty",
+			clusters: []ClusterDetailInfo{},
+			rbSpec:   &workv1alpha2.ResourceBindingSpec{Replicas: 10},
+			watScore: 0,
+		},
+		{
+			name: "get 0 score when all clusters can not meet the replica requirements",
+			clusters: []ClusterDetailInfo{
+				{Name: "member1", Score: 50, AvailableReplicas: 5},
+				{Name: "member2", Score: 50, AvailableReplicas: 5},
+			},
+			rbSpec:   &workv1alpha2.ResourceBindingSpec{Replicas: 10},
+			watScore: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			groupClustersInfo := &GroupClustersInfo{}
+			score := groupClustersInfo.calcGroupScoreForDuplicate(tt.clusters, tt.rbSpec)
+			if score != tt.watScore {
+				t.Errorf("calcGroupScoreForDuplicate: want score %v, but got %v", tt.watScore, score)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cherry pick of #7154 on release-1.14.
#7154: Fix divide-by-zero panic in spread constraint group scoring
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-scheduler`: Fixed a scheduler panic caused by a divide-by-zero error when calculating spread constraints with no valid clusters.
```