### PR TITLE
Automated cherry pick of #7449: Fix issue with tolerations and affinity rules ommited for

### DIFF
--- a/operator/pkg/controlplane/apiserver/apiserver.go
+++ b/operator/pkg/controlplane/apiserver/apiserver.go
@@ -153,7 +153,8 @@ func installKarmadaAggregatedAPIServer(client clientset.Interface, cfg *operator
 
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
 		WithPriorityClassName(cfg.CommonSettings.PriorityClassName).
-		WithExtraArgs(cfg.ExtraArgs).WithFeatureGates(featureGates).WithResources(cfg.Resources).ForDeployment(aggregatedAPIServerDeployment)
+		WithExtraArgs(cfg.ExtraArgs).WithFeatureGates(featureGates).WithResources(cfg.Resources).
+		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).ForDeployment(aggregatedAPIServerDeployment)
 
 	if err := apiclient.CreateOrUpdateDeployment(client, aggregatedAPIServerDeployment); err != nil {
 		return fmt.Errorf("error when creating deployment for %s, err: %w", aggregatedAPIServerDeployment.Name, err)

--- a/operator/pkg/controlplane/apiserver/apiserver_test.go
+++ b/operator/pkg/controlplane/apiserver/apiserver_test.go
@@ -259,6 +259,88 @@ func TestInstallKarmadaAggregatedAPIServer(t *testing.T) {
 	}
 }
 
