### PR TITLE
prohibit Lt/Gt operators in ClusterTolerations of PropagationPolicy/ClusterPropagationPolicy

### DIFF
--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -110,6 +110,26 @@ func ValidatePlacement(placement policyv1alpha1.Placement, fldPath *field.Path) 
 	allErrs = append(allErrs, ValidateClusterAffinities(placement.ClusterAffinities, fldPath.Child("clusterAffinities"))...)
 	allErrs = append(allErrs, ValidateSpreadConstraint(placement.SpreadConstraints, fldPath.Child("spreadConstraints"))...)
 	allErrs = append(allErrs, ValidateWorkloadAffinity(placement.WorkloadAffinity, fldPath.Child("workloadAffinity"))...)
+	allErrs = append(allErrs, validateClusterTolerations(placement.ClusterTolerations, fldPath.Child("clusterTolerations"))...)
+	return allErrs
+}
+
+// validateClusterTolerations validates clusterTolerations in a Placement.
+// The Lt and Gt operators introduced by the Kubernetes TaintTolerationComparisonOperators
+// feature gate (alpha, KEP-5471) are intentionally disallowed here. Karmada applies
+// tolerations to clusters rather than nodes, which represents distinct semantics.
+// Until the upstream feature reaches stability and Karmada defines its own cluster-level
+// SLA semantics, allowing Lt/Gt would risk compatibility issues across member clusters
+// with different feature gate configurations.
+func validateClusterTolerations(tolerations []corev1.Toleration, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	for i, toleration := range tolerations {
+		if toleration.Operator == corev1.TolerationOpLt || toleration.Operator == corev1.TolerationOpGt {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Index(i).Child("operator"),
+				toleration.Operator,
+				[]string{"", string(corev1.TolerationOpExists), string(corev1.TolerationOpEqual)}))
+		}
+	}
 	return allErrs
 }
 

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -248,6 +248,81 @@ func TestValidateOverrideSpec(t *testing.T) {
 	}
 }
 
+func TestValidateClusterTolerations(t *testing.T) {
+	tests := []struct {
+		name        string
+		tolerations []corev1.Toleration
+		expectedErr string
+	}{
+		{
+			name:        "nil tolerations is valid",
+			tolerations: nil,
+			expectedErr: "",
+		},
+		{
+			name: "toleration with Exists operator is valid",
+			tolerations: []corev1.Toleration{
+				{Key: "key1", Operator: corev1.TolerationOpExists},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "toleration with Equal operator is valid",
+			tolerations: []corev1.Toleration{
+				{Key: "key1", Operator: corev1.TolerationOpEqual, Value: "value1"},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "toleration with empty operator is valid (defaults to Equal)",
+			tolerations: []corev1.Toleration{
+				{Key: "key1", Value: "value1"},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "toleration with Lt operator is invalid",
+			tolerations: []corev1.Toleration{
+				{Key: "key1", Operator: corev1.TolerationOpLt, Value: "100"},
+			},
+			expectedErr: "Unsupported value",
+		},
+		{
+			name: "toleration with Gt operator is invalid",
+			tolerations: []corev1.Toleration{
+				{Key: "key1", Operator: corev1.TolerationOpGt, Value: "100"},
+			},
+			expectedErr: "Unsupported value",
+		},
+		{
+			name: "mixed tolerations with one invalid Lt operator",
+			tolerations: []corev1.Toleration{
+				{Key: "key1", Operator: corev1.TolerationOpEqual, Value: "value1"},
+				{Key: "key2", Operator: corev1.TolerationOpLt, Value: "100"},
+			},
+			expectedErr: "Unsupported value",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validateClusterTolerations(tt.tolerations, field.NewPath("spec").Child("placement").Child("clusterTolerations"))
+			err := errs.ToAggregate()
+			if err != nil {
+				errStr := err.Error()
+				if tt.expectedErr == "" {
+					t.Errorf("expected no error:\n  but got:\n  %s", errStr)
+				} else if !strings.Contains(errStr, tt.expectedErr) {
+					t.Errorf("expected to contain:\n  %s\ngot:\n  %s", tt.expectedErr, errStr)
+				}
+			} else {
+				if tt.expectedErr != "" {
+					t.Errorf("unexpected no error, expected to contain:\n  %s", tt.expectedErr)
+				}
+			}
+		})
+	}
+}
+
 func TestEmptyOverrides(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
**What type of PR is this?**

/kind api-change
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

The Kubernetes `corev1.Toleration` type gained two new operators (`Lt` and  `Gt`) as part of  [KEP-5471](https://github.com/kubernetes/enhancements/issues/5471) (*TaintTolerationComparisonOperators*, currently **alpha**). Because Karmada  embeds `corev1.Toleration` directly in `Placement.ClusterTolerations`, these operators are now technically expressible in `PropagationPolicy` and `ClusterPropagationPolicy`.

However, allowing `Lt`/`Gt` in `ClusterTolerations` is premature for two reasons:
   1. **Alpha stability risk** – The feature is guarded by the `TaintTolerationComparisonOperators` feature gate. Accepting these operators now would require Karmada to manage feature-gate alignment across all member clusters and risk breaking changes if the upstream API evolves before reaching stability.
   2. **Different semantics** – Karmada tolerations target *clusters*, not nodes. The SLA-based scheduling user stories defined in KEP-5471 do not directly translate to Karmada's cluster-level model. Proper support requires community discussion and dedicated design work.

   This PR adds a validating webhook check in `ValidatePlacement` (called by both the `propagationpolicy` and `clusterpropagationpolicy` webhook handlers) that rejects any `ClusterToleration` entry whose `Operator` is `Lt` or `Gt`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #7254

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-webhook`: Now rejects `PropagationPolicy` and `ClusterPropagationPolicy` resources that use the `Lt` or `Gt` operator in `spec.placement.clusterTolerations`.
```

