### PR TITLE
Add validation for ResourceRegistry strategy

### DIFF
--- a/pkg/apis/search/validation/validation.go
+++ b/pkg/apis/search/validation/validation.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"net/url"
+
+	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	searchapis "github.com/karmada-io/karmada/pkg/apis/search"
+	utilvalidation "github.com/karmada-io/karmada/pkg/util/validation"
+)
+
+// ValidateResourceRegistry validates a ResourceRegistry object.
+func ValidateResourceRegistry(resourceRegistry *searchapis.ResourceRegistry) field.ErrorList {
+	allErrs := apimachineryvalidation.ValidateObjectMeta(
+		&resourceRegistry.ObjectMeta,
+		false,
+		apimachineryvalidation.NameIsDNSSubdomain,
+		field.NewPath("metadata"),
+	)
+	allErrs = append(allErrs, ValidateResourceRegistrySpec(&resourceRegistry.Spec, field.NewPath("spec"))...)
+	return allErrs
+}
+
+// ValidateResourceRegistryUpdate validates a ResourceRegistry update.
+func ValidateResourceRegistryUpdate(newResourceRegistry, oldResourceRegistry *searchapis.ResourceRegistry) field.ErrorList {
+	allErrs := apimachineryvalidation.ValidateObjectMetaUpdate(
+		&newResourceRegistry.ObjectMeta,
+		&oldResourceRegistry.ObjectMeta,
+		field.NewPath("metadata"),
+	)
+	allErrs = append(allErrs, ValidateResourceRegistry(newResourceRegistry)...)
+	return allErrs
+}
+
+// ValidateResourceRegistrySpec validates a ResourceRegistrySpec.
+func ValidateResourceRegistrySpec(spec *searchapis.ResourceRegistrySpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, utilvalidation.ValidateClusterAffinity(&spec.TargetCluster, fldPath.Child("targetCluster"))...)
+
+	for i := range spec.ResourceSelectors {
+		allErrs = append(allErrs, validateResourceSelector(&spec.ResourceSelectors[i], fldPath.Child("resourceSelectors").Index(i))...)
+	}
+
+	allErrs = append(allErrs, validateBackendStore(spec.BackendStore, fldPath.Child("backendStore"))...)
+
+	return allErrs
+}
+
+// validateResourceSelector validates semantic constraints of a ResourceSelector.
+func validateResourceSelector(selector *searchapis.ResourceSelector, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if selector.APIVersion != "" {
+		if _, err := schema.ParseGroupVersion(selector.APIVersion); err != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("apiVersion"), selector.APIVersion, err.Error()))
+		}
+	}
+
+	if selector.Namespace != "" {
+		if errs := apimachineryvalidation.ValidateNamespaceName(selector.Namespace, false); len(errs) > 0 {
+			for _, err := range errs {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("namespace"), selector.Namespace, err))
+			}
+		}
+	}
+
+	return allErrs
+}
+
+// validateBackendStore validates semantic constraints of a BackendStoreConfig.
+func validateBackendStore(backendStore *searchapis.BackendStoreConfig, fldPath *field.Path) field.ErrorList {
+	if backendStore == nil || backendStore.OpenSearch == nil {
+		return nil
+	}
+
+	allErrs := field.ErrorList{}
+	openSearchPath := fldPath.Child("openSearch")
+	for i, address := range backendStore.OpenSearch.Addresses {
+		u, err := url.Parse(address)
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(openSearchPath.Child("addresses").Index(i), address, err.Error()))
+			continue
+		}
+
+		if u.Scheme == "" || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+			allErrs = append(allErrs, field.Invalid(
+				openSearchPath.Child("addresses").Index(i),
+				address,
+				"must be a valid http or https URL with non-empty scheme and host",
+			))
+		}
+	}
+
+	return allErrs
+}

