### PR TITLE
test(util/lifted): cover resource-name helpers

### DIFF
--- a/pkg/util/lifted/corev1helpers_test.go
+++ b/pkg/util/lifted/corev1helpers_test.go
@@ -65,3 +65,97 @@ func TestIsNativeResource(t *testing.T) {
 		})
 	}
 }
+
+func TestIsPrefixedNativeResource(t *testing.T) {
+	cases := []struct {
+		name corev1.ResourceName
+		want bool
+	}{
+		{"kubernetes.io/foo", true},
+		{"pod.alpha.kubernetes.io/opaque", true},
+		{"example.com/gpu", false},
+		{"foo", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := IsPrefixedNativeResource(c.name); got != c.want {
+			t.Errorf("IsPrefixedNativeResource(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestIsHugePageResourceName(t *testing.T) {
+	cases := []struct {
+		name corev1.ResourceName
+		want bool
+	}{
+		{corev1.ResourceName(string(corev1.ResourceHugePagesPrefix) + "2Mi"), true},
+		{corev1.ResourceName(string(corev1.ResourceHugePagesPrefix) + "1Gi"), true},
+		{"huge-pages-2Mi", false}, // missing the hyphenated `hugepages-` prefix
+		{corev1.ResourceCPU, false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := IsHugePageResourceName(c.name); got != c.want {
+			t.Errorf("IsHugePageResourceName(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestIsAttachableVolumeResourceName(t *testing.T) {
+	cases := []struct {
+		name corev1.ResourceName
+		want bool
+	}{
+		{corev1.ResourceName(string(corev1.ResourceAttachableVolumesPrefix) + "ebs"), true},
+		{"attachable_volumes-foo", false}, // missing exact `attachable-volumes-` prefix
+		{corev1.ResourceMemory, false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := IsAttachableVolumeResourceName(c.name); got != c.want {
+			t.Errorf("IsAttachableVolumeResourceName(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestIsExtendedResourceName(t *testing.T) {
+	cases := []struct {
+		name corev1.ResourceName
+		want bool
+	}{
+		// Native resources are NOT extended.
+		{corev1.ResourceCPU, false},
+		{"foo", false},
+		// Names prefixed with requests. are NOT extended (would clash with quota convention).
+		{corev1.ResourceName(corev1.DefaultResourceRequestsPrefix + "example.com/gpu"), false},
+		// Vendor-prefixed resource that satisfies IsQualifiedName once requests. is prepended IS extended.
+		{"example.com/gpu", true},
+		// Invalid qualified name → not extended.
+		{"BAD!!", false},
+	}
+	for _, c := range cases {
+		if got := IsExtendedResourceName(c.name); got != c.want {
+			t.Errorf("IsExtendedResourceName(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestIsScalarResourceName(t *testing.T) {
+	cases := []struct {
+		name corev1.ResourceName
+		want bool
+	}{
+		{"example.com/gpu", true}, // extended
+		{corev1.ResourceName(string(corev1.ResourceHugePagesPrefix) + "2Mi"), true},
+		{corev1.ResourceName(string(corev1.ResourceAttachableVolumesPrefix) + "ebs"), true},
+		{"kubernetes.io/foo", true}, // prefixed native
+		{corev1.ResourceCPU, false},
+		{"foo", false},
+	}
+	for _, c := range cases {
+		if got := IsScalarResourceName(c.name); got != c.want {
+			t.Errorf("IsScalarResourceName(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Adds unit tests for the previously-uncovered helpers in `pkg/util/lifted/corev1helpers.go` and `resourcename.go`. Pure test additions, no production-code changes.