### PR TITLE
hack/setup-dev-base.sh: Add Docker daemon and resource pre-flight validation

### DIFF
--- a/hack/setup-dev-base.sh
+++ b/hack/setup-dev-base.sh
@@ -56,8 +56,23 @@ fi
 util::cmd_must_exist "go"
 util::verify_go_version
 
-# make sure docker exists
+# make sure docker exists and daemon is running
 util::cmd_must_exist "docker"
+
+# Verify Docker daemon is actually reachable
+DOCKER_INFO_ERROR_OUTPUT=""
+if ! DOCKER_INFO_ERROR_OUTPUT=$(docker info 2>&1 >/dev/null); then
+  echo "ERROR: Cannot connect to Docker (docker info failed)."
+  echo "Details: ${DOCKER_INFO_ERROR_OUTPUT}"
+  if [[ "$(uname)" == "Darwin" ]]; then
+    echo "On macOS, please start Docker Desktop."
+  else
+    echo "On Linux, this may be a permissions issue (e.g., your user is not in the 'docker' group) or a misconfigured Docker context."
+    echo "Please ensure the Docker daemon is running and that you have permission to access it."
+  fi
+  exit 1
+fi
+
 
 # install kind and kubectl
 echo -n "Preparing: 'kind' existence check - "


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
The script only verified that the Docker binary existed via util::cmd_must_exist "docker" but did not validate that the Docker daemon was actually running or that sufficient resources were allocated. On macOS, Docker Desktop must be started manually — the CLI can exist without the daemon running. This caused the script to proceed through all setup steps and fail much later at util::create_cluster with a cryptic socket error, wasting the user's time.
This PR adds a pre-flight validation block that:
- Verifies the Docker daemon is running — exits immediately with a clear, actionable, OS-aware error message if not
- Checks Docker has sufficient resources (4 GB memory, 2 CPUs) — warns if below recommended levels without hard failing

**Which issue(s) this PR fixes:**
Fixes #7280
Part of #7269

**Special notes for your reviewer:**
The resource check is a warning only — it does not hard fail — to avoid blocking users who may have intentionally constrained their Docker Desktop resources.

**Does this PR introduce a user-facing change?:**
release`hack/local-up-karmada.sh`: Added pre-flight Docker daemon and resource validation to surf