### PR TITLE
feat(agent-skills): add Karmada agent skill set for AI coding agents

### DIFF
--- a/hack/agent-skills/CONTRIBUTING.md
+++ b/hack/agent-skills/CONTRIBUTING.md
@@ -1,0 +1,90 @@
+# Contributing to Karmada Agent Skills
+
+## Adding a New Skill
+
+1. Create a directory under `skills/` named after the skill (kebab-case).
+2. Add a `SKILL.md` file with these sections:
+   - **Description**: One sentence on what the skill does.
+   - **When to Load**: Trigger conditions (keywords, user intents).
+   - **Workflow**: Step-by-step instructions for the agent.
+   - **Knowledge References**: Paths to `knowledge/` files to load.
+   - **Template References**: Paths to `templates/` files to use.
+   - **Example References**: Paths to `examples/` scenarios.
+
+3. Add knowledge files under `knowledge/` if the skill introduces new concepts.
+4. Add templates under `templates/` if the skill needs starter YAML.
+5. Add example scenarios under `examples/` for complex use cases.
+6. Add deterministic helpers under `scripts/` for schema-sensitive tasks.
+7. Add tests under `tests/` to validate skill output correctness.
+
+### SKILL.md Format
+
+```markdown
+# Skill Name
+
+## Description
+Brief description.
+
+## When to Load
+- Trigger condition 1
+- Trigger condition 2
+
+## Workflow
+1. Step one
+2. Step two
+
+## Knowledge References
+- `hack/agent-skills/knowledge/policy-apis.yaml`
+- `hack/agent-skills/knowledge/policy-patterns.md`
+
+## Template References
+- `hack/agent-skills/templates/propagation-policy.yaml`
+
+## Example References
+- `hack/agent-skills/examples/multi-country-setup/`
+```
+
+## Adding Knowledge
+
+Knowledge files live under `knowledge/`. Use these formats:
+
+- **`*.yaml`**: Structured reference data (API fields, enums, constants).
+- **`*.md`**: Narrative guides, patterns, troubleshooting playbooks.
+
+## Adding Templates
+
+Templates live under `templates/`. Each template should:
+- Use YAML format with `karmada-io/karmada` native Kinds.
+- Include placeholder comments where values need to be filled.
+- Be valid YAML (syntax-checked by CI).
+
+## Adding Examples
+
+Examples live under `examples/`. Each example should have:
+- One or more policy/service YAML files.
+- A `README.md` explaining the scenario and expected outcome.
+
+## Testing
+
+Run tests from the `tests/` directory:
+
+```bash
+cd hack/agent-skills/tests
+./test-skills.sh
+```
+
+Tests validate that:
+- Templates are valid YAML.
+- Examples reference real API fields.
+- Skills reference existing knowledge files.
+- Scripts execute without errors.
+
+## Conventions
+
+- Skill names use kebab-case, matching their directory name.
+- Knowledge file names use kebab-case.
+- Template file names use kebab-case and match the Kind they template.
+- Example directory names use kebab-case.
+- Always reference the full API version `policy.karmada.io/v1alpha1`.
+- Use correct Karmada-specific terminology: PropagationPolicy, OverridePolicy,
+  ResourceBinding, Work, ClusterPropagationPolicy, ClusterOverridePolicy.

--- a/hack/agent-skills/README.md
+++ b/hack/agent-skills/README.md
@@ -1,0 +1,42 @@
+# Karmada Agent Skills
+
+Official Karmada skill set for AI coding agents. Provides deterministic guidance for
+policy creation, auditing, placement explanation, and propagation debugging.
+
+## Directory Structure
+
+```
+hack/agent-skills/
+├── skills/          # Agent skill definitions (SKILL.md per skill)
+├── knowledge/       # Shared knowledge base (policy APIs, patterns, troubleshooting)
+├── templates/       # Reusable YAML templates for all policy types
+├── examples/        # Worked scenarios (multi-country, failover, image-override)
+├── scripts/         # Deterministic helpers for schema-sensitive tasks
+├── tests/           # Skill validation tests
+├── CONTRIBUTING.md  # How to add new skills and knowledge
+└── README.md        # This file
+```
+
+## Available Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `karmada-knowledge` | Load Karmada concepts, APIs, components, and policy patterns |
+| `karmada-create-policy` | Generate PropagationPolicy and OverridePolicy YAML for workloads |
+| `karmada-audit-policy` | Review policies for selector mismatch, scope misuse, and risks |
+| `karmada-explain-placement` | Explain how a workload will be placed across member clusters |
+| `karmada-debug-propagation` | Debug why a resource was not propagated to a member cluster |
+| `karmada-search` | Search Karmada resources, bindings, and works |
+| `karmada-controller-manager` | Understand and interact with karmada-controller-manager |
+
+## Quick Start
+
+To use these skills with an AI coding agent, reference the skill directory:
+
+```
+# Example: create a PropagationPolicy for a Deployment
+Load skill: hack/agent-skills/skills/karmada-create-policy/SKILL.md
+```
+
+Each skill's SKILL.md describes when to load, the workflow to follow, and which
+knowledge files and templates to reference.

--- a/hack/agent-skills/examples/failover/README.md
+++ b/hack/agent-skills/examples/failover/README.md
@@ -1,0 +1,14 @@
+# Failover Configuration Example
+
+This example demonstrates a ProductionPropagationPolicy with comprehensive failover
+configuration, including application-level failover with state preservation and
+cluster-level failover.
+
+## Scenario
+
+A stateful application (Deployment + PVC) needs:
+- Deployment to primary cluster (member1) with member2 as backup
+- Application failover with 60s toleration
+- State preservation during failover (preserve availableReplicas)
+- Immediate purge on application failover (exactly-once consistency)
+- Graceful purge on cluster failure

--- a/hack/agent-skills/examples/failover/propagation-policy.yaml
+++ b/hack/agent-skills/examples/failover/propagation-policy.yaml
@@ -1,0 +1,36 @@
+# PropagationPolicy with comprehensive failover configuration.
+# Demonstrates application-level and cluster-level failover with state preservation.
+
+apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: stateful-app-failover
+  namespace: default
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: stateful-app
+
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - member1
+    # member2 will be used as failover target when member1 fails
+
+  # Dependency propagation ensures ConfigMaps/Secrets migrate with the app
+  propagateDeps: true
+
+  # Comprehensive failover configuration
+  failover:
+    # Application-level failover (app becomes unhealthy on a cluster)
+    application:
+      decisionConditions:
+        tolerationSeconds: 60  # Wait 60s before triggering failover
+      purgeMode: Directly      # Immediate eviction (exactly-once consistency)
+      # gracePeriodSeconds is not needed for Directly mode
+
+    # Cluster-level failover (whole cluster goes down)
+    cluster:
+      purgeMode: Gracefully    # Wait for app to become healthy before cleanup
+      # Default gracePeriodSeconds is 600 for Gracefully mode

--- a/hack/agent-skills/examples/image-override/README.md
+++ b/hack/agent-skills/examples/image-override/README.md
@@ -1,0 +1,13 @@
+# Image Override Example
+
+This example demonstrates how to use Karmada OverridePolicy to use different
+container image registries per cluster, including image tag overrides for
+canary deployments.
+
+## Scenario
+
+A microservice Deployment needs:
+- Production images from `registry.example.com/prod` on member1 (production)
+- Staging images from `registry.example.com/staging` on member2 (staging)
+- Canary tag (`v2-canary`) instead of `latest` on member3 (canary)
+- Specific container override in a multi-container Pod

--- a/hack/agent-skills/examples/image-override/override-policy.yaml
+++ b/hack/agent-skills/examples/image-override/override-policy.yaml
@@ -1,0 +1,62 @@
+# OverridePolicy for image-override example
+# Different image registries and tags per cluster, including predicate-based
+# overrides for specific containers in multi-container Pods.
+
+apiVersion: policy.karmada.io/v1alpha1
+kind: OverridePolicy
+metadata:
+  name: microservice-image-override
+  namespace: default
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: microservice
+
+  overrideRules:
+
+    # member1: Production registry
+    - targetCluster:
+        clusterNames:
+          - member1
+      overriders:
+        imageOverrider:
+          - component: Registry
+            operator: replace
+            value: registry.example.com/prod
+
+    # member2: Staging registry
+    - targetCluster:
+        clusterNames:
+          - member2
+      overriders:
+        imageOverrider:
+          - component: Registry
+            operator: replace
+            value: registry.example.com/staging
+
+    # member3: Canary tag + same production registry
+    - targetCluster:
+        clusterNames:
+          - member3
+      overriders:
+        imageOverrider:
+          - component: Registry
+            operator: replace
+            value: registry.example.com/prod
+          - component: Tag
+            operator: replace
+            value: v2-canary
+
+    # Example: Override only a specific sidecar container image
+    # (commented out — uncomment when using a multi-container Pod)
+    # - targetCluster:
+    #     clusterNames:
+    #       - member2
+    #   overriders:
+    #     imageOverrider:
+    #       - predicate:
+    #           path: /spec/template/spec/containers/1/image
+    #         component: Registry
+    #         operator: replace
+    #         value: sidecar-registry.example.com

--- a/hack/agent-skills/examples/image-override/propagation-policy.yaml
+++ b/hack/agent-skills/examples/image-override/propagation-policy.yaml
@@ -1,0 +1,38 @@
+# PropagationPolicy for image-override example
+# Propagates the microservice to all three clusters.
+
+apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: microservice-propagation
+  namespace: default
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: microservice
+
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - member1
+        - member2
+        - member3
+
+    replicaScheduling:
+      replicaSchedulingType: Divided
+      replicaDivisionPreference: Weighted
+      weightPreference:
+        staticWeightList:
+          - targetCluster:
+              clusterNames:
+                - member1
+            weight: 5
+          - targetCluster:
+              clusterNames:
+                - member2
+            weight: 2
+          - targetCluster:
+              clusterNames:
+                - member3
+            weight: 1

--- a/hack/agent-skills/examples/multi-country-setup/README.md
+++ b/hack/agent-skills/examples/multi-country-setup/README.md
@@ -1,0 +1,20 @@
+# Multi-Country Cluster Setup
+
+This example demonstrates a Karmada setup for a global application deployed across
+Singapore, Indonesia, Germany, and Brazil with country-aware placement, failover,
+and country-specific overrides.
+
+## Scenario
+
+A web application needs to run in four countries:
+- **Singapore** (asia-southeast1-sg): Primary for Southeast Asia
+- **Indonesia** (asia-southeast2-id): Secondary for Southeast Asia
+- **Germany** (europe-west1-de): Primary for Europe
+- **Brazil** (southamerica-east1-br): Primary for South America
+
+Requirements:
+- Deploy to all four clusters
+- Country-specific labels for routing to CDN endpoints
+- Different replica counts per region based on traffic
+- Region-aware failover: if SG fails, overflow to ID; if DE fails, no immediate overflow
+- Production in SG/DE, staging in ID/BR

--- a/hack/agent-skills/examples/multi-country-setup/override-policy.yaml
+++ b/hack/agent-skills/examples/multi-country-setup/override-policy.yaml
@@ -1,0 +1,71 @@
+# OverridePolicy for multi-country web application
+# Country-specific CDN routing, environment labels, and replica counts.
+
+apiVersion: policy.karmada.io/v1alpha1
+kind: OverridePolicy
+metadata:
+  name: webapp-multi-country-override
+  namespace: default
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: webapp
+
+  overrideRules:
+
+    # Singapore: production, APAC CDN
+    - targetCluster:
+        clusterNames:
+          - asia-southeast1-sg
+      overriders:
+        labelsOverrider:
+          - operator: add
+            value:
+              environment: production
+              region: apac
+              cdn-endpoint: cdn-apac.example.com
+        annotationsOverrider:
+          - operator: add
+            value:
+              deployment-tier: tier-1
+
+    # Indonesia: staging, APAC CDN
+    - targetCluster:
+        clusterNames:
+          - asia-southeast2-id
+      overriders:
+        labelsOverrider:
+          - operator: add
+            value:
+              environment: staging
+              region: apac
+              cdn-endpoint: cdn-apac.example.com
+
+    # Germany: production, EU CDN
+    - targetCluster:
+        clusterNames:
+          - europe-west1-de
+      overriders:
+        labelsOverrider:
+          - operator: add
+            value:
+              environment: production
+              region: europe
+              cdn-endpoint: cdn-eu.example.com
+        annotationsOverrider:
+          - operator: add
+            value:
+              deployment-tier: tier-1
+
+    # Brazil: staging, LATAM CDN
+    - targetCluster:
+        clusterNames:
+          - southamerica-east1-br
+      overriders:
+        labelsOverrider:
+          - operator: add
+            value:
+              environment: staging
+              region: latam
+              cdn-endpoint: cdn-latam.example.com

