### PR TITLE
fix: correct SignerName in cert rotation CSR

### DIFF
--- a/pkg/controllers/certificate/cert_rotation_controller.go
+++ b/pkg/controllers/certificate/cert_rotation_controller.go
@@ -53,8 +53,9 @@ const (
 	// CertRotationControllerName is the controller name that will be used when reporting events and metrics.
 	CertRotationControllerName = "cert-rotation-controller"
 
-	// SignerName defines the signer name for csr, 'kubernetes.io/kube-apiserver-client-kubelet' can sign the csr automatically
-	SignerName = "kubernetes.io/kube-apiserver-client-kubelet"
+	// SignerName defines the signer name for csr, 'kubernetes.io/kube-apiserver-client' is used
+	// to match the signer expected by the agent CSR approver (agent_csr_approving).
+	SignerName = certificatesv1.KubeAPIServerClientSignerName
 
 	// KarmadaKubeconfigName is the name of the secret containing karmada-agent certificate.
 	KarmadaKubeconfigName = "karmada-kubeconfig"

--- a/pkg/controllers/certificate/cert_rotation_controller_test.go
+++ b/pkg/controllers/certificate/cert_rotation_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -355,4 +356,41 @@ func newMockCert(notBefore, notAfter time.Time) (*x509.Certificate, error) {
 	}
 
 	return x509.ParseCertificate(certData)
+}
+
+// TestSignerNameMatchesAgentCSRApprover verifies that the SignerName used when creating
+// a CSR in cert_rotation_controller matches the signer expected by agent_csr_approving,
+// so that rotation CSRs can be auto-approved.
+func TestSignerNameMatchesAgentCSRApprover(t *testing.T) {
+	c := makeFakeCertRotationController(1)
+
+	// Generate a key and a mock cert to drive createCSRInControlPlane.
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	now := time.Now()
+	cert, err := newMockCert(now, now.Add(24*time.Hour))
+	if err != nil {
+		t.Fatalf("failed to create mock cert: %v", err)
+	}
+
+	csrName, err := c.createCSRInControlPlane(context.Background(), "test-cluster", privateKey, []*x509.Certificate{cert})
+	if err != nil {
+		t.Fatalf("createCSRInControlPlane() error = %v", err)
+	}
+
+	csr, err := c.KubeClient.CertificatesV1().CertificateSigningRequests().Get(context.Background(), csrName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get CSR %q: %v", csrName, err)
+	}
+
+	// The approver (agent_csr_approving) only recognises CSRs whose SignerName is
+	// KubeAPIServerClientSignerName ("kubernetes.io/kube-apiserver-client").
+	// Using KubeAPIServerClientKubeletSignerName would cause the CSR to be silently ignored.
+	wantSigner := certificatesv1.KubeAPIServerClientSignerName
+	if csr.Spec.SignerName != wantSigner {
+		t.Errorf("CSR SignerName = %q, want %q (must match agent_csr_approving expectation)", csr.Spec.SignerName, wantSigner)
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`cert_rotation_controller` was creating CSRs with `SignerName` set to `"kubernetes.io/kube-apiserver-client-kubelet"`, but `agent_csr_approving` only recognizes CSRs with `SignerName` equal to `"kubernetes.io/kube-apiserver-client"`. This mismatch caused certificate rotation CSRs to be silently ignored by the approver, resulting in rotation timeout and silent failure. This PR corrects the `SignerName` to align with the approver's expectation.

**Which issue(s) this PR fixes**:

Fixes #7256

**Special notes for your reviewer**:

A regression test `TestSignerNameMatchesAgentCSRApprover` has been added to `cert_rotation_controller_test.go` to assert that the `SignerName` used when creating a rotation CSR always matches the value expected by `agent_csr_approving`, preventing future regressions.

**Does this PR introduce a user-facing change?**:

```release-note
`karmada-agent`: Fixed the issue that certificate rotation CSRs were never auto-approved due to a SignerName mismatch between `cert_rotation_controller` and `agent_csr_approving`.