### PR TITLE
fix(karmadactl): make join and unjoin idempotent

### DIFF
--- a/pkg/karmadactl/join/join.go
+++ b/pkg/karmadactl/join/join.go
@@ -233,7 +233,7 @@ func (j *CommandJoinOption) RunJoinCluster(controlPlaneRestConfig, clusterConfig
 		return err
 	}
 
-	if err = registerOption.Validate(karmadaClient, false); err != nil {
+	if err = registerOption.Validate(karmadaClient, true); err != nil {
 		return err
 	}
 

--- a/pkg/karmadactl/join/join_test.go
+++ b/pkg/karmadactl/join/join_test.go
@@ -113,29 +113,23 @@ func TestRunJoinCluster(t *testing.T) {
 			joinOpts:            &CommandJoinOption{},
 			controlPlaneRestCfg: &rest.Config{},
 			clusterCfg:          &rest.Config{},
+			controlKubeClient:   fakeclientset.NewClientset(),
 			clusterKubeClient:   fakeclientset.NewClientset(),
 			karmadaClient:       fakekarmadaclient.NewClientset(),
 			clusterID:           types.UID(uuid.New().String()),
-			prep: func(karmadaClient karmadaclientset.Interface, _, clusterKubeClient kubeclient.Interface, opts *CommandJoinOption, clusterID types.UID, clusterName string) error {
-				opts.ClusterName = clusterName
-				if err := createNamespace(metav1.NamespaceSystem, clusterID, clusterKubeClient); err != nil {
+			prep: func(karmadaClient karmadaclientset.Interface, controlKubeClient, clusterKubeClient kubeclient.Interface, opts *CommandJoinOption, clusterID types.UID, clusterName string) error {
+				if err := prepJoinCluster(karmadaClient, controlKubeClient, clusterKubeClient, opts, clusterID, clusterName); err != nil {
 					return err
 				}
 				if err := createCluster(clusterName, clusterID, karmadaClient); err != nil {
 					return err
-				}
-				clusterKubeClientBuilder = func(*rest.Config) kubeclient.Interface {
-					return clusterKubeClient
-				}
-				karmadaClientBuilder = func(*rest.Config) karmadaclientset.Interface {
-					return karmadaClient
 				}
 				return nil
 			},
 			verify: func(karmadaclientset.Interface, kubeclient.Interface, kubeclient.Interface, *CommandJoinOption, types.UID) error {
 				return nil
 			},
-			wantErr: true,
+			wantErr: false,
 			errMsg: func(opts *CommandJoinOption, clusterID types.UID) string {
 				return fmt.Sprintf("the cluster ID %s or the cluster name %s has been registered", clusterID, opts.ClusterName)
 			},

--- a/pkg/karmadactl/unjoin/unjoin.go
+++ b/pkg/karmadactl/unjoin/unjoin.go
@@ -200,7 +200,7 @@ func (j *CommandUnjoinOption) RunUnJoinCluster(controlPlaneRestConfig, clusterCo
 
 	target, err := controlPlaneKarmadaClient.ClusterV1alpha1().Clusters().Get(context.TODO(), j.ClusterName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		return fmt.Errorf("no cluster object %s found in karmada control Plane", j.ClusterName)
+		return nil
 	}
 	if err != nil {
 		klog.Errorf("Failed to get cluster object. cluster name: %s, error: %v", j.ClusterName, err)

--- a/pkg/karmadactl/unjoin/unjoin_test.go
+++ b/pkg/karmadactl/unjoin/unjoin_test.go
@@ -112,6 +112,26 @@ func TestRunUnJoinCluster(t *testing.T) {
 		errMsg                                string
 	}{
 		{
+			name:                   "RunUnJoinCluster_ClusterObjectNotFound_AlreadyUnjoined",
+			unjoinOpts:             &CommandUnjoinOption{ClusterName: "member1"},
+			controlPlaneRestConfig: &rest.Config{},
+			controlKubeClient:      fakeclientset.NewClientset(),
+			karmadaClient:          fakekarmadaclient.NewClientset(),
+			prep: func(controlKubeClient kubeclient.Interface, _ kubeclient.Interface, karmadaClient karmadaclientset.Interface, _ *CommandUnjoinOption) error {
+				controlPlaneKarmadaClientBuilder = func(*rest.Config) karmadaclientset.Interface {
+					return karmadaClient
+				}
+				controlPlaneKubeClientBuilder = func(*rest.Config) kubeclient.Interface {
+					return controlKubeClient
+				}
+				return nil
+			},
+			verify: func(kubeclient.Interface, kubeclient.Interface, karmadaclientset.Interface, *CommandUnjoinOption) error {
+				return nil
+			},
+			wantErr: false,
+		},
+		{
 			name:                   "RunUnJoinCluster_DeleteClusterObject_PullModeMemberCluster",
 			unjoinOpts:             &CommandUnjoinOption{ClusterName: "member1"},
 			controlPlaneRestConfig: &rest.Config{},

--- a/pkg/karmadactl/util/cluster.go
+++ b/pkg/karmadactl/util/cluster.go
@@ -43,7 +43,7 @@ func DeleteClusterObject(controlPlaneKubeClient kubeclient.Interface, controlPla
 
 	err := controlPlaneKarmadaClient.ClusterV1alpha1().Clusters().Delete(context.TODO(), clusterName, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
-		return fmt.Errorf("no cluster object %s found in karmada control Plane", clusterName)
+		return nil
 	}
 	if err != nil {
 		klog.Errorf("Failed to delete cluster object. cluster name: %s, error: %v", clusterName, err)

--- a/pkg/util/cluster.go
+++ b/pkg/util/cluster.go
@@ -152,7 +152,10 @@ func CreateClusterObject(controlPlaneClient karmadaclientset.Interface, clusterO
 	}
 
 	if exist {
-		return cluster, fmt.Errorf("cluster(%s) already exist", clusterObj.Name)
+		if clusterObj.Spec.ID != "" && cluster.Spec.ID == clusterObj.Spec.ID {
+			return cluster, nil
+		}
+		return cluster, fmt.Errorf("cluster(%s) already exists with a different ID", clusterObj.Name)
 	}
 
 	if cluster, err = createCluster(controlPlaneClient, clusterObj); err != nil {
@@ -174,7 +177,7 @@ func CreateOrUpdateClusterObject(controlPlaneClient karmadaclientset.Interface, 
 		clusterCopy := cluster.DeepCopy()
 		mutate(cluster)
 		if reflect.DeepEqual(clusterCopy.Spec, cluster.Spec) {
-			klog.Warningf("Cluster(%s) already exist and newest", clusterObj.Name)
+			klog.Warningf("Cluster(%s) already exists and is up to date", clusterObj.Name)
 			return cluster, nil
 		}
 
@@ -212,6 +215,16 @@ func GetClusterWithKarmadaClient(client karmadaclientset.Interface, name string)
 func createCluster(controlPlaneClient karmadaclientset.Interface, cluster *clusterv1alpha1.Cluster) (*clusterv1alpha1.Cluster, error) {
 	newCluster, err := controlPlaneClient.ClusterV1alpha1().Clusters().Create(context.TODO(), cluster, metav1.CreateOptions{})
 	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			existingCluster, getErr := controlPlaneClient.ClusterV1alpha1().Clusters().Get(context.TODO(), cluster.Name, metav1.GetOptions{})
+			if getErr != nil {
+				return nil, getErr
+			}
+			if cluster.Spec.ID != "" && existingCluster.Spec.ID == cluster.Spec.ID {
+				return existingCluster, nil
+			}
+			return nil, fmt.Errorf("cluster(%s) already exists with a different ID", cluster.Name)
+		}
 		klog.Warningf("Failed to create cluster(%s). error: %v", cluster.Name, err)
 		return nil, err
 	}

--- a/pkg/util/cluster_test.go
+++ b/pkg/util/cluster_test.go
@@ -53,6 +53,11 @@ func withSyncMode(cluster *clusterv1alpha1.Cluster, syncMode clusterv1alpha1.Clu
 	return cluster
 }
 
+func withClusterID(cluster *clusterv1alpha1.Cluster, id string) *clusterv1alpha1.Cluster {
+	cluster.Spec.ID = id
+	return cluster
+}
+
 func TestCreateOrUpdateClusterObject(t *testing.T) {
 	type args struct {
 		controlPlaneClient karmadaclientset.Interface
@@ -404,12 +409,21 @@ func TestCreateClusterObject(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "cluster exits, and return error",
+			name: "cluster exists with same id, and return existing cluster",
 			args: args{
-				controlPlaneClient: karmadaclientsetfake.NewClientset(newCluster("test")),
-				clusterObj:         newCluster("test"),
+				controlPlaneClient: karmadaclientsetfake.NewClientset(withClusterID(newCluster("test"), "test-id")),
+				clusterObj:         withClusterID(newCluster("test"), "test-id"),
 			},
-			want:    newCluster("test"),
+			want:    withClusterID(newCluster("test"), "test-id"),
+			wantErr: false,
+		},
+		{
+			name: "cluster exists with different id, and return error",
+			args: args{
+				controlPlaneClient: karmadaclientsetfake.NewClientset(withClusterID(newCluster("test"), "existing-id")),
+				clusterObj:         withClusterID(newCluster("test"), "new-id"),
+			},
+			want:    withClusterID(newCluster("test"), "existing-id"),
 			wantErr: true,
 		},
 		{


### PR DESCRIPTION
### **What type of PR is this?**

/kind bug

### **What this PR does / why we need it**:

This PR makes karmadactl join and unjoin idempotent for common retry scenarios.

**Problem summary:**
1. join failed on retries when the same cluster was already registered, even when the cluster name and cluster ID matched.
2. unjoin failed on retries when the cluster object had already been deleted, returning a not found error instead of treating it as already unjoined.

**What changed:**
1. Updated join flow to allow re-entry for the same cluster identity.
2. Updated cluster creation helpers to treat already exists as success when the existing cluster ID matches.
3. Updated unjoin flow to treat not found as success.
4. Updated cluster deletion helper to return success on not found.
5. Updated join unit tests to expect success for duplicate join of the same cluster identity.
6. Added unjoin unit test coverage for the not found idempotency case.

**Why this is needed:**
1. CLI operations should be safe to retry after partial failures or interrupted runs.
2. This aligns karmadactl behavior with Kubernetes idempotent API semantics for create and delete workflows.

### **Which issue(s) this PR fixes**:

Fixes #4779

### **Special notes for your reviewer**:

**Test report:**
1. go test ./pkg/karmadactl/join -count=1
2. go test ./pkg/karmadactl/unjoin -count=1

Both passed locally.

**Scope notes:**
1. The change is intentionally localized to join and unjoin command paths plus their helper logic and tests.
2. No scheduler, metrics-adapter, or broad architectural behavior is modified.

### **Does this PR introduce a user-facing change?**:

```release-note
karmadactl: Made join and unjoin idempotent. Retrying join for an already-registered cluster with the same identity now succeeds, and retrying unjoin after the cluster object is already removed now succeeds.
```