### PR TITLE
fix: apply ClusterFailureThreshold to ClusterClientSetFunc errors

### DIFF
--- a/pkg/controllers/status/cluster_status_controller.go
+++ b/pkg/controllers/status/cluster_status_controller.go
@@ -191,7 +191,10 @@ func (c *ClusterStatusController) syncClusterStatus(ctx context.Context, cluster
 	clusterClient, err := c.ClusterClientSetFunc(cluster.Name, c.Client, c.ClusterClientOption)
 	if err != nil {
 		klog.ErrorS(err, "Failed to create a ClusterClient for the given member cluster", "cluster", cluster.Name)
-		return setStatusCollectionFailedCondition(ctx, c.Client, cluster, fmt.Sprintf("failed to create a ClusterClient: %v", err))
+		observedReadyCondition := util.NewCondition(clusterv1alpha1.ClusterConditionReady, statusCollectionFailed,
+			fmt.Sprintf("failed to create a ClusterClient: %v", err), metav1.ConditionFalse)
+		readyCondition := c.clusterConditionCache.thresholdAdjustedReadyCondition(cluster, &observedReadyCondition)
+		return updateStatusCondition(ctx, c.Client, cluster, *readyCondition)
 	}
 
 	online, healthy := getClusterHealthStatus(clusterClient)
@@ -283,11 +286,6 @@ func (c *ClusterStatusController) setCurrentClusterStatus(clusterClient *util.Cl
 		}
 	}
 	return conditions, nil
-}
-
-func setStatusCollectionFailedCondition(ctx context.Context, c client.Client, cluster *clusterv1alpha1.Cluster, message string) error {
-	readyCondition := util.NewCondition(clusterv1alpha1.ClusterConditionReady, statusCollectionFailed, message, metav1.ConditionFalse)
-	return updateStatusCondition(ctx, c, cluster, readyCondition)
 }
 
 // updateStatusIfNeeded calls updateStatus only if the status of the member cluster is not the same as the old status

--- a/pkg/controllers/status/cluster_status_controller_test.go
+++ b/pkg/controllers/status/cluster_status_controller_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -227,6 +228,124 @@ func TestClusterStatusController_syncClusterStatus(t *testing.T) {
 		}
 		err := c.syncClusterStatus(context.Background(), cluster)
 		assert.Empty(t, err)
