### PR TITLE
test: add MCS controller event assertions in E2E

### DIFF
--- a/test/e2e/suites/base/mcs_test.go
+++ b/test/e2e/suites/base/mcs_test.go
@@ -38,6 +38,7 @@ import (
 
 	networkingv1alpha1 "github.com/karmada-io/karmada/pkg/apis/networking/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/events"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/test/e2e/framework"
@@ -343,6 +344,12 @@ var _ = ginkgo.Describe("Multi-Cluster Service testing", func() {
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 
+			ginkgo.By(fmt.Sprintf("Check ServiceImport(%s/%s) SyncDerivedServiceSucceed event", serviceImport.Namespace, serviceImport.Name), func() {
+				framework.WaitEventFitWith(kubeClient, serviceImport.Namespace, serviceImport.Name, func(event corev1.Event) bool {
+					return event.Reason == events.EventReasonSyncDerivedServiceSucceed && event.Type == corev1.EventTypeNormal
+				})
+			})
+
 			ginkgo.By(fmt.Sprintf("Wait EndpointSlices have been imported to %s cluster", serviceImportClusterName), func() {
 				gomega.Eventually(func(g gomega.Gomega) (int, error) {
 					endpointSlices, err := importClusterClient.DiscoveryV1().EndpointSlices(demoService.Namespace).List(context.TODO(), metav1.ListOptions{
@@ -437,6 +444,12 @@ var _ = ginkgo.Describe("Multi-Cluster Service testing", func() {
 					}
 					return epNums, nil
 				}, pollTimeout, pollInterval).Should(gomega.Equal(1))
+			})
+
+			ginkgo.By(fmt.Sprintf("Check ServiceImport(%s/%s) SyncDerivedServiceSucceed event", serviceImport.Namespace, serviceImport.Name), func() {
+				framework.WaitEventFitWith(kubeClient, serviceImport.Namespace, serviceImport.Name, func(event corev1.Event) bool {
+					return event.Reason == events.EventReasonSyncDerivedServiceSucceed && event.Type == corev1.EventTypeNormal
+				})
 			})
 
 			klog.Infof("Update Deployment's replicas in %s cluster", serviceExportClusterName)
@@ -555,6 +568,18 @@ var _ = ginkgo.Describe("CrossCluster MultiClusterService testing", func() {
 				return meta.IsStatusConditionTrue(mcs.Status.Conditions, networkingv1alpha1.EndpointSliceDispatched)
 			})
 
+			ginkgo.By(fmt.Sprintf("Check MultiClusterService(%s/%s) SyncServiceSucceed event", testNamespace, mcsName), func() {
+				framework.WaitEventFitWith(kubeClient, testNamespace, mcsName, func(event corev1.Event) bool {
+					return event.Reason == events.EventReasonSyncServiceSucceed && event.Type == corev1.EventTypeNormal
+				})
+			})
+
+			ginkgo.By(fmt.Sprintf("Check MultiClusterService(%s/%s) DispatchEndpointSliceSucceed event", testNamespace, mcsName), func() {
+				framework.WaitEventFitWith(kubeClient, testNamespace, mcsName, func(event corev1.Event) bool {
+					return event.Reason == events.EventReasonDispatchEndpointSliceSucceed && event.Type == corev1.EventTypeNormal
+				})
+			})
+
 			gomega.Eventually(func() bool {
 				return checkEndpointSliceWithMultiClusterService(testNamespace, mcsName, mcs.Spec.ProviderClusters, mcs.Spec.ConsumerClusters)
 			}, pollTimeout, pollInterval).Should(gomega.BeTrue())
@@ -637,6 +662,18 @@ var _ = ginkgo.Describe("CrossCluster MultiClusterService testing", func() {
 
 			framework.WaitMultiClusterServicePresentOnClustersFitWith(karmadaClient, testNamespace, mcsName, func(mcs *networkingv1alpha1.MultiClusterService) bool {
 				return meta.IsStatusConditionTrue(mcs.Status.Conditions, networkingv1alpha1.EndpointSliceDispatched)
+			})
+
+			mcs.Spec.ProviderClusters = []networkingv1alpha1.ClusterSelector{
+				{Name: member2Name},
+				{Name: "member-not-found"},
+			}
+			framework.UpdateMultiClusterService(karmadaClient, mcs)
+
+			ginkgo.By(fmt.Sprintf("Check MultiClusterService(%s/%s) ClusterNotFound event", testNamespace, mcsName), func() {
+				framework.WaitEventFitWith(kubeClient, testNamespace, mcsName, func(event corev1.Event) bool {
+					return event.Reason == events.EventReasonClusterNotFound && event.Type == corev1.EventTypeWarning
+				})
 			})
 		})
 	})
@@ -739,6 +776,7 @@ var _ = ginkgo.Describe("CrossCluster MultiClusterService testing", func() {
 			}, pollTimeout, pollInterval).Should(gomega.BeTrue())
 		})
 	})
+
 })
 
 func checkEndpointSliceWithMultiClusterService(mcsNamespace, mcsName string, providerClusters, consumerClusters []networkingv1alpha1.ClusterSelector) bool {


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR improves E2E coverage for Karmada controller events in the existing MCS test flows.

as of now, the MCS E2E suite validates functional behavior such as ServiceExport/ServiceImport connectivity, derived service creation, and EndpointSlice propagation, but it does not verify the controller events emitted during those workflows. This PR adds inline event assertions to the current MCS scenarios so we also validate that the expected controller events are produced when reconciliation succeeds.

Specifically, this PR:
- adds checks for `SyncDerivedServiceSucceed` in the existing `ServiceImport` flows
- adds checks for `SyncServiceSucceed` and `DispatchEndpointSliceSucceed` in the existing CrossCluster `MultiClusterService` flow
- adds a deterministic negative scenario to verify the `ClusterNotFound` warning event on `MultiClusterService`

We need this to improve E2E event coverage for MCS-related controllers without introducing standalone event-only tests, keeping the assertions close to the user-observable workflows they belong to.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #7252 

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:

This patch focuses on deterministic event coverage that fits naturally into the existing MCS E2E flows.

`SyncDerivedServiceFailed`, `SyncServiceFailed`, and `DispatchEndpointSliceFailed` were not included in this PR because they are harder to trigger reliably in the current E2E environment without introducing artificial failures or making the tests more brittle. `APIIncompatible` was also left out because the E2E clusters are created with a consistent environment, so reproducing an actual API compatibility mismatch is not straightforward in a stable CI-friendly way.

To keep this change aligned with the selected inline-assertion approach, this PR adds coverage for the success-path events that are already exercised by existing MCS scenarios, plus a deterministic negative case for `ClusterNotFound`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

