### PR TITLE
feat: initialize agent-skills directory and policy knowledge

### DIFF
--- a/hack/agent-skills/README.md
+++ b/hack/agent-skills/README.md
@@ -1,0 +1,124 @@
+# hack/agent-skills
+
+This directory contains deterministic knowledge, workflows, examples, and helper assets for AI coding agents working on Karmada.
+
+The goal is simple: reduce hallucinations and make agent output reproducible.
+
+Karmada has several schema-sensitive surfaces where vague natural-language guidance is not enough:
+- PropagationPolicy and ClusterPropagationPolicy generation
+- OverridePolicy and Override APIs
+- placement and replica scheduling semantics
+- troubleshooting controller behavior
+- search and discovery across multi-cluster resources
+
+This repository area gives agents a constrained, reviewable source of truth. It is intended to complement normal documentation, not replace it.
+
+## What belongs here
+
+Store assets that help an agent answer or generate something correctly on the first pass:
+- dense knowledge files in Markdown
+- step-by-step workflow guidance for one task
+- deterministic helper scripts in Go or Bash
+- YAML or JSON fixtures
+- curated examples that are known to be valid
+- troubleshooting notes tied to real Karmada behavior
+- small validation utilities for schema-heavy outputs
+
+Prefer explicit, machine-checkable content over prose when the task is sensitive to schema or API shape.
+
+## How to organize a new skill
+
+Each skill should have a narrow purpose and a predictable layout.
+
+Recommended pattern:
+- one directory per skill
+- one short README that explains the user goal, inputs, outputs, and assumptions
+- one or more dense Markdown knowledge files for rules and edge cases
+- optional helper scripts when the skill needs deterministic generation or validation
+- optional fixtures and examples that demonstrate valid and invalid cases
+
+A good skill should answer these questions:
+- What problem does this skill solve?
+- What exact input should the agent expect?
+- What exact output should the agent produce?
+- What fields or invariants must never be violated?
+- What validation should happen before output is returned?
+
+## File conventions
+
+Use Markdown for durable knowledge and operational guidance.
+
+Use Go or Bash for helper scripts when the output must be deterministic, schema-aware, or easy to validate in CI.
+
+Use YAML for examples that should look like real Karmada resources.
+
+Use JSON only when the target tool or validator expects JSON.
+
+Keep examples small. A skill is more useful when it is precise than when it is broad.
+
+## Writing standards for skill content
+
+When writing agent-facing content:
+- be direct
+- state invariants explicitly
+- prefer rules over explanations
+- include common failure modes
+- avoid contradictory guidance
+- avoid ambiguous words like should unless the behavior is actually optional
+
+For schema-sensitive Karmada objects, always document:
+- required fields
+- mutually exclusive fields
+- default behavior
+- precedence rules
+- behavior on empty or omitted values
+- common mistakes that cause invalid resources or unexpected scheduling
+
+## Deterministic helpers
+
+If a skill needs generated output, validation, or sample data, use a helper script rather than asking the agent to infer the result from prose.
+
+Preferred helper responsibilities:
+- generate canonical YAML snippets
+- validate required fields and mutual exclusions
+- compare an output object against known-good fixtures
+- print concise diagnostics for common mistakes
+- normalize example manifests for review
+
+Helper scripts should be:
+- deterministic
+- small enough to audit
+- easy to run locally
+- safe to execute in CI
+
+## Adding a new skill
+
+When adding a new skill:
+1. Create a dedicated directory under hack/agent-skills/.
+2. Add a README describing the skill goal and expected behavior.
+3. Add dense Markdown knowledge files for rules and edge cases.
+4. Add fixtures and examples that demonstrate valid and invalid cases.
+5. Add helper scripts only when the skill benefits from deterministic generation or validation.
+6. Keep the skill narrow. Do not mix unrelated workflows into one folder.
+7. Update shared knowledge if the new skill reveals a reusable pattern.
+
+## Review checklist
+
+Before merging new skill content, confirm:
+- the guidance is consistent with Karmada APIs
+- required fields are called out explicitly
+- mutually exclusive fields are documented
+- the examples are valid and minimal
+- helper scripts produce stable output
+- the skill does not rely on implicit agent reasoning for schema-critical decisions
+
+## Repository intent
+
+The long-term purpose of this directory is to become the official Karmada skill base for AI coding agents.
+
+That means the content here should evolve toward:
+- shared policy knowledge
+- focused workflow skills
+- reusable troubleshooting notes
+- deterministic generation helpers
+- validated examples that reduce hallucination risk

--- a/hack/agent-skills/karmada-audit-policy/README.md
+++ b/hack/agent-skills/karmada-audit-policy/README.md
@@ -1,0 +1,3 @@
+# karmada-audit-policy
+
+Workflow and assets for auditing Karmada policies.

--- a/hack/agent-skills/karmada-controller-manager/README.md
+++ b/hack/agent-skills/karmada-controller-manager/README.md
@@ -1,0 +1,3 @@
+# karmada-controller-manager
+
+Workflow and assets for controller-manager-specific guidance.

