### PR TITLE
test: add inline event assertions for resource template events

### DIFF
--- a/test/e2e/suites/base/dependenciesdistributor_test.go
+++ b/test/e2e/suites/base/dependenciesdistributor_test.go
@@ -113,6 +113,12 @@ var _ = ginkgo.Describe("[DependenciesDistributor] automatically propagate relev
 							return true
 						})
 				})
+				ginkgo.By("checking GetDependenciesSucceed event on deployment", func() {
+					framework.WaitEventFitWith(kubeClient, deployment.Namespace, deployment.Name,
+						func(event corev1.Event) bool {
+							return event.Reason == events.EventReasonGetDependenciesSucceed
+						})
+				})
 
 				ginkgo.By("updating propagation policy's clusterNames", func() {
 					patch := []map[string]any{
@@ -206,6 +212,13 @@ var _ = ginkgo.Describe("[DependenciesDistributor] automatically propagate relev
 						func(*corev1.Secret) bool {
 							return true
 						})
+
+					ginkgo.By("checking GetDependenciesSucceed event on deployment", func() {
+						framework.WaitEventFitWith(kubeClient, deployment.Namespace, deployment.Name,
+							func(event corev1.Event) bool {
+								return event.Reason == events.EventReasonGetDependenciesSucceed
+							})
+					})
 				})
 
 				ginkgo.By("make the secret is not referenced by the deployment ", func() {
@@ -276,10 +289,16 @@ var _ = ginkgo.Describe("[DependenciesDistributor] automatically propagate relev
 						func(*appsv1.Deployment) bool {
 							return true
 						})
-
 					framework.WaitPVCPresentOnClustersFitWith(initClusterNames, pvc.GetNamespace(), pvc.GetName(),
 						func(*corev1.PersistentVolumeClaim) bool {
 							return true
+						})
+				})
+
+				ginkgo.By("checking GetDependenciesSucceed event on deployment", func() {
+					framework.WaitEventFitWith(kubeClient, deployment.Namespace, deployment.Name,
+						func(event corev1.Event) bool {
+							return event.Reason == events.EventReasonGetDependenciesSucceed
 						})
 				})
 
@@ -341,6 +360,12 @@ var _ = ginkgo.Describe("[DependenciesDistributor] automatically propagate relev
 					framework.WaitServiceAccountPresentOnClustersFitWith(initClusterNames, sa.GetNamespace(), sa.GetName(),
 						func(*corev1.ServiceAccount) bool {
 							return true
+						})
+				})
+				ginkgo.By("checking GetDependenciesSucceed event on deployment", func() {
+					framework.WaitEventFitWith(kubeClient, deployment.Namespace, deployment.Name,
+						func(event corev1.Event) bool {
+							return event.Reason == events.EventReasonGetDependenciesSucceed
 						})
 				})
 
@@ -680,6 +705,13 @@ var _ = ginkgo.Describe("[DependenciesDistributor] automatically propagate relev
 					framework.WaitConfigMapPresentOnClustersFitWith(initClusterNames, configMap.Namespace, configMapName,
 						func(*corev1.ConfigMap) bool {
 							return true
+						})
+				})
+
+				ginkgo.By("checking GetDependenciesSucceed event on deployment", func() {
+					framework.WaitEventFitWith(kubeClient, deployment.Namespace, deployment.Name,
+						func(event corev1.Event) bool {
+							return event.Reason == events.EventReasonGetDependenciesSucceed
 						})
 				})
 

--- a/test/e2e/suites/base/overridepolicy_test.go
+++ b/test/e2e/suites/base/overridepolicy_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/klog/v2"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/events"
 	"github.com/karmada-io/karmada/test/e2e/framework"
 	"github.com/karmada-io/karmada/test/helper"
 )
