### PR TITLE
fix: ignore NotFound when cleaning Work policy metadata

### DIFF
--- a/pkg/controllers/execution/execution_controller.go
+++ b/pkg/controllers/execution/execution_controller.go
@@ -50,6 +50,7 @@ import (
 	"github.com/karmada-io/karmada/pkg/util/helper"
 	"github.com/karmada-io/karmada/pkg/util/names"
 	"github.com/karmada-io/karmada/pkg/util/objectwatcher"
+	"github.com/karmada-io/karmada/pkg/util/restmapper"
 )
 
 const (
@@ -204,8 +205,21 @@ func (c *Controller) cleanupPolicyClaimMetadata(ctx context.Context, work *workv
 
 		clusterObj, err := helper.GetObjectFromCache(c.RESTMapper, c.InformerManager, fedKey)
 		if err != nil {
-			klog.ErrorS(err, "Failed to get the resource from member cluster cache", "kind", workload.GetKind(), "namespace", workload.GetNamespace(), "name", workload.GetName(), "cluster", cluster.Name)
-			return err
+			if apierrors.IsNotFound(err) {
+				clusterObj, err = c.getObjectFromMemberCluster(ctx, cluster.Name, workload)
+				if err != nil {
+					if apierrors.IsNotFound(err) {
+						klog.V(4).InfoS("Resource not found in member cluster, skip cleaning up policy claim metadata",
+							"kind", workload.GetKind(), "namespace", workload.GetNamespace(), "name", workload.GetName(), "cluster", cluster.Name)
+						continue
+					}
+					klog.ErrorS(err, "Failed to get the resource from member cluster API", "kind", workload.GetKind(), "namespace", workload.GetNamespace(), "name", workload.GetName(), "cluster", cluster.Name)
+					return err
+				}
+			} else {
+				klog.ErrorS(err, "Failed to get the resource from member cluster cache", "kind", workload.GetKind(), "namespace", workload.GetNamespace(), "name", workload.GetName(), "cluster", cluster.Name)
+				return err
+			}
 		}
 
 		if workload.GetNamespace() == corev1.NamespaceAll {
@@ -219,12 +233,43 @@ func (c *Controller) cleanupPolicyClaimMetadata(ctx context.Context, work *workv
 		operationResult, err := c.ObjectWatcher.Update(ctx, cluster.Name, workload, clusterObj)
 		metrics.CountUpdateResourceToCluster(err, workload.GetAPIVersion(), workload.GetKind(), cluster.Name, string(operationResult))
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				clusterObj, getErr := c.getObjectFromMemberCluster(ctx, cluster.Name, workload)
+				if getErr != nil {
+					if apierrors.IsNotFound(getErr) {
+						klog.V(4).InfoS("Resource gone during metadata cleanup update, skip it",
+							"kind", workload.GetKind(), "namespace", workload.GetNamespace(), "name", workload.GetName(), "cluster", cluster.Name)
+						continue
+					}
+					klog.ErrorS(getErr, "Failed to re-check resource in member cluster API after update not found", "kind", workload.GetKind(), "namespace", workload.GetNamespace(), "name", workload.GetName(), "cluster", cluster.Name)
+					return getErr
+				}
+				operationResult, err = c.ObjectWatcher.Update(ctx, cluster.Name, workload, clusterObj)
+				metrics.CountUpdateResourceToCluster(err, workload.GetAPIVersion(), workload.GetKind(), cluster.Name, string(operationResult))
+				if err == nil {
+					continue
+				}
+			}
 			klog.ErrorS(err, "Failed to update metadata in the given member cluster", "cluster", cluster.Name)
 			return err
 		}
 	}
 
 	return nil
+}
+
+func (c *Controller) getObjectFromMemberCluster(ctx context.Context, clusterName string, workload *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	gvr, err := restmapper.GetGroupVersionResource(c.RESTMapper, workload.GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+
+	singleClusterManager := c.InformerManager.GetSingleClusterManager(clusterName)
+	if singleClusterManager == nil {
+		return nil, fmt.Errorf("the informer of cluster(%s) has not been initialized", clusterName)
+	}
+
+	return singleClusterManager.GetClient().Resource(gvr).Namespace(workload.GetNamespace()).Get(ctx, workload.GetName(), metav1.GetOptions{})
 }
 
 // tryDeleteWorkload tries to delete resources in the given member cluster.

--- a/pkg/controllers/execution/execution_controller_test.go
+++ b/pkg/controllers/execution/execution_controller_test.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	workv1alpha1 "github.com/karmada-io/karmada/pkg/apis/work/v1alpha1"
@@ -86,14 +87,18 @@ const (
 
 func TestExecutionController_Reconcile(t *testing.T) {
 	tests := []struct {
-		name               string
-		work               *workv1alpha1.Work
-		ns                 string
-		expectRes          controllerruntime.Result
-		expectCondition    *metav1.Condition
-		expectEventMessage string
-		existErr           bool
-		resourceExists     *bool
+		name                   string
+		work                   *workv1alpha1.Work
+		ns                     string
+		expectRes              controllerruntime.Result
+		expectCondition        *metav1.Condition
+		expectEventMessage     string
+		existErr               bool
+		resourceExists         *bool
+		expectFinalizerRemoved bool
+		// noClusterResource indicates the member cluster informer cache should have no pre-seeded
+		// resources. Used to test cleanup behavior when the resource is already absent from the cluster.
+		noClusterResource bool
 	}{
 		{
 			name:      "work dispatching is suspended, no error, no apply",
@@ -190,6 +195,20 @@ func TestExecutionController_Reconcile(t *testing.T) {
 				work.SetFinalizers([]string{util.ExecutionControllerFinalizer})
 			}),
 		},
+		{
+			name:                   "PreserveResourcesOnDeletion=true, resource already absent from member cluster, finalizer removed without error",
+			ns:                     "karmada-es-cluster",
+			expectRes:              controllerruntime.Result{},
+			existErr:               false,
+			expectFinalizerRemoved: true,
+			noClusterResource:      true,
+			work: newWork(func(work *workv1alpha1.Work) {
+				now := metav1.Now()
+				work.SetDeletionTimestamp(&now)
+				work.SetFinalizers([]string{util.ExecutionControllerFinalizer})
+				work.Spec.PreserveResourcesOnDeletion = ptr.To(true)
+			}),
+		},
 	}
 
 	for _, tt := range tests {
@@ -206,7 +225,12 @@ func TestExecutionController_Reconcile(t *testing.T) {
 			}
 
 			eventRecorder := record.NewFakeRecorder(1)
-			c := newController(tt.work, eventRecorder)
+			var c Controller
+			if tt.noClusterResource {
+				c = newControllerWithNoClusterResource(tt.work, eventRecorder)
+			} else {
+				c = newController(tt.work, eventRecorder)
+			}
 			res, err := c.Reconcile(context.Background(), req)
 			assert.Equal(t, tt.expectRes, res)
 			if tt.existErr {
@@ -236,11 +260,28 @@ func TestExecutionController_Reconcile(t *testing.T) {
 					assert.True(t, apierrors.IsNotFound(err), "pod (%s/%s) was not deleted", podNamespace, podName)
 				}
 			}
+
+			if tt.expectFinalizerRemoved {
+				updatedWork := &workv1alpha1.Work{}
+				err = c.Client.Get(context.Background(), req.NamespacedName, updatedWork)
+				if !apierrors.IsNotFound(err) {
+					assert.NoError(t, err)
+					assert.False(t, controllerutil.ContainsFinalizer(updatedWork, util.ExecutionControllerFinalizer))
+				}
+			}
 		})
 	}
 }
 
 func newController(work *workv1alpha1.Work, recorder *record.FakeRecorder) Controller {
+	return newControllerWithMemberResource(work, recorder, true)
+}
+
+func newControllerWithNoClusterResource(work *workv1alpha1.Work, recorder *record.FakeRecorder) Controller {
+	return newControllerWithMemberResource(work, recorder, false)
+}
+
+func newControllerWithMemberResource(work *workv1alpha1.Work, recorder *record.FakeRecorder, seedMemberResource bool) Controller {
 	cluster := newCluster(clusterName, clusterv1alpha1.ClusterConditionReady, metav1.ConditionTrue)
 	pod := testhelper.NewPod(podNamespace, podName)
 	pod.SetLabels(map[string]string{util.ManagedByKarmadaLabel: util.ManagedByKarmadaLabelValue})
@@ -254,7 +295,13 @@ func newController(work *workv1alpha1.Work, recorder *record.FakeRecorder) Contr
 		WithRESTMapper(restMapper).
 		WithInterceptorFuncs(withGVKInterceptor(clientScheme)).
 		Build()
-	dynamicClientSet := dynamicfake.NewSimpleDynamicClient(scheme.Scheme, pod)
+	var dynamicClientSet *dynamicfake.FakeDynamicClient
+	if seedMemberResource {
+		dynamicClientSet = dynamicfake.NewSimpleDynamicClient(scheme.Scheme, pod)
+	} else {
+		// No objects seeded — simulates resource already deleted from member cluster.
+		dynamicClientSet = dynamicfake.NewSimpleDynamicClient(scheme.Scheme)
+	}
 	informerManager := genericmanager.GetInstance()
 	informerManager.ForCluster(cluster.Name, dynamicClientSet, 0).Lister(corev1.SchemeGroupVersion.WithResource("pods"))
 	informerManager.Start(cluster.Name)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

when a Work is deleted with “preserve resources on deletion” enabled, this PR makes the controller handle NotFound more safely: if the cache lookup or the update step returns NotFound, it does a live GET to confirm whether the member‑cluster resource is actually gone. if it is already gone, that manifest is skipped; if it still exists, the update is retried. this lets cleanup finish reliably and the Work’s finalizer be removed, so the Work no longer gets stuck in the Terminating state when the target resource was deleted beforehand

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #7463 

<details>
```
=== RUN   TestExecutionController_Reconcile
=== RUN   TestExecutionController_Reconcile/work_dispatching_is_suspended,_no_error,_no_apply
=== RUN   TestExecutionController_Reconcile/work_dispatching_is_suspended,_adds_false_dispatching_condition
=== RUN   TestExecutionController_Reconcile/work_dispatching_is_suspended,_adds_event_message
=== RUN   TestExecutionController_Reconcile/work_dispatching_is_suspended,_overwrites_existing_dispatching_condition
=== RUN   TestExecutionController_Reconcile/suspend_work_with_deletion_timestamp_is_deleted
I0502 18:28:12.611393   16266 objectwatcher.go:256] Deleted the resource(kind=Pod, default/test) on cluster(cluster).
=== RUN   TestExecutionController_Reconcile/PreserveResourcesOnDeletion=true,_deletion_timestamp_set,_does_not_delete_resource
I0502 18:28:12.719944   16266 objectwatcher.go:199] Updated the resource(kind=Pod, default/test) on cluster(cluster) but the cluster object was not changed.
=== RUN   TestExecutionController_Reconcile/PreserveResourcesOnDeletion=false,_deletion_timestamp_set,_deletes_resource
I0502 18:28:12.842585   16266 objectwatcher.go:256] Deleted the resource(kind=Pod, default/test) on cluster(cluster).
=== RUN   TestExecutionController_Reconcile/PreserveResourcesOnDeletion_unset,_deletion_timestamp_set,_deletes_resource
I0502 18:28:12.960405   16266 objectwatcher.go:256] Deleted the resource(kind=Pod, default/test) on cluster(cluster).
=== RUN   TestExecutionController_Reconcile/PreserveResourcesOnDeletion=true,_resource_already_absent_from_member_cluster,_finalizer_removed_without_error
--- PASS: TestExecutionController_Reconcile (1.26s)
    --- PASS: TestExecutionController_Reconcile/work_dispatching_is_suspended,_no_error,_no_apply (0.33s)
    --- PASS: TestExecutionController_Reconcile/work_dispatching_is_suspended,_adds_false_dispatching_condition (0.11s)
    --- PASS: TestExecutionController_Reconcile/work_dispatching_is_suspended,_adds_event_message (0.11s)
    --- PASS: TestExecutionController_Reconcile/work_dispatching_is_suspended,_overwrites_existing_dispatching_condition (0.12s)
    --- PASS: TestExecutionController_Reconcile/suspend_work_with_deletion_timestamp_is_deleted (0.11s)
    --- PASS: TestExecutionController_Reconcile/PreserveResourcesOnDeletion=true,_deletion_timestamp_set,_does_not_delete_resource (0.11s)
    --- PASS: TestExecutionController_Reconcile/PreserveResourcesOnDeletion=false,_deletion_timestamp_set,_deletes_resource (0.12s)
    --- PASS: TestExecutionController_Reconcile/PreserveResourcesOnDeletion_unset,_deletion_timestamp_set,_deletes_resource (0.12s)
    --- PASS: TestExecutionController_Reconcile/PreserveResourcesOnDeletion=true,_resource_already_absent_from_member_cluster,_finalizer_removed_without_error (0.12s)
PASS
ok  	github.com/karmada-io/karmada/pkg/controllers/execution	1.407s
```
</details>


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
NONE
```

