### PR TITLE
admission webhook: add overflow affinities validation

### DIFF
--- a/pkg/util/policy.go
+++ b/pkg/util/policy.go
@@ -25,3 +25,20 @@ func IsLazyActivationEnabled(activationPreference policyv1alpha1.ActivationPrefe
 	}
 	return activationPreference == policyv1alpha1.LazyActivation
 }
+
+// IsOverflowSchedulingAllowed judges whether the replica scheduling strategy allows overflow.
+// Overflow is allowed with 'Divided' replica scheduling type combined with 'Aggregated' or 'Weighted' (with dynamic weight) preference.
+func IsOverflowSchedulingAllowed(replicaScheduling *policyv1alpha1.ReplicaSchedulingStrategy) bool {
+	if replicaScheduling == nil || replicaScheduling.ReplicaSchedulingType != policyv1alpha1.ReplicaSchedulingTypeDivided {
+		return false
+	}
+
+	switch replicaScheduling.ReplicaDivisionPreference {
+	case policyv1alpha1.ReplicaDivisionPreferenceAggregated:
+		return true
+	case policyv1alpha1.ReplicaDivisionPreferenceWeighted:
+		return replicaScheduling.WeightPreference != nil && replicaScheduling.WeightPreference.DynamicWeight != ""
+	default:
+		return false
+	}
+}

--- a/pkg/util/policy_test.go
+++ b/pkg/util/policy_test.go
@@ -54,3 +54,78 @@ func TestIsLazyActivationEnabled(t *testing.T) {
 		})
 	}
 }
+
+func TestIsOverflowSupport(t *testing.T) {
+	tests := []struct {
+		name     string
+		strategy *policyv1alpha1.ReplicaSchedulingStrategy
+		expected bool
+	}{
+		{
+			name:     "nil strategy",
+			strategy: nil,
+			expected: false,
+		},
+		{
+			name: "Duplicated scheduling type",
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{
+				ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDuplicated,
+			},
+			expected: false,
+		},
+		{
+			name: "Divided with Aggregated preference",
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{
+				ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
+				ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceAggregated,
+			},
+			expected: true,
+		},
+		{
+			name: "Divided with Weighted and dynamic weight",
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{
+				ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
+				ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceWeighted,
+				WeightPreference: &policyv1alpha1.ClusterPreferences{
+					DynamicWeight: policyv1alpha1.DynamicWeightByAvailableReplicas,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Divided with Weighted but nil WeightPreference",
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{
+				ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
+				ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceWeighted,
+			},
+			expected: false,
+		},
+		{
+			name: "Divided with Weighted but empty DynamicWeight",
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{
+				ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
+				ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceWeighted,
+				WeightPreference: &policyv1alpha1.ClusterPreferences{
+					StaticWeightList: []policyv1alpha1.StaticClusterWeight{
+						{TargetCluster: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member1"}}, Weight: 1},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Divided with empty ReplicaDivisionPreference",
+			strategy: &policyv1alpha1.ReplicaSchedulingStrategy{
+				ReplicaSchedulingType: policyv1alpha1.ReplicaSchedulingTypeDivided,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsOverflowSchedulingAllowed(tt.strategy)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/validate/content"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
-	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 
@@ -104,6 +104,14 @@ func ValidatePlacement(placement policyv1alpha1.Placement, fldPath *field.Path) 
 
 	if placement.ClusterAffinity != nil && placement.ClusterAffinities != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath, placement, "clusterAffinities cannot co-exist with clusterAffinity"))
+	}
+
+	// OverflowAffinities can only be used with dynamic weight or aggregated scheduling.
+	allowOverflowScheduling := util.IsOverflowSchedulingAllowed(placement.ReplicaScheduling)
+	for index, affinity := range placement.ClusterAffinities {
+		if affinity.OverflowAffinities != nil && !allowOverflowScheduling {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("clusterAffinities").Index(index).Child("overflowAffinities"), affinity.OverflowAffinities, "overflowAffinities can only be used together with dynamic weight or aggregated scheduling"))
+		}
 	}
 
 	allErrs = append(allErrs, ValidateClusterAffinity(placement.ClusterAffinity, fldPath.Child("clusterAffinity"))...)
@@ -180,7 +188,7 @@ func ValidateClusterAffinities(affinities []policyv1alpha1.ClusterAffinityTerm, 
 
 	affinityNames := make(map[string]bool)
 	for index := range affinities {
-		for _, err := range validation.IsQualifiedName(affinities[index].AffinityName) {
+		for _, err := range content.IsLabelKey(affinities[index].AffinityName) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Index(index), affinities[index].AffinityName, err))
 		}
 		if _, exist := affinityNames[affinities[index].AffinityName]; exist {
@@ -190,7 +198,44 @@ func ValidateClusterAffinities(affinities []policyv1alpha1.ClusterAffinityTerm, 
 		}
 
 		allErrs = append(allErrs, ValidateClusterAffinity(&affinities[index].ClusterAffinity, fldPath.Index(index))...)
+		allErrs = append(allErrs, ValidateOverflowAffinities(affinities[index], fldPath.Index(index))...)
 	}
+	return allErrs
+}
+
+// ValidateOverflowAffinities validates the overflowAffinities of a ClusterAffinityTerm.
+// It checks:
+// 1. OverflowAffinities can only be set when the inline ClusterAffinity is non-empty.
+// 2. Each overflow affinity name must be a valid label key.
+// 3. Overflow affinity names must be unique and must not duplicate the primary group's affinityName.
+// 4. Each overflow affinity's ClusterAffinity is validated recursively.
+func ValidateOverflowAffinities(affinity policyv1alpha1.ClusterAffinityTerm, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	if affinity.OverflowAffinities == nil {
+		return nil
+	}
+
+	// OverflowAffinities can only be set when ClusterAffinity is specified.
+	if emptyClusterAffinity(affinity.ClusterAffinity) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("overflowAffinities"), affinity.OverflowAffinities, "overflowAffinities can only be used together with the inline ClusterAffinity"))
+	}
+
+	// Validate overflow affinity names are unique.
+	overflowNames := sets.New[string](affinity.AffinityName)
+	for oi, oa := range affinity.OverflowAffinities {
+		for _, err := range content.IsLabelKey(oa.AffinityName) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("overflowAffinities").Index(oi).Child("affinityName"), oa.AffinityName, err))
+		}
+		if overflowNames.Has(oa.AffinityName) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("overflowAffinities").Index(oi).Child("affinityName"), oa.AffinityName, "overflow affinity name must be unique and must not duplicate the primary group's affinityName"))
+		} else {
+			overflowNames.Insert(oa.AffinityName)
+		}
+
+		allErrs = append(allErrs, ValidateClusterAffinity(&affinity.OverflowAffinities[oi].ClusterAffinity, fldPath.Child("overflowAffinities").Index(oi))...)
+	}
+
 	return allErrs
 }
 
