### PR TITLE
feat: add progressive rollout strategies sample manifests and wave-rollout script

### DIFF
--- a/samples/progressive-rollout/README.md
+++ b/samples/progressive-rollout/README.md
@@ -1,0 +1,72 @@
+# Progressive Rollout — Sample Manifests
+
+Static YAML manifests and orchestration script used in the
+[Progressive Rollout Strategies with Karmada][tutorial] tutorial.
+
+The tutorial demonstrates three rollout strategies across multiple clusters using only
+Karmada `PropagationPolicy` and `OverridePolicy` — no additional controllers required.
+
+## Directory Structure
+
+```
+progressive-rollout/
+├── wave-rollout.sh       # Orchestration script for Strategy 3 (Wave Rollout)
+├── base/                 # Shared manifests — application and ingress-nginx
+├── canary/               # Strategy 1 — Side-by-Side Testing (Canary)
+├── rolling-upgrade/      # Strategy 2 — In-place Updates (Rolling Upgrade)
+└── wave/                 # Strategy 3 — Percentage-based Shifting (Wave Rollout)
+```
+
+## Files
+
+### `base/` — Shared manifests
+
+| File | Purpose |
+|------|---------|
+| `http-probe-app.yaml` | Base app at `v1`, `replicaSchedulingType: Divided` (2 replicas per cluster) |
+| `http-probe-app-v2.yaml` | Base app at `v2`, `replicaSchedulingType: Divided` — used to finalize Strategies 1 and 2 |
+| `ingress-nginx-deploy.yaml` | ingress-nginx controller workload |
+| `ingress-nginx-propagation.yaml` | `PropagationPolicy` for namespace-scoped ingress-nginx resources |
+| `ingress-nginx-cluster-propagation.yaml` | `ClusterPropagationPolicy` for cluster-scoped ingress-nginx resources |
+
+### `canary/` — Strategy 1: Side-by-Side Testing (Canary)
+
+| File | Purpose |
+|------|---------|
+| `http-probe-app-canary-member1.yaml` | Canary `Deployment` + `PropagationPolicy` targeting `member1` only |
+| `http-probe-app-canary-member2.yaml` | Canary `Deployment` + `PropagationPolicy` targeting `member2` only |
+| `http-probe-app-canary-member3.yaml` | Canary `Deployment` + `PropagationPolicy` targeting `member3` only |
+| `http-probe-app-canary-all.yaml` | Single canary `Deployment` + `PropagationPolicy` targeting all three clusters |
+| `http-probe-promote-override-member1.yaml` | `OverridePolicy` promoting the base to `v2` on `member1` |
+| `http-probe-promote-override-member2.yaml` | `OverridePolicy` promoting the base to `v2` on `member2` |
+| `http-probe-promote-override-member1-member2.yaml` | `OverridePolicy` promoting the base to `v2` on `member1` and `member2` |
+| `http-probe-promote-override-all.yaml` | `OverridePolicy` promoting the base to `v2` on all three clusters |
+
+### `rolling-upgrade/` — Strategy 2: In-place Updates (Rolling Upgrade)
+
+| File | Purpose |
+|------|---------|
+| `http-probe-rolling-upgrade-member1.yaml` | `OverridePolicy` rolling the base to `v2` on `member1` |
+| `http-probe-rolling-upgrade-member1-member2.yaml` | `OverridePolicy` rolling the base to `v2` on `member1` and `member2` |
+| `http-probe-rolling-upgrade-all.yaml` | `OverridePolicy` rolling the base to `v2` on all three clusters |
+
+### `wave/` — Strategy 3: Percentage-based Shifting (Wave Rollout)
+
+| File | Purpose |
+|------|---------|
+| `http-probe-app-wave-base.yaml` | Base app at `v1`, `replicaSchedulingType: Duplicated` (6 replicas per cluster) — required for meaningful percentage steps |
+| `http-probe-app-wave-base-v2.yaml` | Same as above but at `v2` — applied by `wave-rollout.sh finalize` |
+| `http-probe-app-wave-deployment.yaml` | Wave `Deployment` at `v2` — created by `wave-rollout.sh start` |
+
+The wave rollout is orchestrated by [`wave-rollout.sh`](./wave-rollout.sh).
+The `OverridePolicy` resources that scale the base down and the wave up are generated
+dynamically by the script at runtime, since their replica counts depend on the target
+percentage and the `--wait` interval supplied by the operator.
+
+## Usage
+
+See the [Progressive Rollout Strategies with Karmada][tutorial] tutorial for full
+step-by-step instructions including inline YAML, dashboard observations, and sequence
+diagrams for each strategy and demo.
+
+[tutorial]: https://karmada.io/docs/tutorials/rollout/overview

