### PR TITLE
Introduce allowlist for allowed errors when determining flinkDeployment's health in the context of ApplicationFailover

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/customizations.yaml
@@ -12,7 +12,7 @@ spec:
 # Health Rules:
 # 1. If the job is in a terminal state [Failed, Finished, Canceled, Suspended] or in the Running state, it is considered healthy.
 # 2. If the job is in an ephemeral state [Reconciling, Initializing, Created]:
-#    - It is treated as healthy ONLY if there is a published error (e.g., user-related issues like an incorrect image path).
+#    - It is treated as healthy ONLY if there is a published error and the error is specified in ALLOWLIST (e.g. ErrImagePull).
 #    - Otherwise, it is treated as unhealthy and may be rescheduled.
 # 3. Short-lived states [Cancelling, Failing, Restarting] are treated as healthy because they will directly transition to their respective terminal states:
 #    - Cancelling -> Canceled / Suspended
@@ -21,16 +21,58 @@ spec:
 #
 # For more information on the Flink state diagram, refer to the official documentation: https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/internals/job_scheduling/
     healthInterpretation:
-      luaScript: >
-        function InterpretHealth(observedObj)
-          if observedObj.status ~= nil and observedObj.status.jobStatus ~= nil and observedObj.status.jobStatus.state ~= nil then
-            if observedObj.status.jobStatus.state ~= 'CREATED' and observedObj.status.jobStatus.state ~= 'INITIALIZING' and observedObj.status.jobStatus.state ~= 'RECONCILING' then
+      luaScript: |
+        -- Configure which error substrings count as "user errors" (treated as healthy even if state is ephemeral)
+        local ALLOWLIST = {
+          "ErrImagePull",
+          "ImagePullBackOff",
+          "CrashLoopBackOff",
+        }
+        
+        local terminal   = { FINISHED=true, FAILED=true, CANCELED=true, SUSPENDED=true }
+        local shortlived = { CANCELLING=true, FAILING=true, RESTARTING=true }
+
+        local function isAllowedUserError(err)
+          if not err or err == "" then return false end
+          for i = 1, #ALLOWLIST do
+            if string.find(err, ALLOWLIST[i], 1, true) then
               return true
-            else
-              return observedObj.status.error ~= nil or observedObj.status.jobManagerDeploymentStatus == 'ERROR'
             end
           end
-          return observedObj.status.error ~= nil
+          return false
+        end
+        
+        function InterpretHealth(observedObj)
+          local st   = observedObj.status or {}
+          local js   = st.jobStatus or {}
+          local state = js.state
+          local jm    = st.jobManagerDeploymentStatus
+          local life  = st.lifecycleState
+          local err   = st.error
+        
+          -- If no explicit job state, consider healthy only when job looks steady
+          if state == nil then
+            return jm == "READY" and life == "STABLE"
+          end
+        
+          -- RUNNING or terminal states are healthy
+          if state == "RUNNING" or terminal[state] then
+            return true
+          end
+        
+          -- Short-lived transitions are healthy
+          if shortlived[state] then
+            return true
+          end
+        
+          -- Ephemeral states: CREATED / INITIALIZING / RECONCILING
+          -- Treat as healthy ONLY if error is in the allowlist (e.g., ErrImagePull)
+          if state == "CREATED" or state == "INITIALIZING" or state == "RECONCILING" then
+            return isAllowedUserError(err)
+          end
+        
+          -- Default conservative
+          return false
         end
     componentResource:
       luaScript: |

--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/testdata/interprethealth-test.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/testdata/interprethealth-test.yaml
@@ -1,16 +1,20 @@
 # test case for interpreting health of FlinkDeployment
 # case1. FlinkDeployment with RUNNING state should be Healthy
 # case2. FlinkDeployment with CREATED state without error should be Unhealthy