@@ -112,6 +113,13 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 		})
 
 		ginkgo.It("deployment labelsOverride testing", func() {
+			ginkgo.By("checking ApplyOverridePolicySucceed event on deployment", func() {
+				framework.WaitEventFitWith(kubeClient, deploymentNamespace, deploymentName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonApplyOverridePolicySucceed
+					})
+			})
+
 			klog.Infof("check if deployment present on member clusters have correct labels value")
 			framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
 				func(deployment *appsv1.Deployment) bool {
@@ -274,6 +282,13 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 		})
 
 		ginkgo.It("deployment imageOverride testing", func() {
+			ginkgo.By("checking ApplyOverridePolicySucceed event", func() {
+				framework.WaitEventFitWith(kubeClient, deploymentNamespace, deploymentName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonApplyOverridePolicySucceed
+					})
+			})
+
 			klog.Infof("check if deployment present on member clusters have correct image value")
 			framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
 				func(deployment *appsv1.Deployment) bool {
@@ -422,6 +437,13 @@ var _ = ginkgo.Describe("[OverridePolicy] apply overriders testing", func() {
 		})
 
 		ginkgo.It("deployment imageOverride testing", func() {
+			ginkgo.By("checking ApplyOverridePolicySucceed event", func() {
+				framework.WaitEventFitWith(kubeClient, deploymentNamespace, deploymentName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonApplyOverridePolicySucceed
+					})
+			})
+
 			klog.Infof("check if deployment present on member clusters have correct image value")
 			framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
 				func(deployment *appsv1.Deployment) bool {
@@ -703,6 +725,13 @@ var _ = framework.SerialDescribe("OverridePolicy with nil resourceSelector testi
 		})
 
 		ginkgo.It("deployment imageOverride testing", func() {
+			ginkgo.By("checking ApplyOverridePolicySucceed event", func() {
+				framework.WaitEventFitWith(kubeClient, deploymentNamespace, deploymentName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonApplyOverridePolicySucceed
+					})
+			})
+
 			klog.Infof("check if deployment present on member clusters have correct image value")
 			framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
 				func(deployment *appsv1.Deployment) bool {
@@ -788,6 +817,12 @@ var _ = ginkgo.Describe("[OverrideRules] apply overriders testing", func() {
 		})
 
 		ginkgo.It("deployment imageOverride testing", func() {
+			ginkgo.By("checking ApplyOverridePolicySucceed event", func() {
+				framework.WaitEventFitWith(kubeClient, deploymentNamespace, deploymentName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonApplyOverridePolicySucceed
+					})
+			})
 			klog.Infof("check if deployment present on member clusters have correct image value")
 			framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
 				func(deployment *appsv1.Deployment) bool {
@@ -881,6 +916,7 @@ var _ = ginkgo.Describe("[OverrideRules] apply overriders testing", func() {
 				return true
 			})
 		})
+
 	})
 
 	ginkgo.Context("Deployment override specific images in container list", func() {
@@ -946,6 +982,12 @@ var _ = ginkgo.Describe("[OverrideRules] apply overriders testing", func() {
 		})
 
 		ginkgo.It("deployment imageOverride testing", func() {
+			ginkgo.By("checking ApplyOverridePolicySucceed event", func() {
+				framework.WaitEventFitWith(kubeClient, deploymentNamespace, deploymentName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonApplyOverridePolicySucceed
+					})
+			})
 			klog.Infof("check if deployment present on member clusters have correct image value")
 			framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
 				func(deployment *appsv1.Deployment) bool {

--- a/test/e2e/suites/base/preemption_test.go
+++ b/test/e2e/suites/base/preemption_test.go
@@ -19,11 +19,13 @@ package base
 import (
 	"github.com/onsi/ginkgo/v2"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/ptr"
 
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/events"
 	"github.com/karmada-io/karmada/test/e2e/framework"
 	testhelper "github.com/karmada-io/karmada/test/helper"
 )
@@ -87,6 +89,12 @@ var _ = ginkgo.Describe("[Preemption] propagation policy preemption testing", fu
 					framework.CreatePropagationPolicy(karmadaClient, highPriorityPolicy)
 					framework.WaitDeploymentPresentOnClusterFitWith(preemptingClusterName, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 				})
+				ginkgo.By("checking PreemptPolicySucceed event on deployment", func() {
+					framework.WaitEventFitWith(kubeClient, deployment.Namespace, deployment.Name,
+						func(event corev1.Event) bool {
+							return event.Reason == events.EventReasonPreemptPolicySucceed
+						})
+				})
 
 				ginkgo.By("Delete the high-priority PropagationPolicy to let the low-priority PropagationPolicy preempt the deployment", func() {
 					framework.RemovePropagationPolicy(karmadaClient, highPriorityPolicy.Namespace, highPriorityPolicy.Name)
@@ -139,12 +147,20 @@ var _ = ginkgo.Describe("[Preemption] propagation policy preemption testing", fu
 
 			ginkgo.It("Propagate the deployment with the ClusterPropagationPolicy and then create the PropagationPolicy to preempt it", func() {
 				ginkgo.By("Wait for propagating deployment by the ClusterPropagationPolicy", func() {
+
 					framework.WaitDeploymentPresentOnClusterFitWith(preemptedClusterName, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 				})
 
 				ginkgo.By("Create the PropagationPolicy to preempt the ClusterPropagationPolicy", func() {
 					framework.CreatePropagationPolicy(karmadaClient, propagationPolicy)
 					framework.WaitDeploymentPresentOnClusterFitWith(preemptingClusterName, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
+				})
+
+				ginkgo.By("checking PreemptPolicySucceed event on deployment", func() {
+					framework.WaitEventFitWith(kubeClient, deployment.Namespace, deployment.Name,
+						func(event corev1.Event) bool {
+							return event.Reason == events.EventReasonPreemptPolicySucceed
+						})
 				})
 
 				ginkgo.By("Delete the PropagationPolicy to let the ClusterPropagationPolicy preempt the deployment", func() {
@@ -216,6 +232,13 @@ var _ = ginkgo.Describe("[Preemption] propagation policy preemption testing", fu
 					framework.PatchPropagationPolicy(karmadaClient, highPriorityPolicy.Namespace, highPriorityPolicy.Name, patch, types.JSONPatchType)
 					framework.WaitDeploymentPresentOnClusterFitWith(preemptingClusterName, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
 				})
+
+				ginkgo.By("checking PreemptPolicySucceed event on deployment", func() {
+					framework.WaitEventFitWith(kubeClient, deployment.Namespace, deployment.Name,
+						func(event corev1.Event) bool {
+							return event.Reason == events.EventReasonPreemptPolicySucceed
+						})
+				})
 			})
 		})
 	})
@@ -270,6 +293,13 @@ var _ = ginkgo.Describe("[Preemption] propagation policy preemption testing", fu
 				ginkgo.By("Create the high-priority ClusterPropagationPolicy to preempt the low-priority ClusterPropagationPolicy", func() {
 					framework.CreateClusterPropagationPolicy(karmadaClient, highPriorityPolicy)
 					framework.WaitDeploymentPresentOnClusterFitWith(preemptingClusterName, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
+				})
+
+				ginkgo.By("checking PreemptPolicySucceed event on deployment", func() {
+					framework.WaitEventFitWith(kubeClient, deployment.Namespace, deployment.Name,
+						func(event corev1.Event) bool {
+							return event.Reason == events.EventReasonPreemptPolicySucceed
+						})
 				})
 
 				ginkgo.By("Delete the high-priority ClusterPropagationPolicy to let the low-priority ClusterPropagationPolicy preempt the deployment", func() {
@@ -340,6 +370,13 @@ var _ = ginkgo.Describe("[Preemption] propagation policy preemption testing", fu
 					}
 					framework.PatchClusterPropagationPolicy(karmadaClient, highPriorityPolicy.Name, patch, types.JSONPatchType)
 					framework.WaitDeploymentPresentOnClusterFitWith(preemptingClusterName, deployment.Namespace, deployment.Name, func(*appsv1.Deployment) bool { return true })
+				})
+
+				ginkgo.By("checking PreemptPolicySucceed event on deployment", func() {
+					framework.WaitEventFitWith(kubeClient, deployment.Namespace, deployment.Name,
+						func(event corev1.Event) bool {
+							return event.Reason == events.EventReasonPreemptPolicySucceed
+						})
 				})
 			})
 		})

--- a/test/e2e/suites/base/propagationpolicy_test.go
+++ b/test/e2e/suites/base/propagationpolicy_test.go
@@ -97,16 +97,84 @@ var _ = ginkgo.Describe("[BasicCase] PropagationPolicy testing", func() {
 		})
 
 		ginkgo.It("deployment propagation testing", func() {
-			framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
-				func(*appsv1.Deployment) bool {
-					return true
-				})
+			ginkgo.By("checking ApplyPolicySucceed event", func() {
+				framework.WaitEventFitWith(kubeClient, deploymentNamespace, deploymentName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonApplyPolicySucceed
+					})
+			})
 
-			framework.UpdateDeploymentReplicas(kubeClient, deployment, updateDeploymentReplicas)
-			framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
-				func(deployment *appsv1.Deployment) bool {
-					return *deployment.Spec.Replicas == updateDeploymentReplicas
-				})
+			ginkgo.By("checking GetReplicasSucceed event", func() {
+				framework.WaitEventFitWith(kubeClient, deploymentNamespace, deploymentName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonGetReplicasSucceed
+					})
+			})
+
+			// binding events — fired on the Deployment object (mirrored from ResourceBinding)
+			ginkgo.By("checking ScheduleBindingSucceed event", func() {
+				framework.WaitEventFitWith(kubeClient, deploymentNamespace, deploymentName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonScheduleBindingSucceed
+					})
+			})
+
+			ginkgo.By("checking SyncWorkSucceed event", func() {
+				framework.WaitEventFitWith(kubeClient, deploymentNamespace, deploymentName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonSyncWorkSucceed
+					})
+			})
+
+			ginkgo.By("checking SyncWorkloadSucceed event on work object", func() {
+				workName := names.GenerateWorkName(deployment.Kind, deployment.Name, deployment.Namespace)
+				esName := names.GenerateExecutionSpaceName(framework.ClusterNames()[0])
+				framework.WaitEventFitWith(kubeClient, esName, workName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonSyncWorkloadSucceed
+					})
+			})
+
+			ginkgo.By("waiting for deployment to be present on clusters", func() {
+				framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
+					func(*appsv1.Deployment) bool {
+						return true
+					})
+			})
+
+			ginkgo.By("checking AggregateStatusSucceed event", func() {
+				framework.WaitEventFitWith(kubeClient, deploymentNamespace, deploymentName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonAggregateStatusSucceed
+					})
+			})
+
+			// work object events — fired on the Work object in execution space
+			ginkgo.By("checking ReflectStatusSucceed event on work object", func() {
+				workName := names.GenerateWorkName(deployment.Kind, deployment.Name, deployment.Namespace)
+				esName := names.GenerateExecutionSpaceName(framework.ClusterNames()[0])
+				framework.WaitEventFitWith(kubeClient, esName, workName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonReflectStatusSucceed
+					})
+			})
+
+			ginkgo.By("checking InterpretHealthSucceed event on work object", func() {
+				workName := names.GenerateWorkName(deployment.Kind, deployment.Name, deployment.Namespace)
+				esName := names.GenerateExecutionSpaceName(framework.ClusterNames()[0])
+				framework.WaitEventFitWith(kubeClient, esName, workName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonInterpretHealthSucceed
+					})
+			})
+
+			ginkgo.By("updating replicas and verifying propagation", func() {
+				framework.UpdateDeploymentReplicas(kubeClient, deployment, updateDeploymentReplicas)
+				framework.WaitDeploymentPresentOnClustersFitWith(framework.ClusterNames(), deployment.Namespace, deployment.Name,
+					func(deployment *appsv1.Deployment) bool {
+						return *deployment.Spec.Replicas == updateDeploymentReplicas
+					})
+			})
 		})
 
 		ginkgo.It("adds dispatching event with a dispatching message", func() {
@@ -152,10 +220,48 @@ var _ = ginkgo.Describe("[BasicCase] PropagationPolicy testing", func() {
 		})
 
 		ginkgo.It("service propagation testing", func() {
+			ginkgo.By("checking ApplyPolicySucceed event on service", func() {
+				framework.WaitEventFitWith(kubeClient, serviceNamespace, serviceName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonApplyPolicySucceed
+					})
+			})
+
+			ginkgo.By("checking ScheduleBindingSucceed event on service", func() {
+				framework.WaitEventFitWith(kubeClient, serviceNamespace, serviceName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonScheduleBindingSucceed
+					})
+			})
+
+			ginkgo.By("checking SyncWorkSucceed event on service", func() {
+				framework.WaitEventFitWith(kubeClient, serviceNamespace, serviceName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonSyncWorkSucceed
+					})
+			})
+
 			framework.WaitServicePresentOnClustersFitWith(framework.ClusterNames(), service.Namespace, service.Name,
 				func(*corev1.Service) bool {
 					return true
 				})
+
+			ginkgo.By("checking AggregateStatusSucceed event on service binding", func() {
+				bindingName := names.GenerateBindingName(service.Kind, service.Name)
+				framework.WaitEventFitWith(kubeClient, serviceNamespace, bindingName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonAggregateStatusSucceed
+					})
+			})
+
+			ginkgo.By("checking InterpretHealthSucceed event on work object", func() {
+				workName := names.GenerateWorkName(service.Kind, service.Name, service.Namespace)
+				esName := names.GenerateExecutionSpaceName(framework.ClusterNames()[0])
+				framework.WaitEventFitWith(kubeClient, esName, workName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonInterpretHealthSucceed
+					})
+			})
 
 			patch := []map[string]any{{"op": "replace", "path": "/spec/ports/0/port", "value": updateServicePort}}
 			framework.UpdateServiceWithPatch(kubeClient, service.Namespace, service.Name, patch, types.JSONPatchType)
