### PR TITLE
gracefuleviction: use optimistic lock in MergeFrom patch

### DIFF
--- a/pkg/controllers/gracefuleviction/crb_graceful_eviction_controller.go
+++ b/pkg/controllers/gracefuleviction/crb_graceful_eviction_controller.go
@@ -88,7 +88,7 @@ func (c *CRBGracefulEvictionController) syncBinding(ctx context.Context, binding
 		return nextRetry(keptTask, c.GracefulEvictionTimeout, metav1.Now().Time), nil
 	}
 
-	objPatch := client.MergeFrom(binding)
+	objPatch := client.MergeFromWithOptions(binding, client.MergeFromWithOptimisticLock{})
 	modifiedObj := binding.DeepCopy()
 	modifiedObj.Spec.GracefulEvictionTasks = keptTask
 	err := c.Client.Patch(ctx, modifiedObj, objPatch)

--- a/pkg/controllers/gracefuleviction/rb_graceful_eviction_controller.go
+++ b/pkg/controllers/gracefuleviction/rb_graceful_eviction_controller.go
@@ -88,7 +88,7 @@ func (c *RBGracefulEvictionController) syncBinding(ctx context.Context, binding 
 		return nextRetry(keptTask, c.GracefulEvictionTimeout, metav1.Now().Time), nil
 	}
 
-	objPatch := client.MergeFrom(binding)
+	objPatch := client.MergeFromWithOptions(binding, client.MergeFromWithOptimisticLock{})
 	modifiedObj := binding.DeepCopy()
 	modifiedObj.Spec.GracefulEvictionTasks = keptTask
 	err := c.Client.Patch(ctx, modifiedObj, objPatch)


### PR DESCRIPTION
Replace client.MergeFrom with client.MergeFromWithOptions using MergeFromWithOptimisticLock to include resourceVersion in the patch payload. This prevents the API server from applying a stale patch that could silently drop GracefulEvictionTasks added concurrently by the taint manager or application failover controller.

**What type of PR is this?**

/kind bug

---

**What this PR does / why we need it**:

This PR fixes a critical race condition in the graceful eviction controllers where eviction tasks are silently dropped during concurrent writes.

---

**Problem:**
The graceful eviction controllers (`rb_graceful_eviction_controller.go` and `crb_graceful_eviction_controller.go`) use `client.MergeFrom()` without optimistic locking to update `Spec.GracefulEvictionTasks`. This creates a JSON Merge Patch that omits `metadata.resourceVersion`, allowing the Kubernetes API server to apply patches unconditionally without conflict detection.

When three controllers write to the same field concurrently (taint manager, application failover controller, and graceful eviction controller), the last write wins without any conflict error, silently discarding tasks added by other controllers.

---

**Impact:**
- Workloads continue running on tainted/failing clusters that should have been evacuated
- Occurs during cluster failures — exactly when eviction matters most
- Lost eviction tasks cannot self-heal due to predicate filtering (only triggers when len(GracefulEvictionTasks) != 0)

---

**Solution:**
Replace `client.MergeFrom(binding)` with `client.MergeFromWithOptions(binding, client.MergeFromWithOptimisticLock{})`. This forces `metadata.resourceVersion` into the patch, enabling the API server to reject stale updates with HTTP 409 Conflict. The controller-runtime reconcile loop naturally retries with fresh data when conflicts occur.

---

**Which issue(s) this PR fixes**:

Fixes #7290 

---

**Special notes for your reviewer**:

- **Minimal change:** Only 2 lines modified (1 per controller file, lines 91)
- **No retry logic needed:** Relies on controller-runtime's natural reconcile loop to handle 409 conflicts
- **All existing tests pass:** No test modifications required
- **Race scenario:** 
  1. Graceful eviction controller reads binding (RV=100), tasks = [taskA]
  2. Taint manager adds taskB via Update() → RV=101, tasks = [taskA, taskB]
  3. Before fix: MergeFrom patch succeeds (no RV check) → tasks = [], taskB lost
  4. After fix: Patch fails with 409 Conflict → reconcile loop retries with fresh data → taskB preserved

---

```release-note
Fixed a race condition where graceful eviction tasks could be silently dropped when multiple controllers concurrently modify the same ResourceBinding or ClusterResourceBinding, preventing workloads from being evacuated from tainted or failing clusters.
```