--- a/samples/progressive-rollout/base/http-probe-app-v2.yaml
+++ b/samples/progressive-rollout/base/http-probe-app-v2.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: http-probe-app
+  labels:
+    app: http-probe-app
+spec:
+  replicas: 6
+  selector:
+    matchLabels:
+      app: http-probe-app
+  template:
+    metadata:
+      labels:
+        app: http-probe-app
+    spec:
+      containers:
+        - name: http-probe-app
+          image: ghcr.io/cmontemuino/http-probe-test-app:v0.5.0
+          ports:
+            - containerPort: 8080
+          env:
+            - name: ROLLOUT_LABEL
+              value: v2
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 25m
+              memory: 64Mi
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: http-probe-app-service
+  labels:
+    app: http-probe-app
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080
+  selector:
+    app: http-probe-app
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: http-probe-app-ingress
+  labels:
+    app: http-probe-app
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: http-probe.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: http-probe-app-service
+                port:
+                  number: 80
+---
+apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: http-probe-app-propagation
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: http-probe-app
+    - apiVersion: v1
+      kind: Service
+      name: http-probe-app-service
+    - apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      name: http-probe-app-ingress
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - member1
+        - member2
+        - member3
+    replicaScheduling:
+      replicaSchedulingType: Divided

--- a/samples/progressive-rollout/base/http-probe-app.yaml
+++ b/samples/progressive-rollout/base/http-probe-app.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: http-probe-app
+  labels:
+    app: http-probe-app
+spec:
+  replicas: 6
+  selector:
+    matchLabels:
+      app: http-probe-app
+  template:
+    metadata:
+      labels:
+        app: http-probe-app
+    spec:
+      containers:
+        - name: http-probe-app
+          image: ghcr.io/cmontemuino/http-probe-test-app:v0.5.0
+          ports:
+            - containerPort: 8080
+          env:
+            - name: ROLLOUT_LABEL
+              value: v1
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 25m
+              memory: 64Mi
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: http-probe-app-service
+  labels:
+    app: http-probe-app
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080
+  selector:
+    app: http-probe-app
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: http-probe-app-ingress
+  labels:
+    app: http-probe-app
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: http-probe.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: http-probe-app-service
+                port:
+                  number: 80
+---
+apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: http-probe-app-propagation
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: http-probe-app
+    - apiVersion: v1
+      kind: Service
+      name: http-probe-app-service
+    - apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      name: http-probe-app-ingress
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - member1
+        - member2
+        - member3
+    replicaScheduling:
+      replicaSchedulingType: Divided

--- a/samples/progressive-rollout/base/ingress-nginx-cluster-propagation.yaml
+++ b/samples/progressive-rollout/base/ingress-nginx-cluster-propagation.yaml
@@ -1,0 +1,30 @@
+apiVersion: policy.karmada.io/v1alpha1
+kind: ClusterPropagationPolicy
+metadata:
+  name: ingress-nginx-cluster-propagation
+spec:
+  resourceSelectors:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      name: ingress-nginx
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      name: ingress-nginx-admission
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      name: ingress-nginx
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      name: ingress-nginx-admission
+    - apiVersion: networking.k8s.io/v1
+      kind: IngressClass
+      name: nginx
+    - apiVersion: admissionregistration.k8s.io/v1
+      kind: ValidatingWebhookConfiguration
+      name: ingress-nginx-admission
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - member1
+        - member2
+        - member3