@@ -405,10 +511,45 @@ var _ = ginkgo.Describe("[BasicCase] PropagationPolicy testing", func() {
 		})
 
 		ginkgo.It("job propagation testing", func() {
+			ginkgo.By("checking ApplyPolicySucceed event on job", func() {
+				framework.WaitEventFitWith(kubeClient, jobNamespace, jobName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonApplyPolicySucceed
+					})
+			})
+
+			ginkgo.By("checking GetReplicasSucceed event on job", func() {
+				framework.WaitEventFitWith(kubeClient, jobNamespace, jobName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonGetReplicasSucceed
+					})
+			})
+
+			ginkgo.By("checking ScheduleBindingSucceed event on job", func() {
+				framework.WaitEventFitWith(kubeClient, jobNamespace, jobName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonScheduleBindingSucceed
+					})
+			})
+
+			ginkgo.By("checking SyncWorkSucceed event on job", func() {
+				framework.WaitEventFitWith(kubeClient, jobNamespace, jobName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonSyncWorkSucceed
+					})
+			})
+
 			framework.WaitJobPresentOnClustersFitWith(framework.ClusterNames(), job.Namespace, job.Name,
 				func(*batchv1.Job) bool {
 					return true
 				})
+
+			ginkgo.By("checking AggregateStatusSucceed event on job", func() {
+				framework.WaitEventFitWith(kubeClient, jobNamespace, jobName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonAggregateStatusSucceed
+					})
+			})
 
 			patch := []map[string]any{{"op": "replace", "path": "/spec/backoffLimit", "value": ptr.To[int32](updateBackoffLimit)}}
 			bytes, err := json.Marshal(patch)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind test

