### PR TITLE
Remove deprecated cluster_name and cluster metric label

### DIFF
--- a/pkg/metrics/cluster.go
+++ b/pkg/metrics/cluster.go
@@ -44,73 +44,68 @@ const (
 
 	// Canonical label for Karmada member clusters.
 	memberClusterLabel = "member_cluster"
-
-	// DEPRECATED: cluster_name (target removal: 1.18)
-	// Rationale: avoid collision with Prometheus external_labels like cluster and standardize on the metric label name used to denote a Karmada member cluster across all metrics.
-	// Migration: use member_cluster instead across all queries and dashboards.
-	clusterNameLabel = "cluster_name"
 )
 
 var (
 	// clusterReadyGauge reports if the cluster is ready.
 	clusterReadyGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: clusterReadyMetricsName,
-		Help: "State of the cluster (1 if ready, 0 otherwise). [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
-	}, []string{memberClusterLabel, clusterNameLabel})
+		Help: "State of the cluster (1 if ready, 0 otherwise).",
+	}, []string{memberClusterLabel})
 
 	// clusterTotalNodeNumberGauge reports the number of nodes in the given cluster.
 	clusterTotalNodeNumberGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: clusterTotalNodeNumberMetricsName,
-		Help: "Number of nodes in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
-	}, []string{memberClusterLabel, clusterNameLabel})
+		Help: "Number of nodes in the cluster.",
+	}, []string{memberClusterLabel})
 
 	// clusterReadyNodeNumberGauge reports the number of ready nodes in the given cluster.
 	clusterReadyNodeNumberGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: clusterReadyNodeNumberMetricsName,
-		Help: "Number of ready nodes in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
-	}, []string{memberClusterLabel, clusterNameLabel})
+		Help: "Number of ready nodes in the cluster.",
+	}, []string{memberClusterLabel})
 
 	// clusterMemoryAllocatableGauge reports the allocatable memory in the given cluster.
 	clusterMemoryAllocatableGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: clusterMemoryAllocatableMetricsName,
-		Help: "Allocatable cluster memory resource in bytes. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
-	}, []string{memberClusterLabel, clusterNameLabel})
+		Help: "Allocatable cluster memory resource in bytes.",
+	}, []string{memberClusterLabel})
 
 	// clusterCPUAllocatableGauge reports the allocatable CPU in the given cluster.
 	clusterCPUAllocatableGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: clusterCPUAllocatableMetricsName,
-		Help: "Number of allocatable CPU in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
-	}, []string{memberClusterLabel, clusterNameLabel})
+		Help: "Number of allocatable CPU in the cluster.",
+	}, []string{memberClusterLabel})
 
 	// clusterPodAllocatableGauge reports the allocatable Pod number in the given cluster.
 	clusterPodAllocatableGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: clusterPodAllocatableMetricsName,
-		Help: "Number of allocatable pods in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
-	}, []string{memberClusterLabel, clusterNameLabel})
+		Help: "Number of allocatable pods in the cluster.",
+	}, []string{memberClusterLabel})
 
 	// clusterMemoryAllocatedGauge reports the allocated memory in the given cluster.
 	clusterMemoryAllocatedGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: clusterMemoryAllocatedMetricsName,
-		Help: "Allocated cluster memory resource in bytes. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
-	}, []string{memberClusterLabel, clusterNameLabel})
+		Help: "Allocated cluster memory resource in bytes.",
+	}, []string{memberClusterLabel})
 
 	// clusterCPUAllocatedGauge reports the allocated CPU in the given cluster.
 	clusterCPUAllocatedGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: clusterCPUAllocatedMetricsName,
-		Help: "Number of allocated CPU in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
-	}, []string{memberClusterLabel, clusterNameLabel})
+		Help: "Number of allocated CPU in the cluster.",
+	}, []string{memberClusterLabel})
 
 	// clusterPodAllocatedGauge reports the allocated Pod number in the given cluster.
 	clusterPodAllocatedGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: clusterPodAllocatedMetricsName,
-		Help: "Number of allocated pods in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
-	}, []string{memberClusterLabel, clusterNameLabel})
+		Help: "Number of allocated pods in the cluster.",
+	}, []string{memberClusterLabel})
 
 	// clusterSyncStatusDuration reports the duration of the given cluster syncing status.
 	clusterSyncStatusDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name: clusterSyncStatusDurationMetricsName,