@@ -399,6 +444,20 @@ func emptyOverrides(overriders policyv1alpha1.Overriders) bool {
 		return false
 	}
 	return true
+}
+
+// emptyClusterAffinity checks if the cluster affinity is empty. An empty cluster affinity means it doesn't have any selection criteria.
+func emptyClusterAffinity(affinity policyv1alpha1.ClusterAffinity) bool {
+	if affinity.LabelSelector != nil {
+		return false
+	}
+	if affinity.FieldSelector != nil {
+		return false
+	}
+	if len(affinity.ClusterNames) != 0 {
+		return false
+	}
+	return len(affinity.ExcludeClusters) == 0
 }
 
 // ValidateOverrideRules validates the overrideRules of override policy.

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -1385,3 +1385,247 @@ func TestValidateWorkloadAffinity(t *testing.T) {
 		})
 	}
 }
+
+func TestValidatePlacement(t *testing.T) {
+	tests := []struct {
+		name               string
+		placement          policyv1alpha1.Placement
+		expectedErrCount   int
+		expectedErrStrings []string
+	}{
+		{
+			name: "clusterAffinity and clusterAffinities cannot co-exist",
+			placement: policyv1alpha1.Placement{
+				ClusterAffinity:   &policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member1"}},
+				ClusterAffinities: []policyv1alpha1.ClusterAffinityTerm{{AffinityName: "group1"}},
+			},
+			expectedErrCount:   1,
+			expectedErrStrings: []string{"clusterAffinities cannot co-exist with clusterAffinity"},
+		},
+		{
+			name: "overflowAffinities rejected when replicaScheduling is nil",
+			placement: policyv1alpha1.Placement{
+				ClusterAffinities: []policyv1alpha1.ClusterAffinityTerm{
+					{
+						AffinityName:    "primary",
+						ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member1"}},
+						OverflowAffinities: []policyv1alpha1.OverflowClusterAffinity{
+							{AffinityName: "overflow-1", ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member2"}}},
+						},
+					},
+				},
+			},
+			expectedErrCount:   1,
+			expectedErrStrings: []string{"overflowAffinities can only be used together with dynamic weight or aggregated scheduling"},
+		},
+		{
+			name: "overflowAffinities rejected with static weight scheduling",
+			placement: policyv1alpha1.Placement{
+				ClusterAffinities: []policyv1alpha1.ClusterAffinityTerm{
+					{
+						AffinityName:    "primary",
+						ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member1"}},
+						OverflowAffinities: []policyv1alpha1.OverflowClusterAffinity{
+							{AffinityName: "overflow-1", ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member2"}}},
+						},
+					},
+				},
+				ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+					ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
+					ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceWeighted,
+					WeightPreference: &policyv1alpha1.ClusterPreferences{
+						StaticWeightList: []policyv1alpha1.StaticClusterWeight{{TargetCluster: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member1"}}, Weight: 1}},
+					},
+				},
+			},
+			expectedErrCount:   1,
+			expectedErrStrings: []string{"overflowAffinities can only be used together with dynamic weight or aggregated scheduling"},
+		},
+		{
+			name: "overflowAffinities allowed with dynamic weight scheduling",
+			placement: policyv1alpha1.Placement{
+				ClusterAffinities: []policyv1alpha1.ClusterAffinityTerm{
+					{
+						AffinityName:    "primary",
+						ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member1"}},
+						OverflowAffinities: []policyv1alpha1.OverflowClusterAffinity{
+							{AffinityName: "overflow-1", ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member2"}}},
+						},
+					},
+				},
+				ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+					ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
+					ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceWeighted,
+					WeightPreference: &policyv1alpha1.ClusterPreferences{
+						DynamicWeight: policyv1alpha1.DynamicWeightByAvailableReplicas,
+					},
+				},
+			},
+			expectedErrCount: 0,
+		},
+		{
+			name: "overflowAffinities allowed with aggregated scheduling",
+			placement: policyv1alpha1.Placement{
+				ClusterAffinities: []policyv1alpha1.ClusterAffinityTerm{
+					{
+						AffinityName:    "primary",
+						ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member1"}},
+						OverflowAffinities: []policyv1alpha1.OverflowClusterAffinity{
+							{AffinityName: "overflow-1", ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member2"}}},
+						},
+					},
+				},
+				ReplicaScheduling: &policyv1alpha1.ReplicaSchedulingStrategy{
+					ReplicaSchedulingType:     policyv1alpha1.ReplicaSchedulingTypeDivided,
+					ReplicaDivisionPreference: policyv1alpha1.ReplicaDivisionPreferenceAggregated,
+				},
+			},
+			expectedErrCount: 0,
+		},
+		{
+			name: "multiple affinities, only one has overflow rejected",
+			placement: policyv1alpha1.Placement{
+				ClusterAffinities: []policyv1alpha1.ClusterAffinityTerm{
+					{
+						AffinityName:    "group1",
+						ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member1"}},
+					},
+					{
+						AffinityName:    "group2",
+						ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member2"}},
+						OverflowAffinities: []policyv1alpha1.OverflowClusterAffinity{
+							{AffinityName: "overflow-1", ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member3"}}},
+						},
+					},
+				},
+			},
+			expectedErrCount:   1,
+			expectedErrStrings: []string{"overflowAffinities can only be used together with dynamic weight or aggregated scheduling"},
+		},
+		{
+			name: "no overflow affinities with unsupported scheduling, no error",
+			placement: policyv1alpha1.Placement{
+				ClusterAffinities: []policyv1alpha1.ClusterAffinityTerm{
+					{
+						AffinityName:    "primary",
+						ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member1"}},
+					},
+				},
+			},
+			expectedErrCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := ValidatePlacement(tt.placement, field.NewPath("spec").Child("placement"))
+			assert.Len(t, errs, tt.expectedErrCount)
+			if len(tt.expectedErrStrings) > 0 {
+				if len(errs) == 0 {
+					t.Fatalf("expected errors containing:\n  %v\nbut got no error", tt.expectedErrStrings)
+				}
+				errStr := errs.ToAggregate().Error()
+				for _, expected := range tt.expectedErrStrings {
+					assert.Contains(t, errStr, expected)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateOverflowAffinities(t *testing.T) {
+	tests := []struct {
+		name               string
+		affinity           policyv1alpha1.ClusterAffinityTerm
+		expectedErrCount   int
+		expectedErrStrings []string
+	}{
+		{
+			name: "no overflow affinities, no error",
+			affinity: policyv1alpha1.ClusterAffinityTerm{
+				AffinityName:    "primary",
+				ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member1"}},
+			},
+			expectedErrCount: 0,
+		},
+		{
+			name: "valid overflow affinities",
+			affinity: policyv1alpha1.ClusterAffinityTerm{
+				AffinityName:    "primary",
+				ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member1"}},
+				OverflowAffinities: []policyv1alpha1.OverflowClusterAffinity{
+					{AffinityName: "overflow-1", ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member2"}}},
+					{AffinityName: "overflow-2", ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member3"}}},
+				},
+			},
+			expectedErrCount: 0,
+		},
+		{
+			name: "overflow affinities without ClusterAffinity",
+			affinity: policyv1alpha1.ClusterAffinityTerm{
+				AffinityName: "primary",
+				OverflowAffinities: []policyv1alpha1.OverflowClusterAffinity{
+					{AffinityName: "overflow-1", ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member2"}}},
+				},
+			},
+			expectedErrCount:   1,
+			expectedErrStrings: []string{"overflowAffinities can only be used together with the inline ClusterAffinity"},
+		},
+		{
+			name: "duplicate overflow affinity names",
+			affinity: policyv1alpha1.ClusterAffinityTerm{
+				AffinityName:    "primary",
+				ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member1"}},
+				OverflowAffinities: []policyv1alpha1.OverflowClusterAffinity{
+					{AffinityName: "overflow-1", ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member2"}}},
+					{AffinityName: "overflow-1", ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member3"}}},
+				},
+			},
+			expectedErrCount:   1,
+			expectedErrStrings: []string{"overflow affinity name must be unique and must not duplicate the primary group's affinityName"},
+		},
+		{
+			name: "overflow affinity name duplicates primary group's affinityName",
+			affinity: policyv1alpha1.ClusterAffinityTerm{
+				AffinityName:    "primary",
+				ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member1"}},
+				OverflowAffinities: []policyv1alpha1.OverflowClusterAffinity{
+					{AffinityName: "primary", ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member2"}}},
+				},
+			},
+			expectedErrCount:   1,
+			expectedErrStrings: []string{"overflow affinity name must be unique and must not duplicate the primary group's affinityName"},
+		},
+		{
+			name: "multiple errors: empty ClusterAffinity and duplicate names",
+			affinity: policyv1alpha1.ClusterAffinityTerm{
+				AffinityName: "primary",
+				OverflowAffinities: []policyv1alpha1.OverflowClusterAffinity{
+					{AffinityName: "overflow-1", ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member2"}}},
+					{AffinityName: "overflow-1", ClusterAffinity: policyv1alpha1.ClusterAffinity{ClusterNames: []string{"member3"}}},
+				},
+			},
+			expectedErrCount: 2,
+			expectedErrStrings: []string{
+				"overflowAffinities can only be used together with the inline ClusterAffinity",
+				"overflow affinity name must be unique and must not duplicate the primary group's affinityName",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := ValidateOverflowAffinities(tt.affinity, field.NewPath("spec").Child("placement").Child("clusterAffinities").Index(0))
+			assert.Len(t, errs, tt.expectedErrCount)
+			if len(tt.expectedErrStrings) > 0 {
+				if len(errs) == 0 {
+					t.Fatalf("expected errors containing:\n  %v\nbut got no error", tt.expectedErrStrings)
+				}
+				errStr := errs.ToAggregate().Error()
+				for _, expected := range tt.expectedErrStrings {
+					assert.Contains(t, errStr, expected)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

- add a webhook for the (Cluster)PropagationPolicy resource to restrict that spec.placement.clusterAffinities[i].overflowAffinities can only be used together with the inline ClusterAffinity and must not be set independently.
- Adding a validation to restrict that overflowAffinities can only be used with the Divided replica scheduling type combined with dynamicWeight/Aggregated

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Part of #7390

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-webhook`: Added `overflowAffinities` validation for `spec.placement.clusterAffinities` in `PropagationPolicy`/`ClusterPropagationPolicy`.
```

