### PR TITLE
test(e2e): add inline event assertions for binding object events

### DIFF
--- a/test/e2e/suites/base/dependenciesdistributor_test.go
+++ b/test/e2e/suites/base/dependenciesdistributor_test.go
@@ -119,6 +119,13 @@ var _ = ginkgo.Describe("[DependenciesDistributor] automatically propagate relev
 							return event.Reason == events.EventReasonGetDependenciesSucceed
 						})
 				})
+				ginkgo.By("checking SyncScheduleResultToDependenciesSucceed event on binding", func() {
+					bindingName := names.GenerateBindingName("Deployment", deployment.Name)
+					framework.WaitEventFitWith(kubeClient, deployment.Namespace, bindingName,
+						func(event corev1.Event) bool {
+							return event.Reason == events.EventReasonSyncScheduleResultToDependenciesSucceed
+						})
+				})
 
 				ginkgo.By("updating propagation policy's clusterNames", func() {
 					patch := []map[string]any{
@@ -219,6 +226,13 @@ var _ = ginkgo.Describe("[DependenciesDistributor] automatically propagate relev
 								return event.Reason == events.EventReasonGetDependenciesSucceed
 							})
 					})
+					ginkgo.By("checking SyncScheduleResultToDependenciesSucceed event on binding", func() {
+						bindingName := names.GenerateBindingName("Deployment", deployment.Name)
+						framework.WaitEventFitWith(kubeClient, deployment.Namespace, bindingName,
+							func(event corev1.Event) bool {
+								return event.Reason == events.EventReasonSyncScheduleResultToDependenciesSucceed
+							})
+					})
 				})
 
 				ginkgo.By("make the secret is not referenced by the deployment ", func() {
@@ -301,6 +315,13 @@ var _ = ginkgo.Describe("[DependenciesDistributor] automatically propagate relev
 							return event.Reason == events.EventReasonGetDependenciesSucceed
 						})
 				})
+				ginkgo.By("checking SyncScheduleResultToDependenciesSucceed event on binding", func() {
+					bindingName := names.GenerateBindingName("Deployment", deployment.Name)
+					framework.WaitEventFitWith(kubeClient, deployment.Namespace, bindingName,
+						func(event corev1.Event) bool {
+							return event.Reason == events.EventReasonSyncScheduleResultToDependenciesSucceed
+						})
+				})
 
 				ginkgo.By("make the persistentVolumeClaim is not referenced by the deployment ", func() {
 					updateVolumes := []corev1.Volume{
@@ -366,6 +387,13 @@ var _ = ginkgo.Describe("[DependenciesDistributor] automatically propagate relev
 					framework.WaitEventFitWith(kubeClient, deployment.Namespace, deployment.Name,
 						func(event corev1.Event) bool {
 							return event.Reason == events.EventReasonGetDependenciesSucceed
+						})
+				})
+				ginkgo.By("checking SyncScheduleResultToDependenciesSucceed event on binding", func() {
+					bindingName := names.GenerateBindingName("Deployment", deployment.Name)
+					framework.WaitEventFitWith(kubeClient, deployment.Namespace, bindingName,
+						func(event corev1.Event) bool {
+							return event.Reason == events.EventReasonSyncScheduleResultToDependenciesSucceed
 						})
 				})
 
@@ -712,6 +740,13 @@ var _ = ginkgo.Describe("[DependenciesDistributor] automatically propagate relev
 					framework.WaitEventFitWith(kubeClient, deployment.Namespace, deployment.Name,
 						func(event corev1.Event) bool {
 							return event.Reason == events.EventReasonGetDependenciesSucceed
+						})
+				})
+				ginkgo.By("checking SyncScheduleResultToDependenciesSucceed event on binding", func() {
+					bindingName := names.GenerateBindingName("Deployment", deployment.Name)
+					framework.WaitEventFitWith(kubeClient, deployment.Namespace, bindingName,
+						func(event corev1.Event) bool {
+							return event.Reason == events.EventReasonSyncScheduleResultToDependenciesSucceed
 						})
 				})
 

--- a/test/e2e/suites/base/failover_test.go
+++ b/test/e2e/suites/base/failover_test.go
@@ -36,6 +36,7 @@ import (
 
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	"github.com/karmada-io/karmada/pkg/events"
 	"github.com/karmada-io/karmada/pkg/util/helper"
 	"github.com/karmada-io/karmada/test/e2e/framework"
 	testhelper "github.com/karmada-io/karmada/test/helper"
@@ -184,6 +185,13 @@ var _ = framework.SerialDescribe("cluster failover testing", func() {
 
 					return len(currentClusters)
 				}, pollTimeout, pollInterval).Should(gomega.Equal(minGroups))
+			})
+
+			ginkgo.By("checking EvictWorkloadFromClusterSucceed event on deployment", func() {
+				framework.WaitEventFitWith(kubeClient, deploymentNamespace, deploymentName,
+					func(event corev1.Event) bool {
+						return event.Reason == events.EventReasonEvictWorkloadFromClusterSucceed
+					})
 			})
 
 			ginkgo.By(fmt.Sprintf("remove taint %v from the target clusters", taint), func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Part of #7252 — improving E2E test coverage for Karmada controller events.

Adds inline event assertions for two binding object events that were not
yet covered:

1. **`SyncScheduleResultToDependenciesSucceed`** — asserted in
   `dependenciesdistributor_test.go` after the configmap is auto-propagated
   with `propagateDeps: true`. This event is emitted by the
   DependenciesDistributor when it successfully syncs schedule results to
   dependent resources.

2. **`EvictWorkloadFromClusterSucceed`** — asserted in
   `workloadrebalancer_test.go` after graceful eviction tasks complete on
   the tainted cluster. This event is emitted by the graceful eviction
   controller after successfully evicting workloads from a failing cluster.

Both assertions follow the community meeting decision to use **Approach 2
(inline event assertions)** — placing assertions immediately after the
operation that triggers the event for semantic accuracy.

**Which issue(s) this PR fixes**:
Part of #7252

**Special notes for your reviewer**:
cc @XiShanYongYe-Chang

This addresses two remaining binding object events from the
[subtask breakdown](https://github.com/karmada-io/karmada/issues/7252#issuecomment-2726196632).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```