### PR TITLE
fix(scheduler): exclude unhealthy clusters from available replica calculation

### DIFF
--- a/pkg/scheduler/core/util.go
+++ b/pkg/scheduler/core/util.go
@@ -109,8 +109,21 @@ func calAvailableReplicas(clusters []*clusterv1alpha1.Cluster, spec *workv1alpha
 		}
 	}
 
+	applyUnhealthyClusterPolicy(clusters, availableTargetClusters)
+
 	klog.V(4).Infof("Target cluster calculated by estimators (available cluster && maxAvailableReplicas): %v", availableTargetClusters)
 	return availableTargetClusters
+}
+
+// applyUnhealthyClusterPolicy sets available replicas to 0 for clusters that
+// are not in Ready condition, preventing the scheduler from distributing new
+// replicas to unhealthy clusters during scale-up.
+func applyUnhealthyClusterPolicy(clusters []*clusterv1alpha1.Cluster, availableTargetClusters []workv1alpha2.TargetCluster) {
+	for i := range availableTargetClusters {
+		if !util.IsClusterReady(&clusters[i].Status) {
+			availableTargetClusters[i].Replicas = 0
+		}
+	}
 }
 
 // attachZeroReplicasCluster  attach cluster in clusters into targetCluster


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

When using `dynamicWeight: AvailableReplicas` with `replicaDivisionPreference: Weighted`, the karmada-scheduler would distribute newly scaled-up replicas to unhealthy member clusters. This happens because `calAvailableReplicas` consults the estimator for resource availability but does not check whether the cluster is in a Ready condition.

**Scenario**:
1. Workload distributed to cluster A and cluster B
2. Cluster A becomes unhealthy
3. User scales up workload replicas
4. New replicas are assigned to unhealthy cluster A — workload never reaches desired state

**Root cause**: `calAvailableReplicas` (in `pkg/scheduler/core/util.go`) sets an initial upper bound of `math.MaxInt32` for each cluster, then calls the estimator to get actual available replicas. Neither step checks cluster health. Unhealthy clusters remain eligible for new replica assignment.

**Fix**: After calculating available replicas and applying estimator results, iterate through clusters and set available replicas to `0` for any cluster not in Ready condition (`!util.IsClusterReady`).

**Which issue(s) this PR fixes**:
Fixes #6861

**Special notes for your reviewer**:
All 86 scheduler/core tests pass. 450 total scheduler tests pass.

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-scheduler`: Fixed an issue where unhealthy member clusters could receive new replicas during workload scale-up when using dynamicWeight: AvailableReplicas.
```