---

**What this PR does / why we need it**:

This PR adds inline event assertions to existing E2E test cases to improve event coverage for resource template events, as discussed in the related issue.

Following the community decision to use **Approach 2 (Inline Event Assertions)**, event checks are added directly inside existing test cases at the point where the relevant operation completes — no new test cases or files are introduced.

## What changed

### `test/e2e/framework/events.go`

* Added `WaitEventV1FitWith` helper to support `events.k8s.io/v1` Event API alongside the existing `core/v1` helper (foundation for future migration)

### `test/e2e/suites/base/propagationpolicy_test.go`

Added inline event assertions to existing Deployment, Service, and Job propagation test cases:

* `ApplyPolicySucceed` — verified on Deployment, Service, Job
* `GetReplicasSucceed` — verified on Deployment, Job
* `ScheduleBindingSucceed` — verified on Deployment, Service, Job
* `SyncWorkSucceed` — verified on Deployment, Service, Job
* `AggregateStatusSucceed` — verified on Deployment, Job
* `ReflectStatusSucceed` — verified on Work object during Deployment propagation
* `InterpretHealthSucceed` — verified on Work object during Deployment propagation
* `SyncWorkloadSucceed` — verified on Work object during Deployment propagation

### `test/e2e/suites/base/overridepolicy_test.go`

