### PR TITLE
test: add inline event assertions for cluster object events

### DIFF
--- a/test/e2e/suites/base/clustertaintpolicy_test.go
+++ b/test/e2e/suites/base/clustertaintpolicy_test.go
@@ -26,6 +26,7 @@ import (
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/events"
 	"github.com/karmada-io/karmada/pkg/util/helper"
 	"github.com/karmada-io/karmada/test/e2e/framework"
 	karmadaresource "github.com/karmada-io/karmada/test/e2e/framework/resource/karmada"
@@ -103,6 +104,12 @@ var _ = framework.SerialDescribe("Taint cluster with ClusterTaintPolicy", func()
 				})
 			})
 
+			ginkgo.By(fmt.Sprintf("wait for TaintClusterSucceed event on cluster(%s)", targetClusterName), func() {
+				framework.WaitEventFitWith(kubeClient, "default", targetClusterName, func(event corev1.Event) bool {
+					return event.Reason == events.EventReasonTaintClusterSucceed
+				})
+			})
+
 			ginkgo.By(fmt.Sprintf("update cluster(%s) NetworkReady condition to true", targetClusterName), func() {
 				framework.UpdateClusterStatusCondition(karmadaClient, targetClusterName, metav1.Condition{
 					Type:   "NetworkReady",
@@ -116,7 +123,6 @@ var _ = framework.SerialDescribe("Taint cluster with ClusterTaintPolicy", func()
 				})
 			})
 		})
-
 	})
 
 	ginkgo.Context("Multi conditions match", func() {
@@ -177,6 +183,12 @@ var _ = framework.SerialDescribe("Taint cluster with ClusterTaintPolicy", func()
 			ginkgo.By(fmt.Sprintf("wait for the cluster(%s) taint added", targetClusterName), func() {
 				framework.WaitClusterFitWith(controlPlaneClient, targetClusterName, func(cluster *clusterv1alpha1.Cluster) bool {
 					return helper.TaintExists(cluster.Spec.Taints, &corev1.Taint{Key: "testing/all-not-ready", Effect: "NoSchedule"})
+				})
+			})
+
+			ginkgo.By(fmt.Sprintf("wait for TaintClusterSucceed event on cluster(%s)", targetClusterName), func() {
+				framework.WaitEventFitWith(kubeClient, "default", targetClusterName, func(event corev1.Event) bool {
+					return event.Reason == events.EventReasonTaintClusterSucceed
 				})
 			})
 
@@ -249,6 +261,12 @@ var _ = framework.SerialDescribe("Taint cluster with ClusterTaintPolicy", func()
 				framework.WaitClusterFitWith(controlPlaneClient, targetClusterName, func(cluster *clusterv1alpha1.Cluster) bool {
 					return helper.TaintExists(cluster.Spec.Taints, &corev1.Taint{Key: "testing/network-not-ready", Effect: "NoSchedule"}) &&
 						helper.TaintExists(cluster.Spec.Taints, &corev1.Taint{Key: "testing/network-not-ready", Effect: "NoExecute"})
+				})
+			})
+
+			ginkgo.By(fmt.Sprintf("wait for TaintClusterSucceed event on cluster(%s)", targetClusterName), func() {
+				framework.WaitEventFitWith(kubeClient, "default", targetClusterName, func(event corev1.Event) bool {
+					return event.Reason == events.EventReasonTaintClusterSucceed
 				})
 			})
 

--- a/test/e2e/suites/base/karmadactl_test.go
+++ b/test/e2e/suites/base/karmadactl_test.go
@@ -44,6 +44,7 @@ import (
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/events"
 	"github.com/karmada-io/karmada/pkg/karmadactl/cordon"
 	"github.com/karmada-io/karmada/pkg/karmadactl/options"
 	cmdutil "github.com/karmada-io/karmada/pkg/karmadactl/util"
@@ -211,6 +212,11 @@ var _ = ginkgo.Describe("Karmadactl promote testing", func() {
 					return err1 == nil && err2 == nil
 				}, pollTimeout, pollInterval).Should(gomega.Equal(true))
 			})
+			ginkgo.By(fmt.Sprintf("wait for SyncImpersonationConfigSucceed event on cluster(%s)", member1), func() {
+				framework.WaitEventFitWith(kubeClient, "default", member1, func(event corev1.Event) bool {
+					return event.Reason == events.EventReasonSyncImpersonationConfigSucceed
+				})
+			})
 		})
 
 	})
