### PR TITLE
Filter update events in ResourceDetector policy handlers

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -991,6 +991,20 @@ func (d *ResourceDetector) OnPropagationPolicyAdd(obj any, isInInitialList bool)
 
 // OnPropagationPolicyUpdate handles object update event and push the object to queue.
 func (d *ResourceDetector) OnPropagationPolicyUpdate(oldObj, newObj any) {
+	oldPolicyObj := oldObj.(*policyv1alpha1.PropagationPolicy)
+	policyObj := newObj.(*policyv1alpha1.PropagationPolicy)
+
+	// When karmada-apiserver restarts, the reflector's watch stream may break and the list/watch cycle is re-established.
+	// The reflector may resume the watch from the last observed resourceVersion, but the apiserver can return a too old resource version error,
+	// causing the reflector to relist objects.
+	// After the relist, the reflector will produce Replaced deltas to DeltaFIFO, which are surfaced as update callbacks
+	// when the object already exists in the local store.
+	// For this controller path, an unchanged generation means no spec change relevant to reconciliation,
+	// so skip enqueuing to avoid unnecessary reconciles.
+	if oldPolicyObj.Generation == policyObj.Generation {
+		klog.V(4).Infof("Skip enqueue PropagationPolicy(%s/%s) since generation is not changed.", policyObj.Namespace, policyObj.Name)
+		return
+	}
 	d.policyReconcileWorker.Enqueue(newObj)
 
 	// Temporary solution of corner case: After the priority(.spec.priority) of
@@ -1008,8 +1022,6 @@ func (d *ResourceDetector) OnPropagationPolicyUpdate(oldObj, newObj any) {
 	// a status, in that case we can record the observed priority(.status.observedPriority)
 	// which can be used to detect priority changes during reconcile logic.
 	if features.FeatureGate.Enabled(features.PolicyPreemption) {
-		oldPolicyObj := oldObj.(*policyv1alpha1.PropagationPolicy)
-		policyObj := newObj.(*policyv1alpha1.PropagationPolicy)
 		if policyObj.ExplicitPriority() < oldPolicyObj.ExplicitPriority() {
 			d.HandleDeprioritizedPropagationPolicy(*oldPolicyObj, *policyObj)
 		}
@@ -1066,6 +1078,21 @@ func (d *ResourceDetector) OnClusterPropagationPolicyAdd(obj any, isInInitialLis
 
 // OnClusterPropagationPolicyUpdate handles object update event and push the object to queue.
 func (d *ResourceDetector) OnClusterPropagationPolicyUpdate(oldObj, newObj any) {
+	oldPolicy := oldObj.(*policyv1alpha1.ClusterPropagationPolicy)
+	policyObj := newObj.(*policyv1alpha1.ClusterPropagationPolicy)
+
+	// When karmada-apiserver restarts, the reflector's watch stream may break and the list/watch cycle is re-established.
+	// The reflector may resume the watch from the last observed resourceVersion, but the apiserver can return a too old resource version error,
+	// causing the reflector to relist objects.
+	// After the relist, the reflector will produce Replaced deltas to DeltaFIFO, which are surfaced as update callbacks
+	// when the object already exists in the local store.
+	// For this controller path, an unchanged generation means no spec change relevant to reconciliation,
+	// so skip enqueuing to avoid unnecessary reconciles.
+	if oldPolicy.Generation == policyObj.Generation {
+		klog.V(4).Infof("Skip enqueue ClusterPropagationPolicy(%s) since generation is not changed.", policyObj.Name)
+		return
+	}
+
 	d.clusterPolicyReconcileWorker.Enqueue(newObj)
 
 	// Temporary solution of corner case: After the priority(.spec.priority) of
@@ -1083,8 +1110,6 @@ func (d *ResourceDetector) OnClusterPropagationPolicyUpdate(oldObj, newObj any) 
 	// a status, in that case we can record the observed priority(.status.observedPriority)
 	// which can be used to detect priority changes during reconcile logic.
 	if features.FeatureGate.Enabled(features.PolicyPreemption) {
-		oldPolicy := oldObj.(*policyv1alpha1.ClusterPropagationPolicy)
-		policyObj := newObj.(*policyv1alpha1.ClusterPropagationPolicy)
 		if policyObj.ExplicitPriority() < oldPolicy.ExplicitPriority() {
 			d.HandleDeprioritizedClusterPropagationPolicy(*oldPolicy, *policyObj)
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
bug



Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #7403

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
Avoid unnecessary reconciles by skipping no-op updates in ResourceDetector policy handlers
```