--- a/samples/progressive-rollout/base/ingress-nginx-deploy.yaml
+++ b/samples/progressive-rollout/base/ingress-nginx-deploy.yaml
@@ -1,0 +1,680 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+  name: ingress-nginx
+---
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.14.3
+  name: ingress-nginx
+  namespace: ingress-nginx
+---
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.14.3
+  name: ingress-nginx-admission
+  namespace: ingress-nginx
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.14.3
+  name: ingress-nginx
+  namespace: ingress-nginx
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - ingress-nginx-leader
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.14.3
+  name: ingress-nginx-admission
+  namespace: ingress-nginx
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.14.3
+  name: ingress-nginx
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - nodes
+  - pods
+  - secrets
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.14.3
+  name: ingress-nginx-admission
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.14.3
+  name: ingress-nginx
+  namespace: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ingress-nginx
+subjects:
+- kind: ServiceAccount
+  name: ingress-nginx
+  namespace: ingress-nginx
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.14.3
+  name: ingress-nginx-admission
+  namespace: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ingress-nginx-admission
+subjects:
+- kind: ServiceAccount
+  name: ingress-nginx-admission
+  namespace: ingress-nginx
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.14.3
+  name: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ingress-nginx
+subjects:
+- kind: ServiceAccount
+  name: ingress-nginx
+  namespace: ingress-nginx
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.14.3
+  name: ingress-nginx-admission
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ingress-nginx-admission
+subjects:
+- kind: ServiceAccount
+  name: ingress-nginx-admission
+  namespace: ingress-nginx
+---
+apiVersion: v1
+data: {}
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.14.3
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.14.3
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+spec:
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - appProtocol: http
+    name: http
+    port: 80
+    protocol: TCP
+    targetPort: http
+  - appProtocol: https
+    name: https
+    port: 443
+    protocol: TCP
+    targetPort: https
+  selector:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.14.3
+  name: ingress-nginx-controller-admission
+  namespace: ingress-nginx
+spec:
+  ports:
+  - appProtocol: https
+    name: https-webhook
+    port: 443
+    targetPort: webhook
+  selector:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.14.3
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+spec:
+  minReadySeconds: 0
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: ingress-nginx
+      app.kubernetes.io/name: ingress-nginx
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.14.3
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - /nginx-ingress-controller
+        - --election-id=ingress-nginx-leader
+        - --controller-class=k8s.io/ingress-nginx
+        - --ingress-class=nginx
+        - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
+        - --validating-webhook=:8443
+        - --validating-webhook-certificate=/usr/local/certificates/cert
+        - --validating-webhook-key=/usr/local/certificates/key
+        - --watch-ingress-without-class=true
+        - --publish-status-address=localhost
+        - --enable-metrics=true
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LD_PRELOAD
+          value: /usr/local/lib/libmimalloc.so
+        image: registry.k8s.io/ingress-nginx/controller:v1.14.3@sha256:82917be97c0939f6ada1717bb39aa7e66c229d6cfb10dcfc8f1bd42f9efe0f81
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /wait-shutdown
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: controller
+        ports:
+        - containerPort: 80
+          hostPort: 80
+          name: http
+          protocol: TCP
+        - containerPort: 443
+          hostPort: 443
+          name: https
+          protocol: TCP
+        - containerPort: 8443
+          name: webhook
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 90Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          readOnlyRootFilesystem: false
+          runAsGroup: 82
+          runAsNonRoot: true
+          runAsUser: 101
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /usr/local/certificates/
+          name: webhook-cert
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: ingress-nginx
+      terminationGracePeriodSeconds: 0
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Equal
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Equal
+      volumes:
+      - name: webhook-cert
+        secret:
+          secretName: ingress-nginx-admission
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.14.3
+  name: ingress-nginx-admission-create
+  namespace: ingress-nginx
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: admission-webhook
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.14.3
+      name: ingress-nginx-admission-create
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - create
+        - --host=ingress-nginx-controller-admission,ingress-nginx-controller-admission.$(POD_NAMESPACE).svc
+        - --namespace=$(POD_NAMESPACE)
+        - --secret-name=ingress-nginx-admission
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.7@sha256:7c74a715af2c94cb734785b4d3ea1357b4f02b88e1e123c622a9cb68b62f669c
+        imagePullPolicy: IfNotPresent
+        name: create
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: OnFailure
+      serviceAccountName: ingress-nginx-admission
+  ttlSecondsAfterFinished: 0
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.14.3
+  name: ingress-nginx-admission-patch
+  namespace: ingress-nginx
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: admission-webhook
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.14.3
+      name: ingress-nginx-admission-patch
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - patch
+        - --webhook-name=ingress-nginx-admission
+        - --namespace=$(POD_NAMESPACE)
+        - --patch-mutating=false
+        - --secret-name=ingress-nginx-admission
+        - --patch-failure-policy=Fail
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.7@sha256:7c74a715af2c94cb734785b4d3ea1357b4f02b88e1e123c622a9cb68b62f669c
+        imagePullPolicy: IfNotPresent
+        name: patch
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: OnFailure
+      serviceAccountName: ingress-nginx-admission
+  ttlSecondsAfterFinished: 0
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.14.3
+  name: nginx
+spec:
+  controller: k8s.io/ingress-nginx
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.14.3
+  name: ingress-nginx-admission
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: ingress-nginx-controller-admission
+      namespace: ingress-nginx
+      path: /networking/v1/ingresses
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validate.nginx.ingress.kubernetes.io
+  rules:
+  - apiGroups:
+    - networking.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ingresses
+  sideEffects: None

--- a/samples/progressive-rollout/base/ingress-nginx-propagation.yaml
+++ b/samples/progressive-rollout/base/ingress-nginx-propagation.yaml
@@ -1,0 +1,49 @@
+apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: ingress-nginx-propagation
+  namespace: ingress-nginx
+spec:
+  resourceSelectors:
+    - apiVersion: v1
+      kind: ServiceAccount
+      name: ingress-nginx
+    - apiVersion: v1
+      kind: ServiceAccount
+      name: ingress-nginx-admission
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      name: ingress-nginx
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      name: ingress-nginx-admission
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      name: ingress-nginx
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      name: ingress-nginx-admission
+    - apiVersion: v1
+      kind: ConfigMap
+      name: ingress-nginx-controller
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: ingress-nginx-controller
+    - apiVersion: v1
+      kind: Service
+      name: ingress-nginx-controller
+    - apiVersion: v1
+      kind: Service
+      name: ingress-nginx-controller-admission
+    - apiVersion: batch/v1
+      kind: Job
+      name: ingress-nginx-admission-create
+    - apiVersion: batch/v1
+      kind: Job
+      name: ingress-nginx-admission-patch
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - member1
+        - member2
+        - member3

--- a/samples/progressive-rollout/canary/http-probe-app-canary-all.yaml
+++ b/samples/progressive-rollout/canary/http-probe-app-canary-all.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: http-probe-app-canary
+  labels:
+    app: http-probe-app
+    version: canary
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: http-probe-app
+      version: canary
+  template:
+    metadata:
+      labels:
+        app: http-probe-app
+        version: canary
+    spec:
+      containers:
+        - name: http-probe-app
+          image: ghcr.io/cmontemuino/http-probe-test-app:v0.5.0
+          ports:
+            - containerPort: 8080
+          env:
+            - name: ROLLOUT_LABEL
+              value: v2
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 25m
+              memory: 64Mi
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+---
+apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: http-probe-app-canary-propagation
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: http-probe-app-canary
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - member1
+        - member2
+        - member3