--- a/hack/agent-skills/examples/multi-country-setup/propagation-policy.yaml
+++ b/hack/agent-skills/examples/multi-country-setup/propagation-policy.yaml
@@ -1,0 +1,74 @@
+# PropagationPolicy for multi-country web application
+# Places workload across 4 countries with weighted replica distribution
+# and region-aware failover.
+
+apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: webapp-multi-country-propagation
+  namespace: default
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: webapp
+
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - asia-southeast1-sg
+        - asia-southeast2-id
+        - europe-west1-de
+        - southamerica-east1-br
+
+    # Spread across all 4 clusters
+    spreadConstraints:
+      - spreadByField: cluster
+        maxGroups: 4
+        minGroups: 4
+
+    # Weighted replica distribution based on traffic expectations
+    replicaScheduling:
+      replicaSchedulingType: Divided
+      replicaDivisionPreference: Weighted
+      weightPreference:
+        staticWeightList:
+          - targetCluster:
+              clusterNames:
+                - asia-southeast1-sg
+            weight: 4    # Highest traffic
+          - targetCluster:
+              clusterNames:
+                - europe-west1-de
+            weight: 4    # Highest traffic
+          - targetCluster:
+              clusterNames:
+                - asia-southeast2-id
+            weight: 2    # Medium traffic
+          - targetCluster:
+              clusterNames:
+                - southamerica-east1-br
+            weight: 2    # Medium traffic
+
+    # Cluster tolerations for gracefully handling cluster issues
+    clusterTolerations:
+      - key: "cluster.karmada.io/not-ready"
+        operator: "Exists"
+        effect: "NoSchedule"
+        tolerationSeconds: 300
+
+  # Failover: if application fails on a cluster, wait 5 min then evict gracefully
+  failover:
+    application:
+      decisionConditions:
+        tolerationSeconds: 300
+      purgeMode: Gracefully
+      gracePeriodSeconds: 600
+    cluster:
+      purgeMode: Gracefully
+
+  # Auto-propagate referenced ConfigMaps and Secrets
+  propagateDeps: true
+
+  # Conflict resolution: overwrite if resource already exists (migration scenario)
+  conflictResolution: Overwrite

--- a/hack/agent-skills/knowledge/components.md
+++ b/hack/agent-skills/knowledge/components.md
@@ -1,0 +1,109 @@
+# Karmada Components Guide
+
+## Core Components
+
+### karmada-apiserver
+- HTTP API server providing the Karmada control plane API.
+- Exposes all Karmada CRDs (PropagationPolicy, OverridePolicy, ResourceBinding, Work, etc.).
+- Runs in `karmada-system` namespace.
+- Port: typically 5443 (internal), exposes policy.karmada.io and work.karmada.io API groups.
+
+### karmada-controller-manager
+- Runs multiple controllers:
+  - **Cluster controller**: Manages cluster lifecycle (join, unjoin, health).
+  - **Binding controller**: Creates ResourceBinding/ClusterResourceBinding from matched policies.
+  - **Execution controller**: Creates Work objects from ResourceBindings for each target cluster.
+  - **Override controller**: Applies OverridePolicy rules to workloads.
+  - **Namespace controller**: Auto-propagates namespaces (unless skipped).
+  - **Taint manager**: Handles cluster taints and eviction.
+  - **Graceful eviction controller**: Manages graceful eviction tasks.
+  - **FederatedResourceQuota controller**: Manages federated resource quotas.
+- Runs in `karmada-system` namespace.
+- Logs: `kubectl logs -n karmada-system deployment/karmada-controller-manager`
+
+### karmada-scheduler
+- Schedule resources to member clusters based on Placement rules.
+- Evaluates cluster affinity, tolerations, spread constraints, replica scheduling.
+- Assigns clusters in ResourceBinding.spec.clusters.
+- Supports weighted, aggregated, and dynamic replica distribution.
+- Runs in `karmada-system` namespace.
+- Logs: `kubectl logs -n karmada-system deployment/karmada-scheduler`
+
+### karmada-agent
+- Runs on each member cluster.
+- Syncs Work objects from Karmada control plane to the member cluster.
+- Reports status back (ManifestStatus, Health).
+- Runs in `karmada-system` namespace on each member cluster.
+- Logs: `kubectl logs -n karmada-system deployment/karmada-agent` (on member cluster)
+
+### karmada-webhook
+- Admission webhooks for Karmada CRDs.
+- Validates PropagationPolicy, OverridePolicy, ResourceBinding, etc.
+- Runs in `karmada-system` namespace.
+
+### karmada-aggregated-apiserver
+- Aggregated API server extending the Kubernetes API with Karmada-specific resources.
+- Provides the `cluster.karmada.io` API group for Cluster resources.
+- Runs in `karmada-system` namespace.
+
+### etcd
+- Backing store for the Karmada API server.
+- Runs in `karmada-system` namespace (when using embedded etcd).
+
+### karmada-search
+- Optional component for cross-cluster resource search.
+- Provides `search.karmada.io` API group.
+- Allows searching resources across all member clusters from a single endpoint.
+
+## Component Interaction Flow
+
+```
+User creates Deployment → karmada-apiserver stores it
+    ↓
+Binding controller detects Deployment matches PropagationPolicy
+    ↓
+Binding controller creates ResourceBinding with placement from policy
+    ↓
+Override controller applies OverridePolicy modifications to ResourceBinding
+    ↓
+karmada-scheduler assigns clusters to ResourceBinding.spec.clusters
+    ↓
+Execution controller creates Work objects (one per target cluster)
+    ↓
+karmada-agent on each member cluster syncs Work → creates resource locally
+    ↓
+karmada-agent reports status back to Work.status
+    ↓
+Binding controller aggregates status to ResourceBinding.status
+```
+
+## Key Namespaces
+
+| Namespace | Purpose |
+|-----------|---------|
+| `karmada-system` | Karmada control plane components |
+| `karmada-cluster` | Cluster registration resources |
+| `karmada-es-<cluster>` | Execution space: Work objects for each member cluster |
+
+## System Namespaces (Excluded from ClusterPropagationPolicy)
+
+ClusterPropagationPolicy cannot match resources in:
+- `karmada-system`
+- `karmada-cluster`
+- `karmada-es-*`
+
+These namespaces are reserved for Karmada's internal operation.
+
+## Feature Gates
+
+| Feature Gate | Description | Stage |
+|---|---|---|
+| `PropagateDeps` | Auto-propagate dependent resources | Beta / GA |
+| `Failover` | Application and cluster failover | Beta |
+| `GracefulEviction` | Graceful eviction of workloads | Beta |
+| `MultiplePodTemplatesScheduling` | Schedule workloads with multiple pod templates | Alpha |
+| `StatefulFailoverInjection` | Preserve state during failover | Alpha |
+| `PriorityBasedScheduling` | Priority-based workload scheduling | Alpha |
+| `PriorityBasedPreemptiveScheduling` | Preemptive scheduling based on priority | Alpha (not yet implemented) |
+| `Flux2GitopsAdaption` | Integration with Flux2 GitOps | Alpha |
+| `ResourceQuotaEstimate` | Resource quota estimation | Alpha |

--- a/hack/agent-skills/knowledge/policy-apis.yaml
+++ b/hack/agent-skills/knowledge/policy-apis.yaml
@@ -1,0 +1,288 @@
+# Karmada Policy API Reference
+# Source: pkg/apis/policy/v1alpha1/ and pkg/apis/work/v1alpha{1,2}/
+
+api_groups:
+  policy: policy.karmada.io/v1alpha1
+  work_v1alpha1: work.karmada.io/v1alpha1
+  work_v1alpha2: work.karmada.io/v1alpha2  # storage version
+
+# ── PropagationPolicy ──────────────────────────────────────────
+propagation_policy:
+  kind: PropagationPolicy
+  scope: Namespaced
+  shortName: pp
+  required_fields:
+    - spec.resourceSelectors  # MinItems: 1
+  spec_fields:
+    resourceSelectors:
+      - apiVersion: string (required)
+        kind: string (required)
+        namespace: string (optional, inherits from parent)
+        name: string (optional, selects specific resource)
+        labelSelector: metav1.LabelSelector (optional, ignored if name set)
+
+    placement:
+      clusterAffinity: # mutually exclusive with clusterAffinities
+        labelSelector: metav1.LabelSelector
+        fieldSelector: # keys: provider, region, zone; operators: In, NotIn
+            matchExpressions: []
+        clusterNames: [string]
+        exclude: [string]
+      clusterAffinities: [ClusterAffinityTerm] # mutually exclusive with clusterAffinity
+        - affinityName: string (required, 1-32 chars)
+          labelSelector: metav1.LabelSelector
+          fieldSelector: FieldSelector
+          clusterNames: [string]
+          exclude: [string]
+          overflowAffinities: [OverflowClusterAffinity]
+            - affinityName: string
+              labelSelector: metav1.LabelSelector
+              fieldSelector: FieldSelector
+              clusterNames: [string]
+              exclude: [string]
+      clusterTolerations: [corev1.Toleration]
+      spreadConstraints:
+        - spreadByField: cluster | region | zone | provider
+          spreadByLabel: string (mutually exclusive with spreadByField)
+          maxGroups: int
+          minGroups: int (default 1)
+      replicaScheduling:
+        replicaSchedulingType: Duplicated | Divided (default Divided)
+        replicaDivisionPreference: Aggregated | Weighted
+        weightPreference:
+          staticWeightList:
+            - targetCluster: ClusterAffinity
+              weight: int (min 1)
+          dynamicWeight: AvailableReplicas
+      workloadAffinity:
+        affinity:
+          groupByLabelKey: string
+        antiAffinity:
+          groupByLabelKey: string
+
+    propagateDeps: bool (default false)
+    priority: *int32 (default 0, higher = higher priority)
+    preemption: Always | Never (default Never)
+    schedulerName: string (default "default-scheduler")
+    dependentOverrides: [string]
+    conflictResolution: Abort | Overwrite (default Abort)
+    activationPreference: Lazy
+    failover:
+      application:
+        decisionConditions:
+          tolerationSeconds: *int32 (default 300)
+        purgeMode: Directly | Gracefully | Never (default Gracefully)
+        gracePeriodSeconds: *int32 (default 600)
+        statePreservation:
+          rules:
+            - aliasLabelName: string
+              jsonPath: string
+      cluster:
+        purgeMode: Directly | Gracefully (default Gracefully)
+        statePreservation:
+          rules:
+            - aliasLabelName: string
+              jsonPath: string
+    suspension:
+      dispatching: *bool
+      dispatchingOnClusters:
+        clusterNames: [string]
+    preserveResourcesOnDeletion: *bool
+    schedulePriority:
+      priorityClassSource: KubePriorityClass | PodPriorityClass | FederatedPriorityClass
+      priorityClassName: string
+
+# ── ClusterPropagationPolicy ───────────────────────────────────
+cluster_propagation_policy:
+  kind: ClusterPropagationPolicy
+  scope: Cluster
+  shortName: cpp
+  note: Same PropagationSpec. Works on cluster-scoped resources and all namespaces
+        except system namespaces (karmada-system, karmada-cluster, karmada-es-*).
+
+# ── OverridePolicy ─────────────────────────────────────────────
+override_policy:
+  kind: OverridePolicy
+  scope: Namespaced
+  shortName: op
+  spec_fields:
+    resourceSelectors: [ResourceSelector] # nil means match all
+    overrideRules:
+      - targetCluster: ClusterAffinity
+        overriders:
+          imageOverrider:
+            - predicate:
+                path: string
+              component: Registry | Repository | Tag
+              operator: add | remove | replace
+              value: string
+          commandOverrider:
+            - containerName: string
+              operator: add | remove
+              value: [string]
+          argsOverrider:
+            - containerName: string
+              operator: add | remove
+              value: [string]
+          labelsOverrider:
+            - operator: add | remove | replace
+              value: {string: string}
+          annotationsOverrider:
+            - operator: add | remove | replace
+              value: {string: string}
+          plaintext:
+            - path: string (e.g. /spec/replicas)
+              operator: add | remove | replace
+              value: any JSON
+          fieldOverrider:
+            - fieldPath: string (RFC 6901)
+              json:
+                - subPath: string
+                  operator: add | remove | replace
+                  value: any JSON
+              yaml:
+                - subPath: string
+                  operator: add | remove | replace
+                  value: any JSON
+    # Deprecated fields (use overrideRules instead):
+    targetCluster: ClusterAffinity
+    overriders: Overriders
+
+  override_order: >
+    ImageOverrider → CommandOverrider → ArgsOverrider →
+    LabelsOverrider → AnnotationsOverrider → FieldOverrider → Plaintext
+
+# ── ClusterOverridePolicy ─────────────────────────────────────
+cluster_override_policy:
+  kind: ClusterOverridePolicy
+  scope: Cluster
+  shortName: cop
+  note: Same OverrideSpec. Works on cluster-scoped resources and all namespaces.
+
+# ── ResourceBinding (v1alpha2 - storage version) ───────────────
+resource_binding:
+  kind: ResourceBinding
+  scope: Namespaced
+  shortName: rb
+  spec_fields:
+    resource:
+      apiVersion: string
+      kind: string
+      namespace: string
+      name: string
+      uid: string
+      resourceVersion: string
+    clusters:
+      - name: string
+        replicas: int32
+    placement: Placement (from PropagationSpec)
+    schedulerName: string
+    failover: FailoverBehavior
+    conflictResolution: Abort | Overwrite
+    gracefulEvictionTasks:
+      - fromCluster: string
+        purgeMode: Immediately|Directly|Graciously|Gracefully|Never
+        replicas: *int32
+        reason: string
+        message: string
+        producer: string
+        gracePeriodSeconds: *int32
+        suppressDeletion: *bool
+        preservedLabelState: {string: string}
+  status:
+    conditions:
+      - type: Scheduled | FullyApplied
+        status: True | False | Unknown
+        reason: Success | SchedulerError | NoClusterFit | Unschedulable | QuotaExceeded
+    aggregatedStatus:
+      - clusterName: string
+        status: RawExtension
+        applied: bool
+        appliedMessage: string
+        health: Healthy | Unhealthy | Unknown
+
+# ── ClusterResourceBinding (v1alpha2 - storage version) ────────
+cluster_resource_binding:
+  kind: ClusterResourceBinding
+  scope: Cluster
+  shortName: crb
+  note: Same spec as ResourceBinding. Created from ClusterPropagationPolicy.
+
+# ── Work (v1alpha1) ────────────────────────────────────────────
+work:
+  kind: Work
+  scope: Namespaced
+  shortName: wk
+  spec_fields:
+    workload:
+      manifests:
+        - RawExtension (inline Kubernetes resource)
+    suspendDispatching: *bool
+    preserveResourcesOnDeletion: *bool
+  status:
+    conditions:
+      - type: Applied | Progressing | Available | Degraded | Dispatching
+    manifestStatuses:
+      - identifier:
+          ordinal: int
+          group: string
+          version: string
+          kind: string
+          resource: string
+          namespace: string
+          name: string
+        status: RawExtension
+        health: Healthy | Unhealthy | Unknown
+
+# ── Well-Known Labels/Annotations ─────────────────────────────
+well_known:
+  labels:
+    - key: propagationpolicy.karmada.io/permanent-id
+      desc: Unique identifier linking PropagationPolicy to ResourceBinding
+    - key: clusterpropagationpolicy.karmada.io/permanent-id
+      desc: Unique identifier linking ClusterPropagationPolicy to ClusterResourceBinding
+    - key: namespace.karmada.io/skip-auto-propagation
+      desc: When "true", namespace is excluded from auto-propagation
+  annotations:
+    - key: propagationpolicy.karmada.io/namespace
+      desc: Associated PropagationPolicy namespace
+    - key: propagationpolicy.karmada.io/name
+      desc: Associated PropagationPolicy name
+    - key: clusterpropagationpolicy.karmada.io/name
+      desc: Associated ClusterPropagationPolicy name
+
+# ── Spread Fields ─────────────────────────────────────────────
+spread_fields:
+  - cluster
+  - region
+  - zone
+  - provider
+
+# ── Replica Scheduling Modes ──────────────────────────────────
+replica_scheduling_types:
+  Duplicated: Each cluster gets full replica count
+  Divided: Replicas divided across clusters
+
+replica_division_preferences:
+  Aggregated: Divide into as few clusters as possible
+  Weighted: Divide by weight according to WeightPreference
+
+# ── Purge Modes ───────────────────────────────────────────────
+purge_modes:
+  Directly: Immediately evict (was "Immediately", deprecated)
+  Gracefully: Wait for healthy state or timeout (was "Graciously", deprecated)
+  Never: Leave to manual cleanup
+  Immediately: Deprecated alias for Directly
+  Graciously: Deprecated alias for Gracefully
+
+# ── Kinds Summary ─────────────────────────────────────────────
+kinds:
+  policy:
+    - PropagationPolicy (pp, Namespaced)
+    - ClusterPropagationPolicy (cpp, Cluster)
+    - OverridePolicy (op, Namespaced)
+    - ClusterOverridePolicy (cop, Cluster)
+  work:
+    - ResourceBinding (rb, Namespaced, v1alpha2 storage)
+    - ClusterResourceBinding (crb, Cluster, v1alpha2 storage)
+    - Work (wk, Namespaced, v1alpha1)

