### PR TITLE
Cherry pick of #7387: fix: lookup Job completions by cluster name instead of positional index

### DIFF
--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -18,6 +18,7 @@ package binding
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strconv"
 	"time"
@@ -58,11 +59,15 @@ func ensureWork(
 	var err error
 	var errs []error
 
-	var jobCompletions []workv1alpha2.TargetCluster
+	var jobCompletionsMap map[string]int32
 	if workload.GetKind() == util.JobKind && needReviseJobCompletions(bindingSpec.Replicas, bindingSpec.Placement) {
+		var jobCompletions []workv1alpha2.TargetCluster
 		jobCompletions, err = divideReplicasByJobCompletions(workload, targetClusters)
 		if err != nil {
 			return err
+		}
+		if len(jobCompletions) > 0 {
+			jobCompletionsMap = buildJobCompletionsMap(jobCompletions)
 		}
 	}
 
@@ -90,16 +95,8 @@ func ensureWork(
 			}
 		}
 
-		// jobSpec.Completions specifies the desired number of successfully finished pods the job should be run with.
-		// When the replica scheduling policy is set to "divided", jobSpec.Completions should also be divided accordingly.
-		// The weight assigned to each cluster roughly equals that cluster's jobSpec.Parallelism value. This approach helps
-		// balance the execution time of the job across member clusters.
-		if len(jobCompletions) > 0 {
-			// Set allocated completions for Job only when the '.spec.completions' field not omitted from resource template.
-			// For jobs running with a 'work queue' usually leaves '.spec.completions' unset, in that case we skip
-			// setting this field as well.
-			// Refer to: https://kubernetes.io/docs/concepts/workloads/controllers/job/#parallel-jobs.
-			if err = helper.ApplyReplica(clonedWorkload, int64(jobCompletions[i].Replicas), util.CompletionsField); err != nil {
+		if jobCompletionsMap != nil {
+			if err = applyJobCompletions(clonedWorkload, targetCluster.Name, jobCompletionsMap); err != nil {
 				klog.ErrorS(err, "Failed to apply Completions for workload in cluster.",
 					"workloadKind", clonedWorkload.GetKind(), "workloadNamespace", clonedWorkload.GetNamespace(),
 					"workloadName", clonedWorkload.GetName(), "cluster", targetCluster.Name)
@@ -156,6 +153,38 @@ func ensureWork(
 	}
 
 	return errors.NewAggregate(errs)
+}
+
+// buildJobCompletionsMap converts a TargetCluster slice into a cluster-name-keyed
+// completions map so callers can look up per-cluster completions by name.
+func buildJobCompletionsMap(completions []workv1alpha2.TargetCluster) map[string]int32 {
+	m := make(map[string]int32, len(completions))
+	for _, jc := range completions {
+		m[jc.Name] = jc.Replicas
+	}
+	return m
+}
+
+// applyJobCompletions applies job completions to the workload.
+// JobSpec.Completions specifies the desired number of successfully finished pods the job should be run with.
+// When the replica scheduling policy is set to "divided", JobSpec.Completions should also be divided accordingly.
+// The weight assigned to each cluster roughly equals that cluster's JobSpec.Parallelism value. This approach helps
+// balance the execution time of the job across member clusters.
+func applyJobCompletions(workload *unstructured.Unstructured, clusterName string, completionsMap map[string]int32) error {
+	completions, ok := completionsMap[clusterName]
+	if !ok {
+		return fmt.Errorf("no completions found for cluster %s", clusterName)
+	}
+
+	// Set allocated completions for Job only when the '.spec.completions' field not omitted from resource template.
+	// For jobs running with a 'work queue' usually leaves '.spec.completions' unset, in that case we skip
+	// setting this field as well.
+	// Refer to: https://kubernetes.io/docs/concepts/workloads/controllers/job/#parallel-jobs.
+	if err := helper.ApplyReplica(workload, int64(completions), util.CompletionsField); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func getBindingSpec(binding metav1.Object, scope apiextensionsv1.ResourceScope) workv1alpha2.ResourceBindingSpec {

--- a/pkg/controllers/binding/common_test.go
+++ b/pkg/controllers/binding/common_test.go
@@ -499,3 +499,110 @@ func Test_divideReplicasByJobCompletions(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildJobCompletionsMap(t *testing.T) {
+	tests := []struct {
+		name        string
+		completions []workv1alpha2.TargetCluster
+		want        map[string]int32
+	}{
+		{
+			name: "multiple clusters with different replica counts",
+			completions: []workv1alpha2.TargetCluster{
+				{Name: "cluster-a", Replicas: 6},
+				{Name: "cluster-b", Replicas: 4},
+			},
+			want: map[string]int32{
+				"cluster-a": 6,
+				"cluster-b": 4,
+			},
+		},
+		{
+			name:        "empty completions",
+			completions: []workv1alpha2.TargetCluster{},
+			want:        map[string]int32{},
+		},
+		{
+			name: "single cluster",
+			completions: []workv1alpha2.TargetCluster{
+				{Name: "cluster-a", Replicas: 10},
+			},
+			want: map[string]int32{
+				"cluster-a": 10,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildJobCompletionsMap(tt.completions)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildJobCompletionsMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyJobCompletions(t *testing.T) {
+	tests := []struct {
+		name            string
+		workload        *unstructured.Unstructured
+		clusterName     string
+		completionsMap  map[string]int32
+		wantErr         bool
+		wantCompletions int64
+	}{
+		{
+			name:        "apply completions successfully",
+			workload:    generateJobWorkload("test-job"),
+			clusterName: "cluster-a",
+			completionsMap: map[string]int32{
+				"cluster-a": 6,
+				"cluster-b": 4,
+			},
+			wantErr:         false,
+			wantCompletions: 6,
+		},
+		{
+			name:        "cluster not in map returns error",
+			workload:    generateJobWorkload("test-job"),
+			clusterName: "cluster-c",
+			completionsMap: map[string]int32{
+				"cluster-a": 6,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := applyJobCompletions(tt.workload, tt.clusterName, tt.completionsMap)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("applyJobCompletions() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				got, _, _ := unstructured.NestedInt64(tt.workload.Object, "spec", "completions")
+				if got != tt.wantCompletions {
+					t.Errorf("completions = %v, want %v", got, tt.wantCompletions)
+				}
+			}
+		})
+	}
+}
+
+func generateJobWorkload(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "batch/v1",
+			"kind":       "Job",
+			"metadata": map[string]any{
+				"name": name,
+			},
+			"spec": map[string]any{
+				"completions": int64(10),
+				"parallelism": int64(2),
+			},
+		},
+	}
+}


### PR DESCRIPTION
Cherry pick of #7387 on release-1.17.

#7387: fix: lookup Job completions by cluster name instead of positional index

For details on the cherry pick process, see the cherry pick requests process.

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a bug where Job completions were assigned to wrong clusters when using divided replica scheduling with cluster names not in alphabetical order.
```