### PR TITLE
fix(detector): sync propagateDeps and schedulePriority to CRB

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -636,6 +636,7 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 				bindingCopy.Spec.ReplicaRequirements = binding.Spec.ReplicaRequirements
 				bindingCopy.Spec.Replicas = binding.Spec.Replicas
 				bindingCopy.Spec.Components = binding.Spec.Components
+				bindingCopy.Spec.PropagateDeps = binding.Spec.PropagateDeps
 				bindingCopy.Spec.SchedulerName = binding.Spec.SchedulerName
 				bindingCopy.Spec.Placement = binding.Spec.Placement
 				bindingCopy.Spec.Failover = binding.Spec.Failover

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -636,11 +636,13 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 				bindingCopy.Spec.ReplicaRequirements = binding.Spec.ReplicaRequirements
 				bindingCopy.Spec.Replicas = binding.Spec.Replicas
 				bindingCopy.Spec.Components = binding.Spec.Components
+				bindingCopy.Spec.PropagateDeps = binding.Spec.PropagateDeps
 				bindingCopy.Spec.SchedulerName = binding.Spec.SchedulerName
 				bindingCopy.Spec.Placement = binding.Spec.Placement
 				bindingCopy.Spec.Failover = binding.Spec.Failover
 				bindingCopy.Spec.ConflictResolution = binding.Spec.ConflictResolution
 				bindingCopy.Spec.PreserveResourcesOnDeletion = binding.Spec.PreserveResourcesOnDeletion
+				bindingCopy.Spec.SchedulePriority = binding.Spec.SchedulePriority
 				bindingCopy.Spec.Suspension = util.MergePolicySuspension(bindingCopy.Spec.Suspension, policy.Spec.Suspension)
 				return nil
 			})
@@ -927,6 +929,32 @@ func (d *ResourceDetector) BuildClusterResourceBinding(object *unstructured.Unst
 
 	if err := d.applyReplicaInterpretation(object, &binding.Spec); err != nil {
 		return nil, err
+	}
+
+	if features.FeatureGate.Enabled(features.PriorityBasedScheduling) && policySpec.SchedulePriority != nil {
+		var bindingSchedulePriority *workv1alpha2.SchedulePriority
+		priorityClassName := policySpec.SchedulePriority.PriorityClassName
+
+		switch policySpec.SchedulePriority.PriorityClassSource {
+		case policyv1alpha1.KubePriorityClass:
+			kubePriorityClass, err := helper.GetPriorityClassByName(context.TODO(), d.Client, policySpec.SchedulePriority.PriorityClassName)
+			if err != nil {
+				klog.Errorf("Failed to get Kube PriorityClass(%s): %v", priorityClassName, err)
+				return nil, err
+			}
+			bindingSchedulePriority = &workv1alpha2.SchedulePriority{
+				Priority: kubePriorityClass.Value,
+				// TODO add preemptionpolicy
+				// PreemptionPolicy: kubePriorityClass.PreemptionPolicy,
+			}
+		case policyv1alpha1.PodPriorityClass:
+			return nil, fmt.Errorf("priority class source is PodPriorityClass, but PodPriorityClass is not supported yet")
+		case policyv1alpha1.FederatedPriorityClass:
+			return nil, fmt.Errorf("priority class source is FederatedPriorityClass, but FederatedPriorityClass is not supported yet")
+		default:
+			return nil, fmt.Errorf("unsupported priority class source")
+		}
+		binding.Spec.SchedulePriority = bindingSchedulePriority
 	}
 
 	return binding, nil

--- a/pkg/detector/detector_test.go
+++ b/pkg/detector/detector_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -1193,6 +1194,134 @@ func TestApplyClusterPolicy(t *testing.T) {
 	}
 }
 