--- a/pkg/apis/search/validation/validation_test.go
+++ b/pkg/apis/search/validation/validation_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	searchapis "github.com/karmada-io/karmada/pkg/apis/search"
+)
+
+func TestValidateResourceRegistry(t *testing.T) {
+	tests := []struct {
+		name             string
+		resourceRegistry *searchapis.ResourceRegistry
+		wantErrFields    []string
+	}{
+		{
+			name: "valid resource registry",
+			resourceRegistry: &searchapis.ResourceRegistry{
+				ObjectMeta: metav1.ObjectMeta{Name: "registry-a"},
+				Spec: searchapis.ResourceRegistrySpec{
+					TargetCluster: policyv1alpha1.ClusterAffinity{},
+					ResourceSelectors: []searchapis.ResourceSelector{
+						{APIVersion: "apps/v1", Kind: "Deployment", Namespace: "default"},
+					},
+					BackendStore: &searchapis.BackendStoreConfig{
+						OpenSearch: &searchapis.OpenSearchConfig{
+							Addresses: []string{"https://localhost:9200"},
+							SecretRef: clusterv1alpha1.LocalSecretReference{Namespace: "default", Name: "os-auth"},
+						},
+					},
+				},
+			},
+			wantErrFields: nil,
+		},
+		{
+			name: "valid: empty resource selectors",
+			resourceRegistry: &searchapis.ResourceRegistry{
+				ObjectMeta: metav1.ObjectMeta{Name: "registry-b"},
+				Spec: searchapis.ResourceRegistrySpec{
+					TargetCluster:     policyv1alpha1.ClusterAffinity{},
+					ResourceSelectors: nil,
+				},
+			},
+			wantErrFields: nil,
+		},
+		{
+			name: "invalid: malformed selector and backend",
+			resourceRegistry: &searchapis.ResourceRegistry{
+				ObjectMeta: metav1.ObjectMeta{Name: "registry-c"},
+				Spec: searchapis.ResourceRegistrySpec{
+					TargetCluster: policyv1alpha1.ClusterAffinity{},
+					ResourceSelectors: []searchapis.ResourceSelector{
+						{APIVersion: "apps/v1/extra", Kind: "", Namespace: "Bad_Namespace"},
+					},
+					BackendStore: &searchapis.BackendStoreConfig{
+						OpenSearch: &searchapis.OpenSearchConfig{
+							Addresses: []string{"localhost:9200"},
+							SecretRef: clusterv1alpha1.LocalSecretReference{},
+						},
+					},
+				},
+			},
+			wantErrFields: []string{
+				"spec.resourceSelectors[0].apiVersion",
+				"spec.resourceSelectors[0].namespace",
+				"spec.backendStore.openSearch.addresses[0]",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := ValidateResourceRegistry(tt.resourceRegistry)
+			if len(tt.wantErrFields) == 0 {
+				if len(errs) != 0 {
+					t.Fatalf("expected no validation errors, got: %v", errs)
+				}
+				return
+			}
+
+			if len(errs) == 0 {
+				t.Fatalf("expected validation errors, got none")
+			}
+
+			for _, wantField := range tt.wantErrFields {
+				if !containsFieldError(errs, wantField) {
+					t.Fatalf("expected error on field %q, got: %v", wantField, errs)
+				}
+			}
+		})
+	}
+}
+
+func containsFieldError(errs field.ErrorList, wantField string) bool {
+	for _, err := range errs {
+		if err.Field == wantField {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/registry/search/strategy.go
+++ b/pkg/registry/search/strategy.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
 
 	searchapis "github.com/karmada-io/karmada/pkg/apis/search"
+	searchvalidation "github.com/karmada-io/karmada/pkg/apis/search/validation"
 )
 
 // NewStrategy creates and returns a ResourceRegistry Strategy instance.
@@ -91,9 +92,9 @@ func (Strategy) PrepareForUpdate(_ context.Context, _, _ runtime.Object) {
 }
 
 // Validate returns an ErrorList with validation errors or nil.
-func (Strategy) Validate(_ context.Context, _ runtime.Object) field.ErrorList {
-	// TODO: add validation for ResourceRegistry
-	return field.ErrorList{}
+func (Strategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
+	resourceRegistry := obj.(*searchapis.ResourceRegistry)
+	return searchvalidation.ValidateResourceRegistry(resourceRegistry)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -117,9 +118,10 @@ func (Strategy) Canonicalize(_ runtime.Object) {
 
 // ValidateUpdate is invoked after default fields in the object have been
 // filled in before the object is persisted.
-func (Strategy) ValidateUpdate(_ context.Context, _, _ runtime.Object) field.ErrorList {
-	// TODO: add validation for ResourceRegistry
-	return field.ErrorList{}
+func (Strategy) ValidateUpdate(_ context.Context, obj, old runtime.Object) field.ErrorList {
+	newResourceRegistry := obj.(*searchapis.ResourceRegistry)
+	oldResourceRegistry := old.(*searchapis.ResourceRegistry)
+	return searchvalidation.ValidateResourceRegistryUpdate(newResourceRegistry, oldResourceRegistry)
 }
 
 // WarningsOnUpdate returns warnings for the given update.


### PR DESCRIPTION
What type of PR is this?

/kind cleanup

What this PR does / why we need it:

Adds server-side validation for ResourceRegistry in the search API path.
Replaces no-op validation in ResourceRegistry strategy create/update with real validation calls.
Introduces semantic validation for:
targetCluster (existing cluster-affinity validation)
resourceSelectors[*].apiVersion parse validation (when provided)
resourceSelectors[*].namespace format validation (when provided)
[backendStore.openSearch.addresses[*]](vscode-file://vscode-app/snap/code/226/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) URL parse validation (when provided)
Adds unit tests for valid/invalid ResourceRegistry validation scenarios.
Closes the gap where strategy-level validation previously returned no errors.
Which issue(s) this PR fixes:
Fixes #<issue-number>

Special notes for your reviewer:

Updated based on review feedback to avoid duplicating required-field checks already enforced by apiserver/schema.
Kept semantic-only checks in this validation layer.
Local verification:
go test ./pkg/apis/search/validation 
bash hack/verify-staticcheck.sh

Does this PR introduce a user-facing change?:

> `NONE`