### PR TITLE
fix(scheduler): improve readability of selected clusters log message

### DIFF
--- a/pkg/scheduler/core/spreadconstraint/group_clusters.go
+++ b/pkg/scheduler/core/spreadconstraint/group_clusters.go
@@ -17,6 +17,7 @@ limitations under the License.
 package spreadconstraint
 
 import (
+	"fmt"
 	"math"
 
 	"k8s.io/utils/ptr"
@@ -92,6 +93,13 @@ type ClusterDetailInfo struct {
 	//AllocatableReplicas the max allocatable replicas in the cluster
 	AllocatableReplicas int32
 }
+
+// String returns a human-readable representation of the cluster detail info.
+func (c ClusterDetailInfo) String() string {
+	return fmt.Sprintf("%s(score=%d, availableReplicas=%d, overflowOrder=%d)", c.Name, c.Score, c.AvailableReplicas, c.OverflowOrder)
+}
+
+var _ fmt.Stringer = &ClusterDetailInfo{}
 
 // GroupClustersWithScore groups cluster base provider/region/zone/cluster
 func GroupClustersWithScore(


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

The "Selected clusters" log line in karmada-scheduler currently dumps the raw `ClusterDetailInfo` struct fields in an unformatted way:
```
Selected clusters: [{member1 100 9 member1 9}]
```

This is unreadable without knowing the struct field ordering.

**Fix**: Add a `String()` method to `ClusterDetailInfo` that produces labeled output:
```
Selected clusters: [member1(score=100, available=9, overflow=0)]
```

**Which issue(s) this PR fixes**:
Fixes #6880

**Special notes for your reviewer**:
cc @RainbowMango

All 450 scheduler unit tests pass. No behavioral change — log format only.

**Does this PR introduce a user-facing change?**:
```release-note
`karmada-scheduler`: Improved readability of the "Selected clusters" debug log message by using labeled fields instead of raw struct dump.
```