### PR TITLE
Fix component-based scheduling to include single-component workloads

### DIFF
--- a/pkg/scheduler/core/estimation.go
+++ b/pkg/scheduler/core/estimation.go
@@ -29,8 +29,8 @@ import (
 )
 
 // isMultiTemplateSchedulingApplicable checks if the given ResourceBindingSpec
-// meets the criteria for multi-template scheduling:
-//  1. The referenced resource holds multiple pod templates (multiple components).
+// meets the criteria for component-based scheduling:
+//  1. The referenced resource has at least one component populated.
 //  2. The placement configuration schedules the resource to exactly one cluster.
 //     This is currently determined by checking if spread constraints is set and requires exactly one cluster.
 //
@@ -44,7 +44,7 @@ func isMultiTemplateSchedulingApplicable(spec *workv1alpha2.ResourceBindingSpec)
 		return false
 	}
 
-	if len(spec.Components) < 2 {
+	if len(spec.Components) == 0 {
 		return false
 	}
 

--- a/pkg/scheduler/core/estimation_test.go
+++ b/pkg/scheduler/core/estimation_test.go
@@ -128,7 +128,7 @@ func Test_isMultiTemplateSchedulingApplicable(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "spec with single component should not be applicable",
+			name: "spec with single component and valid spread constraint should be applicable",
 			spec: &workv1alpha2.ResourceBindingSpec{
 				Components: []workv1alpha2.Component{
 					{Name: "component1"},
@@ -143,7 +143,7 @@ func Test_isMultiTemplateSchedulingApplicable(t *testing.T) {
 					},
 				},
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "spec with valid cluster spread constraint should be applicable",

--- a/pkg/util/binding.go
+++ b/pkg/util/binding.go
@@ -40,14 +40,14 @@ func IsBindingReplicasChanged(bindingSpec *workv1alpha2.ResourceBindingSpec, str
 		return false
 	}
 
-	// For multi-component workloads, trigger rescheduling when clusters are empty (e.g., after eviction).
+	// For component-based workloads, trigger rescheduling when clusters are empty (e.g., after eviction).
 	// This is a temporary fix to ensure cluster failover works correctly.
 	// Limitation: This only handles the failover scenario where clusters are cleared.
 	// It does not detect component replica changes (e.g., scale up/down) or replica swaps between components.
 	// A complete solution requires changing how scheduling results are stored to support multi-template workloads,
 	// likely by extending TargetCluster to include per-component replica information.
 	// The comprehensive solution is tracked by: https://github.com/karmada-io/karmada/issues/6998
-	if features.FeatureGate.Enabled(features.MultiplePodTemplatesScheduling) && len(bindingSpec.Components) > 1 {
+	if features.FeatureGate.Enabled(features.MultiplePodTemplatesScheduling) && len(bindingSpec.Components) > 0 {
 		if len(bindingSpec.Clusters) == 0 {
 			return true
 		}

--- a/pkg/util/binding_test.go
+++ b/pkg/util/binding_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -27,6 +28,7 @@ import (
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
+	"github.com/karmada-io/karmada/pkg/features"
 	testhelper "github.com/karmada-io/karmada/test/helper"
 )
 
@@ -179,11 +181,73 @@ func TestIsBindingReplicasChanged(t *testing.T) {
 		},
 	}
 
+	// Component-based workload failover tests require the MultiplePodTemplatesScheduling feature gate.
+	componentTests := []struct {
+		name        string
+		bindingSpec *workv1alpha2.ResourceBindingSpec
+		strategy    *policyv1alpha1.ReplicaSchedulingStrategy
+		expected    bool
+	}{
+		{
+			name: "single component with empty clusters should trigger rescheduling",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "component1", Replicas: 3},
+				},
+				Clusters: []workv1alpha2.TargetCluster{},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDuplicated},
+			expected: true,
+		},
+		{
+			name: "multiple components with empty clusters should trigger rescheduling",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "component1", Replicas: 3},
+					{Name: "component2", Replicas: 2},
+				},
+				Clusters: []workv1alpha2.TargetCluster{},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDuplicated},
+			expected: true,
+		},
+		{
+			name: "single component with non-empty clusters should not trigger rescheduling",
+			bindingSpec: &workv1alpha2.ResourceBindingSpec{
+				Components: []workv1alpha2.Component{
+					{Name: "component1", Replicas: 3},
+				},
+				Clusters: []workv1alpha2.TargetCluster{
+					{Name: ClusterMember1},
+				},
+			},
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDuplicated},
+			expected: false,
+		},
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.bindingSpec == nil {
 				t.FailNow()
 			}
+			got := IsBindingReplicasChanged(tt.bindingSpec, tt.strategy)
+			if got != tt.expected {
+				t.Errorf("IsBindingReplicasChanged() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+
+	// Run component-based tests with the feature gate enabled.
+	originalFeatureGates := features.FeatureGate.DeepCopy()
+	if err := features.FeatureGate.Set(fmt.Sprintf("%s=true", features.MultiplePodTemplatesScheduling)); err != nil {
+		t.Fatalf("Failed to enable feature gate %s: %v", features.MultiplePodTemplatesScheduling, err)
+	}
+	t.Cleanup(func() {
+		features.FeatureGate = originalFeatureGates
+	})
+	for _, tt := range componentTests {
+		t.Run(tt.name, func(t *testing.T) {
 			got := IsBindingReplicasChanged(tt.bindingSpec, tt.strategy)
 			if got != tt.expected {
 				t.Errorf("IsBindingReplicasChanged() = %v, want %v", got, tt.expected)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
When the `MultiplePodTemplatesScheduling` feature gate is enabled, the `Components` field is populated for all workloads, including **single-component** workloads. However, `IsBindingReplicasChanged` and `isMultiTemplateSchedulingApplicable` both required `len(Components) > 1 `(i.e., 2+ components) before entering the component-aware code paths. This meant **single**-component workloads were silently excluded from:

1. Failover rescheduling — When all clusters are evicted (clusters become empty), a single-component workload would not trigger rescheduling, leaving it stuck with no target clusters.

2. Component-based replica estimation — The scheduler would skip the `MaxAvailableComponentSets` estimation path for single-component workloads, falling back to the `Replica Scheduling` path even though `Components` was populated.

This contradicts the design of the Components field, which explicitly states it "is also capable of representing single-component workloads, such as Deployment."

This PR fixes both checks to use `len(Components) > 0`, ensuring consistent behavior for all component-based workloads regardless of the number of components. The change is fully guarded by the `MultiplePodTemplatesScheduling` feature gate, so existing behavior is unaffected when the gate is disabled.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #7277

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-scheduler`: Extended the MultiplePodTemplatesScheduling feature to support workloads with only one component.
```

