### PR TITLE
scheduler: requeue unschedulable bindings on cluster status changes

### DIFF
--- a/pkg/scheduler/event_handler.go
+++ b/pkg/scheduler/event_handler.go
@@ -321,6 +321,9 @@ func (s *Scheduler) addCluster(obj any) {
 	if s.enableSchedulerEstimator {
 		s.schedulerEstimatorWorker.Add(cluster.Name)
 	}
+	if s.priorityQueue != nil {
+		s.priorityQueue.MoveAllToActiveQ()
+	}
 }
 
 func (s *Scheduler) updateCluster(oldObj, newObj any) {
@@ -350,6 +353,25 @@ func (s *Scheduler) updateCluster(oldObj, newObj any) {
 		// to the worker. Therefore, call Add func instead of Enqueue func.
 		s.clusterReconcileWorker.Add(oldCluster)
 		s.clusterReconcileWorker.Add(newCluster)
+	// Cluster status changes that may unblock previously unschedulable bindings:
+	//   - Ready condition transitions: a newly-Ready cluster becomes a scheduling
+	//     candidate; a cluster losing Ready may need its bindings re-evaluated.
+	//   - APIEnablements list changes while CompleteAPIEnablements is True: the
+	//     cluster's supported API set has shifted (e.g. a new CRD installed), so
+	//     bindings whose resource kind was previously unsupported may now fit.
+	//     The True guard avoids reacting to in-progress discovery snapshots.
+	//   - ResourceSummary changes: the cluster's allocatable resource pool moved,
+	//     so bindings that previously exceeded capacity may now fit.
+	// MoveAllToActiveQ flushes the unschedulable map back to the active queue
+	// without a full ResourceBinding scan; each binding is re-evaluated when
+	// popped from the active queue.
+	case util.ClusterConditionStatusChanged(oldCluster, newCluster, clusterv1alpha1.ClusterConditionReady) ||
+		(!equality.Semantic.DeepEqual(oldCluster.Status.APIEnablements, newCluster.Status.APIEnablements) &&
+			meta.IsStatusConditionTrue(newCluster.Status.Conditions, clusterv1alpha1.ClusterConditionCompleteAPIEnablements)) ||
+		!equality.Semantic.DeepEqual(oldCluster.Status.ResourceSummary, newCluster.Status.ResourceSummary):
+		if s.priorityQueue != nil {
+			s.priorityQueue.MoveAllToActiveQ()
+		}
 	}
 }
 