--- a/samples/progressive-rollout/canary/http-probe-app-canary-member1.yaml
+++ b/samples/progressive-rollout/canary/http-probe-app-canary-member1.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: http-probe-app-canary-member1
+  labels:
+    app: http-probe-app
+    version: canary
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: http-probe-app
+      version: canary-member1
+  template:
+    metadata:
+      labels:
+        app: http-probe-app
+        version: canary-member1
+    spec:
+      containers:
+        - name: http-probe-app
+          image: ghcr.io/cmontemuino/http-probe-test-app:v0.5.0
+          ports:
+            - containerPort: 8080
+          env:
+            - name: ROLLOUT_LABEL
+              value: v2
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 25m
+              memory: 64Mi
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+---
+apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: http-probe-app-canary-member1-propagation
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: http-probe-app-canary-member1
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - member1

--- a/samples/progressive-rollout/canary/http-probe-app-canary-member2.yaml
+++ b/samples/progressive-rollout/canary/http-probe-app-canary-member2.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: http-probe-app-canary-member2
+  labels:
+    app: http-probe-app
+    version: canary
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: http-probe-app
+      version: canary-member2
+  template:
+    metadata:
+      labels:
+        app: http-probe-app
+        version: canary-member2
+    spec:
+      containers:
+        - name: http-probe-app
+          image: ghcr.io/cmontemuino/http-probe-test-app:v0.5.0
+          ports:
+            - containerPort: 8080
+          env:
+            - name: ROLLOUT_LABEL
+              value: v2
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 25m
+              memory: 64Mi
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+---
+apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: http-probe-app-canary-member2-propagation
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: http-probe-app-canary-member2
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - member2

--- a/samples/progressive-rollout/canary/http-probe-app-canary-member3.yaml
+++ b/samples/progressive-rollout/canary/http-probe-app-canary-member3.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: http-probe-app-canary-member3
+  labels:
+    app: http-probe-app
+    version: canary
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: http-probe-app
+      version: canary-member3
+  template:
+    metadata:
+      labels:
+        app: http-probe-app
+        version: canary-member3
+    spec:
+      containers:
+        - name: http-probe-app
+          image: ghcr.io/cmontemuino/http-probe-test-app:v0.5.0
+          ports:
+            - containerPort: 8080
+          env:
+            - name: ROLLOUT_LABEL
+              value: v2
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 25m
+              memory: 64Mi
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+---
+apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: http-probe-app-canary-member3-propagation
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: http-probe-app-canary-member3
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - member3

--- a/samples/progressive-rollout/canary/http-probe-promote-override-all.yaml
+++ b/samples/progressive-rollout/canary/http-probe-promote-override-all.yaml
@@ -1,0 +1,20 @@
+apiVersion: policy.karmada.io/v1alpha1
+kind: OverridePolicy
+metadata:
+  name: http-probe-promote-override
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: http-probe-app
+  overrideRules:
+    - targetCluster:
+        clusterNames:
+          - member1
+          - member2
+          - member3
+      overriders:
+        plaintext:
+          - path: /spec/template/spec/containers/0/env/0/value
+            operator: replace
+            value: v2

--- a/samples/progressive-rollout/canary/http-probe-promote-override-member1-member2.yaml
+++ b/samples/progressive-rollout/canary/http-probe-promote-override-member1-member2.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy.karmada.io/v1alpha1
+kind: OverridePolicy
+metadata:
+  name: http-probe-promote-override
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: http-probe-app
+  overrideRules:
+    - targetCluster:
+        clusterNames:
+          - member1
+          - member2
+      overriders:
+        plaintext:
+          - path: /spec/template/spec/containers/0/env/0/value
+            operator: replace
+            value: v2

--- a/samples/progressive-rollout/canary/http-probe-promote-override-member1.yaml
+++ b/samples/progressive-rollout/canary/http-probe-promote-override-member1.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy.karmada.io/v1alpha1
+kind: OverridePolicy
+metadata:
+  name: http-probe-promote-override
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: http-probe-app
+  overrideRules:
+    - targetCluster:
+        clusterNames:
+          - member1
+      overriders:
+        plaintext:
+          - path: /spec/template/spec/containers/0/env/0/value
+            operator: replace
+            value: v2

--- a/samples/progressive-rollout/canary/http-probe-promote-override-member2.yaml
+++ b/samples/progressive-rollout/canary/http-probe-promote-override-member2.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy.karmada.io/v1alpha1
+kind: OverridePolicy
+metadata:
+  name: http-probe-promote-override
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: http-probe-app
+  overrideRules:
+    - targetCluster:
+        clusterNames:
+          - member2
+      overriders:
+        plaintext:
+          - path: /spec/template/spec/containers/0/env/0/value
+            operator: replace
+            value: v2

--- a/samples/progressive-rollout/rolling-upgrade/http-probe-rolling-upgrade-all.yaml
+++ b/samples/progressive-rollout/rolling-upgrade/http-probe-rolling-upgrade-all.yaml
@@ -1,0 +1,20 @@
+apiVersion: policy.karmada.io/v1alpha1
+kind: OverridePolicy
+metadata:
+  name: http-probe-rolling-upgrade
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: http-probe-app
+  overrideRules:
+    - targetCluster:
+        clusterNames:
+          - member1
+          - member2
+          - member3
+      overriders:
+        plaintext:
+          - path: /spec/template/spec/containers/0/env/0/value
+            operator: replace
+            value: v2

