### PR TITLE
Remove deprecated InitImage field from LocalEtcd struct in karmadactl

### DIFF
--- a/pkg/karmadactl/cmdinit/config/types.go
+++ b/pkg/karmadactl/cmdinit/config/types.go
@@ -119,11 +119,6 @@ type LocalEtcd struct {
 	// +optional
 	DataPath string `json:"dataPath,omitempty" yaml:"dataPath,omitempty"`
 
-	// InitImage is the image for the Etcd init container
-	// Deprecated: The etcd init container is no longer used, this field is therefore ineffective and will be removed in a future release.
-	// +optional
-	InitImage Image `json:"initImage,omitempty" yaml:"initImage,omitempty"`
-
 	// NodeSelectorLabels are the node selector labels for the Etcd pods
 	// +optional
 	NodeSelectorLabels map[string]string `json:"nodeSelectorLabels,omitempty" yaml:"nodeSelectorLabels,omitempty"`


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
Removes the deprecated InitImage field from LocalEtcd struct in karmadactl

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of https://github.com/karmada-io/karmada/issues/7009

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmadactl`: The deprecated `Etcd.Local.InitImage` in `Karmada Init Configuration` has now been removed.
```

