### PR TITLE
kind: cleanup - fix mergeTargetClusters aliasing bug

### DIFF
--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -214,17 +214,19 @@ func mergeTargetClusters(targetClusters []workv1alpha2.TargetCluster, requiredBy
 	}
 
 	scheduledClusterNames := util.ConvertToClusterNames(targetClusters)
+	// Create a copy to avoid mutating the input slice
+	result := append([]workv1alpha2.TargetCluster{}, targetClusters...)
 
 	for _, requiredByBinding := range requiredByBindingSnapshot {
 		for _, targetCluster := range requiredByBinding.Clusters {
 			if !scheduledClusterNames.Has(targetCluster.Name) {
 				scheduledClusterNames.Insert(targetCluster.Name)
-				targetClusters = append(targetClusters, targetCluster)
+				result = append(result, targetCluster)
 			}
 		}
 	}
 
-	return targetClusters
+	return result
 }
 
 func mergeLabel(workload *unstructured.Unstructured, binding metav1.Object, scope apiextensionsv1.ResourceScope) map[string]string {


### PR DESCRIPTION
**What type of PR is this?**

  /kind cleanup

  **What this PR does / why we need it**:

  There's a subtle bug in `mergeTargetClusters()` that could cause duplicate cluster entries during binding reconciliation. When the input slice `targetClusters` has unused capacity, Go's `append()` modifies the underlying array in place, meaning the original slice passed in gets mutated. This is a classic aliasing bug that can lead to the same cluster appearing twice in subsequent iterations.

The fix is straightforward: create a defensive copy of the input slice before making any modifications.

  **Special notes for your reviewer**:

  - Location: `pkg/controllers/binding/common.go:211-230`
  - All tests in `./pkg/controllers/binding/` pass
  - No behavior change for callers, only internal implementation fix

  **Does this PR introduce a user-facing change?**:

  ```release-note
none
  ```
  
   **Test Command :**

  ```bash
  go test ./pkg/controllers/binding/... -run Test_mergeTargetClusters -v
  ```
  
<img width="1243" height="300" alt="image" src="https://github.com/user-attachments/assets/92585867-a875-41af-a0f9-b67cfae40e9a" />