--- a/samples/progressive-rollout/rolling-upgrade/http-probe-rolling-upgrade-member1-member2.yaml
+++ b/samples/progressive-rollout/rolling-upgrade/http-probe-rolling-upgrade-member1-member2.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy.karmada.io/v1alpha1
+kind: OverridePolicy
+metadata:
+  name: http-probe-rolling-upgrade
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: http-probe-app
+  overrideRules:
+    - targetCluster:
+        clusterNames:
+          - member1
+          - member2
+      overriders:
+        plaintext:
+          - path: /spec/template/spec/containers/0/env/0/value
+            operator: replace
+            value: v2

--- a/samples/progressive-rollout/rolling-upgrade/http-probe-rolling-upgrade-member1.yaml
+++ b/samples/progressive-rollout/rolling-upgrade/http-probe-rolling-upgrade-member1.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy.karmada.io/v1alpha1
+kind: OverridePolicy
+metadata:
+  name: http-probe-rolling-upgrade
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: http-probe-app
+  overrideRules:
+    - targetCluster:
+        clusterNames:
+          - member1
+      overriders:
+        plaintext:
+          - path: /spec/template/spec/containers/0/env/0/value
+            operator: replace
+            value: v2

--- a/samples/progressive-rollout/wave-rollout.sh
+++ b/samples/progressive-rollout/wave-rollout.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Karmada Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# wave-rollout.sh — Percentage-based traffic shifting using two Deployments in tandem.
+#
+# Usage:
+#   wave-rollout.sh start  <cluster|all> <steps>  [--kubeconfig <path>] [--context <ctx>] [--wait <seconds>]
+#   wave-rollout.sh finalize                       [--kubeconfig <path>] [--context <ctx>]
+#   wave-rollout.sh abort  <cluster|all>           [--kubeconfig <path>] [--context <ctx>]
+#
+# Commands:
+#   start    — create the wave Deployment and step through traffic percentages
+#   finalize — update base manifest to v2, restore base replicas, remove wave resources
+#   abort    — restore base replicas and remove wave resources without promoting
+#
+# Arguments:
+#   <cluster>  — target member cluster name (e.g. member1)
+#   all        — target all three member clusters simultaneously
+#   <steps>    — comma-separated traffic percentages (e.g. 25,50,100)
+#
+# Options:
+#   --kubeconfig  path to kubeconfig        (default: ~/.kube/karmada.config)
+#   --context     karmada API context       (default: karmada-apiserver)
+#   --wait        seconds to pause per step (default: 30)
+#
+# Replica table (6 replicas per cluster via Duplicated policy):
+#   Step   Base  Wave  Approx. traffic share
+#   25%      4     2        ~33% wave
+#   50%      3     3        ~50% wave
+#   100%     0     6       100% wave
+#
+# Prerequisites:
+#   - Karmada control plane running (hack/local-up-karmada.sh)
+#   - http-probe-app deployed via samples/progressive-rollout/wave/http-probe-app-wave-base.yaml
+#   - KUBECONFIG pointing to karmada.config or --kubeconfig flag provided
+
+set -euo pipefail
+
+if ! command -v kubectl &> /dev/null; then
+  echo "Error: kubectl is not installed or not in PATH." >&2
+  exit 1
+fi
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# These can be overridden via environment variables to support different environments.
+REPLICAS_PER_CLUSTER=${REPLICAS_PER_CLUSTER:-6}
+NAMESPACE=${NAMESPACE:-default}
+read -ra ALL_CLUSTERS <<< "${CLUSTERS:-member1 member2 member3}"
+
+BASE_DEPLOY="http-probe-app"
+WAVE_DEPLOY="http-probe-app-wave"
+BASE_DOWN_POLICY="http-probe-wave-base-down"
+WAVE_UP_POLICY="http-probe-wave-up"
+WAVE_PROPAGATION="http-probe-app-wave-propagation"
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+KUBECONFIG_PATH="${KUBECONFIG:-$HOME/.kube/karmada.config}"
+KARMADA_CONTEXT="karmada-apiserver"
+WAIT_SECONDS=30
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+COMMAND="${1:-}"
+shift || true
+
+TARGET=""
+STEPS="25,50,100"
+
+case "$COMMAND" in
+  start)
+    TARGET="${1:-}"; shift || true
+    STEPS="${1:-25,50,100}"; shift || true
+    if [[ -z "$TARGET" ]]; then
+      echo "Usage: $0 start <cluster|all> [steps]" >&2
+      exit 1
+    fi
+    ;;
+  abort)
+    TARGET="${1:-all}"; shift || true
+    ;;
+  finalize) ;;
+  *)
+    echo "Usage: $0 <start|finalize|abort> [args]" >&2
+    exit 1
+    ;;
+esac
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --kubeconfig)
+      [[ -z "${2:-}" ]] && { echo "Error: --kubeconfig requires a value." >&2; exit 1; }
+      KUBECONFIG_PATH="$2"; shift 2 ;;
+    --context)
+      [[ -z "${2:-}" ]] && { echo "Error: --context requires a value." >&2; exit 1; }
+      KARMADA_CONTEXT="$2"; shift 2 ;;
+    --wait)
+      [[ -z "${2:-}" ]] && { echo "Error: --wait requires a value." >&2; exit 1; }
+      WAIT_SECONDS="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+export KUBECONFIG="$KUBECONFIG_PATH"
+KC="kubectl --context $KARMADA_CONTEXT"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+# resolve_clusters resolves the target clusters. Returns all clusters if the input is "all",
+# otherwise returns the input cluster name.
+resolve_clusters() {
+  if [[ "$1" == "all" ]]; then
+    echo "${ALL_CLUSTERS[@]}"
+  else
+    echo "$1"
+  fi
+}
+
+# Converts "member1 member2 member3" → "[member1, member2, member3]"
+format_cluster_list() {
+  local clusters=("$@")
+  local result="["
+  for i in "${!clusters[@]}"; do
+    [[ $i -gt 0 ]] && result+=", "
+    result+="${clusters[$i]}"
+  done
+  echo "${result}]"
+}
+
+# Print and apply a manifest passed via stdin or as a string
+apply_manifest() {
+  local description="$1"
+  local manifest="$2"
+  echo "==> ${description}"
+  echo "--- manifest"
+  echo "${manifest}"
+  echo "---"
+  printf "%s\n" "${manifest}" | $KC apply -f -
+}
+
+# Apply a replica-scaling OverridePolicy for a Deployment
+apply_override() {
+  local name="$1"
+  local cluster_list="$2"
+  local deploy="$3"
+  local replicas="$4"
+  local role="$5"
+
+  apply_manifest "OverridePolicy: ${name} (${role}, replicas=${replicas})" "$(cat <<EOF
+apiVersion: policy.karmada.io/v1alpha1
+kind: OverridePolicy
+metadata:
+  name: ${name}
+  namespace: ${NAMESPACE}
+  labels:
+    wave-role: ${role}
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: ${deploy}
+  overrideRules:
+    - targetCluster:
+        clusterNames: ${cluster_list}
+      overriders:
+        plaintext:
+          - path: /spec/replicas
+            operator: replace
+            value: ${replicas}
+EOF
+)"
+}
+
+# Wait for a Deployment's ResourceBinding to reach the expected ready replica count
+wait_for_ready() {
+  local deploy="$1"
+  local cluster="$2"
+  local expected="$3"
+  local label="${4:-$deploy}"
+
+  echo "  Waiting for ${label} to reach ${expected} ready replicas on ${cluster}..."
+  for i in $(seq 1 40); do
+    ready=$($KC get resourcebinding "${deploy}-deployment" -n "$NAMESPACE" \
+      -o jsonpath="{.status.aggregatedStatus[?(@.clusterName==\"${cluster}\")].status.readyReplicas}" \
+      2>/dev/null)
+    desired=$($KC get resourcebinding "${deploy}-deployment" -n "$NAMESPACE" \
+      -o jsonpath="{.status.aggregatedStatus[?(@.clusterName==\"${cluster}\")].status.replicas}" \
+      2>/dev/null)
+    if [[ -n "$ready" ]] && { [[ "$ready" == "$expected" ]] || [[ "$expected" == "desired" && -n "$desired" && "$ready" == "$desired" ]]; }; then
+      echo "  Ready (${ready}/${desired:-$expected})."
+      return 0
+    fi
+    echo "  ($i/40) ${label} ready=${ready:-0}/${expected} — retrying in 5s..."
+    sleep 5
+  done
+  echo "  Timed out waiting for ${label} on ${cluster}." >&2
+  exit 1
+}
+
+# ── Commands ──────────────────────────────────────────────────────────────────
+
+cmd_start() {
+  local manifests="${SCRIPT_DIR}/wave"
+
+  local clusters
+  read -ra clusters <<< "$(resolve_clusters "$TARGET")"
+  local cluster_list
+  cluster_list=$(format_cluster_list "${clusters[@]}")
+
+  echo "==> Applying wave Deployment: ${WAVE_DEPLOY} (v2)"
+  echo "--- manifest: samples/progressive-rollout/wave/http-probe-app-wave-deployment.yaml"
+  cat "${manifests}/http-probe-app-wave-deployment.yaml"
+  echo "---"
+  $KC apply -f "${manifests}/http-probe-app-wave-deployment.yaml" -n "$NAMESPACE"
+
+  # PropagationPolicy is dynamic (clusterNames depends on --target argument)
+  apply_manifest "PropagationPolicy: ${WAVE_PROPAGATION} → ${cluster_list}" "$(cat <<EOF
+apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: ${WAVE_PROPAGATION}
+  namespace: ${NAMESPACE}
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: ${WAVE_DEPLOY}
+  placement:
+    clusterAffinity:
+      clusterNames: ${cluster_list}
+EOF
+)"
+
+  IFS=',' read -ra steps <<< "$STEPS"
+  for pct in "${steps[@]}"; do
+    pct="${pct// /}"
+    pct="${pct//%/}"
+    if ! [[ "$pct" =~ ^[0-9]+$ ]] || (( pct < 0 || pct > 100 )); then
+      echo "Error: invalid step '${pct}' — must be an integer in [0,100]." >&2
+      exit 1
+    fi
+    wave_replicas=$(( (REPLICAS_PER_CLUSTER * pct + 99) / 100 ))
+    [[ $wave_replicas -gt $REPLICAS_PER_CLUSTER ]] && wave_replicas=$REPLICAS_PER_CLUSTER
+    base_replicas=$(( REPLICAS_PER_CLUSTER - wave_replicas ))
+
+    echo ""
+    echo "==> Step ${pct}%: base=${base_replicas}, wave=${wave_replicas} per cluster"
+    apply_override "$WAVE_UP_POLICY"   "$cluster_list" "$WAVE_DEPLOY" "$wave_replicas" "wave-up"
+    apply_override "$BASE_DOWN_POLICY" "$cluster_list" "$BASE_DEPLOY" "$base_replicas" "base-down"
+
+    for cluster in "${clusters[@]}"; do
+      wait_for_ready "$WAVE_DEPLOY" "$cluster" "$wave_replicas" "wave"
+    done
+
+    echo "  Holding for ${WAIT_SECONDS}s — observe the dashboard before advancing..."
+    sleep "$WAIT_SECONDS"
+  done
+
+  echo ""
+  echo "==> All steps complete. Run './wave-rollout.sh finalize' to promote or './wave-rollout.sh abort' to restore."
+}
+
+cmd_finalize() {
+  # Use http-probe-app-wave-base-v2.yaml — identical to http-probe-app-wave-base.yaml
+  # but with ROLLOUT_LABEL: v2. Cannot use http-probe-app-v2.yaml here because it
+  # uses Divided scheduling which would drop replicas from 6 to 2 per cluster.
+  echo "==> Updating base manifest to v2 (preserving Duplicated scheduling)..."
+  echo "--- manifest: samples/progressive-rollout/wave/http-probe-app-wave-base-v2.yaml"
+  cat "${SCRIPT_DIR}/wave/http-probe-app-wave-base-v2.yaml"
+  echo "---"
+  $KC apply -f "${SCRIPT_DIR}/wave/http-probe-app-wave-base-v2.yaml" -n "$NAMESPACE"
+
+  echo "==> Deleting base-down OverridePolicy — base scales back up to ${REPLICAS_PER_CLUSTER}×v2..."
+  $KC delete overridepolicy "$BASE_DOWN_POLICY" -n "$NAMESPACE" --ignore-not-found
+
+  # Determine which clusters the wave was targeting by inspecting the PropagationPolicy
+  local wave_clusters
+  wave_clusters=$($KC get propagationpolicy "$WAVE_PROPAGATION" -n "$NAMESPACE" \
+    -o jsonpath='{.spec.placement.clusterAffinity.clusterNames[*]}' 2>/dev/null || true)
+  if [[ -z "$wave_clusters" ]]; then
+    echo "Warning: could not read wave cluster list from ${WAVE_PROPAGATION}; falling back to ALL_CLUSTERS." >&2
+    wave_clusters="${ALL_CLUSTERS[*]}"
+  fi
+  read -ra finalize_clusters <<< "$wave_clusters"
+
+  echo "==> Waiting for base Deployment to be fully ready on wave clusters: ${finalize_clusters[*]}..."
+  for cluster in "${finalize_clusters[@]}"; do
+    wait_for_ready "$BASE_DEPLOY" "$cluster" "desired" "base"
+  done
+
+  echo "==> Removing wave resources..."
+  $KC delete overridepolicy    "$WAVE_UP_POLICY"   -n "$NAMESPACE" --ignore-not-found
+  $KC delete propagationpolicy "$WAVE_PROPAGATION" -n "$NAMESPACE" --ignore-not-found
+  $KC delete deployment        "$WAVE_DEPLOY"      -n "$NAMESPACE" --ignore-not-found
+
+  echo "==> Done. All clusters are now on v2 with ${REPLICAS_PER_CLUSTER} replicas per cluster."
+}
+
+cmd_abort() {
+  local clusters
+  read -ra clusters <<< "$(resolve_clusters "$TARGET")"
+
+  echo "==> Deleting base-down OverridePolicy — base replicas will restore..."
+  $KC delete overridepolicy "$BASE_DOWN_POLICY" -n "$NAMESPACE" --ignore-not-found
+
+  echo "==> Waiting for base Deployment to be fully ready before removing wave pods..."
+  for cluster in "${clusters[@]}"; do
+    wait_for_ready "$BASE_DEPLOY" "$cluster" "desired" "base"
+  done
+
+  echo "==> Base fully restored — removing wave resources..."
+  $KC delete overridepolicy    "$WAVE_UP_POLICY"   -n "$NAMESPACE" --ignore-not-found
+  $KC delete propagationpolicy "$WAVE_PROPAGATION" -n "$NAMESPACE" --ignore-not-found
+  $KC delete deployment        "$WAVE_DEPLOY"      -n "$NAMESPACE" --ignore-not-found
+
+  echo "==> Done. Base Deployment restored to v1."
+}
+
+# ── Dispatch ──────────────────────────────────────────────────────────────────
+case "$COMMAND" in
+  start)    cmd_start ;;
+  finalize) cmd_finalize ;;
+  abort)    cmd_abort ;;
+esac