--- a/hack/agent-skills/karmada-create-policy/README.md
+++ b/hack/agent-skills/karmada-create-policy/README.md
@@ -1,0 +1,3 @@
+# karmada-create-policy
+
+Workflow and assets for creating Karmada policies.

--- a/hack/agent-skills/karmada-debug-propagation/README.md
+++ b/hack/agent-skills/karmada-debug-propagation/README.md
@@ -1,0 +1,3 @@
+# karmada-debug-propagation
+
+Workflow and assets for debugging Karmada propagation behavior.

--- a/hack/agent-skills/karmada-explain-placement/README.md
+++ b/hack/agent-skills/karmada-explain-placement/README.md
@@ -1,0 +1,3 @@
+# karmada-explain-placement
+
+Workflow and assets for explaining Karmada placement decisions.

--- a/hack/agent-skills/karmada-knowledge/README.md
+++ b/hack/agent-skills/karmada-knowledge/README.md
@@ -1,0 +1,3 @@
+# karmada-knowledge
+
+Shared knowledge for Karmada policy semantics, troubleshooting, and agent-facing rules.

--- a/hack/agent-skills/karmada-knowledge/propagation-policy-rules.md
+++ b/hack/agent-skills/karmada-knowledge/propagation-policy-rules.md
@@ -1,0 +1,172 @@
+# PropagationPolicy rules
+
+This file is a dense rule set for AI agents that generate or review PropagationPolicy objects.
+
+Treat these rules as mandatory unless a newer Karmada API document says otherwise.
+
+## Core objective
+
+A valid PropagationPolicy must precisely identify what resource templates are managed and how they are propagated across clusters.
+
+Do not guess field meaning from generic Kubernetes behavior. Use the Karmada policy semantics below.
+
+## Non-negotiable validity rules
+
+- `spec.resourceSelectors` must be present and non-empty.
+- An empty selector is not a match-all selector.
+- Do not fabricate a policy that omits resourceSelectors.
+- `apiVersion` and `kind` are required in each resource selector.
+- `metadata.name` must be set on the policy.
+- Use the correct namespace for namespaced policies.
+- Do not use deprecated `association` when `propagateDeps` is the intended behavior.
+- Do not invent unsupported fields.
+
+## Resource selector semantics
+
+A PropagationPolicy selects resource templates through `spec.resourceSelectors`.
+
+Each ResourceSelector must obey these rules:
+- `apiVersion` is required.
+- `kind` is required.
+- `namespace` is optional and defaults to the parent object scope.
+- `name` is optional.
+- `labelSelector` is optional.
+
+Selection rules:
+- If `name` is set, the selector targets that exact resource name.
+- If `name` is set, `labelSelector` is ignored.
+- If `name` is empty, the selector can use `labelSelector` to match resources by label.
+- The selector is for identifying resource templates, not clusters.
+
+Security rule:
+- Never treat an omitted selector as meaning all resources of a kind.
+- Never generate an empty resourceSelectors list.
+
+## Dependency propagation
+
+Use `propagateDeps` when the resource template has related objects that should follow it automatically.
+
+Rules:
+- `propagateDeps` is the modern mechanism.
+- `association` is deprecated and should not be the primary choice.
+- For workloads such as a Deployment, dependent ConfigMaps or Secrets may be propagated automatically when `propagateDeps` is true.
+- If dependency propagation is enabled, do not require every referenced object to be listed manually in resourceSelectors unless the scenario explicitly needs that control.
+
+Pitfall:
+- Do not confuse dependency propagation with cluster placement or replica distribution. It only covers related resources.
+
+## Placement vs ReplicaScheduling
+
+These are different layers of intent.
+
+Placement decides where the resource can run.
+ReplicaScheduling decides how replicas are divided among the selected clusters.
+
+Use this distinction strictly:
+- Placement filters and prefers clusters.
+- ReplicaScheduling applies only to resources with replicas in their spec.
+- Placement does not define replica counts.
+- ReplicaScheduling does not choose clusters by itself.
+
+If the resource has no replica-bearing spec, ReplicaScheduling is usually unnecessary.
+
+## Placement rules
+
+Placement belongs in `spec.placement`.
+
+Cluster selection rules:
+- `clusterAffinity` and `clusterAffinities` are mutually exclusive.
+- If both are omitted, any cluster can be a candidate.
+- Use `clusterAffinity` for a single cluster group.
+- Use `clusterAffinities` for ordered cluster groups.
+
+ClusterAffinity semantics:
+- `labelSelector` filters clusters by labels.
+- `fieldSelector` filters clusters by fields.
+- `clusterNames` selects explicit clusters.
+- `exclude` removes clusters from consideration.
+
+Field selector rules:
+- Valid field keys are provider, region, and zone.
+- Valid operators are In and NotIn.
+- Do not invent arbitrary field keys.
+
+Spread constraint rules:
+- `spreadByField` and `spreadByLabel` are mutually exclusive.
+- If both are omitted, spreadByField defaults to cluster.
+- Available spread fields are cluster, region, zone, and provider.
+- `minGroups` and `maxGroups` control cluster group cardinality.
+- Keep spread constraints consistent with the intended blast radius and availability model.
+
+Important behavior:
+- ClusterAffinities are evaluated in order.
+- If one group does not satisfy restrictions, the scheduler can fall through to the next group.
+- If no group satisfies restrictions, scheduling fails.
+
+## ReplicaScheduling rules
+
+ReplicaScheduling belongs under Placement and only matters for replica-based workloads.
+
+ReplicaSchedulingType:
+- Duplicated means every candidate cluster gets the full original replica count.
+- Divided means replicas are split among candidate clusters.
+- Divided is the default behavior when the field is omitted.
+- Do not set replica scheduling for objects that do not have replicas unless the policy design explicitly requires it.
+
+ReplicaDivisionPreference:
+- Aggregated divides replicas into as few clusters as possible while respecting available capacity.
+- Weighted divides replicas according to weight preference.
+- If Weighted is chosen and weightPreference is omitted, clusters are treated equally.
+
+WeightPreference:
+- Static weights are explicit and deterministic.
+- Dynamic weight currently uses available replicas.
+- If dynamic weight is set, static weights are ignored.
+
+Pitfall:
+- Do not confuse duplicated propagation with spreading work evenly. Duplicated means full replicas everywhere.
+
+## Interaction rules
+
+The agent must reason in this order:
+1. identify the target resource template with resourceSelectors
+2. determine cluster eligibility with placement
+3. determine replica distribution with replicaScheduling if the workload has replicas
+4. then consider secondary policy knobs such as priority, preemption, conflict resolution, and dependency propagation
+
+Do not mix these layers.
+
+## Common mistakes to avoid
+
+- Empty resourceSelectors
+- Using labelSelector and name together and expecting both to matter
+- Using clusterAffinity and clusterAffinities together
+- Using spreadByField and spreadByLabel together
+- Treating Placement as a substitute for resource selection
+- Treating ReplicaScheduling as a substitute for placement
+- Using deprecated association instead of propagateDeps
+- Assuming omitted fields mean match all resources
+- Assuming omitted placement means zero clusters instead of any cluster
+- Assuming Duplicated and Divided mean the same thing
+
+## Output checklist for an AI agent
+
+Before returning a generated PropagationPolicy, verify:
+- resourceSelectors is present and non-empty
+- every selector has apiVersion and kind
+- name and labelSelector are not misused together
+- placement is internally consistent
+- clusterAffinity and clusterAffinities are not both set
+- spread constraint fields are not conflicting
+- replicaScheduling only appears when needed
+- deprecated association is not used unless specifically required
+- the final YAML matches the intended resource scope and cluster behavior
+
+## Mental model
+
+Think of PropagationPolicy as three decisions in order:
+- what to manage
+- where it may run
+- how replicas are distributed
+
+If any of those decisions is ambiguous, stop and resolve the ambiguity before generating YAML.

