### PR TITLE
Pin aquasecurity/trivy-action to commit SHA

### DIFF
--- a/.github/workflows/ci-image-scanning-on-schedule.yml
+++ b/.github/workflows/ci-image-scanning-on-schedule.yml
@@ -47,7 +47,7 @@ jobs:
           export REGISTRY="docker.io/karmada"
           make image-${{ matrix.target }}
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
@@ -59,7 +59,7 @@ jobs:
           cache: false
           output: '${{ matrix.target }}:${{ matrix.karmada-version }}.trivy-results.sarif'
       - name: display scan results
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_SKIP_DB_UPDATE: true # Avoid updating the vulnerability db as it was cached in the previous step.
         with:

--- a/.github/workflows/ci-image-scanning.yaml
+++ b/.github/workflows/ci-image-scanning.yaml
@@ -46,7 +46,7 @@ jobs:
           export REGISTRY="docker.io/karmada"
           make image-${{ matrix.target }}
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
@@ -58,7 +58,7 @@ jobs:
           output: 'trivy-results.sarif'
           cache: false
       - name: display scan results
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_SKIP_DB_UPDATE: true # Avoid updating the vulnerability db as it was cached in the previous step.
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Generate sbom for karmada file system
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
       with:
         scan-type: 'fs'
         format: 'spdx'


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
This pull request updates the version pinning of the `aquasecurity/trivy-action` GitHub Action in several workflow files to use a specific commit SHA instead of the version tag. This change helps ensure reproducibility and security by preventing unexpected changes from upstream updates.

**Which issue(s) this PR fixes**:
Fixes #
Part of #7314

**Special notes for your reviewer**:

Find the commit SHA by following the command:
```
-bash-5.0# git ls-remote https://github.com/aquasecurity/trivy-action refs/tags/v0.35.0
57a97c7e7821a5776cebc9bb87c984fa69cba8f1	refs/tags/v0.35.0
```
Or get the commit SHA from the release page:
https://github.com/aquasecurity/trivy-action/releases/tag/v0.35.0

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

