### PR TITLE
Cherry pick of #7302 upstream release 1.15

### DIFF
--- a/pkg/controllers/gracefuleviction/crb_graceful_eviction_controller.go
+++ b/pkg/controllers/gracefuleviction/crb_graceful_eviction_controller.go
@@ -88,7 +88,7 @@ func (c *CRBGracefulEvictionController) syncBinding(ctx context.Context, binding
 		return nextRetry(keptTask, c.GracefulEvictionTimeout, metav1.Now().Time), nil
 	}
 
-	objPatch := client.MergeFrom(binding)
+	objPatch := client.MergeFromWithOptions(binding, client.MergeFromWithOptimisticLock{})
 	modifiedObj := binding.DeepCopy()
 	modifiedObj.Spec.GracefulEvictionTasks = keptTask
 	err := c.Client.Patch(ctx, modifiedObj, objPatch)

--- a/pkg/controllers/gracefuleviction/rb_graceful_eviction_controller.go
+++ b/pkg/controllers/gracefuleviction/rb_graceful_eviction_controller.go
@@ -88,7 +88,7 @@ func (c *RBGracefulEvictionController) syncBinding(ctx context.Context, binding 
 		return nextRetry(keptTask, c.GracefulEvictionTimeout, metav1.Now().Time), nil
 	}
 
-	objPatch := client.MergeFrom(binding)
+	objPatch := client.MergeFromWithOptions(binding, client.MergeFromWithOptimisticLock{})
 	modifiedObj := binding.DeepCopy()
 	modifiedObj.Spec.GracefulEvictionTasks = keptTask
 	err := c.Client.Patch(ctx, modifiedObj, objPatch)


### PR DESCRIPTION
Cherry pick of #7302 on release-1.15.

#7302: Fix race condition in graceful eviction controllers

**Release note:**
```release-note
Fixed a race condition where graceful eviction tasks could be silently dropped when multiple controllers concurrently modify the same ResourceBinding or ClusterResourceBinding, preventing workloads from being evacuated from tainted or failing clusters.
```