### PR TITLE
normalize dependabot with consistent formatting and explicit schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,31 +6,50 @@
 # Configuration options: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    # Check for updates to GitHub Actions every week
-    interval: "weekly"
-    
-- package-ecosystem: docker
-  directory: /cluster/images/
-  schedule:
-    interval: weekly
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates every Monday at 00:00 UTC
+      interval: "weekly"
+      day: "monday"
+      time: "00:00"
+      timezone: "UTC"
 
-- package-ecosystem: docker
-  directory: /cluster/images/
-  target-branch: "release-1.17"
-  schedule:
-    interval: weekly
+  - package-ecosystem: docker
+    directory: /cluster/images/
+    schedule:
+      # Check for updates every Monday at 00:00 UTC
+      interval: "weekly"
+      day: "monday"
+      time: "00:00"
+      timezone: "UTC"
 
-- package-ecosystem: docker
-  directory: /cluster/images/
-  target-branch: "release-1.16"
-  schedule:
-    interval: weekly
+  - package-ecosystem: docker
+    directory: /cluster/images/
+    target-branch: "release-1.17"
+    schedule:
+      # Check for updates every Monday at 00:00 UTC
+      interval: "weekly"
+      day: "monday"
+      time: "00:00"
+      timezone: "UTC"
 
-- package-ecosystem: docker
-  directory: /cluster/images/
-  target-branch: "release-1.15"
-  schedule:
-    interval: weekly
+  - package-ecosystem: docker
+    directory: /cluster/images/
+    target-branch: "release-1.16"
+    schedule:
+      # Check for updates every Monday at 00:00 UTC
+      interval: "weekly"
+      day: "monday"
+      time: "00:00"
+      timezone: "UTC"
+
+  - package-ecosystem: docker
+    directory: /cluster/images/
+    target-branch: "release-1.15"
+    schedule:
+      # Check for updates every Monday at 00:00 UTC
+      interval: "weekly"
+      day: "monday"
+      time: "00:00"
+      timezone: "UTC"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,31 +6,67 @@
 # Configuration options: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    # Check for updates to GitHub Actions every week
-    interval: "weekly"
-    
-- package-ecosystem: docker
-  directory: /cluster/images/
-  schedule:
-    interval: weekly
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates every Monday at 00:00 UTC
+      interval: "weekly"
+      day: "monday"
+      time: "00:00"
+      timezone: "UTC"
 
-- package-ecosystem: docker
-  directory: /cluster/images/
-  target-branch: "release-1.17"
-  schedule:
-    interval: weekly
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      # Check for updates every Monday at 00:00 UTC
+      interval: "weekly"
+      day: "monday"
+      time: "00:00"
+      timezone: "UTC"
+    vendor: true
+    allow:
+      - dependency-type: "direct"
+    ignore:
+      # Kubernetes dependencies require manual handling during version upgrades
+      # due to breaking changes that Dependabot typically cannot resolve automatically.
+      - dependency-name: "k8s.io/*"
+      - dependency-name: "sigs.k8s.io/*"
 
-- package-ecosystem: docker
-  directory: /cluster/images/
-  target-branch: "release-1.16"
-  schedule:
-    interval: weekly
+  - package-ecosystem: docker
+    directory: /cluster/images/
+    schedule:
+      # Check for updates every Monday at 00:00 UTC
+      interval: "weekly"
+      day: "monday"
+      time: "00:00"
+      timezone: "UTC"
 
-- package-ecosystem: docker
-  directory: /cluster/images/
-  target-branch: "release-1.15"
-  schedule:
-    interval: weekly
+  - package-ecosystem: docker
+    directory: /cluster/images/
+    target-branch: "release-1.17"
+    schedule:
+      # Check for updates every Monday at 00:00 UTC
+      interval: "weekly"
+      day: "monday"
+      time: "00:00"
+      timezone: "UTC"
+
+  - package-ecosystem: docker
+    directory: /cluster/images/
+    target-branch: "release-1.16"
+    schedule:
+      # Check for updates every Monday at 00:00 UTC
+      interval: "weekly"
+      day: "monday"
+      time: "00:00"
+      timezone: "UTC"
+
+  - package-ecosystem: docker
+    directory: /cluster/images/
+    target-branch: "release-1.15"
+    schedule:
+      # Check for updates every Monday at 00:00 UTC
+      interval: "weekly"
+      day: "monday"
+      time: "00:00"
+      timezone: "UTC"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This pull request updates the Dependabot configuration to specify the exact day, time, and timezone for automated dependency checks. Now, all scheduled updates will consistently run every Monday at 00:00 UTC.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
I'm hesitant to let Dependabot manage the Go dependencies, as most of them are shared with Kubernetes dependencies, and bumping them might break compatibility.
So, this PR only formats the configuration and sets an explicit schedule.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