--- a/hack/agent-skills/knowledge/policy-patterns.md
+++ b/hack/agent-skills/knowledge/policy-patterns.md
@@ -1,0 +1,307 @@
+# Karmada Policy Patterns
+
+## Pattern 1: Basic Propagation
+
+Propagate a Deployment to specific clusters by name.
+
+```yaml
+apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: basic-propagation
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: my-app
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - member1
+        - member2
+```
+
+When to use: Simple static placement to known cluster names.
+
+## Pattern 2: Label-Based Propagation
+
+Select target clusters by label instead of name.
+
+```yaml
+placement:
+  clusterAffinity:
+    labelSelector:
+      matchLabels:
+        region: us-west
+    fieldSelector:
+      matchExpressions:
+        - key: provider
+          operator: In
+          values:
+            - aws
+```
+
+When to use: Dynamic cluster selection based on cluster metadata.
+
+## Pattern 3: Spread Across Regions/Zones
+
+Spread replicas across availability domains.
+
+```yaml
+placement:
+  spreadConstraints:
+    - spreadByField: region
+      maxGroups: 2
+      minGroups: 2
+  replicaScheduling:
+    replicaSchedulingType: Divided
+    replicaDivisionPreference: Weighted
+```
+
+When to use: High-availability deployments across failure domains.
+
+## Pattern 4: Weighted Replica Distribution
+
+Assign more replicas to larger clusters.
+
+```yaml
+placement:
+  clusterAffinity:
+    clusterNames:
+      - member1
+      - member2
+  replicaScheduling:
+    replicaSchedulingType: Divided
+    replicaDivisionPreference: Weighted
+    weightPreference:
+      staticWeightList:
+        - targetCluster:
+            clusterNames:
+              - member1
+          weight: 2
+        - targetCluster:
+            clusterNames:
+              - member2
+          weight: 1
+```
+
+When to use: Uneven cluster capacities, canary traffic splitting.
+
+## Pattern 5: Image Override
+
+Use different container images per cluster.
+
+```yaml
+apiVersion: policy.karmada.io/v1alpha1
+kind: OverridePolicy
+metadata:
+  name: image-override
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: my-app
+  overrideRules:
+    - targetCluster:
+        clusterNames:
+          - member2
+      overriders:
+        imageOverrider:
+          - component: Registry
+            operator: replace
+            value: registry.member2.example.com
+```
+
+When to use: Different image registries per region/cluster.
+
+## Pattern 6: Image Override by Predicate
+
+Override only specific container images within a multi-container Pod.
+
+```yaml
+overriders:
+  imageOverrider:
+    - predicate:
+        path: /spec/template/spec/containers/0/image
+      component: Registry
+      operator: replace
+      value: private-registry.example.com
+```
+
+When to use: Multi-container Pods where only some images need overriding.
+
+## Pattern 7: Labels and Annotations Override
+
+Add environment-specific labels per cluster.
+
+```yaml
+overrideRules:
+  - targetCluster:
+      clusterNames:
+        - member1
+    overriders:
+      labelsOverrider:
+        - operator: add
+          value:
+            env: production
+      annotationsOverrider:
+        - operator: add
+          value:
+            team: platform
+```
+
+When to use: Environment-specific metadata without changing the workload itself.
+
+## Pattern 8: Command/Args Override
+
+Change container entry point per cluster.
+
+```yaml
+overrideRules:
+  - targetCluster:
+      clusterNames:
+        - member2
+    overriders:
+      commandOverrider:
+        - containerName: main
+          operator: add
+          value:
+            - "--debug"
+            - "--verbose"
+```
+
+When to use: Debug clusters, different configuration flags per environment.
+
+## Pattern 9: Plaintext Field Override
+
+Override arbitrary fields in any resource.
+
+```yaml
+overrideRules:
+  - targetCluster:
+      clusterNames:
+        - member1
+    overriders:
+      plaintext:
+        - path: /spec/replicas
+          operator: replace
+          value: 5
+```
+
+When to use: Replica tuning per cluster, ConfigMap values, any JSONPath field.
+
+## Pattern 10: Failover with Graceful Eviction
+
+Configure application and cluster failover.
+
+```yaml
+spec:
+  failover:
+    application:
+      decisionConditions:
+        tolerationSeconds: 300
+      purgeMode: Gracefully
+      gracePeriodSeconds: 600
+    cluster:
+      purgeMode: Gracefully
+```
+
+When to use: Disaster recovery scenarios requiring automatic migration.
+
+## Pattern 11: Dependency Propagation
+
+Auto-propagate referenced resources (ConfigMaps, Secrets).
+
+```yaml
+spec:
+  propagateDeps: true
+```
+
+When to use: Reduce manual config by propagating dependencies alongside the main workload.
+
+## Pattern 12: Multi-Group Affinity with Overflow
+
+Define primary and backup cluster groups.
+
+```yaml
+placement:
+  clusterAffinities:
+    - affinityName: primary
+      clusterNames:
+        - member1
+        - member2
+      overflowAffinities:
+        - affinityName: overflow-1
+          clusterNames:
+            - member3
+```
+
+When to use: Private datacenter primary + cloud burst overflow.
+
+## Pattern 13: Suspension
+
+Temporarily stop or selectively suspend dispatching.
+
+```yaml
+spec:
+  suspension:
+    dispatching: true  # stop all
+
+# OR per-cluster:
+spec:
+  suspension:
+    dispatchingOnClusters:
+      clusterNames:
+        - member1
+```
+
+When to use: Maintenance windows, controlled rollouts.
+
+## Pattern 14: Priority and Preemption
+
+Define policy priority and preemption behavior.
+
+```yaml
+spec:
+  priority: 100
+  preemption: Always
+```
+
+When to use: Ensure critical workloads claim resources over lower-priority ones.
+
+## Pattern 15: Conflict Resolution
+
+Overwrite existing resources on target clusters.
+
+```yaml
+spec:
+  conflictResolution: Overwrite
+```
+
+When to use: Migrating legacy cluster resources to Karmada management.
+
+## Pattern 16: Preserve Resources on Deletion
+
+Keep resources on member clusters when the Karmada resource template is deleted.
+
+```yaml
+spec:
+  preserveResourcesOnDeletion: true
+```
+
+When to use: Safe rollback during migration where member workloads should not be deleted.
+
+## Pattern 17: Workload Affinity/Anti-Affinity
+
+Co-locate or separate workloads across clusters.
+
+```yaml
+placement:
+  workloadAffinity:
+    affinity:
+      groupByLabelKey: app.group
+    antiAffinity:
+      groupByLabelKey: app.group
+```
+
+When to use: Microservice co-location for latency, or separation for fault isolation.

--- a/hack/agent-skills/knowledge/troubleshooting.md
+++ b/hack/agent-skills/knowledge/troubleshooting.md
@@ -1,0 +1,158 @@
+# Karmada Troubleshooting Guide
+
+## Propagation Chain
+
+The Karmada propagation chain flows as:
+
+```
+Resource Template (Deployment, Service, etc.)
+    ↓  [matched by]
+PropagationPolicy / ClusterPropagationPolicy
+    ↓  [creates]
+ResourceBinding / ClusterResourceBinding
+    ↓  [scheduler assigns clusters]
+ResourceBinding.spec.clusters = [member1, member2]
+    ↓  [execution controller creates]
+Work (one per target cluster, in karmada-es-<cluster> namespace)
+    ↓  [cluster agent syncs]
+Resource on member cluster
+```
+
+## Common Failure Points
+
+### 1. Resource Not Matched by Policy
+
+**Symptom**: Resource template exists in Karmada control plane but no ResourceBinding is created.
+
+**Check**:
+- Does a PropagationPolicy or ClusterPropagationPolicy exist with matching `resourceSelectors`?
+- Are `apiVersion`, `kind` exactly correct? (case-sensitive)
+- Is `name` field set but doesn't match the resource name?
+- Is `namespace` field set correctly? (PropagationPolicy is namespace-scoped; ClusterPropagationPolicy can match all)
+- Is `labelSelector` matching? (only evaluated if `name` is empty)
+
+**Debug commands**:
+```bash
+kubectl get propagationpolicy -A
+kubectl get clusterpropagationpolicy
+kubectl describe propagationpolicy <name> -n <ns>
+kubectl describe clusterpropagationpolicy <name>
+```
+
+### 2. ResourceBinding Created but Not Scheduled
+
+**Symptom**: ResourceBinding exists but `spec.clusters` is empty or `status.conditions[type=Scheduled]=False`.
+
+**Check**:
+- ResourceBinding conditions: `kubectl describe resourcebinding <name> -n <ns>`
+- Reason codes:
+  - `NoClusterFit`: No cluster matches the placement constraints.
+  - `Unschedulable`: Clusters match but lack resources.
+  - `SchedulerError`: Internal scheduler error.
+  - `QuotaExceeded`: FederatedResourceQuota limit exceeded.
+- Are target clusters available? `kubectl get clusters`
+- Do clusters have taints that conflict with `clusterTolerations`?
+- Are `spreadConstraints` satisfiable? (e.g., need 2 regions but only 1 available)
+- Is scheduling suspended? Check `spec.suspension.scheduling`.
+
+**Debug commands**:
+```bash
+kubectl get resourcebinding -A
+kubectl get resourcebinding <name> -n <ns> -o yaml
+```
+
+### 3. Work Not Created for a Target Cluster
+
+**Symptom**: ResourceBinding has clusters in `spec.clusters` but no Work object exists for cluster X.
+
+**Check**:
+- Is dispatching suspended? Check `spec.suspension.dispatching` on the ResourceBinding.
+- Is the specific cluster suspended? Check `spec.suspension.dispatchingOnClusters`.
+- Is the execution controller running? `kubectl get pods -n karmada-system | grep karmada-controller-manager`
+- Check controller logs: `kubectl logs -n karmada-system deployment/karmada-controller-manager`
+
+**Debug commands**:
+```bash
+# Find works for a binding
+kubectl get work -l "resourcebinding.karmada.io/name=<binding-name>" -A
+# Check work in cluster execution namespace
+kubectl get work -n karmada-es-<cluster>
+```
+
+### 4. Work Created but Resource Not Applied on Member Cluster
+
+**Symptom**: Work exists but `status.conditions[type=Applied]=False`.
+
+**Check**:
+- Work status conditions:
+  - `Applied=False`: The resource was not applied. Check `AppliedMessage` for error.
+  - `Dispatching=False`: Dispatching suspended at Work level (`spec.suspendDispatching=true`).
+- Conflict resolution: `spec.conflictResolution=Abort` (default) and resource already exists on the member cluster.
+- RBAC: Does the cluster agent have permission to create the resource?
+- Check cluster agent connectivity: `kubectl get pods -n karmada-system -l app=karmada-agent`
+
+**Debug commands**:
+```bash
+kubectl describe work <name> -n karmada-es-<cluster>
+kubectl get work <name> -n karmada-es-<cluster> -o yaml
+```
+
+### 5. Conflict Resolution Abort
+
+**Symptom**: Resource exists on member cluster, propagation aborted.
+
+**Solution**: Set `conflictResolution: Overwrite` on the PropagationPolicy, OR manually delete the conflicting resource on the member cluster.
+
+### 6. OverridePolicy Not Applied
+
+**Symptom**: Resource propagated but overrides not taking effect.
+
+**Check**:
+- Does the OverridePolicy `resourceSelectors` match the resource?
+- Does the override's `targetCluster` match the cluster?
+- Override order matters: ImageOverrider → Command → Args → Labels → Annotations → Field → Plaintext.
+- Multiple OverridePolicies may conflict (last writer wins for same field).
+
+**Debug commands**:
+```bash
+kubectl get overridepolicy -A
+kubectl get clusteroverridepolicy
+kubectl describe overridepolicy <name> -n <ns>
+```
+
+### 7. Namespace Skip Auto-Propagation
+
+**Symptom**: Namespace not auto-propagated to member clusters.
+
+**Check**: Does the namespace have the label `namespace.karmada.io/skip-auto-propagation: "true"`?
+
+If yes, the namespace controller will skip propagating it. Remove the label to re-enable auto-propagation.
+
+## Diagnostic Flow
+
+```
+1. Check resource exists in control plane
+     ↓ No → Resource was not created or was deleted
+2. Check matching policy exists
+     ↓ No → Create PropagationPolicy or ClusterPropagationPolicy
+3. Check ResourceBinding created
+     ↓ No → Policy selector mismatch; check apiVersion, kind, name, namespace, labels
+4. Check ResourceBinding scheduled (spec.clusters populated)
+     ↓ No → Check conditions for reason; adjust placement constraints
+5. Check Work created for each target cluster
+     ↓ No → Check suspension, execution controller logs
+6. Check Work Applied condition
+     ↓ No → Check conflict resolution, RBAC, agent connectivity
+7. Check resource on member cluster
+     ↓ No → Agent sync failure; check agent logs
+```
+
+## Common Mistakes
+
+1. **Selector mismatch**: `apiVersion: v1` vs `apiVersion: apps/v1` for Deployment.
+2. **Scope mismatch**: Using PropagationPolicy for cluster-scoped resources (use ClusterPropagationPolicy).
+3. **Namespace mismatch**: PropagationPolicy in namespace A cannot match resources in namespace B.
+4. **System namespace**: ClusterPropagationPolicy cannot match resources in `karmada-system`, `karmada-cluster`, or `karmada-es-*`.
+5. **Toleration mismatch**: Cluster has taint but no toleration in policy placement.
+6. **Conflict resolution**: Default `Abort` prevents overwriting existing resources on member clusters.
+7. **Dispatching suspended**: `suspension.dispatching: true` blocks all propagation.

