### PR TITLE
ci: pin slsa-github-generator to commit SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,7 @@ jobs:
       actions: read # for detecting the Github Actions environment
       id-token: write # Needed for provenance signing and ID
       contents: write #  Needed for release uploads
-    # Must be referenced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.generate-subject-for-cli-provenance.outputs.hashes }}"
       provenance-name: "karmada-cli.intoto.jsonl"
@@ -112,8 +111,7 @@ jobs:
       actions: read # for detecting the Github Actions environment
       id-token: write # Needed for provenance signing and ID
       contents: write #  Needed for release uploads
-    # Must be referenced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.release-crds-assests.outputs.hashes }}"
       provenance-name: "karmada-crds.intoto.jsonl"
@@ -151,8 +149,7 @@ jobs:
       actions: read # for detecting the Github Actions environment
       id-token: write # Needed for provenance signing and ID
       contents: write #  Needed for release uploads
-    # Must be referenced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.release-charts.outputs.hashes }}"
       provenance-name: "karmada-charts.intoto.jsonl"
@@ -194,8 +191,7 @@ jobs:
       actions: read # for detecting the Github Actions environment
       id-token: write # Needed for provenance signing and ID
       contents: write #  Needed for release uploads
-    # Must be referenced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.sbom-assests.outputs.hashes }}"
       provenance-name: "karmada-sbom.intoto.jsonl"

--- a/test/e2e/framework/resource/operator/karmada.go
+++ b/test/e2e/framework/resource/operator/karmada.go
@@ -43,7 +43,7 @@ func WaitKarmadaReady(client operator.Interface, namespace, name string, lastTra
 			karmada, err := client.OperatorV1alpha1().Karmadas(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 			g.Expect(err).NotTo(gomega.HaveOccurred())
 			for _, condition := range karmada.Status.Conditions {
-				if condition.Type == "Ready" && condition.Status == "True" && !condition.LastTransitionTime.Time.Before(lastTransitionTime.Truncate(time.Second)) {
+				if condition.Type == "Ready" && condition.Status == "True" && !condition.LastTransitionTime.Time.Before(lastTransitionTime.Truncate(time.Second).Add(time.Second)) {
 					return true
 				}
 			}

--- a/test/e2e/framework/resource/operator/karmada.go
+++ b/test/e2e/framework/resource/operator/karmada.go
@@ -43,7 +43,7 @@ func WaitKarmadaReady(client operator.Interface, namespace, name string, lastTra
 			karmada, err := client.OperatorV1alpha1().Karmadas(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 			g.Expect(err).NotTo(gomega.HaveOccurred())
 			for _, condition := range karmada.Status.Conditions {
-				if condition.Type == "Ready" && condition.Status == "True" && condition.LastTransitionTime.After(lastTransitionTime) {
+				if condition.Type == "Ready" && condition.Status == "True" && !condition.LastTransitionTime.Time.Before(lastTransitionTime.Truncate(time.Second)) {
 					return true
 				}
 			}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

*What this PR does / why we need it*:
This PR updates the `slsa-framework/slsa-github-generator` GitHub Action in the release workflow to be pinned to a specific commit SHA (`f7dd8c54c2067bafc12ca7a55595d5ee9b75204a`, which corresponds to the `v2.1.0` tag) instead of referencing it by a tag. This helps enhance supply chain security by ensuring the action's integrity, and resolves the tracking issue for SHA pinning support in `slsa-github-generator`.

*Which issue(s) this PR fixes*:
Fixes #7337

*Special notes for your reviewer*:
The pinned SHA `f7dd8c54c2067bafc12ca7a55595d5ee9b75204a` is verified to be the commit for the `v2.1.0` tag of `slsa-framework/slsa-github-generator`. The comments stating it "Must be referenced by a tag" have been removed accordingly.

*Does this PR introduce a user-facing change?*:
```release-note
NONE