@@ -331,6 +337,12 @@ var _ = framework.SerialDescribe("Karmadactl join/unjoin testing", ginkgo.Labels
 				_, err := cmd.ExecOrDie()
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
+
+			ginkgo.By(fmt.Sprintf("wait for CreateExecutionSpaceSucceed event on cluster(%s)", clusterName), func() {
+				framework.WaitEventFitWith(kubeClient, "default", clusterName, func(event corev1.Event) bool {
+					return event.Reason == events.EventReasonCreateExecutionSpaceSucceed
+				})
+			})
 		})
 
 		ginkgo.BeforeEach(func() {
@@ -424,12 +436,20 @@ var _ = framework.SerialDescribe("Karmadactl cordon/uncordon testing", ginkgo.La
 			_, err := cmd.ExecOrDie()
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		})
+
+		ginkgo.By(fmt.Sprintf("wait for CreateExecutionSpaceSucceed event on cluster(%s)", clusterName), func() {
+			framework.WaitEventFitWith(kubeClient, "default", clusterName, func(event corev1.Event) bool {
+				return event.Reason == events.EventReasonCreateExecutionSpaceSucceed
+			})
+		})
+
 		// When a newly joined cluster is unready at the beginning, the scheduler will ignore it.
 		ginkgo.By(fmt.Sprintf("wait cluster %s ready", clusterName), func() {
 			framework.WaitClusterFitWith(controlPlaneClient, clusterName, func(cluster *clusterv1alpha1.Cluster) bool {
 				return meta.IsStatusConditionPresentAndEqual(cluster.Status.Conditions, clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)
 			})
 		})
+
 		ginkgo.DeferCleanup(func() {
 			ginkgo.By(fmt.Sprintf("Unjoinning cluster: %s", clusterName), func() {
 				cmd := framework.NewKarmadactlCommand(kubeconfig, karmadaContext, karmadactlPath, "", 5*options.DefaultKarmadactlCommandDuration,
@@ -437,6 +457,13 @@ var _ = framework.SerialDescribe("Karmadactl cordon/uncordon testing", ginkgo.La
 				_, err := cmd.ExecOrDie()
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
+
+			ginkgo.By(fmt.Sprintf("wait for RemoveExecutionSpaceSucceed event on cluster(%s)", clusterName), func() {
+				framework.WaitEventFitWith(kubeClient, "default", clusterName, func(event corev1.Event) bool {
+					return event.Reason == events.EventReasonRemoveExecutionSpaceSucceed
+				})
+			})
+
 			ginkgo.By(fmt.Sprintf("Deleting clusters: %s", clusterName), func() {
 				err := deleteCluster(clusterName, kubeConfigPath)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -1252,6 +1279,12 @@ var _ = framework.SerialDescribe("Karmadactl taint testing", ginkgo.Labels{NeedC
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 
+			ginkgo.By(fmt.Sprintf("wait for CreateExecutionSpaceSucceed event on cluster(%s)", newClusterName), func() {
+				framework.WaitEventFitWith(kubeClient, "default", newClusterName, func(event corev1.Event) bool {
+					return event.Reason == events.EventReasonCreateExecutionSpaceSucceed
+				})
+			})
+
 			ginkgo.By(fmt.Sprintf("wait cluster %s ready", newClusterName), func() {
 				framework.WaitClusterFitWith(controlPlaneClient, newClusterName, func(cluster *clusterv1alpha1.Cluster) bool {
 					return meta.IsStatusConditionPresentAndEqual(cluster.Status.Conditions, clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)
@@ -1264,6 +1297,12 @@ var _ = framework.SerialDescribe("Karmadactl taint testing", ginkgo.Labels{NeedC
 						"unjoin", "--cluster-kubeconfig", kubeConfigPath, "--cluster-context", clusterContext, "--cluster-namespace", "karmada-cluster", newClusterName)
 					_, err := cmd.ExecOrDie()
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				})
+
+				ginkgo.By(fmt.Sprintf("wait for RemoveExecutionSpaceSucceed event on cluster(%s)", newClusterName), func() {
+					framework.WaitEventFitWith(kubeClient, "default", newClusterName, func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonRemoveExecutionSpaceSucceed
+					})
 				})
 
 				ginkgo.By(fmt.Sprintf("Deleting clusters: %s", newClusterName), func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds inline E2E test assertions for cluster object events emitted by Karmada 
controllers, as part of improving the overall event test coverage (~7.8% → higher).

The following events are now covered:

| Event | Test File | Trigger |
|---|---|---|
| `CreateExecutionSpaceSucceed` | `karmadactl_test.go` | After cluster join |
| `RemoveExecutionSpaceSucceed` | `karmadactl_test.go` | After cluster unjoin |
| `TaintClusterSucceed` | `clustertaintpolicy_test.go` | After taint added/removed |
| `SyncImpersonationConfigSucceed` | `karmadactl_test.go` | After cluster resource promotion |

Failed variants (`*Failed`) are skipped for now as they require artificially 
breaking the environment, which is not practical in E2E as noted in the issue.

Assertions follow Approach 2 (inline) as decided in the community meeting — 
placed immediately after the operation that triggers the event, reusing the 
existing resource lifecycle with no additional setup cost.

**Which issue(s) this PR fixes**:
Part of #7252 

**Special notes for your reviewer**:
- All assertions use `controlPlaneClient` since cluster events are emitted by 
  the Karmada control plane, not member clusters
- Events are checked in `default` namespace as cluster-scoped object events 
  land there
- Failed event variants are intentionally omitted per the issue guidance:
  "some failed events may not be easy to construct for testing, so they can 
  be ignored for now"

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```