### PR TITLE
fix: add curl fallback in deploy-k8s-metrics-server.sh for macOS comp…

### DIFF
--- a/hack/deploy-k8s-metrics-server.sh
+++ b/hack/deploy-k8s-metrics-server.sh
@@ -53,7 +53,16 @@ fi
 MEMBER_CLUSTER_NAME=$2
 
 # get deploy yaml
-wget https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.6.3/components.yaml -O "${_tmp}/components.yaml"
+METRICS_SERVER_URL="https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.6.3/components.yaml"
+# Prefer curl (available on macOS + Linux); fall back to wget on failure; fail with a clear error if both fail
+if command -v curl &>/dev/null && curl -fsSL "${METRICS_SERVER_URL}" -o "${_tmp}/components.yaml"; then
+  :
+elif command -v wget &>/dev/null && wget -qO "${_tmp}/components.yaml" "${METRICS_SERVER_URL}"; then
+  :
+else
+  echo "ERROR: failed to download metrics-server components.yaml. Please ensure curl or wget is installed and network access is available."
+  exit 1
+fi
 sed -i'' -e 's/args:/args:\n        - --kubelet-insecure-tls=true/' "${_tmp}/components.yaml"
 
 # deploy metrics-server in member cluster


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
`hack/deploy-k8s-metrics-server.sh` used wget to download the metrics-server manifest, but wget is not available on macOS by default. This caused the Quick Start script to fail immediately on macOS wit`h zsh: command not found: wget`. This PR adds curl as a fallback since curl is available on macOS, Linux, and Windows by default. `hack/install-cli.sh `already follows this pattern of preferring curl.

**Which issue(s) this PR fixes:**
Fixes #7273
Part of #7269

**Special notes for your reviewer:**
`curl` and `wget `fetch the exact same file from the same URL. The only change is the tool used and the flag syntax (-O for wget → -o for curl). Behavior is identical on Linux where wget is typically pre-installed.

**Does this PR introduce a user-facing change?:**
release`hack/deploy-k8s-metrics-server.sh`: Fixed Quick Start failure on macOS caused by missing `wget` by adding `curl` as a fallback.