### PR TITLE
fix: sync PropagateDeps and SchedulePriority to ClusterResourceBindin…

### DIFF
--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -636,6 +636,8 @@ func (d *ResourceDetector) ApplyClusterPolicy(object *unstructured.Unstructured,
 				bindingCopy.Spec.ReplicaRequirements = binding.Spec.ReplicaRequirements
 				bindingCopy.Spec.Replicas = binding.Spec.Replicas
 				bindingCopy.Spec.Components = binding.Spec.Components
+				bindingCopy.Spec.PropagateDeps = binding.Spec.PropagateDeps
+				bindingCopy.Spec.SchedulePriority = binding.Spec.SchedulePriority
 				bindingCopy.Spec.SchedulerName = binding.Spec.SchedulerName
 				bindingCopy.Spec.Placement = binding.Spec.Placement
 				bindingCopy.Spec.Failover = binding.Spec.Failover

--- a/pkg/detector/detector_test.go
+++ b/pkg/detector/detector_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1381,4 +1382,83 @@ func (m *mockResourceInterpreter) ReflectStatus(_ *unstructured.Unstructured) (*
 
 func (m *mockResourceInterpreter) InterpretHealth(_ *unstructured.Unstructured) (bool, error) {
 	return true, nil
+}
+
+// TestApplyClusterPolicy_PropagatesFieldUpdates verifies that PropagateDeps and SchedulePriority
+// are correctly synced to an existing ClusterResourceBinding when a ClusterPropagationPolicy is updated.
+// This is a regression test for the bug where these fields were omitted from the CRB mutation function.
+func TestApplyClusterPolicy_PropagatesFieldUpdates(t *testing.T) {
+	scheme := setupTestScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	fakeRecorder := record.NewFakeRecorder(10)
+	fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme)
+
+	d := &ResourceDetector{
+		Client:              fakeClient,
+		DynamicClient:       fakeDynamicClient,
+		EventRecorder:       fakeRecorder,
+		ResourceInterpreter: &mockResourceInterpreter{},
+		RESTMapper:          &mockRESTMapper{},
+	}
+
+	// cluster-scoped object (empty namespace → triggers ClusterResourceBinding path)
+	object := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "ClusterRole",
+			"metadata": map[string]any{
+				"name": "test-cluster-role",
+				"uid":  "test-uid",
+			},
+		},
+	}
+
+	policy := &policyv1alpha1.ClusterPropagationPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-policy",
+		},
+		Spec: policyv1alpha1.PropagationSpec{
+			PropagateDeps: false,
+			Placement: policyv1alpha1.Placement{
+				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
+					ClusterNames: []string{"member1"},
+				},
+			},
+		},
+	}
+
+	// First call: creates the CRB with PropagateDeps=false.
+	err := d.ApplyClusterPolicy(object, keys.ClusterWideKey{}, false, policy)
+	require.NoError(t, err)
+
+	crbList := &workv1alpha2.ClusterResourceBindingList{}
+	err = fakeClient.List(context.TODO(), crbList)
+	require.NoError(t, err)
+	require.Len(t, crbList.Items, 1, "expected one ClusterResourceBinding after first apply")
+
+	assert.False(t, crbList.Items[0].Spec.PropagateDeps, "initial PropagateDeps should be false")
+	assert.Nil(t, crbList.Items[0].Spec.SchedulePriority, "initial SchedulePriority should be nil")
+
+	// Simulate a SchedulePriority having been written on the CRB by another actor (e.g. an older code path).
+	// The fix ensures this stale value is overwritten on the next policy reconcile.
+	existingCRB := crbList.Items[0].DeepCopy()
+	existingCRB.Spec.SchedulePriority = &workv1alpha2.SchedulePriority{Priority: 999}
+	err = fakeClient.Update(context.TODO(), existingCRB)
+	require.NoError(t, err)
+
+	// Update the policy: flip PropagateDeps to true.
+	policy.Spec.PropagateDeps = true
+
+	// Second call: should update the existing CRB.
+	err = d.ApplyClusterPolicy(object, keys.ClusterWideKey{}, false, policy)
+	require.NoError(t, err)
+
+	crbList = &workv1alpha2.ClusterResourceBindingList{}
+	err = fakeClient.List(context.TODO(), crbList)
+	require.NoError(t, err)
+	require.Len(t, crbList.Items, 1, "expected exactly one ClusterResourceBinding after second apply")
+
+	updatedCRB := crbList.Items[0]
+	assert.True(t, updatedCRB.Spec.PropagateDeps, "PropagateDeps should propagate to true after policy update")
+	assert.Nil(t, updatedCRB.Spec.SchedulePriority, "SchedulePriority should be synced from the newly-built binding (nil when no PriorityClass is configured)")
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
Fixes a bug where ClusterPropagationPolicy updates to `spec.propagateDeps` and `spec.schedulePriority` were silently ignored for cluster-scoped resources.

**Which issue(s) this PR fixes:**
Fixes #7402

**Root cause:**
The CRB mutation closure in `ApplyClusterPolicy` was missing two field assignments that are present in the RB mutation closures. This caused policy updates to be ignored.

**Changes:**
- Added `bindingCopy.Spec.PropagateDeps = binding.Spec.PropagateDeps`
- Added `bindingCopy.Spec.SchedulePriority = binding.Spec.SchedulePriority`
- Added regression test verifying both fields propagate on policy update

**Does this PR introduce a user-facing change?**
```release-note
Fixed a bug where ClusterPropagationPolicy updates to propagateDeps and schedulePriority were silently ignored for cluster-scoped resources.
```