### PR TITLE
karmada-search: wire cluster-api-qps and cluster-api-burst

### DIFF
--- a/cmd/karmada-search/app/karmada-search.go
+++ b/cmd/karmada-search/app/karmada-search.go
@@ -54,6 +54,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/sharedcli"
 	"github.com/karmada-io/karmada/pkg/sharedcli/klogflag"
 	"github.com/karmada-io/karmada/pkg/sharedcli/profileflag"
+	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/lifted"
 	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/pkg/version"
@@ -211,10 +212,12 @@ func config(o *options.Options, outOfTreeRegistryOptions ...Option) (*search.Con
 
 	karmadaClient := karmadaclientset.NewForConfigOrDie(serverConfig.ClientConfig)
 	factory := informerfactory.NewSharedInformerFactory(karmadaClient, 0)
+	rateLimiterGetter := util.GetClusterRateLimiterGetter().SetDefaultLimits(o.ClusterAPIQPS, o.ClusterAPIBurst)
+	clusterClientOption := &util.ClientOption{RateLimiterGetter: rateLimiterGetter.GetRateLimiter}
 
 	var ctl *search.Controller
 	if !o.DisableSearch {
-		ctl, err = search.NewController(serverConfig.ClientConfig, factory, restMapper)
+		ctl, err = search.NewController(serverConfig.ClientConfig, factory, restMapper, clusterClientOption)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/karmada-search/app/options/options.go
+++ b/cmd/karmada-search/app/options/options.go
@@ -47,6 +47,10 @@ type Options struct {
 	KubeAPIQPS float32
 	// KubeAPIBurst is the burst to allow while talking with karmada-search.
 	KubeAPIBurst int
+	// ClusterAPIQPS is the QPS to use while talking with cluster kube-apiserver.
+	ClusterAPIQPS float32
+	// ClusterAPIBurst is the burst to allow while talking with cluster kube-apiserver.
+	ClusterAPIBurst int
 
 	ProfileOpts profileflag.Options
 
@@ -86,6 +90,8 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 
 	flags.Float32Var(&o.KubeAPIQPS, "kube-api-qps", 40.0, "QPS to use while talking with karmada-apiserver.")
 	flags.IntVar(&o.KubeAPIBurst, "kube-api-burst", 60, "Burst to use while talking with karmada-apiserver.")
+	flags.Float32Var(&o.ClusterAPIQPS, "cluster-api-qps", 40.0, "QPS to use while talking with cluster kube-apiserver.")
+	flags.IntVar(&o.ClusterAPIBurst, "cluster-api-burst", 60, "Burst to use while talking with cluster kube-apiserver.")
 	flags.BoolVar(&o.DisableSearch, "disable-search", false, "Disable search feature that would save memory usage significantly.")
 	flags.BoolVar(&o.DisableProxy, "disable-proxy", false, "Disable proxy feature that would save memory usage significantly.")
 

--- a/pkg/search/controller.go
+++ b/pkg/search/controller.go
@@ -64,11 +64,12 @@ func (c *clusterRegistry) unregistry() bool {
 
 // Controller ResourceRegistry controller
 type Controller struct {
-	restConfig      *rest.Config
-	restMapper      meta.RESTMapper
-	informerFactory informerfactory.SharedInformerFactory
-	clusterLister   clusterlister.ClusterLister
-	queue           workqueue.TypedRateLimitingInterface[any]
+	restConfig          *rest.Config
+	restMapper          meta.RESTMapper
+	informerFactory     informerfactory.SharedInformerFactory
+	clusterLister       clusterlister.ClusterLister
+	queue               workqueue.TypedRateLimitingInterface[any]
+	clusterClientOption *util.ClientOption
 
 	clusterRegistry sync.Map
 
@@ -76,16 +77,17 @@ type Controller struct {
 }
 
 // NewController returns a new ResourceRegistry controller
-func NewController(restConfig *rest.Config, factory informerfactory.SharedInformerFactory, restMapper meta.RESTMapper) (*Controller, error) {
+func NewController(restConfig *rest.Config, factory informerfactory.SharedInformerFactory, restMapper meta.RESTMapper, clusterClientOption *util.ClientOption) (*Controller, error) {
 	clusterLister := factory.Cluster().V1alpha1().Clusters().Lister()
 	queue := workqueue.NewTypedRateLimitingQueue[any](workqueue.DefaultTypedControllerRateLimiter[any]())
 
 	c := &Controller{
-		restConfig:      restConfig,
-		informerFactory: factory,
-		clusterLister:   clusterLister,
-		queue:           queue,
-		restMapper:      restMapper,
+		restConfig:          restConfig,
+		informerFactory:     factory,
+		clusterLister:       clusterLister,
+		queue:               queue,
+		clusterClientOption: clusterClientOption,
+		restMapper:          restMapper,
 
 		InformerManager: genericmanager.GetInstance(),
 	}
@@ -348,9 +350,8 @@ func (c *Controller) getRegistryBackendHandler(cluster string, matchedRegistries
 	return handler, nil
 }
 
-var clusterDynamicClientBuilder = func(cluster string, controlPlaneClient client.Client) (*util.DynamicClusterClient, error) {
-	// TODO: Add "--cluster-api-qps" and "--cluster-api-burst" flags to karmada-search and pass them via clientOption， instead of passing a "nil" here
-	return util.NewClusterDynamicClientSet(cluster, controlPlaneClient, nil)
+var clusterDynamicClientBuilder = func(cluster string, controlPlaneClient client.Client, clusterClientOption *util.ClientOption) (*util.DynamicClusterClient, error) {
+	return util.NewClusterDynamicClientSet(cluster, controlPlaneClient, clusterClientOption)
 }
 
 // doCacheCluster processes the resourceRegistry object
@@ -392,7 +393,7 @@ func (c *Controller) doCacheCluster(cluster string) error {
 		klog.Info("Try to build informer manager for cluster ", cluster)
 		controlPlaneClient := gclient.NewForConfigOrDie(c.restConfig)
 
-		clusterDynamicClient, err := clusterDynamicClientBuilder(cluster, controlPlaneClient)
+		clusterDynamicClient, err := clusterDynamicClientBuilder(cluster, controlPlaneClient, c.clusterClientOption)
 		if err != nil {
 			return err
 		}

--- a/pkg/search/controllers_test.go
+++ b/pkg/search/controllers_test.go
@@ -105,7 +105,7 @@ func TestNewKarmadaSearchController(t *testing.T) {
 			if err := test.prep(&test.factory, test.client); err != nil {
 				t.Fatalf("failed to prep test environment before creating new controller, got: %v", err)
 			}
-			_, err := NewController(test.restConfig, test.factory, test.restMapper)
+			_, err := NewController(test.restConfig, test.factory, test.restMapper, nil)
 			if err == nil && test.wantErr {
 				t.Fatal("expected an error, but got none")
 			}
@@ -270,7 +270,7 @@ func TestDeleteClusterEventHandler(t *testing.T) {
 					}
 				)
 
-				clusterDynamicClientBuilder = func(string, client.Client) (*util.DynamicClusterClient, error) {
+				clusterDynamicClientBuilder = func(string, client.Client, *util.ClientOption) (*util.DynamicClusterClient, error) {
 					return &util.DynamicClusterClient{
 						DynamicClientSet: fakedynamic.NewSimpleDynamicClient(scheme.Scheme),
 						ClusterName:      clusterName,
@@ -359,7 +359,7 @@ func TestAddResourceRegistryEventHandler(t *testing.T) {
 					}
 				)
 
-				clusterDynamicClientBuilder = func(string, client.Client) (*util.DynamicClusterClient, error) {
+				clusterDynamicClientBuilder = func(string, client.Client, *util.ClientOption) (*util.DynamicClusterClient, error) {
 					return &util.DynamicClusterClient{
 						DynamicClientSet: fakedynamic.NewSimpleDynamicClient(scheme.Scheme),
 						ClusterName:      clusterName,
@@ -445,7 +445,7 @@ func TestUpdateResourceRegistryEventHandler(t *testing.T) {
 					}
 				)
 
-				clusterDynamicClientBuilder = func(string, client.Client) (*util.DynamicClusterClient, error) {
+				clusterDynamicClientBuilder = func(string, client.Client, *util.ClientOption) (*util.DynamicClusterClient, error) {
 					return &util.DynamicClusterClient{
 						DynamicClientSet: fakedynamic.NewSimpleDynamicClient(scheme.Scheme),
 						ClusterName:      clusterName,
@@ -529,7 +529,7 @@ func TestDeleteResourceRegistryEventHandler(t *testing.T) {
 					}
 				)
 
-				clusterDynamicClientBuilder = func(string, client.Client) (*util.DynamicClusterClient, error) {
+				clusterDynamicClientBuilder = func(string, client.Client, *util.ClientOption) (*util.DynamicClusterClient, error) {
 					return &util.DynamicClusterClient{
 						DynamicClientSet: fakedynamic.NewSimpleDynamicClient(scheme.Scheme),
 						ClusterName:      clusterName,
@@ -585,7 +585,7 @@ func TestDeleteResourceRegistryEventHandler(t *testing.T) {
 // Kubernetes REST configuration, shared informer factory, and REST mapper.
 // It returns the created Controller or an error if initialization fails.
 func createController(ctx context.Context, restConfig *rest.Config, factory informerfactory.SharedInformerFactory, restMapper meta.RESTMapper) (*Controller, error) {
-	newController, err := NewController(restConfig, factory, restMapper)
+	newController, err := NewController(restConfig, factory, restMapper, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new controller, got: %v", err)
 	}


### PR DESCRIPTION
What type of PR is this?

/kind feature
/kind cleanup

**What this PR does / why we need it:**

This PR adds [--cluster-api-qps](vscode-file://vscode-app/snap/code/226/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [--cluster-api-burst](vscode-file://vscode-app/snap/code/226/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to [karmada-search](vscode-file://vscode-app/snap/code/226/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and wires them into member-cluster dynamic client creation used by the search controller.

Previously, the dynamic client path passed nil client options. With this change, [karmada-search](vscode-file://vscode-app/snap/code/226/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now builds a [util.ClientOption](vscode-file://vscode-app/snap/code/226/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with a rate limiter and passes it through, so member-cluster API access uses the configured QPS/burst settings.

Also includes:

small naming cleanup ([clientOption](vscode-file://vscode-app/snap/code/226/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) -> [clusterClientOption](vscode-file://vscode-app/snap/code/226/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) based on review feedback
formatting/lint fix in [controller.go](vscode-file://vscode-app/snap/code/226/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Special notes reviewer:
Validated locally with:
go test [karmada-search]
go test [pkg]
[verify-staticcheck.sh]
[verify-import-aliases.sh]

Does this PR introduce a user-facing change?:
``karmada-search`: add `--cluster-api-qps` and `--cluster-api-burst` flags, and use them when creating member-cluster dynamic clients in search controller.`