### PR TITLE
hack/util.sh: auto-detect macOS host IP instead of interactive prompt

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -710,28 +710,55 @@ function util::get_wsl2_ipaddress() {
   util::verify_ip_address "${WSL2_HOST_IP_ADDRESS}"
 }
 
-# util::get_macos_ipaddress will get ip address on macos interactively, store to 'MAC_NIC_IPADDRESS' if available
-MAC_NIC_IPADDRESS=''
+# util::get_macos_ipaddress will auto-detect the host IP address on macOS, store to 'MAC_NIC_IPADDRESS' if available
+# The function tries the following in order:
+#   1. Use MAC_NIC_IPADDRESS if already set (e.g. by CI or the caller)
+#   2. Detect the active network interface via the routing table
+#   3. Scan common physical interfaces (en0-en3) as a fallback (e.g. when on VPN)
+#   4. Error return
+MAC_NIC_IPADDRESS=${MAC_NIC_IPADDRESS:-}
 function util::get_macos_ipaddress() {
   if [[ $(go env GOOS) = "darwin" ]]; then
-    tmp_ip=$(ipconfig getifaddr en0 || true)
     echo ""
     echo " Detected that you are installing Karmada on macOS "
     echo ""
     echo "It needs a Macintosh IP address to bind Karmada API Server(port 5443),"
-    echo "so that member clusters can access it from docker containers, please"
-    echo -n "input an available IP, "
-    if [[ -z ${tmp_ip} ]]; then
-      echo "you can use the command 'ifconfig' to look for one"
-      tips_msg="[Enter IP address]:"
-    else
-      echo "default IP will be en0 inet addr if exists"
-      tips_msg="[Enter for default ${tmp_ip}]:"
+    echo "so that member clusters can access it from docker containers"
+
+    # If already set by the caller (e.g. CI passing MAC_NIC_IPADDRESS env var), honour it
+    if [[ -n "${MAC_NIC_IPADDRESS:-}" ]]; then
+      util::verify_ip_address "${MAC_NIC_IPADDRESS}"
+      echo "Using provided IP address: ${MAC_NIC_IPADDRESS}"
+      return
     fi
-    read -r -p "${tips_msg}" MAC_NIC_IPADDRESS
-    MAC_NIC_IPADDRESS=${MAC_NIC_IPADDRESS:-$tmp_ip}
+
+    # Auto-detect via routing table (works on any active interface, not just en0)
+    local active_iface
+    active_iface=$(route get default 2>/dev/null | awk '/interface:/{print $2; exit}')
+    MAC_NIC_IPADDRESS=$(ipconfig getifaddr "${active_iface}" 2>/dev/null || true)
+
+    # If the default-route interface has no IP (e.g. VPN tunnel), scan physical NICs
+    if [[ -z "${MAC_NIC_IPADDRESS}" ]]; then
+      echo "Default route interface '${active_iface}' has no IP (VPN?), scanning physical NICs..."
+      local iface
+      for iface in en0 en1 en2 en3; do
+        MAC_NIC_IPADDRESS=$(ipconfig getifaddr "${iface}" 2>/dev/null || true)
+        if [[ -n "${MAC_NIC_IPADDRESS}" ]]; then
+          break
+        fi
+      done
+    fi
+
+    # Fail fast: 127.0.0.1 is not reachable from Docker containers
+    if [[ -z "${MAC_NIC_IPADDRESS}" ]]; then
+      echo "ERROR: Failed to detect a routable macOS host IP address."
+      echo "       Please set MAC_NIC_IPADDRESS to your host's IP and retry, e.g.:"
+      echo "       export MAC_NIC_IPADDRESS=<your-ip>"
+      return 1
+    fi
+
     util::verify_ip_address "${MAC_NIC_IPADDRESS}"
-    echo "Using IP address: ${MAC_NIC_IPADDRESS}"
+    echo "Using macOS host IP: ${MAC_NIC_IPADDRESS}"
   else # non-macOS
     MAC_NIC_IPADDRESS=${MAC_NIC_IPADDRESS:-}
   fi


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
 The `util::get_macos_ipaddress` function in hack/util.sh unconditionally calls read to wait for user input, even when a valid IP was already auto-detected. This causes `hack/local-up-karmada.sh` to hang indefinitely in any non-interactive environment (CI pipelines, GitHub Actions, background scripts).

Additionally, the detection was hardcoded to en0 (WiFi only), which silently fails for developers on USB Ethernet, Thunderbolt, or VPN — resulting in an empty HOST_IPADDRESS and member clusters unable to reach the control plane.

**This PR replaces the interactive prompt with a layered auto-detection approach:**
If MAC_NIC_IPADDRESS is already set (e.g. by CI), use it directly
Detect the active interface via route get default instead of hardcoding en0
If the default route interface has no IP (VPN tunnel), scan en0–en3
Fall back to 127.0.0.1 with a clear warning if all detection fails

**Which issue(s) this PR fixes:** 
Fixes #7257 
Part of #7269

**Special notes for your reviewer:** 
Tested end-to-end on macOS 14.3 (Apple Silicon) — ./hack/local-up-karmada.sh completed without any user input and all three member clusters reached Ready status. Linux and WSL2 code paths are unaffected (change is inside the existing darwin guard).

**Does this PR introduce a user-facing change?:**
`hack/util.sh`: Fixed `util::get_macos_ipaddress` hanging for user input on macOS by replacing the interactive prompt with layered auto-detection from the active network interface, enabling non-interactive and CI usage.
