### PR TITLE
Cleanup the unapplicable nolint markers

### DIFF
--- a/operator/pkg/karmadaresource/apiservice/apiservice_test.go
+++ b/operator/pkg/karmadaresource/apiservice/apiservice_test.go
@@ -38,9 +38,6 @@ func TestEnsureAggregatedAPIService(t *testing.T) {
 	caTestData := "test-ca-data"
 	caBundle := base64.StdEncoding.EncodeToString([]byte(caTestData))
 
-	//nolint:staticcheck
-	// Note: disable `deprecation` check SA1019 until we bump to Kuberentes v1.36.
-	// Tracked by: https://github.com/karmada-io/karmada/issues/7009
 	fakeAggregatorClient := fakeAggregator.NewSimpleClientset()
 	fakeClient := fakeclientset.NewClientset()
 	err := EnsureAggregatedAPIService(
@@ -70,9 +67,6 @@ func TestAggregatedAPIService(t *testing.T) {
 	caTestData := "test-ca-data"
 	caBundle := base64.StdEncoding.EncodeToString([]byte(caTestData))
 
-	//nolint:staticcheck
-	// Note: disable `deprecation` check SA1019 until we bump to Kuberentes v1.36.
-	// Tracked by: https://github.com/karmada-io/karmada/issues/7009
 	fakeClient := fakeAggregator.NewSimpleClientset()
 	err := aggregatedAPIService(fakeClient, name, namespace, caBundle)
 	if err != nil {
@@ -160,9 +154,6 @@ func TestEnsureMetricsAdapterAPIService(t *testing.T) {
 	caTestData := "test-ca-data"
 	caBundle := base64.StdEncoding.EncodeToString([]byte(caTestData))
 
-	//nolint:staticcheck
-	// Note: disable `deprecation` check SA1019 until we bump to Kuberentes v1.36.
-	// Tracked by: https://github.com/karmada-io/karmada/issues/7009
 	fakeAggregatorClient := fakeAggregator.NewSimpleClientset()
 	fakeClient := fakeclientset.NewClientset()
 	err := EnsureMetricsAdapterAPIService(
@@ -192,9 +183,6 @@ func TestKarmadaMetricsAdapterAPIService(t *testing.T) {
 	caTestData := "test-ca-data"
 	caBundle := base64.StdEncoding.EncodeToString([]byte(caTestData))
 
-	//nolint:staticcheck
-	// Note: disable `deprecation` check SA1019 until we bump to Kuberentes v1.36.
-	// Tracked by: https://github.com/karmada-io/karmada/issues/7009
 	fakeAggregatorClient := fakeAggregator.NewSimpleClientset()
 	err := karmadaMetricsAdapterAPIService(fakeAggregatorClient, name, namespace, caBundle)
 	if err != nil {
@@ -299,9 +287,6 @@ func TestEnsureSearchAPIService(t *testing.T) {
 	caTestData := "test-ca-data"
 	caBundle := base64.StdEncoding.EncodeToString([]byte(caTestData))
 
-	//nolint:staticcheck
-	// Note: disable `deprecation` check SA1019 until we bump to Kuberentes v1.36.
-	// Tracked by: https://github.com/karmada-io/karmada/issues/7009
 	fakeAggregatorClient := fakeAggregator.NewSimpleClientset()
 	fakeClient := fakeclientset.NewClientset()
 	err := EnsureSearchAPIService(
@@ -331,9 +316,6 @@ func TestKarmadaSearchAPIService(t *testing.T) {
 	caTestData := "test-ca-data"
 	caBundle := base64.StdEncoding.EncodeToString([]byte(caTestData))
 
-	//nolint:staticcheck
-	// Note: disable `deprecation` check SA1019 until we bump to Kuberentes v1.36.
-	// Tracked by: https://github.com/karmada-io/karmada/issues/7009
 	fakeClient := fakeAggregator.NewSimpleClientset()
 	err := karmadaSearchAPIService(fakeClient, name, namespace, caBundle)
 	if err != nil {

--- a/operator/pkg/util/apiclient/wait_test.go
+++ b/operator/pkg/util/apiclient/wait_test.go
@@ -126,9 +126,6 @@ func TestWaitForAPIService(t *testing.T) {
 					Version: "v1beta1",
 				},
 			},
-			//nolint:staticcheck
-			// Note: disable `deprecation` check SA1019 until we bump to Kuberentes v1.36.
-			// Tracked by: https://github.com/karmada-io/karmada/issues/7009
 			client: fakeAggregator.NewSimpleClientset(),
 			prep: func(client aggregator.Interface, _ *apiregistrationv1.APIService) error {
 				aggregateClientFromConfigBuilder = func(*rest.Config) (aggregator.Interface, error) {
@@ -156,9 +153,6 @@ func TestWaitForAPIService(t *testing.T) {
 					Version: "v1beta1",
 				},
 			},
-			//nolint:staticcheck
-			// Note: disable `deprecation` check SA1019 until we bump to Kuberentes v1.36.
-			// Tracked by: https://github.com/karmada-io/karmada/issues/7009
 			client: fakeAggregator.NewSimpleClientset(),
 			prep: func(client aggregator.Interface, apiService *apiregistrationv1.APIService) error {
 				apiServiceCreated, err := client.ApiregistrationV1().APIServices().Create(context.TODO(), apiService, metav1.CreateOptions{})

--- a/pkg/karmadactl/addons/metricsadapter/metricsadapter_test.go
+++ b/pkg/karmadactl/addons/metricsadapter/metricsadapter_test.go
@@ -95,11 +95,8 @@ func TestStatus(t *testing.T) {
 			name: "Status_WithoutAAAPIService_AddonDisabledStatus",
 			listOpts: &addoninit.CommandAddonsListOption{
 				GlobalCommandOptions: addoninit.GlobalCommandOptions{
-					Namespace:     namespace,
-					KubeClientSet: fakeclientset.NewClientset(),
-					//nolint:staticcheck
-					// Note: disable `deprecation` check SA1019 until we bump to Kuberentes v1.36.
-					// Tracked by: https://github.com/karmada-io/karmada/issues/7009
+					Namespace:                  namespace,
+					KubeClientSet:              fakeclientset.NewClientset(),
 					KarmadaAggregatorClientSet: fakeAggregator.NewSimpleClientset(),
 				},
 			},
@@ -112,11 +109,8 @@ func TestStatus(t *testing.T) {
 			name: "Status_WithoutAvailableAPIService_AddonUnhealthyStatus",
 			listOpts: &addoninit.CommandAddonsListOption{
 				GlobalCommandOptions: addoninit.GlobalCommandOptions{
-					Namespace:     namespace,
-					KubeClientSet: fakeclientset.NewClientset(),
-					//nolint:staticcheck
-					// Note: disable `deprecation` check SA1019 until we bump to Kuberentes v1.36.
-					// Tracked by: https://github.com/karmada-io/karmada/issues/7009
+					Namespace:                  namespace,
+					KubeClientSet:              fakeclientset.NewClientset(),
 					KarmadaAggregatorClientSet: fakeAggregator.NewSimpleClientset(),
 				},
 			},
@@ -137,11 +131,8 @@ func TestStatus(t *testing.T) {
 			name: "Status_WithAllAPIServicesAreAvailable_AddonEnabledStatus",
 			listOpts: &addoninit.CommandAddonsListOption{
 				GlobalCommandOptions: addoninit.GlobalCommandOptions{
-					Namespace:     namespace,
-					KubeClientSet: fakeclientset.NewClientset(),
-					//nolint:staticcheck
-					// Note: disable `deprecation` check SA1019 until we bump to Kuberentes v1.36.
-					// Tracked by: https://github.com/karmada-io/karmada/issues/7009
+					Namespace:                  namespace,
+					KubeClientSet:              fakeclientset.NewClientset(),
 					KarmadaAggregatorClientSet: fakeAggregator.NewSimpleClientset(),
 				},
 			},

--- a/pkg/karmadactl/addons/search/search_test.go
+++ b/pkg/karmadactl/addons/search/search_test.go
@@ -95,11 +95,8 @@ func TestKarmadaSearchAddonStatus(t *testing.T) {
 			name: "Status_WithoutAAAPIServiceOnKarmadaControlplane_AddonDisabledStatus",
 			listOpts: &addoninit.CommandAddonsListOption{
 				GlobalCommandOptions: addoninit.GlobalCommandOptions{
-					Namespace:     namespace,
-					KubeClientSet: fakeclientset.NewClientset(),
-					//nolint:staticcheck
-					// Note: disable `deprecation` check SA1019 until we bump to Kuberentes v1.36.
-					// Tracked by: https://github.com/karmada-io/karmada/issues/7009
+					Namespace:                  namespace,
+					KubeClientSet:              fakeclientset.NewClientset(),
 					KarmadaAggregatorClientSet: fakeAggregator.NewSimpleClientset(),
 				},
 			},
@@ -112,11 +109,8 @@ func TestKarmadaSearchAddonStatus(t *testing.T) {
 			name: "Status_WithoutAvailableAAAPIServiceServiceOnKarmadaControlPlane_AddonUnhealthyStatus",
 			listOpts: &addoninit.CommandAddonsListOption{
 				GlobalCommandOptions: addoninit.GlobalCommandOptions{
-					Namespace:     namespace,
-					KubeClientSet: fakeclientset.NewClientset(),
-					//nolint:staticcheck
-					// Note: disable `deprecation` check SA1019 until we bump to Kuberentes v1.36.
-					// Tracked by: https://github.com/karmada-io/karmada/issues/7009
+					Namespace:                  namespace,
+					KubeClientSet:              fakeclientset.NewClientset(),
 					KarmadaAggregatorClientSet: fakeAggregator.NewSimpleClientset(),
 				},
 			},
@@ -137,11 +131,8 @@ func TestKarmadaSearchAddonStatus(t *testing.T) {
 			name: "Status_WithAllAPIServicesAreAvailable_AddonEnabledStatus",
 			listOpts: &addoninit.CommandAddonsListOption{
 				GlobalCommandOptions: addoninit.GlobalCommandOptions{
-					Namespace:     namespace,
-					KubeClientSet: fakeclientset.NewClientset(),
-					//nolint:staticcheck
-					// Note: disable `deprecation` check SA1019 until we bump to Kuberentes v1.36.
-					// Tracked by: https://github.com/karmada-io/karmada/issues/7009
+					Namespace:                  namespace,
+					KubeClientSet:              fakeclientset.NewClientset(),
 					KarmadaAggregatorClientSet: fakeAggregator.NewSimpleClientset(),
 				},
 			},

--- a/pkg/karmadactl/cmdinit/karmada/check_test.go
+++ b/pkg/karmadactl/cmdinit/karmada/check_test.go
@@ -43,23 +43,17 @@ func TestWaitAPIServiceReady(t *testing.T) {
 		{
 			name:             "WaitAPIServiceReady_AAAPIServiceDoesNotExist_Timeout",
 			aaAPIServiceName: aaAPIServiceName,
-			//nolint:staticcheck
-			// Note: disable `deprecation` check SA1019 until we bump to Kuberentes v1.36.
-			// Tracked by: https://github.com/karmada-io/karmada/issues/7009
-			client:  fakeAggregator.NewSimpleClientset(),
-			timeout: time.Millisecond * 50,
-			prep:    func(aggregator.Interface) error { return nil },
-			wantErr: true,
-			errMsg:  "context deadline exceeded",
+			client:           fakeAggregator.NewSimpleClientset(),
+			timeout:          time.Millisecond * 50,
+			prep:             func(aggregator.Interface) error { return nil },
+			wantErr:          true,
+			errMsg:           "context deadline exceeded",
 		},
 		{
 			name:             "WaitAPIServiceReady_AAAPIServiceIsNotReady_Timeout",
 			aaAPIServiceName: aaAPIServiceName,
-			//nolint:staticcheck
-			// Note: disable `deprecation` check SA1019 until we bump to Kuberentes v1.36.
-			// Tracked by: https://github.com/karmada-io/karmada/issues/7009
-			client:  fakeAggregator.NewSimpleClientset(),
-			timeout: time.Millisecond * 100,
+			client:           fakeAggregator.NewSimpleClientset(),
+			timeout:          time.Millisecond * 100,
 			prep: func(client aggregator.Interface) error {
 				if _, err := createAAAPIService(client, aaAPIServiceName); err != nil {
 					return fmt.Errorf("failed to create %s aaAPIService, got: %v", aaAPIServiceName, err)
@@ -72,11 +66,8 @@ func TestWaitAPIServiceReady(t *testing.T) {
 		{
 			name:             "WaitAPIServiceReady_AAAPIServiceIsReady_ItIsNowReadyToUse",
 			aaAPIServiceName: aaAPIServiceName,
-			//nolint:staticcheck
-			// Note: disable `deprecation` check SA1019 until we bump to Kuberentes v1.36.
-			// Tracked by: https://github.com/karmada-io/karmada/issues/7009
-			client:  fakeAggregator.NewSimpleClientset(),
-			timeout: time.Millisecond * 50,
+			client:           fakeAggregator.NewSimpleClientset(),
+			timeout:          time.Millisecond * 50,
 			prep: func(client aggregator.Interface) error {
 				if err := createAndMarkAAAPIServiceAvailable(client, aaAPIServiceName); err != nil {
 					return fmt.Errorf("failed to create and mark availability status of %s aaAPIService, got: %v", aaAPIServiceName, err)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This pull request removes all `nolint:staticcheck` comments and related deprecation notes regarding `NewSimpleClientset`. 


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
Kubernetes deprecated and undeprecated the `NewSimpleClientset` in v1.35.0 and v1.35.3.

See https://github.com/karmada-io/karmada/issues/7009#issuecomment-4015478142

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