--- a/hack/agent-skills/scripts/policy-generator.py
+++ b/hack/agent-skills/scripts/policy-generator.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Karmada Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Karmada Policy Generator — Deterministic helper for generating
+PropagationPolicy and OverridePolicy YAML from structured input.
+
+Usage:
+  python3 policy-generator.py propagation --name my-app --kind Deployment --api apps/v1 --clusters member1,member2
+  python3 policy-generator.py override --name my-app --kind Deployment --api apps/v1 --cluster member2 --override-type image --overrides '[{"component":"Registry","operator":"replace","value":"registry.example.com"}]'
+"""
+
+import argparse
+import json
+import sys
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: Missing required Python package 'PyYAML' (module 'yaml'). "
+          "Install it with: pip install PyYAML", file=sys.stderr)
+    sys.exit(1)
+
+
+API_VERSION = "policy.karmada.io/v1alpha1"
+
+
+def build_propagation_policy(name, namespace, api_version, kind, resource_name,
+                              cluster_names, exclude_clusters=None,
+                              label_selector=None, field_selector=None,
+                              replica_type="Divided", replica_pref="Weighted",
+                              weights=None, propagate_deps=False,
+                              conflict_resolution="Abort"):
+    """Generate a PropagationPolicy from structured parameters."""
+    policy = {
+        "apiVersion": API_VERSION,
+        "kind": "PropagationPolicy",
+        "metadata": {
+            "name": f"{name}-propagation",
+        },
+        "spec": {
+            "resourceSelectors": [{
+                "apiVersion": api_version,
+                "kind": kind,
+            }],
+            "placement": {
+                "clusterAffinity": {
+                    "clusterNames": cluster_names,
+                },
+            },
+        },
+    }
+
+    if namespace:
+        policy["metadata"]["namespace"] = namespace
+
+    if resource_name:
+        policy["spec"]["resourceSelectors"][0]["name"] = resource_name
+
+    if exclude_clusters:
+        policy["spec"]["placement"]["clusterAffinity"]["exclude"] = exclude_clusters
+
+    if label_selector:
+        policy["spec"]["placement"]["clusterAffinity"]["labelSelector"] = label_selector
+
+    if field_selector:
+        policy["spec"]["placement"]["clusterAffinity"]["fieldSelector"] = field_selector
+
+    if kind in ("Deployment", "StatefulSet", "ReplicaSet", "DaemonSet", "Job"):
+        policy["spec"]["placement"]["replicaScheduling"] = {
+            "replicaSchedulingType": replica_type,
+            "replicaDivisionPreference": replica_pref,
+        }
+        if weights and replica_pref == "Weighted":
+            policy["spec"]["placement"]["replicaScheduling"]["weightPreference"] = {
+                "staticWeightList": [
+                    {"targetCluster": {"clusterNames": [c]}, "weight": w}
+                    for c, w in zip(cluster_names, weights)
+                ]
+            }
+
+    if propagate_deps:
+        policy["spec"]["propagateDeps"] = True
+
+    if conflict_resolution != "Abort":
+        policy["spec"]["conflictResolution"] = conflict_resolution
+
+    return policy
+
+
+def build_override_policy(name, namespace, api_version, kind, resource_name,
+                           cluster_name, overrides, override_type="labels"):
+    """Generate an OverridePolicy from structured parameters."""
+    policy = {
+        "apiVersion": API_VERSION,
+        "kind": "OverridePolicy",
+        "metadata": {
+            "name": f"{name}-override",
+        },
+        "spec": {
+            "resourceSelectors": [{
+                "apiVersion": api_version,
+                "kind": kind,
+            }],
+            "overrideRules": [{
+                "targetCluster": {
+                    "clusterNames": [cluster_name],
+                },
+                "overriders": {},
+            }],
+        },
+    }
+
+    if namespace:
+        policy["metadata"]["namespace"] = namespace
+
+    if resource_name:
+        policy["spec"]["resourceSelectors"][0]["name"] = resource_name
+
+    if override_type == "labels":
+        policy["spec"]["overrideRules"][0]["overriders"]["labelsOverrider"] = overrides
+    elif override_type == "annotations":
+        policy["spec"]["overrideRules"][0]["overriders"]["annotationsOverrider"] = overrides
+    elif override_type == "image":
+        policy["spec"]["overrideRules"][0]["overriders"]["imageOverrider"] = overrides
+    elif override_type == "plaintext":
+        policy["spec"]["overrideRules"][0]["overriders"]["plaintext"] = overrides
+    else:
+        policy["spec"]["overrideRules"][0]["overriders"][f"{override_type}Overrider"] = overrides
+
+    return policy
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate Karmada policy YAML")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # Propagation subcommand
+    prop = subparsers.add_parser("propagation", help="Generate PropagationPolicy")
+    prop.add_argument("--name", required=True, help="Policy name prefix")
+    prop.add_argument("--namespace", help="Policy namespace")
+    prop.add_argument("--api", required=True, dest="api_version", help="Resource apiVersion (e.g. apps/v1)")
+    prop.add_argument("--kind", required=True, help="Resource Kind (e.g. Deployment)")
+    prop.add_argument("--resource-name", help="Specific resource name")
+    prop.add_argument("--clusters", required=True, help="Comma-separated cluster names")
+    prop.add_argument("--exclude", help="Comma-separated cluster names to exclude")
+    prop.add_argument("--weights", help="Comma-separated integer weights")
+    prop.add_argument("--replica-type", default="Divided", choices=["Duplicated", "Divided"])
+    prop.add_argument("--replica-pref", default="Weighted", choices=["Aggregated", "Weighted"])
+    prop.add_argument("--propagate-deps", action="store_true")
+    prop.add_argument("--conflict", default="Abort", choices=["Abort", "Overwrite"])
+
+    # Override subcommand
+    over = subparsers.add_parser("override", help="Generate OverridePolicy")
+    over.add_argument("--name", required=True, help="Policy name prefix")
+    over.add_argument("--namespace", help="Policy namespace")
+    over.add_argument("--api", required=True, dest="api_version", help="Resource apiVersion")
+    over.add_argument("--kind", required=True, help="Resource Kind")
+    over.add_argument("--resource-name", help="Specific resource name")
+    over.add_argument("--cluster", required=True, help="Target cluster name")
+    over.add_argument("--override-type", default="labels", choices=["labels", "annotations", "image", "command", "args", "plaintext"])
+    over.add_argument("--overrides", help="JSON string of overrides (key-value for labels, list for command/args)")
+
+    args = parser.parse_args()
+
+    if args.command == "propagation":
+        cluster_names = [c.strip() for c in args.clusters.split(",")]
+        exclude = [c.strip() for c in args.exclude.split(",")] if args.exclude else None
+        weights = [int(w.strip()) for w in args.weights.split(",")] if args.weights else None
+
+        if weights and len(weights) != len(cluster_names):
+            parser.error(f"--weights count ({len(weights)}) must match --clusters count ({len(cluster_names)})")
+        if weights and any(w < 1 for w in weights):
+            parser.error("all weights must be >= 1")
+
+        policy = build_propagation_policy(
+            name=args.name,
+            namespace=args.namespace,
+            api_version=args.api_version,
+            kind=args.kind,
+            resource_name=args.resource_name,
+            cluster_names=cluster_names,
+            exclude_clusters=exclude,
+            replica_type=args.replica_type,
+            replica_pref=args.replica_pref,
+            weights=weights,
+            propagate_deps=args.propagate_deps,
+            conflict_resolution=args.conflict,
+        )
+
+    elif args.command == "override":
+        overrides = json.loads(args.overrides) if args.overrides else []
+
+        policy = build_override_policy(
+            name=args.name,
+            namespace=args.namespace,
+            api_version=args.api_version,
+            kind=args.kind,
+            resource_name=args.resource_name,
+            cluster_name=args.cluster,
+            overrides=overrides,
+            override_type=args.override_type,
+        )
+
+    print(yaml.dump(policy, default_flow_style=False, sort_keys=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/agent-skills/scripts/validate-policy.py
+++ b/hack/agent-skills/scripts/validate-policy.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Karmada Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Karmada Policy Validator — Deterministic helper for validating
+PropagationPolicy and OverridePolicy YAML against known schema rules.
+
+Usage:
+  python3 validate-policy.py <policy.yaml>
+  python3 validate-policy.py --kind PropagationPolicy <policy.yaml>
+"""
+
+import argparse
+import sys
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: Missing required Python package 'PyYAML' (module 'yaml'). "
+          "Install it with: pip install PyYAML", file=sys.stderr)
+    sys.exit(1)
+
+
+def validate_propagation_policy(policy):
+    """Validate a PropagationPolicy against schema rules. Returns list of (severity, message) tuples."""
+    findings = []
+    spec = policy.get("spec", {})
+    kind = policy.get("kind", "PropagationPolicy")
+
+    # Required: resourceSelectors with min 1 item for PropagationPolicy
+    # OverridePolicy allows empty resourceSelectors to match all resources in scope
+    selectors = spec.get("resourceSelectors", [])
+    if not selectors:
+        if kind in ("PropagationPolicy", "ClusterPropagationPolicy"):
+            findings.append(("ERROR", "spec.resourceSelectors is required and must have at least 1 entry"))
+        else:
+            findings.append(("INFO", "spec.resourceSelectors is empty — OverridePolicy will match all resources in scope"))
+
+    for i, sel in enumerate(selectors):
+        if not sel.get("apiVersion"):
+            findings.append(("ERROR", f"resourceSelectors[{i}].apiVersion is required"))
+        if not sel.get("kind"):
+            findings.append(("ERROR", f"resourceSelectors[{i}].kind is required"))
+        if sel.get("name") and sel.get("labelSelector"):
+            findings.append(("WARNING", f"resourceSelectors[{i}]: name is set, so labelSelector is ignored"))
+
+    # Placement constraints
+    placement = spec.get("placement", {})
+    if placement.get("clusterAffinity") and placement.get("clusterAffinities"):
+        findings.append(("ERROR", "placement.clusterAffinity and clusterAffinities are mutually exclusive"))
+
+    # Spread constraints
+    for i, sc in enumerate(placement.get("spreadConstraints", [])):
+        if sc.get("spreadByField") and sc.get("spreadByLabel"):
+            findings.append(("ERROR", f"spreadConstraints[{i}]: spreadByField and spreadByLabel are mutually exclusive"))
+
+    # Suspension
+    suspension = spec.get("suspension", {})
+    if suspension:
+        if suspension.get("dispatching") and suspension.get("dispatchingOnClusters"):
+            findings.append(("ERROR", "suspension.dispatching and dispatchingOnClusters are mutually exclusive"))
+
+    # Failover
+    failover = spec.get("failover", {})
+    if failover:
+        if failover.get("application"):
+            if spec.get("propagateDeps") is not True:
+                findings.append(("WARNING", "Application failover configured but propagateDeps is not true. Dependencies won't be migrated during failover"))
+
+    # OverridePolicy specific
+    if kind in ("OverridePolicy", "ClusterOverridePolicy"):
+        rules = spec.get("overrideRules", [])
+        deprecated_target = spec.get("targetCluster")
+        deprecated_overriders = spec.get("overriders")
+        if (deprecated_target or deprecated_overriders) and not rules:
+            findings.append(("WARNING", "Using deprecated targetCluster/overriders fields. Use overrideRules instead"))
+
+        for i, rule in enumerate(rules):
+            overriders = rule.get("overriders", {})
+            for img in overriders.get("imageOverrider", []):
+                if not img.get("predicate"):
+                    findings.append(("INFO", f"overrideRules[{i}].imageOverrider: No predicate set — applies to ALL container images"))
+            for pt in overriders.get("plaintext", []):
+                if pt.get("path", "").startswith("spec."):
+                    findings.append(("WARNING", f"overrideRules[{i}].plaintext.path should use JSON pointer syntax (e.g. /spec/replicas), got: {pt['path']}"))
+            for field in overriders.get("fieldOverrider", []):
+                fp = field.get("fieldPath", "")
+                if fp and not fp.startswith("/"):
+                    findings.append(("WARNING", f"overrideRules[{i}].fieldOverrider.fieldPath should use RFC 6901 syntax (e.g. /data/key), got: {fp}"))
+
+    return findings
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate Karmada policy YAML")
+    parser.add_argument("file", help="Policy YAML file to validate")
+    parser.add_argument("--kind", help="Expected policy kind (optional)")
+
+    args = parser.parse_args()
+
+    try:
+        with open(args.file, "r") as f:
+            policy = yaml.safe_load(f)
+    except FileNotFoundError:
+        print(f"ERROR: File not found: {args.file}")
+        sys.exit(1)
+    except yaml.YAMLError as e:
+        print(f"ERROR: Invalid YAML: {e}")
+        sys.exit(1)
+
+    if not isinstance(policy, dict):
+        print("ERROR: Policy must be a YAML object")
+        sys.exit(1)
+
+    yaml_kind = policy.get("kind", "")
+    kind = args.kind or yaml_kind
+    if args.kind and yaml_kind and args.kind != yaml_kind:
+        print(f"ERROR: --kind flag ({args.kind}) does not match YAML kind ({yamlKind})")
+        sys.exit(1)
+    api_version = policy.get("apiVersion", "")
+
+    if api_version != "policy.karmada.io/v1alpha1":
+        print(f"WARNING: Expected apiVersion policy.karmada.io/v1alpha1, got {api_version}")
+
+    if kind not in ("PropagationPolicy", "ClusterPropagationPolicy", "OverridePolicy", "ClusterOverridePolicy"):
+        print(f"ERROR: Unknown kind '{kind}'. Expected one of: PropagationPolicy, ClusterPropagationPolicy, OverridePolicy, ClusterOverridePolicy")
+        sys.exit(1)
+
+    findings = validate_propagation_policy(policy)
+
+    # Categorize
+    errors = [m for s, m in findings if s == "ERROR"]
+    warnings = [m for s, m in findings if s == "WARNING"]
+    infos = [m for s, m in findings if s == "INFO"]
+
+    print(f"\n=== Audit Report: {policy.get('metadata', {}).get('name', 'unknown')} ({kind}) ===")
+
+    if errors:
+        print(f"\n  Errors ({len(errors)}):")
+        for e in errors:
+            print(f"    [ERROR] {e}")
+    if warnings:
+        print(f"\n  Warnings ({len(warnings)}):")
+        for w in warnings:
+            print(f"    [WARN]  {w}")
+    if infos:
+        print(f"\n  Info ({len(infos)}):")
+        for i in infos:
+            print(f"    [INFO]  {i}")
+
+    if not findings:
+        print("\n  No issues found. Policy looks valid.")
+
+    print()
+
+    if errors:
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/agent-skills/skills/karmada-audit-policy/SKILL.md
+++ b/hack/agent-skills/skills/karmada-audit-policy/SKILL.md
@@ -1,0 +1,93 @@
+# karmada-audit-policy
+
+## Description
+Review Karmada PropagationPolicy and OverridePolicy YAML for correctness, including
+selector mismatch detection, scope misuse, dependency issues, API version risks,
+and best practice violations.
+
+## When to Load
+- User asks to "review this policy", "audit", "check my PropagationPolicy", "validate policy".
+- User provides a policy YAML and asks "is this correct?".
+- User asks "what's wrong with this policy?".
+- User is about to apply a policy and wants pre-flight validation.
+
+## Workflow
+
+1. **Parse the policy YAML.**
+   - Identify the Kind: PropagationPolicy, ClusterPropagationPolicy, OverridePolicy, ClusterOverridePolicy.
+   - Extract `apiVersion`, `metadata`, `spec`.
+
+2. **Run deterministic validation checks:**
+
+   **A. Selector Checks:**
+   - [ ] `resourceSelectors` is non-empty (required for PropagationPolicy, MinItems=1).
+   - [ ] `apiVersion` and `kind` are well-formed (e.g., `apps/v1`, not `v1` for Deployment).
+   - [ ] `name` is set? Then `labelSelector` is ignored — warn if both are set.
+   - [ ] OverridePolicy with empty `resourceSelectors` matches ALL resources in namespace — confirm intentional.
+   - [ ] Namespace-scoped policy (PropagationPolicy) cannot match cluster-scoped resources — check Kind.
+
+   **B. Placement Checks:**
+   - [ ] `clusterAffinity` and `clusterAffinities` should not both be set.
+   - [ ] `spreadByField` and `spreadByLabel` should not both be set.
+   - [ ] `clusterNames` reference valid cluster names.
+   - [ ] `spreadConstraints.maxGroups >= minGroups`.
+
+   **C. Dependency Checks:**
+   - [ ] `propagateDeps: true` is set? Ensure referenced ConfigMaps/Secrets exist.
+   - [ ] `dependentOverrides` list references policies that exist.
+
+   **D. Failover Checks:**
+   - [ ] Application failover configured but `propagateDeps` is false → warn that dependencies won't be migrated.
+   - [ ] `purgeMode: Never` set — remind that manual cleanup will be needed.
+   - [ ] `statePreservation` used → confirm `StatefulFailoverInjection` feature gate is enabled.
+
+   **E. Override Checks:**
+   - [ ] Override order: Image → Command → Args → Labels → Annotations → Field → Plaintext — warn about ordering if multiple types used.
+   - [ ] `imageOverrider` without `predicate` applies to ALL images — confirm intentional.
+   - [ ] `plaintext.path` uses correct JSON pointer syntax (e.g., `/spec/replicas` not `spec.replicas`).
+   - [ ] `fieldOverrider.fieldPath` uses RFC 6901 syntax.
+   - [ ] `overrideRules` used (correct) vs deprecated `targetCluster`/`overriders` (incorrect).
+
+   **F. Scope Checks:**
+   - [ ] ClusterPropagationPolicy targeting resources in `karmada-system`, `karmada-cluster`, `karmada-es-*` → invalid.
+   - [ ] PropagationPolicy in namespace A with resourceSelector.namespace=B → may not work as expected.
+   - [ ] ClusterOverridePolicy with `targetCluster` field (deprecated) → suggest `overrideRules`.
+
+   **G. API Version Checks:**
+   - [ ] Using `policy.karmada.io/v1alpha1` (correct).
+   - [ ] Using legacy versions → warn.
+
+   **H. Best Practice Checks:**
+   - [ ] `conflictResolution` default is `Abort` — meaningful choice or oversight?
+   - [ ] `priority` set to specific value — check for conflicts with other policies.
+   - [ ] `preemption: Always` — understand implications.
+   - [ ] `suspension` configured — confirm intentional.
+
+3. **Categorize findings:**
+   - **ERROR**: Will cause policy rejection or non-functional propagation.
+   - **WARNING**: May cause unexpected behavior.
+   - **INFO**: Best practice recommendation.
+
+4. **Produce structured output:**
+   ```markdown
+   ## Audit Report: <Policy Name>
+
+   ### Errors (must fix)
+   - ...
+
+   ### Warnings (should fix)
+   - ...
+
+   ### Info (consider)
+   - ...
+   ```
+
+5. **If zero errors/warnings**, confirm the policy is syntactically and semantically valid.
+
+## Knowledge References
+- `hack/agent-skills/knowledge/policy-apis.yaml`
+- `hack/agent-skills/knowledge/troubleshooting.md`
+
+## Template References
+- `hack/agent-skills/templates/propagation-policy.yaml`
+- `hack/agent-skills/templates/override-policy.yaml`

