### PR TITLE
Add comment/example for how to use retention for flink stateful failover

### DIFF
--- a/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/customizations.yaml
+++ b/pkg/resourceinterpreter/default/thirdparty/resourcecustomizations/flink.apache.org/v1beta1/FlinkDeployment/customizations.yaml
@@ -335,3 +335,24 @@ spec:
           status.taskManager = observedObj.status.taskManager
           return status
         end
+    retention:
+      luaScript: |
+        -- For failing over flink applications, if initialSavepointPath is injected in member clusters, we will need to 
+        -- retain it to avoid being overwritten by karmada control plane
+        -- For example, the following script retains initialSavepointPath if resourcebinding.karmada.io/failover-jobid
+        -- label present, this label is set by defining StatePreservation in propagation policy 
+        ---------------------------- Code Example ----------------------------------------------------------------------
+        -- function Retain(desiredObj, observedObj)
+        --   local ocfg = observedObj.spec and observedObj.spec.flinkConfiguration or nil
+        --   local labels = observedObj.metadata and observedObj.metadata.labels or {}
+        --   -- Retain initialSavepointPath only when failover label present
+        --   if labels["resourcebinding.karmada.io/failover-jobid"] ~= nil then
+        --     if observedObj.spec and observedObj.spec.job then
+        --       if observedObj.spec.job.initialSavepointPath ~= nil then
+        --         desiredObj.spec = desiredObj.spec or {}
+        --         desiredObj.spec.job = desiredObj.spec.job or {}
+        --         desiredObj.spec.job.initialSavepointPath = observedObj.spec.job.initialSavepointPath
+        --       end
+        --     end
+        --   end
+        -- end


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:
This PR adds a section of comment in retention section of flink's resource interpreter. The comment shows what needs to be done if one wants to start flink app from latest checkpoint/savepoint during failover event. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note

```