--- a/samples/progressive-rollout/wave/http-probe-app-wave-base-v2.yaml
+++ b/samples/progressive-rollout/wave/http-probe-app-wave-base-v2.yaml
@@ -1,0 +1,110 @@
+# This manifest is used exclusively for Strategy 3 (Wave Rollout) — finalize step.
+#
+# The key difference from http-probe-app.yaml is replicaSchedulingType: Duplicated —
+# each member cluster receives the full replica count independently (6 per cluster,
+# 18 pods total). This is required to make the wave percentage steps meaningful:
+# with only 2 replicas per cluster (Divided), the 25%/50%/100% steps would not
+# produce clean integer replica counts.
+#
+# Applied by wave-rollout.sh finalize to update the base to v2 while preserving Duplicated scheduling.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: http-probe-app
+  labels:
+    app: http-probe-app
+spec:
+  replicas: 6
+  selector:
+    matchLabels:
+      app: http-probe-app
+  template:
+    metadata:
+      labels:
+        app: http-probe-app
+    spec:
+      containers:
+        - name: http-probe-app
+          image: ghcr.io/cmontemuino/http-probe-test-app:v0.5.0
+          ports:
+            - containerPort: 8080
+          env:
+            - name: ROLLOUT_LABEL
+              value: v2
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 25m
+              memory: 64Mi
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: http-probe-app-service
+  labels:
+    app: http-probe-app
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080
+  selector:
+    app: http-probe-app
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: http-probe-app-ingress
+  labels:
+    app: http-probe-app
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: http-probe.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: http-probe-app-service
+                port:
+                  number: 80
+---
+apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: http-probe-app-propagation
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: http-probe-app
+    - apiVersion: v1
+      kind: Service
+      name: http-probe-app-service
+    - apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      name: http-probe-app-ingress
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - member1
+        - member2
+        - member3
+    replicaScheduling:
+      replicaSchedulingType: Duplicated