+func TestInstallKarmadaAggregatedAPIServerWithTolerationsAndAffinity(t *testing.T) {
+	var replicas int32 = 2
+	image := "karmada-aggregated-apiserver-image"
+	imagePullPolicy := corev1.PullIfNotPresent
+	name := "test-agg-server"
+	namespace := "test-namespace"
+
+	tolerations := []corev1.Toleration{
+		{
+			Key:      "node-role.kubernetes.io/master",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+	}
+	affinity := &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "kubernetes.io/os",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{"linux"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := &operatorv1alpha1.KarmadaAggregatedAPIServer{
+		CommonSettings: operatorv1alpha1.CommonSettings{
+			Image:           operatorv1alpha1.Image{ImageTag: image},
+			Replicas:        ptr.To[int32](replicas),
+			Resources:       corev1.ResourceRequirements{},
+			ImagePullPolicy: imagePullPolicy,
+			Tolerations:     tolerations,
+			Affinity:        affinity,
+		},
+		ExtraArgs: map[string]string{},
+	}
+
+	fakeClient := fakeclientset.NewClientset()
+	etcdCfg := &operatorv1alpha1.Etcd{
+		Local: &operatorv1alpha1.LocalEtcd{},
+	}
+
+	err := installKarmadaAggregatedAPIServer(fakeClient, cfg, etcdCfg, name, namespace, map[string]bool{})
+	if err != nil {
+		t.Fatalf("failed to install karmada aggregated apiserver: %v", err)
+	}
+
+	deployment, err := verifyDeploymentCreation(fakeClient)
+	if err != nil {
+		t.Fatalf("failed to verify deployment creation: %v", err)
+	}
+
+	if len(deployment.Spec.Template.Spec.Tolerations) != 1 {
+		t.Fatalf("expected 1 toleration, but got %d", len(deployment.Spec.Template.Spec.Tolerations))
+	}
+	if deployment.Spec.Template.Spec.Tolerations[0].Key != "node-role.kubernetes.io/master" {
+		t.Errorf("expected toleration key 'node-role.kubernetes.io/master', but got '%s'", deployment.Spec.Template.Spec.Tolerations[0].Key)
+	}
+
+	if deployment.Spec.Template.Spec.Affinity == nil {
+		t.Fatal("expected affinity to be set, but it was nil")
+	}
+	nodeAffinity := deployment.Spec.Template.Spec.Affinity.NodeAffinity
+	if nodeAffinity == nil || nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		t.Fatal("expected node affinity with required scheduling terms, but it was nil")
+	}
+	terms := nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(terms) != 1 {
+		t.Fatalf("expected 1 node selector term, but got %d", len(terms))
+	}
+	if terms[0].MatchExpressions[0].Key != "kubernetes.io/os" {
+		t.Errorf("expected match expression key 'kubernetes.io/os', but got '%s'", terms[0].MatchExpressions[0].Key)
+	}
+}
+
 func TestCreateKarmadaAggregatedAPIServerService(t *testing.T) {
 	// Initialize fake clientset.
 	client := fakeclientset.NewSimpleClientset()

--- a/operator/pkg/controlplane/search/search.go
+++ b/operator/pkg/controlplane/search/search.go
@@ -72,7 +72,8 @@ func installKarmadaSearch(client clientset.Interface, cfg *operatorv1alpha1.Karm
 
 	patcher.NewPatcher().WithAnnotations(cfg.Annotations).WithLabels(cfg.Labels).
 		WithPriorityClassName(cfg.CommonSettings.PriorityClassName).
-		WithExtraArgs(cfg.ExtraArgs).WithResources(cfg.Resources).ForDeployment(searchDeployment)
+		WithExtraArgs(cfg.ExtraArgs).WithResources(cfg.Resources).
+		WithTolerations(cfg.CommonSettings.Tolerations).WithAffinity(cfg.CommonSettings.Affinity).ForDeployment(searchDeployment)
 
 	if err := apiclient.CreateOrUpdateDeployment(client, searchDeployment); err != nil {
 		return fmt.Errorf("error when creating deployment for %s, err: %w", searchDeployment.Name, err)

--- a/operator/pkg/controlplane/search/search_test.go
+++ b/operator/pkg/controlplane/search/search_test.go
@@ -112,6 +112,91 @@ func TestInstallKarmadaSearch(t *testing.T) {
 	}
 }
 
+func TestInstallKarmadaSearchWithTolerationsAndAffinity(t *testing.T) {
+	var replicas int32 = 2
+	image, imageTag := "docker.io/karmada/karmada-search", "latest"
+	name := "karmada-demo"
+	namespace := "test"
+	imagePullPolicy := corev1.PullIfNotPresent
+
+	tolerations := []corev1.Toleration{
+		{
+			Key:      "node-role.kubernetes.io/master",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+	}
+	affinity := &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "kubernetes.io/os",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{"linux"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := &operatorv1alpha1.KarmadaSearch{
+		CommonSettings: operatorv1alpha1.CommonSettings{
+			Image: operatorv1alpha1.Image{
+				ImageRepository: image,
+				ImageTag:        imageTag,
+			},
+			Replicas:        ptr.To[int32](replicas),
+			Resources:       corev1.ResourceRequirements{},
+			ImagePullPolicy: imagePullPolicy,
+			Tolerations:     tolerations,
+			Affinity:        affinity,
+		},
+		ExtraArgs: map[string]string{},
+	}
+
+	fakeClient := fakeclientset.NewClientset()
+	etcdCfg := &operatorv1alpha1.Etcd{
+		Local: &operatorv1alpha1.LocalEtcd{},
+	}
+
+	err := installKarmadaSearch(fakeClient, cfg, etcdCfg, name, namespace, map[string]bool{})
+	if err != nil {
+		t.Fatalf("failed to install karmada search: %v", err)
+	}
+
+	deployment, err := verifyDeploymentCreation(fakeClient)
+	if err != nil {
+		t.Fatalf("failed to verify deployment creation: %v", err)
+	}
+
+	if len(deployment.Spec.Template.Spec.Tolerations) != 1 {
+		t.Fatalf("expected 1 toleration, but got %d", len(deployment.Spec.Template.Spec.Tolerations))
+	}
+	if deployment.Spec.Template.Spec.Tolerations[0].Key != "node-role.kubernetes.io/master" {
+		t.Errorf("expected toleration key 'node-role.kubernetes.io/master', but got '%s'", deployment.Spec.Template.Spec.Tolerations[0].Key)
+	}
+
+	if deployment.Spec.Template.Spec.Affinity == nil {
+		t.Fatal("expected affinity to be set, but it was nil")
+	}
+	nodeAffinity := deployment.Spec.Template.Spec.Affinity.NodeAffinity
+	if nodeAffinity == nil || nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		t.Fatal("expected node affinity with required scheduling terms, but it was nil")
+	}
+	terms := nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(terms) != 1 {
+		t.Fatalf("expected 1 node selector term, but got %d", len(terms))
+	}
+	if terms[0].MatchExpressions[0].Key != "kubernetes.io/os" {
+		t.Errorf("expected match expression key 'kubernetes.io/os', but got '%s'", terms[0].MatchExpressions[0].Key)
+	}
+}
+
 func TestCreateKarmadaSearchService(t *testing.T) {
 	// Define inputs.
 	name := "karmada-demo"


### PR DESCRIPTION
Cherry pick of #7449 on release-1.15.
#7449: Fix issue with tolerations and affinity rules ommited for
For details on the cherry pick process, see the [cherry pick requests](https://karmada.io/docs/contributor/cherry-picks) page.
```release-note
`karmada-operator`: Fixed the issue that operator not applying `tolerations` and `affinity` settings to `karmada-aggregated-apiserver` and `karmada-search` deployments when configured via the Karmada CR.
```