-		Help: "Duration in seconds for syncing the status of the cluster once. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
-	}, []string{memberClusterLabel, clusterNameLabel})
+		Help: "Duration in seconds for syncing the status of the cluster once.",
+	}, []string{memberClusterLabel})
 
 	evictionQueueMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: evictionQueueDepthMetricsName,
@@ -119,8 +114,8 @@ var (
 
 	evictionKindTotalMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: evictionKindTotalMetricsName,
-		Help: "Number of resources in the eviction queue by resource kind [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
-	}, []string{memberClusterLabel, clusterNameLabel, "resource_kind"})
+		Help: "Number of resources in the eviction queue by resource kind",
+	}, []string{memberClusterLabel, "resource_kind"})
 
 	evictionProcessingLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    evictionProcessingLatencyMetricsName,
@@ -136,7 +131,7 @@ var (
 
 // RecordClusterStatus records the status of the given cluster.
 func RecordClusterStatus(cluster *v1alpha1.Cluster) {
-	labels := []string{cluster.Name, cluster.Name} // member_cluster, cluster_name
+	labels := []string{cluster.Name}
 
 	clusterReadyGauge.WithLabelValues(labels...).Set(func() float64 {
 		if util.IsClusterReady(&cluster.Status) {
@@ -167,13 +162,13 @@ func RecordClusterStatus(cluster *v1alpha1.Cluster) {
 
 // RecordClusterSyncStatusDuration records the duration of the given cluster syncing status
 func RecordClusterSyncStatusDuration(cluster *v1alpha1.Cluster, startTime time.Time) {
-	labels := []string{cluster.Name, cluster.Name}
+	labels := []string{cluster.Name}
 	clusterSyncStatusDuration.WithLabelValues(labels...).Observe(utilmetrics.DurationInSeconds(startTime))
 }
 
 // CleanupMetricsForCluster removes the cluster status metrics after the cluster is deleted.
 func CleanupMetricsForCluster(clusterName string) {
-	labels := []string{clusterName, clusterName}
+	labels := []string{clusterName}
 
 	clusterReadyGauge.DeleteLabelValues(labels...)
 	clusterTotalNodeNumberGauge.DeleteLabelValues(labels...)
@@ -199,7 +194,7 @@ func RecordEvictionKindMetrics(clusterName, resourceKind string, increase bool) 
 		return
 	}
 
-	labels := []string{clusterName, clusterName, resourceKind}
+	labels := []string{clusterName, resourceKind}
 	if increase {
 		evictionKindTotalMetrics.WithLabelValues(labels...).Inc()
 	} else {

--- a/pkg/metrics/cluster_test.go
+++ b/pkg/metrics/cluster_test.go
@@ -53,9 +53,9 @@ func TestClusterReadyMetrics(t *testing.T) {
 				},
 			},
 			want: `
-# HELP cluster_ready_state State of the cluster (1 if ready, 0 otherwise). [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]
+# HELP cluster_ready_state State of the cluster (1 if ready, 0 otherwise).
 # TYPE cluster_ready_state gauge
-cluster_ready_state{cluster_name="foo",member_cluster="foo"} 1
+cluster_ready_state{member_cluster="foo"} 1
 `,
 		},
 		{
@@ -74,9 +74,9 @@ cluster_ready_state{cluster_name="foo",member_cluster="foo"} 1
 				},
 			},
 			want: `
-# HELP cluster_ready_state State of the cluster (1 if ready, 0 otherwise). [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]
+# HELP cluster_ready_state State of the cluster (1 if ready, 0 otherwise).
 # TYPE cluster_ready_state gauge
-cluster_ready_state{cluster_name="foo",member_cluster="foo"} 0
+cluster_ready_state{member_cluster="foo"} 0
 `,
 		},
 	}
@@ -110,9 +110,9 @@ func TestClusterTotalNodeNumberMetrics(t *testing.T) {
 		},
 	}
 	want := `
-# HELP cluster_node_number Number of nodes in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]
+# HELP cluster_node_number Number of nodes in the cluster.
 # TYPE cluster_node_number gauge
-cluster_node_number{cluster_name="foo",member_cluster="foo"} 100
+cluster_node_number{member_cluster="foo"} 100
 `
 	clusterTotalNodeNumberGauge.Reset()
 	RecordClusterStatus(testCluster)
@@ -143,9 +143,9 @@ func TestClusterReadyNodeNumberMetrics(t *testing.T) {
 		},
 	}
 	want := `
-# HELP cluster_ready_node_number Number of ready nodes in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]
+# HELP cluster_ready_node_number Number of ready nodes in the cluster.
 # TYPE cluster_ready_node_number gauge
-cluster_ready_node_number{cluster_name="foo",member_cluster="foo"} 10
+cluster_ready_node_number{member_cluster="foo"} 10
 `
 	clusterReadyNodeNumberGauge.Reset()
 	RecordClusterStatus(testCluster)