-# case3. FlinkDeployment with CREATED state with error should be Healthy
-# case4. FlinkDeployment with INITIALIZING state without error should be Unhealthy
-# case5. FlinkDeployment with INITIALIZING state with error should be Healthy
-# case6. FlinkDeployment with RECONCILING state without error should be Unhealthy
-# case7. FlinkDeployment with RECONCILING state with error should be Healthy
-# case8. FlinkDeployment with CREATED state and jobManagerDeploymentStatus ERROR should be Healthy
-# case9. FlinkDeployment with terminal states (FAILED, FINISHED, CANCELED, SUSPENDED) should be Healthy
-# case10. FlinkDeployment with short-lived states (CANCELLING, FAILING, RESTARTING) should be Healthy
-# case11. FlinkDeployment without jobStatus but with error should be Healthy
-# case12. FlinkDeployment without jobStatus and without error should be Unhealthy
+# case3. FlinkDeployment with CREATED state with allowlisted error should be Healthy
+# case4.  FlinkDeployment with CREATED state with non-allowlisted error should be Unhealthy
+# case5. FlinkDeployment with INITIALIZING state without error should be Unhealthy
+# case6. FlinkDeployment with INITIALIZING state with allowlisted error should be Healthy
+# case7. FlinkDeployment with INITIALIZING state with non-allowlisted error should be Unhealthy
+# case8. FlinkDeployment with RECONCILING state without error should be Unhealthy
+# case9. FlinkDeployment with RECONCILING state with allowlisted error should be Healthy
+# case10. FlinkDeployment with RECONCILING state with non-allowlisted error should be Unhealthy
+# case11. FlinkDeployment with CREATED state and jobManagerDeploymentStatus ERROR (no allowlisted error) should be Unhealthy
+# case12. FlinkDeployment with terminal states (FAILED, FINISHED, CANCELED, SUSPENDED) should be Healthy
+# case13. FlinkDeployment with short-lived states (CANCELLING, FAILING, RESTARTING) should be Healthy
+# case14. FlinkDeployment without jobStatus but with error should be Unhealthy
+# case15. FlinkDeployment without jobStatus and without error should be Unhealthy
+# case16. FlinkDeployment without jobStatus but with READY jobManagerDeploymentStatus and STABLE lifecycleState should be Healthy
 
 name: "FlinkDeployment with RUNNING state should be Healthy"
 description: "Test interpreting health of FlinkDeployment when jobStatus.state is RUNNING"
@@ -58,8 +62,8 @@ output:
   healthy: false
 
 ---
-name: "FlinkDeployment with CREATED state with error should be Healthy"
-description: "Test interpreting health of FlinkDeployment when jobStatus.state is CREATED and has error"
+name: "FlinkDeployment with CREATED state with allowlisted error should be Healthy"
+description: "Test interpreting health of FlinkDeployment when jobStatus.state is CREATED and has allowlisted error"
 observedObj:
   apiVersion: flink.apache.org/v1beta1
   kind: FlinkDeployment
@@ -81,12 +85,43 @@ observedObj:
         cpu: 1
         memory: 2048m
   status:
-    error: "Image pull failed"
+    error: "ErrImagePull"
     jobStatus:
       state: CREATED
 operation: InterpretHealth
 output:
   healthy: true
+
+---
+name: "FlinkDeployment with CREATED state with non-allowlisted error should be Unhealthy"
+description: "Test interpreting health of FlinkDeployment when jobStatus.state is CREATED and has non-allowlisted error"
+observedObj:
+  apiVersion: flink.apache.org/v1beta1
+  kind: FlinkDeployment
+  metadata:
+    name: basic-example
+    namespace: test-namespace
+  spec:
+    flinkConfiguration:
+      taskmanager.numberOfTaskSlots: "2"
+    flinkVersion: v1_17
+    image: flink:1.17
+    jobManager:
+      replicas: 1
+      resource:
+        cpu: 1
+        memory: 2048m
+    taskManager:
+      resource:
+        cpu: 1
+        memory: 2048m
+  status:
+    error: "Unknown"
+    jobStatus:
+      state: CREATED
+operation: InterpretHealth
+output:
+  healthy: false
 
 ---
 name: "FlinkDeployment with INITIALIZING state without error should be Unhealthy"
@@ -119,8 +154,8 @@ output:
   healthy: false
 
 ---
-name: "FlinkDeployment with INITIALIZING state with error should be Healthy"
-description: "Test interpreting health of FlinkDeployment when jobStatus.state is INITIALIZING and has error"
+name: "FlinkDeployment with INITIALIZING state with allowlisted error should be Healthy"
+description: "Test interpreting health of FlinkDeployment when jobStatus.state is INITIALIZING and has allowlisted error"
 observedObj:
   apiVersion: flink.apache.org/v1beta1
   kind: FlinkDeployment
@@ -142,12 +177,43 @@ observedObj:
         cpu: 1
         memory: 2048m
   status:
-    error: "Configuration validation failed"
+    error: "ImagePullBackOff"
     jobStatus:
       state: INITIALIZING
 operation: InterpretHealth
 output:
   healthy: true
+
+---
+name: "FlinkDeployment with INITIALIZING state with non-allowlisted error should be Unhealthy"
+description: "Test interpreting health of FlinkDeployment when jobStatus.state is INITIALIZING and has non-allowlisted error"
+observedObj:
+  apiVersion: flink.apache.org/v1beta1
+  kind: FlinkDeployment
+  metadata:
+    name: basic-example
+    namespace: test-namespace
+  spec:
+    flinkConfiguration:
+      taskmanager.numberOfTaskSlots: "2"
+    flinkVersion: v1_17
+    image: flink:1.17
+    jobManager:
+      replicas: 1
+      resource:
+        cpu: 1
+        memory: 2048m
+    taskManager:
+      resource:
+        cpu: 1
+        memory: 2048m
+  status:
+    error: "Unknown"
+    jobStatus:
+      state: INITIALIZING
+operation: InterpretHealth
+output:
+  healthy: false
 
 ---
 name: "FlinkDeployment with RECONCILING state without error should be Unhealthy"
