### PR TITLE
fix: use sed -E instead of sed -r for macOS BSD sed compatibility

### DIFF
--- a/hack/update-estimator-protobuf.sh
+++ b/hack/update-estimator-protobuf.sh
@@ -44,7 +44,7 @@ util:create_gopath_tree "${KARMADA_ROOT}" "${go_path}"
 export GOPATH="${go_path}"
 
 # https://github.com/kubernetes/kubernetes/blob/release-1.23/hack/update-generated-protobuf-dockerized.sh
-if [[ -z "$(which protoc)" || $(protoc --version | sed -r "s/libprotoc ([0-9]+).*/\1/g") -lt 3 ]]; then
+if [[ -z "$(which protoc)" || $(protoc --version | sed -E "s/libprotoc ([0-9]+).*/\1/g") -lt 3 ]]; then
   echo "Generating protobuf requires protoc 3.0.0-beta1 or newer. Please download and"
   echo "install the platform appropriate Protobuf package for your OS: "
   echo


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
`hack/update-estimator-protobuf.sh` uses` sed -r` to extract the `protoc` major version. `-r` is a GNU sed flag not recognized by BSD sed, which ships with macOS. This causes the script to abort immediately with` sed: illegal option -- r` on any fresh Mac. Replacing `-r `with `-E` fixes this — `-E `is POSIX standard and supported by both BSD sed (macOS) and GNU sed (Linux). No functional change.

**Which issue(s) this PR fixes:**
Fixes #7278
Part of #7269

**Special notes for your reviewer:**
One character change — `-r `→ `-E` on line 47. Regex pattern is identical. No functional change on Linux.

**Does this PR introduce a user-facing change?:**
NONE