+func TestApplyClusterPolicyClusterScopedResourceSyncsPropagateDepsAndSchedulePriority(t *testing.T) {
+	scheme := setupTestScheme()
+	priorityClassA := &schedulingv1.PriorityClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-priority-a"},
+		Value:      100,
+	}
+	priorityClassB := &schedulingv1.PriorityClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-priority-b"},
+		Value:      200,
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(priorityClassA, priorityClassB).Build()
+	fakeRecorder := record.NewFakeRecorder(10)
+	fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme)
+
+	d := &ResourceDetector{
+		Client:              fakeClient,
+		DynamicClient:       fakeDynamicClient,
+		EventRecorder:       fakeRecorder,
+		ResourceInterpreter: &mockResourceInterpreter{},
+		RESTMapper:          &mockRESTMapper{},
+	}
+
+	if err := features.FeatureGate.Set(fmt.Sprintf("%s=true", features.PriorityBasedScheduling)); err != nil {
+		t.Fatalf("Failed to enable feature gate %s: %v", features.PriorityBasedScheduling, err)
+	}
+	t.Cleanup(func() {
+		if err := features.FeatureGate.Set(fmt.Sprintf("%s=false", features.PriorityBasedScheduling)); err != nil {
+			t.Fatalf("Failed to disable feature gate %s: %v", features.PriorityBasedScheduling, err)
+		}
+	})
+
+	object := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRole",
+		"metadata": map[string]any{
+			"name": "test-cluster-role",
+			"uid":  "test-uid",
+		},
+	}}
+
+	policy := &policyv1alpha1.ClusterPropagationPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster-policy"},
+		Spec: policyv1alpha1.PropagationSpec{
+			PropagateDeps: false,
+			SchedulePriority: &policyv1alpha1.SchedulePriority{
+				PriorityClassName:   priorityClassA.Name,
+				PriorityClassSource: policyv1alpha1.KubePriorityClass,
+			},
+		},
+	}
+
+	err := d.ApplyClusterPolicy(object, keys.ClusterWideKey{}, false, policy)
+	assert.NoError(t, err)
+
+	bindingName := object.GetName() + "-" + strings.ToLower(object.GetKind())
+	createdBinding := &workv1alpha2.ClusterResourceBinding{}
+	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: bindingName}, createdBinding)
+	assert.NoError(t, err)
+	assert.False(t, createdBinding.Spec.PropagateDeps)
+	if assert.NotNil(t, createdBinding.Spec.SchedulePriority) {
+		assert.Equal(t, priorityClassA.Value, createdBinding.Spec.SchedulePriority.Priority)
+	}
+
+	policy.Spec.PropagateDeps = true
+	policy.Spec.SchedulePriority = &policyv1alpha1.SchedulePriority{
+		PriorityClassName:   priorityClassB.Name,
+		PriorityClassSource: policyv1alpha1.KubePriorityClass,
+	}
+
+	err = d.ApplyClusterPolicy(object, keys.ClusterWideKey{}, false, policy)
+	assert.NoError(t, err)
+
+	updatedBinding := &workv1alpha2.ClusterResourceBinding{}
+	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: bindingName}, updatedBinding)
+	assert.NoError(t, err)
+	assert.True(t, updatedBinding.Spec.PropagateDeps)
+	if assert.NotNil(t, updatedBinding.Spec.SchedulePriority) {
+		assert.Equal(t, priorityClassB.Value, updatedBinding.Spec.SchedulePriority.Priority)
+	}
+}
+
+func TestBuildClusterResourceBindingSetsSchedulePriority(t *testing.T) {
+	scheme := setupTestScheme()
+	priorityClass := &schedulingv1.PriorityClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-priority-class"},
+		Value:      1000,
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(priorityClass).Build()
+	d := &ResourceDetector{
+		Client:              fakeClient,
+		ResourceInterpreter: &mockResourceInterpreter{},
+	}
+
+	if err := features.FeatureGate.Set(fmt.Sprintf("%s=true", features.PriorityBasedScheduling)); err != nil {
+		t.Fatalf("Failed to enable feature gate %s: %v", features.PriorityBasedScheduling, err)
+	}
+	t.Cleanup(func() {
+		if err := features.FeatureGate.Set(fmt.Sprintf("%s=false", features.PriorityBasedScheduling)); err != nil {
+			t.Fatalf("Failed to disable feature gate %s: %v", features.PriorityBasedScheduling, err)
+		}
+	})
+
+	object := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRole",
+		"metadata": map[string]any{
+			"name":            "test-cluster-role",
+			"uid":             "test-uid",
+			"resourceVersion": "1",
+		},
+	}}
+
+	policySpec := &policyv1alpha1.PropagationSpec{
+		SchedulePriority: &policyv1alpha1.SchedulePriority{
+			PriorityClassName:   priorityClass.Name,
+			PriorityClassSource: policyv1alpha1.KubePriorityClass,
+		},
+	}
+
+	binding, err := d.BuildClusterResourceBinding(object, policySpec, "policy-id", metav1.ObjectMeta{Name: "policy"})
+	assert.NoError(t, err)
+	if assert.NotNil(t, binding.Spec.SchedulePriority) {
+		assert.Equal(t, priorityClass.Value, binding.Spec.SchedulePriority.Priority)
+	}
+}
+
 func TestEnqueueResourceKeyWithActivationPref(t *testing.T) {
 	testClusterWideKey := keys.ClusterWideKey{
 		Group:     "foo",
@@ -1265,6 +1394,7 @@ func setupTestScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	_ = workv1alpha2.Install(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = schedulingv1.AddToScheme(scheme)
 	_ = policyv1alpha1.Install(scheme)
 	return scheme
 }

--- a/pkg/detector/detector_test.go
+++ b/pkg/detector/detector_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/features"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/fedinformer/keys"
+	"github.com/karmada-io/karmada/pkg/util/names"
 )
 
 func BenchmarkEventFilterNoSkipNameSpaces(b *testing.B) {
@@ -1191,6 +1192,56 @@ func TestApplyClusterPolicy(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestApplyClusterPolicyClusterScopedResourceSyncsPropagateDeps(t *testing.T) {
+	scheme := setupTestScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	fakeRecorder := record.NewFakeRecorder(10)
+	fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme)
+
+	d := &ResourceDetector{
+		Client:              fakeClient,
+		DynamicClient:       fakeDynamicClient,
+		EventRecorder:       fakeRecorder,
+		ResourceInterpreter: &mockResourceInterpreter{},
+		RESTMapper:          &mockRESTMapper{},
+	}
+
+	object := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRole",
+		"metadata": map[string]any{
+			"name": "test-cluster-role",
+			"uid":  "test-uid",
+		},
+	}}
+
+	policy := &policyv1alpha1.ClusterPropagationPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster-policy"},
+		Spec: policyv1alpha1.PropagationSpec{
+			PropagateDeps: false,
+		},
+	}
+
+	err := d.ApplyClusterPolicy(object, keys.ClusterWideKey{}, false, policy)
+	assert.NoError(t, err)
+
+	bindingName := names.GenerateBindingName(object.GetKind(), object.GetName())
+	createdBinding := &workv1alpha2.ClusterResourceBinding{}
+	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: bindingName}, createdBinding)
+	assert.NoError(t, err)
+	assert.False(t, createdBinding.Spec.PropagateDeps)
+
+	policy.Spec.PropagateDeps = true
+
+	err = d.ApplyClusterPolicy(object, keys.ClusterWideKey{}, false, policy)
+	assert.NoError(t, err)
+
+	updatedBinding := &workv1alpha2.ClusterResourceBinding{}
+	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: bindingName}, updatedBinding)
+	assert.NoError(t, err)
+	assert.True(t, updatedBinding.Spec.PropagateDeps)
 }
 
 func TestEnqueueResourceKeyWithActivationPref(t *testing.T) {

--- a/test/e2e/suites/base/clusterpropagationpolicy_test.go
+++ b/test/e2e/suites/base/clusterpropagationpolicy_test.go
@@ -544,6 +544,7 @@ var _ = ginkgo.Describe("[AdvancedCase] ClusterPropagationPolicy testing", func(
 		ginkgo.When("cluster scope resource", func() {
 			var policy *policyv1alpha1.ClusterPropagationPolicy
 			var clusterRole *rbacv1.ClusterRole
+			var resourceBindingName string
 			var targetMember, updatedMember string
 
 			ginkgo.BeforeEach(func() {
@@ -552,6 +553,7 @@ var _ = ginkgo.Describe("[AdvancedCase] ClusterPropagationPolicy testing", func(
 				policyName := deploymentNamePrefix + rand.String(RandomStrLength)
 
 				clusterRole = testhelper.NewClusterRole(fmt.Sprintf("system:test-%s-01", policyName), nil)
+				resourceBindingName = names.GenerateBindingName(clusterRole.Kind, clusterRole.Name)
 
 				policy = testhelper.NewClusterPropagationPolicy(policyName, []policyv1alpha1.ResourceSelector{
 					{
@@ -577,6 +579,20 @@ var _ = ginkgo.Describe("[AdvancedCase] ClusterPropagationPolicy testing", func(
 					func(*rbacv1.ClusterRole) bool {
 						return true
 					})
+			})
+
+			ginkgo.It("update policy propagateDeps", func() {
+				patch := []map[string]any{
+					{
+						"op":    "replace",
+						"path":  "/spec/propagateDeps",
+						"value": true,
+					},
+				}
+				framework.PatchClusterPropagationPolicy(karmadaClient, policy.Name, patch, types.JSONPatchType)
+				framework.WaitClusterResourceBindingFitWith(karmadaClient, resourceBindingName, func(binding *workv1alpha2.ClusterResourceBinding) bool {
+					return binding.Spec.PropagateDeps
+				})
 			})
 
 			ginkgo.It("update policy placement", func() {


### PR DESCRIPTION
This PR fixes policy-to-binding field drift for cluster-scoped resources.

When a ClusterPropagationPolicy changes, the derived ClusterResourceBinding was not consistently updated for:

- spec.propagateDeps
- spec.schedulePriority

As a result, cluster-scoped workloads could keep stale binding behavior after policy updates, while namespace-scoped workloads behaved correctly.

### Root Cause
There were two gaps in detector logic for cluster-scoped paths:

In ApplyClusterPolicy, the ClusterResourceBinding update closure did not copy propagateDeps and schedulePriority from the desired binding.
BuildClusterResourceBinding did not compute schedulePriority, unlike BuildResourceBinding.

### What Changed
Updated ApplyClusterPolicy (cluster-scoped CRB update closure) to sync:

- spec.propagateDeps
- spec.schedulePriority

Updated BuildClusterResourceBinding to mirror BuildResourceBinding schedule-priority behavior:

- same PriorityBasedScheduling feature-gate check
- same source handling
- same error handling for unsupported/missing classes

Added detector unit tests for:

- cluster-scoped create and update propagation of propagateDeps and schedulePriority
- schedulePriority derivation in BuildClusterResourceBinding

Added E2E coverage in ClusterPropagationPolicy suite:

- cluster-scoped resource (ClusterRole) policy update propagates propagateDeps to derived ClusterResourceBinding

### Why This Is Safe

- The change only brings CRB behavior to parity with existing RB behavior.
- Scheduling result ownership is preserved (no change to scheduler-produced cluster decisions).
- Update flow remains CreateOrUpdate-based and only syncs policy-owned fields.

### Test Plan
Executed:

- go test ./pkg/detector -count=1
- go test ./test/e2e/suites/base -run ClusterPropagationPolicy -count=1

Notes:

- The second command completed successfully as a targeted compile/run invocation in this environment.
- Full base E2E execution still depends on external test cluster setup.

### Related Issue
Fixes #7402

### Checklist

- [ ] 1.  Bug fix with minimal scope
- [ ] 2.  Unit tests added/updated
- [ ] 3.  E2E test added/updated
- [ ] 4.  DCO sign-off commit used