--- a/hack/agent-skills/karmada-search/README.md
+++ b/hack/agent-skills/karmada-search/README.md
@@ -1,0 +1,3 @@
+# karmada-search
+
+Workflow and assets for search and discovery across Karmada resources.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
As outlined in the upcoming "Build Karmada Agent Skills" initiative, AI coding agents frequently struggle with Karmada's multi-cluster orchestration concepts. Without a dedicated skill repository, they hallucinate policy structures, misunderstand `Placement` vs `ReplicaScheduling`, and produce invalid `resourceSelectors`.

This PR lays the foundational scaffolding to solve this problem:
1. **Directory Structure:** Initializes `hack/agent-skills/` following mature multi-skill repository patterns (knowledge bases, focused workflow skills, and helper tools).
2. **Contributor Documentation:** Adds the root `README.md` which acts as the contributor guide, explaining how to write deterministic, machine-readable rules for AI agents.
3. **The First Skill (`karmada-knowledge`):** Introduces `propagation-policy-rules.md`. This is a dense, system-prompt-style markdown file specifically designed for an LLM to ingest. It explicitly defines the non-negotiable rules of Karmada resource propagation to eliminate agent hallucinations.

**Which issue(s) this PR fixes**:
References: karmada-io/community#190

**Special notes for your reviewer**:
cc @XiShanYongYe-Chang @RainbowMango 

I saw the "Build Karmada Agent Skills" project idea for the upcoming LFX term. Over the last month, I have been working heavily with AI agents to contribute to Karmada (E2E testing, webhook panics, state-machine bug fixes, and CLI idempotency). Through that work, I have experienced the exact blind spots these agents have when trying to infer Karmada's API semantics from generic Kubernetes documentation.

I wanted to proactively build out the initial scaffolding and the first critical knowledge file for this initiative. I plan to formally apply for this mentorship when the portal opens on May 4th, but I wanted to get this architectural foundation in place now so we can start iterating on it! 

**Does this PR introduce a user-facing change?**:
```release-note
NONE