### PR TITLE
Automated cherry pick of #7124: set bindingSpec.ReplicaRequirements.Namespace uniformly

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -821,6 +821,16 @@ func (d *ResourceDetector) BuildResourceBinding(object *unstructured.Unstructure
 			klog.Errorf("Failed to customize replicas for %s(%s), %v", object.GroupVersionKind(), object.GetName(), err)
 			return nil, err
 		}
+
+		// Most interpreters (except webhook interpreter) cannot properly obtain the namespace because they extract
+		// information from PodTemplate, and advanced workloads' PodTemplates typically don't have a namespace set.
+		// Therefore, we uniformly check and set the namespace here.
+		// Note: The replicaRequirements.Namespace field is somewhat redundant and could be deprecated in the future,
+		// as the namespace can be obtained directly from ResourceBinding.
+		if features.FeatureGate.Enabled(features.ResourceQuotaEstimate) && replicaRequirements != nil && len(replicaRequirements.Namespace) == 0 {
+			replicaRequirements.Namespace = object.GetNamespace()
+		}
+
 		propagationBinding.Spec.Replicas = replicas
 		propagationBinding.Spec.ReplicaRequirements = replicaRequirements
 	}
@@ -895,6 +905,16 @@ func (d *ResourceDetector) BuildClusterResourceBinding(object *unstructured.Unst
 			klog.Errorf("Failed to customize replicas for %s(%s), %v", object.GroupVersionKind(), object.GetName(), err)
 			return nil, err
 		}
+
+		// Most interpreters (except webhook interpreter) cannot properly obtain the namespace because they extract
+		// information from PodTemplate, and advanced workloads' PodTemplates typically don't have a namespace set.
+		// Therefore, we uniformly check and set the namespace here.
+		// Note: The replicaRequirements.Namespace field is somewhat redundant and could be deprecated in the future,
+		// as the namespace can be obtained directly from ResourceBinding.
+		if features.FeatureGate.Enabled(features.ResourceQuotaEstimate) && replicaRequirements != nil && len(replicaRequirements.Namespace) == 0 {
+			replicaRequirements.Namespace = object.GetNamespace()
+		}
+
 		binding.Spec.Replicas = replicas
 		binding.Spec.ReplicaRequirements = replicaRequirements
 	}

--- a/pkg/util/helper/binding.go
+++ b/pkg/util/helper/binding.go
@@ -403,7 +403,6 @@ func GenerateReplicaRequirements(podTemplate *corev1.PodTemplateSpec) *workv1alp
 			ResourceRequest: resourceRequest,
 		}
 		if features.FeatureGate.Enabled(features.ResourceQuotaEstimate) {
-			replicaRequirements.Namespace = podTemplate.Namespace
 			// PriorityClassName is set from podTemplate
 			// If it is not set from podTemplate, it is default to an empty string
 			replicaRequirements.PriorityClassName = podTemplate.Spec.PriorityClassName

--- a/test/e2e/suites/base/resourceinterpreter_test.go
+++ b/test/e2e/suites/base/resourceinterpreter_test.go
@@ -644,7 +644,9 @@ var _ = framework.SerialDescribe("Resource interpreter customization testing", f
 					expectedReplicaRequirements := &workv1alpha2.ReplicaRequirements{
 						ResourceRequest: map[corev1.ResourceName]resource.Quantity{
 							corev1.ResourceCPU: resource.MustParse("100m"),
-						}}
+						},
+						Namespace: deployment.Namespace,
+					}
 
 					gomega.Eventually(func(g gomega.Gomega) (bool, error) {
 						resourceBinding, err := karmadaClient.WorkV1alpha2().ResourceBindings(deployment.Namespace).Get(context.TODO(), resourceBindingName, metav1.GetOptions{})


### PR DESCRIPTION
Cherry pick of #7124 on release-1.14.
#7124: set bindingSpec.ReplicaRequirements.Namespace uniformly
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-scheduler-estimator`: Fixed the issue where the resource quota plugin failed to list resource quotas due to a missing namespace in the gRPC request.
```