### PR TITLE
fix(dependenciesdistributor): preserve Replicas and SchedulerName in attached bindings

### DIFF
--- a/pkg/dependenciesdistributor/dependencies_distributor.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor.go
@@ -633,6 +633,8 @@ func (d *DependenciesDistributor) createOrUpdateAttachedBinding(ctx context.Cont
 				// Update with effective results.
 				existBinding.Spec.ConflictResolution = effectiveCR
 				existBinding.Spec.PreserveResourcesOnDeletion = ptr.To(effectivePreserve)
+				existBinding.Spec.Replicas = attachedBinding.Spec.Replicas
+				existBinding.Spec.SchedulerName = attachedBinding.Spec.SchedulerName
 			}
 
 			existBinding.Spec.RequiredBy = mergedRequiredBy
@@ -782,8 +784,10 @@ func buildAttachedBinding(independentBinding *workv1alpha2.ResourceBinding, obje
 				ResourceVersion: object.GetResourceVersion(),
 			},
 			RequiredBy:                  result,
+			Replicas:                    independentBinding.Spec.Replicas,
 			PreserveResourcesOnDeletion: independentBinding.Spec.PreserveResourcesOnDeletion,
 			ConflictResolution:          independentBinding.Spec.ConflictResolution,
+			SchedulerName:               independentBinding.Spec.SchedulerName,
 		},
 	}
 }

--- a/pkg/dependenciesdistributor/dependencies_distributor_test.go
+++ b/pkg/dependenciesdistributor/dependencies_distributor_test.go
@@ -3569,12 +3569,14 @@ func Test_buildAttachedBinding(t *testing.T) {
 					Labels:    map[string]string{workv1alpha2.ResourceBindingPermanentIDLabel: "93162d3c-ee8e-4995-9034-05f4d5d2c2b9"},
 				},
 				Spec: workv1alpha2.ResourceBindingSpec{
+					Replicas: 5,
 					Clusters: []workv1alpha2.TargetCluster{
 						{
 							Name:     "member1",
 							Replicas: 2,
 						},
 					},
+					SchedulerName: "test-scheduler",
 				},
 			},
 			object: &unstructured.Unstructured{
@@ -3615,6 +3617,8 @@ func Test_buildAttachedBinding(t *testing.T) {
 						UID:             "db56a4a6-0dff-465a-b046-2c1dea42a42b",
 						ResourceVersion: "22222",
 					},
+					Replicas:      5,
+					SchedulerName: "test-scheduler",
 					RequiredBy: []workv1alpha2.BindingSnapshot{
 						{
 							Namespace: "test",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

When `propagateDeps: true` is set on a PropagationPolicy, the DependenciesDistributor creates attached ResourceBindings for dependent resources (ConfigMaps, Secrets, PVCs). However, `buildAttachedBinding` did not carry over the `Replicas` and `SchedulerName` fields from the independent binding. This caused these values to be reset during the reconcile cycle — ResourceDetector would correctly set replicas, then DependenciesDistributor would overwrite the binding spec with zeroed-out fields.

**Root cause**: `buildAttachedBinding` constructs a new `ResourceBindingSpec` but only copied `ConflictResolution` and `PreserveResourcesOnDeletion`, omitting `Replicas` and `SchedulerName`.

**Fix**:
- `buildAttachedBinding`: copy `Replicas` and `SchedulerName` from the independent binding
- `createOrUpdateAttachedBinding`: preserve `Replicas` and `SchedulerName` during updates

**Which issue(s) this PR fixes**:
Fixes #5929

**Special notes for your reviewer**:
Tests updated in `Test_buildAttachedBinding` to verify `Replicas` and `SchedulerName` are carried over (72/72 tests pass).

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-controller-manager`: Fixed an issue where the DependenciesDistributor would reset the `Replicas` field on ResourceBindings when `propagateDeps` is enabled, causing replica counts to be lost during dependency propagation.
```