### PR TITLE
FIX: use `%w` instead of `%v` to preserve `UnschedulableError` type chain

### DIFF
--- a/pkg/scheduler/core/assignment.go
+++ b/pkg/scheduler/core/assignment.go
@@ -217,7 +217,7 @@ func assignByDynamicStrategy(state *assignState) ([]workv1alpha2.TargetCluster, 
 	if state.assignmentMode == Fresh {
 		result, err := dynamicFreshScale(state)
 		if err != nil {
-			return nil, fmt.Errorf("failed to do fresh scale: %v", err)
+			return nil, fmt.Errorf("failed to do fresh scale: %w", err)
 		}
 		return result, nil
 	}
@@ -227,7 +227,7 @@ func assignByDynamicStrategy(state *assignState) ([]workv1alpha2.TargetCluster, 
 		// We need to reduce the replicas in terms of the previous result.
 		result, err := dynamicScaleDown(state)
 		if err != nil {
-			return nil, fmt.Errorf("failed to scale down: %v", err)
+			return nil, fmt.Errorf("failed to scale down: %w", err)
 		}
 		return result, nil
 	} else if state.assignedReplicas < state.spec.Replicas {
@@ -235,7 +235,7 @@ func assignByDynamicStrategy(state *assignState) ([]workv1alpha2.TargetCluster, 
 		// First scheduling is considered as a special kind of scaling up.
 		result, err := dynamicScaleUp(state)
 		if err != nil {
-			return nil, fmt.Errorf("failed to scale up: %v", err)
+			return nil, fmt.Errorf("failed to scale up: %w", err)
 		}
 		return result, nil
 	}

--- a/pkg/scheduler/core/assignment_test.go
+++ b/pkg/scheduler/core/assignment_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package core
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
@@ -26,6 +27,7 @@ import (
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/scheduler/core/spreadconstraint"
+	"github.com/karmada-io/karmada/pkg/scheduler/framework"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/test/helper"
 )
@@ -936,5 +938,43 @@ func Test_assignByDuplicatedStrategy(t *testing.T) {
 				t.Errorf("assignByDuplicatedStrategy() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// Test_assignByDynamicStrategy_UnschedulableErrorPreserved verifies that when
+// assignByDynamicStrategy returns an error originating from an UnschedulableError,
+// the error type is preserved through fmt.Errorf wrapping so that callers can
+// detect it via errors.As.
+func Test_assignByDynamicStrategy_UnschedulableErrorPreserved(t *testing.T) {
+	// Set up a state where available replicas (3) < requested replicas (10),
+	// which triggers UnschedulableError in dynamicDivideReplicas.
+	candidates := []spreadconstraint.ClusterDetailInfo{
+		{
+			Name: ClusterMember1,
+			Cluster: helper.NewClusterWithResource(ClusterMember1, corev1.ResourceList{
+				corev1.ResourcePods: *resource.NewQuantity(3, resource.DecimalSI),
+			}, util.EmptyResource().ResourceList(), util.EmptyResource().ResourceList()),
+			AllocatableReplicas: 3,
+		},
+	}
+	spec := &workv1alpha2.ResourceBindingSpec{
+		Replicas: 10,
+		ReplicaRequirements: &workv1alpha2.ReplicaRequirements{
+			ResourceRequest: util.EmptyResource().ResourceList(),
+		},
+		Placement: &policyv1alpha1.Placement{
+			ReplicaScheduling: dynamicWeightStrategy,
+		},
+	}
+
+	state := newAssignState(candidates, spec, &workv1alpha2.ResourceBindingStatus{})
+	_, err := assignByDynamicStrategy(state)
+	if err == nil {
+		t.Fatal("assignByDynamicStrategy() expected error, got nil")
+	}
+
+	var unschedulableErr *framework.UnschedulableError
+	if !errors.As(err, &unschedulableErr) {
+		t.Errorf("assignByDynamicStrategy() error type not preserved: errors.As(*UnschedulableError) = false, error = %v", err)
 	}
 }

--- a/pkg/scheduler/helper_test.go
+++ b/pkg/scheduler/helper_test.go
@@ -19,6 +19,7 @@ package scheduler
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -484,6 +485,12 @@ func Test_getConditionByError(t *testing.T) {
 		{
 			name:              "unschedulable error",
 			err:               &framework.UnschedulableError{},
+			expectedCondition: metav1.Condition{Type: workv1alpha2.Scheduled, Reason: workv1alpha2.BindingReasonUnschedulable, Status: metav1.ConditionFalse},
+			ignoreErr:         false,
+		},
+		{
+			name:              "wrapped unschedulable error",
+			err:               fmt.Errorf("failed to assign replicas: %w", fmt.Errorf("failed to scale up: %w", &framework.UnschedulableError{Message: "insufficient replicas"})),
 			expectedCondition: metav1.Condition{Type: workv1alpha2.Scheduled, Reason: workv1alpha2.BindingReasonUnschedulable, Status: metav1.ConditionFalse},
 			ignoreErr:         false,
 		},

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -629,7 +629,7 @@ func (s *Scheduler) scheduleResourceBindingWithClusterAffinities(rb *workv1alpha
 			firstErr = err
 		}
 
-		err = fmt.Errorf("failed to schedule ResourceBinding(%s/%s) with clusterAffiliates index(%d): %v", rb.Namespace, rb.Name, affinityIndex, err)
+		err = fmt.Errorf("failed to schedule ResourceBinding(%s/%s) with clusterAffiliates index(%d): %w", rb.Namespace, rb.Name, affinityIndex, err)
 		klog.Error(err)
 		s.recordScheduleResultEventForResourceBinding(rb, nil, err)
 		affinityIndex++
@@ -772,7 +772,7 @@ func (s *Scheduler) scheduleClusterResourceBindingWithClusterAffinities(crb *wor
 			firstErr = err
 		}
 
-		err = fmt.Errorf("failed to schedule ClusterResourceBinding(%s) with clusterAffiliates index(%d): %v", crb.Name, affinityIndex, err)
+		err = fmt.Errorf("failed to schedule ClusterResourceBinding(%s) with clusterAffiliates index(%d): %w", crb.Name, affinityIndex, err)
 		klog.Error(err)
 		s.recordScheduleResultEventForClusterResourceBinding(crb, nil, err)
 		affinityIndex++

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -42,6 +42,7 @@ import (
 	karmadafake "github.com/karmada-io/karmada/pkg/generated/clientset/versioned/fake"
 	workv1alpha2lister "github.com/karmada-io/karmada/pkg/generated/listers/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/scheduler/core"
+	"github.com/karmada-io/karmada/pkg/scheduler/framework"
 	internalqueue "github.com/karmada-io/karmada/pkg/scheduler/internal/queue"
 	"github.com/karmada-io/karmada/pkg/sharedcli/ratelimiterflag"
 	"github.com/karmada-io/karmada/pkg/util"
@@ -2082,4 +2083,77 @@ func (f *fakeClusterBindingLister) List(_ labels.Selector) (ret []*workv1alpha2.
 
 func (f *fakeClusterBindingLister) Get(_ string) (*workv1alpha2.ClusterResourceBinding, error) {
 	return f.binding, nil
+}
+
+// mockSchedulingQueue records which method handleErr calls.
+type mockSchedulingQueue struct {
+	pushUnschedulableCalled bool
+	pushBackoffCalled       bool
+	forgetCalled            bool
+}
+
+func (m *mockSchedulingQueue) Push(_ *internalqueue.QueuedBindingInfo)       {}
+func (m *mockSchedulingQueue) Pop() (*internalqueue.QueuedBindingInfo, bool) { return nil, false }
+func (m *mockSchedulingQueue) Done(_ *internalqueue.QueuedBindingInfo)       {}
+func (m *mockSchedulingQueue) Len() int                                      { return 0 }
+func (m *mockSchedulingQueue) Run()                                          {}
+func (m *mockSchedulingQueue) Close()                                        {}
+
+func (m *mockSchedulingQueue) PushUnschedulableIfNotPresent(_ *internalqueue.QueuedBindingInfo) {
+	m.pushUnschedulableCalled = true
+}
+
+func (m *mockSchedulingQueue) PushBackoffIfNotPresent(_ *internalqueue.QueuedBindingInfo) {
+	m.pushBackoffCalled = true
+}
+
+func (m *mockSchedulingQueue) Forget(_ *internalqueue.QueuedBindingInfo) {
+	m.forgetCalled = true
+}
+
+func TestHandleErr(t *testing.T) {
+	tests := []struct {
+		name                    string
+		err                     error
+		expectPushUnschedulable bool
+		expectPushBackoff       bool
+		expectForget            bool
+	}{
+		{
+			name:         "nil error calls Forget",
+			err:          nil,
+			expectForget: true,
+		},
+		{
+			name:              "generic error calls PushBackoffIfNotPresent",
+			err:               fmt.Errorf("some transient error"),
+			expectPushBackoff: true,
+		},
+		{
+			name:                    "bare UnschedulableError calls PushUnschedulableIfNotPresent",
+			err:                     &framework.UnschedulableError{Message: "insufficient replicas"},
+			expectPushUnschedulable: true,
+		},
+		{
+			name: "wrapped UnschedulableError calls PushUnschedulableIfNotPresent",
+			err: fmt.Errorf("failed to assign replicas: %w",
+				fmt.Errorf("failed to scale up: %w",
+					&framework.UnschedulableError{Message: "insufficient replicas"})),
+			expectPushUnschedulable: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockSchedulingQueue{}
+			s := &Scheduler{priorityQueue: mock}
+			bindingInfo := &internalqueue.QueuedBindingInfo{NamespacedKey: "default/test"}
+
+			s.handleErr(tt.err, bindingInfo)
+
+			assert.Equal(t, tt.expectPushUnschedulable, mock.pushUnschedulableCalled, "PushUnschedulableIfNotPresent")
+			assert.Equal(t, tt.expectPushBackoff, mock.pushBackoffCalled, "PushBackoffIfNotPresent")
+			assert.Equal(t, tt.expectForget, mock.forgetCalled, "Forget")
+		})
+	}
 }

--- a/test/e2e/suites/base/estimator_test.go
+++ b/test/e2e/suites/base/estimator_test.go
@@ -163,7 +163,7 @@ var _ = ginkgo.Describe("Quota plugin Testing", func() {
 			deployBindingName := names.GenerateBindingName(util.DeploymentKind, deployName)
 			framework.WaitResourceBindingFitWith(karmadaClient, deployNamespace, deployBindingName, func(binding *workv1alpha2.ResourceBinding) bool {
 				cond := meta.FindStatusCondition(binding.Status.Conditions, workv1alpha2.Scheduled)
-				return binding.Spec.Clusters == nil && cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == workv1alpha2.BindingReasonSchedulerError
+				return binding.Spec.Clusters == nil && cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == workv1alpha2.BindingReasonUnschedulable
 			})
 			framework.WaitResourceBindingFitWith(karmadaClient, deployNamespace, deployBindingName, func(binding *workv1alpha2.ResourceBinding) bool {
 				if binding.Spec.ReplicaRequirements == nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
- `assignByDynamicStrategy` (assignment.go:220,230,238) wraps errors with `%v` instead of `%w`, which converts the error to a plain string and breaks the `*UnschedulableError` type chain.
- `handleErr` (scheduler.go:842) and `getConditionByError` (helper.go:118) use`errors.As` to detect `UnschedulableError`. Because `%v` discards the type, the check always fails, and bindings that are genuinely unschedulable (insufficient cluster replicas) are misrouted to `backoffQ` instead of `unschedulableBindings`.
- This causes unschedulable bindings to be retried with exponential backoff, wasting scheduler cycles and delaying scheduling of other work.

The fix changes `%v` to `%w` at all three call sites so `errors.As` can unwrap the error chain correctly.

**Error propagation chain**

dynamicDivideReplicas         — creates *UnschedulableError
  → dynamicScaleUp/Down/Fresh — passes through
    → assignByDynamicStrategy — wraps with %v ← BREAKS type chain
      → AssignReplicas         — passes through
        → Schedule             — wraps with %w (correct, but too late)
          → handleErr          — errors.As fails → wrong queue

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->
With this fix, `UnschedulableError` is now correctly routed to `unschedulableBindings` instead of `backoffQ`.

However, the bindings only move out of `unschedulableBindings` in two ways:

- 5-minute timer flush (`flushUnschedulableBindingsLeftover`)
- event-driven requeue when updateCluster detects spec/label/deletion changes via `clusterReconcileWorker` → `enqueueAffectedBindings` → `Push()` → `moveToActiveQ()`.

Neither mechanism reacts to `ClusterStatus` changes. Since `ResourceSummary` and `Conditions` are in `ClusterStatus` (not ClusterSpec), these updates do not increment `Generation` and are silently dropped by the `updateCluster` switch statement. This means a low-priority binding placed in `unschedulableBindings` will wait up to 5 minutes to be retried when cluster resources become available.

I'd like to follow up with [this issue](https://github.com/karmada-io/karmada/issues/7344) to improve the requeue mechanism.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-scheduler`: Fixed incorrect error type propagation that caused bindings with insufficient cluster replicas to be misrouted to `backoffQ` instead of `unschedulableBindings`, changing retry behavior from exponential backoff (1-10s) to timer-based retry (5 minutes).
```

