### PR TITLE
Automated cherry pick of #7275: fix: correct SignerName in cert rotation CSR

### DIFF
--- a/pkg/controllers/certificate/cert_rotation_controller.go
+++ b/pkg/controllers/certificate/cert_rotation_controller.go
@@ -53,8 +53,9 @@ const (
 	// CertRotationControllerName is the controller name that will be used when reporting events and metrics.
 	CertRotationControllerName = "cert-rotation-controller"
 
-	// SignerName defines the signer name for csr, 'kubernetes.io/kube-apiserver-client-kubelet' can sign the csr automatically
-	SignerName = "kubernetes.io/kube-apiserver-client-kubelet"
+	// SignerName defines the signer name for csr, 'kubernetes.io/kube-apiserver-client' is used
+	// to match the signer expected by the agent CSR approver (agent_csr_approving).
+	SignerName = certificatesv1.KubeAPIServerClientSignerName
 
 	// KarmadaKubeconfigName is the name of the secret containing karmada-agent certificate.
 	KarmadaKubeconfigName = "karmada-kubeconfig"

--- a/pkg/controllers/certificate/cert_rotation_controller_test.go
+++ b/pkg/controllers/certificate/cert_rotation_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -355,4 +356,41 @@ func newMockCert(notBefore, notAfter time.Time) (*x509.Certificate, error) {
 	}
 
 	return x509.ParseCertificate(certData)
+}
+
+// TestSignerNameMatchesAgentCSRApprover verifies that the SignerName used when creating
+// a CSR in cert_rotation_controller matches the signer expected by agent_csr_approving,
+// so that rotation CSRs can be auto-approved.
+func TestSignerNameMatchesAgentCSRApprover(t *testing.T) {
+	c := makeFakeCertRotationController(1)
+
+	// Generate a key and a mock cert to drive createCSRInControlPlane.
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	now := time.Now()
+	cert, err := newMockCert(now, now.Add(24*time.Hour))
+	if err != nil {
+		t.Fatalf("failed to create mock cert: %v", err)
+	}
+
+	csrName, err := c.createCSRInControlPlane(context.Background(), "test-cluster", privateKey, []*x509.Certificate{cert})
+	if err != nil {
+		t.Fatalf("createCSRInControlPlane() error = %v", err)
+	}
+
+	csr, err := c.KubeClient.CertificatesV1().CertificateSigningRequests().Get(context.Background(), csrName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get CSR %q: %v", csrName, err)
+	}
+
+	// The approver (agent_csr_approving) only recognises CSRs whose SignerName is
+	// KubeAPIServerClientSignerName ("kubernetes.io/kube-apiserver-client").
+	// Using KubeAPIServerClientKubeletSignerName would cause the CSR to be silently ignored.
+	wantSigner := certificatesv1.KubeAPIServerClientSignerName
+	if csr.Spec.SignerName != wantSigner {
+		t.Errorf("CSR SignerName = %q, want %q (must match agent_csr_approving expectation)", csr.Spec.SignerName, wantSigner)
+	}
 }


### PR DESCRIPTION
Cherry pick of #7275 on release-1.15.
#7275: fix: correct SignerName in cert rotation CSR
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-agent`: Fixed the issue that certificate rotation CSRs were never auto-approved due to a SignerName mismatch between `cert_rotation_controller` and `agent_csr_approving`.
```