@@ -177,9 +177,9 @@ func TestClusterMemoryAllocatableMetrics(t *testing.T) {
 		},
 	}
 	want := `
-# HELP cluster_memory_allocatable_bytes Allocatable cluster memory resource in bytes. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]
+# HELP cluster_memory_allocatable_bytes Allocatable cluster memory resource in bytes.
 # TYPE cluster_memory_allocatable_bytes gauge
-cluster_memory_allocatable_bytes{cluster_name="foo",member_cluster="foo"} 200
+cluster_memory_allocatable_bytes{member_cluster="foo"} 200
 `
 	clusterMemoryAllocatableGauge.Reset()
 	RecordClusterStatus(testCluster)
@@ -211,9 +211,9 @@ func TestClusterCPUAllocatableMetrics(t *testing.T) {
 		},
 	}
 	want := `
-# HELP cluster_cpu_allocatable_number Number of allocatable CPU in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]
+# HELP cluster_cpu_allocatable_number Number of allocatable CPU in the cluster.
 # TYPE cluster_cpu_allocatable_number gauge
-cluster_cpu_allocatable_number{cluster_name="foo",member_cluster="foo"} 0.2
+cluster_cpu_allocatable_number{member_cluster="foo"} 0.2
 `
 	clusterCPUAllocatableGauge.Reset()
 	RecordClusterStatus(testCluster)
@@ -245,9 +245,9 @@ func TestClusterPodAllocatableMetrics(t *testing.T) {
 		},
 	}
 	want := `
-# HELP cluster_pod_allocatable_number Number of allocatable pods in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]
+# HELP cluster_pod_allocatable_number Number of allocatable pods in the cluster.
 # TYPE cluster_pod_allocatable_number gauge
-cluster_pod_allocatable_number{cluster_name="foo",member_cluster="foo"} 110
+cluster_pod_allocatable_number{member_cluster="foo"} 110
 `
 	clusterPodAllocatableGauge.Reset()
 	RecordClusterStatus(testCluster)
@@ -279,9 +279,9 @@ func TestClusterMemoryAllocatedMetrics(t *testing.T) {
 		},
 	}
 	want := `
-# HELP cluster_memory_allocated_bytes Allocated cluster memory resource in bytes. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]
+# HELP cluster_memory_allocated_bytes Allocated cluster memory resource in bytes.
 # TYPE cluster_memory_allocated_bytes gauge
-cluster_memory_allocated_bytes{cluster_name="foo",member_cluster="foo"} 200
+cluster_memory_allocated_bytes{member_cluster="foo"} 200
 `
 	clusterMemoryAllocatedGauge.Reset()
 	RecordClusterStatus(testCluster)
@@ -313,9 +313,9 @@ func TestClusterCPUAllocatedMetrics(t *testing.T) {
 		},
 	}
 	want := `
-# HELP cluster_cpu_allocated_number Number of allocated CPU in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]
+# HELP cluster_cpu_allocated_number Number of allocated CPU in the cluster.
 # TYPE cluster_cpu_allocated_number gauge
-cluster_cpu_allocated_number{cluster_name="foo",member_cluster="foo"} 0.2
+cluster_cpu_allocated_number{member_cluster="foo"} 0.2
 `
 	clusterCPUAllocatedGauge.Reset()
 	RecordClusterStatus(testCluster)
@@ -347,9 +347,9 @@ func TestClusterPodAllocatedMetrics(t *testing.T) {
 		},
 	}
 	want := `
-# HELP cluster_pod_allocated_number Number of allocated pods in the cluster. [Label deprecation: cluster_name deprecated in 1.16; use member_cluster. Removal planned 1.18.]
+# HELP cluster_pod_allocated_number Number of allocated pods in the cluster.
 # TYPE cluster_pod_allocated_number gauge
-cluster_pod_allocated_number{cluster_name="foo",member_cluster="foo"} 110
+cluster_pod_allocated_number{member_cluster="foo"} 110
 `
 	clusterPodAllocatedGauge.Reset()
 	RecordClusterStatus(testCluster)