--- a/samples/progressive-rollout/wave/http-probe-app-wave-base.yaml
+++ b/samples/progressive-rollout/wave/http-probe-app-wave-base.yaml
@@ -1,0 +1,110 @@
+# This manifest is used exclusively for Strategy 3 (Wave Rollout).
+#
+# The key difference from http-probe-app.yaml is replicaSchedulingType: Duplicated —
+# each member cluster receives the full replica count independently (6 per cluster,
+# 18 pods total). This is required to make the wave percentage steps meaningful:
+# with only 2 replicas per cluster (Divided), the 25%/50%/100% steps would not
+# produce clean integer replica counts.
+#
+# After the wave demo, re-apply http-probe-app.yaml to restore Divided scheduling.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: http-probe-app
+  labels:
+    app: http-probe-app
+spec:
+  replicas: 6
+  selector:
+    matchLabels:
+      app: http-probe-app
+  template:
+    metadata:
+      labels:
+        app: http-probe-app
+    spec:
+      containers:
+        - name: http-probe-app
+          image: ghcr.io/cmontemuino/http-probe-test-app:v0.5.0
+          ports:
+            - containerPort: 8080
+          env:
+            - name: ROLLOUT_LABEL
+              value: v1
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 25m
+              memory: 64Mi
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: http-probe-app-service
+  labels:
+    app: http-probe-app
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080
+  selector:
+    app: http-probe-app
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: http-probe-app-ingress
+  labels:
+    app: http-probe-app
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: http-probe.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: http-probe-app-service
+                port:
+                  number: 80
+---
+apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: http-probe-app-propagation
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: http-probe-app
+    - apiVersion: v1
+      kind: Service
+      name: http-probe-app-service
+    - apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      name: http-probe-app-ingress
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - member1
+        - member2
+        - member3
+    replicaScheduling:
+      replicaSchedulingType: Duplicated