--- a/hack/agent-skills/skills/karmada-controller-manager/SKILL.md
+++ b/hack/agent-skills/skills/karmada-controller-manager/SKILL.md
@@ -1,0 +1,91 @@
+# karmada-controller-manager
+
+## Description
+Understand and interact with the Karmada controller-manager component — its
+controllers, configuration, logging, and troubleshooting.
+
+## When to Load
+- User asks about "karmada-controller-manager", "binding controller", "execution controller".
+- User asks "which controller handles X?".
+- User needs to check controller-manager logs, configuration, or status.
+- User asks about controller-manager flags, leader election, or tuning.
+- User asks about feature gates controlled by the controller-manager.
+
+## Workflow
+
+1. **Understand the user's goal.**
+   - Checking controller health? → Step 2 (status).
+   - Debugging propagation issue? → Step 3 (relevant controller + logs).
+   - Understanding a controller's responsibility? → Step 4 (controller overview).
+   - Configuring controller-manager? → Step 5 (flags/options).
+
+2. **Check controller-manager health:**
+   ```bash
+   kubectl get pods -n karmada-system -l app=karmada-controller-manager
+   kubectl logs -n karmada-system deployment/karmada-controller-manager --tail=50
+   ```
+   Key health indicators:
+   - Pod status: Running, CrashLoopBackOff, Pending?
+   - Logs: Error messages, reconciliation failures?
+   - Leader election: Multiple replicas? Only leader processes.
+
+3. **Identify the relevant controller for debugging:**
+
+   | Controller | Responsibility | Debug Signal |
+   |-----------|---------------|-------------|
+   | **Binding Controller** | Matches resources to policies, creates ResourceBindings | No ResourceBinding for matched resource |
+   | **Execution Controller** | Creates Work objects from scheduled ResourceBindings | No Work for scheduled binding |
+   | **Override Controller** | Applies OverridePolicy rules to workloads | Overrides not taking effect |
+   | **Cluster Controller** | Manages cluster join/unjoin, health status | Cluster status issues |
+   | **Namespace Controller** | Auto-propagates namespaces to member clusters | Namespace not created on member clusters |
+   | **Taint Manager** | Handles cluster taints and workload eviction | Taint-related eviction issues |
+   | **Graceful Eviction Controller** | Manages graceful eviction tasks | Eviction stuck or incomplete |
+   | **FederatedResourceQuota Controller** | Manages federated resource quotas | Quota enforcement issues |
+
+4. **Access controller logs:**
+   ```bash
+   # Last 100 lines
+   kubectl logs -n karmada-system deployment/karmada-controller-manager --tail=100
+
+   # Search for specific resource in logs
+   kubectl logs -n karmada-system deployment/karmada-controller-manager | grep "<resource-name>"
+
+   # Search for errors
+   kubectl logs -n karmada-system deployment/karmada-controller-manager | grep -i error
+
+   # Follow logs in real-time
+   kubectl logs -n karmada-system deployment/karmada-controller-manager -f
+   ```
+
+5. **Controller-manager configuration flags:**
+
+   Common flags (check actual deployment for full list):
+   - `--controllers`: Comma-separated list of controllers to enable (default: all).
+   - `--feature-gates`: Feature gates (e.g., `Failover=true,PropagateDeps=true`).
+   - `--leader-elect`: Enable leader election (default: true).
+   - `--leader-elect-lease-duration`: Lease duration in seconds.
+   - `--bind-address`: Address to bind metrics and health probes.
+   - `--metrics-bind-address`: Address for metrics endpoint.
+   - `--health-probe-bind-address`: Address for health probe endpoint.
+   - `--skipped-propagating-namespaces`: Additional namespaces to skip (beyond system namespaces).
+   - `--skipped-propagating-apis`: APIs to skip propagating (e.g., to exclude specific CRDs).
+   - `--no-execute-taint-eviction-purge-mode`: Default purge mode for taint-based evictions.
+
+6. **Feature gates managed by controller-manager:**
+   - `PropagateDeps`: Auto-propagate dependent resources.
+   - `Failover`: Application and cluster failover handling.
+   - `GracefulEviction`: Graceful workload eviction.
+   - `MultiplePodTemplatesScheduling`: Multi-component workload support.
+   - `StatefulFailoverInjection`: State preservation during failover.
+   - `PriorityBasedScheduling`: Priority-based scheduling.
+   - `Flux2GitopsAdaption`: Flux2 GitOps integration.
+   - `ResourceQuotaEstimate`: Resource quota estimation.
+
+7. **Provide guidance based on findings:**
+   - Controller crash → Check resource usage, recent changes, API server connectivity.
+   - Controller not processing → Check leader election, skipped namespaces/APIs.
+   - Specific error in logs → Match to troubleshooting knowledge base.
+
+## Knowledge References
+- `hack/agent-skills/knowledge/components.md`
+- `hack/agent-skills/knowledge/troubleshooting.md`

