### PR TITLE
fix(helm): use | as sed delimiter for cert substitution

### DIFF
--- a/charts/karmada/templates/pre-install-job.yaml
+++ b/charts/karmada/templates/pre-install-job.yaml
@@ -453,20 +453,20 @@ spec:
           front_proxy_ca=$(base64 /opt/certs/front-proxy-ca.crt | tr -d '\r\n')
           front_proxy_client_crt=$(base64 /opt/certs/front-proxy-client.pem | tr -d '\r\n')
           front_proxy_client_key=$(base64 /opt/certs/front-proxy-client-key.pem | tr -d '\r\n')
-          sed -i'' -e "s/{{ print "{{ ca_crt }}" }}/${karmada_ca}/g" /opt/configs/cert.yaml
-          sed -i'' -e "s/{{ print "{{ ca_key }}" }}/${karmada_ca_key}/g" /opt/configs/cert.yaml
-          sed -i'' -e "s/{{ print "{{ crt }}" }}/${karmada_crt}/g" /opt/configs/cert.yaml
-          sed -i'' -e "s/{{ print "{{ key }}" }}/${karmada_key}/g" /opt/configs/cert.yaml
-          sed -i'' -e "s/{{ print "{{ front_proxy_ca_crt }}" }}/${front_proxy_ca}/g" /opt/configs/cert.yaml
-          sed -i'' -e "s/{{ print "{{ front_proxy_crt }}" }}/${front_proxy_client_crt}/g" /opt/configs/cert.yaml
-          sed -i'' -e "s/{{ print "{{ front_proxy_key }}" }}/${front_proxy_client_key}/g" /opt/configs/cert.yaml
-          sed -i'' -e "s/{{ print "{{ ca_crt }}" }}/${karmada_ca}/g" /opt/configs/kubeconfig.yaml
-          sed -i'' -e "s/{{ print "{{ crt }}" }}/${karmada_crt}/g" /opt/configs/kubeconfig.yaml
-          sed -i'' -e "s/{{ print "{{ key }}" }}/${karmada_key}/g" /opt/configs/kubeconfig.yaml
-          sed -i'' -e "s/{{ print "{{ crt }}" }}/${karmada_crt}/g" /opt/configs/webhook-cert.yaml
-          sed -i'' -e "s/{{ print "{{ key }}" }}/${karmada_key}/g" /opt/configs/webhook-cert.yaml
-          sed -i'' -e "s/{{ print "{{ ca_crt }}" }}/${karmada_ca}/g" /opt/configs/static-resources-configmaps.yaml
-          sed -i'' -e "s/{{ print "{{ ca_crt }}" }}/${karmada_ca}/g" /opt/configs/crds-patches-configmaps.yaml
+          sed -i'' -e "s|{{ print "{{ ca_crt }}" }}|${karmada_ca}|g" /opt/configs/cert.yaml
+          sed -i'' -e "s|{{ print "{{ ca_key }}" }}|${karmada_ca_key}|g" /opt/configs/cert.yaml
+          sed -i'' -e "s|{{ print "{{ crt }}" }}|${karmada_crt}|g" /opt/configs/cert.yaml
+          sed -i'' -e "s|{{ print "{{ key }}" }}|${karmada_key}|g" /opt/configs/cert.yaml
+          sed -i'' -e "s|{{ print "{{ front_proxy_ca_crt }}" }}|${front_proxy_ca}|g" /opt/configs/cert.yaml
+          sed -i'' -e "s|{{ print "{{ front_proxy_crt }}" }}|${front_proxy_client_crt}|g" /opt/configs/cert.yaml
+          sed -i'' -e "s|{{ print "{{ front_proxy_key }}" }}|${front_proxy_client_key}|g" /opt/configs/cert.yaml
+          sed -i'' -e "s|{{ print "{{ ca_crt }}" }}|${karmada_ca}|g" /opt/configs/kubeconfig.yaml
+          sed -i'' -e "s|{{ print "{{ crt }}" }}|${karmada_crt}|g" /opt/configs/kubeconfig.yaml
+          sed -i'' -e "s|{{ print "{{ key }}" }}|${karmada_key}|g" /opt/configs/kubeconfig.yaml
+          sed -i'' -e "s|{{ print "{{ crt }}" }}|${karmada_crt}|g" /opt/configs/webhook-cert.yaml
+          sed -i'' -e "s|{{ print "{{ key }}" }}|${karmada_key}|g" /opt/configs/webhook-cert.yaml
+          sed -i'' -e "s|{{ print "{{ ca_crt }}" }}|${karmada_ca}|g" /opt/configs/static-resources-configmaps.yaml
+          sed -i'' -e "s|{{ print "{{ ca_crt }}" }}|${karmada_ca}|g" /opt/configs/crds-patches-configmaps.yaml
           EOF
         volumeMounts:
         - name: mount

--- a/charts/karmada/templates/pre-upgrade-job.yaml
+++ b/charts/karmada/templates/pre-upgrade-job.yaml
@@ -85,8 +85,8 @@ spec:
           set -ex
           # Fetch certs from existing secret
           karmada_ca=$(kubectl get secret {{ $name }}-cert -n {{ $namespace }} -o jsonpath='{.data.server-ca\.crt}')
-          kubectl get configmap {{ $name }}-static-resources -n {{ $namespace }} -o json | sed -e "s/{{ print "{{ ca_crt }}" }}/${karmada_ca}/g" | kubectl apply -f -
-          kubectl get configmap {{ $name }}-crds-patches -n {{ $namespace }} -o json | sed -e "s/{{ print "{{ ca_crt }}" }}/${karmada_ca}/g" | kubectl apply -f -
+          kubectl get configmap {{ $name }}-static-resources -n {{ $namespace }} -o json | sed -e "s|{{ print "{{ ca_crt }}" }}|${karmada_ca}|g" | kubectl apply -f -
+          kubectl get configmap {{ $name }}-crds-patches -n {{ $namespace }} -o json | sed -e "s|{{ print "{{ ca_crt }}" }}|${karmada_ca}|g" | kubectl apply -f -
         resources:
           requests:
             cpu: 50m


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

The `sed` commands in the pre-install and pre-upgrade Jobs that substitute `{{ ca_crt }}` (and other cert placeholders) with actual base64-encoded certificate values use `/` as the delimiter. Since base64-encoded values can contain `/` characters, this breaks the `sed` substitution pattern, leaving raw `{{ ca_crt }}` placeholders in the `karmada-static-resources` ConfigMap.

When the `karmada-static-resource` Job subsequently runs `kubectl apply -f /static-resources/`, it fails with:

```
error converting YAML to JSON: yaml: invalid map key: map[interface {}]interface {}{"ca_crt":interface {}(nil)}
```

This is because `{{ ca_crt }}` is interpreted as a YAML flow mapping rather than a string value.

## How this PR fixes it

Switches all `sed` commands in `pre-install-job.yaml` and `pre-upgrade-job.yaml` from using `/` to `|` as the delimiter. The `|` character cannot appear in base64-encoded output (`A-Za-z0-9+/=`), making it a safe delimiter choice.

## Which issue(s) this PR fixes

Fixes https://github.com/karmada-io/karmada/issues/7321

## Does this PR introduce a user-facing change?

```release-note
Fixed Helm chart pre-install and pre-upgrade Jobs where certificate placeholder substitution could fail due to sed delimiter conflicts with base64-encoded values.
```