--- a/samples/progressive-rollout/wave/http-probe-app-wave-deployment.yaml
+++ b/samples/progressive-rollout/wave/http-probe-app-wave-deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: http-probe-app-wave
+  labels:
+    app: http-probe-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: http-probe-app
+      version: wave
+  template:
+    metadata:
+      labels:
+        app: http-probe-app
+        version: wave
+    spec:
+      containers:
+        - name: http-probe-app
+          image: ghcr.io/cmontemuino/http-probe-test-app:v0.5.0
+          ports:
+            - containerPort: 8080
+          env:
+            - name: ROLLOUT_LABEL
+              value: v2
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 25m
+              memory: 64Mi
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
Adds samples/progressive-rollout/ with static YAML manifests and hack/wave-rollout.sh to support the Progressive Rollout Strategies with Karmada tutorial (submitted in a companion [PR](https://github.com/karmada-io/website/pull/997) to karmada-io/website).

Three rollout strategies are covered using only PropagationPolicy and OverridePolicy — no additional controllers required:

Strategy 1 — Side-by-Side Testing (Canary):
  Manifests for per-cluster and region-wide canary deployments, plus
  OverridePolicies for progressive per-cluster promotion and finalization.

Strategy 2 — In-place Updates (Rolling Upgrade):
  OverridePolicies that patch the base Deployment cluster by cluster,
  using native Kubernetes rolling update semantics.

Strategy 3 — Percentage-based Shifting (Wave Rollout):
  A second Deployment (wave) runs the new version alongside the base.
  Traffic shifts by balancing replica counts — no ingress weight
  annotations required. The by hack/wave-rollout.sh orchestrates the
  whole rollout process.

hack/wave-rollout.sh is a shell script rather than static manifests because the OverridePolicy replica counts (base-down and wave-up) must be computed at runtime from the target percentage and the configured replicas-per-cluster value. All other strategies use only static YAML.

A companion [PR](https://github.com/karmada-io/website/pull/997) to karmada-io/website adds the full tutorial that references these files via raw.githubusercontent.com URLs, covering inline YAML, step-by-step kubectl commands, Mermaid sequence diagrams, and dashboard observation notes for each strategy and demo.
**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