--- a/hack/agent-skills/skills/karmada-create-policy/SKILL.md
+++ b/hack/agent-skills/skills/karmada-create-policy/SKILL.md
@@ -1,0 +1,69 @@
+# karmada-create-policy
+
+## Description
+Generate Karmada PropagationPolicy and OverridePolicy YAML for a given workload, including
+placement rules, replica scheduling, and per-cluster overrides.
+
+## When to Load
+- User asks to "create a Karmada policy", "generate a PropagationPolicy", "write an OverridePolicy".
+- User describes placement intent: "place this Deployment in member1 and member2".
+- User asks for "multi-cluster deployment" or "propagate to clusters".
+- User wants to "use different image registry in cluster X".
+- User asks "how do I spread replicas across regions".
+
+## Workflow
+
+1. **Identify the workload.**
+   - Ask for or determine: `apiVersion`, `kind`, `name`, `namespace`.
+   - If the resource is cluster-scoped (e.g., ClusterRole, CRD), use `ClusterPropagationPolicy`.
+
+2. **Determine placement requirements.**
+   - Specific cluster names? → `clusterAffinity.clusterNames`
+   - Cluster labels? → `clusterAffinity.labelSelector`
+   - Cluster fields (region, zone, provider)? → `clusterAffinity.fieldSelector`
+   - Spread across regions/zones? → `spreadConstraints`
+   - Need overflow/backup clusters? → `clusterAffinities` with `overflowAffinities`
+
+3. **Determine replica scheduling (for workloads with replicas).**
+   - Same replica count everywhere? → `replicaSchedulingType: Duplicated`
+   - Divide replicas across clusters? → `replicaSchedulingType: Divided`
+   - Equal weight? → omit `weightPreference`
+   - Custom weights? → `weightPreference.staticWeightList`
+   - Dynamic by available resources? → `weightPreference.dynamicWeight: AvailableReplicas`
+
+4. **Determine override requirements.**
+   - Image changes per cluster? → `imageOverrider`
+   - Label/annotation differences? → `labelsOverrider` / `annotationsOverrider`
+   - Command/args changes? → `commandOverrider` / `argsOverrider`
+   - Arbitrary field changes? → `plaintext`
+   - Structured field changes? → `fieldOverrider`
+
+5. **Generate the YAML.**
+   - Use `hack/agent-skills/templates/propagation-policy.yaml` as starter.
+   - Use `hack/agent-skills/templates/override-policy.yaml` as starter.
+   - Fill in all fields based on user requirements.
+   - Always use `apiVersion: policy.karmada.io/v1alpha1`.
+   - Include informative `metadata.name` (e.g., `<workload>-propagation`).
+
+6. **Validate against the API schema:**
+   - `resourceSelectors` must have at least one entry (MinItems=1).
+   - `clusterAffinity` and `clusterAffinities` are mutually exclusive.
+   - `spreadByField` and `spreadByLabel` are mutually exclusive.
+   - `dispatching` and `dispatchingOnClusters` are mutually exclusive.
+
+7. **Present the output** with a brief explanation of what each section does.
+
+## Knowledge References
+- `hack/agent-skills/knowledge/policy-apis.yaml`
+- `hack/agent-skills/knowledge/policy-patterns.md`
+
+## Template References
+- `hack/agent-skills/templates/propagation-policy.yaml`
+- `hack/agent-skills/templates/cluster-propagation-policy.yaml`
+- `hack/agent-skills/templates/override-policy.yaml`
+- `hack/agent-skills/templates/cluster-override-policy.yaml`
+
+## Example References
+- `hack/agent-skills/examples/image-override/`
+- `hack/agent-skills/examples/multi-country-setup/`
+- `hack/agent-skills/examples/failover/`

--- a/hack/agent-skills/skills/karmada-debug-propagation/SKILL.md
+++ b/hack/agent-skills/skills/karmada-debug-propagation/SKILL.md
@@ -1,0 +1,119 @@
+# karmada-debug-propagation
+
+## Description
+Debug why a Kubernetes resource in the Karmada control plane was not propagated
+to one or more member clusters. Follows the propagation chain diagnostically.
+
+## When to Load
+- User says "resource not propagated", "not showing up in member cluster", "why isn't my Deployment in member2?"
+- User says "propagation failed", "binding not created", "Work not applied".
+- User is debugging any part of the Karmada propagation chain.
+
+## Workflow
+
+1. **Identify the resource and target cluster.**
+   - What resource (Deployment, Service, etc.)?
+   - Which namespace?
+   - Which target cluster(s) is it supposed to go to?
+
+2. **Walk the propagation chain step by step:**
+
+   **Step 1: Does the resource exist in Karmada control plane?**
+   ```bash
+   kubectl get <kind> <name> -n <namespace>
+   ```
+   If No → Resource was never created or was deleted. Not a Karmada issue.
+
+   **Step 2: Does a matching policy exist?**
+   - For namespace-scoped resources: Check PropagationPolicy in the same namespace.
+   - For cluster-scoped resources: Check ClusterPropagationPolicy.
+   - Verify `resourceSelectors[].apiVersion` and `resourceSelectors[].kind` match exactly.
+   - If `resourceSelectors[].name` is set, it must match the resource name exactly.
+   - If `resourceSelectors[].labelSelector` is set, verify labels match.
+   - If `resourceSelectors[].namespace` is set in a PropagationPolicy, verify it matches.
+   - Check policy `priority` — higher priority policies may claim the resource first.
+
+   **Step 3: Was a ResourceBinding (or ClusterResourceBinding) created?**
+   ```bash
+   kubectl get resourcebinding -n <namespace>
+   kubectl get clusterresourcebinding
+   ```
+   Look for a binding whose `spec.resource` references the workload.
+   If No → Policy selector mismatch, or binding controller error.
+   Check: `kubectl logs -n karmada-system deployment/karmada-controller-manager`
+   Check for labels: `propagationpolicy.karmada.io/permanent-id` and `propagationpolicy.karmada.io/namespace`/`name` annotations.
+
+   **Step 4: Was the binding scheduled?**
+   ```bash
+   kubectl get resourcebinding <name> -n <ns> -o jsonpath='{.spec.clusters}'
+   ```
+   If `spec.clusters` is empty → check status conditions:
+   ```bash
+   kubectl get resourcebinding <name> -n <ns> -o jsonpath='{.status.conditions}'
+   ```
+   Reason codes:
+   - `NoClusterFit` → placement constraints don't match any available cluster.
+   - `Unschedulable` → clusters match but lack resources.
+   - `SchedulerError` → internal error, check scheduler logs.
+   - `QuotaExceeded` → FederatedResourceQuota limit reached.
+
+   Investigate placement constraints:
+   - `clusterAffinity.labelSelector` matches any clusters?
+   - `clusterAffinity.fieldSelector` matches?
+   - `clusterAffinity.exclude` excluding some?
+   - `clusterTolerations` cover cluster taints?
+   - `spreadConstraints` satisfiable?
+   - Is scheduling suspended? `spec.suspension.scheduling=true`?
+
+   **Step 5: Was a Work object created for the target cluster?**
+   ```bash
+   kubectl get work -n karmada-es-<cluster>
+   ```
+   If No → Check ResourceBinding `spec.suspension.dispatching` or `spec.suspension.dispatchingOnClusters`.
+   Check execution controller logs.
+   Verify the cluster is still joined and healthy: `kubectl get cluster <name>`.
+
+   **Step 6: Was the Work applied?**
+   ```bash
+   kubectl get work <name> -n karmada-es-<cluster> -o jsonpath='{.status.conditions}'
+   ```
+   Check conditions:
+   - `Applied=False` → resource not applied. Check `AppliedMessage` for error.
+   - `Applied=True` → resource was applied.
+   - Check if `Work.spec.suspendDispatching=true` — dispatching suspended at Work level.
+   - Check `Work.spec.preserveResourcesOnDeletion` if relevant.
+
+   Common Work application failures:
+   - Conflict: Resource already exists on member cluster AND `conflictResolution=Abort`.
+   - RBAC: Agent cannot create the resource on the member cluster.
+   - CRD missing: The resource kind's CRD doesn't exist on the member cluster.
+
+   **Step 7: Does the resource exist on the member cluster?**
+   ```bash
+   kubectl --context=<member-cluster> get <kind> <name> -n <namespace>
+   ```
+   If resource exists but is unhealthy → likely not a propagation issue but a workload issue.
+   Check karmada-agent logs on the member cluster.
+
+3. **Collect diagnostic output:**
+   ```bash
+   # Full diagnostic script:
+   kubectl get propagationpolicy -A
+   kubectl get resourcebinding -A
+   kubectl get work -A
+   kubectl get cluster
+   ```
+
+4. **Provide a failure point diagnosis** with the exact step where propagation stopped and the likely cause.
+
+5. **Suggest remediation:**
+   - Selector mismatch → fix `resourceSelectors` in the policy.
+   - NoClusterFit → relax placement constraints or add more clusters.
+   - Conflict → set `conflictResolution: Overwrite` or delete conflicting resource.
+   - Suspended → remove suspension or set to `false`.
+   - RBAC → grant necessary permissions to the karmada-agent service account.
+
+## Knowledge References
+- `hack/agent-skills/knowledge/troubleshooting.md`
+- `hack/agent-skills/knowledge/policy-apis.yaml`
+- `hack/agent-skills/knowledge/components.md`

--- a/hack/agent-skills/skills/karmada-explain-placement/SKILL.md
+++ b/hack/agent-skills/skills/karmada-explain-placement/SKILL.md
@@ -1,0 +1,90 @@
+# karmada-explain-placement
+
+## Description
+Explain how a Karmada workload will be placed across member clusters given a
+PropagationPolicy or ClusterPropagationPolicy, including replica distribution,
+spread constraints, and failover behavior.
+
+## When to Load
+- User asks "how will this be placed?", "which clusters will get this workload?", "explain the placement".
+- User asks about replica distribution or scheduling decisions.
+- User provides a PropagationPolicy and wants to understand the scheduling outcome.
+- User asks "why did the scheduler choose these clusters?".
+
+## Workflow
+
+1. **Parse the PropagationPolicy.**
+   - Extract `resourceSelectors`, `placement`, `replicaScheduling`, `failover`.
+   - Determine the workload type and its spec (especially `replicas`).
+
+2. **Resolve target clusters:**
+   - If `clusterAffinity.clusterNames` is set → explain these specific clusters are targeted.
+   - If `clusterAffinity.labelSelector` is set → explain which clusters match the labels.
+   - If `clusterAffinity.fieldSelector` is set → explain which clusters match the field selectors (provider, region, zone).
+   - If `clusterAffinity.exclude` is set → note which clusters are excluded.
+   - If `clusterAffinities` with multiple groups → explain the group evaluation order.
+     - First group evaluated first; if it fails, next group is tried.
+     - `overflowAffinities` expand the group progressively when resources are insufficient.
+     - Overflow groups contract during scale-down in reverse order.
+   - If neither `clusterAffinity` nor `clusterAffinities` is set → any cluster is a candidate.
+
+3. **Explain spread constraints:**
+   - `spreadByField`: How the spread field (cluster/region/zone/provider) groups clusters.
+   - `spreadByLabel`: How the label groups clusters.
+   - `maxGroups` / `minGroups`: Constraints on how many groups can be selected.
+   - Default spread by `cluster` if no spread constraint is set.
+
+4. **Explain replica scheduling:**
+   - `Duplicated`: Each target cluster gets the full replica count → explain total pods.
+   - `Divided` + `Aggregated`: Replicas packed into as few clusters as possible.
+   - `Divided` + `Weighted` + `staticWeightList`: Show replica distribution calculation.
+   - `Divided` + `Weighted` + `dynamicWeight: AvailableReplicas`: Explain dynamic allocation.
+   - Show the math when applicable (e.g., weight 2:1 → 2/3 and 1/3 of replicas).
+
+5. **Explain tolerations:**
+   - Any `clusterTolerations`? List them and explain which tainted clusters they allow.
+
+6. **Explain workload affinity/anti-affinity:**
+   - Affinity: Workloads with same label value co-located.
+   - Anti-affinity: Workloads with same label value separated.
+   - Note: First workload in a group is not blocked (allows bootstrapping).
+
+7. **Explain failover behavior:**
+   - Application failover: What happens when application fails on a cluster.
+     - `decisionConditions.tolerationSeconds`: Wait time before failover.
+     - `purgeMode`: Directly, Gracefully (with `gracePeriodSeconds`), or Never.
+   - Cluster failover: What happens when a cluster fails.
+     - `purgeMode`: Directly or Gracefully.
+   - `statePreservation`: Any state data preserved during failover.
+
+8. **Check for edge cases:**
+   - If `conflictResolution=Abort` and resource exists on target → placement will fail.
+   - If `suspension.dispatching=true` → placement calculated but not executed.
+   - If `suspension.dispatchingOnClusters` → some clusters suspended.
+   - If `activationPreference=Lazy` → policy changes won't take effect until resource template changes.
+
+9. **Produce structured output:**
+   ```markdown
+   ## Placement Explanation for <Policy Name>
+
+   ### Target Clusters
+   | Cluster | Reason |
+   |---------|--------|
+   | member1 | Listed in clusterNames |
+   | member2 | Listed in clusterNames |
+
+   ### Replica Distribution
+   - Total replicas: 6
+   - Distribution: member1=4, member2=2 (weighted 2:1)
+
+   ### Failover
+   - Application: toleration=300s, purge=Gracefully(600s)
+   - Cluster: purge=Gracefully
+
+   ### Notes
+   - ...
+   ```
+
+## Knowledge References
+- `hack/agent-skills/knowledge/policy-apis.yaml`
+- `hack/agent-skills/knowledge/policy-patterns.md`

