### PR TITLE
Automated cherry pick of #7124: set bindingSpec.ReplicaRequirements.Namespace uniformly

### DIFF
--- a/pkg/util/helper/binding.go
+++ b/pkg/util/helper/binding.go
@@ -444,7 +444,6 @@ func GenerateReplicaRequirements(podTemplate *corev1.PodTemplateSpec) *workv1alp
 			ResourceRequest: resourceRequest,
 		}
 		if features.FeatureGate.Enabled(features.ResourceQuotaEstimate) {
-			replicaRequirements.Namespace = podTemplate.Namespace
 			// PriorityClassName is set from podTemplate
 			// If it is not set from podTemplate, it is default to an empty string
 			replicaRequirements.PriorityClassName = podTemplate.Spec.PriorityClassName

--- a/test/e2e/suites/base/resourceinterpreter_test.go
+++ b/test/e2e/suites/base/resourceinterpreter_test.go
@@ -644,7 +644,9 @@ var _ = framework.SerialDescribe("Resource interpreter customization testing", f
 					expectedReplicaRequirements := &workv1alpha2.ReplicaRequirements{
 						ResourceRequest: map[corev1.ResourceName]resource.Quantity{
 							corev1.ResourceCPU: resource.MustParse("100m"),
-						}}
+						},
+						Namespace: deployment.Namespace,
+					}
 
 					gomega.Eventually(func(g gomega.Gomega) (bool, error) {
 						resourceBinding, err := karmadaClient.WorkV1alpha2().ResourceBindings(deployment.Namespace).Get(context.TODO(), resourceBindingName, metav1.GetOptions{})


### PR DESCRIPTION
Cherry pick of #7124 on release-1.15.
#7124: set bindingSpec.ReplicaRequirements.Namespace uniformly
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-scheduler-estimator`: Fixed the issue where the resource quota plugin failed to list resource quotas due to a missing namespace in the gRPC request.
```