### PR TITLE
cleanup(hack/util.sh): remove unused function `util::wait_nodes_taint_disappear` containing timeout

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -808,26 +808,3 @@ function util::set_mirror_registry_for_china_mainland() {
 RUN echo -e http://mirrors.ustc.edu.cn/alpine/v3.21/main/ > /etc/apk/repositories" ${repo_root}/${dockerfile}
   done
 }
-
-# util::wait_nodes_taint_disappear will wait for all the nodes' taint to disappear
-# Parameters:
-#  - timeout: Timeout in seconds.
-#  - kubeconfig_path: The path of kubeconfig.
-# Returns:
-#  1 if the condition is not met before the timeout, else 0
-function util::wait_nodes_taint_disappear() {
-  local timeout=${1}
-  local kubeconfig_path=${2}
-
-  timeout "${timeout}" bash <<EOF && return 0
-    while true
-    do
-      taints=\$(kubectl get nodes --kubeconfig=${kubeconfig_path} -o=jsonpath="{.items[*].spec.taints}")
-      if [ -z \$taints ]; then
-        exit
-      fi
-    done
-EOF
-  echo "Timeout for nodes' taint to disappear"
-  return 1
-}


### PR DESCRIPTION
# What this PR does
Removes the unused function util::wait_nodes_taint_disappear from hack/util.sh.

# Why
A codebase-wide search confirms this function is defined at hack/util.sh:818 but never called anywhere in the repository. It is dead code.
Additionally, the function uses GNU timeout internally, which is not available by default on macOS. While this does not currently impact any workflow (since the function is never called), it represents a latent platform incompatibility that could cause confusion during macOS compatibility work.

# Changes
Removed function util::wait_nodes_taint_disappear from hack/util.sh

# Testing

Verified no references to util::wait_nodes_taint_disappear exist anywhere in the repository outside of its own definition.

Fixes #7284 

part of #7269 