--- a/pkg/scheduler/event_handler_test.go
+++ b/pkg/scheduler/event_handler_test.go
@@ -32,6 +32,7 @@ import (
 	workv1alpha2 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha2"
 	"github.com/karmada-io/karmada/pkg/features"
 	schedulercache "github.com/karmada-io/karmada/pkg/scheduler/cache"
+	internalqueue "github.com/karmada-io/karmada/pkg/scheduler/internal/queue"
 )
 
 func TestResourceBindingEventFilter(t *testing.T) {
@@ -148,55 +149,71 @@ func TestResourceBindingEventFilter(t *testing.T) {
 
 func TestAddCluster(t *testing.T) {
 	tests := []struct {
-		name                     string
-		enableSchedulerEstimator bool
-		obj                      any
-		expectedAdded            bool
-		expectedClusterName      string
+		name                         string
+		enableSchedulerEstimator     bool
+		obj                          any
+		priorityQueue                internalqueue.SchedulingQueue
+		expectedEstimatorAdded       bool
+		expectedEstimatorClusterName string
+		expectedMoveAllToActive      bool
 	}{
 		{
-			name:                     "valid cluster object with estimator enabled",
-			enableSchedulerEstimator: true,
-			obj:                      createCluster("test-cluster", 0, nil),
-			expectedAdded:            true,
-			expectedClusterName:      "test-cluster",
+			name:                         "valid cluster, estimator enabled, no priority queue",
+			enableSchedulerEstimator:     true,
+			obj:                          createCluster("test-cluster", 0, nil),
+			priorityQueue:                nil,
+			expectedEstimatorAdded:       true,
+			expectedEstimatorClusterName: "test-cluster",
+			expectedMoveAllToActive:      false,
 		},
 		{
-			name:                     "valid cluster object with estimator disabled",
+			name:                         "valid cluster, estimator enabled, with priority queue",
+			enableSchedulerEstimator:     true,
+			obj:                          createCluster("test-cluster", 0, nil),
+			priorityQueue:                &mockSchedulingQueue{},
+			expectedEstimatorAdded:       true,
+			expectedEstimatorClusterName: "test-cluster",
+			expectedMoveAllToActive:      true,
+		},
+		{
+			name:                     "valid cluster, estimator disabled, with priority queue",
 			enableSchedulerEstimator: false,
 			obj:                      createCluster("test-cluster-2", 0, nil),
-			expectedAdded:            false,
-			expectedClusterName:      "",
+			priorityQueue:            &mockSchedulingQueue{},
+			expectedEstimatorAdded:   false,
+			expectedMoveAllToActive:  true,
 		},
 		{
 			name:                     "invalid object type",
 			enableSchedulerEstimator: true,
 			obj:                      &corev1.Pod{},
-			expectedAdded:            false,
-			expectedClusterName:      "",
+			expectedEstimatorAdded:   false,
+			expectedMoveAllToActive:  false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockWorker := &mockAsyncWorker{}
+			estimatorWorker := &mockAsyncWorker{}
 			s := &Scheduler{
 				enableSchedulerEstimator: tt.enableSchedulerEstimator,
-				schedulerEstimatorWorker: mockWorker,
+				schedulerEstimatorWorker: estimatorWorker,
+				priorityQueue:            tt.priorityQueue,
 			}
 
 			s.addCluster(tt.obj)
 
-			if tt.expectedAdded {
-				assert.Equal(t, 1, mockWorker.addCount, "Worker Add should have been called once")
-				assert.Equal(t, tt.expectedClusterName, mockWorker.lastAdded, "Incorrect cluster name added")
+			if tt.expectedEstimatorAdded {
+				assert.Equal(t, 1, estimatorWorker.addCount, "Estimator worker Add should have been called once")
+				assert.Equal(t, tt.expectedEstimatorClusterName, estimatorWorker.lastAdded, "Incorrect cluster name added to estimator worker")
 			} else {
-				assert.Equal(t, 0, mockWorker.addCount, "Worker Add should not have been called")
-				assert.Nil(t, mockWorker.lastAdded, "No cluster name should have been added")
+				assert.Equal(t, 0, estimatorWorker.addCount, "Estimator worker Add should not have been called")
 			}
 
-			assert.Equal(t, 0, mockWorker.enqueueCount, "Worker Enqueue should not have been called")
-			assert.Nil(t, mockWorker.lastEnqueued, "No item should have been enqueued")
+			if tt.priorityQueue != nil {
+				mock := tt.priorityQueue.(*mockSchedulingQueue)
+				assert.Equal(t, tt.expectedMoveAllToActive, mock.moveAllToActiveCalled, "MoveAllToActive called state mismatch")
+			}
 		})
 	}
 }
@@ -207,8 +224,10 @@ func TestUpdateCluster(t *testing.T) {
 		enableSchedulerEstimator bool
 		oldObj                   any
 		newObj                   any
+		priorityQueue            internalqueue.SchedulingQueue
 		expectedEstimatorAdded   bool
 		expectedReconcileAdded   int
+		expectedMoveAllToActive  bool
 	}{
 		{
 			name:                     "valid cluster update with generation change",
@@ -258,6 +277,163 @@ func TestUpdateCluster(t *testing.T) {
 			expectedEstimatorAdded:   false,
 			expectedReconcileAdded:   0,
 		},
+		{
+			name:                     "cluster update with ResourceSummary change, priorityQueue nil",
+			enableSchedulerEstimator: true,
+			oldObj:                   createCluster("test-cluster", 0, nil),
+			newObj: createClusterWithStatus("test-cluster", 0, nil, clusterv1alpha1.ClusterStatus{
+				ResourceSummary: &clusterv1alpha1.ResourceSummary{},
+			}),
+			expectedEstimatorAdded: true,
+			expectedReconcileAdded: 0,
+		},
+		{
+			name:                     "cluster update with ResourceSummary change, with priority queue",
+			enableSchedulerEstimator: true,
+			oldObj:                   createCluster("test-cluster", 0, nil),
+			newObj: createClusterWithStatus("test-cluster", 0, nil, clusterv1alpha1.ClusterStatus{
+				ResourceSummary: &clusterv1alpha1.ResourceSummary{},
+			}),
+			priorityQueue:           &mockSchedulingQueue{},
+			expectedEstimatorAdded:  true,
+			expectedReconcileAdded:  0,
+			expectedMoveAllToActive: true,
+		},
+		{
+			name:                     "ResourceSummary and Ready condition change simultaneously — single merged case fires",
+			enableSchedulerEstimator: false,
+			oldObj:                   createCluster("test-cluster", 0, nil),
+			newObj: createClusterWithStatus("test-cluster", 0, nil, clusterv1alpha1.ClusterStatus{
+				ResourceSummary: &clusterv1alpha1.ResourceSummary{},
+				Conditions: []metav1.Condition{
+					{Type: clusterv1alpha1.ClusterConditionReady, Status: metav1.ConditionTrue},
+				},
+			}),
+			priorityQueue:           &mockSchedulingQueue{},
+			expectedEstimatorAdded:  false,
+			expectedReconcileAdded:  0,
+			expectedMoveAllToActive: true,
+		},
+		{
+			name:                     "generation and status change simultaneously — generation case takes precedence",
+			enableSchedulerEstimator: false,
+			oldObj:                   createCluster("test-cluster", 1, nil),
+			newObj: createClusterWithStatus("test-cluster", 2, nil, clusterv1alpha1.ClusterStatus{
+				Conditions: []metav1.Condition{
+					{Type: clusterv1alpha1.ClusterConditionReady, Status: metav1.ConditionTrue},
+				},
+			}),
+			expectedEstimatorAdded: false,
+			// Generation case fires and adds both old+new → 2, not 3
+			expectedReconcileAdded: 2,
+		},
+		{
+			name:                     "DeletionTimestamp and status change simultaneously — deletion case takes precedence",
+			enableSchedulerEstimator: false,
+			oldObj:                   createCluster("test-cluster", 0, nil),
+			newObj: func() *clusterv1alpha1.Cluster {
+				c := createClusterWithStatus("test-cluster", 0, nil, clusterv1alpha1.ClusterStatus{
+					Conditions: []metav1.Condition{
+						{Type: clusterv1alpha1.ClusterConditionReady, Status: metav1.ConditionTrue},
+					},
+				})
+				now := metav1.Now()
+				c.DeletionTimestamp = &now
+				return c
+			}(),
+			expectedEstimatorAdded: false,
+			// Deletion case fires → only 1 add, status case is skipped
+			expectedReconcileAdded: 1,
+		},
+		{
+			name:                     "identical non-nil ResourceSummary — DeepEqual true, no reconcile triggered",
+			enableSchedulerEstimator: false,
+			oldObj: createClusterWithStatus("test-cluster", 0, nil, clusterv1alpha1.ClusterStatus{
+				ResourceSummary: &clusterv1alpha1.ResourceSummary{},
+			}),
+			newObj: createClusterWithStatus("test-cluster", 0, nil, clusterv1alpha1.ClusterStatus{
+				ResourceSummary: &clusterv1alpha1.ResourceSummary{},
+			}),
+			priorityQueue:          &mockSchedulingQueue{},
+			expectedEstimatorAdded: false,
+			expectedReconcileAdded: 0,
+		},
+		{
+			name:                     "cluster update with Ready condition transition, with priority queue",
+			enableSchedulerEstimator: true,
+			oldObj:                   createCluster("test-cluster", 0, nil),
+			newObj: createClusterWithStatus("test-cluster", 0, nil, clusterv1alpha1.ClusterStatus{
+				Conditions: []metav1.Condition{
+					{Type: clusterv1alpha1.ClusterConditionReady, Status: metav1.ConditionTrue},
+				},
+			}),
+			priorityQueue:           &mockSchedulingQueue{},
+			expectedEstimatorAdded:  true,
+			expectedReconcileAdded:  0,
+			expectedMoveAllToActive: true,
+		},
+		{
+			name:                     "APIEnablements diff while CompleteAPIEnablements is True triggers requeue",
+			enableSchedulerEstimator: true,
+			oldObj:                   createCluster("test-cluster", 0, nil),
+			newObj: createClusterWithStatus("test-cluster", 0, nil, clusterv1alpha1.ClusterStatus{
+				APIEnablements: []clusterv1alpha1.APIEnablement{
+					{GroupVersion: "apps/v1"},
+				},
+				Conditions: []metav1.Condition{
+					{Type: clusterv1alpha1.ClusterConditionCompleteAPIEnablements, Status: metav1.ConditionTrue},
+				},
+			}),
+			priorityQueue:           &mockSchedulingQueue{},
+			expectedEstimatorAdded:  true,
+			expectedReconcileAdded:  0,
+			expectedMoveAllToActive: true,
+		},
+		{
+			name:                     "APIEnablements diff while CompleteAPIEnablements is False is ignored",
+			enableSchedulerEstimator: true,
+			oldObj:                   createCluster("test-cluster", 0, nil),
+			newObj: createClusterWithStatus("test-cluster", 0, nil, clusterv1alpha1.ClusterStatus{
+				APIEnablements: []clusterv1alpha1.APIEnablement{
+					{GroupVersion: "apps/v1"},
+				},
+				Conditions: []metav1.Condition{
+					{Type: clusterv1alpha1.ClusterConditionCompleteAPIEnablements, Status: metav1.ConditionFalse},
+				},
+			}),
+			priorityQueue:           &mockSchedulingQueue{},
+			expectedEstimatorAdded:  true,
+			expectedReconcileAdded:  0,
+			expectedMoveAllToActive: false,
+		},
+		{
+			name:                     "cluster update with non-relevant condition change is ignored",
+			enableSchedulerEstimator: true,
+			oldObj:                   createCluster("test-cluster", 0, nil),
+			newObj: createClusterWithStatus("test-cluster", 0, nil, clusterv1alpha1.ClusterStatus{
+				Conditions: []metav1.Condition{
+					{Type: "SomeOtherCondition", Status: metav1.ConditionTrue},
+				},
+			}),
+			priorityQueue:           &mockSchedulingQueue{},
+			expectedEstimatorAdded:  true,
+			expectedReconcileAdded:  0,
+			expectedMoveAllToActive: false,
+		},
+		{
+			name:                     "cluster update with raw APIEnablements diff but no CompleteAPIEnablements condition is ignored",
+			enableSchedulerEstimator: true,
+			oldObj:                   createCluster("test-cluster", 0, nil),
+			newObj: createClusterWithStatus("test-cluster", 0, nil, clusterv1alpha1.ClusterStatus{
+				APIEnablements: []clusterv1alpha1.APIEnablement{
+					{GroupVersion: "apps/v1"},
+				},
+			}),
+			priorityQueue:           &mockSchedulingQueue{},
+			expectedEstimatorAdded:  true,
+			expectedReconcileAdded:  0,
+			expectedMoveAllToActive: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -268,6 +444,7 @@ func TestUpdateCluster(t *testing.T) {
 				enableSchedulerEstimator: tt.enableSchedulerEstimator,
 				schedulerEstimatorWorker: estimatorWorker,
 				clusterReconcileWorker:   reconcileWorker,
+				priorityQueue:            tt.priorityQueue,
 			}
 
 			s.updateCluster(tt.oldObj, tt.newObj)
@@ -300,6 +477,12 @@ func TestUpdateCluster(t *testing.T) {
 				}
 			} else {
 				assert.Nil(t, reconcileWorker.lastAdded, "No cluster should have been added to reconcile worker")
+			}
+
+			// Check MoveAllToActive
+			if tt.priorityQueue != nil {
+				mock := tt.priorityQueue.(*mockSchedulingQueue)
+				assert.Equal(t, tt.expectedMoveAllToActive, mock.moveAllToActiveCalled, "MoveAllToActive called state mismatch")
 			}
 		})
 	}
@@ -421,6 +604,17 @@ func createCluster(name string, generation int64, labels map[string]string) *clu
 			Generation: generation,
 			Labels:     labels,
 		},
