### PR TITLE
fix: record schedule result correctly in the event

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -660,7 +660,7 @@ func (s *Scheduler) scheduleResourceBindingWithClusterAffinities(rb *workv1alpha
 	patchErr := s.patchScheduleResultForResourceBinding(rb, string(placementBytes), scheduleResult.SuggestedClusters)
 	patchStatusErr := patchBindingStatusWithAffinityName(s.KarmadaClient, rb, updatedStatus.SchedulerObservedAffinityName)
 	scheduleErr := utilerrors.NewAggregate([]error{patchErr, patchStatusErr})
-	s.recordScheduleResultEventForResourceBinding(rb, nil, scheduleErr)
+	s.recordScheduleResultEventForResourceBinding(rb, scheduleResult.SuggestedClusters, scheduleErr)
 	return scheduleErr
 }
 
@@ -803,7 +803,7 @@ func (s *Scheduler) scheduleClusterResourceBindingWithClusterAffinities(crb *wor
 	patchErr := s.patchScheduleResultForClusterResourceBinding(crb, string(placementBytes), scheduleResult.SuggestedClusters)
 	patchStatusErr := patchClusterBindingStatusWithAffinityName(s.KarmadaClient, crb, updatedStatus.SchedulerObservedAffinityName)
 	scheduleErr := utilerrors.NewAggregate([]error{patchErr, patchStatusErr})
-	s.recordScheduleResultEventForClusterResourceBinding(crb, nil, scheduleErr)
+	s.recordScheduleResultEventForClusterResourceBinding(crb, scheduleResult.SuggestedClusters, scheduleErr)
 	return scheduleErr
 }
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -569,7 +568,7 @@ func TestScheduleResourceBindingWithClusterAffinities(t *testing.T) {
 				`{"metadata":{"annotations":{"policy.karmada.io/applied-placement":"{\"clusterAffinities\":[{\"affinityName\":\"affinity1\",\"clusterNames\":[\"cluster1\"]},{\"affinityName\":\"affinity2\",\"clusterNames\":[\"cluster2\"]}]}"}},"spec":{"clusters":[{"name":"cluster1","replicas":1}]}}`,
 				`{"status":{"schedulerObservingAffinityName":"affinity1"}}`,
 			},
-			expectedEvent: "Normal ScheduleBindingSucceed Binding has been scheduled successfully.",
+			expectedEvent: fmt.Sprintf("Normal ScheduleBindingSucceed %s Result: {cluster1:1}", successfulSchedulingMessage),
 		},
 		{
 			name: "successful scheduling with second affinity",
@@ -688,11 +687,7 @@ func TestScheduleResourceBindingWithClusterAffinities(t *testing.T) {
 			// Check if an event was recorded
 			select {
 			case event := <-fakeRecorder.Events:
-				if strings.Contains(event, "ScheduleBindingFailed") {
-					assert.Contains(t, event, tt.expectedEvent, "Event does not match expected")
-				} else {
-					assert.Contains(t, event, "ScheduleBindingSucceed", "Expected ScheduleBindingSucceed event")
-				}
+				assert.Contains(t, event, tt.expectedEvent, "Event does not match expected")
 			default:
 				t.Errorf("Expected an event to be recorded")
 			}
@@ -900,6 +895,7 @@ func TestScheduleClusterResourceBindingWithClusterAffinities(t *testing.T) {
 		scheduleResults []core.ScheduleResult
 		scheduleErrors  []error
 		expectError     bool
+		expectedEvent   string
 	}{
 		{
 			name: "successful scheduling with first affinity",
@@ -935,6 +931,7 @@ func TestScheduleClusterResourceBindingWithClusterAffinities(t *testing.T) {
 			},
 			scheduleErrors: []error{nil},
 			expectError:    false,
+			expectedEvent:  fmt.Sprintf("Normal ScheduleBindingSucceed %s Result {cluster1:1}", successfulSchedulingMessage),
 		},
 		{
 			name: "successful scheduling with second affinity",
@@ -971,6 +968,7 @@ func TestScheduleClusterResourceBindingWithClusterAffinities(t *testing.T) {
 			},
 			scheduleErrors: []error{errors.New("first affinity failed"), nil},
 			expectError:    false,
+			expectedEvent:  "Warning ScheduleBindingFailed failed to schedule ClusterResourceBinding(test-cluster-binding-2) with clusterAffiliates index(0): first affinity failed",
 		},
 		{
 			name: "all affinities fail",
@@ -1000,6 +998,7 @@ func TestScheduleClusterResourceBindingWithClusterAffinities(t *testing.T) {
 			scheduleResults: []core.ScheduleResult{{}, {}},
 			scheduleErrors:  []error{errors.New("first affinity failed"), errors.New("second affinity failed")},
 			expectError:     true,
+			expectedEvent:   "Warning ScheduleBindingFailed failed to schedule ClusterResourceBinding(test-cluster-binding-fail) with clusterAffiliates index(0): first affinity failed",
 		},
 	}
 
@@ -1026,6 +1025,14 @@ func TestScheduleClusterResourceBindingWithClusterAffinities(t *testing.T) {
 
 			if (err != nil) != tt.expectError {
 				t.Errorf("scheduleClusterResourceBindingWithClusterAffinities() error = %v, expectError %v", err, tt.expectError)
+			}
+
+			// Check if an event was recorded
+			select {
+			case event := <-fakeRecorder.Events:
+				assert.Contains(t, event, tt.expectedEvent, "Event does not match expected")
+			default:
+				t.Errorf("Expected an event to be recorded")
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

When using clusterAffinities, the schedule result will be empty in the result. This should be fixed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-scheduler`: Fixed an issue where the schedule success event was missing cluster information when scheduling with ClusterAffinities.
```