@@ -180,8 +246,8 @@ output:
   healthy: false
 
 ---
-name: "FlinkDeployment with RECONCILING state with error should be Healthy"
-description: "Test interpreting health of FlinkDeployment when jobStatus.state is RECONCILING and has error"
+name: "FlinkDeployment with RECONCILING state with allowlisted error should be Healthy"
+description: "Test interpreting health of FlinkDeployment when jobStatus.state is RECONCILING and has allowlisted error"
 observedObj:
   apiVersion: flink.apache.org/v1beta1
   kind: FlinkDeployment
@@ -203,7 +269,7 @@ observedObj:
         cpu: 1
         memory: 2048m
   status:
-    error: "Resource quota exceeded"
+    error: "ErrImagePull"
     jobStatus:
       state: RECONCILING
 operation: InterpretHealth
@@ -211,8 +277,39 @@ output:
   healthy: true
 
 ---
-name: "FlinkDeployment with CREATED state and jobManagerDeploymentStatus ERROR should be Healthy"
-description: "Test interpreting health of FlinkDeployment when jobStatus.state is CREATED and jobManagerDeploymentStatus is ERROR"
+name: "FlinkDeployment with RECONCILING state with non-allowlisted error should be Unhealthy"
+description: "Test interpreting health of FlinkDeployment when jobStatus.state is RECONCILING and has allowlisted error"
+observedObj:
+  apiVersion: flink.apache.org/v1beta1
+  kind: FlinkDeployment
+  metadata:
+    name: basic-example
+    namespace: test-namespace
+  spec:
+    flinkConfiguration:
+      taskmanager.numberOfTaskSlots: "2"
+    flinkVersion: v1_17
+    image: flink:1.17
+    jobManager:
+      replicas: 1
+      resource:
+        cpu: 1
+        memory: 2048m
+    taskManager:
+      resource:
+        cpu: 1
+        memory: 2048m
+  status:
+    error: "Unknown"
+    jobStatus:
+      state: RECONCILING
+operation: InterpretHealth
+output:
+  healthy: false
+
+---
+name: "FlinkDeployment with CREATED state and jobManagerDeploymentStatus ERROR (no allowlisted error) should be Unhealthy"
+description: "Test interpreting health of FlinkDeployment when jobStatus.state is CREATED and jobManagerDeploymentStatus is ERROR but no allowlisted error"
 observedObj:
   apiVersion: flink.apache.org/v1beta1
   kind: FlinkDeployment
@@ -239,7 +336,7 @@ observedObj:
       state: CREATED
 operation: InterpretHealth
 output:
-  healthy: true
+  healthy: false
 
 ---
 name: "FlinkDeployment with FAILED state should be Healthy"
@@ -302,8 +399,8 @@ output:
   healthy: true
 
 ---
-name: "FlinkDeployment without jobStatus but with error should be Healthy"
-description: "Test interpreting health of FlinkDeployment when there is no jobStatus but has error"
+name: "FlinkDeployment without jobStatus but with error should be Unhealthy"
+description: "Test interpreting health of FlinkDeployment when there is no jobStatus and error"
 observedObj:
   apiVersion: flink.apache.org/v1beta1
   kind: FlinkDeployment
@@ -328,7 +425,7 @@ observedObj:
     error: "Deployment failed"
 operation: InterpretHealth
 output:
-  healthy: true
+  healthy: false
 
 ---
 name: "FlinkDeployment without jobStatus and without error should be Unhealthy"
@@ -357,3 +454,33 @@ observedObj:
 operation: InterpretHealth
 output:
   healthy: false
+
+---
+name: "FlinkDeployment without jobStatus but with READY jobManagerDeploymentStatus and STABLE lifecycleState should be Healthy"
+description: "Test interpreting health of FlinkDeployment when there is no jobStatus but jobManagerDeploymentStatus is READY and lifecycleState is STABLE"
+observedObj:
+  apiVersion: flink.apache.org/v1beta1
+  kind: FlinkDeployment
+  metadata:
+    name: basic-example
+    namespace: test-namespace
+  spec:
+    flinkConfiguration:
+      taskmanager.numberOfTaskSlots: "2"
+    flinkVersion: v1_17
+    image: flink:1.17
+    jobManager:
+      replicas: 1
+      resource:
+        cpu: 1
+        memory: 2048m
+    taskManager:
+      resource:
+        cpu: 1
+        memory: 2048m
+  status:
+    jobManagerDeploymentStatus: READY
+    lifecycleState: STABLE
+operation: InterpretHealth
+output:
+  healthy: true


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

Currently, karmada treats flink deployment as health as long as there's a published error. However, not all errors are non-retriable , some errors may be solved by fail over to another cluster. 

This PR adds an allowlist in flinkDeployment's health interpreter and only tolerates `ErrImagePull` and `ImagePullBackOff` in health interpretation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
flink-deployment health interpreter: only treat `ErrImagePull` and `ImagePullBackOff` as healthy in during ephemeral state
```

