### PR TITLE
[refactor] use shared functions to reduce redundancy in the estimator pkg

### DIFF
--- a/pkg/estimator/scheduling_simulator_components.go
+++ b/pkg/estimator/scheduling_simulator_components.go
@@ -18,6 +18,7 @@ package estimator
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
 
 	"github.com/karmada-io/karmada/pkg/estimator/pb"
 	nodeutil "github.com/karmada-io/karmada/pkg/estimator/server/nodes"
@@ -76,10 +77,10 @@ func (s *SchedulingSimulator) scheduleComponent(component pb.Component) bool {
 	requiredPerReplica := util.NewResource(component.ReplicaRequirements.ResourceRequest)
 	requiredPerReplica.AllowedPodNumber = 1
 	remaining := component.Replicas
-	nodeClaim := component.ReplicaRequirements.NodeClaim
+	affinity, tolerations := GetAffinityAndTolerations(component.ReplicaRequirements.NodeClaim)
 
 	for _, node := range s.nodes {
-		if !matchNode(nodeClaim, node) {
+		if !MatchNode(node, affinity, tolerations) {
 			continue
 		}
 
@@ -102,18 +103,21 @@ func (s *SchedulingSimulator) scheduleComponent(component pb.Component) bool {
 	return remaining == 0
 }
 
-// matchNode checks whether the node matches the scheduling constraints defined in the replica requirements.
-func matchNode(nodeClaim *pb.NodeClaim, node *schedulerframework.NodeInfo) bool {
+// GetAffinityAndTolerations extracts node affinity and tolerations from a NodeClaim.
+func GetAffinityAndTolerations(nodeClaim *pb.NodeClaim) (nodeaffinity.RequiredNodeAffinity, []corev1.Toleration) {
+	affinity := nodeutil.GetRequiredNodeAffinity(pb.ReplicaRequirements{NodeClaim: nodeClaim})
+	var tolerations []corev1.Toleration
+	if nodeClaim != nil {
+		tolerations = nodeClaim.Tolerations
+	}
+	return affinity, tolerations
+}
+
+// MatchNode checks whether the node matches the node affinity and tolerations specified in the component's replica requirements.
+func MatchNode(node *schedulerframework.NodeInfo, affinity nodeaffinity.RequiredNodeAffinity, tolerations []corev1.Toleration) bool {
 	if node.Node() == nil {
 		// Always match since we lack node affinity/toleration info, so we skip these checks.
 		return true
-	}
-
-	affinity := nodeutil.GetRequiredNodeAffinity(pb.ReplicaRequirements{NodeClaim: nodeClaim})
-	var tolerations []corev1.Toleration
-
-	if nodeClaim != nil {
-		tolerations = nodeClaim.Tolerations
 	}
 
 	return nodeutil.IsNodeAffinityMatched(node.Node(), affinity) && nodeutil.IsTolerationMatched(node.Node(), tolerations)

--- a/pkg/estimator/scheduling_simulator_components_test.go
+++ b/pkg/estimator/scheduling_simulator_components_test.go
@@ -144,9 +144,10 @@ func TestMatchNode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := matchNode(tt.replicaRequirements.NodeClaim, tt.node)
+			affinity, tolerations := GetAffinityAndTolerations(tt.replicaRequirements.NodeClaim)
+			result := MatchNode(tt.node, affinity, tolerations)
 			if result != tt.expected {
-				t.Errorf("matchNode() = %v, expected %v", result, tt.expected)
+				t.Errorf("MatchNode() = %v, expected %v", result, tt.expected)
 			}
 		})
 	}

--- a/pkg/estimator/server/framework/plugins/noderesource/noderesource.go
+++ b/pkg/estimator/server/framework/plugins/noderesource/noderesource.go
@@ -28,7 +28,6 @@ import (
 	"github.com/karmada-io/karmada/pkg/estimator"
 	"github.com/karmada-io/karmada/pkg/estimator/pb"
 	"github.com/karmada-io/karmada/pkg/estimator/server/framework"
-	nodeutil "github.com/karmada-io/karmada/pkg/estimator/server/nodes"
 	"github.com/karmada-io/karmada/pkg/util"
 	schedcache "github.com/karmada-io/karmada/pkg/util/lifted/scheduler/cache"
 	schedulerframework "github.com/karmada-io/karmada/pkg/util/lifted/scheduler/framework"
@@ -70,27 +69,20 @@ func (pl *nodeResourceEstimator) Name() string {
 // Estimate the replica allowed by the node resources for a given pb.ReplicaRequirements.
 func (pl *nodeResourceEstimator) Estimate(ctx context.Context, snapshot *schedcache.Snapshot, requirements *pb.ReplicaRequirements) (int32, *framework.Result) {
 	if !pl.enabled {
-		klog.V(5).Info("Estimator Plugin", "name", Name, "enabled", pl.enabled)
-		return noNodeConstraint, framework.NewResult(framework.Noopperation, fmt.Sprintf("%s is disabled", pl.Name()))
+		return pl.disabledResult()
 	}
 
 	allNodes, err := snapshot.NodeInfos().List()
 	if err != nil {
 		return 0, framework.AsResult(err)
 	}
-	var (
-		affinity    = nodeutil.GetRequiredNodeAffinity(*requirements)
-		tolerations []corev1.Toleration
-	)
 
-	if requirements.NodeClaim != nil {
-		tolerations = requirements.NodeClaim.Tolerations
-	}
+	affinity, tolerations := estimator.GetAffinityAndTolerations(requirements.NodeClaim)
 
 	var res int32
 	processNode := func(i int) {
-		node := allNodes[i]
-		if !nodeutil.IsNodeAffinityMatched(node.Node(), affinity) || !nodeutil.IsTolerationMatched(node.Node(), tolerations) {
+		node := allNodes[i].Clone()
+		if !estimator.MatchNode(node, affinity, tolerations) {
 			return
 		}
 		maxReplica := pl.nodeMaxAvailableReplica(node, requirements.ResourceRequest)
@@ -102,21 +94,28 @@ func (pl *nodeResourceEstimator) Estimate(ctx context.Context, snapshot *schedca
 }
 
 func (pl *nodeResourceEstimator) nodeMaxAvailableReplica(node *schedulerframework.NodeInfo, rl corev1.ResourceList) int32 {
-	rest := node.Allocatable.Clone().SubResource(node.Requested)
+	rest := getNodeAvailableResource(node)
+	return int32(rest.MaxDivided(rl)) // #nosec G115: integer overflow conversion int64 -> int32
+}
+
+// getNodeAvailableResource calculates a node's available resources after deducting requested resources
+// and adjusting the pod-count capacity, which isn't included in node.Requested.
+func getNodeAvailableResource(node *schedulerframework.NodeInfo) *util.Resource {
+	rest := node.Allocatable
+	rest = rest.SubResource(node.Requested)
 	// The number of pods in a node is a kind of resource in node allocatable resources.
 	// However, total requested resources of all pods on this node, i.e. `node.Requested`,
 	// do not contain pod resources. So after subtraction, we should cope with allowed pod
 	// number manually which is the upper bound of this node available replicas.
 	rest.AllowedPodNumber = util.MaxInt64(rest.AllowedPodNumber-int64(len(node.Pods)), 0)
-	return int32(rest.MaxDivided(rl)) // #nosec G115: integer overflow conversion int64 -> int32
+	return rest
 }
 
 // EstimateComponents estimates the maximum number of complete component sets that can be scheduled.
 // It returns the number of sets that can fit on the available node resources.
 func (pl *nodeResourceEstimator) EstimateComponents(_ context.Context, snapshot *schedcache.Snapshot, components []pb.Component, _ string) (int32, *framework.Result) {
 	if !pl.enabled {
-		klog.V(5).Info("Estimator Plugin", "name", Name, "enabled", pl.enabled)
-		return noNodeConstraint, framework.NewResult(framework.Noopperation, fmt.Sprintf("%s is disabled", pl.Name()))
+		return pl.disabledResult()
 	}
 
 	if len(components) == 0 {
@@ -136,6 +135,11 @@ func (pl *nodeResourceEstimator) EstimateComponents(_ context.Context, snapshot 
 	return sets, framework.NewResult(framework.Success)
 }
 
+func (pl *nodeResourceEstimator) disabledResult() (int32, *framework.Result) {
+	klog.V(5).Info("Estimator Plugin", "name", Name, "enabled", pl.enabled)
+	return noNodeConstraint, framework.NewResult(framework.Noopperation, fmt.Sprintf("%s is disabled", pl.Name()))
+}
+
 // getNodesAvailableResources retrieves and prepares the list of node information from the snapshot.
 // It clones each node's info and adjusts the allocatable resources by subtracting the requested resources.
 // So that the returned node infos reflect the actual available resources for scheduling.
@@ -148,8 +152,7 @@ func getNodesAvailableResources(snapshot *schedcache.Snapshot) ([]*schedulerfram
 	rest := make([]*schedulerframework.NodeInfo, 0, len(allNodes))
 	for _, node := range allNodes {
 		n := node.Clone()
-		n.Allocatable.SubResource(n.Requested)
-		n.Allocatable.AllowedPodNumber = util.MaxInt64(n.Allocatable.AllowedPodNumber-int64(len(node.Pods)), 0)
+		n.Allocatable = getNodeAvailableResource(n)
 		rest = append(rest, n)
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

1. Use shared functions to reduce redundancy in the estimator pkg
2. Reduced unnecessary nodeAffinity parsing.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
3. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
4. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

