### PR TITLE
Fix/graceful eviction race condition

### DIFF
--- a/pkg/controllers/gracefuleviction/crb_graceful_eviction_controller.go
+++ b/pkg/controllers/gracefuleviction/crb_graceful_eviction_controller.go
@@ -88,7 +88,7 @@ func (c *CRBGracefulEvictionController) syncBinding(ctx context.Context, binding
 		return nextRetry(keptTask, c.GracefulEvictionTimeout, metav1.Now().Time), nil
 	}
 
-	objPatch := client.MergeFrom(binding)
+	objPatch := client.MergeFromWithOptions(binding, client.MergeFromWithOptimisticLock{})
 	modifiedObj := binding.DeepCopy()
 	modifiedObj.Spec.GracefulEvictionTasks = keptTask
 	err := c.Client.Patch(ctx, modifiedObj, objPatch)

--- a/pkg/controllers/gracefuleviction/rb_graceful_eviction_controller.go
+++ b/pkg/controllers/gracefuleviction/rb_graceful_eviction_controller.go
@@ -88,7 +88,7 @@ func (c *RBGracefulEvictionController) syncBinding(ctx context.Context, binding 
 		return nextRetry(keptTask, c.GracefulEvictionTimeout, metav1.Now().Time), nil
 	}
 
-	objPatch := client.MergeFrom(binding)
+	objPatch := client.MergeFromWithOptions(binding, client.MergeFromWithOptimisticLock{})
 	modifiedObj := binding.DeepCopy()
 	modifiedObj.Spec.GracefulEvictionTasks = keptTask
 	err := c.Client.Patch(ctx, modifiedObj, objPatch)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

---

**What this PR does / why we need it**:
This PR adds optimistic locking to the graceful eviction controllers (both RB and CRB variants) when patching `Spec.GracefulEvictionTasks`.

Previously, the controller used `client.MergeFrom()` which generates a JSON merge patch that:
- Replaces the entire `GracefulEvictionTasks` array, and
- Does not include `metadata.resourceVersion`, so the API server performs no conflict detection.

If another controller (e.g., taint-manager or application-failover-controller) added a new eviction task via `Update()` between the graceful eviction controller’s `Get` and `Patch`, the new task could be silently overwritten.

By switching to `client.MergeFromWithOptions(..., client.MergeFromWithOptimisticLock{})`, the patch now includes the current `resourceVersion`. If the binding was modified concurrently, the API server returns a 409 Conflict, and the controller requeues and retries with the latest state.

This prevents silent eviction task loss under concurrent failover scenarios.

---

**Special notes for your reviewer**:

The change is minimal (two lines across RB and CRB controllers) and does not alter business logic.  
Existing error handling already propagates conflicts correctly, so no additional retry logic is required.

---

**Does this PR introduce a user-facing change?**:
No

---

```release-note
karmada-controller-manager: Fixed an issue where concurrent updates to GracefulEvictionTasks could be silently overwritten, potentially leading to missed eviction tasks during failover.
```

