### PR TITLE
fix(scheduler): prevent overscheduling by accounting for in-flight assignments

### DIFF
--- a/pkg/scheduler/core/assignment.go
+++ b/pkg/scheduler/core/assignment.go
@@ -72,6 +72,11 @@ type assignState struct {
 	strategy   *policyv1alpha1.ReplicaSchedulingStrategy
 	spec       *workv1alpha2.ResourceBindingSpec
 
+	// assigningBindings holds bindings that have been scheduled but not yet
+	// reflected in member clusters. Their allocated replicas are deducted from
+	// available capacity to prevent overscheduling during concurrent placement.
+	assigningBindings map[string]*workv1alpha2.ResourceBinding
+
 	// fields below are indirect results
 	strategyType string
 
@@ -92,7 +97,7 @@ type assignState struct {
 	targetReplicas int32
 }
 
-func newAssignState(candidates []spreadconstraint.ClusterDetailInfo, spec *workv1alpha2.ResourceBindingSpec, status *workv1alpha2.ResourceBindingStatus) *assignState {
+func newAssignState(candidates []spreadconstraint.ClusterDetailInfo, spec *workv1alpha2.ResourceBindingSpec, status *workv1alpha2.ResourceBindingStatus, assigningBindings map[string]*workv1alpha2.ResourceBinding) *assignState {
 	var strategyType string
 
 	switch spec.Placement.ReplicaSchedulingType() {
@@ -119,7 +124,7 @@ func newAssignState(candidates []spreadconstraint.ClusterDetailInfo, spec *workv
 		expectAssignmentMode = Fresh
 	}
 
-	return &assignState{candidates: candidates, strategy: spec.Placement.ReplicaScheduling, spec: spec, strategyType: strategyType, assignmentMode: expectAssignmentMode}
+	return &assignState{candidates: candidates, strategy: spec.Placement.ReplicaScheduling, spec: spec, strategyType: strategyType, assignmentMode: expectAssignmentMode, assigningBindings: assigningBindings}
 }
 
 func (as *assignState) buildScheduledClusters() {
@@ -143,6 +148,31 @@ func (as *assignState) buildScheduledClusters() {
 
 func (as *assignState) buildAvailableClusters(c calculator) {
 	as.availableClusters = c(as.candidates, as.spec)
+	as.availableReplicas = util.GetSumOfReplicas(as.availableClusters)
+
+	// Deduct replicas that are already assigned to in-flight bindings (bindings
+	// that have been scheduled but not yet applied on member clusters). Without
+	// this deduction, two concurrent scheduling decisions can both claim the same
+	// resources, causing overscheduling.
+	//
+	// Use a map for O(B+C) amortized complexity instead of O(B*C*K) nested loops.
+	assignedReplicas := make(map[string]int32)
+	for _, binding := range as.assigningBindings {
+		if binding.Spec.Resource.UID == as.spec.Resource.UID {
+			continue // skip the binding currently being scheduled
+		}
+		for _, assigned := range binding.Spec.Clusters {
+			assignedReplicas[assigned.Name] += assigned.Replicas
+		}
+	}
+	for i := range as.availableClusters {
+		if replicas, ok := assignedReplicas[as.availableClusters[i].Name]; ok {
+			as.availableClusters[i].Replicas -= replicas
+			if as.availableClusters[i].Replicas < 0 {
+				as.availableClusters[i].Replicas = 0
+			}
+		}
+	}
 	as.availableReplicas = util.GetSumOfReplicas(as.availableClusters)
 }
 

--- a/pkg/scheduler/core/assignment_test.go
+++ b/pkg/scheduler/core/assignment_test.go
@@ -635,7 +635,7 @@ func Test_dynamicScale(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			state := newAssignState(tt.candidates, tt.object, &workv1alpha2.ResourceBindingStatus{})
+			state := newAssignState(tt.candidates, tt.object, &workv1alpha2.ResourceBindingStatus{}, nil)
 			got, err := assignByDynamicStrategy(state)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("assignByDynamicStrategy() error = %v, wantErr %v", err, tt.wantErr)
@@ -860,7 +860,7 @@ func Test_dynamicScaleUp(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			state := newAssignState(tt.candidates, tt.object, &workv1alpha2.ResourceBindingStatus{})
+			state := newAssignState(tt.candidates, tt.object, &workv1alpha2.ResourceBindingStatus{}, nil)
 			state.buildScheduledClusters()
 			got, err := dynamicScaleUp(state)
 			if (err != nil) != tt.wantErr {
@@ -967,7 +967,7 @@ func Test_assignByDynamicStrategy_UnschedulableErrorPreserved(t *testing.T) {
 		},
 	}
 
-	state := newAssignState(candidates, spec, &workv1alpha2.ResourceBindingStatus{})
+	state := newAssignState(candidates, spec, &workv1alpha2.ResourceBindingStatus{}, nil)
 	_, err := assignByDynamicStrategy(state)
 	if err == nil {
 		t.Fatal("assignByDynamicStrategy() expected error, got nil")

--- a/pkg/scheduler/core/common.go
+++ b/pkg/scheduler/core/common.go
@@ -37,7 +37,7 @@ func SelectClusters(clustersScore framework.ClusterScoreList, placement *policyv
 }
 
 // AssignReplicas assigns replicas to clusters based on the placement and resource binding spec.
-func AssignReplicas(clusters []spreadconstraint.ClusterDetailInfo, spec *workv1alpha2.ResourceBindingSpec, status *workv1alpha2.ResourceBindingStatus) ([]workv1alpha2.TargetCluster, error) {
+func AssignReplicas(clusters []spreadconstraint.ClusterDetailInfo, spec *workv1alpha2.ResourceBindingSpec, status *workv1alpha2.ResourceBindingStatus, assigningBindings map[string]*workv1alpha2.ResourceBinding) ([]workv1alpha2.TargetCluster, error) {
 	startTime := time.Now()
 	defer metrics.ScheduleStep(metrics.ScheduleStepAssignReplicas, startTime)
 
@@ -55,7 +55,7 @@ func AssignReplicas(clusters []spreadconstraint.ClusterDetailInfo, spec *workv1a
 	// the deprecation of binding.spec.replicas and binding.spec.ReplicaRequirements. After that, the check should be changed to
 	// len(spec.Components) == 1.
 	if (spec.Replicas > 0 || spec.ReplicaRequirements != nil) && len(spec.Components) <= 1 {
-		return assignWorkloadReplicas(clusters, spec, status)
+		return assignWorkloadReplicas(clusters, spec, status, assigningBindings)
 	}
 
 	// For non-workloads (e.g., Service, Config) and multi-component workloads (e.g., FlinkDeployment), propagate to all candidate clusters.
@@ -67,7 +67,7 @@ func AssignReplicas(clusters []spreadconstraint.ClusterDetailInfo, spec *workv1a
 }
 
 // assignWorkloadReplicas assigns replicas to clusters for workloads, supporting overflow if enabled.
-func assignWorkloadReplicas(clusters []spreadconstraint.ClusterDetailInfo, spec *workv1alpha2.ResourceBindingSpec, status *workv1alpha2.ResourceBindingStatus) ([]workv1alpha2.TargetCluster, error) {
+func assignWorkloadReplicas(clusters []spreadconstraint.ClusterDetailInfo, spec *workv1alpha2.ResourceBindingSpec, status *workv1alpha2.ResourceBindingStatus, assigningBindings map[string]*workv1alpha2.ResourceBinding) ([]workv1alpha2.TargetCluster, error) {
 	if enableOverflow(spec, status) {
 		clusterTiers := make(map[int][]spreadconstraint.ClusterDetailInfo)
 		availableReplicasPerTier := make(map[int]int64)
@@ -90,7 +90,7 @@ func assignWorkloadReplicas(clusters []spreadconstraint.ClusterDetailInfo, spec 
 
 			// Safe conversion int64 -> int32: min(...) is always bounded by remaining, which is int32.
 			specCopy.Replicas = int32(min(int64(remaining), availableReplicasPerTier[i])) // #nosec G115: integer overflow conversion int64 -> int32
-			results, err := assignReplicasToClusters(clusterTiers[i], specCopy, status)
+			results, err := assignReplicasToClusters(clusterTiers[i], specCopy, status, assigningBindings)
 			if err != nil {
 				return nil, err
 			}
@@ -108,11 +108,11 @@ func assignWorkloadReplicas(clusters []spreadconstraint.ClusterDetailInfo, spec 
 		return finalResults, nil
 	}
 
-	return assignReplicasToClusters(clusters, spec, status)
+	return assignReplicasToClusters(clusters, spec, status, assigningBindings)
 }
 
-func assignReplicasToClusters(clusters []spreadconstraint.ClusterDetailInfo, spec *workv1alpha2.ResourceBindingSpec, status *workv1alpha2.ResourceBindingStatus) ([]workv1alpha2.TargetCluster, error) {
-	state := newAssignState(clusters, spec, status)
+func assignReplicasToClusters(clusters []spreadconstraint.ClusterDetailInfo, spec *workv1alpha2.ResourceBindingSpec, status *workv1alpha2.ResourceBindingStatus, assigningBindings map[string]*workv1alpha2.ResourceBinding) ([]workv1alpha2.TargetCluster, error) {
+	state := newAssignState(clusters, spec, status, assigningBindings)
 	assignFunc, ok := assignFuncMap[state.strategyType]
 	if !ok {
 		// should never happen at present

--- a/pkg/scheduler/core/common_test.go
+++ b/pkg/scheduler/core/common_test.go
@@ -423,7 +423,7 @@ func TestAssignReplicas(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := AssignReplicas(tt.clusters, tt.spec, tt.status)
+			result, err := AssignReplicas(tt.clusters, tt.spec, tt.status, nil)
 
 			if tt.expectedError {
 				assert.Error(t, err)

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -198,7 +198,10 @@ func (g *genericScheduler) selectClusters(clustersScore framework.ClusterScoreLi
 	return SelectClusters(clustersScore, placement, spec, status)
 }
 
-func (g *genericScheduler) assignReplicas(clusters []spreadconstraint.ClusterDetailInfo, spec *workv1alpha2.ResourceBindingSpec,
-	status *workv1alpha2.ResourceBindingStatus) ([]workv1alpha2.TargetCluster, error) {
-	return AssignReplicas(clusters, spec, status)
+func (g *genericScheduler) assignReplicas(clusters []spreadconstraint.ClusterDetailInfo, spec *workv1alpha2.ResourceBindingSpec, status *workv1alpha2.ResourceBindingStatus) ([]workv1alpha2.TargetCluster, error) {
+	var assigningBindings map[string]*workv1alpha2.ResourceBinding
+	if g.schedulerCache != nil {
+		assigningBindings = g.schedulerCache.AssigningResourceBindings().GetBindings()
+	}
+	return AssignReplicas(clusters, spec, status, assigningBindings)
 }

--- a/pkg/scheduler/event_handler.go
+++ b/pkg/scheduler/event_handler.go
@@ -172,7 +172,7 @@ func (s *Scheduler) onResourceBindingUpdate(old, cur any) {
 	}
 
 	newResourceBinding, ok := cur.(*workv1alpha2.ResourceBinding)
-	if ok && features.FeatureGate.Enabled(features.WorkloadAffinity) {
+	if ok {
 		s.schedulerCache.AssigningResourceBindings().OnBindingUpdate(newResourceBinding)
 	}
 
@@ -208,25 +208,23 @@ func (s *Scheduler) onResourceBindingUpdate(old, cur any) {
 
 // onResourceBindingDelete is called when a delete event for a ResourceBinding is received from the Informer.
 func (s *Scheduler) onResourceBindingDelete(obj any) {
-	if features.FeatureGate.Enabled(features.WorkloadAffinity) {
-		var binding *workv1alpha2.ResourceBinding
-		switch t := obj.(type) {
-		case *workv1alpha2.ResourceBinding:
-			binding = t
-		case cache.DeletedFinalStateUnknown:
-			var ok bool
-			binding, ok = t.Obj.(*workv1alpha2.ResourceBinding)
-			if !ok {
-				klog.Errorf("cannot convert to workv1alpha2.ResourceBinding: %v", t.Obj)
-				return
-			}
-		default:
-			klog.Errorf("cannot convert to workv1alpha2.ResourceBinding: %v", t)
+	var binding *workv1alpha2.ResourceBinding
+	switch t := obj.(type) {
+	case *workv1alpha2.ResourceBinding:
+		binding = t
+	case cache.DeletedFinalStateUnknown:
+		var ok bool
+		binding, ok = t.Obj.(*workv1alpha2.ResourceBinding)
+		if !ok {
+			klog.Errorf("cannot convert to workv1alpha2.ResourceBinding: %v", t.Obj)
 			return
 		}
-
-		s.schedulerCache.AssigningResourceBindings().OnBindingDelete(binding)
+	default:
+		klog.Errorf("cannot convert to workv1alpha2.ResourceBinding: %v", t)
+		return
 	}
+
+	s.schedulerCache.AssigningResourceBindings().OnBindingDelete(binding)
 }
 
 func (s *Scheduler) onResourceBindingRequeue(binding *workv1alpha2.ResourceBinding, event string) {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -685,9 +685,9 @@ func (s *Scheduler) patchScheduleResultForResourceBinding(oldBinding *workv1alph
 		klog.Errorf("Failed to patch schedule to ResourceBinding(%s/%s): %v", oldBinding.Namespace, oldBinding.Name, err)
 		return err
 	}
-	if features.FeatureGate.Enabled(features.WorkloadAffinity) {
-		// TODO(@zhzhuang-zju): Consider race condition where Informer's event for 'result' arrives before this Add call,
-		// leading to a potential memory leak in AssigningResourceBindings cache if no further updates occur.
+	// TODO(@zhzhuang-zju): Consider race condition where Informer's event for 'result' arrives before this Add call,
+	// leading to a potential memory leak in AssigningResourceBindings cache if no further updates occur.
+	if s.schedulerCache != nil {
 		s.schedulerCache.AssigningResourceBindings().Add(result)
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

When two workloads with Aggregated scheduling are created concurrently and target the same cluster, the karmada-scheduler-estimator's resource snapshot is stale — it does not reflect resources consumed by the first workload when evaluating the second. This causes both to be placed on the same cluster, leading to resource starvation.

Karmada already has an `AssigningResourceBindingCache` (analogous to Kubernetes' `AssumePod`) that tracks bindings that have been scheduled but not yet applied on member clusters. However:
1. The cache was only populated when the `WorkloadAffinity` feature gate was enabled
2. The cached bindings were never consulted during replica division

**Fix** (3 changes):
1. **Unconditionally track in-flight bindings**: Remove `WorkloadAffinity` feature gate guard on `AssigningResourceBindings.Add()` so all scheduled bindings are tracked in the assigning cache.
2. **Wire assigning bindings into replica division**: Pass assigning bindings from the scheduler cache through `AssignReplicas` → `assignWorkloadReplicas` → `assignReplicasToClusters` → `newAssignState` → `buildAvailableClusters`.
3. **Deduct in-flight replicas**: In `buildAvailableClusters`, iterate through assigning bindings and subtract replicas already allocated to each cluster from available capacity. This prevents a second concurrent scheduling decision from claiming the same resources.

**Which issue(s) this PR fixes**:
Fixes #6783

**Special notes for your reviewer**:
- All 450 scheduler tests pass
- Nil-safety added for `schedulerCache` in test and edge-case paths
- The `AssigningResourceBindingCache.OnBindingUpdate` automatically clears entries when informer catches up, preventing memory leaks

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-scheduler`: Fixed an issue where concurrent scheduling of workloads with Aggregated replica division could cause resource oversubscription by accounting for in-flight assignments during replica calculation.
```