--- a/hack/agent-skills/skills/karmada-knowledge/SKILL.md
+++ b/hack/agent-skills/skills/karmada-knowledge/SKILL.md
@@ -1,0 +1,47 @@
+# karmada-knowledge
+
+## Description
+Load Karmada architecture concepts, API types, component relationships, policy patterns,
+and well-known conventions. This is the foundational skill all other Karmada skills depend on.
+
+## When to Load
+- User mentions "Karmada", "multi-cluster", "propagation", "override policy", "resource binding" for the first time.
+- User asks about Karmada's architecture, components, or API structure.
+- User asks how Karmada works or what Karmada can do.
+- Any other Karmada skill is triggered (load this first as prerequisite).
+
+## Workflow
+
+1. **Assess the user's Karmada knowledge level.**
+   - If they use precise terms (PropagationPolicy, ResourceBinding, Work), provide targeted information.
+   - If they use vague terms (spread to clusters, multi-region), start with architectural overview.
+
+2. **Load relevant knowledge files based on the query:**
+   - `hack/agent-skills/knowledge/policy-apis.yaml` for API field references, types, enums.
+   - `hack/agent-skills/knowledge/policy-patterns.md` for common policy configurations.
+   - `hack/agent-skills/knowledge/components.md` for Karmada component architecture.
+   - `hack/agent-skills/knowledge/troubleshooting.md` for debug playbooks.
+
+3. **Explain the propagation chain** when relevant:
+   ```
+   Resource Template → Policy Match → ResourceBinding → Scheduling → Work → Member Cluster
+   ```
+
+4. **Surface the four core CRDs and their relationship:**
+   - `PropagationPolicy` / `ClusterPropagationPolicy` — what to propagate and where.
+   - `OverridePolicy` / `ClusterOverridePolicy` — how to modify per cluster.
+   - `ResourceBinding` / `ClusterResourceBinding` — the intermediate binding object.
+   - `Work` — the per-cluster execution unit.
+
+5. **Clarify scope rules:**
+   - `PropagationPolicy` is Namespace-scoped, only matches resources in its namespace.
+   - `ClusterPropagationPolicy` is Cluster-scoped, can match cluster-scoped resources and resources in any namespace except system namespaces (`karmada-system`, `karmada-cluster`, `karmada-es-*`).
+   - Same scoping applies to OverridePolicy vs ClusterOverridePolicy.
+
+6. **Provide the correct API version:** Always use `policy.karmada.io/v1alpha1` for policies and `work.karmada.io/v1alpha2` (storage) for bindings.
+
+## Knowledge References
+- `hack/agent-skills/knowledge/policy-apis.yaml`
+- `hack/agent-skills/knowledge/policy-patterns.md`
+- `hack/agent-skills/knowledge/components.md`
+- `hack/agent-skills/knowledge/troubleshooting.md`

--- a/hack/agent-skills/skills/karmada-search/SKILL.md
+++ b/hack/agent-skills/skills/karmada-search/SKILL.md
@@ -1,0 +1,98 @@
+# karmada-search
+
+## Description
+Search Karmada resources (policies, bindings, works) and optionally resources
+across member clusters. Covers query patterns, label-based search, and the
+karmada-search component for cross-cluster queries.
+
+## When to Load
+- User asks "find all PropagationPolicies", "search for work objects", "list bindings".
+- User asks "find resources across all clusters", "search member clusters".
+- User wants to locate specific Karmada objects by label, annotation, or field.
+- User asks how to use `karmada-search` or the search API.
+
+## Workflow
+
+1. **Determine the search scope.**
+   - Karmada control plane only? → Use `kubectl` with Karmada CRDs.
+   - Across member clusters? → Use `karmada-search` component or per-cluster `kubectl`.
+
+2. **For Karmada control plane searches:**
+
+   **Find PropagationPolicies matching a resource:**
+   ```bash
+   kubectl get propagationpolicy -A
+   kubectl get propagationpolicy -n <ns> -o yaml
+   ```
+
+   **Find OverridePolicies for a resource:**
+   ```bash
+   kubectl get overridepolicy -A
+   kubectl get clusteroverridepolicy
+   ```
+
+   **Find ResourceBindings for a workload:**
+   ```bash
+   kubectl get resourcebinding -n <ns>
+   kubectl get resourcebinding -n <ns> -o jsonpath='{.items[?(@.spec.resource.name=="<name>")]}'
+   ```
+
+   **Find Works targeting a specific cluster:**
+   ```bash
+   kubectl get work -n karmada-es-<cluster>
+   ```
+
+   **Find all bindings referencing a policy (via permanent-id label):**
+   ```bash
+   kubectl get resourcebinding -A -l propagationpolicy.karmada.io/permanent-id=<id>
+   kubectl get clusterresourcebinding -A -l clusterpropagationpolicy.karmada.io/permanent-id=<id>
+   ```
+
+   **Find all resources claimed by a specific policy (via annotations):**
+   ```bash
+   kubectl get <kind> -A -o json | jq '.items[] | select(.metadata.annotations["propagationpolicy.karmada.io/name"]=="<policy-name>")'
+   ```
+
+3. **For cross-cluster searches (karmada-search):**
+
+   If the `karmada-search` component is enabled, use the search API:
+
+   ```bash
+   # Search Deployments across all member clusters
+   kubectl get --raw "/apis/search.karmada.io/v1alpha1/search/apis/apps/v1/deployments"
+
+   # Search resources by namespace
+   kubectl get --raw "/apis/search.karmada.io/v1alpha1/search/apis/v1/namespaces/<ns>/configmaps"
+   ```
+
+   **ResourceRegistry** defines which resources are cached for search:
+   ```bash
+   kubectl get resourceregistry
+   ```
+
+4. **Search by labels across control plane:**
+
+   ```bash
+   # Resources with skip-auto-propagation
+   kubectl get ns -l namespace.karmada.io/skip-auto-propagation=true
+
+   # Works with specific status
+   kubectl get work -A -o json | jq '.items[] | select(.status.conditions[] | select(.type=="Applied" and .status=="False"))'
+   ```
+
+5. **Search by health status:**
+
+   ```bash
+   # Find unhealthy aggregated statuses across bindings
+   kubectl get resourcebinding -A -o json | jq '.items[] | select(.status.aggregatedStatus[] | select(.health=="Unhealthy"))'
+   ```
+
+6. **Provide an explanation of search scope options:**
+   - Control plane search: Policies, bindings, works, clusters — all via `kubectl`.
+   - Cross-cluster search: `karmada-search` component with `ResourceRegistry`.
+   - Per-cluster search: Direct `kubectl --context=<member>` queries.
+   - Hybrid: Combine finding from bindings(status.aggregatedStatus) to narrow down which member clusters to query.
+
+## Knowledge References
+- `hack/agent-skills/knowledge/policy-apis.yaml`
+- `hack/agent-skills/knowledge/components.md`

--- a/hack/agent-skills/templates/cluster-override-policy.yaml
+++ b/hack/agent-skills/templates/cluster-override-policy.yaml
@@ -1,0 +1,29 @@
+# ClusterOverridePolicy Template
+# For cluster-scoped resources or cross-namespace overrides.
+
+apiVersion: policy.karmada.io/v1alpha1
+kind: ClusterOverridePolicy
+metadata:
+  name: <workload-name>-cluster-override
+spec:
+  resourceSelectors:
+    - apiVersion: rbac.authorization.k8s.io/v1  # <apiVersion of the target resource>
+      kind: ClusterRole                          # <Kind of the target resource>
+      # name: <resource-name>
+
+  overrideRules:
+    - targetCluster:
+        clusterNames:
+          - member2
+      overriders:
+        labelsOverrider:
+          - operator: add
+            value:
+              cluster: member2
+
+  # Same OverrideSpec as OverridePolicy.
+  # See templates/override-policy.yaml for full field reference.
+  #
+  # Key difference: ClusterOverridePolicy can match:
+  #   - Cluster-scoped resources
+  #   - Namespace-scoped resources in any namespace

--- a/hack/agent-skills/templates/cluster-propagation-policy.yaml
+++ b/hack/agent-skills/templates/cluster-propagation-policy.yaml
@@ -1,0 +1,30 @@
+# ClusterPropagationPolicy Template
+# For cluster-scoped resources or resources in any namespace (except system namespaces).
+# System reserved namespaces: karmada-system, karmada-cluster, karmada-es-*
+
+apiVersion: policy.karmada.io/v1alpha1
+kind: ClusterPropagationPolicy
+metadata:
+  name: <workload-name>-cluster-propagation
+spec:
+  resourceSelectors:
+    - apiVersion: rbac.authorization.k8s.io/v1  # <apiVersion of the target resource>
+      kind: ClusterRole                          # <Kind of the target resource>
+      # name: <resource-name>    # Optional: target a specific resource
+      # labelSelector:           # Optional: select resources by labels
+      #   matchLabels:
+      #     app: <label-value>
+
+  # Placement rules (same as PropagationPolicy)
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - member1
+        - member2
+
+  # All other fields are identical to PropagationPolicy.
+  # See templates/propagation-policy.yaml for full field reference.
+  #
+  # Key difference: ClusterPropagationPolicy can match:
+  #   - Cluster-scoped resources (ClusterRole, CRD, etc.)
+  #   - Namespace-scoped resources in any namespace (except karmada-system, karmada-cluster, karmada-es-*)

--- a/hack/agent-skills/templates/override-policy.yaml
+++ b/hack/agent-skills/templates/override-policy.yaml
@@ -1,0 +1,101 @@
+# OverridePolicy Template
+# Replace placeholders with your override rules per target cluster.
+
+apiVersion: policy.karmada.io/v1alpha1
+kind: OverridePolicy
+metadata:
+  name: <workload-name>-override
+  # namespace: <namespace>  # required; must match the workload namespace
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1       # <apiVersion of the target resource>
+      kind: Deployment           # <Kind of the target resource>
+      # name: <resource-name>    # Optional: target a specific resource
+      # labelSelector:           # Optional: select resources by labels
+      #   matchLabels:
+      #     app: <label-value>
+
+  # Override rules per target cluster
+  overrideRules:
+
+    # Rule 1: Override for member2
+    - targetCluster:
+        clusterNames:
+          - member2
+        # labelSelector:          # Alternative: select clusters by labels
+        #   matchLabels:
+        #     region: us-east
+
+      overriders:
+        # Image overrides (applies to all containers by default)
+        # imageOverrider:
+        #   - component: Registry     # Registry | Repository | Tag
+        #     operator: replace       # add | remove | replace
+        #     value: registry.member2.example.com
+        #   - predicate:              # Optional: target specific container images
+        #       path: /spec/template/spec/containers/0/image
+        #     component: Registry
+        #     operator: replace
+        #     value: private-registry.example.com
+
+        # Label overrides
+        # labelsOverrider:
+        #   - operator: add           # add | remove | replace
+        #     value:
+        #       env: production
+        #   - operator: remove
+        #     value:
+        #       deprecated-label: "true"
+
+        # Annotation overrides
+        # annotationsOverrider:
+        #   - operator: add
+        #     value:
+        #       team: platform
+
+        # Command overrides (specific container)
+        # commandOverrider:
+        #   - containerName: main
+        #     operator: add
+        #     value:
+        #       - "--debug"
+
+        # Args overrides (specific container)
+        # argsOverrider:
+        #   - containerName: main
+        #     operator: add
+        #     value:
+        #       - "--verbose"
+
+        # Plaintext overrides (arbitrary JSONPath)
+        # plaintext:
+        #   - path: /spec/replicas
+        #     operator: replace
+        #     value: 3
+
+        # Field overrides (structured fields like ConfigMap data)
+        # fieldOverrider:
+        #   - fieldPath: /data/config.yaml
+        #     yaml:
+        #       - subPath: /database/host
+        #         operator: replace
+        #         value: "db.member2.internal"
+        #     json:
+        #       - subPath: /logging/level
+        #         operator: replace
+        #         value: "debug"
+
+    # Rule 2: Override for member1
+    - targetCluster:
+        clusterNames:
+          - member1
+      overriders:
+        labelsOverrider:
+          - operator: add
+            value:
+              env: staging
+
+# Notes:
+# - Override application order: Image → Command → Args → Labels → Annotations → Field → Plaintext
+# - Multiple OverridePolicies for the same resource/field: last writer wins
+# - Use ClusterOverridePolicy for cluster-scoped resources or cross-namespace overrides

