### PR TITLE
Validate critical initData values in operator init workflow

### DIFF
--- a/operator/pkg/init.go
+++ b/operator/pkg/init.go
@@ -157,7 +157,6 @@ func newRunData(opt *InitOptions) (*initData, error) {
 		return nil, fmt.Errorf("unexpected karmada invalid version %s", opt.KarmadaVersion)
 	}
 
-	// TODO: Verify whether important values of initData is valid
 	var address string
 	if opt.Karmada.Spec.Components.KarmadaAPIServer.ServiceType == corev1.ServiceTypeNodePort {
 		address, err = util.GetAPIServiceIP(remoteClient)


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

This PR adds validation for critical init data in the operator init workflow before those fields are used.

### Specifically, it now checks:

Spec.Components and Spec.Components.KarmadaAPIServer are present
Spec.HostCluster, Spec.HostCluster.Networking, and Spec.HostCluster.Networking.DNSDomain are present
DNSDomain is not empty
If any of these required fields are missing, the init flow now returns a clear error instead of continuing and failing later with less obvious behavior.

This makes operator initialization safer and easier to debug when the Karmada custom resource is incomplete or misconfigured.

### Special notes for your reviewer:

Main code change is in newRunData validation logic.
Added unit tests that cover invalid configuration cases:
missing components
missing KarmadaAPIServer component
missing host cluster
missing host cluster networking
missing dnsDomain
empty dnsDomain
Test report:
go test ./operator/pkg/...

### Does this PR introduce a user-facing change?:

```
 NONE
```
