### PR TITLE
fix(execution): centralize conflict retry and align status updates

### DIFF
--- a/pkg/controllers/execution/execution_controller.go
+++ b/pkg/controllers/execution/execution_controller.go
@@ -82,6 +82,17 @@ type Controller struct {
 func (c *Controller) Reconcile(ctx context.Context, req controllerruntime.Request) (controllerruntime.Result, error) {
 	klog.V(4).InfoS("Reconciling Work", "work", req.NamespacedName.String())
 
+	var result controllerruntime.Result
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var err error
+		result, err = c.reconcile(ctx, req)
+		return err
+	})
+	return result, err
+}
+
+// reconcile performs the actual reconciliation logic for the Work.
+func (c *Controller) reconcile(ctx context.Context, req controllerruntime.Request) (controllerruntime.Result, error) {
 	work := &workv1alpha1.Work{}
 	if err := c.Client.Get(ctx, req.NamespacedName, work); err != nil {
 		// The resource may no longer exist, in which case we stop processing.
@@ -275,9 +286,7 @@ func (c *Controller) syncToClusters(ctx context.Context, clusterName string, wor
 			continue
 		}
 
-		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			return c.tryCreateOrUpdateWorkload(ctx, clusterName, workload)
-		})
+		err = c.tryCreateOrUpdateWorkload(ctx, clusterName, workload)
 		if err != nil {
 			klog.ErrorS(err, "Failed to create or update resource in the given member cluster", "namespace", workload.GetNamespace(), "name", workload.GetName(), "cluster", clusterName)
 			c.eventf(workload, corev1.EventTypeWarning, events.EventReasonSyncWorkloadFailed, "Failed to create or update resource(%s) in member cluster(%s): %v", klog.KObj(workload), clusterName, err)
@@ -379,13 +388,11 @@ func (c *Controller) updateAppliedCondition(ctx context.Context, work *workv1alp
 }
 
 func (c *Controller) setStatusCondition(ctx context.Context, work *workv1alpha1.Work, statusCondition metav1.Condition) error {
-	return retry.RetryOnConflict(retry.DefaultRetry, func() (err error) {
-		_, err = helper.UpdateStatus(ctx, c.Client, work, func() error {
-			meta.SetStatusCondition(&work.Status.Conditions, statusCondition)
-			return nil
-		})
-		return err
+	_, err := helper.UpdateStatusFromExisting(ctx, c.Client, work, func() error {
+		meta.SetStatusCondition(&work.Status.Conditions, statusCondition)
+		return nil
 	})
+	return err
 }
 
 func (c *Controller) eventf(object *unstructured.Unstructured, eventType, reason, messageFmt string, args ...any) {

--- a/pkg/util/helper/status.go
+++ b/pkg/util/helper/status.go
@@ -57,6 +57,35 @@ func UpdateStatus(ctx context.Context, c client.Client, obj client.Object, f con
 	return controllerutil.OperationResultUpdatedStatusOnly, nil
 }
 
+// UpdateStatusFromExisting updates the status subresource of obj.
+//
+// The object is mutated in place by f. If the resulting object is semantically
+// equal to the original object, no update is made and OperationResultNone is
+// returned. Otherwise, the status subresource is updated and
+// OperationResultUpdatedStatusOnly is returned.
+//
+// Note: unlike UpdateStatus, this helper does not re-fetch obj from the API
+// server or informer cache before applying f. It is intended for cases where
+// status should be computed against the object version already observed by the
+// current reconciliation.
+func UpdateStatusFromExisting(ctx context.Context, c client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
+	key := client.ObjectKeyFromObject(obj)
+
+	existing := obj.DeepCopyObject()
+	if err := mutate(f, key, obj); err != nil {
+		return controllerutil.OperationResultNone, err
+	}
+
+	if equality.Semantic.DeepEqual(existing, obj) {
+		return controllerutil.OperationResultNone, nil
+	}
+
+	if err := c.Status().Update(ctx, obj); err != nil {
+		return controllerutil.OperationResultNone, err
+	}
+	return controllerutil.OperationResultUpdatedStatusOnly, nil
+}
+
 // mutate wraps a MutateFn and applies validation to its result.
 func mutate(f controllerutil.MutateFn, key client.ObjectKey, obj client.Object) error {
 	if err := f(); err != nil {

--- a/pkg/util/helper/status_test.go
+++ b/pkg/util/helper/status_test.go
@@ -368,3 +368,261 @@ type mockClient struct {
 func (m *mockClient) Status() client.StatusWriter {
 	return &mockStatusWriter{shouldError: m.shouldError}
 }
+
+type getTrackingClient struct {
+	client.Client
+	getCalls int
+}
+
+func (c *getTrackingClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	c.getCalls++
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func TestUpdateStatusFromExisting(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	tests := []struct {
+		name          string
+		setupObj      *corev1.Pod
+		buildObj      func(*corev1.Pod) *corev1.Pod
+		mutateStatus  func(*corev1.Pod)
+		statusError   bool
+		wrapClient    func(client.Client) client.Client
+		expectedOp    controllerutil.OperationResult
+		expectedError string
+		expectedPhase corev1.PodPhase
+		assertExtra   func(t *testing.T, kubeClient client.Client)
+	}{
+		{
+			name: "successful status update",
+			setupObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			mutateStatus: func(pod *corev1.Pod) {
+				pod.Status.Phase = corev1.PodRunning
+			},
+			statusError:   false,
+			expectedOp:    controllerutil.OperationResultUpdatedStatusOnly,
+			expectedError: "",
+			expectedPhase: corev1.PodRunning,
+		},
+		{
+			name: "status update error",
+			setupObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			mutateStatus: func(pod *corev1.Pod) {
+				pod.Status.Phase = corev1.PodRunning
+			},
+			statusError:   true,
+			expectedOp:    controllerutil.OperationResultNone,
+			expectedError: "Internal error occurred: status update failed",
+		},
+		{
+			name: "no changes needed",
+			setupObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			mutateStatus: func(_ *corev1.Pod) {
+				// No changes to status
+			},
+			statusError:   false,
+			expectedOp:    controllerutil.OperationResultNone,
+			expectedError: "",
+		},
+		{
+			name:     "object not found",
+			setupObj: nil, // Not create the object
+			mutateStatus: func(pod *corev1.Pod) {
+				pod.Status.Phase = corev1.PodRunning
+			},
+			statusError:   false,
+			expectedOp:    controllerutil.OperationResultNone,
+			expectedError: "not found",
+		},
+		{
+			name: "mutation error",
+			setupObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+			},
+			mutateStatus: func(pod *corev1.Pod) {
+				// Simulate mutation error by changing name
+				pod.Name = "different-name"
+			},
+			statusError:   false,
+			expectedOp:    controllerutil.OperationResultNone,
+			expectedError: "cannot mutate object name",
+		},
+		{
+			name: "does not refetch object",
+			setupObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			mutateStatus: func(pod *corev1.Pod) {
+				pod.Status.Phase = corev1.PodRunning
+			},
+			wrapClient: func(kubeClient client.Client) client.Client {
+				return &getTrackingClient{Client: kubeClient}
+			},
+			expectedOp:    controllerutil.OperationResultUpdatedStatusOnly,
+			expectedError: "",
+			expectedPhase: corev1.PodRunning,
+			assertExtra: func(t *testing.T, kubeClient client.Client) {
+				trackingClient, ok := kubeClient.(*getTrackingClient)
+				assert.True(t, ok)
+				assert.Equal(t, 0, trackingClient.getCalls, "UpdateStatusFromExisting should not refetch the object")
+			},
+		},
+		{
+			name: "uses provided snapshot instead of refetched state",
+			setupObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			buildObj: func(setupObj *corev1.Pod) *corev1.Pod {
+				observedPod := setupObj.DeepCopy()
+				observedPod.Status.Phase = corev1.PodPending
+				return observedPod
+			},
+			mutateStatus: func(pod *corev1.Pod) {
+				if pod.Status.Phase == corev1.PodPending {
+					pod.Status.Phase = corev1.PodSucceeded
+					return
+				}
+
+				pod.Status.Phase = corev1.PodFailed
+			},
+			expectedOp:    controllerutil.OperationResultUpdatedStatusOnly,
+			expectedError: "",
+			expectedPhase: corev1.PodSucceeded,
+			assertExtra: func(t *testing.T, _ client.Client) {
+				refetchingClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects((&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "default",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				}).DeepCopy()).Build()
+				obj := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "default",
+					},
+				}
+
+				op, err := UpdateStatus(context.TODO(), refetchingClient, obj, func() error {
+					if obj.Status.Phase == corev1.PodPending {
+						obj.Status.Phase = corev1.PodSucceeded
+						return nil
+					}
+
+					obj.Status.Phase = corev1.PodFailed
+					return nil
+				})
+
+				assert.NoError(t, err)
+				assert.Equal(t, controllerutil.OperationResultUpdatedStatusOnly, op)
+
+				updatedWithRefetch := &corev1.Pod{}
+				err = refetchingClient.Get(context.TODO(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updatedWithRefetch)
+				assert.NoError(t, err)
+				assert.Equal(t, corev1.PodFailed, updatedWithRefetch.Status.Phase)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientBuilder := fake.NewClientBuilder().WithScheme(scheme)
+			if tt.setupObj != nil {
+				clientBuilder = clientBuilder.WithObjects(tt.setupObj)
+			}
+			fakeClient := clientBuilder.Build()
+
+			var kubeClient client.Client
+			if tt.statusError {
+				kubeClient = &mockClient{
+					Client:      fakeClient,
+					shouldError: true,
+				}
+			} else {
+				kubeClient = fakeClient
+			}
+			if tt.wrapClient != nil {
+				kubeClient = tt.wrapClient(kubeClient)
+			}
+
+			obj := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"}}
+			if tt.buildObj != nil {
+				obj = tt.buildObj(tt.setupObj)
+			}
+
+			// Run the update
+			op, err := UpdateStatusFromExisting(context.TODO(), kubeClient, obj, func() error {
+				if tt.mutateStatus != nil {
+					tt.mutateStatus(obj)
+				}
+				return nil
+			})
+
+			// Check error
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Check operation result
+			assert.Equal(t, tt.expectedOp, op)
+
+			// If successful update, verify the status was actually changed
+			if tt.expectedOp == controllerutil.OperationResultUpdatedStatusOnly {
+				updatedPod := &corev1.Pod{}
+				err := fakeClient.Get(context.TODO(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updatedPod)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedPhase, updatedPod.Status.Phase)
+			}
+
+			if tt.assertExtra != nil {
+				tt.assertExtra(t, kubeClient)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

This PR fixes conflict handling and status update behavior in `execution_controller`.

The current implementation may compare a status computed from the object observed at the beginning of reconciliation with a newer object version re-fetched later from the API server or informer cache. In the conflict path, this can cause `AppliedSuccessful` not to be written back correctly, and eventually lead to incorrect status aggregation such as the issue reported in `#6858`.

To address this, this PR:

- moves `RetryOnConflict()` to the outer `Reconcile()` flow, so a `409 Conflict` retries the whole reconciliation against the latest object version
- removes local conflict retry around individual workload sync operations
- introduces `helper.UpdateStatusFromExisting()` and uses it in `execution_controller` status updates
- updates status based on the object version already observed by the current reconciliation, instead of re-fetching it before the deep-equal check

Removing local conflict retries also avoids nested retries. As discussed in #7111, not every 409 Conflict should immediately result in a reconcile error. However, when both the outer reconcile flow and individual operations use RetryOnConflict(), a reconcile error may not be returned until both retry layers are exhausted. With the default retry settings, this can mean up to 5 * 5 = 25 conflicts before a reconcile error is surfaced.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #6858

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #7446
-->
Part of #7446


**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
karmada-controller-manager: Fixed an issue in the execution controller where status updates could be computed against a stale object version after conflicts, which might cause incorrect Work and aggregated status convergence.
```