Added inline event assertions to existing override policy test cases:

* `ApplyOverridePolicySucceed` — verified across OverridePolicy and OverrideRules test cases with Deployment

### `test/e2e/suites/base/preemption_test.go`

Added inline event assertions to existing preemption test cases:

* `PreemptPolicySucceed` — verified when high-priority PropagationPolicy preempts low-priority PropagationPolicy, when PropagationPolicy preempts ClusterPropagationPolicy, and when high-priority ClusterPropagationPolicy preempts low-priority ClusterPropagationPolicy

### `test/e2e/suites/base/dependenciesdistributor_test.go`

Added inline event assertions to existing dependency propagation test cases:

* `GetDependenciesSucceed` — verified in configmap automatic propagation tests with both PropagationPolicy and ClusterPropagationPolicy

---

**Which issue(s) this PR fixes**:

Fixes part of  #7252

---

**Special notes for your reviewer**:

## How was this tested

All assertions were verified by running the E2E suite locally against a kind-based Karmada setup and confirming the expected events fire during the propagation flow.

```bash
export KUBECONFIG=$HOME/.kube/karmada.config
go test ./test/e2e/suites/base/... \
  -v \
  --ginkgo.focus="BasicCase|OverridePolicy|OverrideRules|Preemption|DependenciesDistributor" \
  --ginkgo.timeout=60m \
  -- \
  --host-context=karmada-host \
  --karmada-context=karmada-apiserver \
  --poll-timeout=300s
```

## Notes

* `GetDependenciesFailed`, `GetReplicasFailed`, and `ApplyPolicyFailed` are not covered in this PR as they require specific failure conditions that are difficult to construct reliably in E2E tests
* `events.k8s.io/v1` support added in `framework/events.go` is not yet used in assertions — it is foundation work for the planned migration from `GetEventRecorderFor` to `GetEventRecorder`

---

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