--- a/pkg/metrics/resource.go
+++ b/pkg/metrics/resource.go
@@ -39,11 +39,6 @@ const (
 	cronFederatedHPARuleDurationMetricsName    = "cronfederatedhpa_rule_process_duration_seconds"
 	federatedHPADurationMetricsName            = "federatedhpa_process_duration_seconds"
 	federatedHPAPullMetricsDurationMetricsName = "federatedhpa_pull_metrics_duration_seconds"
-
-	// DEPRECATED: cluster (target removal: 1.18)
-	// Rationale: standardize on the metric label name used to denote a Karmada member cluster across all metrics.
-	// Migration: use member_cluster instead across all queries and dashboards.
-	clusterLabel = "cluster"
 )
 
 var (
@@ -78,18 +73,18 @@ var (
 
 	createResourceWhenSyncWork = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: createResourceToCluster,
-		Help: "Number of creation operations against a target member cluster. The 'result' label indicates outcome ('success' or 'error'), 'recreate' indicates whether the operation is recreated (true/false). Labels 'apiversion', 'kind', and 'cluster' specify the resource type, API version, and target cluster respectively. [Label deprecation: cluster deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
-	}, []string{"result", "apiversion", "kind", memberClusterLabel, clusterLabel, "recreate"})
+		Help: "Number of creation operations against a target member cluster. The 'result' label indicates outcome ('success' or 'error'), 'recreate' indicates whether the operation is recreated (true/false). Labels 'apiversion', 'kind', and 'member_cluster' specify the resource type, API version, and target cluster respectively.",
+	}, []string{"result", "apiversion", "kind", memberClusterLabel, "recreate"})
 
 	updateResourceWhenSyncWork = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: updateResourceToCluster,
-		Help: "Number of updating operation of the resource to a target member cluster. By the result, 'error' means a resource updated failed. Otherwise 'success'. Cluster means the target member cluster. operationResult means the result of the update operation. [Label deprecation: cluster deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
-	}, []string{"result", "apiversion", "kind", memberClusterLabel, clusterLabel, "operationResult"})
+		Help: "Number of updating operation of the resource to a target member cluster. By the result, 'error' means a resource updated failed. Otherwise 'success'. member_cluster means the target member cluster. operationResult means the result of the update operation.",
+	}, []string{"result", "apiversion", "kind", memberClusterLabel, "operationResult"})
 
 	deleteResourceWhenSyncWork = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: deleteResourceFromCluster,
-		Help: "Number of deletion operations against a target member cluster. The 'result' label indicates outcome ('success' or 'error'). Labels 'apiversion', 'kind', and 'cluster' specify the resource's API version, type, and source cluster respectively. [Label deprecation: cluster deprecated in 1.16; use member_cluster. Removal planned 1.18.]",
-	}, []string{"result", "apiversion", "kind", memberClusterLabel, clusterLabel})
+		Help: "Number of deletion operations against a target member cluster. The 'result' label indicates outcome ('success' or 'error'). Labels 'apiversion', 'kind', and 'member_cluster' specify the resource's API version, type, and source cluster respectively.",
+	}, []string{"result", "apiversion", "kind", memberClusterLabel})
 
 	policyPreemptionCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: policyPreemptionMetricsName,
@@ -149,7 +144,6 @@ func CountCreateResourceToCluster(err error, apiVersion, kind, cluster string, r
 		apiVersion,
 		kind,
 		cluster,
-		cluster,
 		strconv.FormatBool(recreate),
 	).Inc()
 }
@@ -161,7 +155,6 @@ func CountUpdateResourceToCluster(err error, apiVersion, kind, cluster string, o
 		apiVersion,
 		kind,
 		cluster,
-		cluster,
 		operationResult,
 	).Inc()
 }
@@ -172,7 +165,6 @@ func CountDeleteResourceFromCluster(err error, apiVersion, kind, cluster string)
 		utilmetrics.GetResultByError(err),
 		apiVersion,
 		kind,
-		cluster,
 		cluster,
 	).Inc()
 }

