### PR TITLE
events: migrate cronfederatedhpa to events.k8s.io recorder

### DIFF
--- a/cmd/controller-manager/app/controllermanager.go
+++ b/cmd/controller-manager/app/controllermanager.go
@@ -737,7 +737,7 @@ func startFederatedHorizontalPodAutoscalerController(ctx controllerscontext.Cont
 func startCronFederatedHorizontalPodAutoscalerController(ctx controllerscontext.Context) (enabled bool, err error) {
 	cronFHPAController := cronfederatedhpa.CronFHPAController{
 		Client:             ctx.Mgr.GetClient(),
-		EventRecorder:      ctx.Mgr.GetEventRecorderFor(cronfederatedhpa.ControllerName), //nolint:staticcheck // Note: GetEventRecorderFor is deprecated in controller-runtime v0.23.0 in favor of GetEventRecorder. This changes event API from v1 events to events.k8s.io. We need to migrate carefully, especially considering the impact on users and RBAC permission changes in installation/deployment tools.
+		EventRecorder:      ctx.Mgr.GetEventRecorder(cronfederatedhpa.ControllerName),
 		RateLimiterOptions: ctx.Opts.RateLimiterOptions,
 	}
 	if err = cronFHPAController.SetupWithManager(ctx.Mgr); err != nil {

--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_controller.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_controller.go
@@ -25,7 +25,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/tools/record"
+	clientgoevents "k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	autoscalingv1alpha1 "github.com/karmada-io/karmada/pkg/apis/autoscaling/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/events"
 	"github.com/karmada-io/karmada/pkg/metrics"
 	"github.com/karmada-io/karmada/pkg/sharedcli/ratelimiterflag"
 	"github.com/karmada-io/karmada/pkg/util/helper"
@@ -46,7 +47,7 @@ const (
 // CronFHPAController is used to operate CronFederatedHPA.
 type CronFHPAController struct {
 	client.Client // used to operate Cron resources.
-	EventRecorder record.EventRecorder
+	EventRecorder clientgoevents.EventRecorder
 
 	RateLimiterOptions ratelimiterflag.Options
 	CronHandler        *CronHandler
@@ -118,7 +119,7 @@ func (c *CronFHPAController) Reconcile(ctx context.Context, req controllerruntim
 
 // SetupWithManager creates a controller and register to controller manager.
 func (c *CronFHPAController) SetupWithManager(mgr controllerruntime.Manager) error {
-	c.CronHandler = NewCronHandler(mgr.GetClient(), mgr.GetEventRecorderFor(ControllerName)) //nolint:staticcheck // Note: GetEventRecorderFor is deprecated in controller-runtime v0.23.0 in favor of GetEventRecorder. This changes event API from v1 events to events.k8s.io. We need to migrate carefully, especially considering the impact on users and RBAC permission changes in installation/deployment tools.
+	c.CronHandler = NewCronHandler(mgr.GetClient(), mgr.GetEventRecorder(ControllerName))
 	return controllerruntime.NewControllerManagedBy(mgr).
 		Named(ControllerName).
 		For(&autoscalingv1alpha1.CronFederatedHPA{}).
@@ -139,14 +140,14 @@ func (c *CronFHPAController) processCronRule(ctx context.Context, cronFHPA *auto
 
 	if !helper.IsCronFederatedHPARuleSuspend(rule) {
 		if err := c.CronHandler.CreateCronJobForExecutor(cronFHPA, rule); err != nil {
-			c.EventRecorder.Event(cronFHPA, corev1.EventTypeWarning, "StartRuleFailed", err.Error())
+			c.EventRecorder.Eventf(cronFHPA, nil, corev1.EventTypeWarning, events.EventReasonStartCronFederatedHPARuleFailed, events.EventActionStartCronFederatedHPARule, err.Error())
 			klog.ErrorS(err, "Fail to start cron for CronFederatedHPA rule", "cronFederatedHPA", cronFHPAKey, "rule", rule.Name)
 			return err
 		}
 	}
 
 	if err := c.updateRuleHistory(ctx, cronFHPA, rule); err != nil {
-		c.EventRecorder.Event(cronFHPA, corev1.EventTypeWarning, "UpdateCronFederatedHPAFailed", err.Error())
+		c.EventRecorder.Eventf(cronFHPA, nil, corev1.EventTypeWarning, events.EventReasonUpdateCronFederatedHPAFailed, events.EventActionUpdateCronFederatedHPA, err.Error())
 		return err
 	}
 	return nil
@@ -207,7 +208,7 @@ func (c *CronFHPAController) removeCronFHPAHistory(ctx context.Context, cronFHPA
 		return nil
 	}
 	if err := c.Client.Status().Update(ctx, cronFHPA); err != nil {
-		c.EventRecorder.Event(cronFHPA, corev1.EventTypeWarning, "UpdateCronFederatedHPAFailed", err.Error())
+		c.EventRecorder.Eventf(cronFHPA, nil, corev1.EventTypeWarning, events.EventReasonUpdateCronFederatedHPAFailed, events.EventActionUpdateCronFederatedHPA, err.Error())
 		klog.ErrorS(err, "Fail to remove CronFederatedHPA rule history", "namespace", cronFHPA.Namespace, "name", cronFHPA.Name, "rule", ruleName)
 		return err
 	}

--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_controller.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_controller.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	autoscalingv1alpha1 "github.com/karmada-io/karmada/pkg/apis/autoscaling/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/events"
@@ -43,6 +44,9 @@ const (
 	// ControllerName is the controller name that will be used when reporting events and metrics.
 	ControllerName = "cronfederatedhpa-controller"
 )
+
+// Check if our CronFHPAController implements necessary interface
+var _ reconcile.Reconciler = &CronFHPAController{}
 
 // CronFHPAController is used to operate CronFederatedHPA.
 type CronFHPAController struct {
@@ -140,14 +144,14 @@ func (c *CronFHPAController) processCronRule(ctx context.Context, cronFHPA *auto
 
 	if !helper.IsCronFederatedHPARuleSuspend(rule) {
 		if err := c.CronHandler.CreateCronJobForExecutor(cronFHPA, rule); err != nil {
-			c.EventRecorder.Eventf(cronFHPA, nil, corev1.EventTypeWarning, events.EventReasonStartCronFederatedHPARuleFailed, events.EventActionStartCronFederatedHPARule, err.Error())
+			c.EventRecorder.Eventf(cronFHPA, nil, corev1.EventTypeWarning, events.EventReasonStartCronFederatedHPARuleFailed, events.EventActionStartCronFederatedHPARule, "%v", err)
 			klog.ErrorS(err, "Fail to start cron for CronFederatedHPA rule", "cronFederatedHPA", cronFHPAKey, "rule", rule.Name)
 			return err
 		}
 	}
 
 	if err := c.updateRuleHistory(ctx, cronFHPA, rule); err != nil {
-		c.EventRecorder.Eventf(cronFHPA, nil, corev1.EventTypeWarning, events.EventReasonUpdateCronFederatedHPAFailed, events.EventActionUpdateCronFederatedHPA, err.Error())
+		c.EventRecorder.Eventf(cronFHPA, nil, corev1.EventTypeWarning, events.EventReasonUpdateCronFederatedHPAFailed, events.EventActionUpdateCronFederatedHPA, "%v", err)
 		return err
 	}
 	return nil
@@ -208,7 +212,7 @@ func (c *CronFHPAController) removeCronFHPAHistory(ctx context.Context, cronFHPA
 		return nil
 	}
 	if err := c.Client.Status().Update(ctx, cronFHPA); err != nil {
-		c.EventRecorder.Eventf(cronFHPA, nil, corev1.EventTypeWarning, events.EventReasonUpdateCronFederatedHPAFailed, events.EventActionUpdateCronFederatedHPA, err.Error())
+		c.EventRecorder.Eventf(cronFHPA, nil, corev1.EventTypeWarning, events.EventReasonUpdateCronFederatedHPAFailed, events.EventActionUpdateCronFederatedHPA, "%v", err)
 		klog.ErrorS(err, "Fail to remove CronFederatedHPA rule history", "namespace", cronFHPA.Namespace, "name", cronFHPA.Name, "rule", ruleName)
 		return err
 	}

--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_events_test.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_events_test.go
@@ -138,3 +138,25 @@ func TestEventConstantsPreserveWireFormat(t *testing.T) {
 		assert.Equal(t, want, got, "reason string drifted from existing wire format")
 	}
 }
+
+// TestEventfFormatStringSafety guards against the regression where an error
+// message containing format verbs (%v, %s, %d, or even raw % characters from
+// URL-encoded paths) is passed as the 'note' format string to Eventf. The
+// safe pattern is to pass "%v" as the format and the error as an argument,
+// so Sprintf treats the error message as data, not as a format directive.
+func TestEventfFormatStringSafety(t *testing.T) {
+	rec := &capturingRecorder{}
+	cronFHPA := newCronFHPAFixture()
+	// An error whose message contains both real format verbs and a raw % —
+	// the kind that arises from wrapped errors and URL-bearing API failures.
+	hostileErr := errors.New("decoding %d failed at https://api/foo%20bar: %v")
+
+	rec.Eventf(cronFHPA, nil, corev1.EventTypeWarning,
+		events.EventReasonUpdateCronFederatedHPAFailed, events.EventActionUpdateCronFederatedHPA,
+		"%v", hostileErr)
+
+	// With the safe pattern, the error message round-trips verbatim — the
+	// %d, %20, and %v inside the error are treated as literal characters.
+	assert.Equal(t, hostileErr.Error(), rec.note)
+	assert.NotContains(t, rec.note, "MISSING", "Sprintf saw the error as a format string and substituted MISSING placeholders")
+}

--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_events_test.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_events_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cronfederatedhpa
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	clientgoevents "k8s.io/client-go/tools/events"
+
+	autoscalingv1alpha1 "github.com/karmada-io/karmada/pkg/apis/autoscaling/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/events"
+)
+
+// capturingRecorder records every field passed to Eventf, including action
+// and related which the upstream events.FakeRecorder discards from its event
+// channel. It satisfies clientgoevents.EventRecorderLogger.
+type capturingRecorder struct {
+	regarding runtime.Object
+	related   runtime.Object
+	eventType string
+	reason    string
+	action    string
+	note      string
+	called    int
+}
+
+func (c *capturingRecorder) Eventf(regarding, related runtime.Object, eventtype, reason, action, note string, args ...interface{}) {
+	c.regarding = regarding
+	c.related = related
+	c.eventType = eventtype
+	c.reason = reason
+	c.action = action
+	c.note = fmt.Sprintf(note, args...)
+	c.called++
+}
+
+func (c *capturingRecorder) WithLogger(klog.Logger) clientgoevents.EventRecorderLogger {
+	return c
+}
+
+var _ clientgoevents.EventRecorderLogger = &capturingRecorder{}
+
+func newCronFHPAFixture() *autoscalingv1alpha1.CronFederatedHPA {
+	return &autoscalingv1alpha1.CronFederatedHPA{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cron-fhpa",
+			Namespace: "default",
+		},
+		Spec: autoscalingv1alpha1.CronFederatedHPASpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: autoscalingv1alpha1.GroupVersion.String(),
+				Kind:       autoscalingv1alpha1.FederatedHPAKind,
+				Name:       "test-fhpa",
+			},
+		},
+	}
+}
+
+func TestTargetReferenceFor(t *testing.T) {
+	cronFHPA := newCronFHPAFixture()
+
+	ref := targetReferenceFor(cronFHPA)
+
+	assert.Equal(t, autoscalingv1alpha1.GroupVersion.String(), ref.APIVersion)
+	assert.Equal(t, autoscalingv1alpha1.FederatedHPAKind, ref.Kind)
+	assert.Equal(t, "test-fhpa", ref.Name)
+	assert.Equal(t, "default", ref.Namespace)
+
+	// The returned reference is itself a runtime.Object — required for use
+	// as the 'related' argument on the new EventRecorder.Eventf signature.
+	var _ runtime.Object = ref
+}
+
+// TestEventRecorderEmitsAllFields exercises the new events.k8s.io/v1
+// Eventf signature with the constants and helpers introduced by this PoC,
+// asserting that every field — including action and related, which the
+// upstream FakeRecorder drops from its channel — round-trips correctly.
+//
+// It does not invoke a controller reconcile (that path is covered by the
+// existing handler tests); it asserts the contract between the recorder
+// and the constants/helpers this migration introduces.
+func TestEventRecorderEmitsAllFields(t *testing.T) {
+	rec := &capturingRecorder{}
+	cronFHPA := newCronFHPAFixture()
+
+	rec.Eventf(cronFHPA, targetReferenceFor(cronFHPA), corev1.EventTypeWarning,
+		events.EventReasonScaleCronFederatedHPAFailed, events.EventActionScaleCronFederatedHPA,
+		"failed to scale %s %s/%s: %v", cronFHPA.Spec.ScaleTargetRef.Kind, cronFHPA.Namespace, cronFHPA.Spec.ScaleTargetRef.Name, errors.New("target not found"))
+
+	assert.Equal(t, 1, rec.called)
+	assert.Same(t, cronFHPA, rec.regarding)
+	assert.Equal(t, corev1.EventTypeWarning, rec.eventType)
+	assert.Equal(t, "ScaleFailed", rec.reason)
+	assert.Equal(t, "ScaleCronFederatedHPA", rec.action)
+	assert.Contains(t, rec.note, "FederatedHPA")
+	assert.Contains(t, rec.note, "default/test-fhpa")
+	assert.Contains(t, rec.note, "target not found")
+
+	related, ok := rec.related.(*corev1.ObjectReference)
+	assert.True(t, ok, "related should be *corev1.ObjectReference, got %T", rec.related)
+	assert.Equal(t, "test-fhpa", related.Name)
+	assert.Equal(t, autoscalingv1alpha1.FederatedHPAKind, related.Kind)
+}
+
+// TestEventConstantsPreserveWireFormat guards against accidental edits to
+// the reason strings, which are part of the public surface of these events
+// — external tooling may match on them.
+func TestEventConstantsPreserveWireFormat(t *testing.T) {
+	cases := map[string]string{
+		"StartRuleFailed":              events.EventReasonStartCronFederatedHPARuleFailed,
+		"UpdateCronFederatedHPAFailed": events.EventReasonUpdateCronFederatedHPAFailed,
+		"ScaleFailed":                  events.EventReasonScaleCronFederatedHPAFailed,
+		"UpdateStatusFailed":           events.EventReasonUpdateCronFederatedHPAStatusFailed,
+	}
+	for want, got := range cases {
+		assert.Equal(t, want, got, "reason string drifted from existing wire format")
+	}
+}

--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_events_test.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_events_test.go
@@ -26,8 +26,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/klog/v2"
 	clientgoevents "k8s.io/client-go/tools/events"
+	"k8s.io/klog/v2"
 
 	autoscalingv1alpha1 "github.com/karmada-io/karmada/pkg/apis/autoscaling/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/events"
@@ -46,7 +46,7 @@ type capturingRecorder struct {
 	called    int
 }
 
-func (c *capturingRecorder) Eventf(regarding, related runtime.Object, eventtype, reason, action, note string, args ...interface{}) {
+func (c *capturingRecorder) Eventf(regarding, related runtime.Object, eventtype, reason, action, note string, args ...any) {
 	c.regarding = regarding
 	c.related = related
 	c.eventType = eventtype

--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_handler.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_handler.go
@@ -25,7 +25,7 @@ import (
 	"github.com/go-co-op/gocron"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/client-go/tools/record"
+	clientgoevents "k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -42,7 +42,7 @@ type RuleCron struct {
 // CronHandler is the handler for CronFederatedHPA
 type CronHandler struct {
 	client        client.Client
-	eventRecorder record.EventRecorder
+	eventRecorder clientgoevents.EventRecorder
 
 	// cronExecutorMap is [cronFederatedHPA name][rule name]RuleCron
 	cronExecutorMap map[string]map[string]RuleCron
@@ -54,7 +54,7 @@ type CronHandler struct {
 }
 
 // NewCronHandler creates new cron handler
-func NewCronHandler(client client.Client, eventRecorder record.EventRecorder) *CronHandler {
+func NewCronHandler(client client.Client, eventRecorder clientgoevents.EventRecorder) *CronHandler {
 	return &CronHandler{
 		client:                 client,
 		eventRecorder:          eventRecorder,

--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_handler_test.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_handler_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -85,7 +85,7 @@ func TestCronFHPAScaleTargetRefUpdates(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := NewCronHandler(fake.NewClientBuilder().Build(), record.NewFakeRecorder(100))
+			handler := NewCronHandler(fake.NewClientBuilder().Build(), events.NewFakeRecorder(100))
 
 			// Empty initialTarget will be skipped
 			if tt.initialTarget != (autoscalingv2.CrossVersionObjectReference{}) {
@@ -100,7 +100,7 @@ func TestCronFHPAScaleTargetRefUpdates(t *testing.T) {
 }
 
 func TestAddCronExecutorIfNotExist(t *testing.T) {
-	handler := NewCronHandler(fake.NewClientBuilder().Build(), record.NewFakeRecorder(100))
+	handler := NewCronHandler(fake.NewClientBuilder().Build(), events.NewFakeRecorder(100))
 
 	cronFHPAKey := "default/test-cronhpa"
 
@@ -115,7 +115,7 @@ func TestAddCronExecutorIfNotExist(t *testing.T) {
 }
 
 func TestRuleCronExecutorExists(t *testing.T) {
-	handler := NewCronHandler(fake.NewClientBuilder().Build(), record.NewFakeRecorder(100))
+	handler := NewCronHandler(fake.NewClientBuilder().Build(), events.NewFakeRecorder(100))
 
 	cronFHPAKey := "default/test-cronhpa"
 	ruleName := "test-rule"
@@ -138,7 +138,7 @@ func TestRuleCronExecutorExists(t *testing.T) {
 }
 
 func TestStopRuleExecutor(t *testing.T) {
-	handler := NewCronHandler(fake.NewClientBuilder().Build(), record.NewFakeRecorder(100))
+	handler := NewCronHandler(fake.NewClientBuilder().Build(), events.NewFakeRecorder(100))
 
 	cronFHPAKey := "default/test-cronhpa"
 	ruleName := "test-rule"
@@ -160,7 +160,7 @@ func TestStopRuleExecutor(t *testing.T) {
 }
 
 func TestStopCronFHPAExecutor(t *testing.T) {
-	handler := NewCronHandler(fake.NewClientBuilder().Build(), record.NewFakeRecorder(100))
+	handler := NewCronHandler(fake.NewClientBuilder().Build(), events.NewFakeRecorder(100))
 
 	cronFHPAKey := "default/test-cronhpa"
 	ruleName1 := "test-rule-1"
@@ -193,7 +193,7 @@ func TestStopCronFHPAExecutor(t *testing.T) {
 }
 
 func TestCreateCronJobForExecutor(t *testing.T) {
-	handler := NewCronHandler(fake.NewClientBuilder().Build(), record.NewFakeRecorder(100))
+	handler := NewCronHandler(fake.NewClientBuilder().Build(), events.NewFakeRecorder(100))
 
 	cronFHPA := &autoscalingv1alpha1.CronFederatedHPA{
 		ObjectMeta: metav1.ObjectMeta{
@@ -265,7 +265,7 @@ func TestCreateCronJobForExecutor(t *testing.T) {
 }
 
 func TestGetRuleNextExecuteTime(t *testing.T) {
-	handler := NewCronHandler(fake.NewClientBuilder().Build(), record.NewFakeRecorder(100))
+	handler := NewCronHandler(fake.NewClientBuilder().Build(), events.NewFakeRecorder(100))
 
 	cronFHPA := &autoscalingv1alpha1.CronFederatedHPA{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_job.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_job.go
@@ -67,8 +67,7 @@ func targetReferenceFor(cronFHPA *autoscalingv1alpha1.CronFederatedHPA) *corev1.
 }
 
 // NewCronFederatedHPAJob creates a new CronFederatedHPAJob.
-func NewCronFederatedHPAJob(client client.Client, eventRecorder clientgoevents.EventRecorder, scheduler *gocron.Scheduler,
-	cronFHPA *autoscalingv1alpha1.CronFederatedHPA, rule autoscalingv1alpha1.CronFederatedHPARule) *ScalingJob {
+func NewCronFederatedHPAJob(client client.Client, eventRecorder clientgoevents.EventRecorder, scheduler *gocron.Scheduler, cronFHPA *autoscalingv1alpha1.CronFederatedHPA, rule autoscalingv1alpha1.CronFederatedHPARule) *ScalingJob {
 	return &ScalingJob{
 		client:        client,
 		eventRecorder: eventRecorder,
@@ -119,7 +118,7 @@ func RunCronFederatedHPARule(c *ScalingJob) {
 			err = c.addSuccessExecutionHistory(cronFHPA, c.rule.TargetReplicas, c.rule.TargetMinReplicas, c.rule.TargetMaxReplicas)
 		}
 		if err != nil {
-			c.eventRecorder.Eventf(cronFHPA, nil, corev1.EventTypeWarning, events.EventReasonUpdateCronFederatedHPAStatusFailed, events.EventActionUpdateCronFederatedHPAStatus, err.Error())
+			c.eventRecorder.Eventf(cronFHPA, nil, corev1.EventTypeWarning, events.EventReasonUpdateCronFederatedHPAStatusFailed, events.EventActionUpdateCronFederatedHPAStatus, "%v", err)
 		}
 	}()
 

--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_job.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_job.go
@@ -29,13 +29,14 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
+	clientgoevents "k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	autoscalingv1alpha1 "github.com/karmada-io/karmada/pkg/apis/autoscaling/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/events"
 	"github.com/karmada-io/karmada/pkg/metrics"
 	"github.com/karmada-io/karmada/pkg/util"
 	"github.com/karmada-io/karmada/pkg/util/helper"
@@ -44,15 +45,29 @@ import (
 // ScalingJob is a job to handle CronFederatedHPA.
 type ScalingJob struct {
 	client        client.Client
-	eventRecorder record.EventRecorder
+	eventRecorder clientgoevents.EventRecorder
 	scheduler     *gocron.Scheduler
 
 	namespaceName types.NamespacedName
 	rule          autoscalingv1alpha1.CronFederatedHPARule
 }
 
+// targetReferenceFor returns the scale target as an ObjectReference suitable
+// for use as the 'related' argument on Eventf. The reference is built from
+// the cronFHPA's ScaleTargetRef and namespace; no API call is made and the
+// returned object is intentionally minimal — it carries enough identity for
+// an event consumer to locate the target, not a fully-loaded copy.
+func targetReferenceFor(cronFHPA *autoscalingv1alpha1.CronFederatedHPA) *corev1.ObjectReference {
+	return &corev1.ObjectReference{
+		APIVersion: cronFHPA.Spec.ScaleTargetRef.APIVersion,
+		Kind:       cronFHPA.Spec.ScaleTargetRef.Kind,
+		Name:       cronFHPA.Spec.ScaleTargetRef.Name,
+		Namespace:  cronFHPA.Namespace,
+	}
+}
+
 // NewCronFederatedHPAJob creates a new CronFederatedHPAJob.
-func NewCronFederatedHPAJob(client client.Client, eventRecorder record.EventRecorder, scheduler *gocron.Scheduler,
+func NewCronFederatedHPAJob(client client.Client, eventRecorder clientgoevents.EventRecorder, scheduler *gocron.Scheduler,
 	cronFHPA *autoscalingv1alpha1.CronFederatedHPA, rule autoscalingv1alpha1.CronFederatedHPARule) *ScalingJob {
 	return &ScalingJob{
 		client:        client,
@@ -96,13 +111,15 @@ func RunCronFederatedHPARule(c *ScalingJob) {
 	defer func() {
 		metrics.ObserveProcessCronFederatedHPARuleLatency(scaleErr, start)
 		if scaleErr != nil {
-			c.eventRecorder.Event(cronFHPA, corev1.EventTypeWarning, "ScaleFailed", scaleErr.Error())
+			c.eventRecorder.Eventf(cronFHPA, targetReferenceFor(cronFHPA), corev1.EventTypeWarning,
+				events.EventReasonScaleCronFederatedHPAFailed, events.EventActionScaleCronFederatedHPA,
+				"failed to scale %s %s/%s: %v", cronFHPA.Spec.ScaleTargetRef.Kind, cronFHPA.Namespace, cronFHPA.Spec.ScaleTargetRef.Name, scaleErr)
 			err = c.addFailedExecutionHistory(cronFHPA, scaleErr.Error())
 		} else {
 			err = c.addSuccessExecutionHistory(cronFHPA, c.rule.TargetReplicas, c.rule.TargetMinReplicas, c.rule.TargetMaxReplicas)
 		}
 		if err != nil {
-			c.eventRecorder.Event(cronFHPA, corev1.EventTypeWarning, "UpdateStatusFailed", err.Error())
+			c.eventRecorder.Eventf(cronFHPA, nil, corev1.EventTypeWarning, events.EventReasonUpdateCronFederatedHPAStatusFailed, events.EventActionUpdateCronFederatedHPAStatus, err.Error())
 		}
 	}()
 

--- a/pkg/controllers/cronfederatedhpa/cronfederatedhpa_job_test.go
+++ b/pkg/controllers/cronfederatedhpa/cronfederatedhpa_job_test.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	autoscalingv1alpha1 "github.com/karmada-io/karmada/pkg/apis/autoscaling/v1alpha1"
@@ -35,7 +35,7 @@ import (
 
 func TestNewCronFederatedHPAJob(t *testing.T) {
 	client := fake.NewClientBuilder().Build()
-	eventRecorder := record.NewFakeRecorder(100)
+	eventRecorder := events.NewFakeRecorder(100)
 	scheduler := gocron.NewScheduler(time.UTC)
 	cronFHPA := &autoscalingv1alpha1.CronFederatedHPA{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -161,3 +161,45 @@ const (
 	// EventReasonAPIIncompatible indicates that the MultiClusterService may not function properly as some member clusters do not support EndpointSlice.
 	EventReasonAPIIncompatible = "APIIncompatible"
 )
+
+// Define events for CronFederatedHPA.
+//
+// Reason and action are distinct: reason describes the specific outcome of an
+// operation (e.g. "ScaleFailed"), while action describes the operation itself
+// independent of outcome (e.g. "ScaleCronFederatedHPA"). A single action may
+// be paired with multiple reasons over time as success and additional failure
+// modes are surfaced; reusing one action constant across those reasons is the
+// intended pattern, matching upstream Kubernetes (e.g. kube-scheduler emits
+// reason "Scheduled" or "FailedScheduling" with action "Binding").
+//
+// Reason values below are kept byte-identical to the strings previously
+// emitted as inline literals, so any external watcher keyed on these strings
+// continues to match. Action values are introduced by the migration to
+// events.k8s.io/v1, where action is a required machine-readable field.
+const (
+	// EventReasonStartCronFederatedHPARuleFailed indicates that starting the
+	// cron executor for a CronFederatedHPA rule failed.
+	EventReasonStartCronFederatedHPARuleFailed = "StartRuleFailed"
+	// EventReasonUpdateCronFederatedHPAFailed indicates that updating the
+	// CronFederatedHPA object failed.
+	EventReasonUpdateCronFederatedHPAFailed = "UpdateCronFederatedHPAFailed"
+	// EventReasonScaleCronFederatedHPAFailed indicates that scaling the target
+	// referenced by a CronFederatedHPA failed.
+	EventReasonScaleCronFederatedHPAFailed = "ScaleFailed"
+	// EventReasonUpdateCronFederatedHPAStatusFailed indicates that updating the
+	// CronFederatedHPA status with execution history failed.
+	EventReasonUpdateCronFederatedHPAStatusFailed = "UpdateStatusFailed"
+
+	// EventActionStartCronFederatedHPARule is the action of starting the cron
+	// executor for a CronFederatedHPA rule.
+	EventActionStartCronFederatedHPARule = "StartCronFederatedHPARule"
+	// EventActionUpdateCronFederatedHPA is the action of updating a
+	// CronFederatedHPA object.
+	EventActionUpdateCronFederatedHPA = "UpdateCronFederatedHPA"
+	// EventActionScaleCronFederatedHPA is the action of scaling the target
+	// referenced by a CronFederatedHPA.
+	EventActionScaleCronFederatedHPA = "ScaleCronFederatedHPA"
+	// EventActionUpdateCronFederatedHPAStatus is the action of updating a
+	// CronFederatedHPA's status with execution history.
+	EventActionUpdateCronFederatedHPAStatus = "UpdateCronFederatedHPAStatus"
+)

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -162,20 +162,9 @@ const (
 	EventReasonAPIIncompatible = "APIIncompatible"
 )
 
-// Define events for CronFederatedHPA.
-//
-// Reason and action are distinct: reason describes the specific outcome of an
-// operation (e.g. "ScaleFailed"), while action describes the operation itself
-// independent of outcome (e.g. "ScaleCronFederatedHPA"). A single action may
-// be paired with multiple reasons over time as success and additional failure
-// modes are surfaced; reusing one action constant across those reasons is the
-// intended pattern, matching upstream Kubernetes (e.g. kube-scheduler emits
-// reason "Scheduled" or "FailedScheduling" with action "Binding").
-//
-// Reason values below are kept byte-identical to the strings previously
-// emitted as inline literals, so any external watcher keyed on these strings
-// continues to match. Action values are introduced by the migration to
-// events.k8s.io/v1, where action is a required machine-readable field.
+// Define event reasons for CronFederatedHPA. Values are kept byte-identical
+// to the strings previously emitted as inline literals, so any external
+// watcher keyed on these strings continues to match.
 const (
 	// EventReasonStartCronFederatedHPARuleFailed indicates that starting the
 	// cron executor for a CronFederatedHPA rule failed.
@@ -189,17 +178,98 @@ const (
 	// EventReasonUpdateCronFederatedHPAStatusFailed indicates that updating the
 	// CronFederatedHPA status with execution history failed.
 	EventReasonUpdateCronFederatedHPAStatusFailed = "UpdateStatusFailed"
+)
 
-	// EventActionStartCronFederatedHPARule is the action of starting the cron
-	// executor for a CronFederatedHPA rule.
+// Event actions for events.k8s.io/v1 Events, established by issue #7251.
+//
+// Action describes the operation a controller performed, independent of
+// outcome (e.g. "ScheduleBinding" pairs with both "ScheduleBindingSucceed"
+// and "ScheduleBindingFailed" reasons). The events.k8s.io/v1 API requires
+// action as a machine-readable string, unlike the deprecated core/v1 Event.
+// A single action may be paired with multiple reasons over time as new
+// failure modes are surfaced; reusing one action across those reasons is
+// the intended pattern, matching upstream Kubernetes (e.g. kube-scheduler
+// emits reason "Scheduled" or "FailedScheduling" with action "Binding").
+//
+// Action names derive from paired reasons by dropping the Failed/Succeed
+// suffix; singleton reasons (no paired success/failure variant) get an
+// action named after the emitting operation.
+const (
+	// EventActionCreateExecutionSpace indicates the action of creating an execution space for a cluster.
+	EventActionCreateExecutionSpace = "CreateExecutionSpace"
+	// EventActionRemoveExecutionSpace indicates the action of removing the execution space of a cluster.
+	EventActionRemoveExecutionSpace = "RemoveExecutionSpace"
+	// EventActionTaintCluster indicates the action of tainting or untainting a cluster.
+	EventActionTaintCluster = "TaintCluster"
+	// EventActionSyncImpersonationConfig indicates the action of syncing impersonation config for a cluster.
+	EventActionSyncImpersonationConfig = "SyncImpersonationConfig"
+
+	// EventActionReflectStatus indicates the action of reflecting member-cluster status into a Work.
+	EventActionReflectStatus = "ReflectStatus"
+	// EventActionInterpretHealth indicates the action of interpreting workload health.
+	EventActionInterpretHealth = "InterpretHealth"
+
+	// EventActionSyncWorkload indicates the action of syncing a workload into a member cluster.
+	EventActionSyncWorkload = "SyncWorkload"
+	// EventActionDispatchWork indicates the action of dispatching a Work to a member cluster.
+	EventActionDispatchWork = "DispatchWork"
+
+	// EventActionCleanupWork indicates the action of cleaning up Work objects for a binding.
+	EventActionCleanupWork = "CleanupWork"
+	// EventActionSyncScheduleResultToDependencies indicates the action of syncing a schedule result to dependent bindings.
+	EventActionSyncScheduleResultToDependencies = "SyncScheduleResultToDependencies"
+	// EventActionResolveDependencyPolicy indicates the action of resolving the policy governing a dependency relationship.
+	EventActionResolveDependencyPolicy = "ResolveDependencyPolicy"
+
+	// EventActionSyncWork indicates the action of syncing a Work derived from a (Cluster)ResourceBinding.
+	EventActionSyncWork = "SyncWork"
+	// EventActionAggregateStatus indicates the action of aggregating per-cluster status into a binding.
+	EventActionAggregateStatus = "AggregateStatus"
+	// EventActionScheduleBinding indicates the action of scheduling a (Cluster)ResourceBinding to member clusters.
+	EventActionScheduleBinding = "ScheduleBinding"
+	// EventActionDescheduleBinding indicates the action of descheduling a (Cluster)ResourceBinding from a member cluster.
+	EventActionDescheduleBinding = "DescheduleBinding"
+	// EventActionEvictWorkloadFromCluster indicates the action of evicting a workload from a member cluster.
+	EventActionEvictWorkloadFromCluster = "EvictWorkloadFromCluster"
+
+	// EventActionSyncFederatedResourceQuota indicates the action of syncing a FederatedResourceQuota into member clusters.
+	EventActionSyncFederatedResourceQuota = "SyncFederatedResourceQuota"
+	// EventActionCollectFederatedResourceQuotaStatus indicates the action of collecting per-cluster status of a FederatedResourceQuota.
+	EventActionCollectFederatedResourceQuotaStatus = "CollectFederatedResourceQuotaStatus"
+	// EventActionCollectFederatedResourceQuotaOverallStatus indicates the action of computing the overall status of a FederatedResourceQuota.
+	EventActionCollectFederatedResourceQuotaOverallStatus = "CollectFederatedResourceQuotaOverallStatus"
+
+	// EventActionApplyPolicy indicates the action of applying a (Cluster)PropagationPolicy to a resource template.
+	EventActionApplyPolicy = "ApplyPolicy"
+	// EventActionApplyOverridePolicy indicates the action of applying a (Cluster)OverridePolicy.
+	EventActionApplyOverridePolicy = "ApplyOverridePolicy"
+	// EventActionPreemptPolicy indicates the action of one policy preempting another's resource template selection.
+	EventActionPreemptPolicy = "PreemptPolicy"
+	// EventActionGetDependencies indicates the action of resolving dependent resources via the interpreter.
+	EventActionGetDependencies = "GetDependencies"
+	// EventActionGetComponents indicates the action of resolving components of a resource template via the interpreter.
+	EventActionGetComponents = "GetComponents"
+	// EventActionGetReplicas indicates the action of resolving the replica count of a resource template via the interpreter.
+	EventActionGetReplicas = "GetReplicas"
+
+	// EventActionSyncDerivedService indicates the action of syncing a derived service for a ServiceImport.
+	EventActionSyncDerivedService = "SyncDerivedService"
+
+	// EventActionSyncService indicates the action of syncing a MultiClusterService across member clusters.
+	EventActionSyncService = "SyncService"
+	// EventActionDispatchEndpointSlice indicates the action of dispatching EndpointSlices for a MultiClusterService.
+	EventActionDispatchEndpointSlice = "DispatchEndpointSlice"
+	// EventActionResolveCluster indicates the action of resolving the member clusters configured on a MultiClusterService.
+	EventActionResolveCluster = "ResolveCluster"
+	// EventActionValidateClusterAPI indicates the action of validating that member clusters expose the APIs required by a MultiClusterService.
+	EventActionValidateClusterAPI = "ValidateClusterAPI"
+
+	// EventActionStartCronFederatedHPARule indicates the action of starting the cron executor for a CronFederatedHPA rule.
 	EventActionStartCronFederatedHPARule = "StartCronFederatedHPARule"
-	// EventActionUpdateCronFederatedHPA is the action of updating a
-	// CronFederatedHPA object.
+	// EventActionUpdateCronFederatedHPA indicates the action of updating a CronFederatedHPA object.
 	EventActionUpdateCronFederatedHPA = "UpdateCronFederatedHPA"
-	// EventActionScaleCronFederatedHPA is the action of scaling the target
-	// referenced by a CronFederatedHPA.
+	// EventActionScaleCronFederatedHPA indicates the action of scaling the target referenced by a CronFederatedHPA.
 	EventActionScaleCronFederatedHPA = "ScaleCronFederatedHPA"
-	// EventActionUpdateCronFederatedHPAStatus is the action of updating a
-	// CronFederatedHPA's status with execution history.
+	// EventActionUpdateCronFederatedHPAStatus indicates the action of updating a CronFederatedHPA's status with execution history.
 	EventActionUpdateCronFederatedHPAStatus = "UpdateCronFederatedHPAStatus"
 )


### PR DESCRIPTION
Part of #7527.

## What this PR does

Proof-of-concept for the migration tracked in #7251. Moves one
controller — cronfederatedhpa — end-to-end from the deprecated
`record.EventRecorder` (core/v1 Events) to the new
`events.EventRecorder` (events.k8s.io/v1), and introduces the
`EventAction*` constant pattern in `pkg/events` that the remaining
controllers will follow.

The intent is to validate the design before opening per-controller
follow-ups. If reviewers approve the pattern here, subsequent PRs
become mechanical applications of it.

## Why cronfederatedhpa

Smallest vertically self-contained slice in the codebase: 1
acquisition site in cmd/controller-manager, 1 in the controller
itself (via `NewCronHandler`), 5 emission sites across the controller
and the scaling job, no shared recorders with other controllers.

## Design choices worth a look

**Per-operation actions, not generic verbs.** Four `EventAction*`
constants (`StartCronFederatedHPARule`, `UpdateCronFederatedHPA`,
`ScaleCronFederatedHPA`, `UpdateCronFederatedHPAStatus`) rather than
a small set of CRUD-style verbs. Matches upstream Kubernetes — see
`staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/` where
actions are operation-specific (`SNICertificateReload`, etc.). Going
coarser would shrink the constant surface but lose information that
`reportingController` doesn't already carry.

**Reason strings preserved byte-for-byte.** "StartRuleFailed",
"UpdateCronFederatedHPAFailed", "ScaleFailed", "UpdateStatusFailed"
remain exactly as before. Constants are introduced for them so
future PRs can reference them, but no wire-format change for any
external consumer keyed on these strings. A new test
(`TestEventConstantsPreserveWireFormat`) guards against accidental
drift.

**`related` is non-nil where it's meaningful, nil otherwise.** The
`ScaleFailed` event now passes a synthetic `*corev1.ObjectReference`
built from `cronFHPA.Spec.ScaleTargetRef` so a consumer can link the
event to the workload that was being scaled. The other four
emissions (StartRuleFailed, UpdateCronFederatedHPAFailed twice,
UpdateStatusFailed) are about the CronFederatedHPA itself with no
meaningful secondary object, and consistently pass nil — matching
@XiShanYongYe-Chang's guidance in the issue thread.

**No RBAC changes.** No explicit ClusterRole in the deploy artifacts
grants karmada-controller-manager `events` permission against
karmada-apiserver — it authenticates via TLS and presumably has
broad access. Adding speculative `events.k8s.io` RBAC here would be
churn for an unverified problem. If events fail to emit at runtime
in a real deployment, RBAC files will be updated in the final
cleanup PR after all controllers have been migrated. Happy to add
an RBAC update here if reviewers prefer the conservative path.

## Behavioral test coverage

`cronfederatedhpa_events_test.go` adds three focused tests:

- `TestTargetReferenceFor` — verifies the `related` object is built
  correctly from `ScaleTargetRef`.
- `TestEventRecorderEmitsAllFields` — captures every field passed
  to `Eventf` (including `action` and `related`, which the upstream
  `events.FakeRecorder` drops from its channel) using a custom
  recorder, and asserts the full contract end-to-end.
- `TestEventConstantsPreserveWireFormat` — wire-format guard for
  the four reason strings.

## Scope

```
 cmd/controller-manager/app/controllermanager.go     |   2 +-
 .../cronfederatedhpa_controller.go                  |  13 +-
 .../cronfederatedhpa/cronfederatedhpa_events_test.go| 140 +++++++++++++++++
 .../cronfederatedhpa/cronfederatedhpa_handler.go    |   6 +-
 .../cronfederatedhpa_handler_test.go                |  16 +-
 .../cronfederatedhpa/cronfederatedhpa_job.go        |  27 ++-
 .../cronfederatedhpa/cronfederatedhpa_job_test.go   |   4 +-
 pkg/events/events.go                                |  42 +++++
```

The other 37 `GetEventRecorderFor` sites and their
`//nolint:staticcheck` markers are intentionally untouched in this
PR.

## Open questions for reviewers

1. Per-operation action constants vs. a smaller set of generic
   verbs — does the per-operation choice match what you have in
   mind for the wider migration?
2. RBAC: leave for the cleanup PR (current approach), or add the
   `events.k8s.io` permission in this PR even though I cannot point
   to a specific ClusterRole that needs it?
3. Should success events (e.g. `ScaleSucceeded`) be added in
   follow-up PRs? Not added here because the existing scale paths
   return nil even on no-op (target replicas already match), which
   would surface false-positive events. Distinguishing actual-change
   from no-change is a separate refactor.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test ./pkg/controllers/cronfederatedhpa/...` (3 new tests + all existing pass)
- Full unit-test sweep clean apart from three pre-existing failures
  on master unrelated to this change
  (`pkg/util/validation/TestValidateCrdsTarBall`,
  `operator/pkg/tasks/init/TestRunUnpack`,
  `pkg/karmadactl/cmdinit/utils/TestListFiles`).
- E2E suites not run (require a live cluster).

/kind cleanup