+	})
+	t.Run("ClusterClientSetFunc error within threshold retains Ready=True", func(t *testing.T) {
+		server := mockServer(http.StatusOK, false)
+		defer server.Close()
+		serverAddress = server.URL
+		cluster := &clusterv1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			Spec: clusterv1alpha1.ClusterSpec{
+				APIEndpoint: server.URL,
+				SecretRef:   &clusterv1alpha1.LocalSecretReference{Namespace: "ns1", Name: "secret1"},
+			},
+			Status: clusterv1alpha1.ClusterStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               clusterv1alpha1.ClusterConditionReady,
+						Status:             metav1.ConditionTrue,
+						Reason:             "ClusterReady",
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+			},
+		}
+		c := &ClusterStatusController{
+			Client:                  fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithStatusSubresource(cluster).Build(),
+			GenericInformerManager:  genericmanager.GetInstance(),
+			TypedInformerManager:    typedmanager.GetInstance(),
+			ClusterSuccessThreshold: metav1.Duration{Duration: 30 * time.Second},
+			ClusterFailureThreshold: metav1.Duration{Duration: 30 * time.Second},
+			clusterConditionCache: clusterConditionStore{
+				failureThreshold: 30 * time.Second,
+				successThreshold: 30 * time.Second,
+			},
+			PredicateFunc: helper.NewClusterPredicateOnAgent("test"),
+			RateLimiterOptions: ratelimiterflag.Options{
+				RateLimiterBaseDelay:  time.Duration(1000),
+				RateLimiterMaxDelay:   time.Duration(1000),
+				RateLimiterQPS:        10,
+				RateLimiterBucketSize: 10,
+			},
+			ClusterClientSetFunc:        clusterClientSetFuncWithError,
+			ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
+		}
+		// seed cache so the controller knows the cluster was previously Ready=True
+		c.clusterConditionCache.update(cluster.Name, &clusterData{readyCondition: metav1.ConditionTrue})
+		if err := c.Client.Create(context.Background(), cluster); err != nil {
+			t.Fatalf("Failed to create cluster: %v", err)
+		}
+		err := c.syncClusterStatus(context.Background(), cluster)
+		assert.Empty(t, err)
+
+		updated := &clusterv1alpha1.Cluster{}
+		if err := c.Client.Get(context.Background(), types.NamespacedName{Name: cluster.Name}, updated); err != nil {
+			t.Fatalf("Failed to get cluster: %v", err)
+		}
+		readyCond := meta.FindStatusCondition(updated.Status.Conditions, clusterv1alpha1.ClusterConditionReady)
+		assert.NotNil(t, readyCond)
+		assert.Equal(t, metav1.ConditionTrue, readyCond.Status, "Ready=True should be retained within threshold")
+	})
+	t.Run("ClusterClientSetFunc error beyond threshold writes Ready=False", func(t *testing.T) {
+		server := mockServer(http.StatusOK, false)
+		defer server.Close()
+		serverAddress = server.URL
+		cluster := &clusterv1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			Spec: clusterv1alpha1.ClusterSpec{
+				APIEndpoint: server.URL,
+				SecretRef:   &clusterv1alpha1.LocalSecretReference{Namespace: "ns1", Name: "secret1"},
+			},
+			Status: clusterv1alpha1.ClusterStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               clusterv1alpha1.ClusterConditionReady,
+						Status:             metav1.ConditionTrue,
+						Reason:             "ClusterReady",
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+			},
+		}
+		c := &ClusterStatusController{
+			Client:                  fake.NewClientBuilder().WithScheme(gclient.NewSchema()).WithStatusSubresource(cluster).Build(),
+			GenericInformerManager:  genericmanager.GetInstance(),
+			TypedInformerManager:    typedmanager.GetInstance(),
+			ClusterSuccessThreshold: metav1.Duration{Duration: time.Millisecond},
+			ClusterFailureThreshold: metav1.Duration{Duration: time.Millisecond},
+			clusterConditionCache: clusterConditionStore{
+				failureThreshold: time.Millisecond,
+				successThreshold: time.Millisecond,
+			},
+			PredicateFunc: helper.NewClusterPredicateOnAgent("test"),
+			RateLimiterOptions: ratelimiterflag.Options{
+				RateLimiterBaseDelay:  time.Duration(1000),
+				RateLimiterMaxDelay:   time.Duration(1000),
+				RateLimiterQPS:        10,
+				RateLimiterBucketSize: 10,
+			},
+			ClusterClientSetFunc:        clusterClientSetFuncWithError,
+			ClusterDynamicClientSetFunc: util.NewClusterDynamicClientSetForAgent,
+		}
+		// seed cache with a failure that started well before the threshold
+		c.clusterConditionCache.update(cluster.Name, &clusterData{
+			readyCondition:     metav1.ConditionFalse,
+			thresholdStartTime: time.Now().Add(-time.Hour),
+		})
+		if err := c.Client.Create(context.Background(), cluster); err != nil {
+			t.Fatalf("Failed to create cluster: %v", err)
+		}
+		err := c.syncClusterStatus(context.Background(), cluster)
+		assert.Empty(t, err)
+
+		updated := &clusterv1alpha1.Cluster{}
+		if err := c.Client.Get(context.Background(), types.NamespacedName{Name: cluster.Name}, updated); err != nil {
+			t.Fatalf("Failed to get cluster: %v", err)
+		}
+		readyCond := meta.FindStatusCondition(updated.Status.Conditions, clusterv1alpha1.ClusterConditionReady)
+		assert.NotNil(t, readyCond)
+		assert.Equal(t, metav1.ConditionFalse, readyCond.Status, "Ready=False should be written after threshold expires")
+		assert.Equal(t, statusCollectionFailed, readyCond.Reason)
 	})
 	t.Run("online is false, readyCondition.Status isn't true", func(t *testing.T) {
 		server := mockServer(http.StatusNotFound, true)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`syncClusterStatus` has two paths that can write `Ready=False`, but only the network probe path respects `ClusterFailureThreshold`. When `ClusterClientSetFunc` fails (e.g. a `SecretRef` that is transiently missing during credential rotation), `Ready=False` is written immediately with no grace period — bypassing `thresholdAdjustedReadyCondition` entirely.

This causes spurious failovers on clusters that are perfectly healthy; Karmada just couldn't build a client for one reconcile cycle.

The fix routes the client build error through the same `thresholdAdjustedReadyCondition` logic used by the probe path. If the cluster was `Ready=True` and the error clears within `ClusterFailureThreshold`, the condition is retained and no failover fires. If the failure persists beyond the threshold, `Ready=False` is written as before.

The `setStatusCollectionFailedCondition` helper is removed since it is now unused.

**Which issue(s) this PR fixes**:

Fixes #7408

**Special notes for your reviewer**:

The behavior table from the issue:

| Scenario | Before | After |
|---|---|---|
| First failed reconcile; cluster was `Ready=True` | Immediate `Ready=False` | `Ready=True` retained; threshold timer starts |
| Failure resolves within `ClusterFailureThreshold` | `Ready=False` written; flips back next pass | `Ready=True` retained throughout; no churn |
| Failure persists beyond `ClusterFailureThreshold` | `Ready=False` (already written) | `Ready=False` written |
| Cold start (cache empty after controller restart) | Immediate `Ready=False` | Same — no protection without prior cache entry |

Two new test cases added to `TestClusterStatusController_syncClusterStatus`:
- `ClusterClientSetFunc error within threshold retains Ready=True`
- `ClusterClientSetFunc error beyond threshold writes Ready=False`

**Does this PR introduce a user-facing change?**:

```release-note
`karmada-controller-manager`: Fixed the issue that a transient `ClusterClientSetFunc` failure (e.g. missing `SecretRef` during credential rotation) would immediately set the cluster `Ready=False` without respecting `ClusterFailureThreshold`, potentially triggering unnecessary workload failover.
```