--- a/pkg/metrics/resource_test.go
+++ b/pkg/metrics/resource_test.go
@@ -36,10 +36,10 @@ func TestCountCreateResourceToCluster(t *testing.T) {
 	CountCreateResourceToCluster(fmt.Errorf("boom"), apiVersion, kind, cluster, false)
 
 	want := `
-# HELP create_resource_to_cluster Number of creation operations against a target member cluster. The 'result' label indicates outcome ('success' or 'error'), 'recreate' indicates whether the operation is recreated (true/false). Labels 'apiversion', 'kind', and 'cluster' specify the resource type, API version, and target cluster respectively. [Label deprecation: cluster deprecated in 1.16; use member_cluster. Removal planned 1.18.]
+# HELP create_resource_to_cluster Number of creation operations against a target member cluster. The 'result' label indicates outcome ('success' or 'error'), 'recreate' indicates whether the operation is recreated (true/false). Labels 'apiversion', 'kind', and 'member_cluster' specify the resource type, API version, and target cluster respectively.
 # TYPE create_resource_to_cluster counter
-create_resource_to_cluster{apiversion="v1",cluster="member-1",kind="Pod",member_cluster="member-1",recreate="false",result="error"} 1
-create_resource_to_cluster{apiversion="v1",cluster="member-1",kind="Pod",member_cluster="member-1",recreate="true",result="success"} 1
+create_resource_to_cluster{apiversion="v1",kind="Pod",member_cluster="member-1",recreate="false",result="error"} 1
+create_resource_to_cluster{apiversion="v1",kind="Pod",member_cluster="member-1",recreate="true",result="success"} 1
 `
 	if err := promtestutil.CollectAndCompare(createResourceWhenSyncWork, strings.NewReader(want), createResourceToCluster); err != nil {
 		t.Fatalf("unexpected collecting result:\n%s", err)
@@ -56,9 +56,9 @@ func TestCountUpdateResourceToCluster(t *testing.T) {
 	CountUpdateResourceToCluster(nil, apiVersion, kind, cluster, "updated")
 
 	want := `
-# HELP update_resource_to_cluster Number of updating operation of the resource to a target member cluster. By the result, 'error' means a resource updated failed. Otherwise 'success'. Cluster means the target member cluster. operationResult means the result of the update operation. [Label deprecation: cluster deprecated in 1.16; use member_cluster. Removal planned 1.18.]
+# HELP update_resource_to_cluster Number of updating operation of the resource to a target member cluster. By the result, 'error' means a resource updated failed. Otherwise 'success'. member_cluster means the target member cluster. operationResult means the result of the update operation.
 # TYPE update_resource_to_cluster counter
-update_resource_to_cluster{apiversion="apps/v1",cluster="member-2",kind="Deployment",member_cluster="member-2",operationResult="updated",result="success"} 1
+update_resource_to_cluster{apiversion="apps/v1",kind="Deployment",member_cluster="member-2",operationResult="updated",result="success"} 1
 `
 	if err := promtestutil.CollectAndCompare(updateResourceWhenSyncWork, strings.NewReader(want), updateResourceToCluster); err != nil {
 		t.Fatalf("unexpected collecting result:\n%s", err)
@@ -76,9 +76,9 @@ func TestCountDeleteResourceFromCluster(t *testing.T) {
 	CountDeleteResourceFromCluster(fmt.Errorf("nope"), apiVersion, kind, cluster)
 
 	want := `
-# HELP delete_resource_from_cluster Number of deletion operations against a target member cluster. The 'result' label indicates outcome ('success' or 'error'). Labels 'apiversion', 'kind', and 'cluster' specify the resource's API version, type, and source cluster respectively. [Label deprecation: cluster deprecated in 1.16; use member_cluster. Removal planned 1.18.]
+# HELP delete_resource_from_cluster Number of deletion operations against a target member cluster. The 'result' label indicates outcome ('success' or 'error'). Labels 'apiversion', 'kind', and 'member_cluster' specify the resource's API version, type, and source cluster respectively.
 # TYPE delete_resource_from_cluster counter
-delete_resource_from_cluster{apiversion="batch/v1",cluster="member-3",kind="Job",member_cluster="member-3",result="error"} 1
+delete_resource_from_cluster{apiversion="batch/v1",kind="Job",member_cluster="member-3",result="error"} 1
 `
 	if err := promtestutil.CollectAndCompare(deleteResourceWhenSyncWork, strings.NewReader(want), deleteResourceFromCluster); err != nil {
 		t.Fatalf("unexpected collecting result:\n%s", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
This PR removes the deprecated `cluster_name` and `cluster` metric labels from https://github.com/karmada-io/karmada/pull/6932

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of https://github.com/karmada-io/karmada/issues/7009

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`Instrumentation`: The deprecated `cluster` and `cluster_name` Prometheus metric labels have been removed. The newly introduced `member_cluster` metric label name will now be used for that purpose moving forward.
```

