### PR TITLE
Cherry pick of #7387: fix: lookup Job completions by cluster name instead of positional index

### DIFF
--- a/pkg/controllers/binding/common.go
+++ b/pkg/controllers/binding/common.go
@@ -18,6 +18,7 @@ package binding
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -57,12 +58,9 @@ func ensureWork(
 	var err error
 	var errs []error
 
-	var jobCompletions []workv1alpha2.TargetCluster
-	if workload.GetKind() == util.JobKind && needReviseJobCompletions(bindingSpec.Replicas, bindingSpec.Placement) {
-		jobCompletions, err = divideReplicasByJobCompletions(workload, targetClusters)
-		if err != nil {
-			return err
-		}
+	jobCompletionsMap, err := buildJobCompletionsMap(workload, bindingSpec, targetClusters)
+	if err != nil {
+		return err
 	}
 
 	for i := range targetClusters {
@@ -89,19 +87,8 @@ func ensureWork(
 			}
 		}
 
-		// jobSpec.Completions specifies the desired number of successfully finished pods the job should be run with.
-		// When the replica scheduling policy is set to "divided", jobSpec.Completions should also be divided accordingly.
-		// The weight assigned to each cluster roughly equals that cluster's jobSpec.Parallelism value. This approach helps
-		// balance the execution time of the job across member clusters.
-		if len(jobCompletions) > 0 {
-			// Set allocated completions for Job only when the '.spec.completions' field not omitted from resource template.
-			// For jobs running with a 'work queue' usually leaves '.spec.completions' unset, in that case we skip
-			// setting this field as well.
-			// Refer to: https://kubernetes.io/docs/concepts/workloads/controllers/job/#parallel-jobs.
-			if err = helper.ApplyReplica(clonedWorkload, int64(jobCompletions[i].Replicas), util.CompletionsField); err != nil {
-				klog.ErrorS(err, "Failed to apply Completions for workload in cluster.",
-					"workloadKind", clonedWorkload.GetKind(), "workloadNamespace", clonedWorkload.GetNamespace(),
-					"workloadName", clonedWorkload.GetName(), "cluster", targetCluster.Name)
+		if jobCompletionsMap != nil {
+			if err = applyJobCompletions(clonedWorkload, targetCluster.Name, jobCompletionsMap); err != nil {
 				errs = append(errs, err)
 				continue
 			}
@@ -155,6 +142,55 @@ func ensureWork(
 	}
 
 	return errors.NewAggregate(errs)
+}
+
+// buildJobCompletionsMap returns a map of cluster name to divided Job completions
+// for the given workload, or nil if the workload is not a Job with divided scheduling.
+func buildJobCompletionsMap(workload *unstructured.Unstructured, bindingSpec workv1alpha2.ResourceBindingSpec, targetClusters []workv1alpha2.TargetCluster) (map[string]int32, error) {
+	if workload.GetKind() != util.JobKind || !needReviseJobCompletions(bindingSpec.Replicas, bindingSpec.Placement) {
+		return nil, nil
+	}
+	jobCompletions, err := divideReplicasByJobCompletions(workload, targetClusters)
+	if err != nil {
+		return nil, err
+	}
+	if len(jobCompletions) == 0 {
+		return nil, nil
+	}
+	m := make(map[string]int32, len(jobCompletions))
+	for _, jc := range jobCompletions {
+		m[jc.Name] = jc.Replicas
+	}
+	return m, nil
+}
+
+// applyJobCompletions applies job completions to the workload.
+// JobSpec.Completions specifies the desired number of successfully finished pods the job should be run with.
+// When the replica scheduling policy is set to "divided", JobSpec.Completions should also be divided accordingly.
+// The weight assigned to each cluster roughly equals that cluster's JobSpec.Parallelism value. This approach helps
+// balance the execution time of the job across member clusters.
+func applyJobCompletions(workload *unstructured.Unstructured, clusterName string, completionsMap map[string]int32) error {
+	completions, ok := completionsMap[clusterName]
+	if !ok {
+		err := fmt.Errorf("no completions found for cluster %s", clusterName)
+		klog.ErrorS(err, "Failed to apply Completions for workload in cluster.",
+			"workloadKind", workload.GetKind(), "workloadNamespace", workload.GetNamespace(),
+			"workloadName", workload.GetName(), "cluster", clusterName)
+		return err
+	}
+
+	// Set allocated completions for Job only when the '.spec.completions' field not omitted from resource template.
+	// For jobs running with a 'work queue' usually leaves '.spec.completions' unset, in that case we skip
+	// setting this field as well.
+	// Refer to: https://kubernetes.io/docs/concepts/workloads/controllers/job/#parallel-jobs.
+	if err := helper.ApplyReplica(workload, int64(completions), util.CompletionsField); err != nil {
+		klog.ErrorS(err, "Failed to apply Completions for workload in cluster.",
+			"workloadKind", workload.GetKind(), "workloadNamespace", workload.GetNamespace(),
+			"workloadName", workload.GetName(), "cluster", clusterName)
+		return err
+	}
+
+	return nil
 }
 
 func getBindingSpec(binding metav1.Object, scope apiextensionsv1.ResourceScope) workv1alpha2.ResourceBindingSpec {

--- a/pkg/controllers/binding/common_test.go
+++ b/pkg/controllers/binding/common_test.go
@@ -527,3 +527,76 @@ func Test_divideReplicasByJobCompletions(t *testing.T) {
 		})
 	}
 }
+
+func TestJobCompletionsCorrectAssignment(t *testing.T) {
+	tests := []struct {
+		name           string
+		targetClusters []workv1alpha2.TargetCluster
+		workload       *unstructured.Unstructured
+		want           map[string]int32
+	}{
+		{
+			name: "non-alphabetical cluster order with asymmetric weights",
+			targetClusters: []workv1alpha2.TargetCluster{
+				{Name: "west", Replicas: 6},
+				{Name: "east", Replicas: 4},
+			},
+			workload: &unstructured.Unstructured{
+				Object: map[string]any{
+					"spec": map[string]any{
+						"completions": int64(10),
+					},
+				},
+			},
+			want: map[string]int32{
+				"west": 6,
+				"east": 4,
+			},
+		},
+		{
+			name: "alphabetical cluster order with symmetric weights",
+			targetClusters: []workv1alpha2.TargetCluster{
+				{Name: "cluster1", Replicas: 5},
+				{Name: "cluster2", Replicas: 5},
+			},
+			workload: &unstructured.Unstructured{
+				Object: map[string]any{
+					"spec": map[string]any{
+						"completions": int64(10),
+					},
+				},
+			},
+			want: map[string]int32{
+				"cluster1": 5,
+				"cluster2": 5,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jobCompletions, err := divideReplicasByJobCompletions(tt.workload, tt.targetClusters)
+			if err != nil {
+				t.Fatalf("divideReplicasByJobCompletions() error = %v", err)
+			}
+
+			jobCompletionsMap := make(map[string]int32, len(jobCompletions))
+			for _, jc := range jobCompletions {
+				jobCompletionsMap[jc.Name] = jc.Replicas
+			}
+
+			got := make(map[string]int32, len(tt.targetClusters))
+			for _, targetCluster := range tt.targetClusters {
+				completions, ok := jobCompletionsMap[targetCluster.Name]
+				if !ok {
+					t.Fatalf("no completions found for cluster %s", targetCluster.Name)
+				}
+				got[targetCluster.Name] = completions
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("TestJobCompletionsCorrectAssignment got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cherry pick of #7387 on release-1.16.

#7387: fix: lookup Job completions by cluster name instead of positional index

**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

Backport of #7387 to release-1.16. Fixes a bug where Job completions were assigned to wrong clusters when using divided replica scheduling with cluster names not in alphabetically ordered.

**Which issue(s) this PR fixes:**

Fixes #7393

**Does this PR introduce a user-facing change?**
```release-note
Fixed a bug where Job completions were assigned to wrong clusters when using divided replica scheduling with cluster names not in alphabetical order.
```

**Additional notes:**

Manual cherry-pick due to merge conflicts in imports section (added `fmt` and `slices` imports needed by the fix).