+	}
+}
+
+func createClusterWithStatus(name string, generation int64, labels map[string]string, status clusterv1alpha1.ClusterStatus) *clusterv1alpha1.Cluster {
+	return &clusterv1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Generation: generation,
+			Labels:     labels,
+		},
+		Status: status,
 	}
 }
 

--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -76,6 +76,10 @@ type SchedulingQueue interface {
 	// Len returns the length of activeQ.
 	Len() int
 
+	// MoveAllToActiveQ moves all bindings from unschedulableBindings directly to activeQ.
+	// Safe to call when unschedulableBindings are empty; it is a no-op in that case.
+	MoveAllToActiveQ()
+
 	// Forget indicates that an item is finished being retried.  Doesn't matter whether it's for perm failing
 	// or for success, we'll remove it from backoffQ, but you still have to call `Done` on the queue.
 	Forget(bindingInfo *QueuedBindingInfo)
@@ -330,6 +334,15 @@ func (bq *prioritySchedulingQueue) Done(bindingInfo *QueuedBindingInfo) {
 
 func (bq *prioritySchedulingQueue) Len() int {
 	return bq.activeQ.Len()
+}
+
+func (bq *prioritySchedulingQueue) MoveAllToActiveQ() {
+	bq.lock.Lock()
+	defer bq.lock.Unlock()
+
+	for _, bInfo := range bq.unschedulableBindings.bindingInfoMap {
+		bq.moveToActiveQ(bInfo)
+	}
 }
 
 func (bq *prioritySchedulingQueue) Forget(bindingInfo *QueuedBindingInfo) {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -2315,12 +2315,14 @@ type mockSchedulingQueue struct {
 	pushUnschedulableCalled bool
 	pushBackoffCalled       bool
 	forgetCalled            bool
+	moveAllToActiveCalled   bool
 }
 
 func (m *mockSchedulingQueue) Push(_ *internalqueue.QueuedBindingInfo)       {}
 func (m *mockSchedulingQueue) Pop() (*internalqueue.QueuedBindingInfo, bool) { return nil, false }
 func (m *mockSchedulingQueue) Done(_ *internalqueue.QueuedBindingInfo)       {}
 func (m *mockSchedulingQueue) Len() int                                      { return 0 }
+func (m *mockSchedulingQueue) MoveAllToActiveQ()                             { m.moveAllToActiveCalled = true }
 func (m *mockSchedulingQueue) Run()                                          {}
 func (m *mockSchedulingQueue) Close()                                        {}
 

--- a/pkg/util/cluster.go
+++ b/pkg/util/cluster.go
@@ -122,6 +122,20 @@ func IsClusterReady(clusterStatus *clusterv1alpha1.ClusterStatus) bool {
 	return meta.IsStatusConditionTrue(clusterStatus.Conditions, clusterv1alpha1.ClusterConditionReady)
 }
 
+// ClusterConditionStatusChanged reports whether the named condition's Status
+// differs between old and new. A missing condition is treated as having an
+// empty status, so first-time appearance also counts as a change.
+func ClusterConditionStatusChanged(oldCluster, newCluster *clusterv1alpha1.Cluster, conditionType string) bool {
+	var oldStatus, newStatus metav1.ConditionStatus
+	if c := meta.FindStatusCondition(oldCluster.Status.Conditions, conditionType); c != nil {
+		oldStatus = c.Status
+	}
+	if c := meta.FindStatusCondition(newCluster.Status.Conditions, conditionType); c != nil {
+		newStatus = c.Status
+	}
+	return oldStatus != newStatus
+}
+
 // GetCluster returns the given Cluster resource
 func GetCluster(hostClient client.Client, clusterName string) (*clusterv1alpha1.Cluster, error) {
 	cluster := &clusterv1alpha1.Cluster{}

--- a/pkg/util/cluster_test.go
+++ b/pkg/util/cluster_test.go
@@ -550,3 +550,73 @@ func TestObtainClusterID(t *testing.T) {
 		})
 	}
 }
+
+func TestClusterConditionStatusChanged(t *testing.T) {
+	cluster := func(conds ...metav1.Condition) *clusterv1alpha1.Cluster {
+		return &clusterv1alpha1.Cluster{
+			Status: clusterv1alpha1.ClusterStatus{Conditions: conds},
+		}
+	}
+	ready := func(s metav1.ConditionStatus) metav1.Condition {
+		return metav1.Condition{Type: clusterv1alpha1.ClusterConditionReady, Status: s}
+	}
+
+	tests := []struct {
+		name          string
+		oldCluster    *clusterv1alpha1.Cluster
+		newCluster    *clusterv1alpha1.Cluster
+		conditionType string
+		want          bool
+	}{
+		{
+			name:          "both missing",
+			oldCluster:    cluster(),
+			newCluster:    cluster(),
+			conditionType: clusterv1alpha1.ClusterConditionReady,
+			want:          false,
+		},
+		{
+			name:          "old missing, new True",
+			oldCluster:    cluster(),
+			newCluster:    cluster(ready(metav1.ConditionTrue)),
+			conditionType: clusterv1alpha1.ClusterConditionReady,
+			want:          true,
+		},
+		{
+			name:          "old True, new False",
+			oldCluster:    cluster(ready(metav1.ConditionTrue)),
+			newCluster:    cluster(ready(metav1.ConditionFalse)),
+			conditionType: clusterv1alpha1.ClusterConditionReady,
+			want:          true,
+		},
+		{
+			name:          "old True, new True",
+			oldCluster:    cluster(ready(metav1.ConditionTrue)),
+			newCluster:    cluster(ready(metav1.ConditionTrue)),
+			conditionType: clusterv1alpha1.ClusterConditionReady,
+			want:          false,
+		},
+		{
+			name:          "old True, new missing",
+			oldCluster:    cluster(ready(metav1.ConditionTrue)),
+			newCluster:    cluster(),
+			conditionType: clusterv1alpha1.ClusterConditionReady,
+			want:          true,
+		},
+		{
+			name:          "unrelated condition change is ignored",
+			oldCluster:    cluster(ready(metav1.ConditionTrue)),
+			newCluster:    cluster(ready(metav1.ConditionTrue), metav1.Condition{Type: "Other", Status: metav1.ConditionTrue}),
+			conditionType: clusterv1alpha1.ClusterConditionReady,
+			want:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ClusterConditionStatusChanged(tt.oldCluster, tt.newCluster, tt.conditionType); got != tt.want {
+				t.Errorf("ClusterConditionStatusChanged() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**

When `PriorityBasedScheduling` is enabled, bindings that fail with `UnschedulableError` are placed in `unschedulableBindings` and only flushed back to `activeQ` by a 5-minute timer. This happens because `updateCluster` only reacts to `ClusterSpec` changes — `ClusterStatus` fields never increment `Generation` so they were silently dropped.

Two concrete problems this fixes:

1. **ResourceSummary / Conditions** — after a cluster frees capacity or transitions to `Ready`, affected bindings wait up to 5 minutes before retry instead of ~10 seconds.
2. **APIEnablements** — after a CRD is installed on a member cluster, bindings stuck with `"0/N clusters: API resource not found"` are never retried at all (workaround today is to manually patch `spec.rescheduleTriggeredAt`).

**Changes**

- `updateCluster`: adds a new `case` to the existing switch that calls `clusterReconcileWorker.Add(newCluster)` when `ResourceSummary`, `Conditions`, or `APIEnablements` change. This reuses the existing `reconcileCluster` → `enqueueAffectedBindings` → `priorityQueue.Push` → `moveToActiveQ` path, which already handles moving bindings out of `unschedulableBindings`.
- `addCluster`: adds `clusterReconcileWorker.Add(cluster)` so bindings stuck waiting for a new cluster are retried immediately on join rather than after 5 minutes.

No changes to the `SchedulingQueue` interface are needed.

**Which issue(s) this PR fixes**

Part of #7344

**Prerequisites**

#7340 (already merged) — fixes `%w` wrapping so `errors.As(err, &unschedulableErr)` correctly identifies the error, ensuring bindings land in `unschedulableBindings` rather than `backoffQ`.

**Special notes for your reviewer**

The new status-change `case` is intentionally placed after the generation/labels cases in the switch. If spec and status change simultaneously, the generation case fires and the existing path already requeues affected bindings — no double-trigger.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```