### PR TITLE
test: add inline event assertions for FederatedResourceQuota controller events

### DIFF
--- a/test/e2e/suites/base/federatedresourcequota_test.go
+++ b/test/e2e/suites/base/federatedresourcequota_test.go
@@ -83,6 +83,9 @@ var _ = framework.SerialDescribe("FederatedResourceQuota auto-provision testing"
 		ginkgo.By("[Create] federatedResourceQuota should be propagated to member clusters", func() {
 			framework.CreateFederatedResourceQuota(karmadaClient, federatedResourceQuota)
 			framework.WaitResourceQuotaPresentOnClusters(clusters, frqNamespace, frqName)
+			framework.WaitEventFitWith(kubeClient, frqNamespace, frqName, func(event corev1.Event) bool {
+				return event.Reason == events.EventReasonSyncFederatedResourceQuotaSucceed
+			})
 		})
 
 		ginkgo.By("[Update] FederatedResourceQuota should be propagated to member clusters according to the new staticAssignments", func() {
@@ -256,6 +259,12 @@ var _ = framework.SerialDescribe("[FederatedResourceQuota] status collection tes
 		ginkgo.It("FederatedResourceQuota status should be collect correctly", func() {
 			framework.CreateFederatedResourceQuota(karmadaClient, federatedResourceQuota)
 			framework.WaitFederatedResourceQuotaCollectStatus(karmadaClient, frqNamespace, frqName)
+			framework.WaitEventFitWith(kubeClient, frqNamespace, frqName, func(event corev1.Event) bool {
+				return event.Reason == events.EventReasonCollectFederatedResourceQuotaStatusSucceed
+			})
+			framework.WaitEventFitWith(kubeClient, frqNamespace, frqName, func(event corev1.Event) bool {
+				return event.Reason == events.EventReasonCollectFederatedResourceQuotaOverallStatusSucceed
+			})
 
 			patch := []map[string]any{
 				{


### PR DESCRIPTION
Add WaitEventFitWith assertions for the three FederatedResourceQuota controller event reasons into existing test cases:
- EventReasonSyncFederatedResourceQuotaSucceed: asserted after Works are distributed to member clusters in the CRUD test.
- EventReasonCollectFederatedResourceQuotaStatusSucceed: asserted after status is collected from Works in the status collection test.
- EventReasonCollectFederatedResourceQuotaOverallStatusSucceed: asserted after overall quota status is computed in the status collection test.


**What type of PR is this?**


  ## Changes
- `EventReasonSyncFederatedResourceQuotaSucceed`: asserted in the CRUD test after Works are successfully distributed to member clusters (sync controller).
- `EventReasonCollectFederatedResourceQuotaStatusSucceed`: asserted in the status collection test after status is collected from Works back into the FederatedResourceQuota (status controller).
- `EventReasonCollectFederatedResourceQuotaOverallStatusSucceed`: asserted in the status collection test after overall quota status is computed (enforcement controller).

All assertions use the existing `framework.WaitEventFitWith` helper and are placed inline at the point where the triggering operation completes.

Related: #7252

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Adds inline `WaitEventFitWith` assertions into existing E2E test cases for the three FederatedResourceQuota controller event reasons, as discussed in #7252.
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #7252 
-->

**Special notes for your reviewer**:
<!--
  Assertions are placed immediately after the operation that triggers each event.

- `SyncFederatedResourceQuotaSucceed` is asserted after `WaitResourceQuotaPresentOnClusters`, which confirms Works have landed in member clusters — the sync controller fires this event at that point.
- `CollectFederatedResourceQuotaStatusSucceed` and `CollectFederatedResourceQuotaOverallStatusSucceed` are both asserted
after `WaitFederatedResourceQuotaCollectStatus` in the status collection test, as both the status controller and enforcement
controller complete their reconciliation by that point.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

