### PR TITLE
test: cover Karmada validation event update paths

### DIFF
--- a/operator/pkg/controller/karmada/validating_test.go
+++ b/operator/pkg/controller/karmada/validating_test.go
@@ -17,9 +17,15 @@ limitations under the License.
 package karmada
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	operatorv1alpha1 "github.com/karmada-io/karmada/operator/pkg/apis/operator/v1alpha1"
 	"github.com/karmada-io/karmada/operator/pkg/util"
@@ -207,4 +213,91 @@ func Test_validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestController_validateKarmada(t *testing.T) {
+	karmada := &operatorv1alpha1.Karmada{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: operatorv1alpha1.KarmadaSpec{
+			CRDTarball: &operatorv1alpha1.CRDTarball{
+				HTTPSource: &operatorv1alpha1.HTTPSource{URL: "bad-url"},
+			},
+		},
+	}
+
+	cl, err := buildValidationFakeClient(karmada, true)
+	if err != nil {
+		t.Fatalf("failed to build fake client: %v", err)
+	}
+	recorder := record.NewFakeRecorder(10)
+	ctrl := &Controller{Client: cl, EventRecorder: recorder}
+
+	err = ctrl.validateKarmada(context.Background(), karmada)
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+
+	updated := &operatorv1alpha1.Karmada{}
+	if getErr := cl.Get(context.Background(), client.ObjectKeyFromObject(karmada), updated); getErr != nil {
+		t.Fatalf("failed to get updated karmada: %v", getErr)
+	}
+
+	if len(updated.Status.Conditions) == 0 {
+		t.Fatal("expected status conditions to be updated")
+	}
+	condition := updated.Status.Conditions[0]
+	if condition.Type != string(operatorv1alpha1.Ready) ||
+		condition.Status != metav1.ConditionFalse ||
+		condition.Reason != ValidationErrorReason {
+		t.Fatalf("unexpected condition: type=%s, status=%s, reason=%s", condition.Type, condition.Status, condition.Reason)
+	}
+
+	select {
+	case event := <-recorder.Events:
+		if !strings.Contains(event, ValidationErrorReason) {
+			t.Fatalf("expected event to contain %q, got %q", ValidationErrorReason, event)
+		}
+	default:
+		t.Fatal("expected validation warning event, got none")
+	}
+}
+
+func TestController_validateKarmada_StatusUpdateError(t *testing.T) {
+	karmada := &operatorv1alpha1.Karmada{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: operatorv1alpha1.KarmadaSpec{
+			CRDTarball: &operatorv1alpha1.CRDTarball{
+				HTTPSource: &operatorv1alpha1.HTTPSource{URL: "bad-url"},
+			},
+		},
+	}
+
+	cl, err := buildValidationFakeClient(karmada, false)
+	if err != nil {
+		t.Fatalf("failed to build fake client: %v", err)
+	}
+	recorder := record.NewFakeRecorder(10)
+	ctrl := &Controller{Client: cl, EventRecorder: recorder}
+
+	err = ctrl.validateKarmada(context.Background(), karmada)
+	if err == nil {
+		t.Fatal("expected status update error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to update validate condition") {
+		t.Fatalf("expected wrapped update error, got %v", err)
+	}
+}
+
+func buildValidationFakeClient(karmada *operatorv1alpha1.Karmada, withStatusSubresource bool) (client.Client, error) {
+	scheme := runtime.NewScheme()
+	if err := operatorv1alpha1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+
+	b := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(karmada)
+	if withStatusSubresource {
+		b = b.WithStatusSubresource(karmada)
+	}
+
+	return b.Build(), nil
 }


### PR DESCRIPTION
### What type of PR is this?
/kind cleanup

### What this PR does / why we need it
This PR adds unit test coverage for Karmada controller validation update paths in validateKarmada.

### Covered paths:

1. Validation failure path:

- emits Warning event with reason ValidationError
- updates Ready condition to False with validation failure details

2. Status update failure path:

- returns wrapped error when status update fails after validation error
- This improves regression detection for controller validation behavior at unit-test level.

### Which issue(s) this PR fixes
None

### Special notes for your reviewer

- Scope is unit test only.
- No production logic changes.
- E2E event validation is handled in a separate PR aligned with issue #7252.

### Test report
go test ./operator/pkg/controller/karmada -run TestController_validateKarmada -count=1

### Does this PR introduce a user-facing change?
```
NONE
```