--- a/hack/agent-skills/templates/propagation-policy.yaml
+++ b/hack/agent-skills/templates/propagation-policy.yaml
@@ -1,0 +1,119 @@
+# PropagationPolicy Template
+# Replace placeholders with your workload details and placement rules.
+
+apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: <workload-name>-propagation
+  # namespace: <namespace>  # required; must match the workload namespace
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1       # <apiVersion of the target resource>
+      kind: Deployment           # <Kind of the target resource>
+      # name: <resource-name>    # Optional: target a specific resource by name
+      # namespace: <namespace>   # Optional: defaults to policy namespace
+      # labelSelector:           # Optional: select resources by labels (ignored if name is set)
+      #   matchLabels:
+      #     app: <label-value>
+
+  # Placement rules (choose one approach):
+  placement:
+    # Option A: Static cluster name list
+    clusterAffinity:
+      clusterNames:
+        - member1
+        - member2
+      # exclude:                   # Optional: exclude specific clusters
+      #   - member3
+
+    # Option B: Label-based cluster selection
+    # clusterAffinity:
+    #   labelSelector:
+    #     matchLabels:
+    #       region: us-west
+    #   fieldSelector:
+    #     matchExpressions:
+    #       - key: provider
+    #         operator: In
+    #         values:
+    #           - aws
+
+    # Option C: Multi-group affinity with overflow (can't coexist with clusterAffinity)
+    # clusterAffinities:
+    #   - affinityName: primary
+    #     clusterNames:
+    #       - member1
+    #     overflowAffinities:
+    #       - affinityName: overflow-1
+    #         clusterNames:
+    #           - member2
+
+    # Optional: Cluster tolerations
+    # clusterTolerations:
+    #   - key: "node.karmada.io/not-ready"
+    #     operator: "Exists"
+    #     effect: "NoSchedule"
+
+    # Optional: Spread constraints
+    # spreadConstraints:
+    #   - spreadByField: region
+    #     maxGroups: 2
+    #     minGroups: 2
+
+    # Optional: Replica scheduling (for workloads with replicas)
+    # replicaScheduling:
+    #   replicaSchedulingType: Divided       # Duplicated | Divided (default)
+    #   replicaDivisionPreference: Weighted  # Aggregated | Weighted
+    #   weightPreference:
+    #     staticWeightList:
+    #       - targetCluster:
+    #           clusterNames:
+    #             - member1
+    #         weight: 1
+    #       - targetCluster:
+    #           clusterNames:
+    #             - member2
+    #         weight: 1
+
+    # Optional: Workload affinity/anti-affinity
+    # workloadAffinity:
+    #   affinity:
+    #     groupByLabelKey: app.group
+    #   antiAffinity:
+    #     groupByLabelKey: app.group
+
+  # Optional: Additional settings
+  # propagateDeps: true                          # Auto-propagate ConfigMaps/Secrets
+  # priority: 0                                  # Higher = higher priority
+  # preemption: Never                            # Always | Never
+  # schedulerName: default-scheduler
+  # conflictResolution: Abort                    # Abort | Overwrite
+  # activationPreference: Lazy                   # Defer policy changes to resource template changes
+  # dependentOverrides:
+  #   - <override-policy-name>
+
+  # Optional: Failover configuration
+  # failover:
+  #   application:
+  #     decisionConditions:
+  #       tolerationSeconds: 300
+  #     purgeMode: Gracefully
+  #     gracePeriodSeconds: 600
+  #   cluster:
+  #     purgeMode: Gracefully
+
+  # Optional: Suspension
+  # suspension:
+  #   dispatching: true                          # Suspend all dispatching
+  #   # OR per-cluster:
+  #   # dispatchingOnClusters:
+  #   #   clusterNames:
+  #   #     - member1
+
+  # Optional: Preserve on deletion
+  # preserveResourcesOnDeletion: true
+
+  # Optional: Schedule priority
+  # schedulePriority:
+  #   priorityClassSource: KubePriorityClass
+  #   priorityClassName: high-priority

--- a/hack/agent-skills/tests/test-policy-generator.py
+++ b/hack/agent-skills/tests/test-policy-generator.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Karmada Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for Karmada policy-generator script.
+Run: python3 tests/test-policy-generator.py
+"""
+
+import json
+import subprocess
+import sys
+import os
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+GENERATOR = os.path.join(SCRIPT_DIR, "..", "scripts", "policy-generator.py")
+VALIDATOR = os.path.join(SCRIPT_DIR, "..", "scripts", "validate-policy.py")
+
+
+def run(cmd):
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def test_generate_propagation():
+    """Generate a basic PropagationPolicy."""
+    result = run([
+        "python3", GENERATOR, "propagation",
+        "--name", "test-app",
+        "--namespace", "default",
+        "--api", "apps/v1",
+        "--kind", "Deployment",
+        "--clusters", "member1,member2",
+        "--weights", "1,1",
+    ])
+    assert result.returncode == 0, f"Generator failed: {result.stderr}"
+    assert "PropagationPolicy" in result.stdout
+    assert "test-app-propagation" in result.stdout
+    assert "member1" in result.stdout
+    assert "member2" in result.stdout
+    print("PASS: test_generate_propagation")
+
+
+def test_generate_override():
+    """Generate a basic OverridePolicy with labels."""
+    overrides = json.dumps([
+        {"operator": "add", "value": {"env": "production"}}
+    ])
+    result = run([
+        "python3", GENERATOR, "override",
+        "--name", "test-app",
+        "--namespace", "default",
+        "--api", "apps/v1",
+        "--kind", "Deployment",
+        "--cluster", "member1",
+        "--override-type", "labels",
+        "--overrides", overrides,
+    ])
+    assert result.returncode == 0, f"Generator failed: {result.stderr}"
+    assert "OverridePolicy" in result.stdout
+    assert "member1" in result.stdout
+    assert "env" in result.stdout
+    print("PASS: test_generate_override")
+
+
+def test_validate_valid_policy():
+    """Validate a known-valid policy."""
+    import tempfile
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write("""apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: test-policy
+  namespace: default
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: test-app
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - member1
+        - member2
+""")
+        f.flush()
+        result = run(["python3", VALIDATOR, f.name])
+        os.unlink(f.name)
+
+    assert result.returncode == 0, f"Validation should pass: {result.stdout}"
+    print("PASS: test_validate_valid_policy")
+
+
+def test_validate_invalid_policy():
+    """Validate a policy with errors."""
+    import tempfile
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write("""apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: bad-policy
+spec:
+  resourceSelectors: []
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - member1
+    clusterAffinities:
+      - affinityName: group1
+        clusterNames:
+          - member2
+""")
+        f.flush()
+        result = run(["python3", VALIDATOR, f.name])
+        os.unlink(f.name)
+
+    assert result.returncode == 1, "Validation should fail for invalid policy"
+    assert "ERROR" in result.stdout or "error" in result.stdout.lower()
+    print("PASS: test_validate_invalid_policy")
+
+
+def main():
+    print("Running Karmada policy generator tests...\n")
+    tests = [
+        test_generate_propagation,
+        test_generate_override,
+        test_validate_valid_policy,
+        test_validate_invalid_policy,
+    ]
+    for test in tests:
+        try:
+            test()
+        except Exception as e:
+            print(f"FAIL: {test.__name__}: {e}")
+            sys.exit(1)
+    print("\nAll tests passed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/agent-skills/tests/test-skills.sh
+++ b/hack/agent-skills/tests/test-skills.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# Copyright 2026 The Karmada Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Skill validation tests
+# Validates that all skills reference valid knowledge files and templates
+
+set -euo pipefail
+
+SKILLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../skills" && pwd)"
+KNOWLEDGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../knowledge" && pwd)"
+TEMPLATES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../templates" && pwd)"
+EXAMPLES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../examples" && pwd)"
+
+echo "=== Karmada Agent Skills Validation ==="
+echo ""
+
+# 1. All expected skills exist
+echo "--- Checking skills ---"
+EXPECTED_SKILLS=(
+  "karmada-knowledge"
+  "karmada-create-policy"
+  "karmada-audit-policy"
+  "karmada-explain-placement"
+  "karmada-debug-propagation"
+  "karmada-search"
+  "karmada-controller-manager"
+)
+
+for skill in "${EXPECTED_SKILLS[@]}"; do
+  if [[ -f "${SKILLS_DIR}/${skill}/SKILL.md" ]]; then
+    echo "  [OK] ${skill}"
+  else
+    echo "  [FAIL] ${skill}: SKILL.md not found"
+    exit 1
+  fi
+done
+echo ""
+
+# 2. All knowledge files exist
+echo "--- Checking knowledge files ---"
+EXPECTED_KNOWLEDGE=(
+  "policy-apis.yaml"
+  "policy-patterns.md"
+  "troubleshooting.md"
+  "components.md"
+)
+
+for kf in "${EXPECTED_KNOWLEDGE[@]}"; do
+  if [[ -f "${KNOWLEDGE_DIR}/${kf}" ]]; then
+    echo "  [OK] ${kf}"
+  else
+    echo "  [FAIL] ${kf}: not found"
+    exit 1
+  fi
+done
+echo ""
+
+# 3. All templates exist and are valid YAML
+echo "--- Checking templates ---"
+EXPECTED_TEMPLATES=(
+  "propagation-policy.yaml"
+  "cluster-propagation-policy.yaml"
+  "override-policy.yaml"
+  "cluster-override-policy.yaml"
+)
+
+for tmpl in "${EXPECTED_TEMPLATES[@]}"; do
+  if [[ -f "${TEMPLATES_DIR}/${tmpl}" ]]; then
+    if python3 -c "import yaml; yaml.safe_load(open('${TEMPLATES_DIR}/${tmpl}'))" 2>/dev/null; then
+      echo "  [OK] ${tmpl} (valid YAML)"
+    else
+      echo "  [FAIL] ${tmpl}: invalid YAML"
+      exit 1
+    fi
+  else
+    echo "  [FAIL] ${tmpl}: not found"
+    exit 1
+  fi
+done
+echo ""
+
+# 4. All example directories have README and at least one YAML
+echo "--- Checking examples ---"
+EXPECTED_EXAMPLES=(
+  "multi-country-setup"
+  "failover"
+  "image-override"
+)
+
+for ex in "${EXPECTED_EXAMPLES[@]}"; do
+  if [[ -d "${EXAMPLES_DIR}/${ex}" ]]; then
+    if [[ -f "${EXAMPLES_DIR}/${ex}/README.md" ]]; then
+      yaml_count=$(find "${EXAMPLES_DIR}/${ex}" -maxdepth 1 -name "*.yaml" | wc -l | tr -d ' ')
+      if [[ "$yaml_count" -gt 0 ]]; then
+        echo "  [OK] ${ex} (README.md + ${yaml_count} YAML files)"
+      else
+        echo "  [FAIL] ${ex}: no YAML files found"
+        exit 1
+      fi
+    else
+      echo "  [FAIL] ${ex}: README.md not found"
+      exit 1
+    fi
+  else
+    echo "  [FAIL] ${ex}: directory not found"
+    exit 1
+  fi
+done
+echo ""
+
+echo "=== All validations passed! ==="


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

AI coding agents lack Karmada-specific guidance. Without a dedicated skill
repository, agents search scattered documentation, infer policy structure
from incomplete context, and produce incorrect PropagationPolicy,
OverridePolicy, or troubleshooting guidance.

This PR adds the official Karmada agent skills directory under
`hack/agent-skills/` following mature multi-skill repository patterns.

**Structure**:

```
hack/agent-skills/
├── skills/          # 7 workflow skills with SKILL.md per skill
├── knowledge/       # Shared reference: policy APIs, patterns, troubleshooting, components
├── templates/       # Reusable YAML starters for all 4 policy types
├── examples/        # 3 worked scenarios (multi-country, failover, image-override)
├── scripts/         # Deterministic helpers: policy-generator.py, validate-policy.py
├── tests/           # test-skills.sh, test-policy-generator.py
├── CONTRIBUTING.md  # Contributor guide for adding skills and knowledge
└── README.md        # Directory overview and usage
```

**Skills delivered**:
| Skill | Purpose |
|-------|---------|
| `karmada-knowledge` | Load Karmada concepts, APIs, components, and policy patterns |
| `karmada-create-policy` | Generate PropagationPolicy and OverridePolicy YAML for workloads |
| `karmada-audit-policy` | Review policies for selector mismatch, scope misuse, dependency risks |
| `karmada-explain-placement` | Explain how a workload will be placed across member clusters |
| `karmada-debug-propagation` | Walk the 7-step propagation chain to diagnose failures |
| `karmada-search` | Search patterns for policies, bindings, works, and cross-cluster queries |
| `karmada-controller-manager` | Controller reference, log access, feature gates |

**Knowledge base**:
- `policy-apis.yaml` — Full API field reference derived from Go types (policy/v1alpha1, work/v1alpha1/v1alpha2)
- `policy-patterns.md` — 17 patterns (propagation, override, failover, affinity, suspension)
- `troubleshooting.md` — Propagation chain failure points with diagnostic flow
- `components.md` — All Karmada components with interaction flow and feature gates

**Deterministic helpers**:
- `policy-generator.py` — CLI tool for generating PropagationPolicy/OverridePolicy YAML
- `validate-policy.py` — Schema-aware policy validator with structured audit reports

**Tests**:
- All 29 files validated (valid YAML, existing references)
- `test-skills.sh` passes, `test-policy-generator.py` 4/4 tests pass

**Which issue(s) this PR fixes**:
References: karmada-io/community#190

**Special notes for your reviewer**:
This is the initial deliverable for the "Build Karmada Agent Skills" LFX mentorship project (CNCF Term 02, 2026). The design follows patterns from the project proposal: shared knowledge base, focused workflow skills, and deterministic helpers for schema-sensitive tasks.

cc @XiShanYongYe-Chang @RainbowMango

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```